### PR TITLE
Add missing Electron exports

### DIFF
--- a/src/main/networking/proxy.ts
+++ b/src/main/networking/proxy.ts
@@ -4,6 +4,7 @@ import tls from 'tls';
 import { URL } from 'url';
 
 import { Agent, ClientRequest, RequestOptions, AgentCallbackReturn } from 'agent-base';
+import Electron from 'electron';
 import HttpProxyAgent from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { BrowserWindow, app, shell } from 'electron';
+import Electron, { BrowserWindow, app, shell } from 'electron';
 
 import Logging from '@/utils/logging';
 


### PR DESCRIPTION
This fixes the broken ElectronProxyAgent class (where it uses `Electron.session.defaultSession`).

Fixes #840.