### PR TITLE
Fix dialog box typos

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -29,7 +29,7 @@ export enum ContainerEngine {
 export const ContainerEngineNames: Record<ContainerEngine, string> = {
   [ContainerEngine.NONE]:       '',
   [ContainerEngine.CONTAINERD]: 'containerd',
-  [ContainerEngine.MOBY]:       'Dockerd',
+  [ContainerEngine.MOBY]:       'dockerd',
 };
 
 export const defaultSettings = {

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -279,7 +279,7 @@ export default {
         false: 'Resetting Kubernetes will delete all workloads and configuration.',
       }[wipe];
 
-      if (confirm(`${ consequence } Do you want to proceed?`)) {
+      if (confirm(`${ consequence }\n\nDo you want to proceed?`)) {
         for (const key in this.notifications) {
           this.handleNotification('info', key, '');
         }
@@ -302,7 +302,7 @@ export default {
         } else {
           confirmationMessage = `Changing from version ${ this.settings.kubernetes.version } to ${ event.target.value } will upgrade Kubernetes`;
         }
-        confirmationMessage += ' Do you want to proceed?';
+        confirmationMessage += '\n\nDo you want to proceed?';
         if (confirm(confirmationMessage)) {
           ipcRenderer.invoke('settings-write', { kubernetes: { version: event.target.value } })
             .then(() => this.restart());
@@ -313,8 +313,8 @@ export default {
     },
     async onChangeEngine(desiredEngine) {
       if (desiredEngine !== this.settings.kubernetes.containerEngine) {
-        const confirmationMessage = [`Changing container engines from ${ this.containerEngineNames[this.currentEngine] } to ${ this.containerEngineNames[desiredEngine] } will require a restart of Kubernetes)`,
-          ' Do you want to proceed?'].join('');
+        const confirmationMessage = [`Changing container engines from ${ this.containerEngineNames[this.currentEngine] } to ${ this.containerEngineNames[desiredEngine] } will require a restart of Kubernetes.`,
+          '\n\nDo you want to proceed?'].join('');
 
         if (confirm(confirmationMessage)) {
           try {


### PR DESCRIPTION
- And place the 'Do you want to proceed?' question below the rest of the text.

Unfortunately the text in confirm boxes can't be styled with CSS as it's rendered
by the platform itself, so we have to live with center-alignment (on macos)

Signed-off-by: Eric Promislow <epromislow@suse.com>