### PR TITLE
[FIX-775] Filter kubeconfig invalid entries instead of throwing exception

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -10,6 +10,7 @@ import util from 'util';
 import fetch from 'node-fetch';
 import semver from 'semver';
 import { KubeConfig } from '@kubernetes/client-node';
+import { ActionOnInvalid } from '@kubernetes/client-node/dist/config_types';
 import yaml from 'yaml';
 
 import * as childProcess from '@/utils/childProcess';
@@ -503,7 +504,7 @@ export default class K3sHelper extends events.EventEmitter {
       const config = new KubeConfig();
 
       try {
-        config.loadFromFile(kubeConfigPath);
+        config.loadFromFile(kubeConfigPath, { onInvalidEntry: ActionOnInvalid.FILTER });
         if (config.contexts.find(ctx => ctx.name === contextName)) {
           return kubeConfigPath;
         }
@@ -586,7 +587,7 @@ export default class K3sHelper extends events.EventEmitter {
 
       console.log(`Updating kubeconfig ${ userPath }...`);
       try {
-        userConfig.loadFromFile(userPath);
+        userConfig.loadFromFile(userPath, { onInvalidEntry: ActionOnInvalid.FILTER });
       } catch (err) {
         if (err.code !== 'ENOENT') {
           console.log(`Error trying to load kubernetes config file ${ userPath }:`, err);


### PR DESCRIPTION
This PR updates the call to `loadFromFile` (implemented in dependency `@kubernetes/client-node`) to make sure it filters invalid config entries instead of throwing an exception.

This makes it so that when we append the `rancher-desktop` config entries, we avoid overwriting the config file as a whole. By filtering invalid entries, only those are removed from the final kubeconfig file.

Fixes #775 