### PR TITLE
Bump the WSL distro version to 0.7

### DIFF
--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.6';
+  const v = '0.7';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -55,7 +55,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.6';
+const DISTRO_VERSION = '0.7';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
Signed-off-by: Eric Promislow <epromislow@suse.com>

This required creating and publishing https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/tag/v0.7