### PR TITLE
Background: don't open preference before protocol registration.

### DIFF
--- a/src/utils/latch.ts
+++ b/src/utils/latch.ts
@@ -1,0 +1,23 @@
+/**
+ * class Latch is a simple extension on Promise that is resolved via calling a
+ * method.
+ */
+export default class Latch extends Promise<void> {
+  #resolve?: () => void;
+  constructor() {
+    super((resolve) => {
+      // We can't set the property from within the callback in the superclass,
+      // because our instance hasn't been constructed yet.  So we need to do it
+      // in a setImmediate() callback.
+      setImmediate(() => {
+        this.#resolve = resolve;
+      });
+    });
+  }
+
+  resolve() {
+    if (this.#resolve) {
+      this.#resolve();
+    }
+  }
+}


### PR DESCRIPTION
It appears that it is possible to click on the dock icon before the app is ready, in which case we attempt to open the preferences window too early. This reports an error saying `Cannot create BrowserWindow before app is ready`.

Instead, we force wait until the protocol handler has been registered (after the app is ready); we delay it this far as otherwise attempting to open the window leads to an unknown protocol error and a white window.

This _should_ fix #519.  Flagging @jandubois for review because I wasn't able to reproduce well enough.