### PR TITLE
Lima: Enable cron

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.3';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.1';
+const alpineLimaTag = 'v0.1.2';
 const alpineLimaEdition = 'std';
 const alpineLimaVersion = '3.13.5';
 

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -30,3 +30,9 @@ provision:
     done
     echo "Done mounting Rancher persistent volumes."
     exit "${errors}"
+- # This sets up cron (used for logrotate)
+  mode: system
+  script: |
+    #!/bin/sh
+    rc-update add crond default
+    rc-service crond start

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -345,7 +345,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const baseConfig: Partial<LimaConfiguration> = currentConfig || {};
     const config: LimaConfiguration = merge(baseConfig, DEFAULT_CONFIG as LimaConfiguration, {
       images:     [{
-        location: resources.get(os.platform(), 'alpline-lima-v0.1.1-std-3.13.5.iso'),
+        location: resources.get(os.platform(), 'alpline-lima-v0.1.2-std-3.13.5.iso'),
         arch:     'x86_64',
       }],
       cpus:       this.cfg?.numberCPUs || 4,


### PR DESCRIPTION
This used for logrotate.  Includes bumping alpine-lima to 0.1.2.

Note that #557 includes the logrotate config for k3s without actually turning it on, so that these two PRs are independent.