### PR TITLE
Be more careful when processing the config file:

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -259,8 +259,13 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         await util.promisify(setTimeout)(500);
       }
 
-      await this.k3sHelper.updateKubeconfig(
-        'wsl.exe', '--distribution', 'k3s', '--exec', '/usr/local/bin/kubeconfig');
+      try {
+        await this.k3sHelper.updateKubeconfig(
+          'wsl.exe', '--distribution', 'k3s', '--exec', '/usr/local/bin/kubeconfig');
+      } catch (err) {
+        console.log(`k3sHelper.updateKubeconfig failed: ${ err }. Will retry...`);
+        throw err;
+      }
 
       this.client = new K8s.Client();
       await this.client.waitForServiceWatcher();

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -242,7 +242,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         }
       });
 
-      // Wait for k3s server; note that we're delibrately sending a HTTP request
+      // Wait for k3s server; note that we're deliberately sending an HTTP request
       // to an HTTPS server, and expecting an error response back.
       while (true) {
         try {

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -84,10 +84,6 @@ export class Tray extends EventEmitter {
     if (!kubeconfigPath) {
       throw new Error('No kubeconfig path found');
     }
-    // Add a delay before starting the file system watcher to avoid hitting a lock on the file
-    // that is taking a while to be cleared.
-    // setTimeout(() => {
-    // Maybe the file exists now...
     this.buildFromConfig(kubeconfigPath);
     const watcher = fs.watch(kubeconfigPath);
 
@@ -101,7 +97,6 @@ export class Tray extends EventEmitter {
       }
       this.buildFromConfig(kubeconfigPath);
     });
-    // }, 1000);
 
     this.on('k8s-check-state', this.k8sStateChanged.bind(this));
     this.on('settings-update', this.settingsChanged.bind(this));


### PR DESCRIPTION
1. Try to process it immediately in case it's ready,
   as the file watcher might not actually fire again.

2. If the file is empty or contains an empty skeleton,
   don't process it.

3. Wait a second before starting up the file watcher --
   this is because sometimes it still has a lock on it,
   even if we're done with the operation that created the lock
   (this happens on Windows sometimes).

Signed-off-by: Eric Promislow <epromislow@suse.com>