### PR TITLE
Handle lack of network on start better

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -76,7 +76,7 @@ Electron.app.whenReady().then(async() => {
 
   k8smanager = newK8sManager();
   try {
-    cfg = settings.init(await k8smanager.availableVersions);
+    cfg = settings.init();
   } catch (err) {
     gone = true;
     Electron.app.quit();

--- a/background.ts
+++ b/background.ts
@@ -126,7 +126,6 @@ Electron.app.whenReady().then(async() => {
     return;
   }
 
-  window.send('k8s-current-port', cfg.kubernetes.port);
   k8smanager.start(cfg.kubernetes).catch(handleFailure);
 
   // Set up protocol handler for app://

--- a/background.ts
+++ b/background.ts
@@ -24,7 +24,7 @@ Electron.app.setName('Rancher Desktop');
 
 const console = new Console(Logging.background.stream);
 
-let k8smanager: K8s.KubernetesBackend;
+let k8smanager = newK8sManager();
 let cfg: settings.Settings;
 let tray: Tray;
 let gone = false; // when true indicates app is shutting down
@@ -74,7 +74,6 @@ Electron.app.whenReady().then(async() => {
   // TODO: Check if first install and start welcome screen
   // TODO: Check if new version and provide window with details on changes
 
-  k8smanager = newK8sManager();
   try {
     cfg = settings.init();
   } catch (err) {
@@ -329,19 +328,15 @@ Electron.ipcMain.on('k8s-restart', async() => {
 });
 
 Electron.ipcMain.on('k8s-versions', async() => {
-  if (k8smanager) {
-    window.send('k8s-versions', await k8smanager.availableVersions);
-  }
+  window.send('k8s-versions', await k8smanager.availableVersions);
 });
 
 Electron.ipcMain.on('k8s-progress', () => {
-  if (k8smanager) {
-    window.send('k8s-progress', k8smanager.progress);
-  }
+  window.send('k8s-progress', k8smanager.progress);
 });
 
 Electron.ipcMain.handle('service-fetch', (event, namespace) => {
-  return k8smanager?.listServices(namespace);
+  return k8smanager.listServices(namespace);
 });
 
 Electron.ipcMain.handle('service-forward', async(event, service, state) => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -25,7 +25,7 @@ const CURRENT_SETTINGS_VERSION = 2;
 const defaultSettings = {
   version:    CURRENT_SETTINGS_VERSION,
   kubernetes: {
-    version:     'v1.19.11',
+    version:     '',
     memoryInGB:  2,
     numberCPUs:  2,
     port:        6443,

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -42,7 +42,7 @@ export type Settings = typeof defaultSettings;
 /**
  * Load the settings file
  */
-export function load(availableVersions: readonly string[]): Settings {
+export function load(): Settings {
   const rawdata = fs.readFileSync(join(paths.config(), 'settings.json'));
   let settings;
 
@@ -54,31 +54,13 @@ export function load(availableVersions: readonly string[]): Settings {
     return defaultSettings;
   }
   // clone settings because we check to see if the returned value is different
-  const cfg = updateSettings(Object.assign({}, settings), availableVersions);
+  const cfg = updateSettings(Object.assign({}, settings));
 
   if (!_.isEqual(cfg, settings)) {
     save(cfg);
   }
 
   return cfg;
-}
-
-/**
- * Verify that the loaded version of kubernetes, if specified, is in the current
- * list of available versions.  Throw an exception if not.
- */
-
-function verifyLocalSettings(settings: Settings, availableVersions: readonly string[] ) {
-  const proposedVersion = settings.kubernetes?.version;
-
-  if (proposedVersion && !availableVersions.includes(proposedVersion)) {
-    const header = 'Error in saved settings.json file';
-    const message = `Proposed kubernetes version ${ proposedVersion } not supported`;
-    const { dialog } = require('electron');
-
-    dialog.showErrorBox(header, message);
-    throw new InvalidStoredSettings(message);
-  }
 }
 
 export function save(cfg: Settings) {
@@ -109,12 +91,11 @@ export async function clear() {
 /**
  * Load the settings file or create it if not present.
  */
-export function init(availableVersions: readonly string[]): Settings {
+export function init(): Settings {
   let settings: Settings;
 
-  console.log(`Initializing with ${ availableVersions.length } versions`);
   try {
-    settings = load(availableVersions);
+    settings = load();
   } catch (err) {
     if (err instanceof InvalidStoredSettings) {
       throw (err);
@@ -237,7 +218,7 @@ const updateTable: Record<number, (settings: any) => void> = {
   },
 };
 
-function updateSettings(settings: Settings, availableVersions: readonly string[]) {
+function updateSettings(settings: Settings) {
   if (Object.keys(settings).length === 0) {
     return defaultSettings;
   }
@@ -254,17 +235,6 @@ function updateSettings(settings: Settings, availableVersions: readonly string[]
     // Try not to step on them.
     // Note that this file will have an older version field but some fields from the future.
     console.log(`Running settings version ${ CURRENT_SETTINGS_VERSION } but loaded a settings file for version ${ settings.version }: some settings will be ignored`);
-  }
-  try {
-    verifyLocalSettings(settings, availableVersions);
-  } catch (err) {
-    if (err instanceof InvalidStoredSettings) {
-      throw (err);
-    }
-    const header = 'Error in saved settings.json file';
-    const { dialog } = require('electron');
-
-    dialog.showErrorBox(header, err.message);
   }
   settings.version = CURRENT_SETTINGS_VERSION;
 

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -206,9 +206,9 @@ describe(K3sHelper, () => {
 
       const subject = new K3sHelper();
       const pendingInit = new Promise((resolve) => {
-        // We need a cast on updateCache here since it's a proected method.
+        // We need a cast on updateCache here since it's a protected method.
         jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {
-          // This will be called, but will not block initilization.
+          // This will be called, but will not block initialization.
           await pendingInit;
 
           return [];

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -9,7 +9,7 @@ import { mocked } from 'ts-jest/utils';
 
 import K3sHelper, { buildVersion, ReleaseAPIEntry } from '../k3sHelper';
 
-const { Response: FetchResponse, Headers: FetchHeaders } = jest.requireActual('node-fetch');
+const { Response: FetchResponse } = jest.requireActual('node-fetch');
 
 // Mock fetch to ensure we never make an actual request.
 jest.mock('node-fetch', () => {
@@ -26,6 +26,7 @@ describe(buildVersion, () => {
   test('parses the build number', () => {
     expect(buildVersion(new semver.SemVer('v1.2.3+k3s4'))).toEqual(4);
   });
+
   test('handles non-conforming versions', () => {
     expect(buildVersion(new semver.SemVer('v1.2.3'))).toEqual(-1);
   });
@@ -56,7 +57,7 @@ describe(K3sHelper, () => {
       subject = new K3sHelper();
       // Note that we _do not_ initialize this, i.e. we don't trigger an
       // initial fetch of the releases.  Instead, we pretend that is done.
-      subject['pendingUpdate'] = Promise.resolve();
+      subject['pendingInitialize'] = Promise.resolve();
     });
     it('should skip invalid versions', async() => {
       expect(process('xxx')).toEqual(true);
@@ -87,6 +88,7 @@ describe(K3sHelper, () => {
       expect(await subject.availableVersions).toHaveLength(1);
     });
   });
+
   test('cache read/write', async() => {
     const subject = new K3sHelper();
     const readFile = util.promisify(fs.readFile);
@@ -178,6 +180,7 @@ describe(K3sHelper, () => {
     });
     expect(await subject.availableVersions).toEqual(['v1.2.3', 'v1.2.1', 'v1.2.0']);
   });
+
   test('fullVersion', () => {
     const subject = new K3sHelper();
     const versionStrings = ['1.2.3+k3s1', '2.3.4+k3s3'];
@@ -190,5 +193,31 @@ describe(K3sHelper, () => {
     expect(subject.fullVersion('1.2.3')).toEqual('1.2.3+k3s1');
     expect(() => subject.fullVersion('1.2.4')).toThrow('1.2.4');
     expect(() => subject.fullVersion('invalid version')).toThrow('not a valid version');
+  });
+
+  describe('initialize', () => {
+    it('should finish initialize without network if cache is available', async() => {
+      const writer = new K3sHelper();
+
+      writer['versions'] = { 'v1.0.0': new semver.SemVer('v1.0.0') };
+      await writer['writeCache']();
+
+      // We want to check that initialize() returns before updateCache() does.
+
+      const subject = new K3sHelper();
+      const pendingInit = new Promise((resolve) => {
+        // We need a cast on updateCache here since it's a proected method.
+        jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {
+          // This will be called, but will not block initilization.
+          await pendingInit;
+
+          return [];
+        });
+        subject.initialize().then(resolve);
+      });
+
+      expect(await subject.availableVersions).toContain('v1.0.0');
+      await pendingInit;
+    });
   });
 });

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -465,8 +465,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
       await this.k3sHelper.updateKubeconfig(
         () => this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME, 'sudo', 'cat', '/etc/rancher/k3s/k3s.yaml'));
-      this.setState(K8s.State.STARTED);
-      this.setProgress(Progress.DONE);
       this.client = new K8s.Client();
       await this.client.waitForServiceWatcher();
       this.client.on('service-changed', (services) => {
@@ -482,6 +480,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       // to nudge kuberlr
       await childProcess.spawnFile(resources.executable('kubectl'), ['cluster-info'],
         { stdio: ['inherit', await Logging.k8s.fdStream, await Logging.k8s.fdStream] });
+      this.setState(K8s.State.STARTED);
+      this.setProgress(Progress.DONE);
     } catch (err) {
       console.error('Error starting lima:', err);
       this.setState(K8s.State.ERROR);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -269,10 +269,15 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   get desiredVersion(): Promise<string> {
     return (async() => {
       const availableVersions = await this.k3sHelper.availableVersions;
-      const version = this.cfg?.version || availableVersions[0];
+      let version = this.cfg?.version || availableVersions[0];
 
       if (!version) {
         throw new Error('No version available');
+      }
+
+      if (!availableVersions.includes(version)) {
+        console.error(`Could not use saved version ${ version }, not in ${ availableVersions }`);
+        version = availableVersions[0];
       }
 
       return this.k3sHelper.fullVersion(version);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -173,10 +173,15 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   get desiredVersion(): Promise<string> {
     return (async() => {
       const availableVersions = await this.k3sHelper.availableVersions;
-      const version = this.cfg?.version || availableVersions[0];
+      let version = this.cfg?.version || availableVersions[0];
 
       if (!version) {
         throw new Error('No version available');
+      }
+
+      if (!availableVersions.includes(version)) {
+        console.error(`Could not use saved version ${ version }, not in ${ availableVersions }`);
+        version = availableVersions[0];
       }
 
       return this.k3sHelper.fullVersion(version);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -424,11 +424,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         this.emit('current-port-changed', this.currentPort);
       }
 
-      this.setState(K8s.State.STARTED);
-      this.setProgress(Progress.DONE);
       // Trigger kuberlr to ensure there's a compatible version of kubectl in place
       await childProcess.spawnFile(resources.executable('kubectl'), ['config', 'current-context'],
         { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
+      this.setState(K8s.State.STARTED);
+      this.setProgress(Progress.DONE);
     } catch (ex) {
       this.setState(K8s.State.ERROR);
       this.setProgress(Progress.EMPTY);

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -164,7 +164,7 @@ export default {
     });
     ipcRenderer.on('k8s-versions', (event, versions) => {
       this.$data.versions = versions;
-      if (versions.length < 1) {
+      if (versions.length === 0) {
         const message = 'No versions of Kubernetes were found';
 
         this.handleNotification('error', 'no-versions', message);

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -164,6 +164,16 @@ export default {
     });
     ipcRenderer.on('k8s-versions', (event, versions) => {
       this.$data.versions = versions;
+      if (!versions.includes(this.settings.kubernetes.version)) {
+        const oldVersion = this.settings.kubernetes.version;
+
+        if (oldVersion) {
+          const message = `Saved Kubernetes version ${ oldVersion } not available, using ${ versions[0] }.`;
+
+          this.handleNotification('info', 'invalid-version', message);
+        }
+        this.settings.kubernetes.version = versions[0];
+      }
     });
     ipcRenderer.on('settings-update', (event, settings) => {
       // TODO: put in a status bar

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -164,7 +164,11 @@ export default {
     });
     ipcRenderer.on('k8s-versions', (event, versions) => {
       this.$data.versions = versions;
-      if (!versions.includes(this.settings.kubernetes.version)) {
+      if (versions.length < 1) {
+        const message = 'No versions of Kubernetes were found';
+
+        this.handleNotification('error', 'no-versions', message);
+      } else if (!versions.includes(this.settings.kubernetes.version)) {
         const oldVersion = this.settings.kubernetes.version;
 
         if (oldVersion) {


### PR DESCRIPTION
This makes it so that it's not a fatal error if there is not network on start (though things won't work quite as well):
- While we still make a request for k3s releases on startup, we no longer need to wait for the result if there is a cache of versions.
- Make the various backends deal with not having a proper version saved in the settings.
- Make the UI handle the same.