### PR TITLE
WSL: Moby fixes.

### DIFF
--- a/src/go/nerdctl-stub/debugging.go
+++ b/src/go/nerdctl-stub/debugging.go
@@ -1,4 +1,5 @@
-//+build debug
+//go:build debug
+// +build debug
 
 package main
 

--- a/src/go/nerdctl-stub/generate/main.go
+++ b/src/go/nerdctl-stub/generate/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // package main produces stubs for the nerdctl subcommands (and their

--- a/src/go/nerdctl-stub/main_unsupported.go
+++ b/src/go/nerdctl-stub/main_unsupported.go
@@ -1,5 +1,5 @@
-// +build !linux,!windows
 //go:build !(linux || windows)
+// +build !linux,!windows
 
 package main
 

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
 
 	// Pull in to register the mungers
 	_ "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/mungers"
@@ -37,6 +38,10 @@ var dockerproxyServeCmd = &cobra.Command{
 		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		proxyEndpoint := dockerproxyServeViper.GetString("proxy-endpoint")
+		err := process.KillOthers()
+		if err != nil {
+			return err
+		}
 		dialer, err := platform.MakeDialer(proxyEndpoint)
 		if err != nil {
 			return err

--- a/src/go/wsl-helper/cmd/root.go
+++ b/src/go/wsl-helper/cmd/root.go
@@ -16,8 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/viper"
 )
 
@@ -26,7 +26,11 @@ var rootCmd = &cobra.Command{
 	Use:   "wsl-helper",
 	Short: "Rancher Desktop WSL2 integration helper",
 	Long:  `This command handles various WSL2 integration tasks for Rancher Desktop.`,
-	// Run: func(cmd *cobra.Command, args []string) { },
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if viper.GetBool("verbose") {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -36,6 +40,8 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().Bool("verbose", false, "enable extra logging")
+	viper.BindPFlags(rootCmd.Flags())
 	cobra.OnInitialize(initConfig)
 }
 

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/linuxkit/virtsock/pkg/hvsock"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -141,7 +142,7 @@ func probeVMGUID(port uint32) (hvsock.GUID, error) {
 			}
 			defer conn.Close()
 
-			fmt.Printf("Got WSL2 VM %s\n", guid.String())
+			logrus.WithField("guid", guid.String()).Info("Got WSL2 VM")
 			r.resolve(guid)
 		}(name)
 	}

--- a/src/go/wsl-helper/pkg/dockerproxy/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve.go
@@ -60,7 +60,7 @@ func Serve(endpoint string, dialer func() (net.Conn, error)) error {
 		signal.Stop(termch)
 		err := listener.Close()
 		if err != nil {
-			fmt.Printf("Error closing listener on interrupt: %s\n", err)
+			logrus.WithError(err).Error("Error closing listener on interrupt")
 		}
 	}()
 

--- a/src/go/wsl-helper/pkg/process/kill_others.go
+++ b/src/go/wsl-helper/pkg/process/kill_others.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package process
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+// KillOthers will kill any other processes with the same command line.
+func KillOthers() error {
+	selfPid := fmt.Sprintf("%d", os.Getpid())
+	selfCmd, err := ioutil.ReadFile("/proc/self/cmdline")
+	if err != nil {
+		logrus.WithError(err).Error("could not read /proc/self/cmdline")
+		return err
+	}
+	var pids []int
+	// Read /proc, ignoring errors - any entries we _could_ read are returned.
+	procs, _ := os.ReadDir("/proc")
+	for _, proc := range procs {
+		if !proc.IsDir() || proc.Name() == selfPid || proc.Name() == "self" {
+			continue
+		}
+		procCmd, err := ioutil.ReadFile(path.Join("/proc", proc.Name(), "cmdline"))
+		if err != nil {
+			// pid died, or we don't have permissions, or it's not a pid.
+			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read cmdline")
+			continue
+		}
+		if bytes.Compare(selfCmd, procCmd) == 0 {
+			// A different pid has the same command line; kill it.
+			pid, err := strconv.Atoi(proc.Name())
+			if err == nil {
+				pids = append(pids, pid)
+			}
+		}
+	}
+	for _, pid := range pids {
+		proc, err := os.FindProcess(pid)
+		if err == nil {
+			err = proc.Signal(syscall.SIGTERM)
+			if err != nil {
+				logrus.WithError(err).WithField("pid", pid).Info("could not kill process; ignoring.")
+			}
+		}
+	}
+	return nil
+}

--- a/src/go/wsl-helper/pkg/process/kill_others.go
+++ b/src/go/wsl-helper/pkg/process/kill_others.go
@@ -1,4 +1,5 @@
 //go:build linux
