### PR TITLE
Bump lima-and-qemu from v1.0 → v1.2

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.0';
+const limaTag = 'v1.2';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.1.1';


### PR DESCRIPTION
Includes:

* Supports `$LIMA_HOME` containing spaces
* No longer uses `~/.ssh/known_hosts`
* Updates `qemu` from `6.0.0` to `6.1.0`.

Fixes #504 
Fixes #518 
Unblocks #547
