### PR TITLE
Adapt linux packaging recipes to better suit CI workflow

### DIFF
--- a/packaging/linux/appimage.yml
+++ b/packaging/linux/appimage.yml
@@ -7,7 +7,7 @@ build:
 
 script:
   - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin
-  - unzip $BUILD_SOURCE_DIR/rancher-desktop*.zip -d $BUILD_APPDIR/opt/rancher-desktop
+  - unzip $BUILD_SOURCE_DIR/rancher-desktop.zip -d $BUILD_APPDIR/opt/rancher-desktop
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/rancher-desktop.desktop $BUILD_APPDIR
   - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop/resources/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop.png
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/rancher-desktop.appdata.xml $BUILD_APPDIR/usr/share/metainfo

--- a/packaging/linux/flatpak.yaml
+++ b/packaging/linux/flatpak.yaml
@@ -42,7 +42,7 @@ modules:
     build-commands:
       # Bundle electron build after npm run build -- --linux dir 
       - mkdir -p /app/lib/io.rancherdesktop.app
-      - unzip rancher-desktop-*-linux.zip -d /app/lib/io.rancherdesktop.app
+      - unzip rancher-desktop.zip -d /app/lib/io.rancherdesktop.app
       # Remove in app qemu binaries
       - rm /app/lib/io.rancherdesktop.app/lib /app/lib/io.rancherdesktop.app/pc-bios /app/lib/io.rancherdesktop.app/qemu-* -rf
       # Include FreeDesktop integration files at expected locations

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -23,7 +23,7 @@ Summary:    Kubernetes and container management on the desktop
 License:    Apache-2.0
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 Group:      Development/Tools/Other
-Source0:    %{name}-%{version}-linux.zip
+Source0:    %{name}.zip
 URL:        https://github.com/rancher-sandbox/rancher-desktop#readme
 
 %if "%{_vendor}" == "debbuild"


### PR DESCRIPTION
This commit assumes the source tarball does not include the version
as part of its file name. This makes CI and OBS integration simpler.

Signed-off-by: David Cassany <dcassany@suse.com>