### PR TITLE
Rename scriptname → scriptdir

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -eu -o pipefail
 
-scriptdir="${BASH_SOURCE[0]}"
-[ -L "${scriptdir}" ] && scriptname="$(readlink "${scriptdir}")"
+scriptname="${BASH_SOURCE[0]}"
+while [ -L "${scriptname}" ]; do
+    scriptname="$(readlink "${scriptname}")"
+done
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
-if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then 
-  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"; 
+if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
+  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
 else
   LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell 0 nerdctl "$@"
 fi


### PR DESCRIPTION
This rename was done before manually, but 2 instances were missed.

(also removes some trailing whitespace)