### PR TITLE
Add hash verification for downloaded resources

### DIFF
--- a/scripts/download-resources.mjs
+++ b/scripts/download-resources.mjs
@@ -82,7 +82,7 @@ export async function download(url, destPath, expectedSHA = '', overwrite = fals
       const actualSHA = await getSHAHashForFile(tempPath);
 
       if (actualSHA !== expectedSHA) {
-        throw new Error(`Expecting URL ${url} to have SHA [${expectedSHA}], got [${actualSHA}]`);
+        throw new Error(`Expecting URL ${ url } to have SHA [${ expectedSHA }], got [${ actualSHA }]`);
       }
     }
     const mode =

--- a/scripts/hyperkit.mjs
+++ b/scripts/hyperkit.mjs
@@ -148,16 +148,13 @@ export default async function run() {
     path.resolve(process.cwd(), 'resources', os.platform(), 'docker-machine-driver-hyperkit'));
   await download(
     'https://github.com/jandubois/tinyk3s/raw/v0.1/run-k3s',
-    path.resolve(process.cwd(), 'resources', os.platform(), 'run-k3s'),
-    false, fs.constants.X_OK);
+    path.resolve(process.cwd(), 'resources', os.platform(), 'run-k3s'));
   await download(
     'https://github.com/jandubois/tinyk3s/raw/v0.1/kubeconfig',
-    path.resolve(process.cwd(), 'resources', os.platform(), 'kubeconfig'),
-    false, fs.constants.X_OK);
+    path.resolve(process.cwd(), 'resources', os.platform(), 'kubeconfig'));
   await download(
     'https://github.com/rancher-sandbox/boot2tcl/releases/download/v1.1.1/boot2tcl.iso',
-    path.resolve(process.cwd(), 'resources', os.platform(), 'boot2tcl-1.1.1.iso'),
-    false, fs.constants.F_OK);
+    path.resolve(process.cwd(), 'resources', os.platform(), 'boot2tcl-1.1.1.iso'));
   if (sudoTasks.length > 0) {
     console.log('Will run the following commands under sudo:');
     for (const task of sudoTasks) {

--- a/scripts/wsl.mjs
+++ b/scripts/wsl.mjs
@@ -11,5 +11,5 @@ export default async function main() {
   await download(
     'https://github.com/jandubois/tinyk3s/releases/download/v0.1/distro.tar',
     path.resolve(process.cwd(), 'resources', os.platform(), 'distro-0.1.tar'),
-    false, fs.constants.F_OK);
+    '', false, fs.constants.F_OK);
 }


### PR DESCRIPTION
Some of the resources we download have an associated SHA256 hash.
If it's available, pull it down and require it to match the
hash calculated for the resource's contents.

Signed-off-by: Eric Promislow <epromislow@suse.com>