### PR TITLE
Windows: Persist data on upgrades

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -283,14 +283,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           // Create a distro archive from the main distro.
           // WSL seems to require a working /bin/sh for initialization.
           const EXTRA_FILES = ['/bin/busybox', '/bin/mount', '/bin/sh', '/lib'];
-          const archivePath = path.join(workdir, 'distro.tgz');
+          const archivePath = path.join(workdir, 'distro.tar');
 
           console.log('Creating initial data distribution...');
           // Make sure all the extra data directories exist
           await Promise.all(DISTRO_DATA_DIRS.map((dir) => {
             return this.execCommand('/bin/busybox', 'mkdir', '-p', dir);
           }));
-          await this.execCommand('tar', '-czf', await this.wslify(archivePath),
+          await this.execCommand('tar', '-cf', await this.wslify(archivePath),
             '-C', '/', ...EXTRA_FILES, ...DISTRO_DATA_DIRS);
           await this.execWSL('--import', DATA_INSTANCE_NAME, paths.wslDistroData, archivePath, '--version', '2');
         } catch (ex) {
@@ -316,7 +316,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         // Copy the new directories into the data distribution.
         // Note that we're not using compression, since we (kind of) don't have gzip...
         console.log(`Data distribution missing directories ${ missingDirs }, adding...`);
-        const archivePath = await this.wslify(path.join(workdir, 'distro.tar'));
+        const archivePath = await this.wslify(path.join(workdir, 'data.tar'));
 
         await this.execCommand('tar', '-cf', archivePath, '-C', '/', ...missingDirs);
         await this.execWSL('--distribution', DATA_INSTANCE_NAME, '--exec', '/bin/busybox', 'tar', '-xf', archivePath, '-C', '/');

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -815,13 +815,19 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     if (await this.isDistroRegistered()) {
       await this.execWSL('--unregister', INSTANCE_NAME);
     }
+    if (await this.isDistroRegistered({ distribution: DATA_INSTANCE_NAME })) {
+      await this.execWSL('--unregister', DATA_INSTANCE_NAME);
+    }
     this.cfg = undefined;
     this.setProgress(Progress.DONE);
   }
 
   async reset(config: Settings['kubernetes']): Promise<void> {
-    // For K3s, doing a full reset is fast enough.
-    await this.del();
+    await this.stop();
+    this.cfg = undefined;
+    if (await this.isDistroRegistered({ distribution: DATA_INSTANCE_NAME })) {
+      await this.execWSL('--unregister', DATA_INSTANCE_NAME);
+    }
     await this.start(config);
   }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -297,13 +297,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           // Figure out what required files actually exist in the distro; they
           // may not exist on various versions.
           const extraFiles = (await Promise.all(REQUIRED_FILES.map(async(path) => {
-            try {
-              await this.execCommand('busybox', 'test', '-e', path);
+            const result = this.captureCommand('busybox', 'sh', '-c', `[ -e ${ path } ] && echo yes ||:`);
 
-              return path;
-            } catch (ex) {
-              return undefined;
-            }
+            return (await result).includes('yes') ? path : undefined;
           }))).filter(defined);
 
           await this.execCommand('tar', '-cf', await this.wslify(archivePath),

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -29,6 +29,10 @@ class DarwinObsoletePaths implements Paths {
   get wslDistro(): string {
     throw new Error('wslDistro not available for darwin');
   }
+
+  get wslDistroData(): string {
+    throw new Error('wslDistro not available for darwin');
+  }
 }
 
 /**
@@ -51,6 +55,10 @@ class Win32ObsoletePaths implements Paths {
 
   get wslDistro() {
     return path.join(this.localAppData, 'xdg.state', APP_NAME, 'distro');
+  }
+
+  get wslDistroData(): string {
+    throw new Error('wslDistroData is not required for migration');
   }
 
   get lima(): string {
@@ -202,7 +210,7 @@ function migrateWSLDistro(oldPath: string, newPath: string) {
     // See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 
     if (existingPath !== oldPath) {
-      console.log(`Warning: old WSL path ${ existingPath } does not match expected ${ oldPath }`);
+      console.log(`Warning: old WSL path ${ existingPath } does not match expected ${ oldPath }, skipping migration.`);
 
       return;
     }

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -24,6 +24,11 @@ describe('paths', () => {
       win32:  '%LOCALAPPDATA%/rancher-desktop/distro/',
       darwin: Error(),
     },
+    wslDistroData: {
+      win32:  '%LOCALAPPDATA%/rancher-desktop/distro-data/',
+      darwin: Error(),
+
+    },
     lima: {
       win32:  Error(),
       darwin: '%HOME%/Library/Application Support/rancher-desktop/lima/',

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -16,6 +16,8 @@ export interface Paths {
   cache: string;
   /** Directory holding the WSL distribution (Windows-specific). */
   wslDistro: string;
+  /** Directory holding the WSL data distribution (Windows-specific). */
+  wslDistroData: string;
   /** Directory holding Lima state (macOS-specific). */
   lima: string;
   /** @deprecated Directory holding hyperkit state (macOS-specific) */
@@ -32,6 +34,10 @@ export class DarwinPaths implements Paths {
   lima = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME, 'lima');
   hyperkit = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'driver');
   get wslDistro(): string {
+    throw new Error('wslDistro not available for darwin');
+  }
+
+  get wslDistroData(): string {
     throw new Error('wslDistro not available for darwin');
   }
 }
@@ -56,6 +62,10 @@ export class Win32Paths implements Paths {
 
   get wslDistro() {
     return path.join(this.localAppData, APP_NAME, 'distro');
+  }
+
+  get wslDistroData() {
+    return path.join(this.localAppData, APP_NAME, 'distro-data');
   }
 
   get lima(): string {
@@ -84,6 +94,10 @@ export class LinuxPaths implements Paths {
   }
 
   get wslDistro(): string {
+    throw new Error('wslDistro not available for Linux');
+  }
+
+  get wslDistroData(): string {
     throw new Error('wslDistro not available for Linux');
   }
 


### PR DESCRIPTION
This is the equivalent of #635 — this makes it so we don't need to wipe everything when we upgrade WSL distro versions.

/cc @mattfarina 