### PR TITLE
Install host CA certificates in VM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "semver": "^7.3.5",
         "socks-proxy-agent": "^6.0.0",
         "sudo-prompt": "^9.2.1",
+        "tar": "^6.1.11",
         "utf-8-validate": "^5.0.4",
         "vue": "^2.6.12",
         "vue-js-modal": "^1.3.31",
@@ -21927,9 +21928,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -43525,9 +43526,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "semver": "^7.3.5",
     "socks-proxy-agent": "^6.0.0",
     "sudo-prompt": "^9.2.1",
+    "tar": "^6.1.11",
     "utf-8-validate": "^5.0.4",
     "vue": "^2.6.12",
     "vue-js-modal": "^1.3.31",

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -382,11 +382,16 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async execCommand(...command: string[]): Promise<void> {
     const args = ['--distribution', INSTANCE_NAME, '--exec'].concat(command);
 
-    await childProcess.spawnFile('wsl.exe', args,
-      {
-        stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
-        windowsHide: true
-      });
+    try {
+      await childProcess.spawnFile('wsl.exe', args,
+        {
+          stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
+          windowsHide: true
+        });
+    } catch (ex) {
+      console.error(`WSL failed to execute ${ command.join(' ') }`);
+      throw ex;
+    }
   }
 
   /**
@@ -407,7 +412,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
       return stdout;
     } catch (ex) {
-      console.error(`wsl ${ args.join(' ') }`, ex);
+      console.error(`WSL failed to execute ${ command.join(' ') }`);
       throw ex;
     }
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -647,7 +647,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     } finally {
       await fs.promises.rmdir(workdir, { recursive: true });
     }
-    await this.execCommand('update-ca-certificates');
+    await this.execCommand('/usr/sbin/update-ca-certificates');
   }
 
   async stop(): Promise<void> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -637,6 +637,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
     try {
       await this.execCommand('/bin/sh', '-c', 'rm -f /usr/local/share/ca-certificates/rd-*.crt');
+      // Unlike the Lima backends, we can freely copy files in parallel into the
+      // WSL distro, so we don't require the use of tar here.
       await Promise.all(certs.map(async(cert, index) => {
         const filename = `rd-${ index }.crt`;
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -6,12 +6,14 @@ import events from 'events';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
 import timers from 'timers';
 import util from 'util';
 
 import semver from 'semver';
 
 import INSTALL_K3S_SCRIPT from '@/assets/scripts/install-k3s';
+import mainEvents from '@/main/mainEvents';
 import * as childProcess from '@/utils/childProcess';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
@@ -553,6 +555,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       await this.execCommand('/bin/mv', '-n', '/tmp/machine-id', '/etc/machine-id');
       await this.execCommand('/bin/rm', '-f', '/tmp/machine-id');
 
+      await this.installCACerts();
       await this.deleteIncompatibleData(desiredVersion);
       await this.installK3s(desiredVersion);
       await this.persistVersion(desiredVersion);
@@ -617,6 +620,34 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
       this.currentAction = Action.NONE;
     }
+  }
+
+  protected async installCACerts(): Promise<void> {
+    const certs: (string|Buffer)[] = await new Promise((resolve) => {
+      mainEvents.once('cert-ca-certificates', resolve);
+      mainEvents.emit('cert-get-ca-certificates');
+    });
+
+    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-ca-'));
+
+    try {
+      await this.execCommand('/bin/sh', '-c', 'rm -f /usr/local/share/ca-certificates/rd-*.crt');
+      await Promise.all(certs.map(async(cert, index) => {
+        const filename = `rd-${ index }.crt`;
+
+        await util.promisify(stream.pipeline)(
+          stream.Readable.from(cert),
+          fs.createWriteStream(path.join(workdir, filename), { mode: 0o600 }),
+        );
+        await this.execCommand(
+          'cp',
+          await this.wslify(path.join(workdir, filename)),
+          '/usr/local/share/ca-certificates/');
+      }));
+    } finally {
+      await fs.promises.rmdir(workdir, { recursive: true });
+    }
+    await this.execCommand('update-ca-certificates');
   }
 
   async stop(): Promise<void> {

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -17,6 +17,15 @@ interface MainEvents extends EventEmitter {
    * Emitted when the settings have been changed.  The new settings are given.
    */
   on(event: 'settings-update', listener: (settings: Settings) => void): this;
+  /**
+   * Emitted as a request to get the CA certificates.
+   */
+  on(event: 'cert-get-ca-certificates', listener: () => void): this;
+  /**
+   * Emitted as a reply to 'cert-get-ca-certificates', with the list of CA
+   * certificates.
+   */
+  on(event: 'cert-ca-certificates', listener:(certs: (string|Buffer)[]) => void): this;
   /* @deprecated */
   on(event: string | symbol, listener: (...args: any[]) => void): this;
 }

