### PR TITLE
Fix the Windows About box

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -84,6 +84,16 @@ Electron.app.whenReady().then(async() => {
     }
 
     buildApplicationMenu();
+    if (os.platform().startsWith('win')) {
+      const appVersion = await getVersion();
+
+      Electron.app.setAboutPanelOptions({
+        copyright:          'Copyright © 2021 SUSE LLC', // TODO: Update this to 2021-... as dev progresses
+        applicationName:    'Rancher Desktop',
+        applicationVersion: `Version ${ appVersion }`,
+        iconPath:           resources.get('icons/logo-square-512.png'),
+      });
+    }
     setupTray();
     window.openPreferences();
 
@@ -426,7 +436,7 @@ Electron.ipcMain.on('troubleshooting/show-logs', async(event) => {
 });
 
 Electron.ipcMain.handle('get-app-version', async(event) => {
-  return process.env.NODE_ENV === 'production' ? getProductionVersion() : await getDevVersion();
+  return await getVersion();
 });
 
 Electron.ipcMain.handle('show-message-box', (event, options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> => {
@@ -453,6 +463,10 @@ async function getDevVersion() {
 
     return '?';
   }
+}
+
+async function getVersion() {
+  return process.env.NODE_ENV === 'production' ? getProductionVersion() : await getDevVersion();
 }
 
 /**

--- a/background.ts
+++ b/background.ts
@@ -84,16 +84,14 @@ Electron.app.whenReady().then(async() => {
     }
 
     buildApplicationMenu();
-    if (os.platform().startsWith('win')) {
-      const appVersion = await getVersion();
 
-      Electron.app.setAboutPanelOptions({
-        copyright:          'Copyright © 2021 SUSE LLC', // TODO: Update this to 2021-... as dev progresses
-        applicationName:    'Rancher Desktop',
-        applicationVersion: `Version ${ appVersion }`,
-        iconPath:           resources.get('icons/logo-square-512.png'),
-      });
-    }
+    Electron.app.setAboutPanelOptions({
+      copyright:          'Copyright © 2021 SUSE LLC', // TODO: Update this to 2021-... as dev progresses
+      applicationName:    Electron.app.name,
+      applicationVersion: `Version ${ await getVersion() }`,
+      iconPath:           resources.get('icons', 'logo-square-512.png'),
+    });
+
     setupTray();
     window.openPreferences();
 


### PR DESCRIPTION
Windows doesn't look at plist files, so the box currently contains generic info.

Signed-off-by: Eric Promislow <epromislow@suse.com>