### PR TITLE
Path migration: Fix Lima VM name.

### DIFF
--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -285,7 +285,7 @@ function migratePaths() {
     if (tryRename(obsoletePaths.lima, paths.lima, 'Lima state') === 'succeeded') {
       // We also changed the VM name.
       const oldVM = path.join(paths.lima, 'rancher-desktop');
-      const newVM = path.join(paths.lima, 'rd');
+      const newVM = path.join(paths.lima, '0');
 
       tryRename(oldVM, newVM, 'Lima VM');
     }


### PR DESCRIPTION
We ended up using `0` instead of `rd`; this meant the VM was never actually migrated correctly.

Should fix https://github.com/rancher-sandbox/rancher-desktop/pull/652#issuecomment-925378271