### PR TITLE
Use production upgrade server.

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,5 +29,5 @@ nsis:
   oneClick: false # Needed for restart prompt
 publish:
   provider: custom
-  #upgradeServer: https://upgrade-server.example.com/v1/checkupgrade
+  upgradeServer: https://desktop.version.rancher.io/v1/checkupgrade
   vPrefixedTagName: true

--- a/src/components/UpdateStatus.vue
+++ b/src/components/UpdateStatus.vue
@@ -78,7 +78,7 @@ class UpdateStatus extends UpdateStatusProps {
   }
 
   get updateReady() {
-    return this.hasUpdate && !!this.updateState?.downloaded;
+    return this.hasUpdate && !!this.updateState?.downloaded && !this.updateState?.error;
   }
 
   get statusMessage(): string {

--- a/src/components/__tests__/UpdateStatus.spec.ts
+++ b/src/components/__tests__/UpdateStatus.spec.ts
@@ -42,11 +42,15 @@ describe('UpdateStatus.vue', () => {
     it('displays error correctly', () => {
       const wrapper = wrap({
         enabled:     true,
-        updateState: { available: true, error: new Error('hello') } as UpdateState,
+        updateState: {
+          available: true, error: new Error('hello'), downloaded: true
+        } as UpdateState,
       });
 
       expect(wrapper.findComponent({ ref: 'updateStatus' }).text())
         .toEqual('There was an error checking for updates.');
+      expect(wrapper.element.querySelector('.update-notification'))
+        .toBeFalsy();
     });
 
     it('hides when there is nothing to display', () => {

--- a/src/main/update/LonghornUpdater.ts
+++ b/src/main/update/LonghornUpdater.ts
@@ -51,6 +51,6 @@ export class MacLonghornUpdater extends MacUpdater {
   }
 
   findAsset(assets: GithubReleaseAsset[]): GithubReleaseAsset | undefined {
-    return assets.find(asset => asset.name.endsWith('.dmg'));
+    return assets.find(asset => asset.name.endsWith('-mac.zip'));
   }
 }


### PR DESCRIPTION
This means that all dev builds will also use the server.

Pros:
- Make sure we can test against the actual server
- Eliminate issues from trying to hack it in at build time

Cons:
- Pollutes production data with dev builds (that can be filtered out, but takes effort)