### PR TITLE
Display trivy output in table

### DIFF
--- a/src/components/BadgeState.vue
+++ b/src/components/BadgeState.vue
@@ -1,0 +1,81 @@
+<script>
+
+export default {
+  props: {
+    // Set either value or color+label
+    // A resource with stateBackground and stateDisplay
+    value: {
+      type:    Object,
+      default: null,
+    },
+
+    color: {
+      type:    String,
+      default: null,
+    },
+
+    icon: {
+      type:    String,
+      default: null
+    },
+
+    label: {
+      type:    String,
+      default: null,
+    },
+  },
+
+  computed: {
+    bg() {
+      return this.value?.stateBackground || this.color;
+    },
+
+    msg() {
+      return this.value?.stateDisplay || this.label;
+    }
+  }
+};
+</script>
+
+<template>
+  <span :class="{'badge-state': true, [bg]: true}">
+    <i v-if="icon" class="icon" :class="{[icon]: true, 'mr-5': !!msg}" />{{ msg }}
+  </span>
+</template>
+
+<style lang="scss">
+  .badge-state {
+    padding: 2px 10px;
+    border: 1px solid transparent;
+    border-radius: 20px;
+
+    &.bg-info {
+      border-color: var(--primary);
+    }
+
+    &.bg-error {
+      border-color: var(--error);
+    }
+
+    &.bg-warning {
+      border-color: var(--warning);
+    }
+
+    // Successful states are de-emphasized by using [text-]color instead of background-color
+    &.bg-success {
+      color: var(--success);
+      background: transparent;
+      border-color: var(--success);
+    }
+  }
+
+  .sortable-table TD .badge-state {
+    @include clip;
+    display: inline-block;
+    max-width: 100%;
+    position: relative;
+    max-width: 110px;
+    font-size: .85em;
+    vertical-align: middle;
+  }
+</style>

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -23,13 +23,6 @@
         </template>
       </SortableTable>
 
-      <images-scan-results
-        v-if="showImageManagerOutput && fromScan"
-        :image="taggedImageName"
-        :table-data="vulnerabilities"
-        @close:output="closeOutputWindow"
-      />
-
       <Card :show-highlight-border="false" :show-actions="false">
         <template #title>
           <div class="type-title">
@@ -95,6 +88,13 @@
           </div>
         </template>
       </Card>
+
+      <images-scan-results
+        v-if="showImageManagerOutput && fromScan"
+        :image="taggedImageName"
+        :table-data="vulnerabilities"
+        @close:output="closeOutputWindow"
+      />
     </div>
     <div v-else>
       <h3 v-if="state === 'K8S_UNREADY'">

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -242,6 +242,21 @@ export default {
     imageManagerProcessFinishedWithFailure() {
       return this.imageManagerProcessIsFinished && !this.completionStatus;
     },
+    vulnerabilities() {
+      const results = JSON.parse(this.jsonOutput)?.Results;
+
+      return results
+        ?.find((_val, i) => i === 0)
+        ?.Vulnerabilities
+        ?.map(({ PkgName, VulnerabilityID, ...rest }) => {
+          return {
+            id: `${ PkgName }-${ VulnerabilityID }`,
+            PkgName,
+            VulnerabilityID,
+            ...rest
+          };
+        });
+    }
   },
 
   mounted() {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -164,6 +164,7 @@ export default {
       imageOutputCuller:                null,
       mainWindowScroll:                 -1,
       postCloseOutputWindowHandler:     null,
+      jsonOutput:                       null,
     };
   },
   computed: {
@@ -252,6 +253,9 @@ export default {
     });
     ipcRenderer.on('kim-process-output', (event, data, isStderr) => {
       this.appendImageManagerOutput(data, isStderr);
+    });
+    ipcRenderer.on('complete:kim-process', (event, data) => {
+      this.jsonOutput = data;
     });
   },
 

--- a/src/components/ImagesScanResults.vue
+++ b/src/components/ImagesScanResults.vue
@@ -3,11 +3,23 @@ import SortableTable from '@/components/SortableTable';
 import Card from '@/components/Card.vue';
 import BadgeState from '@/components/BadgeState.vue';
 
