### PR TITLE
WSL: Silence some migration warnings

### DIFF
--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -184,10 +184,20 @@ function migrateWSLDistro(oldPath: string, newPath: string) {
 
   try {
     const regPath = 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss';
-    let stdout = execFileSync(
-      'reg.exe',
-      ['query', regPath, '/s', '/f', 'rancher-desktop', '/d', '/c', '/e'],
-      { stdio: ['ignore', 'pipe', stream], encoding: 'utf-8' });
+    let stdout: string;
+
+    try {
+      stdout = execFileSync(
+        'reg.exe',
+        ['query', regPath, '/s', '/f', 'rancher-desktop', '/d', '/c', '/e'],
+        { stdio: ['ignore', 'pipe', stream], encoding: 'utf-8' });
+    } catch (ex) {
+      // Failures means that no WSL2 distributions are registered at all.
+      // That's acceptable, and we should just return without an error.
+      console.log('Could not find any WSL2 distributions; not migrating.');
+
+      return;
+    }
     const guid = stdout
       .split(/\r?\n/)
       .find(line => line.includes('HKEY_CURRENT_USER'))

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -194,7 +194,7 @@ function migrateWSLDistro(oldPath: string, newPath: string) {
     } catch (ex) {
       // Failures means that no WSL2 distributions are registered at all.
       // That's acceptable, and we should just return without an error.
-      console.log('Could not find any WSL2 distributions; not migrating.');
+      console.debug('No existing WSL distributions, no need to migrate anything.');
 
       return;
     }
@@ -225,9 +225,9 @@ function migrateWSLDistro(oldPath: string, newPath: string) {
 
     if (existingPath !== oldPath) {
       if (existingPath === newPath) {
-        console.debug(`WSL path ${ oldPath } already migrated, skipping migration.`);
+        console.debug(`WSL path ${ oldPath } already migrated, nothing to be done.`);
       } else {
-        console.log(`Warning: old WSL path ${ existingPath } does not match expected ${ oldPath }, skipping migration.`);
+        console.log(`Old WSL path ${ existingPath } does not match expected ${ oldPath }, skipping migration.`);
       }
 
       return;

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -224,7 +224,11 @@ function migrateWSLDistro(oldPath: string, newPath: string) {
     // See https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 
     if (existingPath !== oldPath) {
-      console.log(`Warning: old WSL path ${ existingPath } does not match expected ${ oldPath }, skipping migration.`);
+      if (existingPath === newPath) {
+        console.debug(`WSL path ${ oldPath } already migrated, skipping migration.`);
+      } else {
+        console.log(`Warning: old WSL path ${ existingPath } does not match expected ${ oldPath }, skipping migration.`);
+      }
 
       return;
     }


### PR DESCRIPTION
This silences some misleading migration warnings on Windows:
- If there are no distros, don't dump a giant error stack about it (it means there's nothing to migrate).
- If the migration is already done, don't spew out a warning — there's nothing to fix.

(Reported via Slack by Everton.)