### PR TITLE
Make the UI for macos symbolic links less clunky

### DIFF
--- a/src/components/Banner.vue
+++ b/src/components/Banner.vue
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 export default {
   props: {
     color: {
@@ -6,7 +6,7 @@ export default {
       default: 'secondary'
     },
     label: {
-      type:    [String, Error],
+      type:    [String, Error, Object],
       default: null,
     },
     labelKey: {

--- a/src/components/Banner.vue
+++ b/src/components/Banner.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
-export default {
+import Vue from 'vue';
+export default Vue.extend({
   props: {
     color: {
       type:    String,
@@ -18,7 +19,7 @@ export default {
       default: false,
     }
   }
-};
+});
 </script>
 <template>
   <div class="banner" :class="{[color]: true, closable}">

--- a/src/components/Integration.vue
+++ b/src/components/Integration.vue
@@ -62,16 +62,17 @@ class Integration extends IntegrationProps {
    * asynchronously, to prevent the user from retrying to toggle too quickly.
    */
   protected busy: Record<string, boolean> = {};
+  protected GlobalFailureIntegrationName = '/usr/local/bin';
 
   get globalError() {
-    return this.integrations['/usr/local/bin'];
+    return this.integrations[this.GlobalFailureIntegrationName];
   }
 
   get integrationsList() {
     const results: {name: string, value: boolean, disabled: boolean, error?: string}[] = [];
 
     for (const [name, value] of Object.entries(this.integrations)) {
-      if (name === '/usr/local/bin') {
+      if (name === this.GlobalFailureIntegrationName) {
         continue;
       }
       if (typeof value === 'boolean') {

--- a/src/components/Integration.vue
+++ b/src/components/Integration.vue
@@ -5,7 +5,7 @@
     </template>
     <template #body>
       <p v-if="description" class="description" v-text="description" />
-        <Banner v-if="globalError" color="error" :label="globalError" />
+      <Banner v-if="globalError" color="error" :label="globalError" />
       <ul>
         <li v-for="item of integrationsList" :key="item.name">
           <checkbox
@@ -51,7 +51,11 @@ const IntegrationProps = Vue.extend({
   },
 });
 
-@Component({ components: { Banner, Card, Checkbox } })
+@Component({
+  components: {
+    Banner, Card, Checkbox
+  }
+})
 class Integration extends IntegrationProps {
   /**
    * A mapping to temporarily disable a selection while work happens

--- a/src/components/Integration.vue
+++ b/src/components/Integration.vue
@@ -5,7 +5,8 @@
     </template>
     <template #body>
       <p v-if="description" class="description" v-text="description" />
-      <ul v-if="integrations" class="integrations">
+        <Banner v-if="globalError" color="error" :label="globalError" />
+      <ul>
         <li v-for="item of integrationsList" :key="item.name">
           <checkbox
             :value="item.value"
@@ -25,6 +26,7 @@ import path from 'path';
 import Vue, { PropType } from 'vue';
 import Component from 'vue-class-component';
 
+import Banner from '@/components/Banner.vue';
 import Card from '@/components/Card.vue';
 import Checkbox from '@/components/form/Checkbox.vue';
 
@@ -49,7 +51,7 @@ const IntegrationProps = Vue.extend({
   },
 });
 
-@Component({ components: { Card, Checkbox } })
+@Component({ components: { Banner, Card, Checkbox } })
 class Integration extends IntegrationProps {
   /**
    * A mapping to temporarily disable a selection while work happens
@@ -57,10 +59,17 @@ class Integration extends IntegrationProps {
    */
   protected busy: Record<string, boolean> = {};
 
+  get globalError() {
+    return this.integrations['/usr/local/bin'];
+  }
+
   get integrationsList() {
     const results: {name: string, value: boolean, disabled: boolean, error?: string}[] = [];
 
     for (const [name, value] of Object.entries(this.integrations)) {
+      if (name === '/usr/local/bin') {
+        continue;
+      }
       if (typeof value === 'boolean') {
         const basename = path.basename(name);
         const warnings = this.integrationWarnings[basename];
@@ -70,7 +79,7 @@ class Integration extends IntegrationProps {
           this.$delete(this.busy, name);
         }
         results.push({
-          name, value, disabled: name in this.busy, error
+          name, value, disabled: name in this.busy || !!this.globalError, error
         });
       } else {
         results.push({

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -7,7 +7,7 @@ import resources from '@/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
 
-const INTEGRATIONS = ['helm', 'kim', 'kubectl', 'nerdctl'];
+const INTEGRATIONS = ['docker', 'helm', 'kim', 'kubectl', 'nerdctl'];
 const console = new Console(Logging.background.stream);
 const PUBLIC_LINK_DIR = '/usr/local/bin';
 
@@ -94,6 +94,7 @@ export default class UnixlikeIntegrations {
     for (const name of INTEGRATIONS) {
       this.pathConflictManager.reportConflicts(name);
     }
+    window.send('k8s-integration-warnings', 'docker', ["Links to rancher-desktop's nerdctl"]);
   }
 
   protected async testUsrLocalBin() {

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -7,7 +7,7 @@ import resources from '@/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
 
-const Integrations = [ 'helm', 'kim', 'kubectl', 'nerdctl' ];
+const Integrations = ['helm', 'kim', 'kubectl', 'nerdctl'];
 const console = new Console(Logging.background.stream);
 
 /*

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -1,0 +1,118 @@
+import path from 'path';
+import fs from 'fs';
+
+import { Console } from 'console';
+import Logging from '@/utils/logging';
+import resources from '@/resources';
+import PathConflictManager from '@/main/pathConflictManager';
+import * as window from '@/window';
+
+const Integrations = [ 'helm', 'kim', 'kubectl', 'nerdctl' ];
+const console = new Console(Logging.background.stream);
+
+/*
+ * There are probably going to be only two kinds of integrations: WSL for Windows,
+ * and everything else for macos and linux, should it be supported. For now, this class
+ * is currently intended to be used for various VM strategies for macOS.
+ */
+export default class UnixlikeIntegrations {
+  #results: Record<string, boolean | string> = {}
+  /*
+   * Used to supply integration-warnings
+   */
+  protected pathConflictManager = new PathConflictManager();
+
+  constructor() {
+    this.setupBinWatcher();
+  }
+
+  async testUsrLocalBin() {
+    try {
+      await fs.promises.access('/usr/local/bin', fs.constants.W_OK | fs.constants.X_OK);
+      this.#results['/usr/local/bin'] = '';
+    } catch (error) {
+      switch (error.code) {
+      case 'ENOENT':
+        this.#results['/usr/local/bin'] = "Directory /usr/local/bin doesn't exist";
+        break;
+      case 'EACCES':
+        this.#results['/usr/local/bin'] = `Insufficient permission to manipulate /usr/local/bin: ${ error }`;
+        break;
+      default:
+        this.#results['/usr/local/bin'] = `Can't work with directory /usr/local/bin: ${ error }'`;
+      }
+    }
+  }
+
+  async setupBinWatcher() {
+    await this.testUsrLocalBin();
+    fs.watch('/usr/local', async(eventType, filename) => {
+      if (filename === 'bin') {
+        await this.testUsrLocalBin();
+        window.send('k8s-integrations', this.#results);
+      }
+    });
+  }
+
+  async listIntegrations(): Promise<Record<string, boolean | string>> {
+    for (const name of Integrations) {
+      const linkPath = path.join('/usr/local/bin', name);
+      const desiredPath = resources.executable(name);
+
+      try {
+        const currentDest = await fs.promises.readlink(linkPath);
+
+        if (currentDest === desiredPath) {
+          this.#results[linkPath] = true;
+        } else {
+          this.#results[linkPath] = `Already linked to ${ currentDest }`;
+        }
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          this.#results[linkPath] = false;
+        } else if (error.code === 'EINVAL') {
+          this.#results[linkPath] = `File exists and is not a symbolic link`;
+        } else {
+          this.#results[linkPath] = `Can't link to ${ linkPath }: ${ error }`;
+        }
+      }
+    }
+
+    return this.#results;
+  }
+
+  async setIntegration(linkPath: string, state: boolean): Promise<string | undefined> {
+    const desiredPath = resources.executable(path.basename(linkPath));
+
+    this.#results[linkPath] = '';
+    if (state) {
+      try {
+        await fs.promises.symlink(desiredPath, linkPath, 'file');
+      } catch (err) {
+        const message = `Error creating symlink for ${ linkPath }:`;
+
+        console.error(message, err);
+        this.#results[linkPath] = `${ message } ${ err.message }`;
+
+        return this.#results[linkPath] as string;
+      }
+    } else {
+      try {
+        await fs.promises.unlink(linkPath);
+      } catch (err) {
+        const message = `Error unlinking symlink for ${ linkPath }`;
+
+        console.error(message, err);
+        this.#results[linkPath] = `${ message } ${ err.message }`;
+
+        return this.#results[linkPath] as string;
+      }
+    }
+  }
+
+  listIntegrationWarnings(): void {
+    for (const name of Integrations) {
+      this.pathConflictManager.reportConflicts(name);
+    }
+  }
+}

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -70,7 +70,7 @@ export default class UnixlikeIntegrations {
     this.#results[linkPath] = '';
     if (state) {
       try {
-        await fs.promises.symlink(desiredPath, linkPath, 'file');
+        await fs.promises.symlink(desiredPath, linkPath);
       } catch (err) {
         const message = `Error creating symlink for ${ linkPath }:`;
 

--- a/src/main/pathConflictManager.ts
+++ b/src/main/pathConflictManager.ts
@@ -62,7 +62,7 @@ export default class PathConflictManager {
     }
     const currentPathDirectories = currentPathAsString.split(path.delimiter)
       .filter(dir => path.resolve(dir) !== '/usr/local/bin');
-    const namesOfInterest = ['helm', 'kim', 'kubectl'];
+    const namesOfInterest = ['helm', 'kim', 'kubectl', 'nerdctl'];
 
     for (const dirName of currentPathDirectories) {
       try {

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -64,6 +64,13 @@ export default async function pathConflict(targetDir: string, binaryName: string
       }
       continue;
     }
+    // nerdctl currently isn't versioned
+    if (binaryName === 'nerdctl') {
+      if (!sawCurrentDir) {
+        notes.push(`Existing instance of ${ binaryName } in ${ currentDir } shadows a linked instance.`);
+      }
+      continue;
+    }
     const currentVersion = await getVersion(currentPath, binaryName);
 
     if (!currentVersion) {

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -29,7 +29,7 @@ export default async function pathConflict(targetDir: string, binaryName: string
 
     return [];
   }
-  // nerdctl isn't versioned, so hardwire a truthy value
+  // We don't ship nerdctl, just an unversioned stub; so hard-wire a truthy value.
   const proposedVersion = binaryName === 'nerdctl' ? '1.2.3' : await getVersion(referencePath, binaryName);
 
   if (!proposedVersion) {

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -29,7 +29,8 @@ export default async function pathConflict(targetDir: string, binaryName: string
 
     return [];
   }
-  const proposedVersion = await getVersion(referencePath, binaryName);
+  // nerdctl isn't versioned, so hardwire a truthy value
+  const proposedVersion = binaryName === 'nerdctl' ? '1.2.3' : await getVersion(referencePath, binaryName);
 
   if (!proposedVersion) {
     return [];


### PR DESCRIPTION
To test:

Bring up the Preferences window

In a terminal window:
```
cd /usr/local
sudo mv bin hide-bin
# Should see an error message, and the checkboxes disabled
sudo mv hide-bin bin
# The error message should disappear, and checkboxes enabled again

# Save the existing permissions:
mode=$(stat -f %A bin)
sudo chmod 0500 bin
# Should see a different error message, and checkboxes disabled
sudo chmod $mode bin
# The error message should disappear, and checkboxes enabled again