### PR TITLE
k8s-engine/client: Ignore cert altname errors when waiting for services

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -18,7 +18,7 @@ import resources from '../resources';
 import DownloadProgressListener from '../utils/DownloadProgressListener';
 import { VersionLister } from './k8s';
 
-const console = new Console(Logging.k3s.stream);
+const console = new Console(Logging.k8s.stream);
 const paths = XDGAppPaths('rancher-desktop');
 
 export interface ReleaseAPIEntry {


### PR DESCRIPTION
If the host running k3s had restarted since the last time it was active, the IP address may have changed, which means the TLS certificate it is using will need to be regenerated.  We will need to wait for that to happen when waiting for the services list to finish initializing.

Fixes #288.

Steps to reproduce:
- Start RD, get k3s up.
- Quit RD, shutting k3s down.
- Run `wsl --shutdown`
- Start RD again.