### PR TITLE
Building on tags

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -2,7 +2,11 @@ name: Package
 
 on:
   pull_request: {}
-  push: { branches: [main] }
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
 
 defaults:
   run:


### PR DESCRIPTION
The internal version that's displayed in the UI comes from the
git tag. This means we need builds associated with the tag to
display properly and cannot use the last run on main that the
tag is associated with.

This change causes builds to be run on tags as well as the main
branch and pull requests.