### PR TITLE
Logo: Add dark mode support

### DIFF
--- a/src/assets/images/logo.svg
+++ b/src/assets/images/logo.svg
@@ -19,6 +19,9 @@
 	.st13{fill:#BC2A46;}
 	.st14{fill:#FF192E;}
 	.st15{fill:#00B056;}
+  @media screen and (prefers-color-scheme: dark) {
+    .st2{fill:white;}
+  }
 </style>
 <g>
 	<g>


### PR DESCRIPTION
This is a follow-up to fix to #176
Screenshots:

Light | Dark
-- | --
![image](https://user-images.githubusercontent.com/3977982/121751769-a922dd80-cac3-11eb-9559-78015bc286d0.png) | ![image](https://user-images.githubusercontent.com/3977982/121751741-97d9d100-cac3-11eb-9c69-3ff1ac6997bc.png)
