### PR TITLE
Check $PATH for a home based location

### DIFF
--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -121,6 +121,16 @@ export class LinuxPaths implements Paths {
   }
 
   get integration(): string {
+    // Looping in reverse order as this seams to be a safer way to avoid
+    // user customized paths. Custom paths are usually pre-appended in $PATH
+    const pths = (process.env.PATH || '').split(path.delimiter).reverse();
+
+    for (const pth of pths) {
+      if (pth.startsWith(os.homedir())) {
+        return pth;
+      }
+    }
+
     return path.join(os.homedir(), '.local', 'bin');
   }
 


### PR DESCRIPTION
This commit checks $PATH in order to set an appropriate integration
tools path under linux. The default path is `~/.local/bin` in
case $PATH does not contain any entry under $HOME.

Fixes #881

Signed-off-by: David Cassany <dcassany@suse.com>