### PR TITLE
Update: Hide update enabled checkbox if no update server configured.

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,5 +29,5 @@ nsis:
   oneClick: false # Needed for restart prompt
 publish:
   provider: custom
-  upgradeServer: https://upgrade-server.example.com/v1/checkupgrade
+  #upgradeServer: https://upgrade-server.example.com/v1/checkupgrade
   vPrefixedTagName: true

--- a/src/components/UpdateStatus.vue
+++ b/src/components/UpdateStatus.vue
@@ -3,6 +3,7 @@
     <div class="version">
       <span class="versionInfo"><b>Version:</b> {{ version }}</span>
       <Checkbox
+        v-if="updatePossible"
         v-model="updatesEnabled"
         class="updatesEnabled"
         label="Check for updates automatically"
@@ -66,6 +67,10 @@ class UpdateStatus extends UpdateStatusProps {
     // We emit an event, but _don't_ set the prop here; we let the containing
     // page update our prop instead.
     this.$emit('enabled', value);
+  }
+
+  get updatePossible() {
+    return !!this.updateState?.configured;
   }
 
   get hasUpdate() {

--- a/src/components/__tests__/UpdateStatus.spec.ts
+++ b/src/components/__tests__/UpdateStatus.spec.ts
@@ -75,6 +75,7 @@ describe('UpdateStatus.vue', () => {
       const wrapper = wrap({
         enabled:     true,
         updateState: {
+          configured: true,
           available:  true,
           downloaded: false,
           info:       {

--- a/src/main/update/LonghornUpdater.ts
+++ b/src/main/update/LonghornUpdater.ts
@@ -6,6 +6,14 @@ import LonghornProvider, { GithubReleaseAsset, LonghornProviderOptions } from '.
 export class NsisLonghornUpdater extends NsisUpdater {
   protected configOnDisk = new Lazy<LonghornProviderOptions>(() => this['loadUpdateConfig']());
 
+  get hasUpdateConfiguration(): Promise<boolean> {
+    return (async() => {
+      const config = await this.configOnDisk.value;
+
+      return !!config.upgradeServer;
+    })();
+  }
+
   protected async getUpdateInfoAndProvider() {
     if (this['clientPromise'] === null) {
       const config = await this.configOnDisk.value;
@@ -23,6 +31,14 @@ export class NsisLonghornUpdater extends NsisUpdater {
 
 export class MacLonghornUpdater extends MacUpdater {
   protected configOnDisk = new Lazy<LonghornProviderOptions>(() => this['loadUpdateConfig']());
+
+  get hasUpdateConfiguration(): Promise<boolean> {
+    return (async() => {
+      const config = await this.configOnDisk.value;
+
+      return !!config.upgradeServer;
+    })();
+  }
 
   protected async getUpdateInfoAndProvider() {
     if (this['clientPromise'] === null) {


### PR DESCRIPTION
This hides the update checkbox if the update server is not configured, so that the users don't get confused by a checkbox that doesn't do anything (and therefore don't manually check for updates).

Fixes #436