### PR TITLE
K8s: Fix port display in UI

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -270,7 +270,11 @@ Electron.ipcMain.on('k8s-state', (event) => {
   event.returnValue = k8smanager.state;
 });
 
-Electron.ipcMain.handle('current-port', event => k8smanager.port);
+Electron.ipcMain.on('k8s-current-port', () => {
+  console.log(`k8s-current-port: ${ k8smanager.desiredPort }`);
+
+  window.send('k8s-current-port', k8smanager.desiredPort);
+});
 
 Electron.ipcMain.on('k8s-reset', async(_, arg) => {
   await doK8sReset(arg);
@@ -290,7 +294,7 @@ async function doK8sReset(arg = ''): Promise<void> {
     } else if ((k8smanager.version !== cfg.kubernetes.version ||
         (await k8smanager.cpus) !== cfg.kubernetes.numberCPUs ||
         (await k8smanager.memory) !== cfg.kubernetes.memoryInGB * 1024 ||
-        (k8smanager.port) !== cfg.kubernetes.port)) {
+        (k8smanager.desiredPort) !== cfg.kubernetes.port)) {
       arg = 'slow';
     }
     switch (arg) {
@@ -322,7 +326,7 @@ Electron.ipcMain.on('k8s-restart-required', async() => {
 });
 
 Electron.ipcMain.on('k8s-restart', async() => {
-  if (cfg.kubernetes.port !== k8smanager.port) {
+  if (cfg.kubernetes.port !== k8smanager.desiredPort) {
     return doK8sReset();
   }
   try {

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -43,8 +43,11 @@ export interface KubernetesBackend extends events.EventEmitter {
   /** The amount of memory in the VM, in MiB, or 0 if the VM is not running. */
   memory: Promise<number>;
 
-  /** The port the Kubernetes server is currently listening on (default 6443) */
-  readonly port: number;
+  /**
+   * The port the Kubernetes server will listen on; this may not reflect the
+   * port correctly if the server is not active.
+   */
+  readonly desiredPort: number;
 
   /** Progress for the current action. */
   progress: {

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -27,7 +27,7 @@ class OSNotImplemented extends events.EventEmitter {
     return 'Not Implemented';
   }
 
-  get port() {
+  get desiredPort() {
     return 0;
   }
 

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -149,6 +149,7 @@ export default {
     ipcRenderer.on('k8s-current-port', (event, port) => {
       this.currentPort = port;
     });
+    ipcRenderer.send('k8s-current-port');
     ipcRenderer.on('k8s-restart-required', (event, required) => {
       console.log(`restart-required-all`, required);
       for (const key in required) {


### PR DESCRIPTION
- Make the port number available explicitly be the _desired_ port, and not the current port; that is, it will reflect the target port number while the backend is still starting.
- Make the k8s page request the desired port when mounting.

Fixes #459