### PR TITLE
Change where we store application data

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -13,9 +13,10 @@ import * as settings from '@/config/settings';
 import * as window from '@/window';
 import * as K8s from '@/k8s-engine/k8s';
 import resources from '@/resources';
-import Logging, { PATH as LoggingPath } from '@/utils/logging';
+import Logging from '@/utils/logging';
 import * as childProcess from '@/utils/childProcess';
 import Latch from '@/utils/latch';
+import paths from '@/utils/paths';
 import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
@@ -381,8 +382,7 @@ Electron.ipcMain.on('factory-reset', async() => {
 });
 
 Electron.ipcMain.on('troubleshooting/show-logs', async(event) => {
-  const logPath = Logging[LoggingPath];
-  const error = await Electron.shell.openPath(logPath);
+  const error = await Electron.shell.openPath(paths.logs);
 
   if (error) {
     const browserWindow = Electron.BrowserWindow.fromWebContents(event.sender);
@@ -390,7 +390,7 @@ Electron.ipcMain.on('troubleshooting/show-logs', async(event) => {
       message: error,
       type:    'error',
       title:   `Error opening logs`,
-      detail:  `Please manually open ${ logPath }`,
+      detail:  `Please manually open ${ paths.logs }`,
     };
 
     console.error(`Failed to open logs: ${ error }`);

--- a/background.ts
+++ b/background.ts
@@ -20,10 +20,13 @@ import paths from '@/utils/paths';
 import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
+import setupPaths from '@/main/paths';
 
 Electron.app.setName('Rancher Desktop');
 
 const console = new Console(Logging.background.stream);
+
+setupPaths();
 
 let k8smanager = newK8sManager();
 let cfg: settings.Settings;

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -220,9 +220,9 @@ const updateTable: Record<number, (settings: any) => void> = {
     if (os.platform() === 'darwin') {
       console.log('Removing hyperkit virtual machine files');
       try {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line deprecation/deprecation -- Needed for compatibility.
         fs.accessSync(paths.hyperkit);
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line deprecation/deprecation -- Needed for compatibility.
         fs.rmSync(paths.hyperkit, { recursive: true, force: true });
       } catch (err) {
         if (err !== 'ENOENT') {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -9,10 +9,10 @@ import { dirname, join } from 'path';
 
 import _ from 'lodash';
 
-import Logging from '../utils/logging';
+import Logging from '@/utils/logging';
+import paths from '@/utils/paths';
 
 const console = new Console(Logging.settings.stream);
-const paths = require('xdg-app-paths')({ name: 'rancher-desktop' });
 
 // Settings versions are independent of app versions.
 // Any time a version changes, increment its version by 1.
@@ -43,7 +43,7 @@ export type Settings = typeof defaultSettings;
  * Load the settings file
  */
 export function load(): Settings {
-  const rawdata = fs.readFileSync(join(paths.config(), 'settings.json'));
+  const rawdata = fs.readFileSync(join(paths.config, 'settings.json'));
   let settings;
 
   try {
@@ -65,10 +65,10 @@ export function load(): Settings {
 
 export function save(cfg: Settings) {
   try {
-    fs.mkdirSync(paths.config(), { recursive: true });
+    fs.mkdirSync(paths.config, { recursive: true });
     const rawdata = JSON.stringify(cfg);
 
-    fs.writeFileSync(join(paths.config(), 'settings.json'), rawdata);
+    fs.writeFileSync(join(paths.config, 'settings.json'), rawdata);
   } catch (err) {
     if (err) {
       const { dialog } = require('electron');
@@ -85,7 +85,7 @@ export function save(cfg: Settings) {
  */
 export async function clear() {
   // The node version packed with electron might not have fs.rm yet.
-  await util.promisify(fs.rmdir as any)(paths.config(), { recursive: true, force: true });
+  await fs.promises.rmdir(paths.config, { recursive: true, force: true } as any);
 }
 
 /**
@@ -115,7 +115,7 @@ export function init(): Settings {
 }
 
 export async function isFirstRun() {
-  const settingsPath = join(paths.config(), 'settings.json');
+  const settingsPath = join(paths.config, 'settings.json');
 
   try {
     await util.promisify(fs.access)(settingsPath, fs.constants.F_OK);
@@ -220,8 +220,10 @@ const updateTable: Record<number, (settings: any) => void> = {
     if (os.platform() === 'darwin') {
       console.log('Removing hyperkit virtual machine files');
       try {
-        fs.accessSync(join(paths.state(), 'driver'));
-        fs.rmSync(join(paths.state(), 'driver'), { recursive: true, force: true });
+        // eslint-disable-next-line deprecation/deprecation
+        fs.accessSync(paths.hyperkit);
+        // eslint-disable-next-line deprecation/deprecation
+        fs.rmSync(paths.hyperkit, { recursive: true, force: true });
       } catch (err) {
         if (err !== 'ENOENT') {
           console.log(err);

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -4,14 +4,13 @@ import path from 'path';
 import util from 'util';
 
 import fetch from 'node-fetch';
-import semver, { valid } from 'semver';
-import XDGAppPaths from 'xdg-app-paths';
+import semver from 'semver';
 import { mocked } from 'ts-jest/utils';
 
+import paths from '@/utils/paths';
 import K3sHelper, { buildVersion, ReleaseAPIEntry } from '../k3sHelper';
 
-const paths = XDGAppPaths('rancher-desktop');
-const cachePath = path.join(paths.cache(), 'k3s-versions.json');
+const cachePath = path.join(paths.cache, 'k3s-versions.json');
 const { Response: FetchResponse } = jest.requireActual('node-fetch');
 
 // Mock fetch to ensure we never make an actual request.

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -536,7 +536,7 @@ export class KubeClient extends events.EventEmitter {
 
   /**
    * Clean up obsolete nodes that match a predicate.
-   * @param predicate A functiont that returns true if a node should be removed.
+   * @param predicate A function that returns true if a node should be removed.
    */
   async cleanupNodes(predicate: (node: k8s.V1Node) => boolean) {
     const { body: nodeList } = await this.coreV1API.listNode();

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -533,4 +533,20 @@ export class KubeClient extends events.EventEmitter {
       });
     });
   }
+
+  /**
+   * Clean up obsolete nodes that match a predicate.
+   * @param predicate A functiont that returns true if a node should be removed.
+   */
+  async cleanupNodes(predicate: (node: k8s.V1Node) => boolean) {
+    const { body: nodeList } = await this.coreV1API.listNode();
+    const promises = nodeList
+      .items
+      .filter(predicate)
+      .map(node => node.metadata?.name)
+      .filter(defined)
+      .map(nodeName => this.coreV1API.deleteNode(nodeName));
+
+    return await Promise.all(promises);
+  }
 }

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -10,18 +10,17 @@ import util from 'util';
 
 import fetch from 'node-fetch';
 import semver from 'semver';
-import XDGAppPaths from 'xdg-app-paths';
 import { KubeConfig } from '@kubernetes/client-node';
 import yaml from 'yaml';
 
-import * as childProcess from '../utils/childProcess';
-import Logging from '../utils/logging';
-import resources from '../resources';
-import DownloadProgressListener from '../utils/DownloadProgressListener';
-import safeRename from '../utils/safeRename';
+import * as childProcess from '@/utils/childProcess';
+import Logging from '@/utils/logging';
+import resources from '@/resources';
+import DownloadProgressListener from '@/utils/DownloadProgressListener';
+import safeRename from '@/utils/safeRename';
+import paths from '@/utils/paths';
 
 const console = new Console(Logging.k8s.stream);
-const paths = XDGAppPaths('rancher-desktop');
 
 /**
  * ShortVersion is the version string without any k3s suffixes; this is the
@@ -60,7 +59,7 @@ export function buildVersion(version: semver.SemVer) {
 export default class K3sHelper extends events.EventEmitter {
   protected readonly releaseApiUrl = 'https://api.github.com/repos/k3s-io/k3s/releases?per_page=100';
   protected readonly releaseApiAccept = 'application/vnd.github.v3+json';
-  protected readonly cachePath = path.join(paths.cache(), 'k3s-versions.json');
+  protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
   readonly filenames = ['k3s', 'k3s-airgap-images-amd64.tar', 'sha256sum-amd64.txt'];
   protected readonly minimumVersion = new semver.SemVer('1.15.0');
 
@@ -97,8 +96,8 @@ export default class K3sHelper extends events.EventEmitter {
   protected async writeCache() {
     const cacheData = JSON.stringify(Object.values(this.versions).map(v => v.raw));
 
-    await util.promisify(fs.mkdir)(paths.cache(), { recursive: true });
-    await util.promisify(fs.writeFile)(this.cachePath, cacheData, 'utf-8');
+    await fs.promises.mkdir(paths.cache, { recursive: true });
+    await fs.promises.writeFile(this.cachePath, cacheData, 'utf-8');
   }
 
   /**
@@ -289,7 +288,7 @@ export default class K3sHelper extends events.EventEmitter {
   */
   async ensureK3sImages(shortVersion: ShortVersion): Promise<void> {
     const fullVersion = this.fullVersion(shortVersion);
-    const cacheDir = path.join(paths.cache(), 'k3s');
+    const cacheDir = path.join(paths.cache, 'k3s');
     const filenames = {
       exe:      'k3s',
       images:   'k3s-airgap-images-amd64.tar',

--- a/src/k8s-engine/kubectl.ts
+++ b/src/k8s-engine/kubectl.ts
@@ -3,7 +3,6 @@
 import childProcess, { spawn } from 'child_process';
 import os from 'os';
 import process from 'process';
-const paths = require('xdg-app-paths')({ name: 'rancher-desktop' });
 
 // The K8s JS library will get the current context but does not have the ability
 // to save the context. The current version of the package targets k8s 1.18 and
@@ -13,7 +12,6 @@ export function setCurrentContext(cxt: string, exitfunc: (code: number | null, s
   const opts: childProcess.SpawnOptions = {};
 
   opts.env = { ...process.env };
-  opts.env.MINIKUBE_HOME = paths.data();
 
   const bat = spawn(`./resources/${ os.platform() }/bin/kubectl`, ['config', 'use-context', cxt], opts);
 

--- a/src/k8s-engine/kubectl.ts
+++ b/src/k8s-engine/kubectl.ts
@@ -1,16 +1,16 @@
 'use strict';
 
-const { spawn } = require('child_process');
-const os = require('os');
-const process = require('process');
+import childProcess, { spawn } from 'child_process';
+import os from 'os';
+import process from 'process';
 const paths = require('xdg-app-paths')({ name: 'rancher-desktop' });
 
 // The K8s JS library will get the current context but does not have the ability
 // to save the context. The current version of the package targets k8s 1.18 and
 // there are new config file features (e.g., proxy) that may be lost by outputting
 // the config with the library. So, we drop down to kubectl for this.
-function setCurrentContext(cxt, exitfunc) {
-  const opts = {};
+export function setCurrentContext(cxt: string, exitfunc: (code: number | null, signal: NodeJS.Signals | null) => void) {
+  const opts: childProcess.SpawnOptions = {};
 
   opts.env = { ...process.env };
   opts.env.MINIKUBE_HOME = paths.data();
@@ -18,15 +18,13 @@ function setCurrentContext(cxt, exitfunc) {
   const bat = spawn(`./resources/${ os.platform() }/bin/kubectl`, ['config', 'use-context', cxt], opts);
 
   // TODO: For data toggle this based on a debug mode
-  bat.stdout.on('data', (data) => {
+  bat.stdout?.on('data', (data) => {
     console.log(data.toString());
   });
 
-  bat.stderr.on('data', (data) => {
+  bat.stderr?.on('data', (data) => {
     console.error(data.toString());
   });
 
   bat.on('exit', exitfunc);
 }
-
-exports.setCurrentContext = setCurrentContext;

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -111,7 +111,7 @@ interface LimaListResult {
 }
 
 const console = new Console(Logging.lima.stream);
-const MACHINE_NAME = 'rd';
+const MACHINE_NAME = '0';
 
 function defined<T>(input: T | null | undefined): input is T {
   return input !== null && typeof input !== 'undefined';

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -656,6 +656,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       this.client.on('service-changed', (services) => {
         this.emit('service-changed', services);
       });
+
+      // We need to remove obsolete nodes because we renamed the VM; otherwise
+      // they get stuck forever.  No need to wait for the result.
+      this.client.cleanupNodes(node => node.metadata?.name === 'lima-rancher-desktop');
+
       this.activeVersion = desiredShortVersion;
       this.currentPort = this.#desiredPort;
       this.emit('current-port-changed', this.currentPort);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -112,7 +112,6 @@ interface LimaListResult {
 
 const console = new Console(Logging.lima.stream);
 const MACHINE_NAME = 'rd';
-const CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
 function defined<T>(input: T | null | undefined): input is T {
   return input !== null && typeof input !== 'undefined';
@@ -131,6 +130,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       });
     }
   }
+
+  protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
   protected cfg: Settings['kubernetes'] | undefined;
 
@@ -370,8 +371,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await fs.promises.writeFile(configPath, yaml.stringify(config), 'utf-8');
     } else {
       // new configuration
-      await fs.promises.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-      await fs.promises.writeFile(CONFIG_PATH, yaml.stringify(config));
+      await fs.promises.mkdir(path.dirname(this.CONFIG_PATH), { recursive: true });
+      await fs.promises.writeFile(this.CONFIG_PATH, yaml.stringify(config));
       await childProcess.spawnFile('tmutil', ['addexclusion', paths.lima]);
     }
   }
@@ -604,7 +605,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       // Start the VM; if it's already running, this does nothing.
       try {
-        await this.lima('start', '--tty=false', await this.isRegistered ? MACHINE_NAME : CONFIG_PATH);
+        await this.lima('start', '--tty=false', await this.isRegistered ? MACHINE_NAME : this.CONFIG_PATH);
       } finally {
         // Symlink the logs (especially if start failed) so the users can find them
         const machineDir = path.join(paths.lima, MACHINE_NAME);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -111,7 +111,7 @@ interface LimaListResult {
 }
 
 const console = new Console(Logging.lima.stream);
-const MACHINE_NAME = 'rancher-desktop';
+const MACHINE_NAME = 'rd';
 const CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
 function defined<T>(input: T | null | undefined): input is T {

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -1,0 +1,209 @@
+/**
+ * This handles migrating from the old path layout to the new one.
+ * See https://github.com/rancher-sandbox/rancher-desktop/issues/298
+ */
+
+import { Console } from 'console';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import Electron from 'electron';
+
+import Logging from '@/utils/logging';
+import paths, { Paths } from '@/utils/paths';
+
+const console = new Console(Logging.background.stream);
+const APP_NAME = 'rancher-desktop';
+
+/**
+ * DarwinObsoletePaths describes the paths we're migrating from.
+ */
+class DarwinObsoletePaths implements Paths {
+  config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
+  electron = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME);
+  logs = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'logs');
+  cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
+  lima = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'lima');
+  hyperkit = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'driver');
+  get wslDistro(): string {
+    throw new Error('wslDistro not available for darwin');
+  }
+}
+
+/**
+ * Win32ObsoletePaths describes the paths we're migrating from.
+ */
+class Win32ObsoletePaths implements Paths {
+  protected appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
+  protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
+  get config() {
+    return path.join(this.appData, 'xdg.config', APP_NAME);
+  }
+
+  get electron() {
+    return path.join(this.appData, APP_NAME);
+  }
+
+  get logs() {
+    return path.join(this.localAppData, 'xdg.state', APP_NAME, 'logs');
+  }
+
+  get cache() {
+    return path.join(this.localAppData, 'xdg.cache', APP_NAME);
+  }
+
+  get wslDistro() {
+    return path.join(this.localAppData, 'xdg.state', APP_NAME, 'distro');
+  }
+
+  get lima(): string {
+    throw new Error('lima not available for win32');
+  }
+
+  get hyperkit(): string {
+    throw new Error('hyperkit not available for win32');
+  }
+}
+
+/**
+ * Recursively remove a directory and its contents.  Also remove any empty
+ * parent directories.  If the given path does not exist, no exception is raised.
+ * @param target The path to remove.
+ */
+function recursiveRemoveSync(target: string) {
+  try {
+    fs.rmSync(target, { recursive: true });
+  } catch (ex) {
+    if (ex.code === 'ENOENT') {
+      return;
+    }
+    throw ex;
+  }
+
+  const expectedErrors = ['ENOTEMPTY', 'EACCES', 'EBUSY', 'ENOENT', 'EPERM'];
+  const isDarwin = os.platform() === 'darwin';
+  const seen = new Set([target]);
+  let parent = path.dirname(target);
+
+  while (!seen.has(parent)) {
+    seen.add(parent);
+    if (isDarwin) {
+      const items = fs.readdirSync(parent);
+
+      if (items.length === 1 && items[0] === '.DS_Store') {
+        // on macOS, we _may_ have directories with just .DS_Store
+        const DSStorePath = path.join(parent, '.DS_Store');
+
+        try {
+          fs.rmSync(DSStorePath);
+        } catch (ex) {
+          console.error(`Error removing ${ DSStorePath }:`, ex);
+          break;
+        }
+      }
+    }
+    try {
+      fs.rmdirSync(parent);
+    } catch (ex) {
+      if (expectedErrors.includes(ex.code)) {
+        break;
+      }
+      throw ex;
+    }
+    parent = path.dirname(parent);
+  }
+}
+
+/**
+ * Try to rename an old directory name to a new one.  If the move failed,
+ * delete the old directory.
+ *
+ * @returns True if the rename occurred and succeeded.
+ */
+function tryRename(oldPath: string, newPath: string, info: string): boolean {
+  if (oldPath === newPath) {
+    return false;
+  }
+  try {
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
+    fs.renameSync(oldPath, newPath);
+    console.log(`Migrated ${ info } data from ${ oldPath } to ${ newPath }`);
+
+    return true;
+  } catch (ex) {
+    if (!['ENOENT', 'EEXIST'].includes(ex.code)) {
+      console.error(`Error moving ${ info }:`, ex);
+    } else {
+      console.log(`Could not move ${ oldPath } to ${ newPath }:`, ex);
+    }
+    recursiveRemoveSync(oldPath);
+
+    return false;
+  }
+}
+
+/**
+ * Migrate old data.  This must run synchronously to ensure Electron doesn't
+ * use any paths before we're done.
+ */
+function migratePaths() {
+  const platform = os.platform();
+  let obsoletePaths: Paths;
+
+  switch (platform) {
+  case 'darwin':
+    obsoletePaths = new DarwinObsoletePaths();
+    break;
+  case 'win32':
+    obsoletePaths = new Win32ObsoletePaths();
+    break;
+  default:
+    console.error(`No paths migration available for platform ${ os.platform() }`);
+
+    return;
+  }
+
+  // Move the settings over
+  tryRename(obsoletePaths.config, paths.config, 'config');
+
+  // Delete old logs.
+  recursiveRemoveSync(obsoletePaths.logs);
+
+  // Move cache.
+  tryRename(obsoletePaths.cache, paths.cache, 'cache');
+
+  // Move electron data.
+  tryRename(obsoletePaths.electron, paths.electron, 'Electron data');
+
+  switch (platform) {
+  case 'win32':
+    // Delete the old distro.
+    break;
+  case 'darwin':
+    // Delete any hyperkit VMs.
+    // eslint-disable-next-line deprecation/deprecation -- needed for migration
+    recursiveRemoveSync(obsoletePaths.hyperkit);
+
+    // Move Lima state
+    if (tryRename(obsoletePaths.lima, paths.lima, 'Lima state')) {
+      // We also changed the VM name.
+      const oldVM = path.join(paths.lima, 'rancher-desktop');
+      const newVM = path.join(paths.lima, 'rd');
+
+      tryRename(oldVM, newVM, 'Lima VM');
+    }
+    break;
+  }
+}
+
+export default function setupPaths() {
+  try {
+    migratePaths();
+  } catch (ex) {
+    console.error(ex);
+  }
+  Electron.app.setPath('userData', paths.electron);
+  Electron.app.setPath('cache', paths.cache);
+  Electron.app.setAppLogsPath(paths.logs);
+}

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -69,11 +69,11 @@ class Win32ObsoletePaths implements Paths {
 function removeEmptyParents(directory: string) {
   const expectedErrors = ['ENOTEMPTY', 'EACCES', 'EBUSY', 'ENOENT', 'EPERM'];
   const isDarwin = os.platform() === 'darwin';
-  const seen = new Set();
   let parent = directory;
+  let previous = '';
 
-  while (!seen.has(parent)) {
-    seen.add(parent);
+  while (parent !== previous) {
+    previous = parent;
     if (isDarwin) {
       const items = fs.readdirSync(parent);
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -9,7 +9,7 @@ import Electron from 'electron';
 import yaml from 'yaml';
 
 import { KubeConfig } from '@kubernetes/client-node';
-import kubectl from '@/k8s-engine/kubectl.js';
+import * as kubectl from '@/k8s-engine/kubectl';
 import kubeconfig from '@/config/kubeconfig.js';
 import { State } from '@/k8s-engine/k8s';
 import resources from '@/resources';

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -8,12 +8,12 @@ import { newError, PublishConfiguration } from 'builder-util-runtime';
 import { AppUpdater, Provider, ResolvedUpdateFileInfo, UpdateInfo } from 'electron-updater';
 import { ProviderRuntimeOptions } from 'electron-updater/out/providers/Provider';
 import fetch from 'node-fetch';
-import XdgAppPaths from 'xdg-app-paths';
 
 import Logging from '@/utils/logging';
+import paths from '@/utils/paths';
 
 const console = new Console(Logging.update.stream);
-const gCachePath = path.join(XdgAppPaths('rancher-desktop').cache(), 'updater-longhorn.json');
+const gCachePath = path.join(paths.cache, 'updater-longhorn.json');
 
 /**
  * LonghornProviderOptions specifies the options available for LonghornProvider.

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -10,15 +10,15 @@ describe('paths', () => {
   const cases: Record<keyof Paths, expectedData> = {
     config: {
       win32:  '%APPDATA%/rancher-desktop/',
-      darwin: '%HOME%/Library/Preferences/io.rancherdesktop/',
+      darwin: '%HOME%/Library/Preferences/rancher-desktop/',
     },
     logs: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/logs/',
-      darwin: '%HOME%/Library/Logs/io.rancherdesktop/'
+      darwin: '%HOME%/Library/Logs/rancher-desktop/'
     },
     cache: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/cache/',
-      darwin: '%HOME%/Library/Caches/io.rancherdesktop/',
+      darwin: '%HOME%/Library/Caches/rancher-desktop/',
     },
     wslDistro: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/distro/',
@@ -26,7 +26,7 @@ describe('paths', () => {
     },
     lima: {
       win32:  Error(),
-      darwin: '%HOME%/Library/Application Support/io.rancherdesktop/lima/',
+      darwin: '%HOME%/Library/Application Support/rancher-desktop/lima/',
     },
     hyperkit: {
       win32:  Error(),

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -12,6 +12,10 @@ describe('paths', () => {
       win32:  '%APPDATA%/rancher-desktop/',
       darwin: '%HOME%/Library/Preferences/io.rancherdesktop/',
     },
+    electron: {
+      win32:  '%APPDATA%/rancher-desktop/electron/',
+      darwin: '%HOME%/Library/Application Support/io.rancherdesktop/electron/',
+    },
     logs: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/logs/',
       darwin: '%HOME%/Library/Logs/io.rancherdesktop/'

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -1,0 +1,88 @@
+import os from 'os';
+import path from 'path';
+
+import paths, { Paths, DarwinPaths, Win32Paths } from '../paths';
+
+type platform = 'darwin' | 'win32';
+type expectedData = Record<platform, string | Error>;
+
+describe('paths', () => {
+  const cases: Record<keyof Paths, expectedData> = {
+    config: {
+      win32:  '%APPDATA%/rancher-desktop/',
+      darwin: '%HOME%/Library/Preferences/io.rancherdesktop/',
+    },
+    logs: {
+      win32:  '%LOCALAPPDATA%/rancher-desktop/logs/',
+      darwin: '%HOME%/Library/Logs/io.rancherdesktop/'
+    },
+    cache: {
+      win32:  '%LOCALAPPDATA%/rancher-desktop/cache/',
+      darwin: '%HOME%/Library/Caches/io.rancherdesktop/',
+    },
+    wslDistro: {
+      win32:  '%LOCALAPPDATA%/rancher-desktop/distro/',
+      darwin: Error(),
+    },
+    lima: {
+      win32:  Error(),
+      darwin: '%HOME%/Library/Application Support/io.rancherdesktop/lima/',
+    }
+  };
+
+  const table = Object.entries(cases).flatMap(
+    ([prop, data]) => Object.entries(data).map<[string, platform, string|Error]>(
+      ([platform, expected]) => [prop, platform as platform, expected]));
+
+  // Make a fake environment, because these would not be available on mac.
+  const env = Object.assign(process.env, {
+    APPDATA:      path.join(os.homedir(), 'AppData', 'Roaming'),
+    LOCALAPPDATA: path.join(os.homedir(), 'AppData', 'Local'),
+  });
+
+  test.each(table)('.%s (%s)', (prop, platform, expected) => {
+    const propName = prop as keyof Paths;
+    let paths: Paths;
+
+    switch (platform) {
+    case 'darwin':
+      paths = new DarwinPaths();
+      break;
+    case 'win32':
+      paths = new Win32Paths();
+      break;
+    default:
+      throw new Error(`Unexpected platform ${ platform }`);
+    }
+
+    if (expected instanceof Error) {
+      expect(() => paths[propName]).toThrow();
+    } else {
+      const replaceEnv = (_: string, name: string) => {
+        const result = env[name];
+
+        if (!result) {
+          throw new Error(`Missing environment variable ${ name }`);
+        }
+
+        return result;
+      };
+      const replaced = expected.replace(/%(.*?)%/g, replaceEnv);
+      const cleaned = path.normalize(path.resolve(replaced, '.'));
+      const actual = path.normalize(path.resolve(paths[propName]));
+
+      expect(actual).toEqual(cleaned);
+    }
+  });
+
+  it('should should be for the correct platform', () => {
+    switch (os.platform()) {
+    case 'darwin':
+      expect(paths).toBeInstanceOf(DarwinPaths);
+      break;
+    case 'win32':
+      expect(paths).toBeInstanceOf(Win32Paths);
+      break;
+    }
+  });
+});

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -87,6 +87,8 @@ describe('paths', () => {
     case 'win32':
       expect(paths).toBeInstanceOf(Win32Paths);
       break;
+    default:
+      console.log(`Skipping platform-specific test on unknown platform ${ os.platform() }`);
     }
   });
 });

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -12,10 +12,6 @@ describe('paths', () => {
       win32:  '%APPDATA%/rancher-desktop/',
       darwin: '%HOME%/Library/Preferences/io.rancherdesktop/',
     },
-    electron: {
-      win32:  '%APPDATA%/rancher-desktop/electron/',
-      darwin: '%HOME%/Library/Application Support/io.rancherdesktop/electron/',
-    },
     logs: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/logs/',
       darwin: '%HOME%/Library/Logs/io.rancherdesktop/'

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -27,7 +27,11 @@ describe('paths', () => {
     lima: {
       win32:  Error(),
       darwin: '%HOME%/Library/Application Support/io.rancherdesktop/lima/',
-    }
+    },
+    hyperkit: {
+      win32:  Error(),
+      darwin: '%HOME%/Library/State/rancher-desktop/driver/',
+    },
   };
 
   const table = Object.entries(cases).flatMap(

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -41,13 +41,9 @@ interface Log {
   fdStream: Promise<stream.Writable>;
 }
 
-export const PATH = Symbol.for('path');
-
 interface Module {
   (topic: string): Log;
   [topic: string]: Log;
-  /** @deprecated use paths.logs directly instead. */
-  [PATH]: string;
 }
 
 /**
@@ -96,12 +92,6 @@ const logging = function(topic: string) {
 
   return logging[topic];
 } as Module;
-
-Object.defineProperty(logging, PATH, {
-  get() {
-    return paths.logs;
-  }
-});
 
 export default new Proxy(logging, {
   get: (target, prop, receiver) => {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -19,6 +19,8 @@ export interface Paths {
   wslDistro: string;
   /** Directory holding Lima state (macOS-specific). */
   lima: string;
+  /** @deprecated Directory holding hyperkit state (macOS-specific) */
+  hyperkit: string;
 }
 
 /**
@@ -29,6 +31,7 @@ export class DarwinPaths implements Paths {
   logs = path.join(os.homedir(), 'Library', 'Logs', APP_BUNDLE);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_BUNDLE);
   lima = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'lima');
+  hyperkit = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'driver');
   get wslDistro(): string {
     throw new Error('wslDistro not available for darwin');
   }
@@ -58,6 +61,10 @@ export class Win32Paths implements Paths {
 
   get lima(): string {
     throw new Error('lima not available for Windows');
+  }
+
+  get hyperkit(): string {
+    throw new Error('hyperkit not available for Windows');
   }
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -11,6 +11,8 @@ const APP_BUNDLE = 'io.rancherdesktop';
 export interface Paths {
   /** Directory which holds configuration. */
   config: string;
+  /** Directory for Electron data. */
+  electron: string;
   /** Directory which holds logs. */
   logs: string;
   /** Directory which holds caches that may be removed. */
@@ -28,6 +30,7 @@ export interface Paths {
  */
 export class DarwinPaths implements Paths {
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_BUNDLE);
+  electron = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'electron');
   logs = path.join(os.homedir(), 'Library', 'Logs', APP_BUNDLE);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_BUNDLE);
   lima = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'lima');
@@ -45,6 +48,10 @@ export class Win32Paths implements Paths {
   protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
   get config() {
     return path.join(this.appData, APP_NAME);
+  }
+
+  get electron() {
+    return path.join(this.appData, APP_NAME, 'electron');
   }
 
   get logs() {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -11,8 +11,6 @@ const APP_BUNDLE = 'io.rancherdesktop';
 export interface Paths {
   /** Directory which holds configuration. */
   config: string;
-  /** Directory for Electron data. */
-  electron: string;
   /** Directory which holds logs. */
   logs: string;
   /** Directory which holds caches that may be removed. */
@@ -30,7 +28,6 @@ export interface Paths {
  */
 export class DarwinPaths implements Paths {
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_BUNDLE);
-  electron = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'electron');
   logs = path.join(os.homedir(), 'Library', 'Logs', APP_BUNDLE);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_BUNDLE);
   lima = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'lima');
@@ -48,10 +45,6 @@ export class Win32Paths implements Paths {
   protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
   get config() {
     return path.join(this.appData, APP_NAME);
-  }
-
-  get electron() {
-    return path.join(this.appData, APP_NAME, 'electron');
   }
 
   get logs() {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,75 @@
+/**
+ * This module describes the various paths we use to store state & data.
+ */
+
+import os from 'os';
+import path from 'path';
+
+const APP_NAME = 'rancher-desktop';
+const APP_BUNDLE = 'io.rancherdesktop';
+
+export interface Paths {
+  /** Directory which holds configuration. */
+  config: string;
+  /** Directory which holds logs. */
+  logs: string;
+  /** Directory which holds caches that may be removed. */
+  cache: string;
+  /** Directory holding the WSL distribution (Windows-specific). */
+  wslDistro: string;
+  /** Directory holding Lima state (macOS-specific). */
+  lima: string;
+}
+
+/**
+ * DarwinPaths implements paths for Darwin / macOS.
+ */
+export class DarwinPaths implements Paths {
+  config = path.join(os.homedir(), 'Library', 'Preferences', APP_BUNDLE);
+  logs = path.join(os.homedir(), 'Library', 'Logs', APP_BUNDLE);
+  cache = path.join(os.homedir(), 'Library', 'Caches', APP_BUNDLE);
+  lima = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'lima');
+  get wslDistro(): string {
+    throw new Error('wslDistro not available for darwin');
+  }
+}
+
+/**
+ * Win32Paths implements paths for Windows.
+ */
+export class Win32Paths implements Paths {
+  protected appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
+  protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
+  get config() {
+    return path.join(this.appData, APP_NAME);
+  }
+
+  get logs() {
+    return path.join(this.localAppData, APP_NAME, 'logs');
+  }
+
+  get cache() {
+    return path.join(this.localAppData, APP_NAME, 'cache');
+  }
+
+  get wslDistro() {
+    return path.join(this.localAppData, APP_NAME, 'distro');
+  }
+
+  get lima(): string {
+    throw new Error('lima not available for Windows');
+  }
+}
+
+function getPaths(): Paths {
+  switch (os.platform()) {
+  case 'darwin':
+    return new DarwinPaths();
+  case 'win32':
+    return new Win32Paths();
+  default:
+    throw new Error(`Paths not implemented for ${ os.platform() }`);
+  }
+}
+
+export default getPaths();

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -6,7 +6,6 @@ import os from 'os';
 import path from 'path';
 
 const APP_NAME = 'rancher-desktop';
-const APP_BUNDLE = 'io.rancherdesktop';
 
 export interface Paths {
   /** Directory which holds configuration. */
@@ -27,10 +26,10 @@ export interface Paths {
  * DarwinPaths implements paths for Darwin / macOS.
  */
 export class DarwinPaths implements Paths {
-  config = path.join(os.homedir(), 'Library', 'Preferences', APP_BUNDLE);
-  logs = path.join(os.homedir(), 'Library', 'Logs', APP_BUNDLE);
-  cache = path.join(os.homedir(), 'Library', 'Caches', APP_BUNDLE);
-  lima = path.join(os.homedir(), 'Library', 'Application Support', APP_BUNDLE, 'lima');
+  config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
+  logs = path.join(os.homedir(), 'Library', 'Logs', APP_NAME);
+  cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
+  lima = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME, 'lima');
   hyperkit = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'driver');
   get wslDistro(): string {
     throw new Error('wslDistro not available for darwin');


### PR DESCRIPTION
This changes where we store our application data; fixes #298 

Directories (unchanged directories marked by†):

Type | Current Location | New (Windows) | New (Mac)
--- | --- | --- | ---
Logs | `${XDG.state}/logs` | `LocalAppData\rancher-desktop\logs` | `~/Library/Logs/rancher-desktop`
Lima VM | `${XDG.state}/lima` | N/A | `~/Library/Application Support/rancher-desktop/lima`
WSL distro | `${XDG.state}/distro` | `LocalAppData\rancher-desktop\distro` | N/A
Caches | `${XDG.cache}` | `LocalAppData\rancher-desktop\cache` | `~/Library/Caches/rancher-desktop`
Settings | `${XDG.config}` | `RoamingAppData\rancher-desktop` | `~/Library/Preferences/rancher-desktop`†
Electron / Chromium Data | `${XDG.data}` | `RoamingAppData\rancher-desktop`† | `~/Library/Application Support/rancher-desktop`†
