### PR TITLE
Background: Clean up unhandled rejection handling

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -40,12 +40,10 @@ Electron.protocol.registerSchemesAsPrivileged([
 ]);
 
 process.on('unhandledRejection', (reason: any, promise: any) => {
-  if (reason.errno === -61 && reason.code === 'ECONNREFUSED' && reason.port === cfg.kubernetes.port) {
+  if (reason.code === 'ECONNREFUSED' && reason.port === cfg.kubernetes.port) {
     // Do nothing: a connection to the kubernetes server was broken
   } else {
-    promise.catch((error: any) => {
-      console.log(`UnhandledRejectionWarning: ${ error }`);
-    });
+    console.error('UnhandledRejectionWarning:', reason);
   }
 });
 


### PR DESCRIPTION
- If code is ECONNREFUSED, then errno is always -61 (because libuv)
- Don't handle the error by attaching a handler to the promise; that emits
  PromiseRejectionHandledWarning instead (because it's trying to warn us
  that it somehow got handled after the unhandled rejection handler ran).