### PR TITLE
Resolve issue with overflow when expanding Reset Kubernetes button

### DIFF
--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -68,7 +68,6 @@ export default {
   }
   .contents {
     flex: 1;
-    overflow-y: auto;
   }
   .banner-background {
     flex: none;

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -100,7 +100,9 @@ export default {
   }
 
   .body {
+    display: grid;
     grid-area: body;
+    grid-template-rows: auto 1fr;
     padding: 20px;
     overflow: auto;
   }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -106,10 +106,6 @@ export default {
     padding: 20px;
     overflow: auto;
   }
-
-  .title {
-    margin-bottom: 1.75rem;
-  }
 }
 
 </style>


### PR DESCRIPTION
This resolves an issue where expanding the dropdown in the Reset Kubernetes split button would cause the container to scroll regardless of window height. 

This also removes the `overflow: auto` from the `notifications` component to get rid of duplicate scrollbars when working with smaller windows. 

#729 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>