### PR TITLE
[E2E Config] Cross-env tool plugin and TestUtils class

### DIFF
--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -1,30 +1,20 @@
 import path from 'path';
 import os from 'os';
 import { Application } from 'spectron';
-import { BrowserWindow } from 'electron';
 import NavBarPage from './pages/navbar';
-import GeneralPage from './pages/general';
-import KubernetesPage from './pages/kubernetes';
-import PortForwardingPage from './pages/portforwarding';
-import ImagesPage from './pages/images';
-import TroubleshootingPage from './pages/troubleshooting';
 const electronPath = require('electron');
 
-jest.setTimeout(60_000);
-
 describe('Rancher Desktop', () => {
-  let browserWindow: BrowserWindow;
+  jest.setTimeout(60000);
   let navBarPage: NavBarPage;
 
   const app = new Application({
-    path:         electronPath as any,
-    args:         [path.dirname(__dirname)],
-    startTimeout: 40000,
+    path: electronPath as any,
+    args: [path.dirname(__dirname)]
   });
 
   beforeAll(async() => {
     await app.start();
-    browserWindow = app.browserWindow;
     navBarPage = new NavBarPage(app);
   });
 
@@ -36,11 +26,9 @@ describe('Rancher Desktop', () => {
 
   it('opens the window', async() => {
     await app.client.waitUntilWindowLoaded();
-    const windowCount = await app.client.getWindowCount();
     const isVisible = await app.browserWindow.isVisible();
-    const title = await browserWindow.getTitle();
+    const title = await app.browserWindow.getTitle();
 
-    expect(windowCount).toBe(1);
     expect(isVisible).toBe(true);
     expect(title).toBe('Rancher Desktop');
   });

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import os from 'os';
-import { Application, SpectronClient } from 'spectron';
+import { Application } from 'spectron';
 import { BrowserWindow } from 'electron';
 import NavBarPage from './pages/navbar';
 import GeneralPage from './pages/general';
@@ -13,22 +13,17 @@ const electronPath = require('electron');
 jest.setTimeout(60_000);
 
 describe('Rancher Desktop', () => {
-  let app: Application;
-  let client: SpectronClient;
   let browserWindow: BrowserWindow;
   let navBarPage: NavBarPage;
 
-  beforeAll(async() => {
-    app = new Application({
-      // 'any' typing is required for now as other alternate usage/import
-      //  cause issues running the tests. Without 'any' typescript
-      //  complains of type mismatch.
-      path: electronPath as any,
-      args: [path.dirname(__dirname)],
-    });
+  const app = new Application({
+    path:         electronPath as any,
+    args:         [path.dirname(__dirname)],
+    startTimeout: 40000,
+  });
 
+  beforeAll(async() => {
     await app.start();
-    client = app.client;
     browserWindow = app.browserWindow;
     navBarPage = new NavBarPage(app);
   });
@@ -40,14 +35,13 @@ describe('Rancher Desktop', () => {
   });
 
   it('opens the window', async() => {
-    await client.waitUntilWindowLoaded();
-    // typescript doesn't see a value of await in below statement, but
-    // removing await makes the statement not wait till the app window loads
-    // Also, Alternate ways to get the app window title, for example using client
-    // didn't work. So, Leaving 'await' for now. We may need to review this and
-    // fix this in future.
+    await app.client.waitUntilWindowLoaded();
+    const windowCount = await app.client.getWindowCount();
+    const isVisible = await app.browserWindow.isVisible();
     const title = await browserWindow.getTitle();
 
+    expect(windowCount).toBe(1);
+    expect(isVisible).toBe(true);
     expect(title).toBe('Rancher Desktop');
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@vue/test-utils": "^1.1.2",
         "babel-core": "^7.0.0-bridge.0",
         "cache-loader": "^4.1.0",
+        "cross-env": "^7.0.3",
         "electron": "^12.0.18",
         "electron-builder": "^22.9.1",
         "electron-devtools-installer": "^3.1.0",
@@ -8018,6 +8019,24 @@
       "version": "1.114.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-1.114.0.tgz",
       "integrity": "sha512-j1JuBHTJKKX41NUJVHmWn2ZYHnLipsIoq7bAZVeVzehA9+rmG6v9NgMiMa0KiiFzozihgt4yGNe5aMVc/IoYLg=="
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -32054,6 +32073,15 @@
       "version": "1.114.0",
       "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-1.114.0.tgz",
       "integrity": "sha512-j1JuBHTJKKX41NUJVHmWn2ZYHnLipsIoq7bAZVeVzehA9+rmG6v9NgMiMa0KiiFzozihgt4yGNe5aMVc/IoYLg=="
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:unit:jest": "jest",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:unit:nerdctl-stub": "cd ./src/go/nerdctl-stub/ && go test ./...",
-    "test:e2e": "node ./scripts/e2e.mjs",
+    "test:e2e": "cross-env NODE_ENV=test node ./scripts/e2e.mjs",
     "generateReleases": "node ./scripts/generateReleaseList.js",
     "postinstall": "node ./scripts/postinstall.mjs",
     "postuninstall": "electron-builder install-app-deps"
@@ -85,6 +85,7 @@
     "@vue/test-utils": "^1.1.2",
     "babel-core": "^7.0.0-bridge.0",
     "cache-loader": "^4.1.0",
+    "cross-env": "^7.0.3",
     "electron": "^12.0.18",
     "electron-builder": "^22.9.1",
     "electron-devtools-installer": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:unit:jest": "jest",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:unit:nerdctl-stub": "cd ./src/go/nerdctl-stub/ && go test ./...",
-    "test:e2e": "cross-env NODE_ENV=test node ./scripts/e2e.mjs",
+    "test:e2e": "node ./scripts/e2e.mjs",
     "generateReleases": "node ./scripts/generateReleaseList.js",
     "postinstall": "node ./scripts/postinstall.mjs",
     "postuninstall": "electron-builder install-app-deps"


### PR DESCRIPTION
## Objective
* As we're going to start test our code against different OS distro, `cross-env` can do the dirty work without change codes or adding weird setup in CI. Cross-env can easily handle the `NODE_ENV` on Windows, without exporting the variables. It is a must have for `jest` framework.
* Handle electron execution during the tests, making sure to close/nuke previous electron instances.

## Changes
1. Installed `cross-env` (dev-dep)
2. Included `cross-env NODE_ENV=test node ./scripts/e2e.mjs`
3. Minor refactor on `main.e2e.spec.ts`
4. Implemented `TestUtils` helper class for e2e tests.

## Results

![Screen Shot 2021-09-29 at 4 49 47 PM](https://user-images.githubusercontent.com/37411123/135359058-93305684-36f5-4158-abd4-a1cd4dc889c7.png)

