### PR TITLE
Lima: fix duplicated mounts in config

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -602,7 +602,7 @@ export default class K3sHelper extends events.EventEmitter {
    * We normally parse all the config files, yaml and json, with yaml.parse, so yaml.parse
    * should work with json here.
    */
-  ensureContentsAreYAML(contents: string): string {
+  protected ensureContentsAreYAML(contents: string): string {
     try {
       return yaml.stringify(yaml.parse(contents));
     } catch (err) {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -10,9 +10,9 @@ import timers from 'timers';
 import util from 'util';
 import { ChildProcess, spawn as spawnWithSignal } from 'child_process';
 
-import deepmerge from 'deepmerge';
 import XDGAppPaths from 'xdg-app-paths';
 import yaml from 'yaml';
+import merge from 'lodash/merge';
 
 import { Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
@@ -336,7 +336,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected async updateConfig() {
     const currentConfig = await this.currentConfig;
     const baseConfig: LimaConfiguration = currentConfig || DEFAULT_CONFIG;
-    const config = deepmerge(baseConfig, {
+    const config = merge(baseConfig, {
       images:     [{
         location: resources.get(os.platform(), 'alpline-lima-v0.1.0-std-3.13.5.iso'),
         arch:     'x86_64',


### PR DESCRIPTION
When encountering an array in both source and destination objects, `deepmerge` appends items from the source to the destination; this isn't what we want when generating Lima configuration, as this leads to duplicated images and mounts.  Instead, use `lodash/merge`, which clobbers existing arrays instead.

This should fix the messages about fuse not having permissions about the cache mount.