### PR TITLE
Tidy up images table header

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -540,4 +540,18 @@ export default {
   .imagesTable::v-deep div.search {
     margin-top: 12px;
   }
+
+  .imagesTable::v-deep .sortable-table-header .fixed-header-actions {
+    align-items: end;
+  }
+
+  .imagesTable::v-deep .sortable-table-header .fixed-header-actions .middle {
+    align-self: start;
+    margin-top: 17px;
+    padding-top: 11px;
+  }
+
+  .select-namespace {
+    max-width: 24rem;
+  }
 </style>


### PR DESCRIPTION
This tidies up alignment in the images table header.

Note for the center checkbox: normally, I would normally, I would use `rem` as a unit of measure, but I stuck with pixels to make sure that the checkbox label aligns with the content of the select and filter.  

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>