### PR TITLE
Windows: Fix factory reset

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -513,7 +513,15 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
     await this.del();
     await rmdir(paths.cache(), { recursive: true });
-    await rmdir(paths.state(), { recursive: true });
+    try {
+      await rmdir(paths.state(), { recursive: true });
+    } catch (error) {
+      // On Windows, we will probably fail to delete the directory as the log
+      // files are held open; we should ignore that error.
+      if (error.code !== 'ENOTEMPTY') {
+        throw error;
+      }
+    }
   }
 
   listServices(namespace?: string): K8s.ServiceEntry[] {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -492,10 +492,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   async del(): Promise<void> {
     await this.stop();
     this.setProgress(Progress.INDETERMINATE, 'Deleting Kubrnetes');
-    await childProcess.spawnFile('wsl.exe', ['--unregister', INSTANCE_NAME], {
-      stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
-      windowsHide: true,
-    });
+    if (await this.isDistroRegistered()) {
+      await childProcess.spawnFile('wsl.exe', ['--unregister', INSTANCE_NAME], {
+        stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
+        windowsHide: true,
+      });
+    }
     this.cfg = undefined;
     this.setProgress(Progress.DONE);
   }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -80,7 +80,7 @@ const logging = function(topic: string) {
           });
         }));
 
-        Object.defineProperty(logging[topic], 'fsStream', {
+        Object.defineProperty(logging[topic], 'fdStream', {
           configurable: true,
           enumerable:   true,
           value:        promise,


### PR DESCRIPTION
Factory reset was broken on Windows, as the logging subsystem holds the log directory open (even though the log files themselves are `FILE_SHARE_DELETE`), causing the deletion to fail.  We can just ignore the error in this case.

There was also an error triggered during factory reset where we will fail to delete the distribution, because it was never registered.  Fix that too.

Fixes #367.