### PR TITLE
WSL: Add more files to data distribution.

### DIFF
--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.5';
+  const v = '0.6';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -55,7 +55,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.5';
+const DISTRO_VERSION = '0.6';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
These only exist to quite some errors when we start the distribution (visible via `dmesg`) because WSL internally runs some commands.  They appear to be purely cosmetic (at least as far as our uses go), but this should help reduce red herrings when we chase down issues.

After this, `dmesg` should should still contain errors about not being able to set up the time zone correctly (we don't care), but not things about `ldconfig` etc.

Note that I still get errors about FS-Cache having duplicate cookies; I suspect that's an issue with how WSL generates disks or something, and it's not anything we can deal with.