### PR TITLE
Focus on image pull for first render of form

### DIFF
--- a/src/components/ImagesFormAdd.vue
+++ b/src/components/ImagesFormAdd.vue
@@ -2,6 +2,7 @@
   <div class="image-input">
     <labeled-input
       v-model="image"
+      v-focus
       type="text"
       class="image"
       :disabled="isInputDisabled"

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -57,6 +57,7 @@ export default {
 
     // First-party
     '~/plugins/i18n',
+    '~/plugins/directives',
     { src: '~/plugins/extend-router' },
   ],
   router: {

--- a/src/plugins/directives.js
+++ b/src/plugins/directives.js
@@ -1,0 +1,41 @@
+import Vue from 'vue';
+
+Vue.directive('focus', {
+  inserted(_el, _binding, vnode) {
+    const element = getElement(vnode);
+
+    if (element) {
+      element.focus();
+    }
+  }
+});
+
+const getElement = (vnode) => {
+  const { componentInstance, componentOptions: { tag } } = vnode;
+
+  if (tag === 'LabeledInput') {
+    return componentInstance.$refs.value;
+  }
+
+  if (tag === 'LabeledSelect') {
+    componentInstance.shouldOpen = false;
+
+    return componentInstance.$refs['select-input'].$refs.search;
+  }
+
+  if (tag === 'SelectPrincipal') {
+    const labeledSelect = componentInstance.$refs['labeled-select'];
+
+    labeledSelect.shouldOpen = false;
+
+    return labeledSelect.$refs['select-input'].$refs.search;
+  }
+
+  if (tag === 'TextAreaAutoGrow') {
+    return componentInstance.$refs.ta;
+  }
+
+  if (tag === 'Password') {
+    return componentInstance.$refs.input.$refs.value;
+  }
+};

--- a/src/plugins/directives.js
+++ b/src/plugins/directives.js
@@ -13,29 +13,7 @@ Vue.directive('focus', {
 const getElement = (vnode) => {
   const { componentInstance, componentOptions: { tag } } = vnode;
 
-  if (tag === 'LabeledInput') {
+  if (tag === 'labeled-input') {
     return componentInstance.$refs.value;
-  }
-
-  if (tag === 'LabeledSelect') {
-    componentInstance.shouldOpen = false;
-
-    return componentInstance.$refs['select-input'].$refs.search;
-  }
-
-  if (tag === 'SelectPrincipal') {
-    const labeledSelect = componentInstance.$refs['labeled-select'];
-
-    labeledSelect.shouldOpen = false;
-
-    return labeledSelect.$refs['select-input'].$refs.search;
-  }
-
-  if (tag === 'TextAreaAutoGrow') {
-    return componentInstance.$refs.ta;
-  }
-
-  if (tag === 'Password') {
-    return componentInstance.$refs.input.$refs.value;
   }
 };


### PR DESCRIPTION
This adds auto-focus to the Image to Pull input on first render by introducing a simple `v-focus` directive for labeled input.

I opted to limit auto-focus to the first render in order to provide a little bit of assistance in the workflow of pulling an image. I considered setting focus on when tab switching and closing the output window, but considered the behavior too disruptive.