### PR TITLE
K8s: Fix port fowarding for services with port names

### DIFF
--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -182,18 +182,18 @@ export interface KubernetesBackendPortForwarder {
    * Forward a single service port, returning the resulting local port number.
    * @param namespace The namespace containing the service to forward.
    * @param service The name of the service to forward.
-   * @param port The internal port number of the service to forward.
+   * @param port The internal port of the service to forward.
    * @returns The port listening on localhost that forwards to the service.
    */
-   forwardPort(namespace: string, service: string, port: number): Promise<number | undefined>;
+  forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined>;
 
-   /**
-    * Cancel an existing port forwarding.
-    * @param {string} namespace The namespace containing the service to forward.
-    * @param {string} service The name of the service to forward.
-    * @param {number} port The internal port number of the service to forward.
-    */
-   cancelForward(namespace: string, service: string, port: number): Promise<void>;
+  /**
+   * Cancel an existing port forwarding.
+   * @param namespace The namespace containing the service to forward.
+   * @param service The name of the service to forward.
+   * @param port The internal port of the service to forward.
+   */
+  cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
 }
 
 export function factory(): KubernetesBackend {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -611,11 +611,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     return this;
   }
 
-  async forwardPort(namespace: string, service: string, port: number): Promise<number | undefined> {
+  async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, port);
   }
 
-  async cancelForward(namespace: string, service: string, port: number): Promise<void> {
+  async cancelForward(namespace: string, service: string, port: number | string): Promise<void> {
     await this.client?.cancelForwardPort(namespace, service, port);
   }
 


### PR DESCRIPTION
When setting up services in Kubernetes, you could either supply a port number or a port name when describing where to forward to.  In the case of a port name, we need to look up the corresponding port number from the
endpoint definition.

Also fixes #485 (by adding a filter to ensure that the endpoint we found matches the target exactly).