### PR TITLE
E2E: Use custom script for building

### DIFF
--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -25,7 +25,6 @@ describe('Rancher Desktop', () => {
       //  complains of type mismatch.
       path: electronPath as any,
       args: [path.dirname(__dirname)],
-      env:  { SPECTRON_RUN: 'yes' }
     });
 
     await app.start();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "npm run lint:nofix && npm run test:unit",
     "test:unit": "jest",
     "test:unit:watch": "npm run test:unit -- --watch",
-    "test:e2e": "npm run build && jest --config ./e2e/jest.e2e.config.json",
+    "test:e2e": "node ./scripts/e2e.mjs",
     "generateReleases": "node ./scripts/generateReleaseList.js",
     "postinstall": "node ./scripts/postinstall.mjs",
     "postuninstall": "electron-builder install-app-deps"

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,0 +1,106 @@
+/**
+ * This script runs the end-to-end tests.
+ */
+
+'use strict';
+
+import events from 'events';
+import buildUtils from './lib/build-utils.mjs';
+
+class E2ETestRunner extends events.EventEmitter {
+  emitError(message, error) {
+    let combinedMessage = message;
+
+    if (error?.message) {
+      combinedMessage += `: ${ error.message }`;
+    }
+    const newError = new Error(combinedMessage);
+
+    newError.code = error?.code;
+    if (error?.stack) {
+      newError.stack += `\nCaused by: ${ error.stack }`;
+    }
+    this.emit('error', newError);
+  }
+
+  get rendererPort() {
+    return 8888;
+  }
+
+  /**
+   * Spawn a child process, set up to emit errors on unexpected exit.
+   * @param {string} title The title of the process to show in messages.
+   * @param {string} command The executable to run.
+   * @param  {...string} args Any arguments to the executable.
+   * @returns {childProcess.ChildProcess} The new child process.
+   */
+  spawn(title, command, ...args) {
+    const promise = buildUtils.spawn(command, ...args);
+
+    promise
+      .then(() => this.exit())
+      .catch(error => this.emitError(`${ title } error`, error));
+
+    return promise.child;
+  }
+
+  exit() {
+    this.#rendererProcess?.kill();
+    this.#testProcess?.kill();
+  }
+
+  #testProcess = null
+  startTestProcess() {
+    this.#testProcess = this.spawn('Test process',
+      'node', 'node_modules/jest/bin/jest.js',
+      '--config', './e2e/jest.e2e.config.json');
+
+    return new Promise((resolve, reject) => {
+      this.#testProcess.on('exit', (code, signal) => {
+        if (code === 201) {
+          console.log('Another instance of Rancher Desktop is already running');
+          resolve();
+        } else if (code > 0) {
+          console.log(`Rancher Desktop: main process exited with status ${ code }`);
+          reject(code);
+        } else if (signal) {
+          console.log(`Rancher Desktop: main process exited with signal ${ signal }`);
+          reject(signal);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  #rendererProcess = null
+  /**
+   * Start the renderer process.
+   * @returns {Promise<void>}
+   */
+  startRendererProcess() {
+    this.#rendererProcess = this.spawn('Renderer process',
+      'node', 'node_modules/nuxt/bin/nuxt.js',
+      '--port', this.rendererPort, buildUtils.rendererSrcDir);
+
+    return Promise.resolve();
+  }
+
+  async run() {
+    try {
+      process.env.NODE_ENV = 'test';
+      await buildUtils.wait(
+        () => this.startRendererProcess(),
+        () => buildUtils.buildMain(),
+      );
+      await this.startTestProcess();
+    } finally {
+      this.exit();
+    }
+  }
+}
+
+(new E2ETestRunner()).run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -175,7 +175,7 @@ export default {
         ],
       },
       plugins: [
-        new webpack.EnvironmentPlugin({ NODE_ENV: process.env.NODE_ENV }),
+        new webpack.EnvironmentPlugin({ NODE_ENV: process.env.NODE_ENV || 'production' }),
       ],
     };
   },

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -175,7 +175,7 @@ export default {
         ],
       },
       plugins: [
-        new webpack.EnvironmentPlugin({ NODE_ENV: mode }),
+        new webpack.EnvironmentPlugin({ NODE_ENV: process.env.NODE_ENV }),
       ],
     };
   },

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -117,7 +117,7 @@ export default new Proxy(logging, {
  * we will quit shortly.
  */
 
-if (process.env.NODE_ENV === 'test' || process.env.SPECTRON_RUN === 'yes') {
+if (process.env.NODE_ENV === 'test') {
   // If we're running under test, just always ensure the directory can be used.
   fs.mkdirSync(logDir, { recursive: true });
 } else if (process.type === 'browser') {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -57,7 +57,7 @@ export function openPreferences() {
   createWindow('preferences', url, {
     nodeIntegration:    true,
     contextIsolation:   false,
-    enableRemoteModule: process.env?.SPECTRON_RUN === 'yes'
+    enableRemoteModule: process.env?.NODE_ENV === 'test'
   });
 }
 


### PR DESCRIPTION
This lets us drop the `SPECTRON_RUN` environment variable, so we can be sure that users will not accidentally stumble upon it (causing the deprecated remoting API to be enabled).

Instructions are unchanged — we still launch the test via `npm run test:e2e`.