### PR TITLE
Provide better status messages on start

### DIFF
--- a/src/components/BackendProgress.vue
+++ b/src/components/BackendProgress.vue
@@ -30,13 +30,13 @@ class BackendProgress extends Vue {
   /** Current Kubernetes backend action progress. */
   progress: {
     /** The current progress, from 0 to max. */
-    current: number;
+    readonly current: number;
     /** Maximum possible progress; if less than zero, the progress is indeterminate. */
-    max: number;
+    readonly max: number;
     /** Description of current action. */
-    description?: string;
+    readonly description?: string;
     /** Time since the description became valid. */
-    transitionTime?: Date;
+    readonly transitionTime?: Date;
   } = { current: 1, max: 1 };
 
   progressInterval: ReturnType<typeof setInterval> | undefined;

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -22,6 +22,17 @@ export class KubernetesError extends Error {
   }
 }
 
+export type KubernetesProgress = {
+    /** The current progress; valid values are 0 to max. */
+    current: number,
+    /** Maximum progress possible; if less than zero, the progress is indeterminate. */
+    max: number,
+    /** Details on the current action. */
+    description?: string,
+    /** When we entered this progress state. */
+    transitionTime?: Date,
+}
+
 export interface KubernetesBackend extends events.EventEmitter {
   /** The name of the Kubernetes backend */
   readonly backend: 'wsl' | 'lima' | 'not-implemented';
@@ -50,16 +61,7 @@ export interface KubernetesBackend extends events.EventEmitter {
   readonly desiredPort: number;
 
   /** Progress for the current action. */
-  progress: {
-    /** The current progress; valid values are 0 to max. */
-    readonly current: number,
-    /** Maximum progress possible; if less than zero, the progress is indeterminate. */
-    readonly max: number,
-    /** Details on the current action. */
-    readonly description?: string,
-    /** When we entered this progress state. */
-    readonly transitionTime?: Date,
-  };
+  progress: Readonly<KubernetesProgress>;
 
   /**
    * Check if the current backend is valid.

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -16,7 +16,6 @@ import tar from 'tar';
 import yaml from 'yaml';
 import merge from 'lodash/merge';
 
-import * as window from '@/window';
 import { Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
 import Logging from '@/utils/logging';

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -755,6 +755,12 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         await childProcess.spawnFile(resources.executable('kubectl'),
           ['--context', 'rancher-desktop', 'cluster-info'],
           { stdio: ['inherit', await Logging.k8s.fdStream, await Logging.k8s.fdStream] });
+
+        await this.progressTracker.action(
+          'Waiting for nodes',
+          100,
+          this.client?.waitForReadyNodes() ?? Promise.reject(new Error('No client')));
+
         this.setState(K8s.State.STARTED);
       } catch (err) {
         console.error('Error starting lima:', err);

--- a/src/k8s-engine/progressTracker.ts
+++ b/src/k8s-engine/progressTracker.ts
@@ -1,0 +1,105 @@
+import * as K8s from './k8s';
+
+/**
+ * ProgressTracker is used to track progress of multiple parallel actions.
+ */
+export default class ProgressTracker {
+  /**
+   * @param notify The callback to invoke on progress change.
+   */
+  constructor(notify: (progress: K8s.KubernetesProgress) => void) {
+    this.notify = notify;
+  }
+
+  /**
+   * Set the progress to a numeric value.  Numeric progress is always shown in
+   * preference to other progress.  There may only be one active numeric
+   * progress at a time.
+   * @param description Descriptive text.
+   * @param current The current numeric progress
+   * @param max Maximum possible numeric prog
+   */
+  numeric(description: string, current: number, max: number) {
+    if (current < max) {
+      this.numericProgress = {
+        current, max, description, transitionTime: new Date()
+      };
+    } else {
+      this.numericProgress = undefined;
+    }
+    this.update();
+  }
+
+  /**
+   * Run a given action.  The currently running action with the highest priority
+   * will be displayed as the progress.
+   * @returns A promise that will be resolved when the passed-in promise resolves.
+   */
+  action<T>(description: string, priority: number, promise: Promise<T>): Promise<T>;
+  action<T>(description: string, priority: number, fn: () => Promise<T>): Promise<T>;
+  action<T>(description: string, priority: number, v: Promise<T> | (() => Promise<T>)) {
+    const id = this.nextActionID;
+
+    this.nextActionID++;
+    this.actionProgress.push({
+      priority,
+      id,
+      progress: {
+        current: 0, max: -1, description, transitionTime: new Date(),
+      }
+    });
+    this.update();
+
+    const promise = (v instanceof Promise) ? v : v();
+
+    return new Promise<T>((resolve, reject) => {
+      promise.then((val) => {
+        this.actionProgress = this.actionProgress.filter(p => p.id !== id);
+        this.update();
+        resolve(val);
+      }).catch((ex) => {
+        this.actionProgress = this.actionProgress.filter(p => p.id !== id);
+        this.update();
+        reject(ex);
+      });
+    });
+  }
+
+  protected notify: (progress: K8s.KubernetesProgress) => void;
+
+  /**
+   * The last set numeric progress.
+   */
+  protected numericProgress?: K8s.KubernetesProgress;
+
+  /**
+   * A list of progress from pending actions.
+   */
+  protected actionProgress: {priority: number, id: number, progress: K8s.KubernetesProgress}[] = [];
+
+  /**
+   * Unique identifier for the next action.
+   */
+  protected nextActionID = 0;
+
+  /**
+   * Update the display of the progress, depending on the current state.
+   */
+  protected update() {
+    if (this.numericProgress) {
+      this.notify(this.numericProgress);
+
+      return;
+    }
+    if (this.actionProgress.length < 1) {
+      // No action progress either; no active progress at all.
+      this.notify({ current: 1, max: 1 });
+
+      return;
+    }
+
+    const { progress } = this.actionProgress.reduce((a, b) => a.priority > b.priority ? a : b);
+
+    this.notify(progress);
+  }
+}

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -727,6 +727,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         // Trigger kuberlr to ensure there's a compatible version of kubectl in place
         await childProcess.spawnFile(resources.executable('kubectl'), ['config', 'current-context'],
           { stdio: ['inherit', Logging.k8s.stream, Logging.k8s.stream] });
+
+        await this.progressTracker.action(
+          'Waiting for nodes',
+          100,
+          this.client?.waitForReadyNodes() ?? Promise.reject(new Error('No client')));
+
         this.setState(K8s.State.STARTED);
       } catch (ex) {
         this.setState(K8s.State.ERROR);

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -80,7 +80,7 @@ interface IpcMainInvokeEvents {
 interface IpcRendererEvents {
   'settings-update': (settings: import('@/config/settings').Settings) => void;
   'update-state': (state: import('@/k8s-engine/k8s').State) => void;
-  'k8s-progress': (progress: {current: number, max: number, description?: string, transitionTime?: Date}) => void;
+  'k8s-progress': (progress: Readonly<{current: number, max: number, description?: string, transitionTime?: Date}>) => void;
   'k8s-check-state': (state: import('@/k8s-engine/k8s').State) => void;
   'k8s-current-port': (port: number) => void;
   'k8s-restart-required': (required: Record<string, [any, any] | []>) => void;


### PR DESCRIPTION
This adds more details to the status messages on start, to let the user know what _precisely_ is happening; this fixes #660.

Also adds an explicit wait for the nodes to be ready; fixes #698.