### PR TITLE
When stopping hyperkit, don't create a promise

### DIFF
--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -1,6 +1,7 @@
 // Kubernetes backend for macOS, based on Hyperkit
 
 import { Console } from 'console';
+import { execFile } from 'child_process';
 import events from 'events';
 import fs from 'fs';
 import os from 'os';
@@ -246,6 +247,15 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
     const finalArgs = defaultArgs.concat(args);
 
     console.log(JSON.stringify([driver].concat(finalArgs)));
+    if (args[0] === 'stop') {
+      // Fire and forget to prevent creation of a long-running promise during shutdown
+      // See https://github.com/rancher-sandbox/rancher-desktop/issues/333
+      execFile(driver, finalArgs);
+
+      return new Promise((resolve) => {
+        resolve();
+      });
+    }
     await childProcess.spawnFile(driver, finalArgs,
       { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
   }


### PR DESCRIPTION
When hyperkit is stopped inside a promise, the shutdown mechanism
in Electron issues an unresolved-promise warning just before the
promise is actually resolved. The simplest solution is to replace
the promise associated with the outcome of running `hyperkit stop`
with a trivial promise that resolves earlier, as we don't care about
the outcome of stopping the server (because we're shutting down).

Note that while fixing Issue 315 simplified the hyperkit method, the 
unhandled promise exception problem still happened. The more I look
at it, the more I think it's because shutting down takes long enough
that the electron/node shutdown process still sees an unresolved promise
and complains about it, even if we will eventually always resolve it.