### PR TITLE
Update layout for Troubleshooting

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4486,7 +4486,7 @@ troubleshooting:
       description: Resetting Kubernetes will delete workloads and configuration. Use this when...
       buttonText: Reset Kubernetes
     resetContainer:
-      title: Reset Kubernetes & Container Images
+      title: 'Reset Kubernetes & Container Images'
       description: All images will be lost and Kubernetes will be reset. Use this when...
       buttonText: Reset Container Images
   general:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4473,6 +4473,33 @@ resourceQuota:
   resourceType:
     label: Resource Type
 
+##############################
+### Troubleshooting Page
+##############################
+troubleshooting: 
+  title: Troubleshooting
+  description: Use these tools to help identify and resolve issues.
+  kubernetes:
+    title: Kubernetes
+    resetKubernetes:
+      title: Reset Kubernetes
+      description: Resetting Kubernetes will delete workloads and configuration. Use this when...
+      buttonText: Reset Kubernetes
+    resetContainer:
+      title: Reset Kubernetes & Container Images
+      description: All images will be lost and Kubernetes will be reset. Use this when...
+      buttonText: Reset Container Images
+  general:
+    title: General
+    logs:
+      title: Logs
+      description: Show Rancher Desktop logs
+      buttonText: Show Logs
+    factoryReset:
+      title: Factory Reset
+      description: Factory Reset will remove all Rancher Desktop Configurations. Use this when...
+      buttonText: Factory Reset
+  needHelp: 'Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.'
 
 ##############################
 ### Support Page

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4483,11 +4483,11 @@ troubleshooting:
     title: Kubernetes
     resetKubernetes:
       title: Reset Kubernetes
-      description: Resetting Kubernetes will delete workloads and configuration. Use this when...
+      description: Resetting Kubernetes will delete workloads and configuration.
       buttonText: Reset Kubernetes
     resetContainer:
       title: 'Reset Kubernetes & Container Images'
-      description: All images will be lost and Kubernetes will be reset. Use this when...
+      description: All images will be lost and Kubernetes will be reset.
       buttonText: Reset Container Images
   general:
     title: General
@@ -4497,7 +4497,7 @@ troubleshooting:
       buttonText: Show Logs
     factoryReset:
       title: Factory Reset
-      description: Factory Reset will remove all Rancher Desktop Configurations. Use this when...
+      description: Factory Reset will remove all Rancher Desktop Configurations.
       buttonText: Factory Reset
   needHelp: 'Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.'
 

--- a/src/components/TroubleshootingLineItem.vue
+++ b/src/components/TroubleshootingLineItem.vue
@@ -1,0 +1,37 @@
+<script lang="ts">
+
+import Vue from 'vue';
+export default Vue.extend({});
+
+</script>
+
+<template>
+  <div class="troubleshooting-line-item">
+    <div class="description">
+      <h3>
+        <slot name="title">
+        </slot>
+      </h3>
+      <span>
+        <slot name="description">
+        </slot>
+      </span>
+    </div>
+    <slot>
+    </slot>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .troubleshooting-line-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+
+  .description {
+    margin-right: 24px;
+  }
+</style>

--- a/src/components/TroubleshootingLineItem.vue
+++ b/src/components/TroubleshootingLineItem.vue
@@ -27,8 +27,8 @@ export default Vue.extend({});
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 24px;
-    margin-bottom: 24px;
+    margin-top: 16px;
+    margin-bottom: 16px;
   }
 
   .description {

--- a/src/components/TroubleshootingLineItem.vue
+++ b/src/components/TroubleshootingLineItem.vue
@@ -27,11 +27,11 @@ export default Vue.extend({});
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 16px;
-    margin-bottom: 16px;
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
   }
 
   .description {
-    margin-right: 24px;
+    margin-right: 1.5rem;
   }
 </style>

