### PR TITLE
Indicate when kim is not ready

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -128,6 +128,9 @@ Electron.app.whenReady().then(async() => {
   imageManager.on('images-changed', (images: KimImage[]) => {
     window.send('images-changed', images);
   });
+  imageManager.on('readiness-changed', (state: boolean) => {
+    window.send('images-check-state', state);
+  });
 
   k8smanager.start(cfg.kubernetes).catch(handleFailure);
   imageManager.start();
@@ -375,6 +378,10 @@ Electron.ipcMain.on('do-image-push', async(event, imageName, imageID, tag) => {
 
 Electron.ipcMain.handle('images-fetch', (event) => {
   return imageManager.listImages();
+});
+
+Electron.ipcMain.handle('images-check-state', () => {
+  return imageManager.isReady;
 });
 
 Electron.ipcMain.on('k8s-state', (event) => {

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -1,8 +1,8 @@
-const { EventEmitter } = require('events');
-const { spawn } = require('child_process');
-const path = require('path');
-const timers = require('timers');
-const resources = require('../resources');
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import path from 'path';
+import timers from 'timers';
+import resources from '../resources';
 
 const REFRESH_INTERVAL = 5 * 1000;
 

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -1,10 +1,15 @@
-import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
+import { Console } from 'console';
+import { EventEmitter } from 'events';
 import path from 'path';
 import timers from 'timers';
+
+import Logging from '../utils/logging';
 import resources from '../resources';
 
 const REFRESH_INTERVAL = 5 * 1000;
+
+const console = new Console(Logging.kim.stream);
 
 interface childResultType {
   stdout: string,

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -8,7 +8,6 @@ import path from 'path';
 import timers from 'timers';
 import util from 'util';
 
-import fetch from 'node-fetch';
 import XDGAppPaths from 'xdg-app-paths';
 
 import * as childProcess from '../utils/childProcess';
@@ -394,6 +393,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       // Right now the builder pod needs to be restarted after the remount
       // TODO: When this code is removed, make `client.getActivePod` protected again.
       try {
+        this.setProgress(Progress.INDETERMINATE, 'Installing kim');
         await childProcess.spawnFile(
           resources.executable('kim'),
           ['builder', 'install', '--force', '--no-wait'],

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -3,7 +3,7 @@
     <Images
       class="content"
       :images="images"
-      :k8s-state="state"
+      :state="state"
       :show-all="settings.images.showAll"
       @toggledShowAll="onShowAllImagesChanged"
     />
@@ -11,17 +11,29 @@
 </template>
 
 <script>
-import Images from '@/components/Images.vue';
 import { ipcRenderer } from 'electron';
+import Images from '@/components/Images.vue';
+import * as K8s from '@/k8s-engine/k8s';
 
 export default {
   components: { Images },
   data() {
     return {
       settings:      ipcRenderer.sendSync('settings-read'),
-      state:         ipcRenderer.sendSync('k8s-state'),
+      k8sState:      ipcRenderer.sendSync('k8s-state'),
+      kimState:      false,
       images:        [],
     };
+  },
+
+  computed: {
+    state() {
+      if (this.k8sState !== K8s.State.STARTED) {
+        return 'K8S_UNREADY';
+      }
+
+      return this.kimState ? 'READY' : 'KIM_UNREADY';
+    }
   },
 
   mounted() {
@@ -29,7 +41,10 @@ export default {
       this.$data.images = images;
     });
     ipcRenderer.on('k8s-check-state', (event, state) => {
-      this.$data.state = state;
+      this.$data.k8sState = state;
+    });
+    ipcRenderer.on('images-check-state', (event, state) => {
+      this.kimState = state;
     });
     ipcRenderer.on('settings-update', (event, settings) => {
       // TODO: put in a status bar
@@ -38,6 +53,10 @@ export default {
     ipcRenderer.invoke('images-fetch')
       .then((images) => {
         this.$data.images = images;
+      });
+    ipcRenderer.invoke('images-check-state')
+      .then((/** @type boolean */ state) => {
+        this.$data.kimState = state;
       });
   },
 


### PR DESCRIPTION
When starting, kim can take a while to get ready; currently, we just show a screen indicating no images, which is rather confusing (as there's no indication that things will be resolved if they wait longer).  Add a state (piggybacking on the image refresh) so that the user can tell that kim is just not working yet, rather than working with no images.

This also adds an intermediate progress message on Windows to indicate when we reinstall kim.  We should probably consider doing that on mac too, in case the VM IP changes.  Or opportunistically reinstalling it when the cert is wrong, maybe?

Fixes #356.