### PR TITLE
Lima: Add symlinks to lima logs in main log dir.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -562,12 +562,13 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       } finally {
         // Symlink the logs (especially if start failed) so the users can find them
         const machineDir = path.join(LIMA_HOME, MACHINE_NAME);
-        const fileNames = ['serial.log', 'ha.stdout.log', 'ha.stderr.log'];
 
         // Start the process, but ignore the result.
-        fileNames.forEach(filename => fs.promises.symlink(
-          path.join(machineDir, filename),
-          path.join(Logging[LoggingPath], filename)));
+        fs.promises.readdir(machineDir)
+          .then(filenames => filenames.filter(x => x.endsWith('.log'))
+            .forEach(filename => fs.promises.symlink(
+              path.join(machineDir, filename),
+              path.join(Logging[LoggingPath], filename))));
       }
 
       await this.killStaleProcesses();

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -17,7 +17,7 @@ import merge from 'lodash/merge';
 
 import { Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
-import Logging from '@/utils/logging';
+import Logging, { PATH as LoggingPath } from '@/utils/logging';
 import resources from '@/resources';
 import DEFAULT_CONFIG from '@/assets/lima-config.yaml';
 import INSTALL_K3S_SCRIPT from '@/assets/scripts/install-k3s';
@@ -557,7 +557,18 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }
 
       // Start the VM; if it's already running, this does nothing.
-      await this.lima('start', '--tty=false', await this.isRegistered ? MACHINE_NAME : CONFIG_PATH);
+      try {
+        await this.lima('start', '--tty=false', await this.isRegistered ? MACHINE_NAME : CONFIG_PATH);
+      } finally {
+        // Symlink the logs (especially if start failed) so the users can find them
+        const machineDir = path.join(LIMA_HOME, MACHINE_NAME);
+        const fileNames = ['serial.log', 'ha.stdout.log', 'ha.stderr.log'];
+
+        // Start the process, but ignore the result.
+        fileNames.forEach(filename => fs.promises.symlink(
+          path.join(machineDir, filename),
+          path.join(Logging[LoggingPath], filename)));
+      }
 
       await this.killStaleProcesses();
       await this.deleteIncompatibleData(isDowngrade);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -568,7 +568,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           .then(filenames => filenames.filter(x => x.endsWith('.log'))
             .forEach(filename => fs.promises.symlink(
               path.join(machineDir, filename),
-              path.join(Logging[LoggingPath], filename))));
+              path.join(Logging[LoggingPath], `lima.${ filename }`))));
       }
 
       await this.killStaleProcesses();


### PR DESCRIPTION
This makes it easier for the users to find them (and send them to us). From interacting with people reporting issues, it seems like locating the lima logs is an issue (because they're out of the way); combined with the show logs button this should make things easier.
