### PR TITLE
Fix various startup issues

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -425,7 +425,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
         return entries.find(entry => entry.name === MACHINE_NAME);
       } catch (ex) {
-        console.error('Could not parse status:', ex);
+        console.error('Could not parse lima status, assuming machine is unavailable.');
 
         return undefined;
       }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -304,6 +304,14 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   #sshPort = 0;
   get sshPort(): Promise<number> {
     return (async() => {
+      if ((await this.status)?.status === 'Running') {
+        // if the machine is already running, we can't change the port.
+        const existingPort = (await this.currentConfig)?.ssh.localPort;
+
+        if (existingPort) {
+          return existingPort;
+        }
+      }
       if (this.#sshPort === 0) {
         const server = net.createServer();
 


### PR DESCRIPTION
This should fix some issues around starting the VM, especially on Lima:

- Lima: set config before looking for desired version; mentioned in https://github.com/rancher-sandbox/rancher-desktop/issues/458#issuecomment-893772586
- Generally, be more explicit around k3s when we use the short version (`v1.2.3`) vs the full K3s version (`v1.2.3+k3s4`). This was also mentioned in https://github.com/rancher-sandbox/rancher-desktop/issues/458#issuecomment-893772586
- Lima: don't attempt to find a new SSH port if the VM is already running (since we won't restart the VM, so the port isn't going to change).
- Lima: force terminate any k3s instances in the VM before trying to start it.
- Lima: when we fail to get the VM status (e.g. because it doesn't exist), don't fall over.
- Lima: if the user aborts halfway through start, actually stop starting.

We should double check if this fixes #455 and #457.