### PR TITLE
Add some space between Reset Kubernetes button and label

### DIFF
--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -26,7 +26,7 @@
     <labeled-input :value="settings.kubernetes.port" label="Port" type="number" @input="handleUpdatePort" />
 
     <split-button
-      class="role-secondary"
+      class="role-secondary btn-reset"
       label="Reset Kubernetes"
       value="auto"
       :disabled="cannotReset"
@@ -305,5 +305,9 @@ export default {
 .select-k8s-version {
   width: inherit;
   display: inline-block;
+}
+
+.btn-reset {
+  margin-right: 1rem;
 }
 </style>


### PR DESCRIPTION
This adds a bit of separation between the `Reset Kubernetes` button and the label that explains its behavior. 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>