### PR TITLE
Remove hyperkit files when moving to lima

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -4,7 +4,6 @@
 import { Console } from 'console';
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
 import util from 'util';
 import { dirname, join } from 'path';
 
@@ -221,10 +220,12 @@ const updateTable: Record<number, (settings: any) => void> = {
     if (os.platform() === 'darwin') {
       console.log('Removing hyperkit virtual machine files');
       try {
-        fs.accessSync(path.join(paths.state(), 'driver'));
-        fs.rmSync(path.join(paths.state(), 'driver'), { recursive: true, force: true});
-      } catch(err) {
-        console.log(err);
+        fs.accessSync(join(paths.state(), 'driver'));
+        fs.rmSync(join(paths.state(), 'driver'), { recursive: true, force: true });
+      } catch (err) {
+        if (err !== 'ENOENT') {
+          console.log(err);
+        }
       }
     }
   }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -4,6 +4,7 @@
 import { Console } from 'console';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import util from 'util';
 import { dirname, join } from 'path';
 
@@ -20,7 +21,7 @@ const paths = require('xdg-app-paths')({ name: 'rancher-desktop' });
 // it will be picked up from the default settings object.
 // Version incrementing is for when a breaking change is introduced in the settings object.
 
-const CURRENT_SETTINGS_VERSION = 2;
+const CURRENT_SETTINGS_VERSION = 3;
 
 const defaultSettings = {
   version:    CURRENT_SETTINGS_VERSION,
@@ -216,6 +217,17 @@ const updateTable: Record<number, (settings: any) => void> = {
       delete settings.kubernetes.rancherMode;
     }
   },
+  2: (settings) => {
+    if (os.platform() === 'darwin') {
+      console.log('Removing hyperkit virtual machine files');
+      try {
+        fs.accessSync(path.join(paths.state(), 'driver'));
+        fs.rmSync(path.join(paths.state(), 'driver'), { recursive: true, force: true});
+      } catch(err) {
+        console.log(err);
+      }
+    }
+  }
 };
 
 function updateSettings(settings: Settings) {


### PR DESCRIPTION
This only happens when:
1. running on macos
2. Starting up with a preferences file of version 1 or 2

This means in the future we can safely use the directory
~/Library/State/rancher-desktop/driver
as long as the settings file has a version # > 3

Yes, this is piggy-backing on the settings upgrade mechanism
to avoid writing yet another one.  If you think of it as
an `at-startup-upgrade mechanism' it's less problematic.

Signed-off-by: Eric Promislow <epromislow@suse.com>