### PR TITLE
Bump alpine ISO from v0.1.8 → 0.1.9

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -13,7 +13,7 @@ const limaLinuxRepo = 'https://github.com/lima-vm/lima';
 const limaLinuxVersion = '0.6.4';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.8';
+const alpineLimaTag = 'v0.1.9';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.13.5';
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -103,7 +103,7 @@ interface LimaListResult {
 
 const console = Logging.lima;
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.1.8';
+const IMAGE_VERSION = '0.1.9';
 
 function defined<T>(input: T | null | undefined): input is T {
   return input !== null && typeof input !== 'undefined';


### PR DESCRIPTION
Only difference is that it has docker pre-installed (but stopped).
Can be started via `rc-service docker start`.

Closes #808