### PR TITLE
Refresh the docker warning each time integration warnings are refreshed.

### DIFF
--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -94,7 +94,6 @@ export default class UnixlikeIntegrations {
     for (const name of INTEGRATIONS) {
       this.pathConflictManager.reportConflicts(name);
     }
-    window.send('k8s-integration-warnings', 'docker', ["Links to rancher-desktop's nerdctl"]);
   }
 
   protected async testUsrLocalBin() {

--- a/src/main/pathConflictManager.ts
+++ b/src/main/pathConflictManager.ts
@@ -46,6 +46,9 @@ export default class PathConflictManager {
       console.log(`Error gathering conflicts for file ${ binaryName }`, err);
       // And leave results as an empty array, to clear the current warnings
     }
+    if (binaryName === 'docker') {
+      results.push("Links to rancher-desktop's nerdctl");
+    }
     window.send('k8s-integration-warnings', binaryName, results);
   }
 


### PR DESCRIPTION
If we only issue the warning at startup, it will be lost the first time the checkbox is pressed.

Signed-off-by: Eric Promislow <epromislow@suse.com>