### PR TITLE
Signing: pull in tsconfig-paths.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rancher-desktop",
       "version": "0.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -85,9 +86,11 @@
         "spectron": "14.0.0",
         "ts-jest": "^24.3.0",
         "ts-node": "^10.0.0",
+        "tsconfig-paths": "^3.11.0",
         "vue-jest": "^3.0.7",
         "vue-template-compiler": "^2.6.12",
-        "webpack": "^4.46.0"
+        "webpack": "^4.46.0",
+        "xvfb-maybe": "^0.2.1"
       },
       "engines": {
         "node": ">=14.14"
@@ -22666,9 +22669,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -24812,6 +24815,46 @@
       "dev": true,
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/xvfb-maybe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz",
+      "integrity": "sha1-7YyxMpV7eEi0OZhMZvAQ6n8kNhs=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "which": "^1.2.4"
+      },
+      "bin": {
+        "xvfb-maybe": "src/xvfb-maybe.js"
+      }
+    },
+    "node_modules/xvfb-maybe/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/xvfb-maybe/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/xvfb-maybe/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/xxhashjs": {
@@ -44144,9 +44187,9 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "spectron": "14.0.0",
     "ts-jest": "^24.3.0",
     "ts-node": "^10.0.0",
+    "tsconfig-paths": "^3.11.0",
     "vue-jest": "^3.0.7",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.46.0",

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -9,7 +9,7 @@ import { getSignVendorPath } from 'app-builder-lib/out/codeSign/windowsCodeSign'
 import yaml from 'js-yaml';
 import defaults from 'lodash/defaultsDeep';
 
-import * as childProcess from '../../src/utils/childProcess';
+import * as childProcess from '@/utils/childProcess';
 
 /**
  * Mandatory configuration for Windows.

--- a/scripts/ts-wrapper.js
+++ b/scripts/ts-wrapper.js
@@ -5,6 +5,10 @@
  * fine elsewhere, but not on the command line.
  */
 
+// Load tsconfig-paths so that ts-node can resolve files based on the 'paths'
+// compiler options key in tsconfig.json.
+require('tsconfig-paths/register');
+
 const { main: tsNodeMain } = require('ts-node/dist/bin');
 
 function main(args) {


### PR DESCRIPTION
This is required to use the tsconfig paths compiler option (which we already use in the main code); resolves an issue where childProcess imports logging, causing an error when attempting to sign.

Fixes #875 