### PR TITLE
Add support for nerdctl on macos.

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -4,7 +4,7 @@ scriptdir="${BASH_SOURCE[0]}"
 [ -L "${scriptdir}" ] && scriptname="$(readlink "${scriptdir}")"
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
-if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl ls | grep -q -E "rancher-desktop +Running"; then 
+if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl ls --json | grep '"name":"rancher-desktop"' | grep -q '"status":"Running"'; then 
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"; 
 else
   LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl shell rancher-desktop nerdctl $@

--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -1,11 +1,12 @@
 #!/bin/bash
+set -eu -o pipefail
 
 scriptdir="${BASH_SOURCE[0]}"
 [ -L "${scriptdir}" ] && scriptname="$(readlink "${scriptdir}")"
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
-if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl ls --json | grep '"name":"rancher-desktop"' | grep -q '"status":"Running"'; then 
+if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"rancher-desktop"' | grep -q '"status":"Running"'; then 
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"; 
 else
-  LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl shell rancher-desktop nerdctl $@
+  LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell rancher-desktop nerdctl "$@"
 fi

--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -5,8 +5,8 @@ scriptdir="${BASH_SOURCE[0]}"
 [ -L "${scriptdir}" ] && scriptname="$(readlink "${scriptdir}")"
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
-if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"rancher-desktop"' | grep -q '"status":"Running"'; then 
+if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then 
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"; 
 else
-  LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell rancher-desktop nerdctl "$@"
+  LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell 0 nerdctl "$@"
 fi

--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+scriptdir="${BASH_SOURCE[0]}"
+[ -L "${scriptdir}" ] && scriptname="$(readlink "${scriptdir}")"
+scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
+
+if ! LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl ls | grep -q -E "rancher-desktop +Running"; then 
+  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"; 
+else
+  LIMA_HOME="$HOME/Library/State/rancher-desktop/lima" ${scriptdir}/../lima/bin/limactl shell rancher-desktop nerdctl $@
+fi

--- a/resources/scripts/profile
+++ b/resources/scripts/profile
@@ -1,0 +1,1 @@
+export CONTAINERD_ADDRESS=/run/k3s/containerd/containerd.sock

--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.3';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.2';
+const alpineLimaTag = 'v0.1.3';
 const alpineLimaEdition = 'std';
 const alpineLimaVersion = '3.13.5';
 

--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,8 +10,8 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.3';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.3';
-const alpineLimaEdition = 'std';
+const alpineLimaTag = 'v0.1.4';
+const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.13.5';
 
 async function getLima() {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -363,7 +363,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }],
       cpus:   this.cfg?.numberCPUs || 4,
       memory: (this.cfg?.memoryInGB || 4) * 1024 * 1024 * 1024,
-      mounts: [{ location: path.join(paths.cache, 'k3s'), writable: false },{location: "~", writable: false }],
+      mounts: [{ location: path.join(paths.cache, 'k3s'), writable: false }, { location: '~', writable: false }],
       ssh:    { localPort: await this.sshPort },
       k3s:    { version: desiredVersion },
     });

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -49,6 +49,7 @@ enum Integrations {
   HELM = 'helm',
   KIM = 'kim',
   KUBECTL = 'kubectl',
+  NERDCTL = 'nerdctl',
 }
 
 /**
@@ -362,7 +363,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }],
       cpus:   this.cfg?.numberCPUs || 4,
       memory: (this.cfg?.memoryInGB || 4) * 1024 * 1024 * 1024,
-      mounts: [{ location: path.join(paths.cache, 'k3s'), writable: false }],
+      mounts: [{ location: path.join(paths.cache, 'k3s'), writable: false },{location: "~", writable: false }],
       ssh:    { localPort: await this.sshPort },
       k3s:    { version: desiredVersion },
     });
@@ -482,6 +483,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await this.ssh('chmod', 'a+x', 'bin/install-k3s');
       await fs.promises.chmod(path.join(paths.cache, 'k3s', fullVersion, 'k3s'), 0o755);
       await this.ssh('sudo', 'bin/install-k3s', fullVersion, path.join(paths.cache, 'k3s'));
+      await this.lima('copy', resources.get('scripts', 'profile'), `${ MACHINE_NAME }:~/.profile`);
     } finally {
       await fs.promises.rm(workdir, { recursive: true });
     }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -363,7 +363,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }],
       cpus:   this.cfg?.numberCPUs || 4,
       memory: (this.cfg?.memoryInGB || 4) * 1024 * 1024 * 1024,
-      mounts: [{ location: path.join(paths.cache, 'k3s'), writable: false }, { location: '~', writable: false }],
+      mounts: [
+        { location: path.join(paths.cache, 'k3s'), writable: false },
+        { location: '~', writable: false },
+        { location: '/tmp/rancher-desktop', writable: true },
+      ],
       ssh:    { localPort: await this.sshPort },
       k3s:    { version: desiredVersion },
     });

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -357,8 +357,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const currentConfig = await this.currentConfig;
     const baseConfig: Partial<LimaConfiguration> = currentConfig || {};
     const config: LimaConfiguration = merge(baseConfig, DEFAULT_CONFIG as LimaConfiguration, {
-      images: [{
-        location: resources.get(os.platform(), 'alpline-lima-v0.1.2-std-3.13.5.iso'),
+      images:     [{
+        location: resources.get(os.platform(), 'alpline-lima-v0.1.4-rd-3.13.5.iso'),
         arch:     'x86_64',
       }],
       cpus:   this.cfg?.numberCPUs || 4,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -7,6 +7,7 @@ const adjustNameWithDir: Record<string, string> = {
   helm:    path.join('bin', 'helm'),
   kim:     path.join('bin', 'kim'),
   kubectl: path.join('bin', 'kubectl'),
+  nerdctl: path.join('bin', 'nerdctl'),
 };
 
 function fixedSourceName(name: string) {


### PR DESCRIPTION
This includes:
- nerdctl as a CLI that can be added to the path like the other
  tools.
- An updated version of alpine-lima that includes nerdctl and the
  other binaries it needs.
- ~ is mounted so that nerdctl build can access the files to build.
  nerdctl build will not work for locations outside of ~.
- A .profile file exporting an environment variable to tell nerdctl
  where the containerd socket is as k3s puts it in a non-standard
  location.

Note, in the future we should look at taring up the build directory
and sending it to the VM. That would be a more substancial effort
to accomplish.

Related to #566

Thanks to Jan for all the pointers in creating this and the alpine-lima
build.