--- a/src/main/networking/index.ts
+++ b/src/main/networking/index.ts
@@ -6,6 +6,7 @@ import Electron from 'electron';
 import MacCA from 'mac-ca';
 import WinCA from 'win-ca';
 
+import mainEvents from '@/main/mainEvents';
 import ElectronProxyAgent from './proxy';
 
 export default function setupNetworking() {
@@ -71,4 +72,17 @@ Electron.app.on('certificate-error', (event, webContents, url, error, certificat
 
   // eslint-disable-next-line node/no-callback-literal
   callback(false);
+});
+
+function defined<T>(input: T | undefined | null): input is T {
+  return typeof input !== 'undefined' && input !== null;
+}
+
+mainEvents.on('cert-get-ca-certificates', () => {
+  let certs = https.globalAgent.options.ca;
+
+  if (!Array.isArray(certs)) {
+    certs = [certs].filter(defined);
+  }
+  mainEvents.emit('cert-ca-certificates', certs);
 });

--- a/src/main/networking/index.ts
+++ b/src/main/networking/index.ts
@@ -84,5 +84,13 @@ mainEvents.on('cert-get-ca-certificates', () => {
   if (!Array.isArray(certs)) {
     certs = [certs].filter(defined);
   }
+
+  if (os.platform() === 'win32') {
+    // On Windows, win-ca doesn't add CAs into the agent; rather, it patches
+    // `tls.createSecureContext()` instead, so we don't have a list of CAs here.
+    // We need to fetch it manually.
+    certs.push(...WinCA({ generator: true, format: WinCA.der2.pem }));
+  }
+
   mainEvents.emit('cert-ca-certificates', certs);
 });

--- a/src/typings/win-ca.d.ts
+++ b/src/typings/win-ca.d.ts
@@ -1,4 +1,5 @@
 declare module 'win-ca/der2' {
+  // eslint-disable-next-line import/no-duplicates -- because we're importing into different namespaces
   import * as forge from 'node-forge';
 
   namespace der2 {
@@ -59,18 +60,17 @@ declare module 'win-ca/lib/save' {
 }
 
 declare module 'win-ca' {
+  // eslint-disable-next-line import/no-duplicates -- because we're importing into different namespaces
+  import * as forge from 'node-forge';
   import _der2 from 'win-ca/der2';
 
   interface apiOptions {
     disabled?: boolean;
     fallback?: boolean;
     store?: string[];
-    async?: boolean;
     unique?: boolean;
-    format?: _der2.format;
     ondata?: any[] | ((cert: any) => void);
     onend?: () => void;
-    generator?: boolean;
     inject?: boolean | '+';
     save?: boolean | string | string[];
     onsave?: (path: string | undefined) => void;
@@ -85,6 +85,17 @@ declare module 'win-ca' {
       const forge = _der2.forge;
     }
   }
-  function api(params?: apiOptions): void;
+
+  function api(params?: apiOptions & { genarator?: false, format?: _der2.format }): void;
+  function api(params: apiOptions & { generator: true, async?: false, format?: _der2.format.der }): Iterable<Buffer>;
+  function api(params: apiOptions & { generator: true, async?: false, format: _der2.format.pem }): Iterable<string>;
+  function api(params: apiOptions & { generator: true, async?: false, format: _der2.format.txt }): Iterable<string>;
+  function api(params: apiOptions & { generator: true, async?: false, format: _der2.format.asn1 }): Iterable<any>;
+  function api(params: apiOptions & { generator: true, async?: false, format: _der2.format.x509 }): Iterable<forge.pki.Certificate>;
+  function api(params: apiOptions & { generator: true, async: true, format?: _der2.format.der }): AsyncIterable<Buffer>;
+  function api(params: apiOptions & { generator: true, async: true, format: _der2.format.pem }): AsyncIterable<string>;
+  function api(params: apiOptions & { generator: true, async: true, format: _der2.format.txt }): AsyncIterable<string>;
+  function api(params: apiOptions & { generator: true, async: true, format: _der2.format.asn1 }): AsyncIterable<any>;
+  function api(params: apiOptions & { generator: true, async: true, format: _der2.format.x509 }): AsyncIterable<forge.pki.Certificate>;
   export default api;
 }


### PR DESCRIPTION
This PR will install all host CA certificates into the VM, so that things like (transparent) proxies should just work.  Since we're already getting the CA certs into Node via the `win-ca` / `mac-ca` NodeKS packages, I'm just reading the list off the global HTTPS agent options.

Note that this is a draft, as tinyk3s doesn't have `update-ca-certificates` (https://github.com/jandubois/tinyk3s/issues/2), so this will break WSL.

Should fix #305 but needs more testing.