### PR TITLE
Avoid unnecessarily deleting the VM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -201,7 +201,9 @@ module.exports.overrides = [
     rules: {
       // For TypeScript, disable no-undef because the compiler checks it.
       // Also, it is unaware of TypeScript types.
-      'no-undef': 'off',
+      'no-undef':              'off',
+      // For TypeScript, allow duplicate class members (function overloads).
+      'no-dupe-class-members': 'off',
     }
   }
 ];

--- a/background.ts
+++ b/background.ts
@@ -388,10 +388,8 @@ Electron.ipcMain.on('k8s-reset', async(event, arg) => {
 
       console.log(`Stopped Kubernetes backened cleanly.`);
       console.log('Deleting VM to reset...');
-
-      const code = await k8smanager.del();
-
-      console.log(`Deleted minikube to reset exited with code ${ code }`);
+      await k8smanager.del();
+      console.log(`Deleted VM to reset exited cleanly.`);
 
       // The desired Kubernetes version might have changed
       k8smanager = newK8sManager();

--- a/background.ts
+++ b/background.ts
@@ -160,9 +160,9 @@ Electron.app.on('before-quit', async(event) => {
   event.preventDefault();
 
   try {
-    const code = await k8smanager?.stop();
+    await k8smanager?.stop();
 
-    console.log(`2: Child exited with code ${ code }`);
+    console.log(`2: Child exited cleanly.`);
   } catch (ex) {
     console.log(`2: Child exited with code ${ ex.errCode }`);
     handleFailure(ex);
@@ -384,12 +384,13 @@ Electron.ipcMain.on('k8s-reset', async(event, arg) => {
       await k8smanager.reset(cfg.kubernetes);
       break;
     case 'slow': {
-      let code = await k8smanager.stop();
+      await k8smanager.stop();
 
-      console.log(`Stopped minikube with code ${ code }`);
-      console.log('Deleting minikube to reset...');
+      console.log(`Stopped Kubernetes backened cleanly.`);
+      console.log('Deleting VM to reset...');
 
-      code = await k8smanager.del();
+      const code = await k8smanager.del();
+
       console.log(`Deleted minikube to reset exited with code ${ code }`);
 
       // The desired Kubernetes version might have changed

--- a/background.ts
+++ b/background.ts
@@ -416,13 +416,7 @@ Electron.ipcMain.on('k8s-restart', async() => {
   try {
     switch (k8smanager.state) {
     case K8s.State.STOPPED:
-      await k8smanager.start(cfg.kubernetes);
-      break;
     case K8s.State.STARTED:
-      await k8smanager.stop();
-      // The desired Kubernetes version might have changed
-      k8smanager = newK8sManager();
-
       await k8smanager.start(cfg.kubernetes);
       break;
     }

--- a/background.ts
+++ b/background.ts
@@ -417,6 +417,8 @@ Electron.ipcMain.on('k8s-restart', async() => {
     switch (k8smanager.state) {
     case K8s.State.STOPPED:
     case K8s.State.STARTED:
+      // Calling start() will restart the backend, possible switching versions
+      // as a side-effect.
       await k8smanager.start(cfg.kubernetes);
       break;
     }

--- a/background.ts
+++ b/background.ts
@@ -431,6 +431,12 @@ Electron.ipcMain.on('k8s-versions', async() => {
   }
 });
 
+Electron.ipcMain.on('k8s-progress', () => {
+  if (k8smanager) {
+    window.send('k8s-progress', k8smanager.progress);
+  }
+});
+
 Electron.ipcMain.handle('service-fetch', (event, namespace) => {
   return k8smanager?.listServices(namespace);
 });
@@ -582,8 +588,8 @@ function newK8sManager() {
     window.send('service-changed', services);
   });
 
-  mgr.on('progress', (current: number, max: number) => {
-    window.send('k8s-progress', current, max);
+  mgr.on('progress', (progress: {current: number, max: number}) => {
+    window.send('k8s-progress', progress.current, progress.max);
   });
 
   mgr.on('versions-updated', async() => {

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -300,9 +300,6 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     this.cfg = config;
     const desiredVersion = await this.desiredVersion;
 
-    // Unconditionally stop, in case a previous run broke.
-    await this.stop();
-
     this.setState(K8s.State.STARTING);
     if (this.progressInterval) {
       timers.clearInterval(this.progressInterval);
@@ -329,6 +326,14 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     // We have no good estimate for the rest of the steps, go indeterminate.
     timers.clearInterval(this.progressInterval);
     this.progressInterval = undefined;
+    this.setProgress(Progress.INDETERMINATE);
+
+    // Unconditionally stop, in case a previous run broke.
+    await this.stop();
+
+    // Stopping would have reset the state; set it again.
+    this.setState(K8s.State.STARTING);
+    // We have no good estimate for the rest of the steps, go indeterminate.
     this.setProgress(Progress.INDETERMINATE);
 
     // Start the VM

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -420,7 +420,14 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     });
   }
 
+  protected isStopping = false;
   async stop(): Promise<number> {
+    // When we manually call stop, the subprocess will terminate, which will
+    // cause stop to get called again.  Prevent the re-entrancy.
+    if (this.isStopping) {
+      return 0;
+    }
+    this.isStopping = true;
     try {
       this.setState(K8s.State.STOPPING);
       this.setProgress(Progress.INDETERMINATE);
@@ -435,6 +442,8 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
       this.setState(K8s.State.ERROR);
       this.setProgress(Progress.EMPTY);
       throw ex;
+    } finally {
+      this.isStopping = false;
     }
 
     return 0;

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -476,7 +476,7 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     }
   }
 
-  async del(): Promise<number> {
+  async del(): Promise<void> {
     try {
       await this.stop();
       this.setProgress(Progress.INDETERMINATE);
@@ -488,8 +488,6 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     }
     this.cfg = undefined;
     this.setProgress(Progress.DONE);
-
-    return Promise.resolve(0);
   }
 
   async reset(config: Settings['kubernetes']): Promise<void> {

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -1,6 +1,7 @@
 // Kubernetes backend for macOS, based on Hyperkit
 
 import childProcess from 'child_process';
+import { Console } from 'console';
 import events from 'events';
 import fs from 'fs';
 import os from 'os';
@@ -22,6 +23,8 @@ import K3sHelper from './k3sHelper';
 const paths = XDGAppPaths('rancher-desktop');
 /** The GID of the 'admin' group on macOS */
 const adminGroup = 80;
+
+const console = new Console(Logging.k8s.stream);
 
 /**
  * The possible states for the docker-machine driver.

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -450,11 +450,11 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
   }
 
   protected isStopping = false;
-  async stop(): Promise<number> {
+  async stop(): Promise<void> {
     // When we manually call stop, the subprocess will terminate, which will
     // cause stop to get called again.  Prevent the re-entrancy.
     if (this.isStopping) {
-      return 0;
+      return;
     }
     this.isStopping = true;
     try {
@@ -474,8 +474,6 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     } finally {
       this.isStopping = false;
     }
-
-    return 0;
   }
 
   async del(): Promise<number> {

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -17,7 +17,6 @@ import Logging from '../utils/logging';
 import resources from '../resources';
 import DownloadProgressListener from '../utils/DownloadProgressListener';
 import safeRename from '../utils/safeRename';
-import { VersionLister } from './k8s';
 
 const console = new Console(Logging.k8s.stream);
 const paths = XDGAppPaths('rancher-desktop');
@@ -45,7 +44,7 @@ export function buildVersion(version: semver.SemVer) {
   return parseInt(`${ numString || '-1' }`);
 }
 
-export default class K3sHelper extends events.EventEmitter implements VersionLister {
+export default class K3sHelper extends events.EventEmitter {
   protected readonly releaseApiUrl = 'https://api.github.com/repos/k3s-io/k3s/releases?per_page=100';
   protected readonly releaseApiAccept = 'application/vnd.github.v3+json';
   protected readonly cachePath = path.join(paths.cache(), 'k3s-versions.json');

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -41,6 +41,13 @@ export interface KubernetesBackend extends events.EventEmitter {
   memory: Promise<number>;
 
   /**
+   * Progress for the current action.
+   * If the maximum is less than zero, it should be considered to be
+   * indeterminate.
+   */
+  progress: { readonly current: number, readonly max: number };
+
+  /**
    * Check if the current backend is valid.
    * @returns Null if the backend is valid, otherwise an error describing why
    * the backend is invalid that can be shown to the user.
@@ -96,6 +103,30 @@ export interface KubernetesBackend extends events.EventEmitter {
    * @param {number} port The internal port number of the service to forward.
    */
   cancelForward(namespace: string, service: string, port: number): Promise<void>;
+
+  // #region Events
+
+  /**
+   * Emitted when there has been a change in the progress in the current action.
+   */
+  on(event: 'progress', listener: (progress: { current: number, max: number }) => void): this;
+
+  /**
+   * Emitted when the set of Kubernetes services has changed.
+   */
+  on(event: 'service-changed', listener: (services: ServiceEntry[]) => void): this;
+
+  /**
+   * Emitted when the state of the Kubernetes backend has changed.
+   */
+  on(event: 'state-changed', listener: (state: State) => void): this;
+
+  /**
+   * Emitted when the versions of Kubernetes available has changed.
+   */
+  on(event: 'versions-updated', listener: () => void): this;
+
+  // #endregion
 
 }
 

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -64,7 +64,7 @@ export interface KubernetesBackend extends events.EventEmitter {
   stop(): Promise<void>;
 
   /** Delete the Kubernetes cluster, returning the exit code. */
-  del(): Promise<number>;
+  del(): Promise<void>;
 
   /** Reset the Kubernetes cluster, removing all workloads. */
   reset(config: Settings['kubernetes']): Promise<void>;

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -3,7 +3,6 @@ import os from 'os';
 import { Settings } from '../config/settings';
 import { ServiceEntry } from './client';
 import Hyperkit from './hyperkit';
-import K3sHelper from './k3sHelper';
 import { OSNotImplemented } from './notimplemented.js';
 import WSLBackend from './wsl';
 export { KubeClient as Client, ServiceEntry } from './client';
@@ -72,7 +71,7 @@ export interface KubernetesBackend extends events.EventEmitter {
   getBackendInvalidReason(): Promise<KubernetesError | null>;
 
   /** Start the Kubernetes cluster. */
-  start(): Promise<void>;
+  start(config: Settings['kubernetes']): Promise<void>;
 
   /** Stop the Kubernetes cluster, returning the exit code. */
   stop(): Promise<number>;
@@ -81,7 +80,7 @@ export interface KubernetesBackend extends events.EventEmitter {
   del(): Promise<number>;
 
   /** Reset the Kubernetes cluster, removing all workloads. */
-  reset(): Promise<void>;
+  reset(config: Settings['kubernetes']): Promise<void>;
 
   /**
    * Reset the cluster, completely deleting any user configuration.  This does
@@ -123,17 +122,13 @@ export interface KubernetesBackend extends events.EventEmitter {
 
 }
 
-export function availableVersions(): Promise<readonly string[]> {
-  return (new K3sHelper()).availableVersions;
-}
-
-export function factory(cfg: Settings['kubernetes']): KubernetesBackend {
+export function factory(): KubernetesBackend {
   switch (os.platform()) {
   case 'darwin':
-    return new Hyperkit(cfg);
+    return new Hyperkit();
   case 'win32':
-    return new WSLBackend(cfg);
+    return new WSLBackend();
   default:
-    return new OSNotImplemented(cfg);
+    return new OSNotImplemented();
   }
 }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -60,8 +60,8 @@ export interface KubernetesBackend extends events.EventEmitter {
    */
   start(config: Settings['kubernetes']): Promise<void>;
 
-  /** Stop the Kubernetes cluster, returning the exit code. */
-  stop(): Promise<number>;
+  /** Stop the Kubernetes cluster. */
+  stop(): Promise<void>;
 
   /** Delete the Kubernetes cluster, returning the exit code. */
   del(): Promise<number>;

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -54,7 +54,10 @@ export interface KubernetesBackend extends events.EventEmitter {
    */
   getBackendInvalidReason(): Promise<KubernetesError | null>;
 
-  /** Start the Kubernetes cluster. */
+  /**
+   * Start the Kubernetes cluster.  If it is already started, it will be
+   * restarted.
+   */
   start(config: Settings['kubernetes']): Promise<void>;
 
   /** Stop the Kubernetes cluster, returning the exit code. */

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -15,29 +15,6 @@ export enum State {
   ERROR, // There is an error and we cannot recover automatically.
 }
 
-/**
- * This interface fetches the versions available to be installed.
- */
-export interface VersionLister {
-  /**
-   * The versions that are available to be installed.  This should be sorted in
-   * a way that is appropriate for presenting to the user.  The version strings
-   * are in the form `v1.2.3`.
-   */
-  availableVersions: Promise<string[]>;
-
-  /**
-   * Return the full version string for a short version (without the build).
-   * @param shortVersion The base version string, of the form `v1.2.3`.
-   */
-  fullVersion(shortVersion: string): string;
-
-  /**
-   * Event listener callback to be notified when the list changes.
-   */
-  on(event: 'versions-updated', callback: ()=>void): void;
-}
-
 export class KubernetesError extends Error {
   constructor(name: string, message: string) {
     super(message);

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -26,7 +26,6 @@ const K8s = require('./k8s');
 const console = new Console(Logging.minikube.stream);
 
 /** @typedef { import("../config/settings").Settings } Settings */
-/** @typedef { import("./k8s").VersionLister } VersionLister */
 
 /**
  * Kubernetes backend using minikube on macOS

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -9,10 +9,6 @@ const { State } = require('./k8s');
  */
 class OSNotImplemented extends events.EventEmitter {
   #notified = false
-  constructor(cfg) {
-    super();
-    this.cfg = cfg;
-  }
 
   get state() {
     return State.ERROR;
@@ -42,7 +38,7 @@ class OSNotImplemented extends events.EventEmitter {
     return Promise.resolve(null);
   }
 
-  start() {
+  start(config) {
     this.#notified = displayError(this.#notified);
 
     return Promise.reject(new Error('not implemented'));
@@ -60,7 +56,7 @@ class OSNotImplemented extends events.EventEmitter {
     return Promise.reject(new Error('not implemented'));
   }
 
-  reset() {
+  reset(config) {
     this.#notified = displayError(this.#notified);
 
     return Promise.reject(new Error('not implemented'));

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -34,6 +34,12 @@ class OSNotImplemented extends events.EventEmitter {
     return Promise.reject(new Error('not implemented'));
   }
 
+  get progress() {
+    this.#notified = displayError(this.#notified);
+
+    return { current: 0, max: 0 };
+  }
+
   getBackendInvalidReason() {
     return Promise.resolve(null);
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -380,11 +380,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected isStopping = false;
-  async stop(): Promise<number> {
+  async stop(): Promise<void> {
     // When we manually call stop, the subprocess will terminate, which will
     // cause stop to get called again.  Prevent the re-entrancy.
     if (this.isStopping) {
-      return 0;
+      return;
     }
     this.isStopping = true;
     try {
@@ -408,8 +408,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     } finally {
       this.isStopping = false;
     }
-
-    return 0;
   }
 
   async del(): Promise<number> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -211,10 +211,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   async start(config: Settings['kubernetes']): Promise<void> {
     this.cfg = config;
     try {
-      if (this.process) {
-        await this.stop();
-      }
-
       this.setState(K8s.State.STARTING);
 
       if (this.progressInterval) {
@@ -243,6 +239,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       // We have no good estimate for the rest of the steps, go indeterminate.
       timers.clearInterval(this.progressInterval);
       this.progressInterval = undefined;
+      this.setProgress(Progress.INDETERMINATE);
+
+      // Unconditionally stop, in case a previous run broke.
+      await this.stop();
+
+      // Stopping would have reset the state; set it again.
+      this.setState(K8s.State.STARTING);
+      // We have no good estimate for the rest of the steps, go indeterminate.
       this.setProgress(Progress.INDETERMINATE);
 
       // Run run-k3s with NORUN, to set up the environment.

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -286,6 +286,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           console.log(`K3s exited with status ${ status } signal ${ signal }`);
           this.stop();
           this.setState(K8s.State.ERROR);
+          this.setProgress(Progress.EMPTY);
         }
       });
 
@@ -365,8 +366,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         console.log('The images page will probably be empty');
       }
       this.setState(K8s.State.STARTED);
+      this.setProgress(Progress.DONE);
     } catch (ex) {
       this.setState(K8s.State.ERROR);
+      this.setProgress(Progress.EMPTY);
       throw ex;
     } finally {
       if (this.progressInterval) {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -410,15 +410,13 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     }
   }
 
-  async del(): Promise<number> {
+  async del(): Promise<void> {
     await this.stop();
     await childProcess.spawnFile('wsl.exe', ['--unregister', 'k3s'], {
       stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
       windowsHide: true,
     });
     this.cfg = undefined;
-
-    return 0;
   }
 
   async reset(config: Settings['kubernetes']): Promise<void> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -295,7 +295,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             break;
           }
         } catch (e) {
-          if (e.code !== 'ECONNREFUSED') {
+          if (!['ECONNREFUSED', 'ECONNRESET'].includes(e.code)) {
             throw e;
           }
         }

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -196,6 +196,7 @@ export default {
     });
     ipcRenderer.send('k8s-restart-required');
     ipcRenderer.send('k8s-versions');
+    ipcRenderer.send('k8s-progress');
     ipcRenderer.send('install-state', 'helm');
     ipcRenderer.send('install-state', 'kim');
     ipcRenderer.send('install-state', 'kubectl');

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -222,7 +222,7 @@ export default {
         if (semver.lt(event.target.value, this.settings.kubernetes.version)) {
           if (confirm(`Changing from version ${ this.settings.kubernetes.version } to ${ event.target.value } will reset Kubernetes. Do you want to proceed?`)) {
             ipcRenderer.invoke('settings-write', { kubernetes: { version: event.target.value } })
-              .then(() => this.reset());
+              .then(() => this.restart());
           } else {
             alert('The Kubernetes version was not changed');
           }

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -4,7 +4,7 @@
 <template>
   <Notifications :notifications="notificationsList">
     <select class="select-k8s-version" :value="settings.kubernetes.version" @change="onChange($event)">
-      <option v-for="item in versions" :key="item" :value="item">
+      <option v-for="item in versions" :key="item" :value="item" :selected="item === settings.kubernetes.version">
         {{ item }}
       </option>
     </select> Kubernetes version

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -118,13 +118,13 @@ export default {
       return os.platform() === 'darwin';
     },
     progressComputed() {
-      return this.state === K8s.State.STARTING ? this.progress.current : this.progressMax;
+      return this.progress.current;
     },
     progressIndeterminate() {
       return this.progressMax < 1;
     },
     progressMax() {
-      return this.state === K8s.State.STARTING ? this.progress.max : 100;
+      return this.progress.max;
     },
     availMemoryInGB() {
       return os.totalmem() / 2 ** 30;


### PR DESCRIPTION
This makes a few changes:
- Change the K8s backend interface to take the config on start/reset instead of in the constructor
- Make the progress a property on the backend, so that we can read it back if the user switches to the Kubernetes settings tab in the middle.
- Stop deleting the VM on upgrade: just ensure the files are there, stop and immediately start again.
- Stop deleting the VM on downgrade: just do the above + remove the db as appropriate.
- To reduce downtime, don't immediately stop when trying to start again; instead, do it after files are downloaded.
- Display progress in all states, not just during start.

Fixes #201, #291