### PR TITLE
Run nerdctl via sudo

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -10,5 +10,5 @@ scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
 else
-  LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell 0 nerdctl "$@"
+  LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell 0 sudo --preserve-env=CONTAINERD_ADDRESS nerdctl "$@"
 fi


### PR DESCRIPTION
Also needs to pass-through `CONTAINERD_ADDRESS` because we set it in `~/.profile` and not yet in `/etc/environment`.

Fixes #648