### PR TITLE
Remove attempts to shim docker with nerdctl.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -117,7 +117,6 @@ async function doFirstRun() {
       linkResource('kim', true),
       linkResource('kubectl', true),
       linkResource('nerdctl', true),
-      linkResource('docker', true),
     ]);
   }
 }

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -135,16 +135,6 @@ export default async function main(platform) {
     throw new Error(`Matched ${ kimSHA.length } hits, not exactly 1, for platform ${ kubePlatform } in [${ allKimSHAs }]`);
   }
   await download(kimURL, kimPath, { expectedChecksum: kimSHA[0].split(/\s+/, 1)[0] });
-
-  if (kubePlatform === 'darwin') {
-    // On macos nerdctl is an existing resource, so we can connect our fabricated docker utility
-    // to it during tool installation. On Windows this happens during the build process.
-    const sourcePath = path.join(binDir, 'nerdctl');
-    const destPath = path.join(binDir, 'docker');
-
-    await fs.promises.copyFile(sourcePath, destPath);
-  }
-
   // Download Trivy
   // Always run this in the VM, so download the *LINUX* version into binDir
   // and move it over to the wsl/lima partition at runtime.

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -228,22 +228,19 @@ export default {
     if (!['windows', 'linux'].includes(os)) {
       throw new Error(`Unexpected os of ${ os }`);
     }
-    let platDir, basename, parentDir, outFile, sourceFile, destFile;
+    let platDir, parentDir, outFile;
 
     if (os === 'windows') {
       platDir = 'win32';
       parentDir = path.join(this.srcDir, 'resources', platDir, 'bin');
-      sourceFile = outFile = path.join(parentDir, 'nerdctl.exe');
-      destFile = path.join(parentDir, 'docker.exe');
+      outFile = path.join(parentDir, 'nerdctl.exe');
     } else {
       platDir = 'linux';
       parentDir = path.join(this.srcDir, 'resources', platDir, 'bin');
-      // nerdctl-stub is the actual nerdctl binary to be run on linux
+      // nerdctl-stub is the actual nerdctl binary to be run on linux;
+      // there is also a `nerdctl` wrapper in the same directory to make it
+      // easier to handle permissions for Linux-in-WSL.
       outFile = path.join(parentDir, 'nerdctl-stub');
-      // nerdctl is a shell script wrapper to point to the above nerdctl binary,
-      // hiding mount permissions from the linux/wsl-side user
-      sourceFile = path.join(parentDir, 'nerdctl');
-      destFile = path.join(parentDir, 'docker');
     }
     // The linux build produces both nerdctl-stub and nerdctl
     await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', outFile, '.', {
@@ -253,7 +250,6 @@ export default {
         GOOS: os,
       }
     });
-    await fs.promises.copyFile(sourceFile, destFile);
   },
 
   /**

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -7,7 +7,7 @@ import resources from '@/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
 
-const INTEGRATIONS = ['docker', 'helm', 'kim', 'kubectl', 'nerdctl'];
+const INTEGRATIONS = ['helm', 'kim', 'kubectl', 'nerdctl'];
 const console = new Console(Logging.background.stream);
 const PUBLIC_LINK_DIR = '/usr/local/bin';
 

--- a/src/main/pathConflictManager.ts
+++ b/src/main/pathConflictManager.ts
@@ -46,9 +46,6 @@ export default class PathConflictManager {
       console.log(`Error gathering conflicts for file ${ binaryName }`, err);
       // And leave results as an empty array, to clear the current warnings
     }
-    if (binaryName === 'docker') {
-      results.push("Links to rancher-desktop's nerdctl");
-    }
     window.send('k8s-integration-warnings', binaryName, results);
   }
 

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -4,7 +4,6 @@ import { app } from 'electron';
 import memoize from 'lodash/memoize';
 
 const adjustNameWithDir: Record<string, string> = {
-  docker:  path.join('bin', 'docker'),
   helm:    path.join('bin', 'helm'),
   kim:     path.join('bin', 'kim'),
   kubectl: path.join('bin', 'kubectl'),

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -22,8 +22,7 @@ const regexes: Record<string, RegExp> = {
 export default async function pathConflict(targetDir: string, binaryName: string): Promise<Array<string>> {
   const referencePath = resources.executable(binaryName);
   // We don't ship nerdctl, just an unversioned stub; so hard-wire a truthy value.
-  // And our docker is a symlink to nerdctl
-  const isUnversioned = ['docker', 'nerdctl'].includes(binaryName);
+  const isUnversioned = ['nerdctl'].includes(binaryName);
 
   try {
     await fs.promises.access(referencePath, fs.constants.R_OK | fs.constants.X_OK);


### PR DESCRIPTION
At this point, nerdctl is missing too many features to be a good docker CLI replacement; don't attempt to do so.

Fixes #671