### PR TITLE
Use Node.js v14 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Rancher can be built from source on macOS or Windows. The following provides som
 
 ### Prerequisites
 
-Rancher Desktop is an [electron](https://www.electronjs.org/) and [node.js](https://nodejs.org/) application. node.js needs to be installed to build the source.
+Rancher Desktop is an [electron](https://www.electronjs.org/) and [node.js](https://nodejs.org/) application. node.js v14 needs to be installed to build the source.
 
 The following is a breakdown of the pre-requisites for each platform. These need to be installed first.
 
@@ -82,8 +82,8 @@ You are now ready to clone the repository and run `npm install`.
    2. Install git and nvm via `scoop install git nvm`
    3. Add the old versions bucket via `scoop bucket add versions`
    4. Install nvm and Python 2 via `scoop install python27`
-   5. Install NodeJS via `nvm install latest`
-      * Remember to use it by running `nvm use $(nvm list)`
+   5. Install NodeJS via `nvm install 14.17.0`
+      * Remember to use it by running `nvm use 14.17.0`
 5. Configure NPM to use the version of MSBuild installed:
    ```powershell
    npm config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -53,8 +53,11 @@ if (!$SkipTools) {
         # support); however, PowerShell will see _anything_ going to stderr and
         # treat the result as fatal.  Redirect the output so we can continue.
         scoop install nvm python27 2>&1
-        nvm install latest
-        nvm use $(nvm list | Where-Object { $_ } | Select-Object -First 1)
+        # Temporarily commented out until we can handle later versions of node.js:
+        # nvm install latest
+        # nvm use $(nvm list | Where-Object { $_ } | Select-Object -First 1)
+        nvm install 14.17.0
+        nvm use 14.17.0
     }
 }
 


### PR DESCRIPTION
"Latest" is now v16 and `npm install` will fail on that.

Signed-off-by: Eric Promislow <epromislow@suse.com>