### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,37 @@
+---
+name: Issue template
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**For bugs, describe what you're seeing**
+A clear and concise description of what the bug is.
+
+**For feature requests, describe what you'd like to add or change**
+A clear and concise description of what enhancement you'd like.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+
+**Result**
+Show what error or behaviour you're seeing.
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Setup (please complete the following information):**
+ - OS: [e.g. macos/Windows/Linux with details on versions or distro]
+ - Rancher Desktop version
+ - Kubernetes version
+
+**Additional context**
+Add any other context about the problem here. Excerpt or attach logs if appropriate.


### PR DESCRIPTION
Mostly taking the default bug report and adding Kubernetes to the mix. Also has a section for feature requests in case we don't want to have separate templates yet.

Signed-off-by: Gary Korhonen <gary.korhonen@suse.com>