### PR TITLE
Map mac port forwards to 0.0.0.0

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -40,3 +40,6 @@ provision:
     mv -n /etc/periodic/daily/logrotate /etc/periodic/hourly/
     rc-update add crond default
     rc-service crond start
+portForwards:
+- guestPortRange: [1, 65535]
+  hostIP: "0.0.0.0"


### PR DESCRIPTION
This enables the use of priviledged ports and makes content
available on the machines IP.

Part of #566