### PR TITLE
222 fix menu bars

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -21,6 +21,7 @@ import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
 import setupPaths from '@/main/paths';
+import buildApplicationMenu from '@/main/mainmenu';
 
 Electron.app.setName('Rancher Desktop');
 
@@ -153,6 +154,7 @@ Electron.app.whenReady().then(async() => {
     callback(result);
   });
   protocolRegistered.resolve();
+  buildApplicationMenu();
   window.openPreferences();
 
   setupKim(k8smanager);

--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -23,7 +23,7 @@ function getEditMenu(isMac: boolean): MenuItem {
     label:   '&Edit',
     submenu: [
       { role: 'undo', label: '&Undo' },
-      { role: 'redo', label: 'Redo' },
+      { role: 'redo', label: '&Redo' },
       { type: 'separator' },
       { role: 'cut', label: 'Cu&t' },
       { role: 'copy', label: '&Copy' },
@@ -39,7 +39,7 @@ function getHelpMenu(isMac: boolean): MenuItem {
   const helpMenuItems: Array<MenuItemConstructorOptions> = [
     ...(!isMac ? [
       { role: 'about', label: `&About ${ Electron.app.name }` } as MenuItemConstructorOptions,
-      { type: 'separator' } as Electron.MenuItemConstructorOptions] : []),
+      { type: 'separator' } as MenuItemConstructorOptions] : []),
     {
       label: 'Get &Help',
       click() {

--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -1,0 +1,137 @@
+import Electron, { Menu, MenuItem, MenuItemConstructorOptions, shell } from 'electron';
+
+export default function buildApplicationMenu(): void {
+  const menuItems: Array<MenuItem> = getApplicationMenu();
+  const menu = Menu.buildFromTemplate(menuItems);
+
+  Menu.setApplicationMenu(menu);
+}
+
+function getApplicationMenu(): Array<MenuItem> {
+  switch (process.platform) {
+  case 'darwin':
+    return getMacApplicationMenu();
+  case 'win32':
+    return getWindowsApplicationMenu();
+  default:
+    throw new Error(`Unsupported platform: ${ process.platform }`);
+  }
+}
+
+function getEditMenu(isMac: boolean): MenuItem {
+  return new MenuItem({
+    label:   '&Edit',
+    submenu: [
+      { role: 'undo', label: '&Undo' },
+      { role: 'redo', label: 'Redo' },
+      { type: 'separator' },
+      { role: 'cut', label: 'Cu&t' },
+      { role: 'copy', label: '&Copy' },
+      { role: 'paste', label: '&Paste' },
+      { role: 'delete', label: 'De&lete' },
+      ...(!isMac ? [{ type: 'separator' } as MenuItemConstructorOptions] : []),
+      { role: 'selectAll', label: 'Select &All' },
+    ]
+  });
+}
+
+function getHelpMenu(isMac: boolean): MenuItem {
+  const helpMenuItems: Array<MenuItemConstructorOptions> = [
+    ...(!isMac ? [
+      { role: 'about', label: `&About ${ Electron.app.name }` } as MenuItemConstructorOptions,
+      { type: 'separator' } as Electron.MenuItemConstructorOptions] : []),
+    {
+      label: 'Get &Help',
+      click() {
+        shell.openExternal('https://github.com/rancher-sandbox/rancher-desktop/tree/main/docs');
+      },
+    },
+    {
+      label: 'File a &Bug',
+      click() {
+        shell.openExternal('https://github.com/rancher-sandbox/rancher-desktop/issues');
+      },
+    },
+    {
+      label: '&Project Page',
+      click() {
+        shell.openExternal('https://rancherdesktop.io/');
+      },
+    },
+    {
+      label: '&Discuss',
+      click() {
+        shell.openExternal('https://slack.rancher.io/');
+      },
+    },
+  ];
+
+  return new MenuItem({
+    role:    'help',
+    label:   '&Help',
+    submenu: helpMenuItems
+  });
+}
+
+function getMacApplicationMenu(): Array<MenuItem> {
+  return [
+    new MenuItem({
+      label: Electron.app.name,
+      role:  'appMenu',
+    }),
+    new MenuItem({
+      label: 'File',
+      role:  'fileMenu',
+    }),
+    getEditMenu(true),
+    Electron.app.isPackaged ? new MenuItem({
+      label:   'View',
+      submenu: [
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ]
+    }) : new MenuItem({
+      label: 'View',
+      role:  'viewMenu',
+    }),
+    new MenuItem({
+      label: '&Window',
+      role:  'windowMenu',
+    }),
+    getHelpMenu(true),
+  ];
+}
+
+function getWindowsApplicationMenu(): Array<MenuItem> {
+  return [
+    new MenuItem({
+      label:   '&File',
+      role:    'fileMenu',
+      submenu: [
+        { role: 'quit', label: 'E&xit' }
+      ]
+    }),
+    getEditMenu(false),
+    new MenuItem({
+      label:   '&View',
+      role:    'viewMenu',
+      submenu: [
+        ...(Electron.app.isPackaged ? [] : [
+          { role: 'reload', label: '&Reload' },
+          { role: 'forceReload', label: '&Force Reload' },
+          { role: 'toggleDevTools', label: 'Toggle &Developer Tools' },
+          { type: 'separator' },
+        ] as MenuItemConstructorOptions[]),
+        { role: 'resetZoom', label: '&Actual Size' },
+        { role: 'zoomIn', label: 'Zoom &In' },
+        { role: 'zoomOut', label: 'Zoom &Out' },
+        { type: 'separator' },
+        { role: 'togglefullscreen', label: 'Toggle Full &Screen' },
+      ]
+    }),
+    getHelpMenu(false),
+  ];
+}


### PR DESCRIPTION
So this is a somewhat brute-force, brittle approach that will get out of date when Electron changes the menubar structure on a future version. We control which version we're using, so at least we can control what the menus look like.

Now the Electron menu is not modifiable per se, but there's nothing stopping me from calling `Menu.getApplicationMenu()` to get the current menu, convert it to a template, make desired changes to the template, and then reset the menu based on the template.

Except the only changes were to completely change the Help menu, and disable the `Edit|Speech` submenu and the `Edit|Paste and Match Style` menu items.  And Electron ignored my request to disable the fancy-paste menuitem. So I went with the simpler code.