### PR TITLE
[Metrics] Codecov setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,3 +20,13 @@ jobs:
     - run: npm ci
     - run: npm run lint:nofix
     - run: npm test
+    - name: Upload Coverage
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./coverage/coverage-jest
+        fail_ci_if_error: true
+        files: ./coverage/coverage-jest/coverage-final.json
+        flags: unit-tests
+        name: rancher-desktop
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /.idea/
 .nuxt/
 /src/node_modules/
+coverage/
 *~
 \#*
 *.log

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: true
+coverage:
+  status:
+    patch: false
+  range: 50..90
+  round: down
+  precision: 2
+comment:
+  layout: diff, files 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "sign": "node scripts/ts-wrapper.js scripts/sign.ts",
     "test": "npm run lint:nofix && npm run test:unit",
     "test:unit": "npm run test:unit:jest && npm run test:unit:nerdctl-stub",
-    "test:unit:jest": "jest",
+    "test:unit:jest": "jest --coverage --coverageDirectory=coverage/coverage-jest",
     "test:unit:watch": "npm run test:unit -- --watch",
     "test:unit:nerdctl-stub": "cd ./src/go/nerdctl-stub/ && go test ./...",
     "test:e2e": "node ./scripts/e2e.mjs",


### PR DESCRIPTION
### Changes
1. Set up Codecov for Rancher Desktop
2. Enabled only `pull-request` metrics comment
3. Enabled auto upload in GHA

Demo: https://github.com/evertonlperes/rancher-desktop/pull/5

Note:
In order to finish the set up for RD, codecov need to have access to our repository and also include `CODECOV_TOKEN` as part of the repository secrets.
![Screen Shot 2021-11-16 at 10 50 20 AM](https://user-images.githubusercontent.com/37411123/142029344-fd4e6000-82a7-4957-b84a-4e328a327fd6.png)


