### PR TITLE
Launch k3s with the specified `--flannel-iface NAME` option

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -349,10 +349,14 @@ async function doK8sReset(arg: 'fast' | 'wipe'): Promise<void> {
   }
 }
 
-Electron.ipcMain.on('k8s-restart-required', async() => {
+async function doK8sRestartRequired() {
   const restartRequired = (await k8smanager?.requiresRestartReasons()) ?? {};
 
   window.send('k8s-restart-required', restartRequired);
+}
+
+Electron.ipcMain.on('k8s-restart-required', async() => {
+  await doK8sRestartRequired();
 });
 
 Electron.ipcMain.on('k8s-restart', async() => {
@@ -571,8 +575,29 @@ function handleFailure(payload: any) {
     message = payload.message || message;
     titlePart = payload.context || titlePart;
   }
-  console.log(`Kubernetes was unable to start:`, payload);
-  Electron.dialog.showErrorBox(`Error ${ titlePart }`, message);
+  if (titlePart === 'Rancher Desktop Update Required') {
+    (async() => {
+      const options = {
+        message:   `${ message }\n\nPress yes to update now, or press the Reset button in the Kubernetes Settings page`,
+        type:      'question',
+        buttons:   ['Yes', 'No'],
+        defaultId: 0,
+        title:     titlePart,
+      };
+      const buttonID = (await Electron.dialog.showMessageBox(options)).response;
+
+      if (buttonID === 0) {
+        await doK8sReset('wipe');
+      } else {
+        doK8sRestartRequired().catch((err) => {
+          console.log('Error calculating restart stuff: ', err);
+        });
+      }
+    })();
+  } else {
+    console.log(`Kubernetes was unable to start:`, payload);
+    Electron.dialog.showErrorBox(`Error ${ titlePart }`, message);
+  }
 }
 
 function newK8sManager() {

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -62,3 +62,4 @@ portForwards:
   hostIP: "0.0.0.0"
 networks:
 - lima: shared
+  interface: rd0

--- a/src/assets/scripts/service-k3s
+++ b/src/assets/scripts/service-k3s
@@ -17,7 +17,7 @@ start_pre() {
 supervisor=supervise-daemon
 name=k3s
 command=/usr/local/bin/k3s
-command_args="server --https-listen-port @PORT@ >>/var/log/k3s 2>&1"
+command_args="server --https-listen-port @PORT@ --flannel-iface @INTERFACE@ >>/var/log/k3s 2>&1"
 output_log=/var/log/k3s
 error_log=/var/log/k3s
 


### PR DESCRIPTION
Note that when the option isn't specified, the network name is "lima0",
and the VM needs to be rebuilt with the new interface name.

I pulled out code that ran `ip a` and `ps auxww | grep k3s.*server` remotely
to verify that the running networks aligned. I found that they would
align with a new value in the config file, but ingress didn't work
until the VM was rebuilt. So this might need documentation, or further exploring.

Also, the config was being calculated by merging the default config over the
user's current settings. This only works if we want to give the default settings
priority over any changes the user might wish to make.

Signed-off-by: Eric Promislow <epromislow@suse.com>

Note that this PR is based on 609-provide-routable-address 