+// +build linux
 
 package process
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -127,6 +127,7 @@ class BackgroundProcess {
    */
   protected async restart() {
     if (!this.shouldRun || ![K8s.State.STARTING, K8s.State.STARTED].includes(this.backend.state)) {
+      console.debug(`Not restarting ${ this.name }: ${ this.shouldRun } / ${ this.backend.state }`);
       this.stop();
 
       return;
@@ -142,10 +143,12 @@ class BackgroundProcess {
       }
       if (this.shouldRun) {
         if (this.timer) {
-          this.timer.refresh();
-        } else {
-          this.timer = setTimeout(this.restart.bind(this), 1_000);
+          // Ideally, we should use this.timer.refresh(); however, it does not
+          // appear to actually trigger.
+          timers.clearTimeout(this.timer);
         }
+        this.timer = timers.setTimeout(this.restart.bind(this), 1_000);
+        console.debug(`Background process ${ this.name } will restart.`);
       }
     });
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -868,6 +868,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     if (conf) {
       await this.writeConf(service, conf);
     }
+    // Run rc-update as we have dynamic dependencies.
+    await this.execCommand('/sbin/rc-update', '--update');
     await this.execCommand('/usr/local/bin/wsl-service', service, 'start');
   }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -178,7 +178,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       const exe = resources.get('win32', 'bin', 'wsl-helper.exe');
 
       return childProcess.spawn(exe, ['docker-proxy', 'serve'], {
-        stdio:       ['ignore', await Logging.wsl.fdStream, await Logging.wsl.fdStream],
+        stdio:       ['ignore', await Logging['wsl-helper.windows'].fdStream, await Logging['wsl-helper.windows'].fdStream],
         windowsHide: true,
       });
     });

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -29,6 +29,11 @@ import ProgressTracker from './progressTracker';
 const console = Logging.wsl;
 const INSTANCE_NAME = 'rancher-desktop';
 const DATA_INSTANCE_NAME = 'rancher-desktop-data';
+/**
+ * INTEGRATION_HOST is a key for WSLBackend.mobySocketProxyProcesses to indicate
+ * the integration (moby socket proxy) process for the Win32 host.
+ */
+const INTEGRATION_HOST = Symbol('host');
 
 /**
  * Enumeration for tracking what operation the backend is undergoing.
@@ -185,15 +190,17 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       this.progress = progress;
       this.emit('progress');
     });
-    this.mobySocketProxyProcess = new BackgroundProcess(this, 'Win32 socket proxy', async() => {
-      const exe = resources.get('win32', 'bin', 'wsl-helper.exe');
-      const stream = await Logging['wsl-helper'].fdStream;
+    this.mobySocketProxyProcesses = {
+      [INTEGRATION_HOST]: new BackgroundProcess(this, 'Win32 socket proxy', async() => {
+        const exe = resources.get('win32', 'bin', 'wsl-helper.exe');
+        const stream = await Logging['wsl-helper'].fdStream;
 
-      return childProcess.spawn(exe, ['docker-proxy', 'serve'], {
-        stdio:       ['ignore', stream, stream],
-        windowsHide: true,
-      });
-    });
+        return childProcess.spawn(exe, ['docker-proxy', 'serve'], {
+          stdio:       ['ignore', stream, stream],
+          windowsHide: true,
+        });
+      })
+    };
   }
 
   protected get distroFile() {
@@ -214,16 +221,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected process: childProcess.ChildProcess | null = null;
 
   /**
-   * Handle to the process that listens on the Windows pipe and forwards to the
-   * docker socket in the WSL VM.
-   */
-  protected mobySocketProxyProcess: BackgroundProcess;
-
-  /**
    * Handle to processes handling dockerd integration with other WSL
-   * distributions.
+   * distributions.  If the key is INTEGRATION_HOST, then it is the process for
+   * the host (i.e. proxies to the Windows pipe).
    */
-  protected integrationProcesses: Record<string, BackgroundProcess> = {};
+  protected mobySocketProxyProcesses: Record<string | typeof INTEGRATION_HOST, BackgroundProcess>;
 
   protected client: K8s.Client | null = null;
 
@@ -532,7 +534,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       this.execWSL('--terminate', INSTANCE_NAME),
       this.execWSL('--terminate', DATA_INSTANCE_NAME),
     ]);
