### PR TITLE
Bump alpine-lima iso from v0.2.1 → v0.2.2

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,9 +10,9 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.12';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.1';
+const alpineLimaTag = 'v0.2.2';
 const alpineLimaEdition = 'rd';
-const alpineLimaVersion = '3.13.5';
+const alpineLimaVersion = '3.14.3';
 
 async function getLima(platform) {
   const url = `${ limaRepo }/releases/download/${ limaTag }/lima-and-qemu.${ platform }.tar.gz`;

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -39,22 +39,31 @@ provision:
     rm -rf /var/lib/rancher/k3s/data
     # Delete all tmp files older than 3 days.
     find /tmp -depth -mtime +3 -delete
-- # When the ISO image is updated, copy all newer files in /etc
-  # and /usr/local to the data volume on /mnt/data.
+- # When the ISO image is updated, only preserve selected data from /etc but otherwise use the new files.
   mode: system
   script: |
     #!/bin/sh
     set -o errexit -o nounset -o xtrace
     mkdir -p /bootfs
     mount --bind / /bootfs
-    rm /bootfs/etc/machine-id
-    cp -pruT /bootfs/etc /etc
-    cp -pruT /bootfs/usr/local /usr/local
+    # /bootfs/etc is empty on first boot because it has been moved to /mnt/data/etc by lima
+    if [ -f /bootfs/etc/os-release ] && ! diff -q /etc/os-release /bootfs/etc/os-release; then
+      cp /etc/machine-id /bootfs/machine-id
+      cp /etc/ssh/ssh_host* /bootfs/etc/ssh/
+      cp -pr /etc/rancher /bootfs/etc
+
+      rm -rf /mnt/data/etc.prev
+      mkdir /mnt/data/etc.prev
+      mv /etc/* /mnt/data/etc.prev
+      mv /bootfs/etc/* /etc
+
+      # lima may have applied this change while the "old" /etc was in place; make sure it carries over
+      if ! grep -q "^user_allow_other" /etc/fuse.conf; then
+        echo "user_allow_other" >>/etc/fuse.conf
+      fi
+    fi
     umount /bootfs
     rmdir /bootfs
-    # The new Alpine ISO makes this change, but it gets lost because the
-    # lima boot scripts also modify sshd_config.
-    sed -i 's/#UsePAM no/UsePAM yes/g' /etc/ssh/sshd_config
 - # Make mount-points shared.
   mode: system
   script: |

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -110,7 +110,9 @@ interface LimaListResult {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.1';
+const IMAGE_VERSION = '0.2.2';
+const ALPINE_EDITION = 'rd';
+const ALPINE_VERSION = '3.14.3';
 const INTERFACE_NAME = 'rd0';
 
 /** The following files, and their parents up to /, must only be writable by root,
@@ -414,7 +416,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected get baseDiskImage() {
-    return resources.get(os.platform(), `alpine-lima-v${ IMAGE_VERSION }-rd-3.13.5.iso`);
+    return resources.get(os.platform(), `alpine-lima-v${ IMAGE_VERSION }-${ ALPINE_EDITION }-${ ALPINE_VERSION }.iso`);
   }
 
   #sshPort = 0;


### PR DESCRIPTION
* Bumps Alpine from 3.13.5 → 3.14.3

* Installs qemu-aarch64 from tonistiigi/binfmt instead of Alpine repo
  to include additional patches.

* Installs qemu-x86_64 in the aarch64 iso
