### PR TITLE
Explain why a link doesn't hold in the checkbox label

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -466,7 +466,9 @@ Electron.ipcMain.handle('service-forward', async(event, service, state) => {
  * (not installed, but can be), or null (install unavailable, e.g. because a
  * different executable already exists).
  * @param {string} name The name of the executable, e.g. "kubectl", "helm".
- * @returns {boolean?} The state of the installable binary.
+ * @returns [{boolean?} state, {string} failureReason]
+ *   state: The state of the installable binary.
+ *   failureReason: An error string, or the actual error encountered when trying to link
  */
 async function refreshInstallState(name: string) {
   const linkPath = path.join('/usr/local/bin', name);
@@ -493,7 +495,7 @@ async function refreshInstallState(name: string) {
     case 'EINVAL':
       return [null, `${ linkPath } exists and is not a symbolic link`];
     default:
-      return [null, err];
+      return [null, `Can't link to ${ linkPath }: err`];
     }
   } else {
     return [null, `${ linkPath } is already linked to ${ dest }`];

--- a/background.ts
+++ b/background.ts
@@ -466,11 +466,14 @@ Electron.ipcMain.handle('service-forward', async(event, service, state) => {
  * (not installed, but can be), or null (install unavailable, e.g. because a
  * different executable already exists).
  * @param {string} name The name of the executable, e.g. "kubectl", "helm".
- * @returns [{boolean?} state, {string} failureReason]
- *   state: The state of the installable binary.
- *   failureReason: An error string, or the actual error encountered when trying to link
+ * @return {Promise<[boolean|null, string|null]>}
+ *   first value: The state of the installable binary:
+ *     true: the symlink exists, and points to a file we control
+ *     false: the target file does not exist (so a symlink can be created)
+ *     null: a file exists, and is either not a symlink, or points to a non-rd file
+ *   second value: The reason for a null first value, or the actual error encountered when trying to link
  */
-async function refreshInstallState(name: string) {
+async function refreshInstallState(name: string): Promise<[boolean | null, string | null]> {
   const linkPath = path.join('/usr/local/bin', name);
   const desiredPath = await resources.executable(name);
   const [err, dest] = await new Promise((resolve) => {

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -242,27 +242,8 @@ export default {
       this.handleNotification('warning', key, message);
     },
     linkLabel(baseName) {
-      if (this.symlinks[baseName] === null) {
-        let parts = ["Can't link to /usr/local/bin/", baseName];
-
-        if (this.symlinkBlockers[baseName]) {
-          const ptn = new RegExp(`${ baseName } is already linked to (.+)`);
-          const m = ptn.exec(this.symlinkBlockers[baseName]);
-
-          if (m) {
-            parts = ['/usr/local/bin/', baseName, ' is already linked to ', m[1]];
-          } else {
-            const ptn = new RegExp(`${ baseName } exists and is not a symbolic link`);
-
-            if (ptn.test(this.symlinkBlockers[baseName])) {
-              parts = ['/usr/local/bin/', baseName, ' exists and is not a symbolic link'];
-            } else {
-              parts.push(': ', this.symlinkBlockers[baseName]);
-            }
-          }
-        }
-
-        return parts.join('');
+      if (this.symlinkBlockers[baseName]) {
+        return this.symlinkBlockers[baseName];
       }
 
       return `Link to /usr/local/bin/${ baseName }`;


### PR DESCRIPTION
Why: because dashboard tooltips present as a small unlabeled button,
clicking on which displays the underlying text in a hover tip.

We've already seen the dashboard tooltip at work and rejected it.

The backend is responsible for figuring out why a link can't happen,
and the frontend displays it with a minimum of processing.

Signed-off-by: Eric Promislow <epromislow@suse.com>