### PR TITLE
Use resources.executable to locate kubectl instead of using a relative path

### DIFF
--- a/src/k8s-engine/kubectl.ts
+++ b/src/k8s-engine/kubectl.ts
@@ -3,6 +3,7 @@
 import childProcess, { spawn } from 'child_process';
 import os from 'os';
 import process from 'process';
+import resources from '@/resources';
 
 // The K8s JS library will get the current context but does not have the ability
 // to save the context. The current version of the package targets k8s 1.18 and
@@ -13,7 +14,7 @@ export function setCurrentContext(cxt: string, exitfunc: (code: number | null, s
 
   opts.env = { ...process.env };
 
-  const bat = spawn(`./resources/${ os.platform() }/bin/kubectl`, ['config', 'use-context', cxt], opts);
+  const bat = spawn(resources.executable('kubectl'), ['config', 'use-context', cxt], opts);
 
   // TODO: For data toggle this based on a debug mode
   bat.stdout?.on('data', (data) => {


### PR DESCRIPTION
The relative path doesn't work from the compiled app.

Fixes #623