### PR TITLE
Kim: Fix broken deployments.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,6 +204,8 @@ module.exports.overrides = [
       'no-undef':              'off',
       // For TypeScript, allow duplicate class members (function overloads).
       'no-dupe-class-members': 'off',
+      // For TypeScript, allow redeclartions (interface vs class).
+      'no-redeclare':          'off',
     }
   }
 ];

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,7 @@ module.exports.overrides = [
       'no-undef':              'off',
       // For TypeScript, allow duplicate class members (function overloads).
       'no-dupe-class-members': 'off',
-      // For TypeScript, allow redeclartions (interface vs class).
+      // For TypeScript, allow redeclarations (interface vs class).
       'no-redeclare':          'off',
     }
   }

--- a/background.ts
+++ b/background.ts
@@ -3,18 +3,18 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { URL } from 'url';
-import util from 'util';
 
 import Electron from 'electron';
 import _ from 'lodash';
 import MacCA from 'mac-ca';
 import WinCA from 'win-ca';
 
+import mainEvents from '@/main/mainEvents';
+import { setupKim } from '@/main/kim';
 import * as settings from './src/config/settings';
 import { Tray } from './src/menu/tray.js';
 import window from './src/window/window.js';
 import * as K8s from './src/k8s-engine/k8s';
-import Kim from './src/k8s-engine/kim';
 import resources from './src/resources';
 import Logging from './src/utils/logging';
 import * as childProcess from './src/utils/childProcess';
@@ -24,11 +24,9 @@ Electron.app.setName('Rancher Desktop');
 const console = new Console(Logging.background.stream);
 
 let k8smanager: K8s.KubernetesBackend;
-let imageManager: Kim;
 let cfg: settings.Settings;
 let tray: Tray;
 let gone = false; // when true indicates app is shutting down
