### PR TITLE
[Fix] Cannot read property 'type' of null - E2E Tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15]
+        os: [macos-10.15, windows-latest]
 
     name: RD E2E Test - ${{ matrix.os}}
     steps:

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -80,7 +80,7 @@ export function openPreferences() {
     width:          940,
     height:         600,
     webPreferences: {
-      devTools:           !app.isPackaged,
+      devTools:           !(app.isPackaged || process.env?.NODE_ENV === 'test'),
       nodeIntegration:    true,
       contextIsolation:   false,
       enableRemoteModule: process.env?.NODE_ENV === 'test'
@@ -103,7 +103,7 @@ export async function openFirstRun() {
     autoHideMenuBar: !app.isPackaged,
     show:            false,
     webPreferences:  {
-      devTools:           !app.isPackaged,
+      devTools:           !(app.isPackaged || process.env?.NODE_ENV === 'test'),
       nodeIntegration:    true,
       contextIsolation:   false,
       enableRemoteModule: process.env?.NODE_ENV === 'test'


### PR DESCRIPTION
## Changes
1. Modified `window/index.ts` CreateWindow property in order to force disable `devTools` during E2E tests ([spectron issue related](https://github.com/electron-userland/spectron/issues/720#issuecomment-743950042)

### Possible root cause
Possible root cause related to the error: `Cannot read property 'type' of null`
1. For E2E tests, spectron requires to the `devTools` be disabled in order to avoid crashes when the app starts. Looking into spectron issues, `devTools` can be messed when the test framework starts (issues seen on both jest and mocha). More details: Spectron issue [174](https://github.com/electron-userland/spectron/issues/174)

### Image
Local intermittent issue:
![Screen Shot 2021-10-21 at 1 55 20 PM](https://user-images.githubusercontent.com/37411123/138347788-489199a5-dd77-437e-b862-05633a1c61f7.png)
s
