### PR TITLE
K3s-helper: Add support for aarch64

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -576,7 +576,8 @@ function handleFailure(payload: any) {
 }
 
 function newK8sManager() {
-  const mgr = K8s.factory();
+  const arch = Electron.app.runningUnderRosettaTranslation ? 'arm64' : 'amd64';
+  const mgr = K8s.factory(arch);
 
   mgr.on('state-changed', (state: K8s.State) => {
     mainEvents.emit('k8s-check-state', mgr);

--- a/background.ts
+++ b/background.ts
@@ -576,7 +576,7 @@ function handleFailure(payload: any) {
 }
 
 function newK8sManager() {
-  const arch = Electron.app.runningUnderRosettaTranslation ? 'arm64' : 'amd64';
+  const arch = Electron.app.runningUnderRosettaTranslation ? 'aarch64' : 'x86_64';
   const mgr = K8s.factory(arch);
 
   mgr.on('state-changed', (state: K8s.State) => {

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -73,7 +73,7 @@ describe(K3sHelper, () => {
     };
 
     beforeEach(() => {
-      subject = new K3sHelper();
+      subject = new K3sHelper('amd64');
       // Note that we _do not_ initialize this, i.e. we don't trigger an
       // initial fetch of the releases.  Instead, we pretend that is done.
       subject['pendingInitialize'] = Promise.resolve();
@@ -109,7 +109,7 @@ describe(K3sHelper, () => {
   });
 
   test('cache read/write', async() => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const readFile = util.promisify(fs.readFile);
     const mkdtemp = util.promisify(fs.mkdtemp);
     const workDir = await mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
@@ -142,7 +142,7 @@ describe(K3sHelper, () => {
   });
 
   test('updateCache', async() => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const validAssets = subject['filenames']
       .map(name => ({ name, browser_download_url: name }));
 
@@ -201,7 +201,7 @@ describe(K3sHelper, () => {
   });
 
   test('fullVersion', () => {
-    const subject = new K3sHelper();
+    const subject = new K3sHelper('amd64');
     const versionStrings = ['1.2.3+k3s1', '2.3.4+k3s3'];
 
     subject['versions'] = Object.fromEntries(versionStrings.map((s) => {
@@ -216,14 +216,14 @@ describe(K3sHelper, () => {
 
   describe('initialize', () => {
     it('should finish initialize without network if cache is available', async() => {
-      const writer = new K3sHelper();
+      const writer = new K3sHelper('amd64');
 
       writer['versions'] = { 'v1.0.0': new semver.SemVer('v1.0.0') };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.
 
-      const subject = new K3sHelper();
+      const subject = new K3sHelper('amd64');
       const pendingInit = new Promise((resolve) => {
         // We need a cast on updateCache here since it's a protected method.
         jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -58,7 +58,7 @@ describe(K3sHelper, () => {
       const assets: ReleaseAPIEntry['assets'] = [];
 
       if (hasAssets) {
-        for (const name of subject['filenames']) {
+        for (const name of Object.values(subject['filenames'])) {
           assets.push({ name, browser_download_url: name });
         }
       }
@@ -143,7 +143,7 @@ describe(K3sHelper, () => {
 
   test('updateCache', async() => {
     const subject = new K3sHelper('x86_64');
-    const validAssets = subject['filenames']
+    const validAssets = Object.values(subject['filenames'])
       .map(name => ({ name, browser_download_url: name }));
 
     // Stub out touching the cache; not used for this.

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -73,7 +73,7 @@ describe(K3sHelper, () => {
     };
 
     beforeEach(() => {
-      subject = new K3sHelper('amd64');
+      subject = new K3sHelper('x86_64');
       // Note that we _do not_ initialize this, i.e. we don't trigger an
       // initial fetch of the releases.  Instead, we pretend that is done.
       subject['pendingInitialize'] = Promise.resolve();
@@ -109,7 +109,7 @@ describe(K3sHelper, () => {
   });
 
   test('cache read/write', async() => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const readFile = util.promisify(fs.readFile);
     const mkdtemp = util.promisify(fs.mkdtemp);
     const workDir = await mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
@@ -142,7 +142,7 @@ describe(K3sHelper, () => {
   });
 
   test('updateCache', async() => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const validAssets = subject['filenames']
       .map(name => ({ name, browser_download_url: name }));
 
@@ -201,7 +201,7 @@ describe(K3sHelper, () => {
   });
 
   test('fullVersion', () => {
-    const subject = new K3sHelper('amd64');
+    const subject = new K3sHelper('x86_64');
     const versionStrings = ['1.2.3+k3s1', '2.3.4+k3s3'];
 
     subject['versions'] = Object.fromEntries(versionStrings.map((s) => {
@@ -216,14 +216,14 @@ describe(K3sHelper, () => {
 
   describe('initialize', () => {
     it('should finish initialize without network if cache is available', async() => {
-      const writer = new K3sHelper('amd64');
+      const writer = new K3sHelper('x86_64');
 
       writer['versions'] = { 'v1.0.0': new semver.SemVer('v1.0.0') };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.
 
-      const subject = new K3sHelper('amd64');
+      const subject = new K3sHelper('x86_64');
       const pendingInit = new Promise((resolve) => {
         // We need a cast on updateCache here since it's a protected method.
         jest.spyOn(subject, 'updateCache' as any).mockImplementation(async() => {

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -19,6 +19,7 @@ import resources from '@/resources';
 import DownloadProgressListener from '@/utils/DownloadProgressListener';
 import safeRename from '@/utils/safeRename';
 import paths from '@/utils/paths';
+import * as K8s from './k8s';
 
 const console = Logging.k8s;
 
@@ -62,7 +63,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
   protected readonly minimumVersion = new semver.SemVer('1.15.0');
 
-  constructor(arch: 'amd64' | 'arm64') {
+  constructor(arch: K8s.Architecture) {
     super();
     this.arch = arch;
   }
@@ -77,7 +78,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected pendingInitialize: Promise<void> | undefined;
 
   /** The current architecture. */
-  protected readonly arch: 'amd64' | 'arm64';
+  protected readonly arch: K8s.Architecture;
 
   /** Read the cached data and fill out this.versions. */
   protected async readCache() {
@@ -110,9 +111,9 @@ export default class K3sHelper extends events.EventEmitter {
   /** The files we need to download for the current architecture. */
   protected get filenames(): string[] {
     switch (this.arch) {
-    case 'amd64':
+    case 'x86_64':
       return ['k3s', 'k3s-airgap-images-amd64.tar', 'sha256sum-amd64.txt'];
-    case 'arm64':
+    case 'aarch64':
       return ['k3s-arm64', 'k3s-airgap-images-arm64.tar', 'sha256sum-arm64.txt'];
     }
     throw new Error(`Unsupported architecture ${ this.arch }`);

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -499,7 +499,7 @@ export default class K3sHelper extends events.EventEmitter {
     if (process.env.HOMEDRIVE && process.env.HOMEPATH) {
       const homePath = path.join(process.env.HOMEDRIVE, process.env.HOMEPATH);
 
-      if (tryAccess(homePath)) {
+      if (await tryAccess(homePath)) {
         return homePath;
       }
     }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -205,12 +205,12 @@ export interface KubernetesBackendPortForwarder {
   cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
 }
 
-export function factory(): KubernetesBackend {
+export function factory(arch: 'amd64' | 'arm64'): KubernetesBackend {
   switch (os.platform()) {
   case 'linux':
-    return new LimaBackend();
+    return new LimaBackend(arch);
   case 'darwin':
-    return new LimaBackend();
+    return new LimaBackend(arch);
   case 'win32':
     return new WSLBackend();
   default:

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -33,6 +33,8 @@ export type KubernetesProgress = {
     transitionTime?: Date,
 }
 
+export type Architecture = 'x86_64' | 'aarch64';
+
 export interface KubernetesBackend extends events.EventEmitter {
   /** The name of the Kubernetes backend */
   readonly backend: 'wsl' | 'lima' | 'not-implemented';
@@ -205,7 +207,7 @@ export interface KubernetesBackendPortForwarder {
   cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
 }
 
-export function factory(arch: 'amd64' | 'arm64'): KubernetesBackend {
+export function factory(arch: Architecture): KubernetesBackend {
   switch (os.platform()) {
   case 'linux':
     return new LimaBackend(arch);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -117,7 +117,7 @@ function defined<T>(input: T | null | undefined): input is T {
 }
 
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor(arch: 'amd64' | 'arm64') {
+  constructor(arch: K8s.Architecture) {
     super();
     this.k3sHelper = new K3sHelper(arch);
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -117,8 +117,9 @@ function defined<T>(input: T | null | undefined): input is T {
 }
 
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor() {
+  constructor(arch: 'amd64' | 'arm64') {
     super();
+    this.k3sHelper = new K3sHelper(arch);
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
     this.k3sHelper.initialize();
 
@@ -155,7 +156,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper();
+  protected readonly k3sHelper: K3sHelper;
 
   protected client: K8s.Client | null = null;
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -119,7 +119,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper('amd64');
+  protected k3sHelper = new K3sHelper('x86_64');
 
   /**
    * The current operation underway; used to avoid responding to state changes

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -119,7 +119,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   #desiredPort = 6443;
 
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper();
+  protected k3sHelper = new K3sHelper('amd64');
 
   /**
    * The current operation underway; used to avoid responding to state changes


### PR DESCRIPTION
This makes k3s-helper take the architecture into account when determining the files to download.  The architecture names follow what lima uses.

Note that this _doesn't_ change what we look for when trying to start k3s, so things don't actually work.