### PR TITLE
Ensure the # of bytes read is reset to 0 before starting to read a download

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -334,6 +334,8 @@ export default class K3sHelper extends events.EventEmitter {
           throw new Error(`Error downloading ${ filename } ${ version }: ${ response.statusText }`);
         }
         const status = this.progress[<keyof typeof filenames>filekey];
+
+        status.current = 0;
         const progress = new DownloadProgressListener(status);
         const writeStream = fs.createWriteStream(outPath);
 


### PR DESCRIPTION
The reason why sometimes there was a solid blue bar during downloading is that the UI was showing
the progress for reading from N/N to 2*N/N bytes, where it's supposed to be 0/N through N/N.
The progress counter is attached to the WSLBackend object and needs to be reset.

Open to a more elegant way of doing this.

Signed-off-by: Eric Promislow <epromislow@suse.com>