### PR TITLE
Dev only: restore the cache file (or absence of) after tests

### DIFF
--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -5,10 +5,13 @@ import util from 'util';
 
 import fetch from 'node-fetch';
 import semver, { valid } from 'semver';
+import XDGAppPaths from 'xdg-app-paths';
 import { mocked } from 'ts-jest/utils';
 
 import K3sHelper, { buildVersion, ReleaseAPIEntry } from '../k3sHelper';
 
+const paths = XDGAppPaths('rancher-desktop');
+const cachePath = path.join(paths.cache(), 'k3s-versions.json');
 const { Response: FetchResponse } = jest.requireActual('node-fetch');
 
 // Mock fetch to ensure we never make an actual request.
@@ -16,6 +19,23 @@ jest.mock('node-fetch', () => {
   return jest.fn((...args) => {
     throw new Error('Unexpected network traffic');
   });
+});
+
+let cacheData: Buffer|null;
+
+beforeAll(() => {
+  try {
+    cacheData = fs.readFileSync(cachePath);
+  } catch (err) {
+    cacheData = null;
+  }
+});
+afterAll(() => {
+  if (cacheData) {
+    fs.writeFileSync(cachePath, cacheData);
+  } else {
+    fs.rmSync(cachePath);
+  }
 });
 
 beforeEach(() => {


### PR DESCRIPTION
This was manifesting as a failure to fetch
https://github.com/k3s-io/k3s/releases/download/v1.20.0/k3s-airgap-images-amd64.tar
at startup, and rd would freeze.

`~/Library/Caches/rancher-desktop/k3s-versions.json` contained one entry:

`["v1.20.0"]`

This is because unit tests created a cache file with that entry.

A partial fix is to restore the existing list of versions after running
tests, done here.

A better fix would be to use a different cache file, but that's probably
overkill for something that affects only devs. This doesn't affect the
CI system (which runs tests but not the final build) or end-users
(who run final builds but not unit tests).

The reason for the `1.0.0` in the branch name is that at some point a `v1.0.0` ended up in my `k3s-versions.json` file (on both mac and windows). I have a separate change that checks for those, but that might be overkill for non-devs. Still, it's done only once, when the existing cache file is loaded, and might be worth considering. This commit takes care of the main problem: unit tests pollute the cache file with bogus entries, and lose existing valid entries.

Signed-off-by: Eric Promislow <epromislow@suse.com>