### PR TITLE
WSL: Unregister WSL distribution on factory reset.

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -676,6 +676,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
   async factoryReset(): Promise<void> {
     await this.del();
+    if (await this.isDistroRegistered()) {
+      await childProcess.spawnFile('wsl.exe', ['--unregister', INSTANCE_NAME], {
+        stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
+        windowsHide: true,
+      });
+    }
     await Promise.all([paths.cache, paths.config].map(
       dir => fs.promises.rm(dir, { recursive: true })));
 


### PR DESCRIPTION
Fixes #549.

Have to check if it's registered first, as otherwise WSL exits with `-1`.