### PR TITLE
Fix issue with process hold on renaming kubectl with kuberlr

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -46,7 +46,7 @@ async function findHome(onWindows) {
 }
 
 async function downloadKuberlr(kubePlatform, destDir) {
-  const kuberlrVersion = '0.4.0';
+  const kuberlrVersion = '0.4.1';
   const baseURL = `https://github.com/flavio/kuberlr/releases/download/v${ kuberlrVersion }`;
   const platformDir = `kuberlr_${ kuberlrVersion }_${ kubePlatform }_amd64`;
   const archiveName = platformDir + (kubePlatform.startsWith('win') ? '.zip' : '.tar.gz');


### PR DESCRIPTION
The fix was in upstream kuberlr and this pulls in the fix.

This fixes the issue experienced with...

```
Cross-device error trying to rename a file: rename C:\Users\Matt\AppData\Local\Temp\kuberlr-kubectl-891226303 C:\Users\Matt\.kuberlr\windows-amd64\kubectl1.17.17.exe: The process cannot access the file because it is being used by another process. -- will do a full copy
F0816 20:37:52.143752   14380 main.go:69] rename C:\Users\Matt\AppData\Local\Temp\kuberlr-kubectl-891226303 C:\Users\Matt\.kuberlr\windows-amd64\kubectl1.17.17.exe: The process cannot access the file because it is being used by another process.
```