### PR TITLE
Bump lima-qemu and iso

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.9';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.1.9';
+const alpineLimaTag = 'v0.2.0';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.13.5';
 

--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.9';
+const limaTag = 'v1.10';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.0';

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -105,7 +105,7 @@ interface LimaListResult {
 
 const console = Logging.lima;
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.1.9';
+const IMAGE_VERSION = '0.2.0';
 
 /** The root-owned directory the VDE tools are installed into. */
 const VDE_DIR = '/opt/rancher-desktop';


### PR DESCRIPTION
This fixes the @executable_path setting for /opt/rancher-desktop/vde_vmnet

Also bumps to latest lima:
- unix socket forwarding
- support ssh.forwardAgent option
- don't fail when system_profiler doesn't support -json option
- replace localhost/127.0.0.1 in proxy settings with the gateway address
- host dns forwarder works inside containers too

No changes in ISO, just making sure the binary generated by Github Action works the same as before.