### PR TITLE
Image scan close button: Fix display in dark mode

### DIFF
--- a/src/assets/styles/rancher-desktop.scss
+++ b/src/assets/styles/rancher-desktop.scss
@@ -11,3 +11,10 @@ margin-right: 1em;
         background-color: var(--input-bg);
     }
 }
+
+:is(.btn, button, [class*='btn-']):not([class*='role-']) {
+  /* buttons should have one of the role- classes:
+   * .role-primary, .role-secondary, .role-tertiary, .role-multi-action, etc.
+   */
+  outline: 10px dashed red !important;
+}

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -68,8 +68,8 @@
           <div v-if="showImageManagerOutput">
             <hr>
             <button
-              class="role-tertiary"
               v-if="imageManagerProcessIsFinished"
+              class="role-tertiary"
               @click="closeOutputWindow"
             >
               Close Output to Continue

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -68,6 +68,7 @@
           <div v-if="showImageManagerOutput">
             <hr>
             <button
+              class="role-tertiary"
               v-if="imageManagerProcessIsFinished"
               @click="closeOutputWindow"
             >


### PR DESCRIPTION
The button to close the output in the images view didn't have any role classes, which caused it to be incorrectly styled in dark mode.  Fix that, and also add a broad selector to warn us in the future.

Fixes #493