### PR TITLE
Only render image add button when image manager is ready

### DIFF
--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -42,14 +42,28 @@ export default {
     }
   },
 
+  watch: {
+    imageManagerState: {
+      handler(state) {
+        if (!state) {
+          return;
+        }
+
+        this.$store.dispatch(
+          'page/setAction',
+          { action: 'images-button-add' }
+        );
+      },
+      immediate: true
+    }
+  },
+
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      {
-        title:  this.t('images.title'),
-        action: 'images-button-add'
-      }
+      { title: this.t('images.title') }
     );
+
     ipcRenderer.on('images-changed', (event, images) => {
       this.$data.images = images;
       if (this.imageNamespaces.length === 0) {

--- a/src/store/page.js
+++ b/src/store/page.js
@@ -21,5 +21,8 @@ export const actions = {
     commit('setTitle', title);
     commit('setDescription', description);
     commit('setAction', action);
+  },
+  setAction({ commit }, { action }) {
+    commit('setAction', action);
   }
 };


### PR DESCRIPTION
This only renders the add button when the image manager is in a ready state by asserting that `imageManagerState` is true before dispatching the action for the button.