-const SEVERITY_BADGE_MAP = {
-  LOW:      'bg-darker',
-  MEDIUM:   'bg-info',
-  HIGH:     'bg-warning',
-  CRITICAL: 'bg-error'
+const SEVERITY_MAP = {
+  LOW:      {
+    color: 'bg-darker',
+    id:    0,
+  },
+  MEDIUM:   {
+    color: 'bg-info',
+    id:    1,
+  },
+  HIGH:     {
+    color: 'bg-warning',
+    id:    2,
+  },
+  CRITICAL: {
+    color: 'bg-error',
+    id:    3,
+  }
 };
 
 export default {
@@ -34,12 +46,7 @@ export default {
         {
           name:      'Severity',
           label:     'Severity',
-          sort:      ['Severity', 'PkgName', 'InstalldeVersion'],
-        },
-        {
-          name:  'VulnerabilityID',
-          label: 'Vulnerability ID',
-          sort:  ['VulnerabilityID', 'Severity', 'PkgName', 'InstalldeVersion'],
+          sort:      ['SeverityId:desc', 'PkgName', 'InstalldeVersion'],
         },
         {
           name:  'PkgName',
@@ -47,20 +54,41 @@ export default {
           sort:  ['PkgName', 'Severity', 'InstalledVersion'],
         },
         {
+          name:  'VulnerabilityID',
+          label: 'Vulnerability ID',
+          sort:  ['VulnerabilityID', 'Severity', 'PkgName', 'InstalldeVersion'],
+        },
+        {
           name:  'InstalledVersion',
-          label: 'Installed Version'
+          label: 'Installed'
         },
         {
           name:  'FixedVersion',
-          label: 'Fixed Version'
+          label: 'Fixed'
         }
       ],
     };
   },
 
+  computed: {
+    rows() {
+      return this.tableData
+        .map(({ Severity, ...rest }) => {
+          return {
+            SeverityId: this.id(Severity),
+            Severity,
+            ...rest
+          };
+        });
+    }
+  },
+
   methods: {
     color(severity) {
-      return SEVERITY_BADGE_MAP[severity];
+      return SEVERITY_MAP[severity].color;
+    },
+    id(severity) {
+      return SEVERITY_MAP[severity].id;
     }
   }
 };
@@ -76,7 +104,7 @@ export default {
     <template #body>
       <sortable-table
         :headers="headers"
-        :rows="tableData"
+        :rows="rows"
         key-field="id"
         default-sort-by="Severity"
         :table-actions="false"
@@ -103,8 +131,7 @@ export default {
             <badge-state
               :label="row.Severity"
               :color="color(row.Severity)"
-            >
-            </badge-state>
+            />
           </td>
         </template>
       </sortable-table>

--- a/src/components/ImagesScanResults.vue
+++ b/src/components/ImagesScanResults.vue
@@ -1,0 +1,89 @@
+<script>
+import SortableTable from '@/components/SortableTable';
+import Card from '@/components/Card.vue';
+
+export default {
+  components: {
+    SortableTable,
+    Card
+  },
+
+  props: {
+    image: {
+      type:     String,
+      required: true,
+    },
+    tableData: {
+      type:    Array,
+      default: () => []
+    }
+  },
+
+  data() {
+    return {
+      headers: [
+        {
+          name:      'Severity',
+          label:     'Severity',
+          sort:      ['Severity', 'PkgName', 'InstalldeVersion'],
+        },
+        {
+          name:  'VulnerabilityID',
+          label: 'Vulnerability ID',
+          sort:  ['VulnerabilityID', 'Severity', 'PkgName', 'InstalldeVersion'],
+        },
+        {
+          name:  'PkgName',
+          label: 'Package',
+          sort:  ['PkgName', 'Severity', 'InstalledVersion'],
+        },
+        {
+          name:  'InstalledVersion',
+          label: 'Installed Version'
+        },
+        {
+          name:  'FixedVersion',
+          label: 'Fixed Version'
+        }
+      ],
+    };
+  }
+};
+</script>
+
+<template>
+  <Card :show-highlight-border="false" :show-actions="false">
+    <template #title>
+      <div class="type-title">
+        <h3>Image Scan Results - {{ image }}</h3>
+      </div>
+    </template>
+    <template #body>
+      <sortable-table
+        :headers="headers"
+        :rows="tableData"
+        key-field="id"
+        default-sort-by="Severity"
+        :table-actions="false"
+        :row-actions="false"
+        :paging="true"
+      >
+        <template #header-left>
+          <button
+            class="role-tertiary"
+            @click="$emit('close:output')"
+          >
+            {{ t('images.manager.close') }}
+          </button>
+        </template>
+        <template #col:VulnerabilityID="{row}">
+          <td>
+            <span>
+              <a :href="row.PrimaryURL">{{ row.VulnerabilityID }}</a>
+            </span>
+          </td>
+        </template>
+      </sortable-table>
+    </template>
+  </Card>
+</template>

--- a/src/components/ImagesScanResults.vue
+++ b/src/components/ImagesScanResults.vue
@@ -1,11 +1,20 @@
 <script>
 import SortableTable from '@/components/SortableTable';
 import Card from '@/components/Card.vue';
+import BadgeState from '@/components/BadgeState.vue';
+
+const SEVERITY_BADGE_MAP = {
+  LOW:      'bg-darker',
+  MEDIUM:   'bg-info',
+  HIGH:     'bg-warning',
+  CRITICAL: 'bg-error'
+};
 
 export default {
   components: {
     SortableTable,
-    Card
+    Card,
+    BadgeState
   },
 
   props: {
@@ -47,6 +56,12 @@ export default {
         }
       ],
     };
+  },
+
+  methods: {
+    color(severity) {
+      return SEVERITY_BADGE_MAP[severity];
+    }
   }
 };
 </script>
