### PR TITLE
Launch dockerd on lima

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -889,6 +889,15 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           return;
         }
 
+        const username = process.env.USER || process.env.LOGNAME || process.env.USERNAME;
+
+        if (username) {
+          await this.progressTracker.action('Adding user to docker group', 30, async() => {
+            await this.ssh('sudo', 'usermod', '-G', 'docker', '-a', username);
+          });
+        } else {
+          console.log("Can't figure out the name of the current user");
+        }
         await this.progressTracker.action('Starting docker server', 30, async() => {
           await this.ssh('sudo', '/sbin/rc-service', 'docker', 'start');
         });

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -496,7 +496,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       config.portForwards = allPortForwards = DEFAULT_CONFIG.portForwards ?? [];
     }
     const dockerPortForwards = allPortForwards?.find(entry => Object.keys(entry).length === 2 &&
-      entry.guestSocket === '/run/docker.sock' &&
+      entry.guestSocket === '/var/run/docker.sock' &&
       ('hostSocket' in entry));
 
     if (!dockerPortForwards) {
@@ -504,7 +504,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       this.checkMaxSocketLength(hostSocketPath);
       config.portForwards?.push({
-        guestSocket: '/run/docker.sock',
+        guestSocket: '/var/run/docker.sock',
         hostSocket:  hostSocketPath,
       });
     }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -462,9 +462,9 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       // This shouldn't happen, but fix it anyway
       config.portForwards = allPortForwards = DEFAULT_CONFIG.portForwards ?? [];
     }
-    const dockerPortForwards = allPortForwards?.find(pair => Object.keys(pair).length === 2 &&
-      pair.guestSocket === '/run/docker.sock' &&
-      ('hostSocket' in pair));
+    const dockerPortForwards = allPortForwards?.find(entry => Object.keys(entry).length === 2 &&
+      entry.guestSocket === '/run/docker.sock' &&
+      ('hostSocket' in entry));
 
     if (!dockerPortForwards) {
       config.portForwards?.push({

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -469,7 +469,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     if (!dockerPortForwards) {
       config.portForwards?.push({
         guestSocket: '/run/docker.sock',
-        hostSocket: path.join(paths.lima, MACHINE_NAME, 'docker.sock')
+        hostSocket:  `{{.LimaHome}}/${ MACHINE_NAME }/docker.sock`,
       });
     }
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -889,15 +889,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           return;
         }
 
-        const username = process.env.USER || process.env.LOGNAME || process.env.USERNAME;
-
-        if (username) {
-          await this.progressTracker.action('Adding user to docker group', 30, async() => {
-            await this.ssh('sudo', 'usermod', '-G', 'docker', '-a', username);
-          });
-        } else {
-          console.log("Can't figure out the name of the current user");
-        }
         await this.progressTracker.action('Starting docker server', 30, async() => {
           await this.ssh('sudo', '/sbin/rc-service', 'docker', 'start');
         });
@@ -961,6 +952,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           'Waiting for nodes',
           100,
           this.client?.waitForReadyNodes() ?? Promise.reject(new Error('No client')));
+
+        // The socket isn't present immediately after `docker start` finishes, but it should be by this point
+        await this.progressTracker.action('Adjusting docker.sock permissions', 30, async() => {
+          await this.ssh('sudo', 'chmod', 'a+rw', '/run/docker.sock');
+        });
 
         this.setState(K8s.State.STARTED);
       } catch (err) {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -434,7 +434,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       k3s: { version: desiredVersion },
     });
 
-    await this.updateConfigPortForwards(config);
+    this.updateConfigPortForwards(config);
     if (currentConfig) {
       // update existing configuration
       const configPath = path.join(paths.lima, MACHINE_NAME, 'lima.yaml');
@@ -455,7 +455,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
-  protected async updateConfigPortForwards(config: LimaConfiguration) {
+  protected updateConfigPortForwards(config: LimaConfiguration) {
     let allPortForwards: Array<Record<string, any>> | undefined = config.portForwards;
 
     if (!allPortForwards) {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -472,16 +472,20 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         actualPath = currentPath;
       }
     }
+
+    return actualPath;
+  }
+
+  protected checkMaxSocketLength(proposedPath: string) {
     // See https://serverfault.com/questions/641347/check-if-a-path-exceeds-maximum-for-unix-domain-socket
     // for an example of how to determine these values.
     const socketLengthLimit = os.platform() === 'darwin' ? 103 : 107;
 
-    if (actualPath.length > socketLengthLimit) {
-      console.log(`Specified path ${ proposedPath } symlink-expands to ${ actualPath }`);
-      console.log(`The path ${ actualPath } has ${ actualPath.length } characters, over limit of ${ socketLengthLimit }`);
-      throw new Error(`Specified path ${ proposedPath } is too long, symlink-expands to ${ actualPath }, ;exceeds limit by ${ actualPath.length - socketLengthLimit } characters.`);
+    if (proposedPath.length > socketLengthLimit) {
+      console.log(`Specified path ${ proposedPath } symlink-expands to ${ proposedPath }`);
+      console.log(`The path ${ proposedPath } has ${ proposedPath.length } characters, over limit of ${ socketLengthLimit }`);
+      throw new Error(`Specified path ${ proposedPath } is too long, symlink-expands to ${ proposedPath }, ;exceeds limit by ${ proposedPath.length - socketLengthLimit } characters.`);
     }
-    return actualPath;
   }
 
   protected async updateConfigPortForwards(config: LimaConfiguration) {
@@ -498,6 +502,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     if (!dockerPortForwards) {
       const hostSocketPath = await this.evalSymlinks(`${ paths.lima }/${ MACHINE_NAME }/docker.sock`);
 
+      this.checkMaxSocketLength(hostSocketPath);
       config.portForwards?.push({
         guestSocket: '/run/docker.sock',
         hostSocket:  hostSocketPath,


### PR DESCRIPTION
This PR does launch `dockerd` on lima, and modifies the user config to forward ports, but we get permission-denied errors when trying to access the dockerd socket from the client, even after adding the VM user to the `docker` group.

Creating the PR now in case the permission work should be done in a later task. Note that this PR _does_ launch `dockerd` on lima, as per the label.