### PR TITLE
Ensure the rd node has the builder label on it

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -768,6 +768,9 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await childProcess.spawnFile(resources.executable('kubectl'),
         ['--context', 'rancher-desktop', 'cluster-info'],
         { stdio: ['inherit', await Logging.k8s.fdStream, await Logging.k8s.fdStream] });
+      await childProcess.spawnFile(resources.executable('kubectl'),
+        ['label', '--context', 'rancher-desktop', '--overwrite', 'nodes', 'lima-rancher-desktop', 'node-role.kubernetes.io/builder=true'],
+        { stdio: ['inherit', await Logging.k8s.fdStream, await Logging.k8s.fdStream] });
       this.setState(K8s.State.STARTED);
       this.setProgress(Progress.DONE);
     } catch (err) {


### PR DESCRIPTION
Kim expects its builder daemonset to use the node selector
node-role.kubernetes.io/builder=true

Sometimes on restart this label is dropped off the
lima-rancher-desktop node, so we can ensure it's always there.

Signed-off-by: Eric Promislow <epromislow@suse.com>