### PR TITLE
WSL: Run k3s in its own mount namespace.

### DIFF
--- a/src/assets/scripts/wsl-launch-k3s
+++ b/src/assets/scripts/wsl-launch-k3s
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script is used to launch K3s on WSL2; this is necessary as we need to do
+# some mount namespace shenanigans, since we store the data on the WSL shared
+# mount (/mnt/wsl/rancher/desktop/) and that can have issues with lingering
+# tmpfs mounts after we exit.  This means we need to run this script under
+# unshare (to get a private mount namespace), and then we can mark various
+# mount points as shared (for kim / buildkit).  Kubelet will internally do some
+# tmpfs mounts for volumes (secrets, etc.), which will stay private and go away
+# once k3s exits, so that we can delete the data as necessary.
+
+set -o errexit -o nounset -o xtrace
+
+(
+    IFS=:
+    for dir in / ${DISTRO_DATA_DIRS}; do
+        mount --make-shared "${dir}"
+    done
+)
+exec /usr/local/bin/k3s server "$@"


### PR DESCRIPTION
This ensures that any tmpfs mounts kubelet makes stays private, so that the directories it gets mounted on can get deleted once kubelet exits.

Fixes #712.

Note that you may need to run `wsl --shutdown` to get rid of the previous broken state; however, after that, you should be able to downgrade once you have the new code.  Once this code is in effect, you should _not_ be able to see the kubelet mounts from a different WSL distribution.  (Actually, not even `rancher-desktop`, unless you `nsenter` into the mount namespace of the `k3s` process.)