### PR TITLE
E2E: Fix broken tests

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -126,10 +126,12 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
     this.k3sHelper.initialize();
 
-    process.on('exit', () => {
-      // Attempt to shut down any stray qemu processes.
-      process.kill(0);
-    });
+    if (!(process.env.NODE_ENV ?? '').includes('test')) {
+      process.on('exit', () => {
+        // Attempt to shut down any stray qemu processes.
+        process.kill(0);
+      });
+    }
   }
 
   protected cfg: Settings['kubernetes'] | undefined;

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -68,7 +68,7 @@ function createWindow(name: string, url: string, prefs: Electron.WebPreferences)
 export function openPreferences() {
   let url = 'app://./index.html';
 
-  if (/^dev/i.test(process.env.NODE_ENV || '')) {
+  if (/^(?:dev|test)/i.test(process.env.NODE_ENV || '')) {
     url = 'http://localhost:8888/';
   }
   createWindow('preferences', url, {


### PR DESCRIPTION
- Because the test runner is in the same process group, we can't just kill the whole process group on exit.
- We use the nuxt development server in tests (where `NODE_ENV` is `test`); make sure we load pages from there during testing.