### PR TITLE
Support running on M1 (via Rosetta) with native lima and qemu

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-10.15
+        - macos-10.15 # Intel build with Intel assets
+        - macos-11    # Intel build with M1 assets
         - windows-2019
         - ubuntu-latest
     runs-on: ${{ matrix.os }}
@@ -47,12 +48,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install flatpak flatpak-builder
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-    - run: npm ci
+    - name: npm ci
+      if: "!startsWith(matrix.os, 'macos-11')"
+      run: npm ci
+    - name: npm ci (for M1)
+      if: startsWith(matrix.os, 'macos-11')
+      run: M1=1 npm ci
     - name: npm run build
       run: |
         case "${{ matrix.os }}" in
-          macos-*)
+          macos-10*)
+            # Build Intel version with Intel assets
             npm run build -- --mac --publish=never
+            ;;
+          macos-11*)
+            # Build Intel version with M1 assets
+            M1=1 npm run build -- --mac --publish=never
             ;;
           windows-*)
             npm run build -- --win --publish=never
@@ -62,16 +73,28 @@ jobs:
             ;;
         esac
     - uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'macos-')
+      if: startsWith(matrix.os, 'macos-10')
       with:
-        name: Rancher Desktop.dmg
+        name: Rancher Desktop.x86_64.dmg
         path: dist/Rancher Desktop*.dmg
         if-no-files-found: error
     - uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'macos-')
+      if: startsWith(matrix.os, 'macos-10')
       with:
-        name: Rancher Desktop-mac.zip
-        path: dist/Rancher Desktop*-mac.zip
+        name: Rancher Desktop-mac.x86_64.zip
+        path: dist/Rancher Desktop*.zip
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'macos-11')
+      with:
+        name: Rancher Desktop.aarch64.dmg
+        path: dist/Rancher Desktop*.dmg
+        if-no-files-found: error
+    - uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'macos-11')
+      with:
+        name: Rancher Desktop-mac.aarch64.zip
+        path: dist/Rancher Desktop*.zip
         if-no-files-found: error
     - uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'windows-')