--- a/src/components/TroubleshootingLineItem.vue
+++ b/src/components/TroubleshootingLineItem.vue
@@ -1,10 +1,3 @@
-<script lang="ts">
-
-import Vue from 'vue';
-export default Vue.extend({});
-
-</script>
-
 <template>
   <div class="troubleshooting-line-item">
     <div class="description">

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -10,42 +10,6 @@
       </span>
     </header>
     <section class="troubleshooting">
-      <section class="kubernetes">
-        <h2>{{ t('troubleshooting.kubernetes.title') }}</h2>
-        <troubleshooting-line-item>
-          <template #title>
-            {{ t('troubleshooting.kubernetes.resetKubernetes.title') }}
-          </template>
-          <template #description>
-            {{ t('troubleshooting.kubernetes.resetKubernetes.description') }}
-          </template>
-          <button
-            type="button"
-            class="btn btn-xs role-secondary"
-            :disabled="cannotReset"
-            @click="reset"
-          >
-            {{ t('troubleshooting.kubernetes.resetKubernetes.buttonText') }}
-          </button>
-        </troubleshooting-line-item>
-        <hr>
-        <troubleshooting-line-item>
-          <template #title>
-            {{ t('troubleshooting.kubernetes.resetContainer.title', { }, true) }}
-          </template>
-          <template #description>
-            {{ t('troubleshooting.kubernetes.resetContainer.description') }}
-          </template>
-          <button
-            type="button"
-            class="btn btn-xs role-secondary"
-            :disabled="cannotReset"
-            @click="reset('wipe')"
-          >
-            {{ t('troubleshooting.kubernetes.resetContainer.buttonText') }}
-          </button>
-        </troubleshooting-line-item>
-      </section>
       <section class="general">
         <h2>{{ t('troubleshooting.general.title') }}</h2>
         <troubleshooting-line-item>
@@ -114,9 +78,6 @@ export default {
         return false;
       }
     },
-    cannotReset() {
-      return ![K8s.State.STARTED, K8s.State.ERROR].includes(this.state);
-    },
   },
   mounted() {
     ipcRenderer.on('k8s-check-state', (event, newState) => {
@@ -135,27 +96,7 @@ export default {
       }
     },
     showLogs() {
-      console.log('show logs?');
       ipcRenderer.send('troubleshooting/show-logs');
-    },
-    /**
-     * Reset a Kubernetes cluster to default at the same version
-     * @param { 'auto' | 'wipe' } mode How to do the reset
-     */
-    reset(mode) {
-      const wipe = (mode === 'wipe') || (this.state !== K8s.State.STARTED);
-      const consequence = {
-        true:  'Wiping Kubernetes will delete all workloads, configuration, and images.',
-        false: 'Resetting Kubernetes will delete all workloads and configuration.',
-      }[wipe];
-
-      if (confirm(`${ consequence } Do you want to proceed?`)) {
-        // for (const key in this.notifications) {
-        //   this.handleNotification('info', key, '');
-        // }
-        this.state = K8s.State.STOPPING;
-        ipcRenderer.send('k8s-reset', wipe ? 'wipe' : 'fast');
-      }
     },
   },
 };

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -1,24 +1,35 @@
 <template>
-  <ul class="troubleshooting">
-    <li>
-      <label>
-        <button
-          id="btnTroubleShootingFactoryReset"
-          :disabled="!canFactoryReset"
-          class="btn role-secondary"
-          @click="factoryReset"
-        >
-          Factory Reset
+  <section class="dashboard">
+    <header>
+      <div class="title">
+        <h1>Troubleshooting</h1>
+      </div>
+      <hr>
+      <div>
+        <span>Short explanation about when you might need to use these facilities</span>
+      </div>
+    </header>
+    <ul class="troubleshooting">
+      <li>
+        <label>
+          <button
+            id="btnTroubleShootingFactoryReset"
+            :disabled="!canFactoryReset"
+            class="btn role-secondary"
+            @click="factoryReset"
+          >
+            Factory Reset
+          </button>
+          Factory reset will remove all Rancher Desktop configuration.
+        </label>
+      </li>
+      <li>
+        <button class="btn role-secondary" @click="showLogs">
+          Show Logs
         </button>
