### PR TITLE
Updater: support aarch64 on mac.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -69,7 +69,7 @@ Electron.app.whenReady().then(async() => {
 
     // Set up the updater; we may need to quit the app if an update is already
     // queued.
-    if (await setupUpdate(cfg, true)) {
+    if (await setupUpdate(cfg.updater, true)) {
       gone = true;
       // The update code will trigger a restart; don't do it here, as it may not
       // be ready yet.

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -24,7 +24,7 @@ export interface LonghornProviderOptions extends PublishConfiguration {
    * upgradeServer is the URL for the upgrade-responder server
    * @example "https://responder.example.com:8314/v1/checkupgrade"
    */
-  readonly upgradeServer: URL;
+  readonly upgradeServer: string;
 
   /**
    * The provider. Must be `custom`.
@@ -147,6 +147,7 @@ export async function hasQueuedUpdate(): Promise<boolean> {
 
       return false;
     }
+    console.debug(`Performing update from ${ currentVersion } to ${ stagedVersion }...`);
 
     return true;
   } catch (error) {
@@ -233,9 +234,11 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
       appVersion: this.updater.currentVersion.format(),
       extraInfo:  { platform: `${ os.platform() }-${ os.arch() }` },
     };
-    const responseRaw = await fetch(
-      this.configuration.upgradeServer,
-      { method: 'POST', body: JSON.stringify(requestPayload) });
+    const requestOptions = /^https?:\/\/[^/]+\.github\.io\//.test(this.configuration.upgradeServer) ? { method: 'GET' } : {
+      method: 'POST',
+      body:   JSON.stringify(requestPayload),
+    };
+    const responseRaw = await fetch(this.configuration.upgradeServer, requestOptions);
     const response = await responseRaw.json() as LonghornUpgraderResponse;
     const latest = response.versions.find(v => v.Tags.includes('latest'));
     const requestIntervalInMs = response.requestIntervalInMinutes * 1000 * 60;

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -234,6 +234,10 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
       appVersion: this.updater.currentVersion.format(),
       extraInfo:  { platform: `${ os.platform() }-${ os.arch() }` },
     };
+    // If we are using anything on `github.io` as the update server, we're
+    // trying to run a simplified test.  In that case, break the protocol and do
+    // a HTTP GET instead of the HTTP POST with data we should do for actual
+    // longhorn upgrade-responder servers.
     const requestOptions = /^https?:\/\/[^/]+\.github\.io\//.test(this.configuration.upgradeServer) ? { method: 'GET' } : {
       method: 'POST',
       body:   JSON.stringify(requestPayload),

--- a/src/main/update/LonghornUpdater.ts
+++ b/src/main/update/LonghornUpdater.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+import Electron from 'electron';
 import { MacUpdater, NsisUpdater, AppImageUpdater } from 'electron-updater';
 import { Lazy } from 'lazy-val';
 
@@ -50,8 +52,12 @@ export class MacLonghornUpdater extends MacUpdater {
     return await super.getUpdateInfoAndProvider();
   }
 
+  private readonly isArm64 = Electron.app.runningUnderRosettaTranslation || os.arch() === 'arm64';
+
   findAsset(assets: GithubReleaseAsset[]): GithubReleaseAsset | undefined {
-    return assets.find(asset => asset.name.endsWith('-mac.zip'));
+    const suffix = this.isArm64 ? '-mac.aarch64.zip' : '-mac.x86_64.zip';
+
+    return assets.find(asset => asset.name.endsWith(suffix));
   }
 }
 

--- a/src/main/update/index.ts
+++ b/src/main/update/index.ts
@@ -117,10 +117,6 @@ mainEvent.on('settings-update', (settings: Settings) => {
  * @returns Whether the update is being installed.
  */
 export default async function setupUpdate(settings: Settings, doInstall = false): Promise<boolean> {
-  enabled = settings.updater;
-  if (!enabled) {
-    return false;
-  }
   autoUpdater ||= newUpdater();
 
   try {
@@ -134,6 +130,11 @@ export default async function setupUpdate(settings: Settings, doInstall = false)
   }
   updateState.configured = true;
   window.send('update-state', updateState);
+
+  enabled = settings.updater;
+  if (!enabled) {
+    return false;
+  }
 
   if (doInstall && await hasQueuedUpdate()) {
     console.log('Update is cached; forcing re-check to install.');


### PR DESCRIPTION
This adds support for our new mac zip file names (due to the introduction of aarch64 / Apple M1).

This also fixes an issue where if you turn off updates, you can never turn it back on again (because we aborted so early we thought no update server was configured).

This also makes it possible to test updates against GitHub pages acting as the update responder (hard-coding HTTP GET for those).

To test on x86_64 and aarch64:
- Download the appropriate build
- Edit `Rancher Desktop.app/Contents/Resources/app-update.yml` to have the following contents:
   ```yaml
   provider: custom
   upgradeServer: https://mook-as.github.io/rd/response.json
   vPrefixedTagName: true
   owner: mook-as
   repo: rd
   updaterCacheDirName: rancher-desktop-updater
   ```
- Watch the update logs — note that the build on the server is actually broken and doesn't start :)

Fixes #986.