### PR TITLE
Bump lima-and-qemu to v1.12

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.11';
+const limaTag = 'v1.12';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.1';


### PR DESCRIPTION
Updates `limactl info` command to include `LIMA_HOME` setting after evaluating all symlinks. Needed by #910.
