### PR TITLE
Add a timestamp to log messages

### DIFF
--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -88,7 +88,7 @@ export class Log {
   }
 
   protected logWithDate(method: consoleKey, message: any, optionalParameters: any[]) {
-    this.console[method](`%s: ${ message }`, ...[new Date()].concat(optionalParameters));
+    this.console[method](`%s: ${ message }`, new Date(), ...optionalParameters);
   }
 
   /**


### PR DESCRIPTION
- pertains only to the messages we control. Many other logs come from other components,
  some with their own timestamps.

Signed-off-by: Eric Promislow <epromislow@suse.com>