### PR TITLE
Lima: Assign port dynamically

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -1,7 +1,6 @@
 # Default Lima configuration; parts will be overridden in code.
 
 ssh:
-  localPort: 60020
   loadDotSSHPubKeys: false
 firmware:
   legacyBIOS: true


### PR DESCRIPTION
This picks a random port on every startup, instead of hard coding one.  This is still much better solved within lima, but it should at least reduce issues for now.

@jandubois  — please close this if you think we should wait for a fix from the lima side.