--- a/background.ts
+++ b/background.ts
@@ -576,7 +576,7 @@ function handleFailure(payload: any) {
 }
 
 function newK8sManager() {
-  const arch = (Electron.app.runningUnderRosettaTranslation || os.arch() === 'arm64') ? 'arm64' : 'amd64';
+  const arch = (Electron.app.runningUnderRosettaTranslation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';
   const mgr = K8s.factory(arch);
 
   mgr.on('state-changed', (state: K8s.State) => {

--- a/background.ts
+++ b/background.ts
@@ -576,7 +576,8 @@ function handleFailure(payload: any) {
 }
 
 function newK8sManager() {
-  const mgr = K8s.factory();
+  const arch = (Electron.app.runningUnderRosettaTranslation || os.arch() === 'arm64') ? 'arm64' : 'amd64';
+  const mgr = K8s.factory(arch);
 
   mgr.on('state-changed', (state: K8s.State) => {
     mainEvents.emit('k8s-check-state', mgr);

--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -40,8 +40,8 @@ async function getLima(platform) {
   });
 }
 
-async function getAlpineLima() {
-  const url = `${ alpineLimaRepo }/releases/download/${ alpineLimaTag }/alpine-lima-${ alpineLimaEdition }-${ alpineLimaVersion }-x86_64.iso`;
+async function getAlpineLima(arch) {
+  const url = `${ alpineLimaRepo }/releases/download/${ alpineLimaTag }/alpine-lima-${ alpineLimaEdition }-${ alpineLimaVersion }-${ arch }.iso`;
   const destPath = path.join(process.cwd(), 'resources', os.platform(), `alpine-lima-${ alpineLimaTag }-${ alpineLimaEdition }-${ alpineLimaVersion }.iso`);
   const expectedChecksum = (await getResource(`${ url }.sha512sum`)).split(/\s+/)[0];
 
@@ -52,10 +52,15 @@ async function getAlpineLima() {
 
 export default function run() {
   let platform = os.platform();
+  let arch = 'x86_64';
 
   if (platform === 'darwin') {
     platform = 'macos';
+    if (process.env.M1) {
+      arch = 'aarch64';
+      platform = `macos-${ arch }`;
+    }
   }
 
-  return Promise.all([getLima(platform), getAlpineLima()]);
+  return Promise.all([getLima(platform), getAlpineLima(arch)]);
 }

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -46,8 +46,8 @@ async function findHome(onWindows) {
 }
 
 async function downloadKuberlr(kubePlatform, cpu, destDir) {
-  const kuberlrVersion = '0.4.2';
-  const baseURL = `https://github.com/rancher-sandbox/kuberlr/releases/download/v${ kuberlrVersion }`;
+  const kuberlrVersion = '0.4.1';
+  const baseURL = `https://github.com/flavio/kuberlr/releases/download/v${ kuberlrVersion }`;
   const platformDir = `kuberlr_${ kuberlrVersion }_${ kubePlatform }_${ cpu }`;
   const archiveName = platformDir + (kubePlatform.startsWith('win') ? '.zip' : '.tar.gz');
   const exeName = kubePlatform.startsWith('win') ? 'kuberlr.exe' : 'kuberlr';
@@ -95,7 +95,8 @@ export default async function main(platform) {
 
   fs.mkdirSync(binDir, { recursive: true });
 
-  const kuberlrPath = await downloadKuberlr(kubePlatform, cpu, binDir);
+  // We use the x86_64 version even on aarch64 because kubectl binaries before v1.21.0 are unavailable
+  const kuberlrPath = await downloadKuberlr(kubePlatform, 'amd64', binDir);
 
   await bindKubectlToKuberlr(kuberlrPath, path.join(binDir, exeName('kubectl')));
 

--- a/src/assets/scripts/install-k3s
+++ b/src/assets/scripts/install-k3s
@@ -20,12 +20,19 @@ fi
 mkdir -p /etc/rancher/k3s
 rm -f /etc/rancher/k3s/k3s.yaml
 
+K3S=k3s
+ARCH=amd64
+if [ "$(uname -m)" = "aarch64" ]; then
+    K3S=k3s-arm64
+    ARCH=arm64
+fi
+
 # Add images
 IMAGES="/var/lib/rancher/k3s/agent/images"
 mkdir -p "${IMAGES}"
-ln -s -f "${K3S_DIR}/k3s-airgap-images-amd64.tar" "${IMAGES}"
+ln -s -f "${K3S_DIR}/k3s-airgap-images-${ARCH}.tar" "${IMAGES}"
 
 # Add k3s binary
-ln -s -f "${K3S_DIR}/k3s" /usr/local/bin
+ln -s -f "${K3S_DIR}/${K3S}" /usr/local/bin/k3s
 # The file system may be readonly (on macOS)
-chmod a+x "${K3S_DIR}/k3s" || true
+chmod a+x "${K3S_DIR}/${K3S}" || true

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -73,7 +73,7 @@ describe(K3sHelper, () => {
     };
 
     beforeEach(() => {
-      subject = new K3sHelper();
+      subject = new K3sHelper('amd64');
       // Note that we _do not_ initialize this, i.e. we don't trigger an
       // initial fetch of the releases.  Instead, we pretend that is done.
       subject['pendingInitialize'] = Promise.resolve();
@@ -109,7 +109,7 @@ describe(K3sHelper, () => {
   });
 
   test('cache read/write', async() => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const readFile = util.promisify(fs.readFile);
     const mkdtemp = util.promisify(fs.mkdtemp);
     const workDir = await mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
@@ -142,7 +142,7 @@ describe(K3sHelper, () => {
   });
 
   test('updateCache', async() => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const validAssets = subject['filenames']
       .map(name => ({ name, browser_download_url: name }));
 
@@ -201,7 +201,7 @@ describe(K3sHelper, () => {
   });
 
   test('fullVersion', () => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const versionStrings = ['1.2.3+k3s1', '2.3.4+k3s3'];
 
     subject['versions'] = Object.fromEntries(versionStrings.map((s) => {
@@ -216,14 +216,14 @@ describe(K3sHelper, () => {
 
   describe('initialize', () => {
     it('should finish initialize without network if cache is available', async() => {
-      const writer = new K3sHelper();
+      const writer = new K3sHelper('amd64');
 
       writer['versions'] = { 'v1.0.0': new semver.SemVer('v1.0.0') };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.
 
-      const subject = new K3sHelper();
+      const subject = new K3sHelper('amd64');
       const pendingInit = new Promise((resolve) => {
         // We need a cast on updateCache here since it's a protected method.
         jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -58,7 +58,7 @@ describe(K3sHelper, () => {
       const assets: ReleaseAPIEntry['assets'] = [];
 
       if (hasAssets) {
-        for (const name of subject['filenames']) {
+        for (const name of Object.values(subject['filenames'])) {
           assets.push({ name, browser_download_url: name });
         }
       }
@@ -143,7 +143,7 @@ describe(K3sHelper, () => {
 
   test('updateCache', async() => {
     const subject = new K3sHelper('x86_64');
-    const validAssets = subject['filenames']
+    const validAssets = Object.values(subject['filenames'])
       .map(name => ({ name, browser_download_url: name }));
 
     // Stub out touching the cache; not used for this.

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -73,7 +73,7 @@ describe(K3sHelper, () => {
     };
 
     beforeEach(() => {
-      subject = new K3sHelper('amd64');
+      subject = new K3sHelper('x86_64');
       // Note that we _do not_ initialize this, i.e. we don't trigger an
       // initial fetch of the releases.  Instead, we pretend that is done.
       subject['pendingInitialize'] = Promise.resolve();
@@ -109,7 +109,7 @@ describe(K3sHelper, () => {
   });
 
   test('cache read/write', async() => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const readFile = util.promisify(fs.readFile);
     const mkdtemp = util.promisify(fs.mkdtemp);
     const workDir = await mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
@@ -142,7 +142,7 @@ describe(K3sHelper, () => {
   });
 
   test('updateCache', async() => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const validAssets = subject['filenames']
       .map(name => ({ name, browser_download_url: name }));
 
@@ -201,7 +201,7 @@ describe(K3sHelper, () => {
   });
 
   test('fullVersion', () => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const versionStrings = ['1.2.3+k3s1', '2.3.4+k3s3'];
 
     subject['versions'] = Object.fromEntries(versionStrings.map((s) => {
@@ -216,14 +216,14 @@ describe(K3sHelper, () => {
 
   describe('initialize', () => {
     it('should finish initialize without network if cache is available', async() => {
-      const writer = new K3sHelper('amd64');
+      const writer = new K3sHelper('x86_64');
 
       writer['versions'] = { 'v1.0.0': new semver.SemVer('v1.0.0') };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.
 
-      const subject = new K3sHelper('amd64');
+      const subject = new K3sHelper('x86_64');
       const pendingInit = new Promise((resolve) => {
         // We need a cast on updateCache here since it's a protected method.
         jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -19,6 +19,7 @@ import resources from '@/resources';
 import DownloadProgressListener from '@/utils/DownloadProgressListener';
 import safeRename from '@/utils/safeRename';
 import paths from '@/utils/paths';
+import * as K8s from './k8s';
 
 const console = Logging.k8s;
 
@@ -62,7 +63,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
   protected readonly minimumVersion = new semver.SemVer('1.15.0');
 
-  constructor(arch: 'amd64' | 'arm64') {
+  constructor(arch: K8s.Architecture) {
     super();
     this.arch = arch;
   }
@@ -77,7 +78,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected pendingInitialize: Promise<void> | undefined;
 
   /** The current architecture. */
-  protected readonly arch: 'amd64' | 'arm64';
+  protected readonly arch: K8s.Architecture;
 
   /** Read the cached data and fill out this.versions. */
   protected async readCache() {
@@ -110,9 +111,9 @@ export default class K3sHelper extends events.EventEmitter {
   /** The files we need to download for the current architecture. */
   protected get filenames(): string[] {
     switch (this.arch) {
-    case 'amd64':
+    case 'x86_64':
       return ['k3s', 'k3s-airgap-images-amd64.tar', 'sha256sum-amd64.txt'];
-    case 'arm64':
+    case 'aarch64':
       return ['k3s-arm64', 'k3s-airgap-images-arm64.tar', 'sha256sum-arm64.txt'];
     }
     throw new Error(`Unsupported architecture ${ this.arch }`);

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -499,7 +499,7 @@ export default class K3sHelper extends events.EventEmitter {
     if (process.env.HOMEDRIVE && process.env.HOMEPATH) {
       const homePath = path.join(process.env.HOMEDRIVE, process.env.HOMEPATH);
 
-      if (tryAccess(homePath)) {
+      if (await tryAccess(homePath)) {
         return homePath;
       }
     }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -205,12 +205,12 @@ export interface KubernetesBackendPortForwarder {
   cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
 }
 
-export function factory(): KubernetesBackend {
+export function factory(arch: 'amd64' | 'arm64'): KubernetesBackend {
   switch (os.platform()) {
   case 'linux':
-    return new LimaBackend();
+    return new LimaBackend(arch);
   case 'darwin':
-    return new LimaBackend();
+    return new LimaBackend(arch);
   case 'win32':
     return new WSLBackend();
   default:

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -33,6 +33,8 @@ export type KubernetesProgress = {
     transitionTime?: Date,
 }
 
+export type Architecture = 'x86_64' | 'aarch64';
+
 export interface KubernetesBackend extends events.EventEmitter {
   /** The name of the Kubernetes backend */
   readonly backend: 'wsl' | 'lima' | 'not-implemented';
@@ -205,7 +207,7 @@ export interface KubernetesBackendPortForwarder {
   cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
 }
 
-export function factory(arch: 'amd64' | 'arm64'): KubernetesBackend {
+export function factory(arch: Architecture): KubernetesBackend {
   switch (os.platform()) {
   case 'linux':
     return new LimaBackend(arch);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -715,12 +715,13 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
     try {
       const scriptPath = path.join(workdir, 'install-k3s');
+      const k3s = Electron.app.runningUnderRosettaTranslation ? 'k3s-arm64' : 'k3s';
 
       await fs.promises.writeFile(scriptPath, INSTALL_K3S_SCRIPT, { encoding: 'utf-8' });
       await this.ssh('mkdir', '-p', 'bin');
       await this.lima('copy', scriptPath, `${ MACHINE_NAME }:bin/install-k3s`);
       await this.ssh('chmod', 'a+x', 'bin/install-k3s');
-      await fs.promises.chmod(path.join(paths.cache, 'k3s', fullVersion, 'k3s'), 0o755);
+      await fs.promises.chmod(path.join(paths.cache, 'k3s', fullVersion, k3s), 0o755);
       await this.ssh('sudo', 'bin/install-k3s', fullVersion, path.join(paths.cache, 'k3s'));
       await this.lima('copy', resources.get('scripts', 'profile'), `${ MACHINE_NAME }:~/.profile`);
     } finally {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -11,6 +11,7 @@ import timers from 'timers';
 import util from 'util';
 import { ChildProcess, spawn as spawnWithSignal } from 'child_process';
 
+import Electron from 'electron';
 import merge from 'lodash/merge';
 import semver from 'semver';
 import sudo from 'sudo-prompt';
@@ -48,7 +49,7 @@ type LimaConfiguration = {
   arch?: 'x86_64' | 'aarch64';
   images: {
     location: string;
-    arch?: 'x86_64';
+    arch?: 'x86_64' | 'aarch64';
     digest?: string;
   }[];
   cpus?: number;
@@ -421,7 +422,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const config: LimaConfiguration = merge({}, baseConfig, DEFAULT_CONFIG as LimaConfiguration, {
       images: [{
         location: this.baseDiskImage,
-        arch:     'x86_64',
+        arch:     Electron.app.runningUnderRosettaTranslation ? 'aarch64' : 'x86_64',
       }],
       cpus:   this.cfg?.numberCPUs || 4,
       memory: (this.cfg?.memoryInGB || 4) * 1024 * 1024 * 1024,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -117,7 +117,7 @@ function defined<T>(input: T | null | undefined): input is T {
 }
 
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor(arch: 'amd64' | 'arm64') {
+  constructor(arch: K8s.Architecture) {
     super();
     this.k3sHelper = new K3sHelper(arch);
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -117,8 +117,9 @@ function defined<T>(input: T | null | undefined): input is T {
 }
 
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor() {
+  constructor(arch: 'amd64' | 'arm64') {
     super();
+    this.k3sHelper = new K3sHelper(arch);
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
     this.k3sHelper.initialize();
 
@@ -155,7 +156,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper();
+  protected readonly k3sHelper: K3sHelper;
 
   protected client: K8s.Client | null = null;
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -119,7 +119,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper('amd64');
+  protected k3sHelper = new K3sHelper('x86_64');
 
   /**
    * The current operation underway; used to avoid responding to state changes

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -119,7 +119,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper();
+  protected k3sHelper = new K3sHelper('amd64');
 
   /**
    * The current operation underway; used to avoid responding to state changes


### PR DESCRIPTION
The changes in this PR let us run the `x86_64` build of `Rancher Desktop.app` on `aarch64` after replacing the ISO and the lima directory:

```console
$ cd "/Applications/Rancher Desktop.app/Contents/Resources/resources/darwin"
$ mv alpine-lima-v0.2.1-rd-3.13.5.iso alpine-lima-v0.2.1-rd-3.13.5.iso.orig
$ cp ~/Downloads/alpine-lima-rd-3.13.5-aarch64.iso alpine-lima-v0.2.1-rd-3.13.5.iso
$ mv lima lima.orig
$ mkdir lima
$ cd lima
$ tar xvfz ~/Downloads/lima-and-qemu.macos.aarch64.tar.gz
```
Download links:
https://github.com/lima-vm/alpine-lima/releases/download/v0.2.1/alpine-lima-rd-3.13.5-aarch64.iso
https://github.com/rancher-sandbox/lima-and-qemu/releases/download/v1.12/lima-and-qemu.macos-aarch64.tar.gz

Closes #957