### PR TITLE
WSL-helper: Handle docker socket forwarding

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy.go
+++ b/src/go/wsl-helper/cmd/dockerproxy.go
@@ -1,0 +1,31 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// dockerproxyStartCmd is the `wsl-helper docker-proxy` command.
+// It only has subcommands, and no functionality of its own.
+var dockerproxyCmd = &cobra.Command{
+	Use:   "docker-proxy",
+	Short: "Commands for managing the docker socket proxy",
+}
+
+func init() {
+	rootCmd.AddCommand(dockerproxyCmd)
+}

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
+)
+
+var dockerproxyServeViper = viper.New()
+
+// dockerproxyServeCmd is the `wsl-helper docker-proxy serve` command.
+var dockerproxyServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the docker socket proxy server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		endpoint := dockerproxyServeViper.GetString("endpoint")
+		proxyEndpoint := dockerproxyServeViper.GetString("proxy-endpoint")
+		err := dockerproxy.Serve(endpoint, proxyEndpoint)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	dockerproxyServeCmd.Flags().String("endpoint", dockerproxy.DefaultEndpoint, "Endpoint to listen on")
+	dockerproxyServeCmd.Flags().String("proxy-endpoint", dockerproxy.DefaultProxyEndpoint, "Endpoint dockerd is listening on")
+	dockerproxyServeViper.AutomaticEnv()
+	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
+}

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -1,0 +1,48 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
+)
+
+var dockerproxyServeViper = viper.New()
+
+// dockerproxyServeCmd is the `wsl-helper docker-proxy serve` command.
+var dockerproxyServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the docker socket proxy server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		endpoint := dockerproxyServeViper.GetString("endpoint")
+		port := dockerproxyServeViper.GetUint32("port")
+		err := dockerproxy.Serve(endpoint, port)
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	dockerproxyServeCmd.Flags().String("endpoint", dockerproxy.DefaultEndpoint, "Endpoint to listen on")
+	dockerproxyServeCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port docker is listening on")
+	dockerproxyServeViper.AutomaticEnv()
+	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
+}

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+Copyright © 2021 SUSE LLC
+1
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
+)
+
+var dockerproxyStartViper = viper.New()
+
+// dockerproxyStartCmd is the `wsl-helper docker-proxy start` command.
+// This command is Linux-only.
+var dockerproxyStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the docker daemon using vsock",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return dockerproxy.Start(dockerproxyStartViper.GetUint32("port"), args)
+	},
+}
+
+func init() {
+	dockerproxyStartCmd.Flags().Uint32("port", 0, "Vsock port to listen on")
+	dockerproxyStartViper.AutomaticEnv()
+	dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
+	dockerproxyCmd.AddCommand(dockerproxyStartCmd)
+}

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -32,12 +33,15 @@ var dockerproxyStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the docker daemon using vsock",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return dockerproxy.Start(dockerproxyStartViper.GetUint32("port"), args)
+		port := dockerproxyStartViper.GetUint32("port")
+		endpoint := dockerproxyStartViper.GetString("endpoint")
+		return dockerproxy.Start(port, endpoint, args)
 	},
 }
 
 func init() {
-	dockerproxyStartCmd.Flags().Uint32("port", 0, "Vsock port to listen on")
+	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
+	dockerproxyStartCmd.Flags().String("endpoint", dockerproxy.DefaultProxyEndpoint, "Dockerd socket endpoint")
 	dockerproxyStartViper.AutomaticEnv()
 	dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyStartCmd)

