### PR TITLE
Build: Ensure that resources are user-writable.

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -72,6 +72,17 @@ class Builder {
   async package() {
     console.log('Packaging...');
     const args = process.argv.slice(2).filter(x => x !== '--serial');
+
+    // Ensure that all files to be packaged are user-writable.  This is required
+    // to correctly support Squirrel.Mac updating.
+    for await (const [dir, entry] of buildUtils.walk(path.join(buildUtils.srcDir, 'resources'))) {
+      const stat = await fs.lstat(path.join(dir, entry.name));
+
+      if ((stat.mode & 0o200) === 0) {
+        await fs.chmod(path.join(dir, entry.name), stat.mode | 0o200);
+      }
+    }
+
     // On Windows, electron-builder will run the installer to generate the
     // uninstall stub; however, we set the installer to be elevated, in order
     // to ensure that we can install WSL if necessary.  To make it possible to

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -65,6 +65,25 @@ export default {
   },
 
   /**
+   * Recursively walk a directory, recursively returning the directory entries.
+   * @param {String} [root] The directory to walk.
+   * @returns {AsyncGenerator<[string, fs.Dirent], void, unknown>} Directory
+   *  entries and path of their containing folder.
+   */
+  async *walk(root) {
+    for await (const entry of await fs.promises.opendir(root)) {
+      if (entry.isSymbolicLink()) {
+        yield [root, entry];
+      } else if (entry.isDirectory()) {
+        yield [root, entry];
+        yield * this.walk(path.join(root, entry.name));
+      } else {
+        yield [root, entry];
+      }
+    }
+  },
+
+  /**
    * @typedef {Object} ObjectWithProcessChild - Any type holding a child process.
    * @property {childProcess.ChildProcess} child - The child process.
    *


### PR DESCRIPTION
This is required on Mac for updates to work correctly.  This is a branch-specific fix for #807.