### PR TITLE
Lima: Use OpenRC to manage dockerd lifetime.

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -82,6 +82,13 @@ provision:
     mv -n /etc/periodic/daily/logrotate /etc/periodic/hourly/
     rc-update add crond default
     rc-service crond start
+- # Ensure the user is in the docker group to access the docker socket
+  mode: system
+  script: |
+    set -o errexit -o nounset
+    . /mnt/lima-cidata/lima.env
+    set -o xtrace
+    usermod --append --groups docker "${LIMA_CIDATA_USER}"
 portForwards:
 - guestPortRange: [1, 65535]
   hostIP: "0.0.0.0"

--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -10,8 +10,8 @@ ENGINE="${ENGINE:-containerd}"
 depend() {
   after network-online
   want cgroups
-  if [ "${ENGINE}" == "moby" ] && [ -e /etc/init.d/dockerd ]; then
-    need dockerd
+  if [ "${ENGINE}" == "moby" ]; then
+    need docker
   fi
 }
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1135,16 +1135,6 @@ ${ commands.join('\n') }
           return;
         }
 
-        if (this.#currentContainerEngine === ContainerEngine.MOBY) {
-          await this.progressTracker.action('Starting docker server', 30, async() => {
-            await this.ssh('sudo', '/sbin/rc-service', 'docker', 'start');
-            this.ssh('sudo', 'sh', '-c',
-              'while [ ! -S /var/run/docker.sock ] ; do sleep 1 ; done; chmod a+rw /var/run/docker.sock').catch((err) => {
-              console.log('Error trying to chmod /var/run/docker.sock: ', err);
-            });
-          });
-        }
-
         await this.progressTracker.action('Starting k3s', 100, async() => {
           await this.ssh('sudo', '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
           await this.followLogs();
@@ -1269,16 +1259,6 @@ ${ commands.join('\n') }
     }
     this.currentAction = Action.STOPPING;
 
-    if (this.#currentContainerEngine === ContainerEngine.MOBY) {
-      await this.progressTracker.action('Stopping docker server', 30, async() => {
-        try {
-          await this.ssh('sudo', '/sbin/rc-service', 'docker', 'stop');
-        } catch (ex) {
-          console.log(`Error stopping docker: `, ex);
-        }
-      });
-    }
-
     await this.progressTracker.action('Stopping Kubernetes', 10, async() => {
       try {
         this.setState(K8s.State.STOPPING);
@@ -1287,6 +1267,7 @@ ${ commands.join('\n') }
 
         if (defined(status) && status.status === 'Running') {
           await this.ssh('sudo', '/sbin/rc-service', 'k3s', 'stop');
+          await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'docker', 'stop');
           await this.lima('stop', MACHINE_NAME);
         }
         this.setState(K8s.State.STOPPED);

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1136,6 +1136,8 @@ ${ commands.join('\n') }
         }
 
         await this.progressTracker.action('Starting k3s', 100, async() => {
+          // Run rc-update as we have dynamic dependencies.
+          await this.ssh('sudo', '/sbin/rc-update', '--update');
           await this.ssh('sudo', '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
           await this.followLogs();
         });

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -934,8 +934,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             const rotateConf = LOGROTATE_K3S_SCRIPT.replace(/\r/g, '').replace('/var/log', logPath);
 
             await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, 0o755);
-            await this.writeFile('/etc/init.d/dockerd', SERVICE_SCRIPT_DOCKERD, 0o755);
-            await this.writeConf('dockerd', {
+            await this.writeFile('/etc/init.d/docker', SERVICE_SCRIPT_DOCKERD, 0o755);
+            await this.writeConf('docker', {
               WSL_HELPER_BINARY: await this.getWSLHelperPath(),
               LOG_DIR:           logPath,
             });
@@ -1078,6 +1078,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     try {
       this.setState(K8s.State.STOPPING);
       await this.progressTracker.action('Stopping Kubernetes', 10, async() => {
+        await this.execCommand('/usr/local/bin/wsl-service', 'k3s', 'stop');
+        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'docker', 'stop');
         this.process?.kill('SIGTERM');
         this.mobySocketProxyProcess.stop();
         try {


### PR DESCRIPTION
This changes the K3s OpenRC init script to depend on docker (when using the moby backend), so that we can automatically start/stop it via OpenRC instead of manually managing its lifetime.  This ensures correct start up and shutdown ordering.

Also update the WSL side to use the same service name ("docker" rather than "dockerd").

Fixes #1009