--- a/src/go/wsl-helper/cmd/root.go
+++ b/src/go/wsl-helper/cmd/root.go
@@ -24,7 +24,7 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "wsl-helper",
-	Short: "Rancher Desktop WSL2 intergration helper",
+	Short: "Rancher Desktop WSL2 integration helper",
 	Long:  `This command handles various WSL2 integration tasks for Rancher Desktop.`,
 	// Run: func(cmd *cobra.Command, args []string) { },
 }

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -5,5 +5,6 @@ go 1.16
 require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -3,6 +3,8 @@ module github.com/rancher-sandbox/rancher-desktop/src/wsl-helper
 go 1.16
 
 require (
+	github.com/Microsoft/go-winio v0.5.1
+	github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007

--- a/src/go/wsl-helper/go.sum
+++ b/src/go/wsl-helper/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
+github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -177,6 +179,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3 h1:jUp75lepDg0phMUJBCmvaeFDldD2N3S1lBuPwUTszio=
+github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -198,6 +202,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -209,6 +215,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -367,6 +374,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -388,6 +396,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/src/go/wsl-helper/pkg/dockerproxy/defaults.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/defaults.go
@@ -1,0 +1,20 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+// DefaultPort is the default (vsock) port we're listening on.
+const DefaultPort = 23752375

--- a/src/go/wsl-helper/pkg/dockerproxy/hyperv.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/hyperv.go
@@ -55,7 +55,7 @@ func newRacer(n int) *racer {
 func (r *racer) wait() (hvsock.GUID, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	for r.result == hvsock.GUIDZero && r.count > 0 {
+	for r.count > 0 {
 		r.cond.Wait()
 	}
 	if r.result != hvsock.GUIDZero {
@@ -68,7 +68,10 @@ func (r *racer) wait() (hvsock.GUID, error) {
 func (r *racer) resolve(guid hvsock.GUID) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.result = guid
+	if r.result == hvsock.GUIDZero {
+		r.result = guid
+	}
+	r.count = 0
 	r.cond.Signal()
 }
 

--- a/src/go/wsl-helper/pkg/dockerproxy/hyperv.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/hyperv.go
@@ -1,0 +1,127 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"golang.org/x/sys/windows/registry"
+)
+
+// Racer is a helper structure to return either a successful result (the GUID of
+// the Hyper-V virtual machine for WSL2), or an error if all attempts have
+// failed.
+type racer struct {
+	result    hvsock.GUID
+	lastError error
+	count     int
+	lock      sync.Locker
+	cond      *sync.Cond
+}
+
+// newRacer constructs a new racer that will return an error after the given
+// number of calls to reject().
+func newRacer(n int) *racer {
+	mutex := &sync.Mutex{}
+	return &racer{
+		result: hvsock.GUIDZero,
+		count:  n,
+		lock:   mutex,
+		cond:   sync.NewCond(mutex),
+	}
+}
+
+// Wait for a result; either the parameter of any resolve() call, or the last
+// error from a reject() call.
+func (r *racer) wait() (hvsock.GUID, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	for r.result == hvsock.GUIDZero && r.count > 0 {
+		r.cond.Wait()
+	}
+	if r.result != hvsock.GUIDZero {
+		return r.result, nil
+	}
+	return hvsock.GUIDZero, r.lastError
+}
+
+// Resolve the racer with the given successful result.
+func (r *racer) resolve(guid hvsock.GUID) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.result = guid
+	r.cond.Signal()
+}
+
+// Reject the racer with the given unsuccessful result.
+func (r *racer) reject(err error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.lastError = err
+	r.count -= 1
+	r.cond.Signal()
+}
+
+// Probe the system to detect the correct VM GUID for the WSL virtual machine.
+// This requires that WSL2 is already running.
+func probeVMGUID(port uint32) (hvsock.GUID, error) {
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion\HostComputeService\VolatileStore\ComputeSystem`,
+		registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return hvsock.GUIDZero, fmt.Errorf("could not open registry key: %w", err)
+	}
+	names, err := key.ReadSubKeyNames(0)
+	if err != nil {
+		return hvsock.GUIDZero, fmt.Errorf("could not list virtual machine IDs: %w", err)
+	}
+
+	r := newRacer(len(names))
+	for _, name := range names {
+		go func(name string) {
+			guid, err := hvsock.GUIDFromString(name)
+			if err != nil {
+				fmt.Printf("skipping invalid VM name %s\n", name)
+				r.reject(fmt.Errorf("invalid VM name %w", err))
+				return
+			}
+			conn, err := dialHvsock(guid, port)
+			if err != nil {
+				err := fmt.Errorf("could not dial VM %s: %w", name, err)
+				fmt.Printf("%s\n", err)
+				r.reject(err)
+				return
+			}
+			defer conn.Close()
+
+			fmt.Printf("Got WSL2 VM %s\n", guid.String())
+			r.resolve(guid)
+		}(name)
+	}
+
+	result, err := r.wait()
+	if err != nil {
+		return hvsock.GUIDZero, fmt.Errorf("could not find WSL2 VM ID: %w", err)
+	}
+	return result, nil
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/hyperv_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/hyperv_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+// +build windows
+
+package dockerproxy
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRacer(t *testing.T) {
+	t.Run("simple-resolve", func(t *testing.T) {
+		t.Parallel()
+		r := newRacer(1)
+
+		go func() {
+			time.Sleep(time.Millisecond)
+			r.resolve(hvsock.GUIDLoopback)
+		}()
+
+		v, err := r.wait()
+		assert.NoError(t, err)
+		assert.Equal(t, hvsock.GUIDLoopback, v)
+	})
+
+	t.Run("simple-reject", func(t *testing.T) {
+		t.Parallel()
+		r := newRacer(1)
+
+		go func() {
+			time.Sleep(time.Millisecond)
+			r.reject(os.ErrInvalid)
+		}()
+
+		_, err := r.wait()
+		assert.ErrorIs(t, err, os.ErrInvalid)
+	})
+
+	t.Run("any-resolve", func(t *testing.T) {
+		t.Parallel()
+		r := newRacer(2)
+
+		go func() {
+			time.Sleep(time.Millisecond)
+			r.reject(os.ErrInvalid)
+			r.resolve(hvsock.GUIDLoopback)
+		}()
+
+		v, err := r.wait()
+		if assert.NoError(t, err) {
+			assert.Equal(t, v, hvsock.GUIDLoopback)
+		}
+	})
+
+	t.Run("first-resolve", func(t *testing.T) {
+		t.Parallel()
+		r := newRacer(2)
+
+		go func() {
+			time.Sleep(time.Millisecond)
+			r.resolve(hvsock.GUIDLoopback)
+			r.resolve(hvsock.GUIDParent)
+		}()
+
+		v, err := r.wait()
+		if assert.NoError(t, err) {
+			assert.Equal(t, v, hvsock.GUIDLoopback)
+		}
+	})
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/pipe.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/pipe.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"io"
+	"net"
+)
+
+// pipe bidirectionally between two connections.
+func pipe(c1, c2 net.Conn) error {
+	copy := func(reader, writer net.Conn) <-chan error {
+		ch := make(chan error)
+		go func() {
+			_, err := io.Copy(writer, reader)
+			ch <- err
+		}()
+		return ch
+	}
+
+	ch1 := copy(c1, c2)
+	ch2 := copy(c2, c1)
+	select {
+	case err := <-ch1:
+		c1.Close()
+		if err != io.EOF {
+			return err
+		}
+	case err := <-ch2:
+		c2.Close()
+		if err != io.EOF {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/pipe_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/pipe_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type nopReadWriteCloser struct {
+	io.ReadWriter
+}
+
+func (nopReadWriteCloser) Close() error {
+	return nil
+}
+
+type passthroughReadWriteCloser struct {
+	io.ReadCloser
+	io.WriteCloser
+}
+
+func newPipeReadWriter() io.ReadWriteCloser {
+	r, w := io.Pipe()
+	return &passthroughReadWriteCloser{
+		ReadCloser:  r,
+		WriteCloser: w,
+	}
+}
+
+func (p *passthroughReadWriteCloser) Close() error {
+	err := p.ReadCloser.Close()
+	if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		return err
+	}
+	err = p.WriteCloser.Close()
+	if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		return err
+	}
+	return nil
+}
+
+func TestPipe(t *testing.T) {
+	rw := newPipeReadWriter()
+	output := bytes.Buffer{}
+	data := &passthroughReadWriteCloser{
+		ReadCloser:  nopReadWriteCloser{bytes.NewBufferString("some data")},
+		WriteCloser: nopReadWriteCloser{&output},
+	}
+	err := pipe(rw, data)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "some data", output.String())
+	}
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve.go
@@ -1,0 +1,65 @@
+//go:build linux || windows
+// +build linux windows
+
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"net"
+)
+
+// serve up the docker proxy at the given endpoint, using the given function to
+// create a connection to the real dockerd.
+func serve(endpoint string, dialer func() (net.Conn, error)) error {
+	listener, err := listen(endpoint)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("got listener %+v\n", listener)
+	defer func() {
+		err := listener.Close()
+		fmt.Printf("Closed listener: %s", err)
+	}()
+
+	for {
+		clientConn, err := listener.Accept()
+		if err != nil {
+			fmt.Printf("error accepting: %s", err)
+			continue
+		}
+
+		go func(clientConn net.Conn) {
+			conn, err := dialer()
+			if err != nil {
+				fmt.Printf("Error dialing: %s\n", err)
+				return
+			}
+			defer conn.Close()
+
+			fmt.Printf("Got client %+v\n", clientConn)
+			fmt.Printf("Dialed: %+v\n", conn)
+
+			err = pipe(clientConn, conn)
+			if err != nil {
+				fmt.Printf("Error copying: %s\n", err)
+			}
+		}(clientConn)
+	}
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/serve_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve_linux.go
@@ -29,6 +29,10 @@ import (
 // default.
 const DefaultEndpoint = "unix:///var/run/docker.sock"
 
+// errListenerClosed is the error that is returned when we attempt to call
+// Accept() on a closed listener.
+var errListenerClosed = net.ErrClosed
+
 // Serve up the docker proxy at the given endpoint, forwarding to the underlying
 // docker server at the given unix socket.
 func Serve(endpoint, proxyEndpoint string) error {

--- a/src/go/wsl-helper/pkg/dockerproxy/serve_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve_linux.go
@@ -1,0 +1,63 @@
+//go:build linux || windows
+// +build linux windows
+
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// DefaultEndpoint is the platform-specific location that dockerd listens on by
+// default.
+const DefaultEndpoint = "unix:///var/run/docker.sock"
+
+// Serve up the docker proxy at the given endpoint, forwarding to the underlying
+// docker server at the given unix socket.
+func Serve(endpoint, proxyEndpoint string) error {
+	dialer := func() (net.Conn, error) {
+		conn, err := net.Dial("unix", proxyEndpoint)
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
+	}
+	return serve(endpoint, dialer)
+}
+
+// listen on the given Unix socket endpoint.
+func listen(endpoint string) (net.Listener, error) {
+	prefix := "unix://"
+	if !strings.HasPrefix(endpoint, prefix) {
+		return nil, fmt.Errorf("endpoint %s does not start with protocol %s", endpoint, prefix)
+	}
+
+	addr, err := net.ResolveUnixAddr("unix", endpoint[len(prefix):])
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve endpoint %s: %w", endpoint, err)
+	}
+
+	listener, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, fmt.Errorf("could not listen on %s: %w", endpoint, err)
+	}
+
+	return listener, nil
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/serve_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve_windows.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+)
+
+const DefaultEndpoint = "npipe:////./pipe/docker_engine"
+
+// Serve up the docker proxy at the given endpoint, forwarding to the underlying
+// docker server at the given vsock port.
+func Serve(endpoint string, port uint32) error {
+	return serve(endpoint, makeDialer(port))
+}
+
+// makeDialer creates the dialer function to create a vsock connection on the
+// given port.
+func makeDialer(port uint32) func() (net.Conn, error) {
+	return func() (net.Conn, error) {
+		// go-winio doesn't implement DialHvsock(), but luckily LinuxKit has an
+		// implementation.  We still need go-winio to convert port to GUID.
+		vmGuid, err := hvsock.GUIDFromString("ADC5B3E0-AFAB-4D8B-8139-FAF16CE7B463")
+		if err != nil {
+			return nil, fmt.Errorf("could not parse WSL VM GUID: %w", err)
+		}
+		svcGuid, err := hvsock.GUIDFromString(winio.VsockServiceID(port).String())
+		if err != nil {
+			return nil, fmt.Errorf("could not parse Hyper-V service GUID: %w", err)
+		}
+		addr := hvsock.Addr{
+			VMID:      vmGuid,
+			ServiceID: svcGuid,
+		}
+
+		conn, err := hvsock.Dial(addr)
+		if err != nil {
+			return nil, fmt.Errorf("could not dial Hyper-V socket: %w", err)
+		}
+
+		return conn, nil
+	}
+}
+
+// listen on the given Windows named pipe endpoint.
+func listen(endpoint string) (net.Listener, error) {
+	const prefix = "npipe://"
+
+	if !strings.HasPrefix(endpoint, prefix) {
+		return nil, fmt.Errorf("endpoint %s does not start with protocol %s", endpoint, prefix)
+	}
+
+	listener, err := winio.ListenPipe(endpoint[len(prefix):], nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not listen on %s: %w", endpoint, err)
+	}
+
+	return listener, nil
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/serve_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve_windows.go
@@ -25,7 +25,13 @@ import (
 	"github.com/linuxkit/virtsock/pkg/hvsock"
 )
 
+// DefaultEndpoint is the platform-specific location that dockerd listens on by
+// default.
 const DefaultEndpoint = "npipe:////./pipe/docker_engine"
+
+// errListenerClosed is the error that is returned when we attempt to call
+// Accept() on a closed listener.
+var errListenerClosed = winio.ErrPipeListenerClosed
 
 // Serve up the docker proxy at the given endpoint, forwarding to the underlying
 // docker server at the given vsock port.

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -1,0 +1,101 @@
+// +build linux
+
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+// sdListenFdsStart is SD_LISTEN_FDS_START from sd_listen_fds(3)
+const sdListenFdsStart = 3
+
+// Start the dockerd process within this WSL distribution on the given vsock
+// port.  All other arguments are passed to dockerd as-is.
+//
+// On success, this function never returns; the current process is replaced by
+// the dockerd process directly.
+func Start(port uint32, args []string) error {
+	dockerd, err := exec.LookPath("dockerd")
+	if err != nil {
+		return fmt.Errorf("could not find dockerd: %w", err)
+	}
+
+	// We can't use github.com/linuxkit/virtsock/pkg/vsock here, as it opens
+	// things as CLOEXEC (also we can't get the fd out).
+	fd, err := unix.Socket(unix.AF_VSOCK, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return fmt.Errorf("could not create vsock socket: %w", err)
+	}
+
+	// As we never exit (in the successful case), we can defer to close the
+	// vsock here.
+	defer unix.Close(fd)
+
+	if port == 0 {
+		port = unix.VMADDR_PORT_ANY
+	}
+	vmsockaddr := &unix.SockaddrVM{CID: unix.VMADDR_CID_ANY, Port: port}
+
+
+	err = unix.Bind(fd, vmsockaddr)
+	if err != nil {
+		return fmt.Errorf("could not bind to vsock %+v: %w", vmsockaddr, err)
+	}
+
+	err = unix.Listen(fd, unix.SOMAXCONN)
+	if err != nil {
+		return fmt.Errorf("could not listen on vsock: %w", err)
+	}
+
+	sockaddr, err := unix.Getsockname(fd)
+	if err != nil {
+		return fmt.Errorf("could not get bound sockaddr: %w", err)
+	}
+	fmt.Printf("docker proxy listening on port %x\n", sockaddr.(*unix.SockaddrVM).Port)
+
+	pollfds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN|unix.POLLOUT}}
+	n, err := unix.Poll(pollfds, -1)
+	if err != nil {
+		return fmt.Errorf("could not poll vsock: %w", err)
+	}
+
+	fmt.Printf("poll returned %d: %+v\n", n, pollfds)
+
+	args = append([]string{dockerd}, args...)
+	args = append(args, fmt.Sprintf("--host=fd://%d", fd))
+	err = os.Setenv("LISTEN_PID", fmt.Sprintf("%d", os.Getpid()))
+	if err != nil {
+		return fmt.Errorf("could not set environment variable LISTEN_PID: %w", err)
+	}
+	err = os.Setenv("LISTEN_FDS", fmt.Sprintf("%d", fd - sdListenFdsStart + 1))
+	if err != nil {
+		return fmt.Errorf("could not set environment variable LISTEN_FDS: %w", err)
+	}
+
+	err = unix.Exec(dockerd, args, os.Environ())
+	if err != nil {
+		return fmt.Errorf("could not run docker: %w", err)
+	}
+
+	panic("unix.Exec() should not return")
+}


### PR DESCRIPTION
This is the first part of #812.

This PR adds some capabilities to `wsl-helper`:
- On the Linux side (for the `rancher-desktop` distribution), we can now run `wsl-helper docker-proxy start` to start `dockerd`, listening on `/mnt/wsl/rancher-desktop/run/docker.sock` (which is exposed to all WSL2 distributions).
- We can then run `wsl-helper docker-proxy serve` on a different Linux distribution (still in WSL2) to forward that to the default `/var/run/docker.sock`, so that `docker` executables without patches can work with it without additional consideration.
- We can also run `wsl-helper.exe docker-proxy serve` on the _Windows_ side; that listens on `\\.\pipe\docker_engine`, so that the normal `docker.exe` (actually, `com.docker.cli.exe`) will work with it.

For future improvement:
- `wsl-helper docker-proxy serve` should actually intercept the HTTP requests and deal with file paths; this is not implemented currently.

Additional discussion:
- We may want to look more into using docker contexts, to interoperate with a _running_ Docker Desktop installation.  I've opted to not do this, as that would only work with the default CLI (per distribution); I'm not convinced that third-party clients would work with it correctly.  (For example, I haven't yet checked if whatever Docker extension that VSCode uses would deal with contexts.)
- I'm using `AF_VSOCK` for communication with Windows, because I've found reports that Windows may terminate all active TCP connections at times (e.g. reset network card, VPN setup?), and using hypervisor-specific methods here avoids that.