### PR TITLE
Create host.rancher-desktop.internal and host.docker.internal aliases

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -14,6 +14,11 @@ provision:
   script: |
     #!/bin/sh
     hostname lima-rancher-desktop
+- # Create host.rancher-desktop.internal and host.docker.internal aliases for host.lima.internal
+  mode: system
+  script: |
+    #!/bin/sh
+    sed -i 's/host.lima.internal.*/host.lima.internal host.rancher-desktop.internal host.docker.internal/' /etc/hosts
 - # Make sure interface rd0 takes priority over eth0
   mode: system
   script: |


### PR DESCRIPTION
as symbolic names to access a service running on the host from inside the VM.

Implements #893 for Linux and macOS

```console
lima-rancher-desktop:/Users/jan$ ping host.rancher-desktop.internal
PING host.rancher-desktop.internal (192.168.5.2): 56 data bytes
64 bytes from 192.168.5.2: seq=0 ttl=42 time=0.159 ms
64 bytes from 192.168.5.2: seq=1 ttl=42 time=0.335 ms
64 bytes from 192.168.5.2: seq=2 ttl=42 time=0.128 ms
^C
```