### PR TITLE
Allow for a missing <$HOME>/config file

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -583,7 +583,10 @@ export default class K3sHelper extends events.EventEmitter {
       console.log(`Updating kubeconfig ${ userPath }...`);
       try {
         userConfig.loadFromFile(userPath);
-      } catch (_) {
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          console.log(`Error trying to load kubernetes config file ${ userPath }:`, err);
+        }
         // continue to merge into an empty userConfig == `{ contexts: [], clusters: [], users: [] }`
       }
       merge(userConfig.contexts, workConfig.contexts);

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -581,7 +581,11 @@ export default class K3sHelper extends events.EventEmitter {
       };
 
       console.log(`Updating kubeconfig ${ userPath }...`);
-      userConfig.loadFromFile(userPath);
+      try {
+        userConfig.loadFromFile(userPath);
+      } catch (_) {
+        // continue to merge into an empty userConfig == `{ contexts: [], clusters: [], users: [] }`
+      }
       merge(userConfig.contexts, workConfig.contexts);
       merge(userConfig.users, workConfig.users);
       merge(userConfig.clusters, workConfig.clusters);


### PR DESCRIPTION
Allow the kube/config populator to continue when there's no config file on reset (regardless of the `wipe` setting in the `reset` handler).

Signed-off-by: Eric Promislow <epromislow@suse.com>