### PR TITLE
Restoring the integrations location on Windows

### DIFF
--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -38,7 +38,12 @@ describe('paths', () => {
       darwin: '%HOME%/Library/State/rancher-desktop/driver/',
     },
     integration: {
-      win32:  Error(),
+      // The integration code paths do not currently support error handling
+      // and returning an error causes exceptions on Windows. This needs to
+      // be reworked to handle no location on Windows. See that paths.ts
+      // file for more detail.
+      // win32:  Error(),
+      win32:  '/usr/local/bin',
       darwin: '/usr/local/bin',
     },
   };

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -80,7 +80,12 @@ export class Win32Paths implements Paths {
   }
 
   get integration(): string {
-    throw new Error('integration path not available for Windows');
+    return '/usr/local/bin';
+    // The current code paths on Windows fail if no location is returned to watch.
+    // Before we can throw an exception, the code paths that use the returned string
+    // need to be refactored to handle an error. The current location being returned
+    // is the location that has been in use.
+    // throw new Error('integration path not available for Windows');
   }
 }
 


### PR DESCRIPTION
Windows does not need this location but there are code paths that
do not handle an error being returned. There are multiple code paths
like this. Restoring the mac location, which has long been used.

In a future change, this can be removed and the other code paths fixed
to handle an error being returned.