### PR TITLE
K3s: Don't specify group for log file.

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -17,7 +17,7 @@ depend() {
 
 start_pre() {
   rm -f /tmp/k3s.*
-  checkpath --file --mode 0644 --owner root:root "${output_log}" "${error_log}"
+  checkpath --file --mode 0644 --owner root "${output_log}" "${error_log}"
 }
 
 supervisor=supervise-daemon


### PR DESCRIPTION
On WSL, we do not have a "root" group.  Despite the docs for `checkpath`, it does not appear to take numeric IDs (`0:0`) either.  So just don't specify a group at all.

Fixes a regression on Windows caused by #1023.