### PR TITLE
[GitActions] Windows and Ubuntu Runners

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15]
+        os: [macos-10.15, windows-2019, ubuntu-20.04]
 
     name: RD E2E Test - ${{ matrix.os}}
     steps:


### PR DESCRIPTION
## Changes
1. Enabled `windows` and `ubuntu` runners on GitActions.

Note: The E2E pipeline still being trigger manually, the pipeline won't be triggered on pushes ([under analysis](https://github.com/rancher-sandbox/rancher-desktop/pull/855))

## How to
1. Navigate to `Actions`
2. Select `E2E Test` workflow
3. On right corner, select `Run Workflow` drop-down
4. Select the `branch` you would like to test against and press `Run Workflow

![Screen Shot 2021-10-22 at 4 56 57 PM](https://user-images.githubusercontent.com/37411123/138531479-340c5762-7202-4ce0-af33-86b1d8870f30.png)
`

Note: Could be closed after merge this [PR](https://github.com/rancher-sandbox/rancher-desktop/pull/856)