@@ -81,6 +96,15 @@ export default {
             <span>
               <a :href="row.PrimaryURL">{{ row.VulnerabilityID }}</a>
             </span>
+          </td>
+        </template>
+        <template #col:Severity="{row}">
+          <td>
+            <badge-state
+              :label="row.Severity"
+              :color="color(row.Severity)"
+            >
+            </badge-state>
           </td>
         </template>
       </sortable-table>

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -140,12 +140,12 @@ class Kim extends EventEmitter {
     const subcommandName = args[0];
 
     if (os.platform().startsWith('win')) {
-      args = ['-d', 'rancher-desktop', 'trivy'].concat(args);
+      args = ['-d', 'rancher-desktop', 'TRIVY_NEW_JSON_SCHEMA=true', 'trivy'].concat(args);
       child = spawn('wsl', args);
     } else if (os.platform().startsWith('darwin')) {
       const limaBackend = this.k8sManager as LimaBackend;
 
-      args = ['trivy'].concat(args);
+      args = ['TRIVY_NEW_JSON_SCHEMA=true', 'trivy'].concat(args);
       child = limaBackend.limaSpawn(args);
     } else {
       throw new Error(`Don't know how to run trivy on platform ${ os.platform() }`);
@@ -421,8 +421,13 @@ class Kim extends EventEmitter {
   }
 
   async scanImage(taggedImageName: string): Promise<childResultType> {
-    return await this.runTrivyCommand(['image', '--no-progress', '--format', 'template',
-      '--template', '@/var/lib/trivy.tpl', taggedImageName]);
+    return await this.runTrivyCommand([
+      '--quiet',
+      'image',
+      '--format',
+      'json',
+      taggedImageName
+    ]);
   }
 
   parse(data: string): imageType[] {

--- a/src/k8s-engine/kim.ts
+++ b/src/k8s-engine/kim.ts
@@ -13,6 +13,7 @@ import * as k8s from '@kubernetes/client-node';
 
 import * as childProcess from '@/utils/childProcess';
 import * as K8s from '@/k8s-engine/k8s';
+import * as window from '@/window';
 import mainEvents from '@/main/mainEvents';
 import Logging from '@/utils/logging';
 import resources from '@/resources';
@@ -190,6 +191,9 @@ class Kim extends EventEmitter {
           }
         }
         if (code === 0) {
+          if (sendNotifications) {
+            window.send('complete:kim-process', result.stdout);
+          }
           resolve({ ...result, code });
         } else if (signal) {
           reject({

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -86,6 +86,7 @@ interface IpcRendererEvents {
   'kim-process-cancelled': () => void;
   'kim-process-ended': (exitCode: number) => void;
   'kim-process-output': (data: string, isStdErr: boolean) => void;
+  'complete:kim-process': (data: string) => void;
   'images-changed': (images: {imageName: string, tag: string, imageID: string, size: string}[]) => void;
   'images-check-state': (state: boolean) => void;
   // #endregion


### PR DESCRIPTION
This outputs trivy scan results to a table instead of a textarea. Some benefits we get with the table output:

1. Ability to sort and filter by severity
2. Ability to quickly open links to severities
3. Output that is more easy to read and scan at a glance

Please note that this change updates the trivy command to make use of `--format json` instead of `--format template`. If this is seen as too risky/unstable, I should be able to revert to the original flags without any loss of functionality. I would like to keep the `--quiet` flag, as it makes parsing output much more simple.

Also note that sought to separate the vulnerability scans from the image acquisition output. I tried to keep the overall user experience the same and applied the same patterns that we have in place. This will be the first of a few changes that we can make to improve the overall UX for image scanning in Rancher Desktop.