### PR TITLE
Remove code causing node roles to be deleted

### DIFF
--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -533,20 +533,4 @@ export class KubeClient extends events.EventEmitter {
       });
     });
   }
-
-  /**
-   * Clean up obsolete nodes that match a predicate.
-   * @param predicate A function that returns true if a node should be removed.
-   */
-  async cleanupNodes(predicate: (node: k8s.V1Node) => boolean) {
-    const { body: nodeList } = await this.coreV1API.listNode();
-    const promises = nodeList
-      .items
-      .filter(predicate)
-      .map(node => node.metadata?.name)
-      .filter(defined)
-      .map(nodeName => this.coreV1API.deleteNode(nodeName));
-
-    return await Promise.all(promises);
-  }
 }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -673,10 +673,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         this.emit('service-changed', services);
       });
 
-      // We need to remove obsolete nodes because we renamed the VM; otherwise
-      // they get stuck forever.  No need to wait for the result.
-      this.client.cleanupNodes(node => node.metadata?.name === 'lima-rancher-desktop');
-
       this.activeVersion = desiredShortVersion;
       this.currentPort = this.#desiredPort;
       this.emit('current-port-changed', this.currentPort);


### PR DESCRIPTION
At one point we renamed the instance from lima-rancher-desktop to
lima-0. The rancher-desktop and 0 are names passed to lima. The
full name shows up in the socket path which has a limited number
of characters. The shorter the name the better.

Recently, we set the host name back to rancher-desktop. This is
internal to the OS running on the node and not lima. This caused
the node name to again be lima-rancher-desktop.

The code deleted in this change removes the cleanup. The cleanup
was deleting the node. It was then being added back by k3s without
any roles on it.

Closes #667