### PR TITLE
Move to latest lima-and-qemu package and latest Alpine iso

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,10 +7,10 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.5';
+const limaTag = 'v1.7';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.4';
+const alpineLimaTag = 'v0.1.8';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.13.5';
 

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -31,13 +31,14 @@ provision:
     set -o errexit -o nounset -o xtrace
     mkdir -p /bootfs
     mount --bind / /bootfs
-    if ! diff -q /etc/os-release /bootfs/etc/os-release; then
-        rm /bootfs/etc/machine-id
-        cp -pruT /bootfs/etc /etc
-        cp -pruT /bootfs/usr/local /usr/local
-    fi
+    rm /bootfs/etc/machine-id
+    cp -pruT /bootfs/etc /etc
+    cp -pruT /bootfs/usr/local /usr/local
     umount /bootfs
     rmdir /bootfs
+    # The new Alpine ISO makes this change, but it gets lost because the
+    # lima boot scripts also modify sshd_config.
+    sed -i 's/#UsePAM no/UsePAM yes/g' /etc/ssh/sshd_config
 - # Make mount-points shared.
   mode: system
   script: |

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -111,7 +111,7 @@ interface LimaListResult {
 
 const console = new Console(Logging.lima.stream);
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.1.4';
+const IMAGE_VERSION = '0.1.8';
 
 function defined<T>(input: T | null | undefined): input is T {
   return input !== null && typeof input !== 'undefined';


### PR DESCRIPTION
Lima adds hostagent based DNS resolver and automatically sets proxy environment variables.

ISO adds support for `/etc/environment` in ssh sessions, and network access in provisioning scripts.

Update `nerdctl` to `0.12.1`.

Add `BUILD_ID` and `VARIANT_ID` to `/etc/os-version`.
