### PR TITLE
Lima: Disable port forwarding

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -346,10 +346,14 @@ Electron.ipcMain.handle('service-fetch', (event, namespace) => {
 });
 
 Electron.ipcMain.handle('service-forward', async(event, service, state) => {
-  if (state) {
-    await k8smanager.forwardPort(service.namespace, service.name, service.port);
-  } else {
-    await k8smanager.cancelForward(service.namespace, service.name, service.port);
+  const forwarder = k8smanager?.portForwarder;
+
+  if (forwarder) {
+    if (state) {
+      await forwarder.forwardPort(service.namespace, service.name, service.port);
+    } else {
+      await forwarder.cancelForward(service.namespace, service.name, service.port);
+    }
   }
 });
 

--- a/background.ts
+++ b/background.ts
@@ -341,6 +341,10 @@ Electron.ipcMain.on('k8s-progress', () => {
   }
 });
 
+Electron.ipcMain.handle('k8s-supports-port-forwarding', () => {
+  return !!k8smanager.portForwarder;
+});
+
 Electron.ipcMain.handle('service-fetch', (event, namespace) => {
   return k8smanager?.listServices(namespace);
 });

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -118,21 +118,10 @@ export interface KubernetesBackend extends events.EventEmitter {
   isServiceReady(namespace: string, service: string): Promise<boolean>;
 
   /**
-   * Forward a single service port, returning the resulting local port number.
-   * @param namespace The namespace containing the service to forward.
-   * @param service The name of the service to forward.
-   * @param port The internal port number of the service to forward.
-   * @returns The port listening on localhost that forwards to the service.
+   * Helper to handle port forwarding for this backend.  This may be null, in
+   * which case port forwarding isn't supported.
    */
-  forwardPort(namespace: string, service: string, port: number): Promise<number | undefined>;
-
-  /**
-   * Cancel an existing port forwarding.
-   * @param {string} namespace The namespace containing the service to forward.
-   * @param {string} service The name of the service to forward.
-   * @param {number} port The internal port number of the service to forward.
-   */
-  cancelForward(namespace: string, service: string, port: number): Promise<void>;
+  readonly portForwarder: KubernetesBackendPortForwarder | null;
 
   /**
    * Return a list of possible integration points.
@@ -183,6 +172,25 @@ export interface KubernetesBackend extends events.EventEmitter {
 
   // #endregion
 
+}
+
+export interface KubernetesBackendPortForwarder {
+  /**
+   * Forward a single service port, returning the resulting local port number.
+   * @param namespace The namespace containing the service to forward.
+   * @param service The name of the service to forward.
+   * @param port The internal port number of the service to forward.
+   * @returns The port listening on localhost that forwards to the service.
+   */
+   forwardPort(namespace: string, service: string, port: number): Promise<number | undefined>;
+
+   /**
+    * Cancel an existing port forwarding.
+    * @param {string} namespace The namespace containing the service to forward.
+    * @param {string} service The name of the service to forward.
+    * @param {number} port The internal port number of the service to forward.
+    */
+   cancelForward(namespace: string, service: string, port: number): Promise<void>;
 }
 
 export function factory(): KubernetesBackend {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -580,14 +580,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return (await this.client?.isServiceReady(namespace, service)) || false;
   }
 
-  forwardPort(namespace: string, service: string, port: number): Promise<number | undefined> {
-    // Lima automatically forwards all the ports.
-    return Promise.resolve(undefined);
-  }
-
-  cancelForward(namespace: string, service: string, port: number): Promise<void> {
-    // Lima automatically forwards all the ports.
-    return Promise.resolve();
+  get portForwarder() {
+    return null;
   }
 
   async listIntegrations(): Promise<Record<string, boolean | string>> {

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -107,16 +107,8 @@ class OSNotImplemented extends events.EventEmitter {
     return Promise.reject(new Error('not implemented'));
   }
 
-  forwardPort(namespace, service, port) {
-    this.#notified = displayError(this.#notified);
-
-    return Promise.reject(new Error('not implemented'));
-  }
-
-  cancelForward(namespace, service, port) {
-    this.#notified = displayError(this.#notified);
-
-    return Promise.reject(new Error('not implemented'));
+  get portForwarder() {
+    return null;
   }
 
   listIntegrations() {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -533,6 +533,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
   }
 
+  get portForwarder() {
+    return this;
+  }
+
   async forwardPort(namespace: string, service: string, port: number): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, port);
   }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -14,6 +14,7 @@ import ActionMenu from '@/components/ActionMenu.vue';
 import Header from '@/components/Header.vue';
 import Nav from '@/components/Nav.vue';
 import BackendProgress from '@/components/BackendProgress.vue';
+import { ipcRenderer } from 'electron';
 
 export default {
   name:       'App',
@@ -25,7 +26,7 @@ export default {
   },
 
   data() {
-    return { routes: ['/General', '/K8s', '/PortForwarding', '/Images', '/Troubleshooting'] };
+    return { routes: ['/General', '/K8s', '/Images', '/Troubleshooting'] };
   },
 
   head() {
@@ -35,6 +36,14 @@ export default {
     // the "dark" part will be a dynamic pref.
     // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
     return { bodyAttrs: { class: 'theme-dark' } };
+  },
+
+  mounted() {
+    ipcRenderer.invoke('k8s-supports-port-forwarding').then((supported) => {
+      if (supported) {
+        this.$data.routes = ['/General', '/K8s', '/PortForwarding', '/Images', '/Troubleshooting'];
+      }
+    });
   },
 };
 </script>

--- a/src/typings/shims-vue.d.ts
+++ b/src/typings/shims-vue.d.ts
@@ -1,4 +1,6 @@
 declare module '*.vue' {
   import Vue from 'vue';
+  /* Load @nuxt/types, as a side effect it aguments Vue */
+  import {} from '@nuxt/types';
   export default Vue;
 }


### PR DESCRIPTION
This hides the port forwarding view for Lima, as that isn't supported (possibly pending Jan's changes).  Fixes #390.

This should not be reviewed until #403 is merged.