### PR TITLE
Add first-run dialog to pick Kubernetes version

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -76,17 +76,13 @@ Electron.app.whenReady().then(async() => {
 
     installDevtools();
     await setupIntegration();
-    await checkBackendValid();
-
-    k8smanager.start(cfg.kubernetes).catch(handleFailure);
 
     setupProtocolHandler();
     buildApplicationMenu();
 
     window.openPreferences();
 
-    setupKim(k8smanager);
-    setupUpdate(cfg);
+    await startBackend(cfg);
   } catch (ex) {
     console.error('Error starting up:', ex);
     gone = true;
@@ -159,6 +155,18 @@ function setupProtocolHandler() {
     callback(result);
   });
   protocolRegistered.resolve();
+}
+
+/**
+ * Start the Kubernetes backend.
+ *
+ * @precondition cfg.kubernetes.version is set.
+ */
+async function startBackend(cfg: settings.Settings) {
+  await checkBackendValid();
+
+  k8smanager.start(cfg.kubernetes).catch(handleFailure);
+  setupKim(k8smanager);
 }
 
 Electron.app.on('second-instance', async() => {

--- a/background.ts
+++ b/background.ts
@@ -75,7 +75,8 @@ Electron.app.whenReady().then(async() => {
 
     installDevtools();
     setupProtocolHandler();
-    await setupFirstRun();
+    await doFirstRun();
+
     if (gone) {
       console.log('User triggered quit during first-run');
 
@@ -105,7 +106,7 @@ function installDevtools() {
   installExtension(VUEJS_DEVTOOLS);
 }
 
-async function setupFirstRun() {
+async function doFirstRun() {
   if (!settings.isFirstRun()) {
     return;
   }

--- a/background.ts
+++ b/background.ts
@@ -77,6 +77,11 @@ Electron.app.whenReady().then(async() => {
     installDevtools();
     setupProtocolHandler();
     await setupFirstRun();
+    if (gone) {
+      console.log('User triggered quit during first-run');
+
+      return;
+    }
 
     buildApplicationMenu();
     window.openPreferences();

--- a/background.ts
+++ b/background.ts
@@ -208,6 +208,10 @@ Electron.app.on('activate', async() => {
   window.openPreferences();
 });
 
+Electron.ipcMain.handle('settings-read', () => {
+  return cfg;
+});
+
 Electron.ipcMain.on('settings-read', (event) => {
   event.returnValue = cfg;
 });

--- a/background.ts
+++ b/background.ts
@@ -75,11 +75,10 @@ Electron.app.whenReady().then(async() => {
     }
 
     installDevtools();
-    await setupIntegration();
-
     setupProtocolHandler();
-    buildApplicationMenu();
+    await setupFirstRun();
 
+    buildApplicationMenu();
     window.openPreferences();
 
     await startBackend(cfg);
@@ -101,15 +100,19 @@ function installDevtools() {
   installExtension(VUEJS_DEVTOOLS);
 }
 
-async function setupIntegration() {
-  if (await settings.isFirstRun()) {
-    if (os.platform() === 'darwin') {
-      await Promise.all([
-        linkResource('helm', true),
-        linkResource('kim', true),
-        linkResource('kubectl', true),
-      ]);
-    }
+async function setupFirstRun() {
+  if (!settings.isFirstRun()) {
+    return;
+  }
+
+  await window.openFirstRun();
+
+  if (os.platform() === 'darwin') {
+    await Promise.all([
+      linkResource('helm', true),
+      linkResource('kim', true),
+      linkResource('kubectl', true),
+    ]);
   }
 }
 

--- a/background.ts
+++ b/background.ts
@@ -221,6 +221,8 @@ Electron.ipcMain.handle('settings-read', () => {
   return cfg;
 });
 
+// This is the synchronous version of the above; we still use
+// ipcRenderer.sendSync in some places, so it's required for now.
 Electron.ipcMain.on('settings-read', (event) => {
   event.returnValue = cfg;
 });

--- a/background.ts
+++ b/background.ts
@@ -59,52 +59,53 @@ process.on('unhandledRejection', (reason: any, promise: any) => {
 
 Electron.app.whenReady().then(async() => {
   try {
-    console.log(`app version: ${ Electron.app.getVersion() }`);
-  } catch (err) {
-    console.log(`Can't get app version: ${ err }`);
-  }
-  setupNetworking();
-  try {
+    setupNetworking();
     setupTray();
-  } catch (e) {
-    console.log(`\nERROR: ${ e.message }`);
-    gone = true;
-    Electron.app.quit();
-
-    return;
-  }
-
-  // TODO: Check if first install and start welcome screen
-  // TODO: Check if new version and provide window with details on changes
-
-  try {
     cfg = settings.init();
-  } catch (err) {
+
+    // Set up the updater; we may need to quit the app if an update is already
+    // queued.
+    if (await setupUpdate(cfg, true)) {
+      gone = true;
+      // The update code will trigger a restart; don't do it here, as it may not
+      // be ready yet.
+      console.log('Will apply update; skipping startup.');
+
+      return;
+    }
+
+    installDevtools();
+    await setupIntegration();
+    await checkBackendValid();
+
+    k8smanager.start(cfg.kubernetes).catch(handleFailure);
+
+    setupProtocolHandler();
+    buildApplicationMenu();
+
+    window.openPreferences();
+
+    setupKim(k8smanager);
+    setupUpdate(cfg);
+  } catch (ex) {
+    console.error('Error starting up:', ex);
     gone = true;
     Electron.app.quit();
+  }
+});
 
+function installDevtools() {
+  if (Electron.app.isPackaged) {
     return;
   }
 
-  console.log(cfg);
+  const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
 
-  // Set up the updater; we may need to quit the app if an update is already
-  // queued.
-  if (await setupUpdate(cfg, true)) {
-    gone = true;
-    // The update code will trigger a restart; don't do it here, as it may not
-    // be ready yet.
-    console.log('Will apply update; skipping startup.');
+  // No need to wait for it to complete.
+  installExtension(VUEJS_DEVTOOLS);
+}
 
-    return;
-  }
-
-  if (!Electron.app.isPackaged) {
-    // Install devtools; no need to wait for it to complete.
-    const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
-
-    installExtension(VUEJS_DEVTOOLS);
-  }
+async function setupIntegration() {
   if (await settings.isFirstRun()) {
     if (os.platform() === 'darwin') {
       await Promise.all([
@@ -114,24 +115,28 @@ Electron.app.whenReady().then(async() => {
       ]);
     }
   }
+}
 
-  // Check if there are any reasons that would mean it makes no sense to
-  // continue starting the app.
+/**
+ * Check if there are any reasons that would mean it makes no sense to continue
+ * starting the app.  Should be invoked before attempting to start the backend.
+ */
+async function checkBackendValid() {
   const invalidReason = await k8smanager.getBackendInvalidReason();
 
   if (invalidReason) {
     handleFailure(invalidReason);
     gone = true;
     Electron.app.quit();
-
-    return;
   }
+}
 
-  k8smanager.start(cfg.kubernetes).catch(handleFailure);
-
-  // Set up protocol handler for app://
-  // This is needed because in packaged builds we'll not be allowed to access
-  // file:// URLs for our resources.
+/**
+ * Set up protocol handler for app://
+ * This is needed because in packaged builds we'll not be allowed to access
+ * file:// URLs for our resources.
+ */
+function setupProtocolHandler() {
   Electron.protocol.registerFileProtocol('app', (request, callback) => {
     let relPath = (new URL(request.url)).pathname;
 
@@ -154,12 +159,7 @@ Electron.app.whenReady().then(async() => {
     callback(result);
   });
   protocolRegistered.resolve();
-  buildApplicationMenu();
-  window.openPreferences();
-
-  setupKim(k8smanager);
-  setupUpdate(cfg);
-});
+}
 
 Electron.app.on('second-instance', async() => {
   // Someone tried to run another instance of Rancher Desktop,
@@ -210,10 +210,10 @@ Electron.ipcMain.on('settings-read', (event) => {
 // allows any decendent properties to be omitted.
 type RecursivePartial<T> = {
   [P in keyof T]?:
-    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    T[P] extends object ? RecursivePartial<T[P]> :
-    T[P];
+  T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  T[P] extends object ? RecursivePartial<T[P]> :
+  T[P];
 }
 
 function writeSettings(arg: RecursivePartial<settings.Settings>) {

--- a/background.ts
+++ b/background.ts
@@ -60,7 +60,6 @@ process.on('unhandledRejection', (reason: any, promise: any) => {
 Electron.app.whenReady().then(async() => {
   try {
     setupNetworking();
-    setupTray();
     cfg = settings.init();
 
     // Set up the updater; we may need to quit the app if an update is already
@@ -84,6 +83,7 @@ Electron.app.whenReady().then(async() => {
     }
 
     buildApplicationMenu();
+    setupTray();
     window.openPreferences();
 
     await startBackend(cfg);

--- a/src/assets/styles/rancher-desktop.scss
+++ b/src/assets/styles/rancher-desktop.scss
@@ -1,9 +1,14 @@
 /** Rancher Desktop specific styles */
+body {
+  color: var(--body-text);
+  font-size: 14px;
+}
+
 .labeled-input {
     margin-bottom: 1em;
-  }
+}
 label > button:first-child:not(.btn-sm) {
-margin-right: 1em;
+    margin-right: 1em;
 }
 
 @media screen and (prefers-color-scheme: dark) {

--- a/src/assets/styles/rancher-desktop.scss
+++ b/src/assets/styles/rancher-desktop.scss
@@ -1,5 +1,6 @@
 /** Rancher Desktop specific styles */
 body {
+  background-color: var(--body-bg);
   color: var(--body-text);
   font-size: 14px;
 }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -732,10 +732,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     try {
       this.setState(K8s.State.STOPPING);
       this.setProgress(Progress.INDETERMINATE, 'Stopping Kubernetes');
-      await this.ssh('sudo', '/sbin/rc-service', 'k3s', 'stop');
+
       const status = await this.status;
 
       if (defined(status) && status.status === 'Running') {
+        await this.ssh('sudo', '/sbin/rc-service', 'k3s', 'stop');
         await this.lima('stop', MACHINE_NAME);
       }
       this.setState(K8s.State.STOPPED);

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -86,9 +86,4 @@ export default {
   }
 }
 
-body {
-  color: var(--body-text);
-  font-size: 14px;
-}
-
 </style>

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -1,4 +1,4 @@
-<!-- This layout is used dialog boxes that do not want navigation -->
+<!-- This layout is used by dialog boxes that do not want navigation -->
 
 <template>
   <dialog ref="wrapper" class="wrapper" open>

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -1,0 +1,23 @@
+<!-- This layout is used dialog boxes that do not want navigation -->
+
+<template>
+  <dialog class="wrapper" open>
+    <Nuxt class="body" />
+  </dialog>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/styles/app.scss";
+
+.wrapper {
+  display: grid;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+}
+
+</style>

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -9,6 +9,14 @@
 <script lang="ts">
 import Vue from 'vue';
 export default Vue.extend({
+  head() {
+    // If dark-mode is set to auto (follow system-prefs) this is all we need
+    // In a possible future with a three-way pref
+    // (Always off // Always on // Follow system pref)
+    // the "dark" part will be a dynamic pref.
+    // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
+    return { bodyAttrs: { class: 'theme-dark' } };
+  },
   mounted() {
     const wrapper = this.$refs.wrapper as HTMLDialogElement;
 
@@ -25,7 +33,9 @@ export default Vue.extend({
 @import "@/assets/styles/app.scss";
 
 .wrapper {
+  background-color: var(--body-bg);
   border: none;
+  color: var(--body-text);
 }
 
 </style>

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -1,22 +1,30 @@
 <!-- This layout is used dialog boxes that do not want navigation -->
 
 <template>
-  <dialog class="wrapper" open>
+  <dialog ref="wrapper" class="wrapper" open>
     <Nuxt class="body" />
   </dialog>
 </template>
 
-<script>
-export default {};
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({
+  mounted() {
+    const wrapper = this.$refs.wrapper as HTMLDialogElement;
+
+    // Dynamically resize the window to fit the contents.
+    // We need a bit extra on the width to ensure we don't get scroll bars.
+    window.resizeBy(
+      wrapper.offsetWidth - document.documentElement.offsetWidth + 14,
+      wrapper.offsetHeight - document.documentElement.offsetHeight);
+  }
+});
 </script>
 
 <style lang="scss" scoped>
 @import "@/assets/styles/app.scss";
 
 .wrapper {
-  display: grid;
-  width: 100vw;
-  height: 100vh;
   border: none;
 }
 

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <h3>Welcome to Rancher Desktop</h3>
+    <label>
+      Please select a Kubernetes version:
+      <select v-model="settings.kubernetes.version" class="select-k8s-version" @change="onChange">
+        <option v-for="item in versions" :key="item" :value="item" :selected="item === versions[0]">
+          {{ item }}
+        </option>
+      </select>
+    </label>
+    <div class="button-area">
+      <button class="role-primary" @click="close">
+        Accept
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { ipcRenderer } from 'electron';
+import Vue from 'vue';
+
+import { Settings } from '@/config/settings';
+
+export default Vue.extend({
+  layout: 'dialog',
+  data() {
+    return {
+      settings: { kubernetes: {} } as Settings,
+      versions: [] as string[],
+    };
+  },
+  mounted() {
+    ipcRenderer.invoke('settings-read').then((settings) => {
+      this.settings = settings;
+    });
+    ipcRenderer.on('k8s-versions', (event, versions) => {
+      this.versions = versions;
+      this.settings.kubernetes.version = versions[0];
+    });
+    ipcRenderer.send('k8s-versions');
+  },
+  methods: {
+    onChange() {
+      ipcRenderer.invoke('settings-write',
+        { kubernetes: { version: this.settings.kubernetes.version } });
+    },
+    close() {
+      this.onChange();
+      window.close();
+    },
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+  .select-k8s-version {
+    margin: 1ex 0;
+  }
+  .button-area {
+    // sass doesn't understand `end` here, and sets up `[dir]` selectors that
+    // will never match anything.  So we need to use `right`, which breaks RTL.
+    text-align: right;
+  }
+</style>

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -38,6 +38,7 @@ export default Vue.extend({
     ipcRenderer.on('k8s-versions', (event, versions) => {
       this.versions = versions;
       this.settings.kubernetes.version = versions[0];
+      ipcRenderer.send('firstrun/ready');
     });
     ipcRenderer.send('k8s-versions');
   },

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -46,6 +46,10 @@ interface IpcMainEvents {
   'do-image-deletion': (imageName: string, imageID: string) => void;
   // #endregion
 
+  // #region firstrun
+  'firstrun/ready': () => void;
+  // #endregion
+
   'troubleshooting/show-logs': () => void;
 }
 

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -54,6 +54,7 @@ interface IpcMainEvents {
  * invoke on the main process, i.e. ipcRenderer.invoke() -> ipcMain.handle()
  */
 interface IpcMainInvokeEvents {
+  'settings-read': () => import('@/config/settings').Settings;
   'settings-write': (arg: RecursivePartial<import('@/config/settings').Settings>) => void;
   'k8s-supports-port-forwarding': () => boolean;
   'service-fetch': (namespace?: string) => import('@/k8s-engine/k8s').ServiceEntry[];

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -101,6 +101,7 @@ export async function openFirstRun() {
     width:           400,
     height:          200,
     autoHideMenuBar: !app.isPackaged,
+    show:            false,
     webPreferences:  {
       devTools:           !app.isPackaged,
       nodeIntegration:    true,
@@ -109,6 +110,11 @@ export async function openFirstRun() {
     },
   });
 
+  window.webContents.on('ipc-message', (event, channel) => {
+    if (channel === 'firstrun/ready') {
+      window.show();
+    }
+  });
   window.menuBarVisible = false;
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -98,9 +98,10 @@ export function openPreferences() {
 export async function openFirstRun() {
   const webRoot = getWebRoot();
   const window = createWindow('first-run', `${ webRoot }index.html#FirstRun`, {
-    width:          400,
-    height:         200,
-    webPreferences: {
+    width:           400,
+    height:          200,
+    autoHideMenuBar: !app.isPackaged,
+    webPreferences:  {
       devTools:           !app.isPackaged,
       nodeIntegration:    true,
       contextIsolation:   false,
@@ -108,6 +109,7 @@ export async function openFirstRun() {
     },
   });
 
+  window.menuBarVisible = false;
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);
   }));

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -16,10 +16,10 @@ const windowMapping: Record<string, number> = {};
 
 function getWebRoot() {
   if (/^(?:dev|test)/i.test(process.env.NODE_ENV || '')) {
-    return 'http://localhost:8888/';
+    return 'http://localhost:8888';
   }
 
-  return 'app://./';
+  return 'app://.';
 }
 
 /**
@@ -43,7 +43,7 @@ function createWindow(name: string, url: string, options: Electron.BrowserWindow
   }
 
   const isInternalURL = (url: string) => {
-    return url.startsWith(getWebRoot());
+    return url.startsWith(`${ getWebRoot() }/`);
   };
 
   window = new BrowserWindow(options);
@@ -78,7 +78,7 @@ function createWindow(name: string, url: string, options: Electron.BrowserWindow
 export function openPreferences() {
   const webRoot = getWebRoot();
 
-  createWindow('preferences', `${ webRoot }index.html`, {
+  createWindow('preferences', `${ webRoot }/index.html`, {
     width:          940,
     height:         600,
     webPreferences: {
@@ -97,7 +97,9 @@ export function openPreferences() {
  */
 export async function openFirstRun() {
   const webRoot = getWebRoot();
-  const window = createWindow('first-run', `${ webRoot }index.html#FirstRun`, {
+  // We use hash mode for the router, so `index.html#FirstRun` loads
+  // src/pages/FirstRun.vue.
+  const window = createWindow('first-run', `${ webRoot }/index.html#FirstRun`, {
     width:           400,
     height:          200,
     autoHideMenuBar: !app.isPackaged,


### PR DESCRIPTION
This adds a dialog to prompt the user for a version.  Includes some refactoring of the startup path to move bits into separate functions for better reasoning in the main function.

Fixes #234.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/3977982/132593249-0ce96c87-eb22-4aed-8f51-2dcb256ffdd4.png"> <img width="280" alt="image" src="https://user-images.githubusercontent.com/3977982/132593233-9aa33b52-e577-48a6-a492-2e02f7a21263.png">
![image](https://user-images.githubusercontent.com/3977982/132591021-6aba7b10-a61a-40ff-b070-06d2e8ee3ece.png) ![image](https://user-images.githubusercontent.com/3977982/132593065-a77f9ed5-954f-4407-9f35-2eb61af885f7.png)


Things to note:
- We do not set up the tray icon until after the first run dialog goes away (so the user can't attempt to do things to the cluster before it's set up).
- We correctly handle quitting the app from within the first-run dialog.
- We hide the menu bar on Windows (they're mostly not useful there), except in dev mode (for devtools / inspector).
- If the user _cancels_ the dialog (by closing the window manually instead of the giant button), we still take their choices into account.