### PR TITLE
[macOS/Linux] Disabling E2E tests - intermittent issues - temporarily

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,6 +1,6 @@
 name: E2E Test
 
-on: {}
+on: workflow_dispatch
 
 jobs:
   e2e-test:


### PR DESCRIPTION
## Changes
1. Removed E2E pipeline for further investigation on the build e2e script.
2. Due a failure ratio ~20%, disabling it temporarily until implement a definitive fix.
3. Noticed the same error on linux runner (20.04)

## Errors
`Cannot read property type of null`

Windows runner issue ref: https://github.com/rancher-sandbox/rancher-desktop/pull/837