### PR TITLE
Fix hostname to lima-rancher-desktop

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -9,6 +9,11 @@ containerd:
   user: false
 # Provisioning scripts run on every boot, not just initial VM provisioning.
 provision:
+- # Make sure hostname doesn't change during upgrade from earlier versions
+  mode: system
+  script: |
+    #!/bin/sh
+    hostname lima-rancher-desktop
 - # Clean up filesystems
   mode: system
   script: |


### PR DESCRIPTION
This way the hostname doesn't change during upgrades from Rancher Desktop 0.4.x, which would break deployed kubernetes workloads.

Fixes #661