### PR TITLE
Stop a running k8s before restarting

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -327,8 +327,10 @@ Electron.ipcMain.on('k8s-restart', async() => {
   }
   try {
     switch (k8smanager.state) {
-    case K8s.State.STOPPED:
     case K8s.State.STARTED:
+      await k8smanager.stop();
+      //FALLTHROUGH
+    case K8s.State.STOPPED:
       // Calling start() will restart the backend, possible switching versions
       // as a side-effect.
       await k8smanager.start(cfg.kubernetes);


### PR DESCRIPTION
Lima-based systems are unable to change versions without
shutting down RD and restarting it.

Signed-off-by: Eric Promislow <epromislow@suse.com>