-        Factory reset will remove all Rancher Desktop configuration.
-      </label>
-    </li>
-    <li>
-      <button class="btn role-secondary" @click="showLogs">
-        Show Logs
-      </button>
-    </li>
-  </ul>
+      </li>
+    </ul>
+  </section>
 </template>
 
 <script>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -23,7 +23,7 @@
             type="button"
             class="btn btn-xs role-secondary"
             :disabled="cannotReset"
-            @click="showLogs"
+            @click="reset"
           >
             {{ t('troubleshooting.kubernetes.resetKubernetes.buttonText') }}
           </button>
@@ -40,7 +40,7 @@
             type="button"
             class="btn btn-xs role-secondary"
             :disabled="cannotReset"
-            @click="factoryReset"
+            @click="reset('wipe')"
           >
             {{ t('troubleshooting.kubernetes.resetContainer.buttonText') }}
           </button>
@@ -137,6 +137,25 @@ export default {
     showLogs() {
       console.log('show logs?');
       ipcRenderer.send('troubleshooting/show-logs');
+    },
+    /**
+     * Reset a Kubernetes cluster to default at the same version
+     * @param { 'auto' | 'wipe' } mode How to do the reset
+     */
+    reset(mode) {
+      const wipe = (mode === 'wipe') || (this.state !== K8s.State.STARTED);
+      const consequence = {
+        true:  'Wiping Kubernetes will delete all workloads, configuration, and images.',
+        false: 'Resetting Kubernetes will delete all workloads and configuration.',
+      }[wipe];
+
+      if (confirm(`${ consequence } Do you want to proceed?`)) {
+        // for (const key in this.notifications) {
+        //   this.handleNotification('info', key, '');
+        // }
+        this.state = K8s.State.STOPPING;
+        ipcRenderer.send('k8s-reset', wipe ? 'wipe' : 'fast');
+      }
     },
   },
 };

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -150,19 +150,19 @@ export default {
   }
 
   .title {
-    padding-bottom: 4px;
+    padding-bottom: 0.25rem;
   }
 
   .general,
   .kubernetes {
-    max-width: 768px;
-    margin-top: 32px;
+    max-width: 56rem;
+    margin-top: 2rem;
   }
 
   .btn-xs {
-    min-height: 32px;
-    max-height: 32px;
-    line-height: 4px;
+    min-height: 2.25rem;
+    max-height: 2.25rem;
+    line-height: 0.25rem;
   }
 
   button.btn-danger {
@@ -171,10 +171,10 @@ export default {
   }
 
   .description {
-    line-height: 6 px;
+    line-height: 0.50rem;
   }
 
   .need-help {
-    margin-top: 32px;
+    margin-top: 2.25rem;
   }
 </style>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -81,6 +81,12 @@
           Factory Reset
         </button>
       </troubleshooting-line-item>
+      <section class="need-help">
+        <hr>
+        <span class="description">
+          Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+        </span>
+      </section>
     </section>
   </section>
 </template>
@@ -162,5 +168,13 @@ export default {
   button.btn-danger {
     color: var(--error) !important;
     border-color: var(--error);
+  }
+
+  .description {
+    line-height: 6 px;
+  }
+
+  .need-help {
+    margin-top: 32px;
   }
 </style>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -141,9 +141,10 @@ export default {
     padding-bottom: 4px;
   }
 
-  .content {
+  .general,
+  .kubernetes {
     max-width: 768px;
-    margin-top: 48px;
+    margin-top: 32px;
   }
 
   .btn-xs {

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -11,81 +11,83 @@
         </span>
       </div>
     </header>
-    <section class="kubernetes">
-      <h2>Kubernetes</h2>
-      <troubleshooting-line-item>
-        <template #title>
-          Reset Kubernetes
-        </template>
-        <template #description>
-          Resetting Kubernetes will delete workloads and configuration. Use this when...
-        </template>
-        <button
-          type="button"
-          class="btn btn-xs role-secondary"
-          :disabled="cannotReset"
-          @click="showLogs"
-        >
-          Reset Kubernetes
-        </button>
-      </troubleshooting-line-item>
-      <hr>
-      <troubleshooting-line-item>
-        <template #title>
-          Reset Kubernetes & Container Images
-        </template>
-        <template #description>
-          All images will be lost and Kubernetes will be reset. Use this when...
-        </template>
-        <button
-          type="button"
-          class="btn btn-xs role-secondary"
-          :disabled="cannotReset"
-          @click="factoryReset"
-        >
-          Reset Container Images
-        </button>
-      </troubleshooting-line-item>
-    </section>
-    <section class="general">
-      <h2>General</h2>
-      <troubleshooting-line-item>
-        <template #title>
-          Logs
-        </template>
-        <template #description>
-          Show Rancher Desktop logs
-        </template>
-        <button
-          type="button"
-          class="btn btn-xs role-secondary"
-          @click="showLogs"
-        >
-          Show Logs
-        </button>
-      </troubleshooting-line-item>
-      <hr>
-      <troubleshooting-line-item>
-        <template #title>
-          Factory Reset
-        </template>
-        <template #description>
-          Factory Reset will remove all Rancher Desktop Configurations. Use this when...
-        </template>
-        <button
-          type="button"
-          class="btn btn-xs btn-danger role-secondary"
-          :disabled="!canFactoryReset"
-          @click="factoryReset"
-        >
-          Factory Reset
-        </button>
-      </troubleshooting-line-item>
-      <section class="need-help">
+    <section class="troubleshooting">
+      <section class="kubernetes">
+        <h2>Kubernetes</h2>
+        <troubleshooting-line-item>
+          <template #title>
+            Reset Kubernetes
+          </template>
+          <template #description>
+            Resetting Kubernetes will delete workloads and configuration. Use this when...
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs role-secondary"
+            :disabled="cannotReset"
+            @click="showLogs"
+          >
+            Reset Kubernetes
+          </button>
+        </troubleshooting-line-item>
         <hr>
-        <span class="description">
-          Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
-        </span>
+        <troubleshooting-line-item>
+          <template #title>
+            Reset Kubernetes & Container Images
+          </template>
+          <template #description>
+            All images will be lost and Kubernetes will be reset. Use this when...
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs role-secondary"
+            :disabled="cannotReset"
+            @click="factoryReset"
+          >
+            Reset Container Images
+          </button>
+        </troubleshooting-line-item>
+      </section>
+      <section class="general">
+        <h2>General</h2>
+        <troubleshooting-line-item>
+          <template #title>
+            Logs
+          </template>
+          <template #description>
+            Show Rancher Desktop logs
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs role-secondary"
+            @click="showLogs"
+          >
+            Show Logs
+          </button>
+        </troubleshooting-line-item>
+        <hr>
+        <troubleshooting-line-item>
+          <template #title>
+            Factory Reset
+          </template>
+          <template #description>
+            Factory Reset will remove all Rancher Desktop Configurations. Use this when...
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs btn-danger role-secondary"
+            :disabled="!canFactoryReset"
+            @click="factoryReset"
+          >
+            Factory Reset
+          </button>
+        </troubleshooting-line-item>
+        <section class="need-help">
+          <hr>
+          <span class="description">
+            Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+          </span>
+        </section>
       </section>
     </section>
   </section>
@@ -143,20 +145,16 @@ export default {
 
 <style lang="scss" scoped>
   .troubleshooting {
-    list-style-type: none;
-    li {
-      margin-bottom: 1em;
-    }
-  }
-
-  .title {
-    padding-bottom: 0.25rem;
+    max-width: 56rem;
   }
 
   .general,
   .kubernetes {
-    max-width: 56rem;
     margin-top: 2rem;
+  }
+
+  .title {
+    padding-bottom: 0.25rem;
   }
 
   .btn-xs {

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -11,7 +11,6 @@
     </header>
     <section class="troubleshooting">
       <section class="general">
-        <h2>{{ t('troubleshooting.general.title') }}</h2>
         <troubleshooting-line-item>
           <template #title>
             {{ t('troubleshooting.general.logs.title') }}

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -130,8 +130,4 @@ export default {
   .description {
     line-height: 0.50rem;
   }
-
-  .need-help {
-    margin-top: 2.25rem;
-  }
 </style>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -9,39 +9,56 @@
         <span>Short explanation about when you might need to use these facilities</span>
       </div>
     </header>
-    <ul class="troubleshooting">
-      <li>
-        <label>
-          <button
-            id="btnTroubleShootingFactoryReset"
-            :disabled="!canFactoryReset"
-            class="btn role-secondary"
-            @click="factoryReset"
-          >
-            Factory Reset
-          </button>
-          Factory reset will remove all Rancher Desktop configuration.
-        </label>
-      </li>
-      <li>
-        <button class="btn role-secondary" @click="showLogs">
+    <section class="content">
+      <h2>General</h2>
+      <troubleshooting-line-item>
+        <template #title>
+          Factory Reset
+        </template>
+        <template #description>
+          Factory Reset will remove all Rancher Desktop Configurations. Use this when...
+        </template>
+        <button
+          type="button"
+          class="btn btn-xs role-secondary"
+          :disabled="!canFactoryReset"
+          @click="factoryReset"
+        >
+          Factory Reset
+        </button>
+      </troubleshooting-line-item>
+      <hr>
+      <troubleshooting-line-item>
+        <template #title>
+          Logs
+        </template>
+        <template #description>
+          Show Rancher Desktop logs
+        </template>
+        <button
+          type="button"
+          class="btn btn-xs role-secondary"
+          @click="showLogs"
+        >
           Show Logs
         </button>
-      </li>
-    </ul>
+      </troubleshooting-line-item>
+    </section>
   </section>
 </template>
 
 <script>
+import TroubleshootingLineItem from '@/components/TroubleshootingLineItem.vue';
 
 const { ipcRenderer } = require('electron');
 const K8s = require('../k8s-engine/k8s');
 
 export default {
-  name:     'Troubleshooting',
-  title:    'Troubleshooting',
-  data:     () => ({ state: ipcRenderer.sendSync('k8s-state') }),
-  computed: {
+  name:       'Troubleshooting',
+  title:      'Troubleshooting',
+  components: { TroubleshootingLineItem },
+  data:       () => ({ state: ipcRenderer.sendSync('k8s-state') }),
+  computed:   {
     canFactoryReset() {
       switch (this.state) {
       case K8s.State.STOPPED:
@@ -83,5 +100,20 @@ export default {
     li {
       margin-bottom: 1em;
     }
+  }
+
+  .title {
+    padding-bottom: 4px;
+  }
+
+  .content {
+    max-width: 768px;
+    margin-top: 48px;
+  }
+
+  .btn-xs {
+    min-height: 32px;
+    max-height: 32px;
+    line-height: 4px;
   }
 </style>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -9,7 +9,42 @@
         <span>Short explanation about when you might need to use these facilities</span>
       </div>
     </header>
-    <section class="content">
+    <section class="kubernetes">
+      <h2>Kubernetes</h2>
+      <troubleshooting-line-item>
+        <template #title>
+          Reset Kubernetes
+        </template>
+        <template #description>
+          Resetting Kubernetes will delete workloads and configuration. Use this when...
+        </template>
+        <button
+          type="button"
+          class="btn btn-xs role-secondary"
+          @click="showLogs"
+        >
+          Reset Kubernetes
+        </button>
+      </troubleshooting-line-item>
+      <hr>
+      <troubleshooting-line-item>
+        <template #title>
+          Reset Kubernetes & Container Images
+        </template>
+        <template #description>
+          All images will be lost and Kubernetes will be reset. Use this when...
+        </template>
+        <button
+          type="button"
+          class="btn btn-xs role-secondary"
+          :disabled="!canFactoryReset"
+          @click="factoryReset"
+        >
+          Reset Container Images
+        </button>
+      </troubleshooting-line-item>
+    </section>
+    <section class="general">
       <h2>General</h2>
       <troubleshooting-line-item>
         <template #title>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -31,7 +31,7 @@
         <hr>
         <troubleshooting-line-item>
           <template #title>
-            {{ t('troubleshooting.kubernetes.resetContainer.title') }}
+            {{ t('troubleshooting.kubernetes.resetContainer.title', { }, true) }}
           </template>
           <template #description>
             {{ t('troubleshooting.kubernetes.resetContainer.description') }}

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -21,6 +21,7 @@
         <button
           type="button"
           class="btn btn-xs role-secondary"
+          :disabled="cannotReset"
           @click="showLogs"
         >
           Reset Kubernetes
@@ -37,7 +38,7 @@
         <button
           type="button"
           class="btn btn-xs role-secondary"
-          :disabled="!canFactoryReset"
+          :disabled="cannotReset"
           @click="factoryReset"
         >
           Reset Container Images
@@ -103,6 +104,9 @@ export default {
       default:
         return false;
       }
+    },
+    cannotReset() {
+      return ![K8s.State.STARTED, K8s.State.ERROR].includes(this.state);
     },
   },
   mounted() {

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -6,7 +6,9 @@
       </div>
       <hr>
       <div>
-        <span>Short explanation about when you might need to use these facilities</span>
+        <span class="description">
+          Use these tools to help identify and resolve issues.
+        </span>
       </div>
     </header>
     <section class="kubernetes">

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -20,7 +20,7 @@
         </template>
         <button
           type="button"
-          class="btn btn-xs role-secondary"
+          class="btn btn-xs btn-danger role-secondary"
           :disabled="!canFactoryReset"
           @click="factoryReset"
         >
@@ -115,5 +115,10 @@ export default {
     min-height: 32px;
     max-height: 32px;
     line-height: 4px;
+  }
+
+  button.btn-danger {
+    color: var(--error) !important;
+    border-color: var(--error);
   }
 </style>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -2,24 +2,22 @@
   <section class="dashboard">
     <header>
       <div class="title">
-        <h1>Troubleshooting</h1>
+        <h1>{{ t('troubleshooting.title') }}</h1>
       </div>
       <hr>
-      <div>
-        <span class="description">
-          Use these tools to help identify and resolve issues.
-        </span>
-      </div>
+      <span class="description">
+        {{ t('troubleshooting.description') }}
+      </span>
     </header>
     <section class="troubleshooting">
       <section class="kubernetes">
-        <h2>Kubernetes</h2>
+        <h2>{{ t('troubleshooting.kubernetes.title') }}</h2>
         <troubleshooting-line-item>
           <template #title>
-            Reset Kubernetes
+            {{ t('troubleshooting.kubernetes.resetKubernetes.title') }}
           </template>
           <template #description>
-            Resetting Kubernetes will delete workloads and configuration. Use this when...
+            {{ t('troubleshooting.kubernetes.resetKubernetes.description') }}
           </template>
           <button
             type="button"
@@ -27,16 +25,16 @@
             :disabled="cannotReset"
             @click="showLogs"
           >
-            Reset Kubernetes
+            {{ t('troubleshooting.kubernetes.resetKubernetes.buttonText') }}
           </button>
         </troubleshooting-line-item>
         <hr>
         <troubleshooting-line-item>
           <template #title>
-            Reset Kubernetes & Container Images
+            {{ t('troubleshooting.kubernetes.resetContainer.title') }}
           </template>
           <template #description>
-            All images will be lost and Kubernetes will be reset. Use this when...
+            {{ t('troubleshooting.kubernetes.resetContainer.description') }}
           </template>
           <button
             type="button"
@@ -44,34 +42,34 @@
             :disabled="cannotReset"
             @click="factoryReset"
           >
-            Reset Container Images
+            {{ t('troubleshooting.kubernetes.resetContainer.buttonText') }}
           </button>
         </troubleshooting-line-item>
       </section>
       <section class="general">
-        <h2>General</h2>
+        <h2>{{ t('troubleshooting.general.title') }}</h2>
         <troubleshooting-line-item>
           <template #title>
-            Logs
+            {{ t('troubleshooting.general.logs.title') }}
           </template>
           <template #description>
-            Show Rancher Desktop logs
+            {{ t('troubleshooting.general.logs.description') }}
           </template>
           <button
             type="button"
             class="btn btn-xs role-secondary"
             @click="showLogs"
           >
-            Show Logs
+            {{ t('troubleshooting.general.logs.buttonText') }}
           </button>
         </troubleshooting-line-item>
         <hr>
         <troubleshooting-line-item>
           <template #title>
-            Factory Reset
+            {{ t('troubleshooting.general.factoryReset.title') }}
           </template>
           <template #description>
-            Factory Reset will remove all Rancher Desktop Configurations. Use this when...
+            {{ t('troubleshooting.general.factoryReset.description') }}
           </template>
           <button
             type="button"
@@ -79,14 +77,15 @@
             :disabled="!canFactoryReset"
             @click="factoryReset"
           >
-            Factory Reset
+            {{ t('troubleshooting.general.factoryReset.buttonText') }}
           </button>
         </troubleshooting-line-item>
         <section class="need-help">
           <hr>
-          <span class="description">
-            Still having problems? Start a discussion on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
-          </span>
+          <span
+            class="description"
+            v-html="t('troubleshooting.needHelp', { }, true)"
+          />
         </section>
       </section>
     </section>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -13,6 +13,22 @@
       <h2>General</h2>
       <troubleshooting-line-item>
         <template #title>
+          Logs
+        </template>
+        <template #description>
+          Show Rancher Desktop logs
+        </template>
+        <button
+          type="button"
+          class="btn btn-xs role-secondary"
+          @click="showLogs"
+        >
+          Show Logs
+        </button>
+      </troubleshooting-line-item>
+      <hr>
+      <troubleshooting-line-item>
+        <template #title>
           Factory Reset
         </template>
         <template #description>
@@ -25,22 +41,6 @@
           @click="factoryReset"
         >
           Factory Reset
-        </button>
-      </troubleshooting-line-item>
-      <hr>
-      <troubleshooting-line-item>
-        <template #title>
-          Logs
-        </template>
-        <template #description>
-          Show Rancher Desktop logs
-        </template>
-        <button
-          type="button"
-          class="btn btn-xs role-secondary"
-          @click="showLogs"
-        >
-          Show Logs
         </button>
       </troubleshooting-line-item>
     </section>


### PR DESCRIPTION
This updates the troubleshooting page by organizing actions into lists with associated titles and descriptions. This also brings in the Kubernetes actions from the Images Page, "Reset Kubernetes" and "Reset Kubernetes & Container Images".

## Light

![Screen Shot 2021-09-30 at 10 12 54 AM](https://user-images.githubusercontent.com/835961/135500767-e2cb3c10-e3a9-4693-9886-26cffb59acce.png)

## Dark

![Screen Shot 2021-09-30 at 10 12 35 AM](https://user-images.githubusercontent.com/835961/135500782-40edfe68-da04-4a65-bf39-5378c9e5f672.png)

#703 
