### PR TITLE
When creating ~/.kube/config, harden permissions.

### DIFF
--- a/src/config/kubeconfig.js
+++ b/src/config/kubeconfig.js
@@ -36,7 +36,7 @@ function path() {
         kind:              'Config',
         preferences:       {},
         users:             [],
-      }, undefined, 2));
+      }, undefined, 2), { mode: 0o600 });
     }
 
     return cfg;

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -551,7 +551,7 @@ export default class K3sHelper extends events.EventEmitter {
       merge(userConfig.users, workConfig.users);
       merge(userConfig.clusters, workConfig.clusters);
       const userYAML = this.ensureContentsAreYAML(userConfig.exportConfig());
-      const writeStream = fs.createWriteStream(workPath);
+      const writeStream = fs.createWriteStream(workPath, { mode: 0o600 });
 
       await new Promise((resolve, reject) => {
         writeStream.on('error', reject);


### PR DESCRIPTION
Make it owner-readable only

Signed-off-by: Eric Promislow <epromislow@suse.com>