### PR TITLE
WSL: Stop showing some pointless error messages

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -33,6 +33,8 @@ var dockerproxyServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the docker socket proxy server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		proxyEndpoint := dockerproxyServeViper.GetString("proxy-endpoint")
 		dialer, err := platform.MakeDialer(proxyEndpoint)

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -33,6 +33,8 @@ var dockerproxyServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the docker socket proxy server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		port := dockerproxyServeViper.GetUint32("port")
 		dialer, err := platform.MakeDialer(port)


### PR DESCRIPTION
When we start the dockerd socket proxy, we try to connect to each Hyper-V VM to try to find the correct one for WSL.  We shouldn't print error messages for those unless all of them fail, since _some_ failures are expected if you have multiple Hyper-V VMs on your system.