### PR TITLE
Delete everything on Factory Reset (macos/linux only).

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1340,9 +1340,14 @@ ${ commands.join('\n') }
   }
 
   async factoryReset(): Promise<void> {
+    const pathsToDelete = [paths.cache, paths.appHome, paths.config, paths.logs];
+
+    if (!pathsToDelete.some( dir => paths.lima.startsWith(dir))) {
+      // Add lima if it isn't in any of the subtrees slated for deletion.
+      pathsToDelete.push(paths.lima);
+    }
     await this.del(true);
-    await Promise.all([paths.cache, paths.appHome, paths.config, paths.logs]
-      .map(p => fs.promises.rmdir(p, { recursive: true })));
+    await Promise.all(pathsToDelete.map(p => fs.promises.rmdir(p, { recursive: true })));
   }
 
   async requiresRestartReasons(): Promise<Record<string, [any, any] | []>> {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1341,7 +1341,7 @@ ${ commands.join('\n') }
 
   async factoryReset(): Promise<void> {
     await this.del(true);
-    await Promise.all([paths.cache, paths.lima, paths.config, paths.logs]
+    await Promise.all([paths.cache, paths.appHome, paths.config, paths.logs]
       .map(p => fs.promises.rmdir(p, { recursive: true })));
   }
 

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -20,6 +20,7 @@ const APP_NAME = 'rancher-desktop';
  * DarwinObsoletePaths describes the paths we're migrating from.
  */
 class DarwinObsoletePaths implements Paths {
+  appHome = '*NOT USED*';
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
   logs = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'logs');
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
@@ -41,6 +42,8 @@ class DarwinObsoletePaths implements Paths {
 class Win32ObsoletePaths implements Paths {
   protected appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
   protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
+  appHome = '*NOT USED*';
+
   get config() {
     return path.join(this.appData, 'xdg.config', APP_NAME);
   }

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -20,7 +20,6 @@ const APP_NAME = 'rancher-desktop';
  * DarwinObsoletePaths describes the paths we're migrating from.
  */
 class DarwinObsoletePaths implements Paths {
-  appHome = '*NOT USED*';
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
   logs = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'logs');
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
@@ -34,6 +33,10 @@ class DarwinObsoletePaths implements Paths {
   get wslDistroData(): string {
     throw new Error('wslDistro not available for darwin');
   }
+
+  get appHome(): string {
+    throw new Error('appHome not available for darwin');
+  }
 }
 
 /**
@@ -42,7 +45,10 @@ class DarwinObsoletePaths implements Paths {
 class Win32ObsoletePaths implements Paths {
   protected appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
   protected localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
-  appHome = '*NOT USED*';
+
+  get appHome(): string {
+    throw new Error('appHome not available for windows');
+  }
 
   get config() {
     return path.join(this.appData, 'xdg.config', APP_NAME);

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -111,7 +111,7 @@ describe('paths', () => {
   });
 
   it('lima should be in one of the main subtrees', () => {
-    const pathsToDelete: Array<string> = [paths.cache, paths.appHome, paths.config, paths.logs];
+    const pathsToDelete = [paths.cache, paths.appHome, paths.config, paths.logs];
     const platform = os.platform();
 
     if (['darwin', 'linux'].includes(platform)) {

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -112,9 +112,10 @@ describe('paths', () => {
 
   it('lima should be in one of the main subtrees', () => {
     const pathsToDelete: Array<string> = [paths.cache, paths.appHome, paths.config, paths.logs];
+    const platform = os.platform();
 
-    if (os.platform() !== 'win32') {
-      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toBeTruthy();
+    if (['darwin', 'linux'].includes(platform)) {
+      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toEqual(platform === 'darwin');
       expect(pathsToDelete.some( dir => '/bobs/friendly/llama/farm'.startsWith(dir))).toBeFalsy();
     }
   });

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -8,6 +8,10 @@ type expectedData = Record<platform, string | Error>;
 
 describe('paths', () => {
   const cases: Record<keyof Paths, expectedData> = {
+    appHome: {
+      win32:  '%APPDATA%/rancher-desktop/',
+      darwin: '%HOME%/Library/Application Support/rancher-desktop/',
+    },
     config: {
       win32:  '%APPDATA%/rancher-desktop/',
       darwin: '%HOME%/Library/Preferences/rancher-desktop/',

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -109,4 +109,13 @@ describe('paths', () => {
       console.log(`Skipping platform-specific test on unknown platform ${ os.platform() }`);
     }
   });
+
+  it('lima should be in one of the main subtrees', () => {
+    const pathsToDelete: Array<string> = [paths.cache, paths.appHome, paths.config, paths.logs];
+
+    if (os.platform() !== 'win32') {
+      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toBeTruthy();
+      expect(pathsToDelete.some( dir => '/bobs/friendly/llama/farm'.startsWith(dir))).toBeFalsy();
+    }
+  });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -8,6 +8,8 @@ import path from 'path';
 const APP_NAME = 'rancher-desktop';
 
 export interface Paths {
+  /** appHome: the location of the main appdata directory. */
+  appHome: string;
   /** Directory which holds configuration. */
   config: string;
   /** Directory which holds logs. */
@@ -30,10 +32,11 @@ export interface Paths {
  * DarwinPaths implements paths for Darwin / macOS.
  */
 export class DarwinPaths implements Paths {
+  appHome = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME);
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
   logs = path.join(os.homedir(), 'Library', 'Logs', APP_NAME);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
-  lima = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME, 'lima');
+  lima = path.join(this.appHome, 'lima');
   hyperkit = path.join(os.homedir(), 'Library', 'State', APP_NAME, 'driver');
   integration = '/usr/local/bin';
   get wslDistro(): string {
@@ -51,6 +54,10 @@ export class DarwinPaths implements Paths {
 export class Win32Paths implements Paths {
   protected readonly appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');
   protected readonly localAppData = process.env['LOCALAPPDATA'] || path.join(os.homedir(), 'AppData', 'Local');
+  get appHome() {
+    return path.join(this.appData, APP_NAME);
+  }
+
   get config() {
     return path.join(this.appData, APP_NAME);
   }
@@ -96,6 +103,10 @@ export class LinuxPaths implements Paths {
   protected readonly dataHome = process.env['XDG_DATA_HOME'] || path.join(os.homedir(), '.local', 'share');
   protected readonly configHome = process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config');
   protected readonly cacheHome = process.env['XDG_CACHE_HOME'] || path.join(os.homedir(), '.cache');
+  get appHome() {
+    return path.join(this.configHome, APP_NAME);
+  }
+
   get config() {
     return path.join(this.configHome, APP_NAME);
   }


### PR DESCRIPTION
Expose concepts of `appHome` and `localAppHome`, even though
`localAppHome` is supported only on Windows.

Signed-off-by: Eric Promislow <epromislow@suse.com>