### PR TITLE
Update docs to current state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,12 @@ This document outlines the process to get your pull request accepted.
 
 ## Start With An Issue
 
-Prior to creating a pull request it is a good idea to create an issue.
+Prior to creating a pull request it is a good idea to [create an issue].
 This is especially true if the change request is something large.
 The bug, feature request, or other type of issue can be discussed prior to
 creating the pull request. This can reduce rework.
+
+[create an issue]: https://github.com/rancher-sandbox/rancher-desktop/issues/new
 
 ## Sign Your Commits
 
@@ -61,7 +63,7 @@ Then you add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@example.com>
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
+Use your real name (sorry, no pseudonyms or anonymous contributions).
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note, [development builds] are available from the CI system. Development builds
 are not signed.
 
 [development builds]:
-https://github.com/rancher-sandbox/rd/actions/workflows/package.yaml
+https://github.com/rancher-sandbox/rancher-desktop/actions/workflows/package.yaml?query=branch%3Amain
 
 ## Base Design Details
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ You are now ready to clone the repository and run `npm install`.
 
 ##### Manual Development Environment Setup
 
-1. Install [Scoop] via `iwr -useb get.scoop.sh | iex`
-2. Install git and nvm via `scoop install git nvm`
-3. Install NodeJS via `nvm install 14.17.0`
+1. Install [Windows Subsystem for Linux (WSL)] on your machine.
+2. Install [Scoop] via `iwr -useb get.scoop.sh | iex`
+3. Install git and nvm via `scoop install git nvm`
+4. Install NodeJS via `nvm install 14.17.0`
   * Remember to use it by running `nvm use 14.17.0`
 
 [Scoop]: https://scoop.sh/

--- a/README.md
+++ b/README.md
@@ -9,48 +9,53 @@ Rancher Desktop provides the following features in the form of a desktop applica
 
 - The version of Kubernetes you choose
 - Ability to test upgrading Kubernetes to a new version and see how your workloads respond
