### PR TITLE
Add input next to slider components

### DIFF
--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -148,33 +148,49 @@ export default {
   <div class="system-preferences">
     <div id="memoryInGBWrapper" class="labeled-input">
       <label>Memory (GB)</label>
-      <vue-slider
-        ref="memory"
-        :value="safeMemory"
-        :min="safeMinMemory"
-        :max="availMemoryInGB"
-        :marks="memoryMarks"
-        :tooltip="'none'"
-        :disabled="disableMemory"
-        :process="processMemory"
-        @change="updatedMemory"
-      />
+      <section class="slider-container">
+        <input
+          type="text"
+          class="slider-input"
+          :value="safeMemory"
+          @input="updatedVal($event.target.value, 'memory')"
+        />
+        <vue-slider
+          ref="memory"
+          :value="safeMemory"
+          :min="safeMinMemory"
+          :max="availMemoryInGB"
+          :marks="memoryMarks"
+          :tooltip="'none'"
+          :disabled="disableMemory"
+          :process="processMemory"
+          @change="updatedVal($event, 'memory')"
+        />
+      </section>
     </div>
 
     <div id="numCPUWrapper" class="labeled-input">
       <label># CPUs</label>
-      <vue-slider
-        ref="cpu"
-        :value="safeCPUs"
-        :min="safeMinCPUs"
-        :max="availNumCPUs"
-        :interval="1"
-        :marks="CPUMarks"
-        :tooltip="'none'"
-        :disabled="disableCPUs"
-        :process="processCPUs"
-        @change="updatedCPU"
-      />
+      <section class="slider-container">
+        <input
+          type="text"
+          class="slider-input"
+          :value="safeCPUs"
+          @input="updatedVal($event.target.value, 'cpu')"
+        />
+        <vue-slider
+          ref="cpu"
+          :value="safeCPUs"
+          :min="safeMinCPUs"
+          :max="availNumCPUs"
+          :interval="1"
+          :marks="CPUMarks"
+          :tooltip="'none'"
+          :disabled="disableCPUs"
+          :process="processCPUs"
+          @change="updatedVal($event, 'cpu')"
+        />
+      </section>
     </div>
   </div>
 </template>
@@ -183,6 +199,7 @@ export default {
 
 .labeled-input .vue-slider {
   margin: 2em 1em;
+  flex: 1;
 }
 .vue-slider >>> .vue-slider-rail {
   background-color: var(--progress-bg);
@@ -202,6 +219,17 @@ export default {
 }
 .vue-slider >>> .vue-slider-process {
   background-color: var(--error);
+}
+
+.slider-container {
+  display: flex;
+  align-items: center;
+}
+
+.slider-input, .slider-input:focus, .slider-input:hover {
+  max-width: 4rem;
+  border: solid var(--border-width) var(--input-border);
+  padding:10px;
 }
 
 </style>

--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -171,7 +171,7 @@ export default {
       <label>Memory (GB)</label>
       <section class="slider-container">
         <input
-          type="text"
+          type="number"
           class="slider-input"
           :value="safeMemory"
           @input="updatedVal($event.target.value, 'memory')"
@@ -194,7 +194,7 @@ export default {
       <label># CPUs</label>
       <section class="slider-container">
         <input
-          type="text"
+          type="number"
           class="slider-input"
           :value="safeCPUs"
           @input="updatedVal($event.target.value, 'cpu')"

--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -248,7 +248,7 @@ export default {
 }
 
 .slider-input, .slider-input:focus, .slider-input:hover {
-  max-width: 4rem;
+  max-width: 6rem;
   border: solid var(--border-width) var(--input-border);
   padding:10px;
 }

--- a/src/components/__tests__/SystemPreferences.spec.js
+++ b/src/components/__tests__/SystemPreferences.spec.js
@@ -192,7 +192,7 @@ describe('SystemPreferences.vue', () => {
     const slider1vm = slider1.vm;
 
     await slider1vm.setValue(3);
-    const updateMemoryEmitter = wrapper.emitted().updateMemory;
+    const updateMemoryEmitter = wrapper.emitted()['update:memory'];
 
     expect(updateMemoryEmitter).toBeTruthy();
     expect(updateMemoryEmitter.length).toBe(1);
@@ -207,7 +207,7 @@ describe('SystemPreferences.vue', () => {
     const slider2vm = slider2.vm;
 
     await slider2vm.setValue(2);
-    const updateCPUEmitter = wrapper.emitted().updateCPU;
+    const updateCPUEmitter = wrapper.emitted()['update:cpu'];
 
     expect(updateCPUEmitter).toBeTruthy();
     expect(updateCPUEmitter.length).toBe(1);

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -30,7 +30,7 @@
       data-test="k8sResetBtn"
       label="Reset Kubernetes"
       value="auto"
-      :disabled="cannotReset"
+      :disabled="hasError || cannotReset"
       :options="[{id: 'wipe', label: 'Reset Kubernetes and Container Images'}]"
       @input="reset"
     />
@@ -104,6 +104,10 @@ export default {
         return NotificationLevels.indexOf(left.color) - NotificationLevels.indexOf(right.color);
       });
     },
+    hasError() {
+      return Object.entries(this.notifications)
+        ?.some(([_key, val]) => val.level === 'error');
+    }
   },
 
   created() {

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -2,7 +2,10 @@
   name: Kubernetes Settings
 </router>
 <template>
-  <notifications class="k8s-wrapper" :notifications="notificationsList">
+  <notifications
+    class="k8s-wrapper"
+    :notifications="notificationsList"
+  >
     <div class="labeled-input">
       <label>Kubernetes version</label>
       <select class="select-k8s-version" :value="settings.kubernetes.version" @change="onChange($event)">
@@ -19,9 +22,10 @@
       :avail-num-c-p-us="availNumCPUs"
       :reserved-memory-in-g-b="6"
       :reserved-num-c-p-us="1"
-      @updateMemory="handleUpdateMemory"
-      @updateCPU="handleUpdateCPU"
+      @update:memory="handleUpdateMemory"
+      @update:cpu="handleUpdateCPU"
       @warning="handleWarning"
+      @error="handleError"
     />
     <labeled-input :value="settings.kubernetes.port" label="Port" type="number" data-test="portConfig" @input="handleUpdatePort" />
 
@@ -247,6 +251,9 @@ export default {
     },
     handleWarning(key, message) {
       this.handleNotification('warning', key, message);
+    },
+    handleError(key, message) {
+      this.handleNotification('error', key, message);
     },
   },
 };


### PR DESCRIPTION
This provides direct feedback to the currently selected value and allows for keyboard entry of CPU and Memory by adding an input next to each slider in the K8s page.

The addition of a text box allows for entering values that might fall outside of bounds for available/minimum memory & cpu, so an error state is introduced to prevent restarting Kubernetes. 

resolves #863 

#514 