### PR TITLE
Create `/etc/machine-id`

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -8,11 +8,11 @@ containerd:
   system: false
   user: false
 provision:
-- mode: system
+- # This sets up the K3s persistent volumes.
+  # It is run on every boot, not just initial VM provisioning.
+  mode: system
   script: |
     #!/bin/sh
-    # This sets up the K3s persistent volumes.  It is run on every boot, not
-    # just initial VM provisioning.
     set -o errexit -o nounset -o xtrace
     errors=0
     for dir in /etc/rancher; do
@@ -30,3 +30,6 @@ provision:
     done
     echo "Done mounting Rancher persistent volumes."
     exit "${errors}"
+- # This ensures we have a persisted /etc/machine-id
+  mode: system
+  script: rc-service machine-id start

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -335,8 +335,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
   protected async updateConfig() {
     const currentConfig = await this.currentConfig;
-    const baseConfig: LimaConfiguration = currentConfig || DEFAULT_CONFIG;
-    const config = merge(baseConfig, {
+    const baseConfig: Partial<LimaConfiguration> = currentConfig || {};
+    const config: LimaConfiguration = merge(baseConfig, DEFAULT_CONFIG as LimaConfiguration, {
       images:     [{
         location: resources.get(os.platform(), 'alpline-lima-v0.1.0-std-3.13.5.iso'),
         arch:     'x86_64',


### PR DESCRIPTION
This ensures we have `/etc/machine-id` in both WSL & Lima, as K3s is complaining about it (see logs from #505, #508).

Note that this probably does _not_ fix those issues.