### PR TITLE
Squelch expected unhandled rejections

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -39,6 +39,16 @@ Electron.protocol.registerSchemesAsPrivileged([
   { scheme: 'app', privileges: { secure: true, standard: true } },
 ]);
 
+process.on('unhandledRejection', (reason: any, promise: any) => {
+  if (reason.errno === -61 && reason.code === 'ECONNREFUSED' && reason.port === 6443) {
+    // Do nothing: a connection to the kubernetes server was broken
+  } else {
+    promise.catch((error: any) => {
+      console.log(`UnhandledRejectionWarning: ${ error }`);
+    });
+  }
+});
+
 Electron.app.whenReady().then(async() => {
   if (os.platform().startsWith('win')) {
     // Inject the Windows certs.


### PR DESCRIPTION
Most of these are due to an abrupt disconnection from the kubernetes server.
I don't think this is due to our code, but lower-library code (possibly in
the electron framework).

This code emits error messages for other rejections by handling the rejection.

Signed-off-by: Eric Promislow <epromislow@suse.com>