### PR TITLE
NSIS: Only elevate for WSL installation

### DIFF
--- a/build/install-wsl.ps1
+++ b/build/install-wsl.ps1
@@ -31,7 +31,7 @@ function Get-ElevationStatus {
 # Re-run the script if elevation is required.  Must pass in the script arguments.
 function Restart-ScriptForElevation {
   if (Get-ElevationStatus) {
-    Write-Output "Script is already elevated, no need to restart."
+    Write-Output "Script is already elevated, no need to restart; continuing with installation..."
     return
   }
   $CommandLine = "-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File `"${PSCommandPath}`" $($args)"

--- a/build/install-wsl.ps1
+++ b/build/install-wsl.ps1
@@ -44,7 +44,7 @@ function Install-Features {
   # Install Windows features as needed.
   $features = @('Microsoft-Windows-Subsystem-Linux', 'VirtualMachinePlatform')
   foreach ($feature in $features) {
-    # Get-WinddowsOptionalFeature requires elevation, but Get-CimInstance is fine...
+    # Get-WindowsOptionalFeature requires elevation, but Get-CimInstance is fine...
     # https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-optionalfeature
     # InstallState == 1 means installed
     $installed = Get-CimInstance -ClassName Win32_OptionalFeature -Filter "NAME = `"$feature`"" | Where-Object InstallState -eq 1
@@ -73,7 +73,7 @@ function Install-Kernel {
   param([switch]$CanReboot)
 
   # Install the updated WSL kernel, if not already installed.
-  # Note that we have to filter by name here, since IdentifiyingNumber seems to
+  # Note that we have to filter by name here, since IdentifyingNumber seems to
   # change across versions.
   $installed = Get-CimInstance -ClassName Win32_Product -Filter 'NAME = "Windows Subsystem for Linux Update"'
   if ($installed) {

--- a/build/install-wsl.ps1
+++ b/build/install-wsl.ps1
@@ -36,7 +36,9 @@ function Install-Kernel {
   param([switch]$CanReboot)
 
   # Install the updated WSL kernel, if not already installed.
-  $installed = Get-WmiObject Win32_Product -Filter 'IdentifyingNumber = "{8D646799-DB00-4000-AE7A-756A05A4F1D8}"'
+  # Note that we have to filter by name here, since IdentifiyingNumber seems to
+  # change across versions.
+  $installed = Get-CimInstance -ClassName Win32_Product -Filter 'NAME = "Windows Subsystem for Linux Update"'
   if ($installed) {
     $oldVersion = [System.Version]::Parse($installed.Version)
     # The .net version comparator only does major/minor

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,12 +1,37 @@
 !include "x64.nsh"
 
+# ### Variables
+# whether we need to install WSL components
+Var /GLOBAL isWSLInstallRequired
+
 !macro customHeader
-  # We always want to be admin, so that we can install Windows features.
   ManifestSupportedOS Win10
-  RequestExecutionLevel admin
   # Enable ShowInstDetails to get logs from scripts.
   #ShowInstDetails show
 !macroend
+
+!macro preInit
+  # We need to set this in the uninstaller to mute a warning about the variable
+  # never being used
+  strCpy $isWSLInstallRequired 0
+!macroEnd
+
+!macro customInit
+  # Check if we need to install WSL
+  DetailPrint "Checking if we need to install WSL..."
+  File "/oname=$PLUGINSDIR\install-wsl.ps1" "${BUILD_RESOURCES_DIR}\install-wsl.ps1"
+  nsExec::ExecToLog 'powershell.exe \
+    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
+    -File "$PLUGINSDIR\install-wsl.ps1" "-DryRun"'
+  Pop $R0
+
+  ${If} $R0 == 102
+    StrCpy $isWSLInstallRequired 1
+    DetailPrint "WSL installation is required."
+  ${Else}
+    DetailPrint "WSL installation is not required."
+  ${EndIf}
+!macroEnd
 
 !macro customInstall
   Push $R0
@@ -23,22 +48,26 @@
   Pop $R0
 
   # Install WSL, if required
-  DetailPrint "Installing Windows Subsystem for Linux"
-  File "/oname=$PLUGINSDIR\install-wsl.ps1" "${BUILD_RESOURCES_DIR}\install-wsl.ps1"
-  nsExec::ExecToLog 'powershell.exe \
-    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
-    -File "$PLUGINSDIR\install-wsl.ps1"'
-  Pop $R0
-  ${If} $R0 == "error"
-    Abort "Could not install Windows Subsystem for Linux."
-  ${ElseIf} $R0 == 0
-    # WSL was already installed
-  ${ElseIf} $R0 == 101
-    # WSL was installed, a reboot is required.
-    SetRebootFlag true
-  ${Else}
-    # Unexpected exit code
-    Abort "Unexpected error installing Windows subsystem for Linux: $R0"
+  ${If} $isWSLInstallRequired > 0
+    DetailPrint "Installing Windows Subsystem for Linux"
+    File "/oname=$PLUGINSDIR\install-wsl.ps1" "${BUILD_RESOURCES_DIR}\install-wsl.ps1"
+    # Note that the script might restart itself (synchronously) if we need to
+    # elevate here.
+    nsExec::ExecToLog 'powershell.exe \
+      -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
+      -File "$PLUGINSDIR\install-wsl.ps1"'
+    Pop $R0
+    ${If} $R0 == "error"
+      Abort "Could not install Windows Subsystem for Linux."
+    ${ElseIf} $R0 == 0
+      # WSL was already installed
+    ${ElseIf} $R0 == 101
+      # WSL was installed, a reboot is required.
+      SetRebootFlag true
+    ${Else}
+      # Unexpected exit code
+      Abort "Unexpected error installing Windows subsystem for Linux: $R0"
+    ${EndIf}
   ${EndIf}
 
   # Migrate WSL distro name from 'k3s' to 'rancher-desktop'


### PR DESCRIPTION
This changes the Windows installer to only elevate the parts that need to install WSL.  This means people who normally use a non-privileged account (e.g. #613) will be able to work correctly.

This is a first pass — currently there's no indication ahead of time that we'll require elevation, and it's currently just popping up a PowerShell terminal for the installation.  I intend to attempt to get rid of at least the command prompt window while this is reviewed.