### PR TITLE
Bump lima-and-qemu from v1.8 → v1.9

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.8';
+const limaTag = 'v1.9';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.1.9';


### PR DESCRIPTION
This adds back the `vde/*` binaries for macOS that went missing when the tarball was built using Github Actions.