-let lastBuildDirectory = '';
 
 if (!Electron.app.requestSingleInstanceLock()) {
   gone = true;
@@ -118,23 +116,8 @@ Electron.app.whenReady().then(async() => {
     return;
   }
 
-  imageManager = new Kim();
-  interface KimImage {
-    imageName: string,
-    tag: string,
-    imageID: string,
-    size: string
-  }
-  imageManager.on('images-changed', (images: KimImage[]) => {
-    window.send('images-changed', images);
-  });
-  imageManager.on('readiness-changed', (state: boolean) => {
-    window.send('images-check-state', state);
-  });
-
   window.send('k8s-current-port', cfg.kubernetes.port);
   k8smanager.start(cfg.kubernetes).catch(handleFailure);
-  imageManager.start();
 
   // Set up protocol handler for app://
   // This is needed because in packaged builds we'll not be allowed to access
@@ -162,9 +145,7 @@ Electron.app.whenReady().then(async() => {
   });
   window.openPreferences();
 
-  imageManager.on('kim-process-output', (data: string, isStderr: boolean) => {
-    window.send('kim-process-output', data, isStderr);
-  });
+  setupKim();
 });
 
 Electron.app.on('second-instance', () => {
@@ -188,7 +169,6 @@ Electron.app.on('before-quit', async(event) => {
     handleFailure(ex);
   } finally {
     gone = true;
-    imageManager.stop();
     Electron.app.quit();
   }
 });
@@ -263,126 +243,6 @@ Electron.app.on('certificate-error', (event, webContents, url, error, certificat
 
   // eslint-disable-next-line node/no-callback-literal
   callback(false);
-});
-
-Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
-  const choice = Electron.dialog.showMessageBoxSync( {
-    message:   `Delete image ${ imageName }?`,
-    type:      'warning',
-    buttons:   ['Yes', 'No'],
-    defaultId: 1,
-    title:     `Delete image ${ imageName }`,
-    cancelId:  1
-  });
-
-  if (choice === 0) {
-    try {
-      const maxNumAttempts = 2;
-      // On macOS a second attempt is needed to actually delete the image.
-      // Probably due to a timing issue on the server part of kim, but not determined why.
-      // Leave this in for windows in case it can happen there too.
-      let i = 0;
-
-      for (i = 0; i < maxNumAttempts; i++) {
-        await imageManager.deleteImage(imageID);
-        await imageManager.refreshImages();
-        if (!imageManager.listImages().some(image => image.imageID === imageID)) {
-          break;
-        }
-        await util.promisify(setTimeout)(500);
-      }
-      if (i === maxNumAttempts) {
-        console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
-      }
-      event.reply('kim-process-ended', 0);
-    } catch (err) {
-      Electron.dialog.showMessageBox({
-        message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
-        type:    'error'
-      });
-    }
-  }
-});
-
-Electron.ipcMain.on('do-image-build', async(event, taggedImageName: string) => {
-  const options: any = {
-    title:      'Pick the build directory',
-    properties: ['openFile'],
-    message:    'Please select the Dockerfile to use (could have a different name)'
-  };
-
-  if (lastBuildDirectory) {
-    options.defaultPath = lastBuildDirectory;
-  }
-  const results = Electron.dialog.showOpenDialogSync(options);
-
-  if (results === undefined) {
-    return;
-  }
-  if (results.length !== 1) {
-    console.log(`Expecting exactly one result, got ${ results.join(', ') }`);
-
-    return;
-  }
-  const pathParts = path.parse(results[0]);
-  let code;
-
-  lastBuildDirectory = pathParts.dir;
-  try {
-    code = (await imageManager.buildImage(lastBuildDirectory, pathParts.base, taggedImageName)).code;
-    await imageManager.refreshImages();
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to build ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.on('do-image-pull', async(event, imageName) => {
-  let taggedImageName = imageName;
-  let code;
-
-  if (!imageName.includes(':')) {
-    taggedImageName += ':latest';
-  }
-  try {
-    code = (await imageManager.pullImage(taggedImageName)).code;
-    await imageManager.refreshImages();
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to pull ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.on('do-image-push', async(event, imageName, imageID, tag) => {
-  const taggedImageName = `${ imageName }:${ tag }`;
-  let code;
-
-  try {
-    code = (await imageManager.pushImage(taggedImageName)).code;
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to push ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.handle('images-fetch', (event) => {
-  return imageManager.listImages();
-});
-
-Electron.ipcMain.handle('images-check-state', () => {
-  return imageManager.isReady;
 });
 
 Electron.ipcMain.on('k8s-state', (event) => {
@@ -645,13 +505,9 @@ function newK8sManager() {
   const mgr = K8s.factory();
 
   mgr.on('state-changed', (state: K8s.State) => {
+    mainEvents.emit('k8s-check-state', mgr);
     tray.emit('k8s-check-state', state);
     window.send('k8s-check-state', state);
-    if (state === K8s.State.STARTED) {
-      imageManager.start();
-    } else {
-      imageManager.stop();
-    }
   });
 
   mgr.on('current-port-changed', (port: number) => {

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -304,6 +304,7 @@ export class KubeClient extends events.EventEmitter {
 
   async isServiceReady(namespace: string, service: string): Promise<boolean> {
     const pod = await this.getActivePod(namespace, service);
+
     return pod?.status?.phase === 'Running';
   }
 

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -302,6 +302,11 @@ export class KubeClient extends events.EventEmitter {
     return pod;
   }
 
+  async isServiceReady(namespace: string, service: string): Promise<boolean> {
+    const pod = await this.getActivePod(namespace, service);
+    return pod?.status?.phase === 'Running';
+  }
+
   /**
    * Create a port forwarding, listening on localhost.  Note that if the
    * endpoint isn't ready yet, the port forwarding might not work correctly

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -1,7 +1,7 @@
 import events from 'events';
 import os from 'os';
 import { Settings } from '../config/settings';
-import { ServiceEntry } from './client';
+import { KubeClient, ServiceEntry } from './client';
 import Hyperkit from './hyperkit';
 import { OSNotImplemented } from './notimplemented.js';
 import WSLBackend from './wsl';
@@ -92,11 +92,27 @@ export interface KubernetesBackend extends events.EventEmitter {
   requiresRestartReasons(): Promise<Record<string, [any, any] | []>>;
 
   /**
+   * Get the external IP address where the services would be listening on, if
+   * available.  For VM-based systems, this would be the address of the VM's
+   * network interface.  This address may be undefined if the backend is
+   * currently not in a state that supports services; for example, if the VM is
+   * off.
+   */
+  readonly ipAddress: Promise<string | undefined>;
+
+  /**
    * Fetch the list of services currently known to Kubernetes.
    * @param namespace The namespace containing services; omit this to
    *                  return services across all namespaces.
    */
   listServices(namespace?: string): ServiceEntry[];
+
+  /**
+   * Check if a given service is ready.
+   * @param namespace The namespace in which to lookup the service.
+   * @param service The name of the service to lookup.
+   */
+  isServiceReady(namespace: string, service: string): Promise<boolean>;
 
   /**
    * Forward a single service port, returning the resulting local port number.

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -1,9 +1,16 @@
+import { Buffer } from 'buffer';
 import { spawn } from 'child_process';
 import { Console } from 'console';
 import { EventEmitter } from 'events';
+import net from 'net';
 import path from 'path';
 import timers from 'timers';
+import tls from 'tls';
+import util from 'util';
 
+import * as k8s from '@kubernetes/client-node';
+
+import * as childProcess from '@/utils/childProcess';
 import * as K8s from '@/k8s-engine/k8s';
 import mainEvents from '@/main/mainEvents';
 import Logging from '@/utils/logging';
@@ -12,6 +19,10 @@ import resources from '@/resources';
 const REFRESH_INTERVAL = 5 * 1000;
 
 const console = new Console(Logging.kim.stream);
+
+function defined<T>(input: T | undefined | null): input is T {
+  return typeof input !== "undefined" && input !== null;
+}
 
 interface childResultType {
   stdout: string;
@@ -77,9 +88,12 @@ class Kim extends EventEmitter {
         this.updateWatchStatus();
       }
     });
-    mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
+    mainEvents.on('k8s-check-state', async (mgr: K8s.KubernetesBackend) => {
       this.isK8sReady = mgr.state === K8s.State.STARTED;
       this.updateWatchStatus();
+      if (this.isK8sReady) {
+        this.install(mgr, !(await this.isInstallValid(mgr)));
+      }
     });
   }
 
@@ -151,6 +165,165 @@ class Kim extends EventEmitter {
         }
       });
     });
+  }
+
+  /**
+   * Determine if the Kim service needs to be reinstalled.
+   */
+  protected async isInstallValid(mgr: K8s.KubernetesBackend): Promise<boolean> {
+    const host = await mgr.ipAddress;
+
+    if (!host) {
+      return false;
+    }
+
+    const client = new k8s.KubeConfig();
+    client.loadFromDefault();
+    client.setCurrentContext('rancher-desktop');
+    const api = client.makeApiClient(k8s.CoreV1Api);
+
+    // Remove any stale pods; do this first, as we may end up having an invalid
+    // configuration but with stale pods.  Note that `kim builder install --force`
+    // will _not_ fix any stale pods.  We need to wait for the node IP to be
+    // correct first, though, to ensure that we don't end up with a recreated
+    // pod with the stale address.
+    await this.waitForNodeIP(api, host);
+    await this.removeStalePods(api);
+
+    // Check if the endpoint has the correct address
+    const { body: endpointBody } = await api.readNamespacedEndpoints('builder', 'kube-image');
+    const subset = endpointBody.subsets?.find(subset => subset.ports?.some(port => port.name === 'kim'));
+    if (!(subset?.addresses || []).some(address => address.ip === host)) {
+      console.log('Existing kim install invalid: incorrect endpoint address.');
+      return false;
+    }
+
+    // Check if the certificate has the correct address
+    const { body: secretBody } = await api.readNamespacedSecret('kim-tls-server', 'kube-image');
+    const encodedCert = (secretBody.data || {})['tls.crt'];
+    // If we don't have a cert, that's fine — kim wil fix it.
+    if (encodedCert) {
+      const cert = Buffer.from(encodedCert, 'base64');
+      const secureContext = tls.createSecureContext({ cert });
+      const socket = new tls.TLSSocket(new net.Socket(), { secureContext });
+      const parsedCert = socket.getCertificate();
+      console.log(parsedCert);
+      if (parsedCert && 'subjectaltname' in parsedCert) {
+        const { subjectaltname } = parsedCert;
+        const names = subjectaltname.split(',').map(s => s.trim());
+        const acceptable = [`IP Address:${host}`, `DNS:${host}`];
+        if (!names.some(name => acceptable.includes(name))) {
+          console.log(`Existing kim install invalid: incorrect certificate (${subjectaltname} does not contain ${host}).`);
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Wait for the Kubernetes node to have the expected IP address.
+   *
+   * When the (single-node) cluster initially starts up, the node (internal)
+   * address can take a while to be updated.
+   * @param api API to communicate with Kubernetes.
+   * @param hostAddr The expected node address.
+   */
+  protected async waitForNodeIP(api: k8s.CoreV1Api, hostAddr: string) {
+    console.log(`Waiting for Kubernetes node IP to become ${hostAddr}...`);
+    while (true) {
+      const { body: nodeList } = await api.listNode();
+      const addresses = nodeList.items
+        .flatMap(node => node.status?.addresses)
+        .filter(defined)
+        .filter(address => address.type === 'InternalIP')
+        .flatMap(address => address.address);
+      if (addresses.includes(hostAddr)) {
+        break;
+      }
+      await util.promisify(setTimeout)(1_000);
+    }
+  }
+
+  /**
+   * When we start the cluster, we may have leftover pods from the builder
+   * daemonset that have stale addresses.  They will not work correctly (not
+   * listening on the new address), but their existence will prevent a new,
+   * correct pod from being created.
+   *
+   * @param api API to communicate with Kubernetes.
+   * @param hostAddr The expected node address.
+   */
+  protected async removeStalePods(api: k8s.CoreV1Api) {
+    const { body: nodeList } = await api.listNode();
+    const addresses = nodeList.items
+      .flatMap(node => node.status?.addresses)
+      .filter(defined)
+      .filter(address => address.type === 'InternalIP')
+      .flatMap(address => address.address);
+
+    const { body: podList } = await api.listNamespacedPod(
+      'kube-image', undefined, undefined, undefined, undefined,
+      "app.kubernetes.io/name=kim,app.kubernetes.io/component=builder");
+    for (const pod of podList.items) {
+      const { namespace, name } = pod.metadata || {};
+      if (!namespace || !name) {
+        continue;
+      }
+      const currentAddress = pod.status?.podIP;
+      if (currentAddress && !addresses.includes(currentAddress)) {
+        console.log(`Deleting stale builder pod ${namespace}:${name} - pod IP ${currentAddress} not in ${addresses}`);
+        api.deleteNamespacedPod(name, namespace);
+      } else {
+        console.log(`Keeping builder pod ${namespace}:${name} - pod IP ${currentAddress} in ${addresses}`);
+      }
+    }
+  }
+
+  /**
+   * Install the kim backend if required; this returns when the backend is ready.
+   * @param force If true, force a reinstall of the backend.
+   */
+  async install(backend: K8s.KubernetesBackend, force = false) {
+    console.log(`Installing kim ${force ? '--force' : ''}`);
+    if (!force && await backend.isServiceReady('kube-image', 'builder')) {
+      return;
+    }
+
+    const startTime = Date.now();
+    const maxWaitTime = 120_000;
+    const waitTime = 3_000;
+    const args = ['builder', 'install'];
+    if (force) {
+      args.push('--force');
+    }
+
+    try {
+      await childProcess.spawnFile(
+        resources.executable('kim'),
+        args,
+        {
+          stdio: ['ignore', await Logging.kim.fdStream, await Logging.kim.fdStream],
+          windowsHide: true,
+        });
+
+      while (true) {
+        const currentTime = Date.now();
+
+        if ((currentTime - startTime) > maxWaitTime) {
+          console.log(`Waited more than ${maxWaitTime / 1000} secs, it might start up later`);
+          break;
+        }
+        if (await backend.isServiceReady('kube-image', 'builder')) {
+          break;
+        }
+        await util.promisify(setTimeout)(waitTime);
+      }
+    } catch (e) {
+      console.error(`Failed to restart the kim builder: ${e.message}.`);
+      console.error('The images page will probably be empty');
+    }
   }
 
   async buildImage(dirPart: string, filePart: string, taggedImageName: string): Promise<childResultType> {

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -95,6 +95,7 @@ class Kim extends EventEmitter {
     }
     if (shouldWatch) {
       this.refreshInterval = timers.setInterval(this._refreshImages, REFRESH_INTERVAL);
+      timers.setImmediate(this._refreshImages);
     }
     this.isWatching = shouldWatch;
   }

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -25,7 +25,25 @@ interface imageType {
   size: string,
 }
 
-export default class Kim extends EventEmitter {
+interface Kim extends EventEmitter {
+  /**
+   * Emitted when the images are different.  Note that we will only refresh the
+   * image list when listeners are registered for this event.
+   */
+  on(event: 'images-changed', listener: (images: imageType[]) => void): this;
+
+  /**
+   * Emitted when command output is received.
+   */
+  on(event: 'kim-process-output', listener: (data: string, isStderr: boolean) => void): this;
+
+  /**
+   * Emitted when the Kim backend readiness has changed.
+   */
+  on(event: 'readiness-changed', listener: (isReady: boolean) => void): this;
+}
+
+class Kim extends EventEmitter {
   private showedStderr = false;
   private refreshInterval: ReturnType<typeof timers.setInterval> | null = null;
   // During startup `kim images` repeatedly fires the same error message. Instead,
@@ -178,3 +196,5 @@ export default class Kim extends EventEmitter {
     }
   }
 }
+
+export default Kim;

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -84,10 +84,22 @@ class OSNotImplemented extends events.EventEmitter {
     return Promise.reject(new Error('not implemented'));
   }
 
+  get ipAddress() {
+    this.#notified = displayError(this.#notified);
+
+    return Promise.reject(new Error('not implemented'));
+  }
+
   listServices(namespace) {
     this.#notified = displayError(this.#notified);
 
     return [];
+  }
+
+  isServiceReady(namespace, service) {
+    this.#notified = displayError(this.#notified);
+
+    return Promise.reject(new Error('not implemented'));
   }
 
   forwardPort(namespace, service, port) {

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -1,0 +1,171 @@
+/**
+ * This module contains code for handling kim (images).
+ */
+
+import { Console } from 'console';
+import path from 'path';
+import util from 'util';
+
+import Electron from 'electron';
+
+import mainEvents from '@/main/mainEvents';
+import * as K8s from '@/k8s-engine/k8s';
+import Kim from '@/k8s-engine/kim';
+import Logging from '@/utils/logging';
+import window from '@/window/window.js';
+
+const console = new Console(Logging.kim.stream);
+const imageManager = new Kim();
+let lastBuildDirectory = '';
+
+interface KimImage {
+    imageName: string,
+    tag: string,
+    imageID: string,
+    size: string
+}
+imageManager.on('images-changed', (images: KimImage[]) => {
+  window.send('images-changed', images);
+});
+imageManager.on('readiness-changed', (state: boolean) => {
+  window.send('images-check-state', state);
+});
+imageManager.on('kim-process-output', (data: string, isStderr: boolean) => {
+  window.send('kim-process-output', data, isStderr);
+});
+
+Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
+  const choice = Electron.dialog.showMessageBoxSync({
+    message:   `Delete image ${ imageName }?`,
+    type:      'warning',
+    buttons:   ['Yes', 'No'],
+    defaultId: 1,
+    title:     `Delete image ${ imageName }`,
+    cancelId:  1
+  });
+
+  if (choice === 0) {
+    try {
+      const maxNumAttempts = 2;
+      // On macOS a second attempt is needed to actually delete the image.
+      // Probably due to a timing issue on the server part of kim, but not determined why.
+      // Leave this in for windows in case it can happen there too.
+      let i = 0;
+
+      for (i = 0; i < maxNumAttempts; i++) {
+        await imageManager.deleteImage(imageID);
+        await imageManager.refreshImages();
+        if (!imageManager.listImages().some(image => image.imageID === imageID)) {
+          break;
+        }
+        await util.promisify(setTimeout)(500);
+      }
+      if (i === maxNumAttempts) {
+        console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
+      }
+      event.reply('kim-process-ended', 0);
+    } catch (err) {
+      Electron.dialog.showMessageBox({
+        message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
+        type:    'error'
+      });
+    }
+  }
+});
+
+Electron.ipcMain.on('do-image-build', async(event, taggedImageName: string) => {
+  const options: any = {
+    title:      'Pick the build directory',
+    properties: ['openFile'],
+    message:    'Please select the Dockerfile to use (could have a different name)'
+  };
+
+  if (lastBuildDirectory) {
+    options.defaultPath = lastBuildDirectory;
+  }
+  const results = Electron.dialog.showOpenDialogSync(options);
+
+  if (results === undefined) {
+    return;
+  }
+  if (results.length !== 1) {
+    console.log(`Expecting exactly one result, got ${ results.join(', ') }`);
+
+    return;
+  }
+  const pathParts = path.parse(results[0]);
+  let code;
+
+  lastBuildDirectory = pathParts.dir;
+  try {
+    code = (await imageManager.buildImage(lastBuildDirectory, pathParts.base, taggedImageName)).code;
+    await imageManager.refreshImages();
+  } catch (err) {
+    code = err.code;
+    Electron.dialog.showMessageBox({
+      message: `Error trying to build ${ taggedImageName }:\n\n ${ err.stderr } `,
+      type:    'error'
+    });
+  }
+  event.reply('kim-process-ended', code);
+});
+
+Electron.ipcMain.on('do-image-pull', async(event, imageName) => {
+  let taggedImageName = imageName;
+  let code;
+
+  if (!imageName.includes(':')) {
+    taggedImageName += ':latest';
+  }
+  try {
+    code = (await imageManager.pullImage(taggedImageName)).code;
+    await imageManager.refreshImages();
+  } catch (err) {
+    code = err.code;
+    Electron.dialog.showMessageBox({
+      message: `Error trying to pull ${ taggedImageName }:\n\n ${ err.stderr } `,
+      type:    'error'
+    });
+  }
+  event.reply('kim-process-ended', code);
+});
+
+Electron.ipcMain.on('do-image-push', async(event, imageName, imageID, tag) => {
+  const taggedImageName = `${ imageName }:${ tag }`;
+  let code;
+
+  try {
+    code = (await imageManager.pushImage(taggedImageName)).code;
+  } catch (err) {
+    code = err.code;
+    Electron.dialog.showMessageBox({
+      message: `Error trying to push ${ taggedImageName }:\n\n ${ err.stderr } `,
+      type:    'error'
+    });
+  }
+  event.reply('kim-process-ended', code);
+});
+
+Electron.ipcMain.handle('images-fetch', (event) => {
+  return imageManager.listImages();
+});
+
+Electron.ipcMain.handle('images-check-state', () => {
+  return imageManager.isReady;
+});
+
+Electron.app.on('will-quit', () => {
+  imageManager.stop();
+});
+
+mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
+  if (mgr.state === K8s.State.STARTED) {
+    imageManager.start();
+  } else {
+    imageManager.stop();
+  }
+});
+
+export function setupKim() {
+  imageManager.start();
+}

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -13,152 +13,154 @@ import Logging from '@/utils/logging';
 import window from '@/window/window.js';
 
 const console = new Console(Logging.kim.stream);
-const imageManager = new Kim();
+
+let imageManager: Kim;
 let lastBuildDirectory = '';
 let mountCount = 0;
 
-interface KimImage {
+export function setupKim() {
+  imageManager = imageManager ?? new Kim();
+
+  interface KimImage {
     imageName: string,
     tag: string,
     imageID: string,
     size: string
-}
-imageManager.on('readiness-changed', (state: boolean) => {
-  window.send('images-check-state', state);
-});
-imageManager.on('kim-process-output', (data: string, isStderr: boolean) => {
-  window.send('kim-process-output', data, isStderr);
-});
-
-function onImagesChanged(images: KimImage[]) {
-  window.send('images-changed', images);
-}
-Electron.ipcMain.handle('images-mounted', (_, mounted: boolean) => {
-  mountCount += mounted ? 1 : -1;
-  if (mountCount < 1) {
-    imageManager.removeListener('images-changed', onImagesChanged);
-  } else if (mountCount === 1) {
-    imageManager.on('images-changed', onImagesChanged);
   }
-
-  return imageManager.listImages();
-});
-
-Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
-  const choice = Electron.dialog.showMessageBoxSync({
-    message:   `Delete image ${ imageName }?`,
-    type:      'warning',
-    buttons:   ['Yes', 'No'],
-    defaultId: 1,
-    title:     `Delete image ${ imageName }`,
-    cancelId:  1
+  imageManager.on('readiness-changed', (state: boolean) => {
+    window.send('images-check-state', state);
+  });
+  imageManager.on('kim-process-output', (data: string, isStderr: boolean) => {
+    window.send('kim-process-output', data, isStderr);
   });
 
-  if (choice === 0) {
-    try {
-      const maxNumAttempts = 2;
-      // On macOS a second attempt is needed to actually delete the image.
-      // Probably due to a timing issue on the server part of kim, but not determined why.
-      // Leave this in for windows in case it can happen there too.
-      let i = 0;
+  function onImagesChanged(images: KimImage[]) {
+    window.send('images-changed', images);
+  }
+  Electron.ipcMain.handle('images-mounted', (_, mounted: boolean) => {
+    mountCount += mounted ? 1 : -1;
+    if (mountCount < 1) {
+      imageManager.removeListener('images-changed', onImagesChanged);
+    } else if (mountCount === 1) {
+      imageManager.on('images-changed', onImagesChanged);
+    }
 
-      for (i = 0; i < maxNumAttempts; i++) {
-        await imageManager.deleteImage(imageID);
-        await imageManager.refreshImages();
-        if (!imageManager.listImages().some(image => image.imageID === imageID)) {
-          break;
+    return imageManager.listImages();
+  });
+
+  Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
+    const choice = Electron.dialog.showMessageBoxSync({
+      message:   `Delete image ${ imageName }?`,
+      type:      'warning',
+      buttons:   ['Yes', 'No'],
+      defaultId: 1,
+      title:     `Delete image ${ imageName }`,
+      cancelId:  1
+    });
+
+    if (choice === 0) {
+      try {
+        const maxNumAttempts = 2;
+        // On macOS a second attempt is needed to actually delete the image.
+        // Probably due to a timing issue on the server part of kim, but not determined why.
+        // Leave this in for windows in case it can happen there too.
+        let i = 0;
+
+        for (i = 0; i < maxNumAttempts; i++) {
+          await imageManager.deleteImage(imageID);
+          await imageManager.refreshImages();
+          if (!imageManager.listImages().some(image => image.imageID === imageID)) {
+            break;
+          }
+          await util.promisify(setTimeout)(500);
         }
-        await util.promisify(setTimeout)(500);
+        if (i === maxNumAttempts) {
+          console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
+        }
+        event.reply('kim-process-ended', 0);
+      } catch (err) {
+        Electron.dialog.showMessageBox({
+          message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
+          type:    'error'
+        });
       }
-      if (i === maxNumAttempts) {
-        console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
-      }
-      event.reply('kim-process-ended', 0);
+    }
+  });
+
+  Electron.ipcMain.on('do-image-build', async(event, taggedImageName: string) => {
+    const options: any = {
+      title:      'Pick the build directory',
+      properties: ['openFile'],
+      message:    'Please select the Dockerfile to use (could have a different name)'
+    };
+
+    if (lastBuildDirectory) {
+      options.defaultPath = lastBuildDirectory;
+    }
+    const results = Electron.dialog.showOpenDialogSync(options);
+
+    if (results === undefined) {
+      return;
+    }
+    if (results.length !== 1) {
+      console.log(`Expecting exactly one result, got ${ results.join(', ') }`);
+
+      return;
+    }
+    const pathParts = path.parse(results[0]);
+    let code;
+
+    lastBuildDirectory = pathParts.dir;
+    try {
+      code = (await imageManager.buildImage(lastBuildDirectory, pathParts.base, taggedImageName)).code;
+      await imageManager.refreshImages();
     } catch (err) {
+      code = err.code;
       Electron.dialog.showMessageBox({
-        message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
+        message: `Error trying to build ${ taggedImageName }:\n\n ${ err.stderr } `,
         type:    'error'
       });
     }
-  }
-});
+    event.reply('kim-process-ended', code);
+  });
 
-Electron.ipcMain.on('do-image-build', async(event, taggedImageName: string) => {
-  const options: any = {
-    title:      'Pick the build directory',
-    properties: ['openFile'],
-    message:    'Please select the Dockerfile to use (could have a different name)'
-  };
+  Electron.ipcMain.on('do-image-pull', async(event, imageName) => {
+    let taggedImageName = imageName;
+    let code;
 
-  if (lastBuildDirectory) {
-    options.defaultPath = lastBuildDirectory;
-  }
-  const results = Electron.dialog.showOpenDialogSync(options);
+    if (!imageName.includes(':')) {
+      taggedImageName += ':latest';
+    }
+    try {
+      code = (await imageManager.pullImage(taggedImageName)).code;
+      await imageManager.refreshImages();
+    } catch (err) {
+      code = err.code;
+      Electron.dialog.showMessageBox({
+        message: `Error trying to pull ${ taggedImageName }:\n\n ${ err.stderr } `,
+        type:    'error'
+      });
+    }
+    event.reply('kim-process-ended', code);
+  });
 
-  if (results === undefined) {
-    return;
-  }
-  if (results.length !== 1) {
-    console.log(`Expecting exactly one result, got ${ results.join(', ') }`);
+  Electron.ipcMain.on('do-image-push', async(event, imageName, imageID, tag) => {
+    const taggedImageName = `${ imageName }:${ tag }`;
+    let code;
 
-    return;
-  }
-  const pathParts = path.parse(results[0]);
-  let code;
+    try {
+      code = (await imageManager.pushImage(taggedImageName)).code;
+    } catch (err) {
+      code = err.code;
+      Electron.dialog.showMessageBox({
+        message: `Error trying to push ${ taggedImageName }:\n\n ${ err.stderr } `,
+        type:    'error'
+      });
+    }
+    event.reply('kim-process-ended', code);
+  });
 
-  lastBuildDirectory = pathParts.dir;
-  try {
-    code = (await imageManager.buildImage(lastBuildDirectory, pathParts.base, taggedImageName)).code;
-    await imageManager.refreshImages();
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to build ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.on('do-image-pull', async(event, imageName) => {
-  let taggedImageName = imageName;
-  let code;
-
-  if (!imageName.includes(':')) {
-    taggedImageName += ':latest';
-  }
-  try {
-    code = (await imageManager.pullImage(taggedImageName)).code;
-    await imageManager.refreshImages();
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to pull ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.on('do-image-push', async(event, imageName, imageID, tag) => {
-  const taggedImageName = `${ imageName }:${ tag }`;
-  let code;
-
-  try {
-    code = (await imageManager.pushImage(taggedImageName)).code;
-  } catch (err) {
-    code = err.code;
-    Electron.dialog.showMessageBox({
-      message: `Error trying to push ${ taggedImageName }:\n\n ${ err.stderr } `,
-      type:    'error'
-    });
-  }
-  event.reply('kim-process-ended', code);
-});
-
-Electron.ipcMain.handle('images-check-state', () => {
-  return imageManager.isReady;
-});
-
-export function setupKim() {
+  Electron.ipcMain.handle('images-check-state', () => {
+    return imageManager.isReady;
+  });
 }

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -31,17 +31,18 @@ imageManager.on('kim-process-output', (data: string, isStderr: boolean) => {
 });
 
 function onImagesChanged(images: KimImage[]) {
-    window.send('images-changed', images);
+  window.send('images-changed', images);
 }
 Electron.ipcMain.handle('images-mounted', (_, mounted: boolean) => {
-    mountCount += mounted ? 1 : -1;
-    if (mountCount < 1) {
-        imageManager.removeListener('images-changed', onImagesChanged);
-    } else if (mountCount === 1) {
-        imageManager.on('images-changed', onImagesChanged);
-    }
-    return imageManager.listImages();
-})
+  mountCount += mounted ? 1 : -1;
+  if (mountCount < 1) {
+    imageManager.removeListener('images-changed', onImagesChanged);
+  } else if (mountCount === 1) {
+    imageManager.on('images-changed', onImagesChanged);
+  }
+
+  return imageManager.listImages();
+});
 
 Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
   const choice = Electron.dialog.showMessageBoxSync({

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -8,8 +8,6 @@ import util from 'util';
 
 import Electron from 'electron';
 
-import mainEvents from '@/main/mainEvents';
-import * as K8s from '@/k8s-engine/k8s';
 import Kim from '@/k8s-engine/kim';
 import Logging from '@/utils/logging';
 import window from '@/window/window.js';
@@ -154,18 +152,5 @@ Electron.ipcMain.handle('images-check-state', () => {
   return imageManager.isReady;
 });
 
-Electron.app.on('will-quit', () => {
-  imageManager.stop();
-});
-
-mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
-  if (mgr.state === K8s.State.STARTED) {
-    imageManager.start();
-  } else {
-    imageManager.stop();
-  }
-});
-
 export function setupKim() {
-  imageManager.start();
 }

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -1,0 +1,19 @@
+/**
+ * This module is an EventEmitter for communication between various parts of the
+ * main process.
+ */
+
+import { EventEmitter } from 'events';
+
+import * as K8s from '@/k8s-engine/k8s';
+
+interface MainEvents extends EventEmitter {
+    /**
+     * Emitted when the Kubernetes backend state has changed.
+     */
+    on(event: 'k8s-check-state', listener: (mgr: K8s.KubernetesBackend) => void): this;
+}
+class MainEventsImpl extends EventEmitter implements MainEvents { }
+const mainEvents = new MainEventsImpl();
+
+export default mainEvents;

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -51,7 +51,7 @@ export default {
       this.$data.settings = settings;
     });
     (async() => {
-      this.$data.images = await ipcRenderer.invoke('images-mounted', true)
+      this.$data.images = await ipcRenderer.invoke('images-mounted', true);
     })();
     (async() => {
       this.$data.kimState = await ipcRenderer.invoke('images-check-state');

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -50,14 +50,16 @@ export default {
       // TODO: put in a status bar
       this.$data.settings = settings;
     });
-    ipcRenderer.invoke('images-fetch')
-      .then((images) => {
-        this.$data.images = images;
-      });
-    ipcRenderer.invoke('images-check-state')
-      .then((/** @type boolean */ state) => {
-        this.$data.kimState = state;
-      });
+    (async() => {
+      this.$data.images = await ipcRenderer.invoke('images-mounted', true)
+    })();
+    (async() => {
+      this.$data.kimState = await ipcRenderer.invoke('images-check-state');
+    })();
+  },
+
+  beforeDestroy() {
+    ipcRenderer.send('images-mounted', false);
   },
 
   methods: {


### PR DESCRIPTION
- Reorganize the kim code to be in a separate file.
- Manually check the state of the kim deployment on startup, and run `kim builder install --force` as needed.
- Manually check the kim builder pod for having an outdated pod IP (which could happen if the WSL VM was restarted); manually delete the pod in that case, as Kubernetes DaemonSet controller doesn't appear to do so automatically in this case.

Fixes #351 (hopefully)

To test:
- Start RD as normal
- Quit RD
- Run `wsl --shutdown` to force terminate the VM (and let it get a new IP address)
- Start RD again