### PR TITLE
Lima: exclude state directory from Time Machine

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -297,6 +297,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
     await fs.promises.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
     await fs.promises.writeFile(CONFIG_PATH, yaml.stringify(config));
+    await childProcess.spawnFile('tmutil', ['addexclusion', LIMA_HOME]);
   }
 
   protected get currentConfig(): Promise<LimaConfiguration | undefined> {


### PR DESCRIPTION
This manually excludes the Lima state directory (where the disk image is) from Time Machine.  Obsoletes #421, fixes #354, depends on #403.