-- Build, push, and pull images (powered by [KIM](https://github.com/rancher/kim))
+- Build, push, and pull images (powered by [KIM])
 - Expose an application in Kubernetes for local access
 
 All of this is wrapped in an open-source application.
 
+[KIM]: https://github.com/rancher/kim
+
 ## Get The App
 
-You can download the application for macOS and Windows on the [releases page](https://github.com/rancher-sandbox/rd/releases).
+You can download the application for macOS and Windows on the [releases page].
 
-Running on Windows requires [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-Please install WSL prior to installing Rancher Desktop. In a future release
-Rancher Desktop will automate the step for you.
+[releases page]: https://github.com/rancher-sandbox/rd/releases
 
-Note, [development builds](https://github.com/rancher-sandbox/rd/actions/workflows/package.yaml) are available from the CI system. Development builds are not signed.
+Running on Windows requires [Windows Subsystem for Linux (WSL)].  This will be
+installed automatically during Rancher Desktop installation.
+
+[Windows Subsystem for Linux (WSL)]:
+https://docs.microsoft.com/en-us/windows/wsl/install-win10
+
+Note, [development builds] are available from the CI system. Development builds
+are not signed.
+
+[development builds]:
+https://github.com/rancher-sandbox/rd/actions/workflows/package.yaml
 
 ## Base Design Details
 
-Rancher Desktop is an electron application with the primary business logic being written in TypeScript and JavaScript. It leverages several other pieces of technology to provide the platform elements which include k3s, kim, kubectl, wsl, hyperkit, and more. The application wraps numerous pieces of technology to provide one cohesive application.
+Rancher Desktop is an Electron application with the primary business logic
+written in TypeScript and JavaScript.  It leverages several other pieces of
+technology to provide the platform elements which include k3s, kim, kubectl,
+WSL, hyperkit, and more. The application wraps numerous pieces of technology to
+provide one cohesive application.
 
 ## Building The Source
 
-Rancher can be built from source on macOS or Windows. The following provides some detail on building.
+Rancher can be built from source on macOS or Windows.  Cross-compilation is
+currently not supported.  The following provides some detail on building.
 
 ### Prerequisites
 
-Rancher Desktop is an [electron](https://www.electronjs.org/) and [node.js](https://nodejs.org/) application. node.js v14 needs to be installed to build the source.
+Rancher Desktop is an [Electron] and [Node.js] application. Node.js v14 needs to
+be installed to build the source.
 
-The following is a breakdown of the pre-requisites for each platform. These need to be installed first.
+[Electron]: https://www.electronjs.org/
+[Node.js]: https://nodejs.org/
 
-**macOS:**
-
-```bash
-brew install pkg-config cairo pango libpng jpeg giflib librsvg
-```
-
-**Ubuntu:**
-
-```bash
-sudo apt-get install -y libcairo2-dev libpango1.0-dev libpng-dev libjpeg-dev libgif-dev librsvg2-dev
-```
-
-### Windows
+#### Windows
 
 1. Download a Microsoft Windows 10 [development virtual machine].
 2. Open a privileged PowerShell prompt (hit Windows Key + `X` and open
@@ -59,7 +64,7 @@ sudo apt-get install -y libcairo2-dev libpango1.0-dev libpng-dev libjpeg-dev lib
    ```powershell
    Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-   iwr -useb 'https://github.com/rancher-sandbox/rd/raw/main/scripts/windows-setup.ps1' | iex
+   iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
    ```
 4. Close the privileged PowerShell prompt.
 
@@ -68,39 +73,13 @@ You are now ready to clone the repository and run `npm install`.
 [development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
 [automated setup script]: ./scripts/windows-setup.ps1
 
-#### Manual Development Environment Setup
+##### Manual Development Environment Setup
 
-1. Download and install [Visual Studio], taking care to install:
-   - MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
-   - MSVC v142 - VS 2019 C++ x64/x86 build tools (Latest)
-2. Download the [GTK+ Win64 bundle]; it is recommended to install it in the
-   default location at `C:\GTK`.
-3. Download the [libjpeg-turbo development files]; it is recommended to install
-   it in the default location at `C:\libjpeg-turbo64`.
-4. Install git, Python 2.x, and NodeJS.
-   1. Install [Scoop] via `iwr -useb get.scoop.sh | iex`
-   2. Install git and nvm via `scoop install git nvm`
-   3. Add the old versions bucket via `scoop bucket add versions`
-   4. Install nvm and Python 2 via `scoop install python27`
-   5. Install NodeJS via `nvm install 14.17.0`
-      * Remember to use it by running `nvm use 14.17.0`
-5. Configure NPM to use the version of MSBuild installed:
-   ```powershell
-   npm config set msbuild_path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
-   ```
-   Note that this is the default path; the path on your system may differ.
+1. Install [Scoop] via `iwr -useb get.scoop.sh | iex`
+2. Install git and nvm via `scoop install git nvm`
+3. Install NodeJS via `nvm install 14.17.0`
+  * Remember to use it by running `nvm use 14.17.0`
 
-If you have customized the GTK and libjpeg paths, you will need to run
-`npm install` with the `GYP_DEFINES` variable set to point to them.  In
-PowerShell, this would look something like:
-
-```powershell
-$Env:GYP_DEFINES = 'GTK_Root="C:/Path/To/GTK" jpeg_root="C:/Path/To/libjpeg"'
-```
-
-[Visual Studio]: https://visualstudio.microsoft.com/
-[GTK+ Win64 bundle]: https://download.gnome.org/binaries/win64/gtk+/2.22/
-[libjpeg-turbo development files]: https://sourceforge.net/projects/libjpeg-turbo/files/2.0.6/libjpeg-turbo-2.0.6-vc64.exe/download
 [Scoop]: https://scoop.sh/
 
 ### How To Run
@@ -112,3 +91,6 @@ update is pulled from upstream. The latter is needed for follow-up starts.
 npm install
 npm run dev
 ```
+
+To build the distributable (application bundle on macOS, installer on Windows),
+run `npm run build`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All of this is wrapped in an open-source application.
 
 You can download the application for macOS and Windows on the [releases page].
 
-[releases page]: https://github.com/rancher-sandbox/rd/releases
+[releases page]: https://github.com/rancher-sandbox/rancher-desktop/releases
 
 Running on Windows requires [Windows Subsystem for Linux (WSL)].  This will be
 installed automatically during Rancher Desktop installation.

--- a/docs/images.md
+++ b/docs/images.md
@@ -3,9 +3,8 @@
 Rancher Desktop provides the ability to build, push, and pull images via the
 [KIM](https://github.com/rancher/kim) project.
 
-Note, on Mac `kim` is put into the path. This feature is not yet working on
-Windows and you will need to either manually add the binary to your path or
-install KIM directly. Adding KIM to your path is coming soon.
+Note, `kim` is put into the path automatically.  This occurs during the
+installer on Windows, and upon first run on macOS.
 
 ## Using KIM
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -7,9 +7,11 @@ When run for the first time or when changing versions, Kubernetes container
 images are downloaded. It may take a little time to load on first run for a new
 Kubernetes version.
 
-Running on Windows requires [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-Please install WSL prior to installing Rancher Desktop. In a future release
-Rancher Desktop will automate the step for you.
+Running on Windows requires [Windows Subsystem for Linux(WSL)].  This will be
+installed automatically during the Rancher Desktop setup process.
+
+[Windows Subsystem for Linux(WSL)]:
+https://docs.microsoft.com/en-us/windows/wsl/install-win10
 
 Note, the Windows installer is not yet signed. This will happen soon. In the
 meantime, when presented with a dialog box like the following, click on "More

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,7 +1,7 @@
 # Installing Rancher Desktop
 
 Rancher Desktop is delivered as a desktop application. You can download it from
-the [releases page on GitHub](https://github.com/rancher-sandbox/rd/releases).
+the [releases page on GitHub](https://github.com/rancher-sandbox/rancher-desktop/releases).
 
 When run for the first time or when changing versions, Kubernetes container
 images are downloaded. It may take a little time to load on first run for a new

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -1,5 +1,4 @@
 param (
-    [switch] $SkipVisualStudio,
     [switch] $SkipTools,
     [switch] $SkipWSL
 )
@@ -10,50 +9,13 @@ Write-Information 'Installing components required for Rancher Desktop developmen
 
 # Start separate jobs for things we want to install (in subprocesses).
 
-if (!$SkipVisualStudio) {
-    Start-Job -Name 'Visual Studio' -ErrorAction Stop -ScriptBlock {
-        $location = Get-CimInstance -ClassName MSFT_VSInstance `
-            | Where-Object { $_.IsComplete } `
-            | Select-Object -First 1 -ExpandProperty InstallLocation
-        # This path appears to be hard-coded:
-        # https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio#open-the-visual-studio-installer
-        $installer = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe'
-
-        # Updating first is required, otherwise the installer just complains that
-        # the installer itself is out of date.
-        Write-Information 'Updating Visual Studio components...'
-        & $installer update --installPath $location --passive
-        Write-Information 'Waiting for Visual Studio update to complete...'
-        Get-Process | Where-Object Name -in ('setup', 'vs_installer') | Wait-Process
-
-        Write-Information 'Installing additional Visual Studio components...'
-        & $installer modify --installPath $location --passive `
-            --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 `
-            --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-        Write-Information 'Waiting for Visual Studio installation to complete...'
-        Get-Process | Where-Object Name -in ('setup', 'vs_installer') | Wait-Process
-
-        # Tell NPM to use MSBuild from the just-updated copy of Visual Studio.
-        # This is required as otherwise node-gyp will be unable to find it.
-        $msbuild = Join-Path $location 'MSBuild/Current/Bin/MSBuild.exe'
-        Write-Output "msbuild_path=${msbuild}" `
-            | Out-File -Encoding UTF8 -FilePath ~/.npmrc
-    }
-}
-
 if (!$SkipTools) {
     Start-Job -Name 'Install Tools' -ErrorAction Stop -ScriptBlock {
-        Write-Information 'Installing Git, NodeJS & Python 2...'
+        Write-Information 'Installing Git & NodeJS...'
 
         Invoke-WebRequest -UseBasicParsing -Uri 'https://get.scoop.sh' `
             | Invoke-Expression
-        # Install git first, so that we can get the versions bucket for python27
-        scoop install git
-        scoop bucket add versions
-        # Installing Python2 emits a deprecation warning (because it's long out of
-        # support); however, PowerShell will see _anything_ going to stderr and
-        # treat the result as fatal.  Redirect the output so we can continue.
-        scoop install nvm python27 2>&1
+        scoop install git nvm
         # Temporarily commented out until we can handle later versions of node.js:
         # nvm install latest
         # nvm use $(nvm list | Where-Object { $_ } | Select-Object -First 1)
@@ -76,8 +38,7 @@ if (! (Get-Command wsl -ErrorAction SilentlyContinue) -and !$SkipWSL) {
 
     $files = ("install-wsl.ps1", "restart-helpers.ps1", "sudo-install-wsl.ps1", "uninstall-wsl.ps1")
     foreach ($file in $files) {
-        #TODO: replace branch with main after the branch is merged
-        $url = "https://raw.githubusercontent.com/rancher-sandbox/rd/185-install-wsl/scripts/windows/$file"
+        $url = "https://raw.githubusercontent.com/rancher-sandbox/rancher-desktop/main/scripts/windows/$file"
         $outFile = (Join-Path $targetDir $file)
         Invoke-WebRequest -UseBasicParsing -Uri $url -OutFile $outFile
     }

--- a/src/pages/General.vue
+++ b/src/pages/General.vue
@@ -11,7 +11,7 @@
       <ul>
         <li>Project Status: <i>alpha</i></li>
         <li>Project Discussions: #rancher-desktop in <a href="#" onclick="require('electron').shell.openExternal('https://slack.rancher.io/')">Rancher Users</a> Slack</li>
-        <li>Project Links: <a href="#" onclick="require('electron').shell.openExternal('https://github.com/rancher-sandbox/rd')">Homepage</a> <a href="#" onclick="require('electron').shell.openExternal('https://github.com/rancher-sandbox/rd/issues')">Issues</a></li>
+        <li>Project Links: <a href="#" onclick="require('electron').shell.openExternal('https://github.com/rancher-sandbox/rancher-desktop')">Homepage</a> <a href="#" onclick="require('electron').shell.openExternal('https://github.com/rancher-sandbox/rancher-desktop/issues')">Issues</a></li>
       </ul>
     </div>
     <hr>


### PR DESCRIPTION
Fixes #332 

- We no longer need Visual Studio & Python 2.7 on Windows, since we removed the `canvas` dependency in 9049e1e861586b4f6c702559294bc62dd1cca7f5.
- We now put `kim` &c in the `PATH` in the Windows installer.
- We now install WSL automatically in the Windows installer.
- Update project links — the repo is no longer called `rd`.