### PR TITLE
K3s: Skip version 1.22+

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -245,7 +245,12 @@ export default class K3sHelper extends events.EventEmitter {
    */
   get availableVersions(): Promise<ShortVersion[]> {
     return this.initialize().then(() => {
-      return Object.keys(this.versions).sort(semver.compare).reverse();
+      let versions = Object.keys(this.versions);
+
+      // XXX Temporary hack for Rancher Desktop 0.6.0: Skip 1.22+
+      versions = versions.filter(v => semver.lt(v, '1.22.0'));
+
+      return versions.sort(semver.compare).reverse();
     });
   }
 


### PR DESCRIPTION
There's an issue with k3s 1.22; skip it for now.  We will need to redo the version fetching to be based on the k3s channel server instead later.

See also #740

Note that we seem to cache for too long — we may need to manually remove `~/Library/Caches/rancher-desktop/k3s-versions.json` (or the Window equivalent) to see changes.