### PR TITLE
308b-link-to-kuberlr

### DIFF
--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -245,7 +245,6 @@ export default async function main() {
   const helmVersion = '3.6.1';
   const helmURL = `https://get.helm.sh/helm-v${ helmVersion }-${ kubePlatform }-amd64.tar.gz`;
   const helmSHA = (await getResource(`${ helmURL }.sha256sum`)).split(/\s+/, 1)[0];
-  const helmDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rd-helm-'));
 
   await downloadTarGZ(helmURL, helmSHA, 'helm', `${ kubePlatform }-amd64`);
 

--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -266,7 +266,7 @@ export default async function main() {
   }
   await download(kimURL, kimPath, kimSHA[0].split(/\s+/, 1)[0]);
 
-  const kuberlrVersion = '0.3.1';
+  const kuberlrVersion = '0.3.2';
   const kuberlrBase = `https://github.com/flavio/kuberlr/releases/download/v${ kuberlrVersion }`;
   const kuberlrBaseURL = `${ kuberlrBase }/kuberlr_${ kuberlrVersion }_${ kubePlatform }_amd64`;
   const kuberlrPlatformDir = `kuberlr_${ kuberlrVersion }_${ kubePlatform }_amd64`;

--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -275,7 +275,7 @@ export default async function main() {
       if (kuberlrPath) {
         const actualTarget = await fs.promises.readlink(binKubectlPath);
 
-        if (actualTarget === exeName('kuberlr')) {
+        if (actualTarget === 'kuberlr') {
           needToRelink = false;
         } else {
           console.log(`Deleting symlink ${ binKubectlPath } unexpectedly pointing to ${ actualTarget }`);
@@ -300,7 +300,7 @@ export default async function main() {
 
         process.chdir(binDir);
         try {
-          await fs.promises.symlink(exeName('kuberlr'), exeName('kubectl'));
+          await fs.promises.symlink('kuberlr', 'kubectl');
         } finally {
           process.chdir(currentDir);
         }

--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -128,7 +128,7 @@ async function downloadTarGZ(url, expectedSHA, binaryBasename, platformDir) {
 
   try {
     const tgzPath = path.join(workDir, `${ binaryBasename }.tar.gz`);
-    const args = ['tar', '-zxvf', tgzPath, '--directory', workDir, fileToExtract];
+    const args = ['tar', '-zxvf', tgzPath, '--directory', workDir, fileToExtract.replace(/\\/g, '/')];
 
     await download(url, tgzPath, expectedSHA, false, fs.constants.W_OK);
     if (onWindows) {
@@ -166,7 +166,7 @@ async function downloadZip(url, expectedSHA, binaryBasename, platformDir) {
 
   try {
     const zipPath = path.join(zipDir, `${ binaryBasename }.zip`);
-    const args = ['unzip', '-o', zipPath, fileToExtract, '-d', zipDir];
+    const args = ['unzip', '-o', zipPath, fileToExtract.replace(/\\/g, '/'), '-d', zipDir];
 
     await download(url, zipPath, expectedSHA, false, fs.constants.W_OK);
     spawnSync(...args);

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -21,6 +21,8 @@ if (!$SkipTools) {
         # nvm use $(nvm list | Where-Object { $_ } | Select-Object -First 1)
         nvm install 14.17.0
         nvm use 14.17.0
+        # Install unzip to get kuberlr -- released only as a zip file
+        scoop install unzip
     }
 }
 

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -455,6 +455,10 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
         this.emit('service-changed', services);
       });
       this.activeVersion = desiredVersion;
+      // Trigger kuberlr to ensure there's a compatible version of kubectl in place
+      await childProcess.spawnFile(resources.executable('kubectl'), ['config', 'current-context'],
+        { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
+
     } finally {
       this.currentAction = Action.NONE;
     }

--- a/src/k8s-engine/hyperkit.ts
+++ b/src/k8s-engine/hyperkit.ts
@@ -455,10 +455,11 @@ export default class HyperkitBackend extends events.EventEmitter implements K8s.
         this.emit('service-changed', services);
       });
       this.activeVersion = desiredVersion;
-      // Trigger kuberlr to ensure there's a compatible version of kubectl in place
-      await childProcess.spawnFile(resources.executable('kubectl'), ['config', 'current-context'],
+      // Trigger kuberlr to ensure there's a compatible version of kubectl in place for the users
+      // rancher-desktop mostly uses the K8s API instead of kubectl, so we need to invoke kubectl
+      // to nudge kuberlr
+      await childProcess.spawnFile(resources.executable('kubectl'), ['cluster-info'],
         { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
-
     } finally {
       this.currentAction = Action.NONE;
     }

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -564,7 +564,8 @@ export default class K3sHelper extends events.EventEmitter {
       // Update the current context.
       console.log('Setting default context...');
       await childProcess.spawnFile(
-        resources.executable('kubectl'), ['config', 'use-context', contextName]);
+        resources.executable('kubectl'), ['config', 'use-context', contextName],
+        { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
     } finally {
       await fs.promises.rmdir(workDir, { recursive: true, maxRetries: 10 });
     }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -426,6 +426,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
       this.setState(K8s.State.STARTED);
       this.setProgress(Progress.DONE);
+      // Trigger kuberlr to ensure there's a compatible version of kubectl in place
+      await childProcess.spawnFile(resources.executable('kubectl'), ['config', 'current-context'],
+        { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
     } catch (ex) {
       this.setState(K8s.State.ERROR);
       this.setProgress(Progress.EMPTY);


### PR DESCRIPTION
Shadow `kubectl` with [`kuberlr`](https://github.com/flavio/kuberlr) and let `kuberlr` decide which version of kubectl to use against a particular API.