### PR TITLE
Manage scrolling locations in the images tab so the final locations are saner

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -403,6 +403,10 @@ Electron.ipcMain.handle('get-app-version', async(event) => {
   return process.env.NODE_ENV === 'production' ? getProductionVersion() : await getDevVersion();
 });
 
+Electron.ipcMain.handle('show-message-box', (event, options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> => {
+  return Electron.dialog.showMessageBox(options);
+});
+
 function getProductionVersion() {
   try {
     return Electron.app.getVersion();

--- a/src/assets/styles/rancher-desktop.scss
+++ b/src/assets/styles/rancher-desktop.scss
@@ -18,15 +18,3 @@ margin-right: 1em;
    */
   outline: 10px dashed red !important;
 }
-
-@keyframes greenfade {
-  from {
-    background: DarkSeaGreen;
-  } to {
-    background: transparent;
-  }
-}
-
-tr.greenfade td {
-  animation: greenfade 2s;
-}

--- a/src/assets/styles/rancher-desktop.scss
+++ b/src/assets/styles/rancher-desktop.scss
@@ -18,3 +18,15 @@ margin-right: 1em;
    */
   outline: 10px dashed red !important;
 }
+
+@keyframes greenfade {
+  from {
+    background: DarkSeaGreen;
+  } to {
+    background: transparent;
+  }
+}
+
+tr.greenfade td {
+  animation: greenfade 2s;
+}

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -342,14 +342,9 @@ export default {
       }
       this.currentCommand = `delete ${ obj.imageName }:${ obj.tag }`;
       this.mainWindowScroll = this.$refs.fullWindow.parentElement.parentElement.scrollTop;
-      this.postOpSuccessHandler = this.postDeleteSuccessHandler;
+      this.postOpSuccessHandler = this.postHandleNoOutputHandler;
       this.startRunningCommand('delete');
       ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
-    },
-    postDeleteSuccessHandler() {
-      if (this.imageManagerOutput === '') {
-        this.closeOutputWindow(null);
-      }
     },
     postHandleNoOutputHandler() {
       if (!this.keepImageManagerOutputWindowOpen) {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -308,11 +308,14 @@ export default {
       }
     },
     deleteImage(obj) {
+      if (!window.confirm(`Delete image ${ obj.imageName }:${ obj.tag }?`)) {
+        return;
+      }
       this.currentCommand = `delete ${ obj.imageName }:${ obj.tag }`;
       this.mainWindowScroll = this.$refs.fullWindow.parentElement.parentElement.scrollTop;
       this.postOpSuccessHandler = this.postDeleteSuccessHandler;
       this.startRunningCommand('delete');
-      ipcRenderer.send('confirm-do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
+      ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
     },
     postDeleteSuccessHandler() {
       if (this.imageManagerOutput === '') {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -380,7 +380,8 @@ export default {
       return m ? [m[1], m[2]] : [fullImageName, 'latest'];
     },
     getImageByNameAndTag(imageName, tag) {
-      return this.images.find(image => image.imageName === imageName && image.tag === tag);
+      return this.images.find(image => image.imageName === imageName &&
+        (image.tag === tag || (image.tag === '<none>' && tag === 'latest')));
     },
     scrollToImage(image) {
       const row = this.$refs.imagesTable.$el.querySelector(`tr[data-node-id="${ image.imageID }"]`);
@@ -417,7 +418,7 @@ export default {
       this.imageManagerOutput = '';
       if (!image) {
         if (!operationEndedBadly) {
-          console.log(`Can't find ${ taggedImageName } ([${ imageName }, ${ tag }]) in the table`);
+          console.log(`Can't find ${ taggedImageName } ([${ imageName }, ${ tag }]) in the table`, this.images);
           console.log(`Image names: ${ this.images.map(img => `[ ${ img.imageName }:${ img.tag }]`).join('; ') }`);
         }
         // Otherwise we wouldn't expect to find the tag in the list

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -312,8 +312,18 @@ export default {
         });
       }
     },
-    deleteImage(obj) {
-      if (!window.confirm(`Delete image ${ obj.imageName }:${ obj.tag }?`)) {
+    async deleteImage(obj) {
+      const options = {
+        message:   `Delete image ${ obj.imageName }:${ obj.tag }?`,
+        type:      'question',
+        buttons:   ['Yes', 'No'],
+        defaultId: 1,
+        title:     'Confirming image deletion',
+        cancelId:  1
+      };
+      const result = await ipcRenderer.invoke('show-message-box', options);
+
+      if (result.response === 1) {
         return;
       }
       this.currentCommand = `delete ${ obj.imageName }:${ obj.tag }`;

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -5,6 +5,7 @@
   <div>
     <div v-if="state === 'READY'" ref="fullWindow">
       <SortableTable
+        class="imagesTable"
         ref="imagesTable"
         :headers="headers"
         :rows="rows"
@@ -366,14 +367,18 @@ export default {
       if (row) {
         this.$nextTick(() => {
           row.scrollIntoView();
-          row.classList.add('greenfade');
+          row.addEventListener('animationend', this.animationEndHandler);
+          row.classList.add('highlightFade');
         });
-        setTimeout(() => {
-          row.classList.remove('greenfade');
-        }, 3_000);
       } else {
         console.log(`Can't find row for ${ image.imageName }:${ image.tag } in the image table`);
       }
+    },
+    animationEndHandler(event) {
+      const row = event.target;
+
+      row.classList.remove('highlightFade');
+      row.removeEventListener('animationend', this.animationEndHandler);
     },
     scrollToNewImage(imageToPull) {
       return () => {
@@ -457,5 +462,17 @@ export default {
   }
   textarea#imageManagerOutput.finished {
     border: 2px solid dodgerblue;
+  }
+
+  @keyframes highlightFade {
+    from {
+      background: var(--accent-btn);
+    } to {
+        background: transparent;
+      }
+  }
+
+  .imagesTable::v-deep tr.highlightFade {
+    animation: highlightFade 1s;
   }
 </style>

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -493,8 +493,8 @@ export default {
     from {
       background: var(--accent-btn);
     } to {
-        background: transparent;
-      }
+      background: transparent;
+    }
   }
 
   .imagesTable::v-deep tr.highlightFade {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -4,25 +4,24 @@
 <template>
   <div>
     <div v-if="state === 'READY'" ref="fullWindow">
-      <div id="imagesTable">
-        <SortableTable
-          :headers="headers"
-          :rows="rows"
-          key-field="imageID"
-          default-sort-by="imageName"
-          :table-actions="false"
-          :paging="true"
-        >
-          <template #header-middle>
-            <Checkbox
-              :disabled="showImageManagerOutput"
-              :value="showAll"
-              :label="t('images.manager.table.label')"
-              @input="handleShowAllCheckbox"
-            />
-          </template>
-        </SortableTable>
-      </div>
+      <SortableTable
+        ref="imagesTable"
+        :headers="headers"
+        :rows="rows"
+        key-field="imageID"
+        default-sort-by="imageName"
+        :table-actions="false"
+        :paging="true"
+      >
+        <template #header-middle>
+          <Checkbox
+            :disabled="showImageManagerOutput"
+            :value="showAll"
+            :label="t('images.manager.table.label')"
+            @input="handleShowAllCheckbox"
+          />
+        </template>
+      </SortableTable>
 
       <Card :show-highlight-border="false" :show-actions="false">
         <template #title>
@@ -384,14 +383,14 @@ export default {
       return this.images.find(image => image.imageName === imageName && image.tag === tag);
     },
     scrollToImage(image) {
-      const row = document.querySelector(`div#imagesTable table.sortable-table tr[data-node-id="${ image.imageID }"]`);
+      const row = this.$refs.imagesTable.$el.querySelector(`tr[data-node-id="${ image.imageID }"]`);
 
       if (row) {
         this.$nextTick(() => {
           row.scrollIntoView();
         });
       } else {
-        console.log(`Can't find row for ${ imageName }:${ tag } in the image table`);
+        console.log(`Can't find row for ${ image.imageName }:${ image.tag } in the image table`);
       }
     },
     scrollToNewImage(imageToPull) {
@@ -408,7 +407,7 @@ export default {
 
         if (!image) {
           console.log(`Can't find ${ imageToPull } ([${ imageName }, ${ tag }]) in the table`);
-          console.log(`Image names: ${ this.images.map(img => `[ ${ img.imageName }:${ img.tag }]`).join('; ') }`)
+          console.log(`Image names: ${ this.images.map(img => `[ ${ img.imageName }:${ img.tag }]`).join('; ') }`);
 
           return;
         }

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -286,7 +286,11 @@ export default {
         this.imageManagerOutput = '';
         if (this.mainWindowScroll >= 0) {
           this.$nextTick(() => {
-            this.$refs.fullWindow.parentElement.parentElement.scrollTop = this.mainWindowScroll;
+            try {
+              this.$refs.fullWindow.parentElement.parentElement.scrollTop = this.mainWindowScroll;
+            } catch (e) {
+              console.log(`trying to reset scroll to ${ this.mainWindowScroll }, got error ${ e }`);
+            }
             this.mainWindowScroll = -1;
           });
         }
@@ -388,7 +392,11 @@ export default {
       if (row) {
         this.$nextTick(() => {
           row.scrollIntoView();
+          row.classList.add('greenfade');
         });
+        setTimeout(() => {
+          row.classList.remove('greenfade');
+        }, 3_000);
       } else {
         console.log(`Can't find row for ${ image.imageName }:${ image.tag } in the image table`);
       }

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -79,7 +79,7 @@
               id="imageManagerOutput"
               ref="outputWindow"
               v-model="imageManagerOutput"
-              :class="{ finished: imageManagerProcessIsFinished}"
+              :class="{ success: imageManagerProcessFinishedWithSuccess, failure: imageManagerProcessFinishedWithFailure }"
               rows="10"
               readonly="true"
             />
@@ -131,7 +131,8 @@ export default {
 
   data() {
     return {
-      currentCommand: null,
+      currentCommand:   null,
+      completionStatus: false,
       headers:
       [
         {
@@ -233,6 +234,12 @@ export default {
     },
     imageManagerProcessIsFinished() {
       return !this.currentCommand;
+    },
+    imageManagerProcessFinishedWithSuccess() {
+      return this.imageManagerProcessIsFinished && this.completionStatus;
+    },
+    imageManagerProcessFinishedWithFailure() {
+      return this.imageManagerProcessIsFinished && !this.completionStatus;
     },
   },
 
@@ -450,6 +457,7 @@ export default {
         this.imageManagerOutput = this.imageOutputCuller.getProcessedData();
       }
       this.currentCommand = null;
+      this.completionStatus = status === 0;
       if (!this.keepImageManagerOutputWindowOpen) {
         this.closeOutputWindow();
       }
@@ -485,8 +493,11 @@ export default {
     font-family: monospace;
     font-size: smaller;
   }
-  textarea#imageManagerOutput.finished {
-    border: 2px solid dodgerblue;
+  textarea#imageManagerOutput.success {
+    border: 2px solid var(--success);
+  }
+  textarea#imageManagerOutput.failure {
+    border: 2px solid var(--error);
   }
 
   @keyframes highlightFade {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -333,9 +333,6 @@ export default {
       ipcRenderer.send('do-image-push', obj.imageName.trim(), obj.imageID.trim(), obj.tag.trim());
     },
     doBuildAnImage() {
-      if (this.highlightExistingImage(this.imageToBuild)) {
-        return;
-      }
       this.currentCommand = `build ${ this.imageToBuild }`;
       this.fieldToClear = 'imageToBuild';
       this.postCloseOutputWindowHandler = this.scrollToNewImage(this.imageToBuild);
@@ -343,34 +340,11 @@ export default {
       ipcRenderer.send('do-image-build', this.imageToBuild.trim());
     },
     doPullAnImage() {
-      if (this.highlightExistingImage(this.imageToPull)) {
-        return;
-      }
       this.currentCommand = `pull ${ this.imageToPull }`;
       this.fieldToClear = 'imageToPull';
       this.postCloseOutputWindowHandler = this.scrollToNewImage(this.imageToPull);
       this.startRunningCommand('pull');
       ipcRenderer.send('do-image-pull', this.imageToPull.trim());
-    },
-    /**
-     * If the named image is loaded, scroll to it and return true.
-     * Otherwise return false.
-     * @param fullImageName {string{}}
-     * @returns {boolean}
-     */
-    highlightExistingImage(fullImageName) {
-      const [imageName, tag] = this.parseFullImageName(fullImageName);
-
-      const image = this.getImageByNameAndTag(imageName, tag);
-
-      if (image) {
-        window.alert(`Image ${ fullImageName } is already loaded`);
-        this.scrollToImage(image);
-
-        return true;
-      }
-
-      return false;
     },
     /**
      * syntax of a fully qualified tag could start with <hostname>:<port>/

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -162,7 +162,6 @@ export default {
       fieldToClear:                     '',
       imageOutputCuller:                null,
       mainWindowScroll:                 -1,
-      postOpSuccessHandler:             null,
       postCloseOutputWindowHandler:     null,
     };
   },
@@ -342,7 +341,6 @@ export default {
       }
       this.currentCommand = `delete ${ obj.imageName }:${ obj.tag }`;
       this.mainWindowScroll = this.$refs.fullWindow.parentElement.parentElement.scrollTop;
-      this.postOpSuccessHandler = this.postHandleNoOutputHandler;
       this.startRunningCommand('delete');
       ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
     },
@@ -362,7 +360,6 @@ export default {
 
       this.currentCommand = `build ${ imageName }`;
       this.fieldToClear = 'imageToBuild';
-      this.postOpSuccessHandler = this.postHandleNoOutputHandler;
       this.postCloseOutputWindowHandler = () => this.scrollToImageOnSuccess(imageName);
       this.startRunningCommand('build');
       ipcRenderer.send('do-image-build', imageName);
@@ -372,7 +369,6 @@ export default {
 
       this.currentCommand = `pull ${ imageName }`;
       this.fieldToClear = 'imageToPull';
-      this.postOpSuccessHandler = this.postHandleNoOutputHandler;
       this.postCloseOutputWindowHandler = () => this.scrollToImageOnSuccess(imageName);
       this.startRunningCommand('pull');
       ipcRenderer.send('do-image-pull', imageName);
@@ -458,9 +454,8 @@ export default {
         this.imageManagerOutput = this.imageOutputCuller.getProcessedData();
       }
       this.currentCommand = null;
-      if (this.postOpSuccessHandler) {
-        this.postOpSuccessHandler();
-        this.postOpSuccessHandler = null;
+      if (!this.keepImageManagerOutputWindowOpen) {
+        this.closeOutputWindow();
       }
     },
     isDeletable(row) {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -321,7 +321,6 @@ export default {
       this.postOpSuccessHandler = this.postDeleteSuccessHandler;
       this.startRunningCommand('delete');
       ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
-      ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
     },
     postDeleteSuccessHandler() {
       if (this.imageManagerOutput === '') {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -289,7 +289,7 @@ export default {
             try {
               this.$refs.fullWindow.parentElement.parentElement.scrollTop = this.mainWindowScroll;
             } catch (e) {
-              console.log(`trying to reset scroll to ${ this.mainWindowScroll }, got error ${ e }`);
+              console.log(`Trying to reset scroll to ${ this.mainWindowScroll }, got error:`, e);
             }
             this.mainWindowScroll = -1;
           });

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -70,7 +70,7 @@ export function setupKim(k8sManager: K8s.KubernetesBackend) {
       }
       event.reply('kim-process-ended', 0);
     } catch (err) {
-      Electron.dialog.showMessageBox({
+      await Electron.dialog.showMessageBox({
         message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
         type:    'error'
       });

--- a/src/main/kim.ts
+++ b/src/main/kim.ts
@@ -49,44 +49,32 @@ export function setupKim(k8sManager: K8s.KubernetesBackend) {
     return imageManager.listImages();
   });
 
-  Electron.ipcMain.on('confirm-do-image-deletion', async(event, imageName, imageID) => {
-    const choice = Electron.dialog.showMessageBoxSync({
-      message:   `Delete image ${ imageName }?`,
-      type:      'warning',
-      buttons:   ['Yes', 'No'],
-      defaultId: 1,
-      title:     `Delete image ${ imageName }`,
-      cancelId:  1
-    });
+  Electron.ipcMain.on('do-image-deletion', async(event, imageName, imageID) => {
+    try {
+      const maxNumAttempts = 2;
+      // On macOS a second attempt is needed to actually delete the image.
+      // Probably due to a timing issue on the server part of kim, but not determined why.
+      // Leave this in for windows in case it can happen there too.
+      let i = 0;
 
-    if (choice === 0) {
-      try {
-        const maxNumAttempts = 2;
-        // On macOS a second attempt is needed to actually delete the image.
-        // Probably due to a timing issue on the server part of kim, but not determined why.
-        // Leave this in for windows in case it can happen there too.
-        let i = 0;
-
-        for (i = 0; i < maxNumAttempts; i++) {
-          await imageManager.deleteImage(imageID);
-          await imageManager.refreshImages();
-          if (!imageManager.listImages().some(image => image.imageID === imageID)) {
-            break;
-          }
-          await util.promisify(setTimeout)(500);
+      for (i = 0; i < maxNumAttempts; i++) {
+        await imageManager.deleteImage(imageID);
+        await imageManager.refreshImages();
+        if (!imageManager.listImages().some(image => image.imageID === imageID)) {
+          break;
         }
-        if (i === maxNumAttempts) {
-          console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
-        }
-        event.reply('kim-process-ended', 0);
-      } catch (err) {
-        Electron.dialog.showMessageBox({
-          message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
-          type:    'error'
-        });
+        await util.promisify(setTimeout)(500);
       }
-    } else {
-      event.reply('kim-process-cancelled');
+      if (i === maxNumAttempts) {
+        console.log(`Failed to delete ${ imageID } in ${ maxNumAttempts } tries`);
+      }
+      event.reply('kim-process-ended', 0);
+    } catch (err) {
+      Electron.dialog.showMessageBox({
+        message: `Error trying to delete image ${ imageName } (${ imageID }):\n\n ${ err.stderr } `,
+        type:    'error'
+      });
+      event.reply('kim-process-ended', 1);
     }
   });
 

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -43,6 +43,7 @@ interface IpcMainEvents {
   'do-image-pull': (imageName: string) => void;
   'do-image-scan': (imageName: string) => void;
   'do-image-push': (imageName: string, imageID: string, tag: string) => void;
+  'do-image-deletion': (imageName: string, imageID: string) => void;
   // #endregion
 
   'troubleshooting/show-logs': () => void;
@@ -58,6 +59,7 @@ interface IpcMainInvokeEvents {
   'service-fetch': (namespace?: string) => import('@/k8s-engine/k8s').ServiceEntry[];
   'service-forward': (service: {namespace: string, name: string, port: string | number}, state: boolean) => void;
   'get-app-version': () => string;
+  'show-message-box': (options: Electron.MessageBoxOptions) => Promise<Electron.MessageBoxReturnValue>;
 
   // #region main/kim
   'images-mounted': (mounted: boolean) => {imageName: string, tag: string, imageID: string, size: string}[];


### PR DESCRIPTION
1. Post-successful-op (usually no need to see the output window)
2. Post-close-output-window (either scroll back, or see the new row)

In particular:
- Finish a pull: show the new image in the image table
- Finish a delete: close the output-window

  -- Closing the output window will carry out the default action
     of scrolling back to the previous spot.

Also:
- Verify that an attempted pull or build doesn't duplicate an existing image
- Use a highlighted fade to indicate image row of interest
- Extract the call to `Electron.dialog.showMessageBoxSync` into a general-purpose handler.

Signed-off-by: Eric Promislow <epromislow@suse.com>