### PR TITLE
Kim: Check for the correct endpoint

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -16,8 +16,6 @@ provision:
     # just initial VM provisioning.
     set -o errexit -o nounset -o xtrace
     errors=0
-    mount --make-shared /
-    mount --make-shared /var/lib
     for dir in /etc/rancher; do
       if [ -d "${dir}" ]; then
         if [ -n "$(ls -A "${dir}")" ]; then
@@ -27,6 +25,9 @@ provision:
       fi
       mkdir -p "/mnt/data/${dir}" "${dir}"
       mount --bind "/mnt/data/${dir}" "${dir}"
+    done
+    for dir in / /etc/rancher /tmp /var/lib; do
+      mount --make-shared "${dir}"
     done
     echo "Done mounting Rancher persistent volumes."
     exit "${errors}"

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -92,14 +92,16 @@ class Kim extends EventEmitter {
       this.isK8sReady = mgr.state === K8s.State.STARTED;
       this.updateWatchStatus();
       if (this.isK8sReady) {
-        const needsForce = !(await this.isInstallValid(mgr));
+        let endpoint: string | undefined;
 
+        // XXX temporary hack: use a fixed address for kim endpoint
         if (mgr.backend === 'lima') {
-          // XXX temporary hack: use a fixed address for kim endpoint
-          this.install(mgr, needsForce, '127.0.0.1');
-        } else {
-          this.install(mgr, needsForce );
+          endpoint = '127.0.0.1';
         }
+
+        const needsForce = !(await this.isInstallValid(mgr, endpoint));
+
+        this.install(mgr, needsForce, endpoint);
       }
     });
   }
@@ -177,7 +179,7 @@ class Kim extends EventEmitter {
   /**
    * Determine if the Kim service needs to be reinstalled.
    */
-  protected async isInstallValid(mgr: K8s.KubernetesBackend): Promise<boolean> {
+  protected async isInstallValid(mgr: K8s.KubernetesBackend, endpoint?: string): Promise<boolean> {
     const host = await mgr.ipAddress;
 
     if (!host) {
@@ -198,12 +200,14 @@ class Kim extends EventEmitter {
     await this.waitForNodeIP(api, host);
     await this.removeStalePods(api);
 
+    const wantedEndpoint = endpoint || host;
+
     // Check if the endpoint has the correct address
     try {
       const { body: endpointBody } = await api.readNamespacedEndpoints('builder', 'kube-image');
       const subset = endpointBody.subsets?.find(subset => subset.ports?.some(port => port.name === 'kim'));
 
-      if (!(subset?.addresses || []).some(address => address.ip === host)) {
+      if (!(subset?.addresses || []).some(address => address.ip === wantedEndpoint)) {
         console.log('Existing kim install invalid: incorrect endpoint address.');
 
         return false;
@@ -222,7 +226,7 @@ class Kim extends EventEmitter {
     const { body: secretBody } = await api.readNamespacedSecret('kim-tls-server', 'kube-image');
     const encodedCert = (secretBody.data || {})['tls.crt'];
 
-    // If we don't have a cert, that's fine — kim wil fix it.
+    // If we don't have a cert, that's fine — kim will fix it.
     if (encodedCert) {
       const cert = Buffer.from(encodedCert, 'base64');
       const secureContext = tls.createSecureContext({ cert });
@@ -233,10 +237,10 @@ class Kim extends EventEmitter {
       if (parsedCert && 'subjectaltname' in parsedCert) {
         const { subjectaltname } = parsedCert;
         const names = subjectaltname.split(',').map(s => s.trim());
-        const acceptable = [`IP Address:${ host }`, `DNS:${ host }`];
+        const acceptable = [`IP Address:${ wantedEndpoint }`, `DNS:${ wantedEndpoint }`];
 
         if (!names.some(name => acceptable.includes(name))) {
-          console.log(`Existing kim install invalid: incorrect certificate (${ subjectaltname } does not contain ${ host }).`);
+          console.log(`Existing kim install invalid: incorrect certificate (${ subjectaltname } does not contain ${ wantedEndpoint }).`);
 
           return false;
         }


### PR DESCRIPTION
This should resolve the issue @ericpromislow had around kim not starting correctly (because a previous kim that didn't have `--endpoint-addr` set was already running).  Also fixes kim not starting due to `mount --make-shared` missing for `/tmp` and `/var/lib`.