### PR TITLE
Fixed typo.

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -15,7 +15,7 @@ Rancher Desktop requires the following on macOS:
 - Intel CPU with VT-x.
 - Persistent internet connection.
 
-Apple Silion (M1) support is planned, but not currently implemented.
+Apple Silicon (M1) support is planned, but not currently implemented.
 
 ## Windows
 


### PR DESCRIPTION
Apple Silion -> Silicon

Signed-off-by: Simon Flood <simonflood@users.noreply.github.com>