### PR TITLE
Bump lima-and-qemu to v1.11 and Alpine ISOs to v0.2.1

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,10 +7,10 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.10';
+const limaTag = 'v1.11';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.0';
+const alpineLimaTag = 'v0.2.1';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.13.5';
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -105,7 +105,7 @@ interface LimaListResult {
 
 const console = Logging.lima;
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.0';
+const IMAGE_VERSION = '0.2.1';
 
 /** The root-owned directory the VDE tools are installed into. */
 const VDE_DIR = '/opt/rancher-desktop';


### PR DESCRIPTION
The ISO now includes nerdctl 0.13.0

Lima updates include
* bugfix for OpenSSH version check for cipher selection
* truncate DNS messages to 512 bytes for busybox compatibility
* fix race conditions in setting up/using /etc/environment
