### PR TITLE
Update page layout to include title and description

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -164,6 +164,7 @@ suffix:
 # Components & Pages
 ##############################
 images:
+  title: Images 
   state: 
     k8sUnready: Waiting for Kubernetes to be ready
     kimUnready: Waiting for image manager to be ready
@@ -192,6 +193,15 @@ images:
         push: Push
         delete: Delete
         scan: Scan...
+k8s: 
+  title: Kubernetes Settings
+troubleshooting:
+  title: Troubleshooting
+portForwarding:
+  title: Port Forwarding
+general:
+  title: Welcome to Rancher Desktop
+  description: Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
 about:
   title: About
   versions:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -195,8 +195,6 @@ images:
         scan: Scan...
 k8s: 
   title: Kubernetes Settings
-troubleshooting:
-  title: Troubleshooting
 portForwarding:
   title: Port Forwarding
 general:

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -2,7 +2,16 @@
   <div class="wrapper">
     <Header class="header" />
     <Nav class="nav" :items="routes" />
-    <Nuxt class="body" />
+    <body class="body">
+      <section class="title">
+        <h1>{{ title }}</h1>
+      </section>
+      <hr>
+      <section class="description">
+        {{ description }}
+      </section>
+      <Nuxt />
+    </body>
     <BackendProgress class="progress" />
     <!-- The ActionMenu is used by SortableTable for per-row actions. -->
     <ActionMenu />
@@ -15,6 +24,7 @@ import Header from '@/components/Header.vue';
 import Nav from '@/components/Nav.vue';
 import BackendProgress from '@/components/BackendProgress.vue';
 import { ipcRenderer } from 'electron';
+import { mapState } from 'vuex';
 
 export default {
   name:       'App',
@@ -36,6 +46,13 @@ export default {
     // the "dark" part will be a dynamic pref.
     // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
     return { bodyAttrs: { class: 'theme-dark' } };
+  },
+
+  computed: {
+    ...mapState('page', {
+      title:       state => state.title,
+      description: state => state.description
+    }),
   },
 
   mounted() {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <Header class="header" />
     <Nav class="nav" :items="routes" />
-    <body class="body">
+    <main class="body">
       <section class="title">
         <h1>{{ title }}</h1>
       </section>
@@ -11,7 +11,7 @@
         {{ description }}
       </section>
       <Nuxt />
-    </body>
+    </main>
     <BackendProgress class="progress" />
     <!-- The ActionMenu is used by SortableTable for per-row actions. -->
     <ActionMenu />

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -5,10 +5,10 @@
     <main class="body">
       <section class="title">
         <h1>{{ title }}</h1>
-      </section>
-      <hr>
-      <section class="description">
-        {{ description }}
+        <hr>
+        <section class="description">
+          {{ description }}
+        </section>
       </section>
       <Nuxt />
     </main>

--- a/src/pages/General.vue
+++ b/src/pages/General.vue
@@ -53,8 +53,8 @@ export default {
     this.$store.dispatch(
       'page/setHeader',
       {
-        title:       'Welcome to Rancher Desktop',
-        description: 'Rancher Desktop provides Kubernetes and image management through the use of a desktop application.'
+        title:       this.t('general.title'),
+        description: this.t('general.description'),
       }
     );
     ipcRenderer.on('settings-update', this.onSettingsUpdate);

--- a/src/pages/General.vue
+++ b/src/pages/General.vue
@@ -4,10 +4,6 @@
 <template>
   <div>
     <div class="general">
-      <h1>
-        Welcome to Rancher Desktop
-      </h1>
-      <p>Rancher Desktop provides Kubernetes and image management through the use of a desktop application.</p>
       <ul>
         <li>Project Status: <i>alpha</i></li>
         <li>Project Discussions: #rancher-desktop in <a href="https://slack.rancher.io/">Rancher Users</a> Slack</li>
@@ -54,6 +50,13 @@ export default {
   },
 
   async mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      {
+        title:       'Welcome to Rancher Desktop',
+        description: 'Rancher Desktop provides Kubernetes and image management through the use of a desktop application.'
+      }
+    );
     ipcRenderer.on('settings-update', this.onSettingsUpdate);
     ipcRenderer.on('update-state', this.onUpdateState);
     ipcRenderer.send('update-state');

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -37,6 +37,10 @@ export default {
   },
 
   mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      { title: 'Images' }
+    );
     ipcRenderer.on('images-changed', (event, images) => {
       this.$data.images = images;
     });

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -39,7 +39,7 @@ export default {
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: 'Images' }
+      { title: this.t('images.title') }
     );
     ipcRenderer.on('images-changed', (event, images) => {
       this.$data.images = images;

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -139,7 +139,7 @@ export default {
   created() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: 'Kubernetes Settings' }
+      { title: this.t('k8s.title') }
     );
     if (this.hasSystemPreferences) {
       // We don't configure WSL metrics, so don't bother making these checks on Windows.

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -137,6 +137,10 @@ export default {
   },
 
   created() {
+    this.$store.dispatch(
+      'page/setHeader',
+      { title: 'Kubernetes Settings' }
+    );
     if (this.hasSystemPreferences) {
       // We don't configure WSL metrics, so don't bother making these checks on Windows.
       if (this.settings.kubernetes.memoryInGB > this.availMemoryInGB) {

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -31,7 +31,7 @@ export default {
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: 'Port Forwarding' }
+      { title: this.t('portForwarding.title') }
     );
     ipcRenderer.on('k8s-check-state', (event, state) => {
       this.$data.state = state;

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -29,6 +29,10 @@ export default {
   },
 
   mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      { title: 'Port Forwarding' }
+    );
     ipcRenderer.on('k8s-check-state', (event, state) => {
       this.$data.state = state;
     });

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -79,6 +79,10 @@ export default {
     },
   },
   mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      { title: 'Troubleshooting' }
+    );
     ipcRenderer.on('k8s-check-state', (event, newState) => {
       this.$data.state = newState;
     });

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -81,7 +81,7 @@ export default {
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: 'Troubleshooting' }
+      { title: this.t('troubleshooting.title') }
     );
     ipcRenderer.on('k8s-check-state', (event, newState) => {
       this.$data.state = newState;

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -1,14 +1,5 @@
 <template>
   <section class="dashboard">
-    <header>
-      <div class="title">
-        <h1>{{ t('troubleshooting.title') }}</h1>
-      </div>
-      <hr>
-      <span class="description">
-        {{ t('troubleshooting.description') }}
-      </span>
-    </header>
     <section class="troubleshooting">
       <section class="general">
         <troubleshooting-line-item>

--- a/src/store/page.js
+++ b/src/store/page.js
@@ -1,0 +1,20 @@
+export const state = () => ({
+  title:       '',
+  description: ''
+});
+
+export const mutations = {
+  setTitle(state, title) {
+    state.title = title;
+  },
+  setDescription(state, description) {
+    state.description = description;
+  }
+};
+
+export const actions = {
+  setHeader({ commit }, { title, description }) {
+    commit('setTitle', title);
+    commit('setDescription', description);
+  }
+};


### PR DESCRIPTION
This updates the default to include both a title and a page description. A pages title and description are manged centrally through the store and each page can dispatch a `setHeader` action to update the title and description. 

We have a lot of pages that will be following this pattern and I think it makes sense to manage this through the layout instead of having each page repeat a similar pattern to setup a title & description. 