-    Object.values(this.integrationProcesses).map(proc => proc.stop());
+    Object.values(this.mobySocketProxyProcesses).forEach(proc => proc.stop());
   }
 
   /**
@@ -982,10 +984,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           return;
         }
 
-        if (config.containerEngine === ContainerEngine.MOBY) {
-          this.mobySocketProxyProcess.start();
-        }
-
         await this.progressTracker.action(
           'Waiting for Kubernetes API',
           100,
@@ -996,21 +994,24 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           this.k3sHelper.updateKubeconfig(
             async() => await this.captureCommand(await this.getWSLHelperPath(), 'k3s', 'kubeconfig')));
 
-        await this.progressTracker.action(
-          'Starting integrations',
-          100,
-          async() => {
-            const integrations = await this.listIntegrations();
+        if (config.containerEngine === ContainerEngine.MOBY) {
+          await this.progressTracker.action(
+            'Starting integrations',
+            100,
+            async() => {
+              const integrations = await this.listIntegrations();
 
-            for (const [distro, status] of Object.entries(integrations)) {
-              if (config.containerEngine === ContainerEngine.MOBY && status === true) {
-                await this.setupIntegrationProcess(distro);
-                this.integrationProcesses[distro].start();
-              } else {
-                this.integrationProcesses[distro]?.stop();
+              this.mobySocketProxyProcesses[INTEGRATION_HOST].start();
+              for (const [distro, status] of Object.entries(integrations)) {
+                if (status === true) {
+                  await this.setupIntegrationProcess(distro);
+                  this.mobySocketProxyProcesses[distro].start();
+                } else {
+                  this.mobySocketProxyProcesses[distro]?.stop();
+                }
               }
-            }
-          });
+            });
+        }
 
         await this.progressTracker.action(
           'Waiting for services',
@@ -1097,7 +1098,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       this.setState(K8s.State.STOPPING);
       await this.progressTracker.action('Stopping Kubernetes', 10, async() => {
         this.process?.kill('SIGTERM');
-        this.mobySocketProxyProcess.stop();
+        Object.values(this.mobySocketProxyProcesses).forEach(proc => proc.stop());
         try {
           await this.execWSL('--terminate', INSTANCE_NAME);
         } catch (ex) {
@@ -1108,9 +1109,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           }
         }
       });
-      for (const proc of Object.values(this.integrationProcesses)) {
-        proc?.stop();
-      }
       this.setState(K8s.State.STOPPED);
     } catch (ex) {
       this.setState(K8s.State.ERROR);
@@ -1255,7 +1253,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async setupIntegrationProcess(distro: string) {
     const executable = await this.getWSLHelperPath();
 
-    this.integrationProcesses[distro] ??= new BackgroundProcess(this, `${ distro } socket proxy`, async() => {
+    this.mobySocketProxyProcesses[distro] ??= new BackgroundProcess(this, `${ distro } socket proxy`, async() => {
       const stream = await Logging[`wsl-helper.${ distro }`].fdStream;
 
       return childProcess.spawn('wsl.exe',
@@ -1292,9 +1290,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       );
       if (state) {
         await this.setupIntegrationProcess(distro);
-        this.integrationProcesses[distro].start();
+        this.mobySocketProxyProcesses[distro].start();
       } else {
-        this.integrationProcesses[distro]?.stop();
+        this.mobySocketProxyProcesses[distro]?.stop();
       }
     } catch (error) {
       console.error(`Could not set up kubeconfig integration for ${ distro }:`, error);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -132,7 +132,7 @@ class BackgroundProcess {
       return;
     }
     this.process?.kill('SIGTERM');
-    console.log(`Launching background process ${ this.name }`);
+    console.log(`Launching background process ${ this.name }.`);
     this.process = await this.spawn();
     this.process.on('exit', (status, signal) => {
       if ([0, null].includes(status) && ['SIGTERM', null].includes(signal)) {
@@ -154,6 +154,7 @@ class BackgroundProcess {
    * Stop the process and do not restart it.
    */
   stop() {
+    console.log(`Stopping background process ${ this.name }.`);
     this.shouldRun = false;
     if (this.timer) {
       clearTimeout(this.timer);
@@ -519,6 +520,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       this.execWSL('--terminate', INSTANCE_NAME),
       this.execWSL('--terminate', DATA_INSTANCE_NAME),
     ]);
+    Object.values(this.integrationProcesses).map(proc => proc.stop());
   }
 
   /**
@@ -987,7 +989,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             const integrations = await this.listIntegrations();
 
             for (const [distro, status] of Object.entries(integrations)) {
-              if (status === true) {
+              if (config.containerEngine === ContainerEngine.MOBY && status === true) {
                 await this.setupIntegrationProcess(distro);
                 this.integrationProcesses[distro].start();
               } else {


### PR DESCRIPTION
This PR contains a few reliability fixes for the moby backend.
- Don't run the docker-proxy helper if we're not using the moby engine (there's nothing to forward to).
- Force OpenRC to re-evaluate dependencies on start, since the dependency list depends on which engine we're using.
- For the Linux docker-proxy helper, if a unix socket already exists at the path we wish to listen on (i.e. `/var/run/docker.sock`), and attempting to connect it results in a `Connect refused`, delete the file.  This happens if a previous process listened on that socket and has already terminated.
- On Linux, manually terminate any previous instances (in the same pid namespace) that have the exact same command line, including the executable path.  This can happen if a previous instance has failed to quit correctly.