### PR TITLE
Updating CI to push linux build to s3

### DIFF
--- a/.github/workflows/linux-release.sh
+++ b/.github/workflows/linux-release.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Get the tag in the two forms it's needed.
+withV=${GITHUB_REF#"refs/tags/"}
+withoutV=${GITHUB_REF#"refs/tags/v"}
+
+mkdir dist
+
+cd dist && curl -L -O https://github.com/rancher-sandbox/rancher-desktop/releases/download/${withV}/rancher-desktop-${withoutV}-linux.zip

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -1,0 +1,34 @@
+# Used to upload the release asset to S3 for Linux
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  linux-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Fetch the release asset
+      run: .github/workflows/linux-release.sh
+    - name: Copy linux zip to release for tags
+      uses: canastro/copy-file-action@0.0.2
+      with:
+        source: "dist/rancher-desktop*.zip"
+        target: "dist/rancher-desktop-release.zip"
+    - name: Copy release to s3
+      uses: prewk/s3-cp-action@v2
+      with:
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        source: './dist/rancher-desktop-release.zip'
+        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-release.zip'
+    - name: Trigger OBS services
+      uses: distributhor/workflow-webhook@v2
+      env:
+        webhook_type: 'form-urlencoded'
+        webhook_url: ${{ secrets.OBS_WEBHOOK_URL_RELEASE }}
+        webhook_secret: ${{ secrets.OBS_WEBHOOK_TOKEN_RELEASE }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -105,20 +105,13 @@ jobs:
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         source: './dist/rancher-desktop-canary.zip'
         dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-canary.zip'
-    - name: Copy linux zip to release for tags
-      uses: canastro/copy-file-action@0.0.2
-      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag' }}
-      with:
-        source: "dist/rancher-desktop*.zip"
-        target: "dist/rancher-desktop-release.zip"
-    - name: Copy release to s3
-      uses: prewk/s3-cp-action@v2
-      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag' }}
-      with:
-        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: './dist/rancher-desktop-release.zip'
-        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-release.zip'
+    - name: Trigger OBS services
+      uses: distributhor/workflow-webhook@v2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main' }}
+      env:
+        webhook_type: 'form-urlencoded'
+        webhook_url: ${{ secrets.OBS_WEBHOOK_URL_CANARY }}
+        webhook_secret: ${{ secrets.OBS_WEBHOOK_TOKEN_CANARY }}
 
   sign:
     name: Test Signing

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -91,6 +91,34 @@ jobs:
         name: Rancher Desktop-linux.zip
         path: dist/rancher-desktop*.zip
         if-no-files-found: error
+    - name: Copy linux zip to canary for main
+      uses: canastro/copy-file-action@0.0.2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main' }}
+      with:
+        source: "dist/rancher-desktop*.zip"
+        target: "dist/rancher-desktop-canary.zip"
+    - name: Copy canary to s3
+      uses: prewk/s3-cp-action@v2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main' }}
+      with:
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        source: './dist/rancher-desktop-canary.zip'
+        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-canary.zip'
+    - name: Copy linux zip to release for tags
+      uses: canastro/copy-file-action@0.0.2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag' }}
+      with:
+        source: "dist/rancher-desktop*.zip"
+        target: "dist/rancher-desktop-release.zip"
+    - name: Copy release to s3
+      uses: prewk/s3-cp-action@v2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag' }}
+      with:
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        source: './dist/rancher-desktop-release.zip'
+        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-release.zip'
 
   sign:
     name: Test Signing


### PR DESCRIPTION
On release the linux build will be pushed to https://rancher-desktop-assets-for-obs.s3.amazonaws.com/rancher-desktop-release.zip. Any time main is updated a canary build is pushed to https://rancher-desktop-assets-for-obs.s3.amazonaws.com/rancher-desktop-canary.zip.