### PR TITLE
Lima: Swallow error on failure to symlink lima logs.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -568,7 +568,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           .then(filenames => filenames.filter(x => x.endsWith('.log'))
             .forEach(filename => fs.promises.symlink(
               path.join(machineDir, filename),
-              path.join(Logging[LoggingPath], `lima.${ filename }`))));
+              path.join(Logging[LoggingPath], `lima.${ filename }`))
+              .catch( () => {})));
       }
 
       await this.killStaleProcesses();


### PR DESCRIPTION
If there are errors (e.g. the symlinks already exist), ignore them properly rather than dropping the errors con the floor (causing an `UnhandledRejectionWarning`).