### PR TITLE
Proposal - Define Pattern for working with IPC

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -24,7 +24,7 @@ import setupTray from '@/main/tray';
 import setupPaths from '@/main/paths';
 import buildApplicationMenu from '@/main/mainmenu';
 import { IpcChannel } from '@/main/ipc/ipc-channel.interface';
-import { DialogChannel } from '@/main/ipc/dialog-channel';
+import { DialogChannel, DialogErrorChannel } from '@/main/ipc/dialog-channel';
 
 Electron.app.setName('Rancher Desktop');
 
@@ -111,11 +111,12 @@ Electron.app.whenReady()
       setupTray();
       window.openPreferences();
 
-      await startBackend(cfg);
-
       registerIpcChannels([
-        new DialogChannel()
+        new DialogChannel(),
+        new DialogErrorChannel()
       ]);
+
+      await startBackend(cfg);
     } catch (ex) {
       console.error('Error starting up:', ex);
       gone = true;

--- a/src/main/ipc/dialog-channel.ts
+++ b/src/main/ipc/dialog-channel.ts
@@ -1,0 +1,35 @@
+import { IpcMainEvent, BrowserWindow, dialog } from 'electron';
+import { IpcChannel, IpcRequest } from './ipc-channel.interface';
+
+export class DialogChannel implements IpcChannel {
+  getName(): string {
+    return 'dialog';
+  }
+
+  async handle(event: IpcMainEvent, request: IpcRequest): Promise<void> {
+    if (!request.responseChannel) {
+      request.responseChannel = `${ this.getName() }_response`;
+    }
+
+    const browserWindow = BrowserWindow.fromWebContents(event.sender);
+
+    if (!browserWindow) {
+      return;
+    }
+
+    const result = await dialog.showMessageBox(
+      browserWindow,
+      {
+        title:   'Message Box',
+        message: 'Please select an option',
+        detail:  'Message details',
+        buttons: ['Yes', 'No', 'Maybe']
+      }
+    );
+
+    event.sender.send(
+      request.responseChannel,
+      { result }
+    );
+  }
+}

--- a/src/main/ipc/ipc-channel.interface.ts
+++ b/src/main/ipc/ipc-channel.interface.ts
@@ -1,0 +1,13 @@
+import { IpcMainEvent } from 'electron';
+
+export interface IpcRequest {
+  responseChannel?: string;
+
+  params?: string[];
+}
+
+export interface IpcChannel {
+  getName(): string;
+
+  handle(event: IpcMainEvent, request: IpcRequest): void;
+}

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -52,6 +52,9 @@
         </section>
       </section>
     </section>
+    <button @click="getInfo">
+      SOME BUTTON
+    </button>
   </section>
 </template>
 
@@ -59,9 +62,11 @@
 import TroubleshootingLineItem from '@/components/TroubleshootingLineItem.vue';
 import Checkbox from '@/components/form/Checkbox';
 import { defaultSettings } from '@/config/settings';
+import { Ipc } from '@/services/ipc';
 
 const { ipcRenderer } = require('electron');
 const K8s = require('../k8s-engine/k8s');
+const ipc = new Ipc();
 
 export default {
   name:       'Troubleshooting',
@@ -116,6 +121,12 @@ export default {
     updateDebug(value) {
       ipcRenderer.invoke('settings-write', { debug: value });
     },
+    async getInfo() {
+      console.debug({ ipc });
+      const t = await ipc.send('dialog');
+
+      console.debug('NOT FAIL', { t });
+    }
   },
 };
 </script>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -43,6 +43,31 @@
             {{ t('troubleshooting.general.factoryReset.buttonText') }}
           </button>
         </troubleshooting-line-item>
+        <hr>
+        <troubleshooting-line-item>
+          <template #title>
+            Test Dialog
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs btn-info role-secondary"
+            @click="getDialog"
+          >
+            Dialog
+          </button>
+        </troubleshooting-line-item>
+        <troubleshooting-line-item>
+          <template #title>
+            Test Error
+          </template>
+          <button
+            type="button"
+            class="btn btn-xs btn-info role-secondary"
+            @click="getDialogError"
+          >
+            Dialog Error
+          </button>
+        </troubleshooting-line-item>
         <section class="need-help">
           <hr>
           <span
@@ -52,9 +77,6 @@
         </section>
       </section>
     </section>
-    <button @click="getInfo">
-      SOME BUTTON
-    </button>
   </section>
 </template>
 
@@ -121,11 +143,21 @@ export default {
     updateDebug(value) {
       ipcRenderer.invoke('settings-write', { debug: value });
     },
-    async getInfo() {
-      console.debug({ ipc });
-      const t = await ipc.send('dialog');
-
-      console.debug('NOT FAIL', { t });
+    async getDialog() {
+      await ipc.send(
+        'dialog',
+        {
+          options: {
+            title:   'Message Box',
+            message: 'Please select an option',
+            detail:  'Message details',
+            buttons: ['Yes', 'No', 'Maybe']
+          }
+        }
+      );
+    },
+    async getDialogError() {
+      await ipc.send('dialog-error');
     }
   },
 };

--- a/src/services/ipc.ts
+++ b/src/services/ipc.ts
@@ -1,0 +1,35 @@
+import { IpcRenderer } from 'electron';
+import { IpcRequest } from '@/main/ipc/ipc-channel.interface';
+
+export class Ipc {
+  private ipcRenderer?: IpcRenderer;
+
+  public send<T>(channel: string, request: IpcRequest = {}): Promise<T> {
+    if (!this.ipcRenderer) {
+      this.initializeIpcRenderer();
+    }
+
+    if (!request.responseChannel) {
+      request.responseChannel = `${ channel }_response_${ new Date().getTime() }`;
+    }
+
+    const ipcRenderer = this.ipcRenderer;
+
+    ipcRenderer?.send(channel, request);
+
+    return new Promise((resolve) => {
+      ipcRenderer?.once(
+        request.responseChannel || '',
+        (_event: any, response: any) => resolve(response)
+      );
+    });
+  }
+
+  private initializeIpcRenderer() {
+    if (!window || !window.process || !window.require) {
+      throw new Error('Unable to require renderer process');
+    }
+
+    this.ipcRenderer = window.require('electron').ipcRenderer;
+  }
+}

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -172,7 +172,6 @@ declare module 'electron' {
       channel: eventName,
       listener: (event: Electron.IpcRendererEvent, ...args: globalThis.Parameters<IpcRendererEvents[eventName]>) => void
     ): this;
-    /** @deprecated */
     once(channel: string, listener: (...args: any[]) => void): this;
 
     removeListener<eventName extends keyof IpcRendererEvents>(
@@ -195,7 +194,6 @@ declare module 'electron' {
       channel: eventName,
       ...args: any[],
     ): this;
-    /** @deprecated */
     send(channel: string, ...args: any[]): void;
 
     // When the renderer side is implement in JavaScript (rather than TypeScript),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "Node",
     "lib": [
       "ESNext",
-      "ESNext.AsyncIterable"
+      "ESNext.AsyncIterable",
+      "DOM"
     ],
     "esModuleInterop": true,
     "allowJs": true,


### PR DESCRIPTION
## Motivations
The bulk of IPC logic is defined in `background.ts`. This region of our app is a kind of “catch-all” zone, especially when working with IPC. `src/main/imageEvents.ts` demonstrates another way of registering IPC channels; this PR introduces a third option 😁.  There should be enough here to start a conversation about what we might prefer as a development team. It would be nice to have a consistent way to manage IPC usage as Rancher Desktop grows. 

## Goals

- [ ] Define a location where IPC events can be defined - proposed `src/main/ipc`
- [ ] Settle on a pattern so that we can refactor `background.ts` in such a way that it only registers events that are defined elsewhere
- [ ] Make it clear for a developer to know where to look when creating a new channel or updating an existing one

## Considerations for this approach 

One class per channel introduces quite a bit of boilerplate
Remembering to add a newly created channel to the collection of channels to register can be problematic. This portion can be improved.

## TODO

- [ ] Refactor work with existing IpcRenderer & IpcMain interfaces
- [ ] Reintroduce deprecated flags where they belong