### PR TITLE
WSL: Ensure CA certs don't have DOS line endings.

### DIFF
--- a/src/main/networking/index.ts
+++ b/src/main/networking/index.ts
@@ -39,7 +39,9 @@ Electron.app.on('certificate-error', async(event, webContents, url, error, certi
     // Ask the system store.
     console.log(`Attempting to check system certificates for ${ url } (${ certificate.subjectName }/${ certificate.fingerprint })`);
     if (os.platform().startsWith('win')) {
-      for (const cert of WinCA({ format: WinCA.der2.pem, generator: true, fallback: false })) {
+      for (const cert of WinCA({
+        format: WinCA.der2.pem, generator: true, fallback: false
+      })) {
         // For now, just check that the PEM data matches exactly; this is
         // probably a little more strict than necessary, but avoids issues like
         // an attacker generating a cert with the same serial.


### PR DESCRIPTION
It appears that the certs we get come with DOS line endings (`\r\n`); this can cause issues when we use them in the WSL VM (where Unix line endings are expected).

Fixes #751.