### PR TITLE
WSL: Quote command for dockerd

### DIFF
--- a/src/assets/scripts/service-wsl-dockerd.initd
+++ b/src/assets/scripts/service-wsl-dockerd.initd
@@ -9,7 +9,7 @@ name="Rancher Desktop Docker Daemon"
 description="Starts dockerd for Rancher Desktop"
 
 supervisor=supervise-daemon
-command="${WSL_HELPER_BINARY:-/usr/local/bin/wsl-helper}"
+command="'${WSL_HELPER_BINARY:-/usr/local/bin/wsl-helper}'"
 command_args="docker-proxy start"
 
 DOCKER_LOGFILE="${DOCKER_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"


### PR DESCRIPTION
The path to wsl-helper (which we run to spawn dockerd) is likely to have spaces in it due to the default install location.  This means we need to quote it when passing it to supervise-daemon.