### PR TITLE
Increase Kuberentes default version

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -25,7 +25,7 @@ const CURRENT_SETTINGS_VERSION = 2;
 const defaultSettings = {
   version:    CURRENT_SETTINGS_VERSION,
   kubernetes: {
-    version:     'v1.19.10',
+    version:     'v1.19.11',
     memoryInGB:  2,
     numberCPUs:  2,
   },


### PR DESCRIPTION
This updates to the latest patch verion of 1.19 by default. 1.19 is
the latest version available in most public clouds.