### PR TITLE
Reset split

### DIFF
--- a/src/components/form/SplitButton.vue
+++ b/src/components/form/SplitButton.vue
@@ -211,6 +211,8 @@ export default SplitButton;
     border: 1px solid var(--dropdown-border);
     border-radius: var(--border-radius);
     box-shadow: 0 5px 20px var(--shadow);
+    /* Hide overflow to clip out the corners from border-radius */
+    overflow: hidden;
 
     li {
       margin: 0;

--- a/src/components/form/SplitButton.vue
+++ b/src/components/form/SplitButton.vue
@@ -189,13 +189,22 @@ export default SplitButton;
     position: relative;
     /* Remove the right padding so that the split button goes all the way */
     padding-right: 0;
+
+    &.role-secondary {
+      .indicator {
+        border-left: 1px solid var(--primary);
+      }
+    }
   }
   .indicator {
-    padding-right: $btn-padding;
+    margin-left: $btn-padding / 2;
+    padding: 0 ($btn-padding / 2);
     background: transparent;
     border: none;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
     box-shadow: none;
-    &:focus {
+    &:focus::before {
       outline: 1px dashed;
     }
   }

--- a/src/components/form/SplitButton.vue
+++ b/src/components/form/SplitButton.vue
@@ -1,0 +1,237 @@
+<!--
+  - Split Button, as found in Windows:
+  -
+  - Normal State:          Click on the dropdown button (expanded):
+  - +-------------+---+    +-------------+---+
+  - | Button Text | v |    | Button Text | v |
+  - +-------------+---+    +-------------+---+
+  -                        | Option 1        |
+  -                        | Option 2        |
+  -                        +-----------------+
+  -
+  -->
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import Component from 'vue-class-component';
+
+type Option = {
+  /** The label to display as the option. */
+  label: string;
+  /** The value that will be emitted on @input */
+  id: string;
+  /** Optional icon */
+  icon?: string;
+}
+
+const SplitButtonProps = Vue.extend({
+  props: {
+    /** The main button text */
+    label: {
+      type:    String,
+      default: '',
+    },
+    /**
+     * The dropdown options.
+     * If the item is a string, then the label will be emitted.
+     */
+    options: {
+      type:    Array as PropType<(Option | string)[]>,
+      default: () => [],
+    },
+    /** The value to emit when the main button is clicked. */
+    value: {
+      type:    String,
+      default: '',
+    },
+    disabled: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+});
+
+@Component
+class SplitButton extends SplitButtonProps {
+  /** Whether the popup is open */
+  protected showing = false;
+
+  /**
+   * Because everything is inside the top <button>, we need to suppress any
+   * click events that are fired on it when its children (e.g. the dropdown) are
+   * clicked.  Call this to do so.
+   * @returns true if suppression is active.
+   */
+  protected suppress() {
+    if (this.suppressed) {
+      return true;
+    }
+    this.suppressed = true;
+    setImmediate(() => (this.suppressed = false));
+
+    return false;
+  }
+
+  protected suppressed = false;
+
+  get computedOptions(): Option[] {
+    return this.options.map((option) => {
+      if (typeof (option) === 'string') {
+        return { label: option, id: option };
+      }
+
+      return option;
+    });
+  }
+
+  show() {
+    this.showing = !this.disabled;
+    this.$nextTick(() => this.popupFocus(1));
+  }
+
+  hide() {
+    // Call suppress here, in case user clicked on .background to close the popup.
+    this.suppress();
+    this.showing = false;
+    (this.$el as HTMLElement).focus();
+  }
+
+  execute(id?: string) {
+    if (this.suppress()) {
+      return;
+    }
+
+    this.$emit('input', typeof id === 'undefined' ? this.value : id);
+    this.hide();
+  }
+
+  popupUp(event: KeyboardEvent) {
+    const elem = event.target as Element | null;
+    const prev = elem?.previousElementSibling as HTMLElement | null;
+
+    prev?.focus();
+  }
+
+  popupDown(event: KeyboardEvent) {
+    const elem = event.target as Element | null;
+    const next = elem?.nextElementSibling as HTMLElement | null;
+
+    next?.focus();
+  }
+
+  popupFocus(n: number) {
+    if (n < 0) {
+      n += this.computedOptions.length + 1;
+    }
+    const elem = this.$el.querySelector(`.menu > li:nth-child(${ n })`) as HTMLElement | null;
+
+    elem?.focus();
+  }
+
+  popupHover(event: MouseEvent) {
+    (event.target as HTMLElement | null)?.focus();
+  }
+
+  popupTrigger(event: KeyboardEvent) {
+    const newEvent = new MouseEvent('click');
+
+    event.target?.dispatchEvent(newEvent);
+  }
+}
+
+export default SplitButton;
+</script>
+
+<template>
+  <button
+    class="btn split-button"
+    :disabled="disabled"
+    @click.self="execute()"
+    @keyup.esc="hide"
+  >
+    {{ label }}
+    <button
+      v-if="computedOptions.length > 0"
+      ref="indicator"
+      class="indicator icon-btn icon icon-chevron-down role-multi-action"
+      :aria-expanded="showing"
+      @click="show"
+    >
+    </button>
+    <div v-if="showing" class="background" @click="hide" @contextmenu.prevent></div>
+    <ul v-if="showing" class="list-unstyled menu">
+      <li
+        v-for="opt in computedOptions"
+        :key="opt.id"
+        role="menuitem"
+        tabindex="0"
+        @click.stop="execute(opt.id)"
+        @keydown.home.prevent="popupFocus(1)"
+        @keydown.end.prevent="popupFocus(-1)"
+        @keydown.arrow-up.prevent="popupUp"
+        @keydown.arrow-down.prevent="popupDown"
+        @keypress.space.prevent="popupTrigger"
+        @keypress.enter.prevent="popupTrigger"
+        @mouseover="popupHover"
+      >
+        <i v-if="opt.icon" :class="{icon: true, [opt.icon]: true}" />
+        <span v-text="opt.label" />
+      </li>
+    </ul>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+  /* $btn-padding copied from _button.scss */
+  $btn-padding: 21px;
+
+  .split-button {
+    position: relative;
+    /* Remove the right padding so that the split button goes all the way */
+    padding-right: 0;
+  }
+  .indicator {
+    padding-right: $btn-padding;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    &:focus {
+      outline: 1px dashed;
+    }
+  }
+  .menu {
+    @include list-unstyled;
+
+    position: absolute;
+    margin-left: 0px - $btn-padding - /* border */ 1px;
+    z-index: z-index('dropdownContent');
+
+    color: var(--dropdown-text);
+    background-color: var(--dropdown-bg);
+    border: 1px solid var(--dropdown-border);
+    border-radius: var(--border-radius);
+    box-shadow: 0 5px 20px var(--shadow);
+
+    li {
+      margin: 0;
+      padding: 0 1em;
+      &:focus {
+        background-color: var(--dropdown-hover-bg);
+        color: var(--dropdown-hover-text);
+      }
+      .icon {
+        display: unset;
+      }
+    }
+  }
+
+  .background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    z-index: z-index('dropdownOverlay');
+  }
+  </style>

--- a/src/components/form/SplitButton.vue
+++ b/src/components/form/SplitButton.vue
@@ -174,7 +174,7 @@ export default SplitButton;
         @keypress.enter.prevent="popupTrigger"
         @mouseover="popupHover"
       >
-        <i v-if="opt.icon" :class="{icon: true, [opt.icon]: true}" />
+        <i v-if="opt.icon" :class="{icon: true, [`icon-${opt.icon}`]: true}" />
         <span v-text="opt.label" />
       </li>
     </ul>

--- a/src/components/form/__tests__/SplitButton.spec.ts
+++ b/src/components/form/__tests__/SplitButton.spec.ts
@@ -1,0 +1,154 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import SplitButton from '../SplitButton.vue';
+
+function wrap(props: Record<string, any>) {
+  return mount(SplitButton, { propsData: props });
+}
+
+describe('SplitButton.vue', () => {
+  it('should have the correct label', () => {
+    const wrapper = wrap({ label: 'hello' });
+
+    expect(wrapper.get('button').text()).toEqual('hello');
+  });
+
+  it('should not have dropdown if no options given', () => {
+    const wrapper = wrap({});
+
+    expect(wrapper.find({ ref: 'indicator' }).exists()).toBeFalsy();
+    expect(wrapper.find('ul').exists()).toBeFalsy();
+  });
+
+  it('should accept click and emit the correct value', async() => {
+    const wrapper = wrap({ value: 'yes' });
+
+    await wrapper.trigger('click');
+    expect(wrapper.emitted('input')?.flat() ?? []).toContain('yes');
+  });
+
+  it('should not work when disabled', async() => {
+    const wrapper = wrap({ value: 'yes', disabled: true });
+
+    await wrapper.trigger('click');
+    expect(wrapper.emitted('input')).toBeUndefined();
+  });
+
+  describe('dropdown handling', () => {
+    let wrapper: Wrapper<SplitButton>;
+
+    beforeEach(async() => {
+      wrapper = wrap({
+        value:    'top',
+        options:  ['hello', 'world', { id: 'lorem', icon: 'sun' }, 'ipsum'],
+      });
+      await wrapper.get({ ref: 'indicator' }).trigger('click');
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
+    it('should generate a dropdown', () => {
+      expect(wrapper.findAll('ul li').length).toBeGreaterThan(0);
+    });
+
+    it('supports icons', () => {
+      const icon = wrapper.find('ul li:nth-child(3) i');
+
+      expect(icon).not.toBeNull();
+      expect(icon.element.classList).toContain('icon');
+      expect(icon.element.classList).toContain('icon-sun');
+    });
+
+    it('shoud trigger on click', async() => {
+      const item = wrapper.findAll('ul li').filter(w => w.text() === 'hello').at(0);
+
+      await item.trigger('click');
+      expect(Object.keys(wrapper.emitted())).toContain('input');
+      expect(wrapper.emitted('input')?.flat() ?? []).not.toContain('top');
+      expect(wrapper.emitted('input')?.flat() ?? []).toContain('hello');
+    });
+
+    it('shoud trigger on enter', async() => {
+      const item = wrapper.findAll('ul li').filter(w => w.text() === 'hello').at(0);
+
+      await item.trigger('keypress.enter');
+      expect(Object.keys(wrapper.emitted())).toContain('input');
+      expect(wrapper.emitted('input')?.flat() ?? []).not.toContain('top');
+      expect(wrapper.emitted('input')?.flat() ?? []).toContain('hello');
+    });
+
+    it('shoud trigger on space', async() => {
+      const item = wrapper.findAll('ul li').filter(w => w.text() === 'hello').at(0);
+
+      await item.trigger('keypress.space');
+      expect(Object.keys(wrapper.emitted())).toContain('input');
+      expect(wrapper.emitted('input')?.flat() ?? []).not.toContain('top');
+      expect(wrapper.emitted('input')?.flat() ?? []).toContain('hello');
+    });
+
+    it('should focus the first element by default', () => {
+      const options = wrapper.findAll('ul li');
+      const firstOption = options.filter(w => w.text() === 'hello').at(0);
+      const document = wrapper.element.ownerDocument;
+
+      expect(document.activeElement).toBe(firstOption.element);
+    });
+
+    it('should focus on mouse over', async() => {
+      const options = wrapper.findAll('ul li');
+      const secondOption = options.filter(w => w.text() === 'world').at(0);
+      const document = wrapper.element.ownerDocument;
+
+      expect(document.activeElement).not.toBe(secondOption.element);
+      await secondOption.trigger('mouseover');
+      expect(document.activeElement).toBe(secondOption.element);
+    });
+
+    it('should respond to arrow-up key', async() => {
+      const options = wrapper.findAll('ul li');
+      const document = wrapper.element.ownerDocument;
+      const lastOption = options.at(options.length - 1);
+      const secondLastOption = options.at(options.length - 2);
+
+      await lastOption.trigger('mouseover');
+      expect(document.activeElement).toBe(lastOption.element);
+      await lastOption.trigger('keydown', { key: 'ArrowUp' });
+      expect(document.activeElement).toBe(secondLastOption.element);
+    });
+
+    it('should respond to arrow-down key', async() => {
+      const options = wrapper.findAll('ul li');
+      const document = wrapper.element.ownerDocument;
+      const firstOption = options.at(0);
+      const secondOption = options.at(1);
+
+      expect(document.activeElement).toBe(firstOption.element);
+      await firstOption.trigger('keydown', { key: 'ArrowDown' });
+      expect(document.activeElement).toBe(secondOption.element);
+    });
+
+    it('should respond to home key', async() => {
+      const options = wrapper.findAll('ul li');
+      const document = wrapper.element.ownerDocument;
+      const firstOption = options.at(0);
+      const secondOption = options.at(1);
+
+      await secondOption.trigger('mouseover');
+      expect(document.activeElement).toBe(secondOption.element);
+      await secondOption.trigger('keydown', { key: 'Home' });
+      expect(document.activeElement).toBe(firstOption.element);
+    });
+
+    it('should respond to end key', async() => {
+      const options = wrapper.findAll('ul li');
+      const document = wrapper.element.ownerDocument;
+      const firstOption = options.at(0);
+      const lastOption = options.at(options.length - 1);
+
+      expect(document.activeElement).not.toBe(lastOption.element);
+      await firstOption.trigger('keydown', { key: 'End' });
+      expect(document.activeElement).toBe(lastOption.element);
+    });
+  });
+});

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -24,7 +24,7 @@ interface IpcMainEvents {
   'k8s-restart': () => void;
   'settings-read': () => void;
   'k8s-versions': () => void;
-  'k8s-reset': (mode: 'slow' | 'fast' | undefined) => void;
+  'k8s-reset': (mode: 'fast' | 'wipe') => void;
   'k8s-state': () => void;
   'k8s-current-port': () => void;
   'k8s-restart-required': () => void;


### PR DESCRIPTION
This make it possible to force-wipe the VM, instead of just deleting select data. Fixes #391.

I didn't use dashboard's `ButtonMenu` because it behaves like a `<select>`: the main display really isn't meant to be clicked on.  The new component is modelled more after a [Windows split button](https://docs.microsoft.com/en-us/windows/win32/controls/button-types-and-styles).

This is built on top of #515.

<img width="196" alt="image" src="https://user-images.githubusercontent.com/3977982/130132654-553796d1-1e2e-47ad-8c6e-d0ffdb0547bd.png"> Focusing on the drop down part of the button.

<img width="304" alt="image" src="https://user-images.githubusercontent.com/3977982/130132625-3d8d2a12-7724-42f5-b77d-c3a3b88f7460.png"> Menu opened. Clicking the selection will trigger the action.
