### PR TITLE
Lima: replace base disk if it's out of date.

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -42,7 +42,7 @@ async function getLima() {
 
 async function getAlpineLima() {
   const url = `${ alpineLimaRepo }/releases/download/${ alpineLimaTag }/alpine-lima-${ alpineLimaEdition }-${ alpineLimaVersion }-x86_64.iso`;
-  const destPath = path.join(process.cwd(), 'resources', os.platform(), `alpline-lima-${ alpineLimaTag }-${ alpineLimaEdition }-${ alpineLimaVersion }.iso`);
+  const destPath = path.join(process.cwd(), 'resources', os.platform(), `alpine-lima-${ alpineLimaTag }-${ alpineLimaEdition }-${ alpineLimaVersion }.iso`);
   const expectedChecksum = (await getResource(`${ url }.sha512sum`)).split(/\s+/)[0];
 
   await download(url, destPath, {


### PR DESCRIPTION
We will now replace the Lima base image (from under Lima) if the existing version is old.  Note that the heuristics are based purely on the file name in the configuration file; the image itself doesn't keep a record of the version.

Fixes #636.