### PR TITLE
Allow k3s customization via K3S_EXEC variable

### DIFF
--- a/src/assets/scripts/service-k3s
+++ b/src/assets/scripts/service-k3s
@@ -17,7 +17,7 @@ start_pre() {
 supervisor=supervise-daemon
 name=k3s
 command=/usr/local/bin/k3s
-command_args="server --https-listen-port @PORT@ >>/var/log/k3s 2>&1"
+command_args="server --https-listen-port @PORT@ ${K3S_EXEC:-} >>/var/log/k3s 2>&1"
 output_log=/var/log/k3s
 error_log=/var/log/k3s
 


### PR DESCRIPTION
This is just a workaround to allow k3s customization while it is not yet supported by the GUI.

With this PR i can add this to `lima.yaml`:

```yaml
env:
  K3S_EXEC: --disable=traefik
```

Then I can uninstall `traefik`:

```console
$ helm delete -n kube-system traefik
$ helm delete -n kube-system traefik-crd
```

And even when I restart RD, `traefik` is not being reinstalled.