### PR TITLE
K3s: Make logs world-readable.

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -17,6 +17,8 @@ depend() {
 
 start_pre() {
   rm -f /tmp/k3s.*
+  touch "${output_log}" "${error_log}"
+  chmod a+r "${output_log}" "${error_log}"
 }
 
 supervisor=supervise-daemon

--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -17,8 +17,7 @@ depend() {
 
 start_pre() {
   rm -f /tmp/k3s.*
-  touch "${output_log}" "${error_log}"
-  chmod a+r "${output_log}" "${error_log}"
+  checkpath --file --mode 0644 --owner root:root "${output_log}" "${error_log}"
 }
 
 supervisor=supervise-daemon


### PR DESCRIPTION
On the Lima side, we tail the logs as an unprivileged user; ensure that can happen by making it world-readable.  There's no interesting detail that might be an issue if people can read the logs anyway.

Fixes https://github.com/rancher-sandbox/rancher-desktop/pull/1014#pullrequestreview-818306531