### PR TITLE
[936] Cirrus CI - E2E/Integration Pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,6 +30,7 @@ task:
 
   # Tests should run as non-root user - setting up a test user
   prepare_user_script:
+    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
     - useradd -m -G kvm ranchertest
     - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
     - chown -R ranchertest.ranchertest /home/ranchertest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,35 +1,36 @@
 task:
   trigger_type: manual
-  matrix:
-    - name: E2E/Integration Tests
-      timeout_in: 45
-      container:
-        image: ubuntu:20.04
-        kvm: true # required for E2E/Integrations tests
-        cpu: 4
-        memory: 8G
-      env:
-        DEBIAN_FRONTEND: noninteractive
-        CI: true
-        FORCE_COLOR: 1 # force terminal color
-        CIRRUS_CLONE_DEPTH: 0 # Required to get app version
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
-      install_deps_script: |
-        apt-get update
-        apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
-        curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && apt-get install -y nodejs && node --version && npm -v
-        apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+  name: E2E/Integration Tests
+  timeout_in: 45
+  container:
+    image: ubuntu:20.04
+    kvm: true # required for E2E/Integrations tests
+    cpu: 4
+    memory: 8G
+  env:
+    DEBIAN_FRONTEND: noninteractive
+    CI: true
+    FORCE_COLOR: 1 # force terminal color
+    CIRRUS_CLONE_DEPTH: 0 # Required to get app version
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
+  install_deps_script: |
+    apt-get update
+    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
+    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && apt-get install -y nodejs && node --version && npm -v
+    apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |
     useradd -m -G kvm ranchertest
     cp -rf . /home/ranchertest
 
-  build_script: |
-    chown -R ranchertest:ranchertest /home/ranchertest
-    chown -R ranchertest:ranchertest /dev/kvm
-    sudo -iu ranchertest DEBUG=pw:install npm ci
-    sudo -iu ranchertest npx playwright install-deps
+  node_modules_cache:
+    folder: /home/ranchertest/node_modules
+    populate_script: |
+      chown -R ranchertest:ranchertest /home/ranchertest
+      chown -R ranchertest:ranchertest /dev/kvm
+      sudo -iu ranchertest DEBUG=pw:install npm ci
+      sudo -iu ranchertest ./node_modules/.bin/playwright install-deps
 
   test_script: |
     export KUBECONFIG=/home/ranchertest/.kube/config
@@ -37,4 +38,4 @@ task:
 
   on_failure:
     logs_artifacts:
-      path: ./home/ranchertest/e2e/reports/*
+      path: "/home/ranchertest/e2e/reports/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,26 +15,29 @@ task:
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
     KEYRING: /usr/share/keyrings/nodesource.gpg
     NODE_VERSION: node_14.x # set node version e.g: "node_16.x" for Node 16 LTS
-    DISTRO: hirsute # release codename for Ubuntu 21.04 - see "lsb_release -s -c"
   install_deps_script: |
     apt-get update
-    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg \
+    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg lsb-core \
                     libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-    curl -sLf -o /dev/null "https://deb.nodesource.com/"$NODE_VERSION"/dists/"$DISTRO"/Release"
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
-    echo "deb [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" > /etc/apt/sources.list.d/nodesource.list
-    echo "deb-src [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" >> /etc/apt/sources.list.d/nodesource.list
-    apt-get update && apt-get install -y  nodejs && node -v && npm -v
+    export DISTRO="$(lsb_release --short --codename)"
+    curl -sLf -o /dev/null "https://deb.nodesource.com/${NODE_VERSION}/dists/${DISTRO}/Release"
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
+    echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
+    echo "deb-src [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
+    apt-get update 
+    apt-get install --yes  nodejs 
+    node --version && npm --version
 
   # Tests should run as non-root user - setting up a test user
-  prepate_user_script:
+  prepare_user_script:
     - groupadd -g $(stat -c '%g' /dev/kvm) kvm
     - useradd -m -G kvm ranchertest
-    - cp -rf . /home/ranchertest
+    - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
     - chown -R ranchertest.ranchertest /home/ranchertest
 
   node_modules_cache:
     folder: /home/ranchertest/node_modules
+    fingerprint_script: cat package-lock.json
     populate_script:
       - sudo -iu ranchertest DEBUG=pw:install npm ci
       - sudo -iu ranchertest ./node_modules/.bin/playwright install-deps
@@ -44,6 +47,7 @@ task:
     - sudo -iu ranchertest CI=1 xvfb-run --auto-servernum -- npm run test:e2e
 
   on_failure: 
-    custom_script: cp -R /home/ranchertest/e2e/reports/ . # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197
+    # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197
+    custom_script: cp -R /home/ranchertest/e2e/reports/ .
     logs_artifacts:
       path: "/reports/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,9 +15,9 @@ task:
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
   install_deps_script: |
     apt-get update
-    apt-get install -y --no-install-recommends golang openssh-client netcat sudo vim curl
-    apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
     curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && apt-get install -y nodejs && node -v && npm -v
+    apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,6 +30,7 @@ task:
 
   # Tests should run as non-root user - setting up a test user
   prepare_user_script:
+    - groupadd -f -g $(stat -c '%g' /dev/kvm) kvm
     - useradd -m -G kvm ranchertest
     - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
     - chown -R ranchertest.ranchertest /home/ranchertest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ task:
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |
     cp /bin/tar /usr/bin/tar
+    groupadd -g $(stat -c '%g' /dev/kvm) kvm
     useradd -m -G kvm ranchertest
     cp -rf . /home/ranchertest
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,29 +13,37 @@ task:
     FORCE_COLOR: 1 # force terminal color
     CIRRUS_CLONE_DEPTH: 0 # Required to get app version
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
+    KEYRING: /usr/share/keyrings/nodesource.gpg
+    NODE_VERSION: node_14.x # set node version e.g: "node_16.x" for Node 16 LTS
+    DISTRO: hirsute # release codename for Ubuntu 21.04 - see "lsb_release -s -c"
   install_deps_script: |
     apt-get update
-    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
-    curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && apt-get install -y nodejs && node -v && npm -v
-    apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg \
+                    libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+    curl -sLf -o /dev/null "https://deb.nodesource.com/"$NODE_VERSION"/dists/hirsute/Release"
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+    echo "deb [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" > /etc/apt/sources.list.d/nodesource.list
+    echo "deb-src [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" >> /etc/apt/sources.list.d/nodesource.list
+    apt-get update && apt-get install -y  nodejs && node -v && npm -v
 
   # Tests should run as non-root user - setting up a test user
-  prepate_user_script: |
-    useradd -m -G kvm ranchertest
-    cp -rf . /home/ranchertest
+  prepate_user_script:
+    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
+    - useradd -m -G kvm ranchertest
+    - cp -rf . /home/ranchertest
+    - chown -R ranchertest.ranchertest /home/ranchertest
 
   node_modules_cache:
     folder: /home/ranchertest/node_modules
-    populate_script: |
-      chown -R ranchertest:ranchertest /home/ranchertest
-      chown -R ranchertest:ranchertest /dev/kvm
-      sudo -iu ranchertest DEBUG=pw:install npm ci
-      sudo -iu ranchertest ./node_modules/.bin/playwright install-deps
+    populate_script:
+      - sudo -iu ranchertest DEBUG=pw:install npm ci
+      - sudo -iu ranchertest ./node_modules/.bin/playwright install-deps
 
-  test_script: |
-    export KUBECONFIG=/home/ranchertest/.kube/config
-    sudo -iu ranchertest xvfb-run --auto-servernum -- npm run test:e2e
+  test_script:
+    - export KUBECONFIG=/home/ranchertest/.kube/config
+    - sudo -iu ranchertest CI=1 xvfb-run --auto-servernum -- npm run test:e2e
 
-  on_failure:
+  on_failure: 
+    custom_script: cp -R /home/ranchertest/e2e/reports/ . # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197
     logs_artifacts:
-      path: "/home/ranchertest/e2e/reports/*"
+      path: "/reports/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,6 +27,12 @@ task:
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg lsb-core \
                     libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+  # The process to install Node w/o sudo|bash requires a validation:
+  # Step.1 - Check if node package is available on nodesoure, if not it will fail
+  # Step.2 - Add node key and update source list
+  # Step.3 - Update source and install node+npm
+  install_node_script: |
     export DISTRO="$(lsb_release --short --codename)"
     curl --silent --location --fail --output /dev/null "https://deb.nodesource.com/${NODE_VERSION}/dists/${DISTRO}/Release"
     curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
@@ -36,15 +42,13 @@ task:
     apt-get install --yes nodejs 
     node --version && npm --version
 
-  # Info about Cirrus CI caching - After the last script instruction for the task succeeds, Cirrus CI will calculate checksum of the cached folder
-  # (note that it's unrelated to fingerprint_script or fingerprint_key fields) and re-upload the cache if it finds any changes.
-  # Heads up: to avoid a time-costly re-upload, remove volatile files from the cache (for example, in the last script instruction of a task).
+  # Info about Cirrus CI caching see: https://cirrus-ci.org/guide/writing-tasks/#cache-instruction
   node_modules_cache:
     folder: /home/ranchertest/node_modules
     fingerprint_script: cat package-lock.json
     populate_script:
       # Passing DEBUG=pw:install in order to verify if all Playwright deps were installed properly
-      - sudo --login --user=ranchertest DEBUG=pw:install npm ci
+      - sudo --login --user=ranchertest DEBUG=pw:install npm ci 
       - sudo --login --user=ranchertest ranchertest ./node_modules/.bin/playwright install-deps
 
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,40 @@
+task:
+  trigger_type: manual
+  matrix:
+    - name: E2E/Integration Tests
+      timeout_in: 45
+      container:
+        image: ubuntu:20.04
+        kvm: true # required for E2E/Integrations tests
+        cpu: 4
+        memory: 8G
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        CI: true
+        FORCE_COLOR: 1 # force terminal color
+        CIRRUS_CLONE_DEPTH: 0 # Required to get app version
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
+      install_deps_script: |
+        apt-get update
+        apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
+        curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && apt-get install -y nodejs && node --version && npm -v
+        apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+  # Tests should run as non-root user - setting up a test user
+  prepate_user_script: |
+    useradd -m -G kvm ranchertest
+    cp -rf . /home/ranchertest
+
+  build_script: |
+    chown -R ranchertest:ranchertest /home/ranchertest
+    chown -R ranchertest:ranchertest /dev/kvm
+    sudo -iu ranchertest DEBUG=pw:install npm ci
+    sudo -iu ranchertest npx playwright install-deps
+
+  test_script: |
+    export KUBECONFIG=/home/ranchertest/.kube/config
+    sudo -iu ranchertest xvfb-run --auto-servernum -- npm run test:e2e
+
+  on_failure:
+    logs_artifacts:
+      path: ./home/ranchertest/e2e/reports/*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,6 @@ task:
 
   # Tests should run as non-root user - setting up a test user
   prepare_user_script:
-    - groupadd -f -g $(stat -c '%g' /dev/kvm) kvm
     - useradd -m -G kvm ranchertest
     - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
     - chown -R ranchertest.ranchertest /home/ranchertest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ task:
   name: E2E/Integration Tests
   timeout_in: 45
   container:
-    image: ubuntu:20.04
+    image: node:14.18.2
     kvm: true # required for E2E/Integrations tests
     cpu: 4
     memory: 8G
@@ -15,12 +15,13 @@ task:
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
   install_deps_script: |
     apt-get update
-    apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim
-    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && apt-get install -y nodejs && node --version && npm -v
+    apt-get install -y --no-install-recommends golang openssh-client netcat sudo vim
     apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+    node --version && npm -v
 
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |
+    cp /bin/tar /usr/bin/tar
     useradd -m -G kvm ranchertest
     cp -rf . /home/ranchertest
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg \
                     libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-    curl -sLf -o /dev/null "https://deb.nodesource.com/"$NODE_VERSION"/dists/hirsute/Release"
+    curl -sLf -o /dev/null "https://deb.nodesource.com/"$NODE_VERSION"/dists/"$DISTRO"/Release"
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
     echo "deb [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" > /etc/apt/sources.list.d/nodesource.list
     echo "deb-src [signed-by="$KEYRING"] https://deb.nodesource.com/"$NODE_VERSION" "$DISTRO" main" >> /etc/apt/sources.list.d/nodesource.list

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ task:
   name: E2E/Integration Tests
   timeout_in: 45
   container:
-    image: ubuntu:21.04
+    image: ubuntu:20.04
     kvm: true # required for E2E/Integrations tests
     cpu: 6
     memory: 12G
@@ -18,34 +18,38 @@ task:
 
   # Setting up a non-root user
   prepare_user_script:
-    - groupadd -f -g $(stat -c '%g' /dev/kvm) kvm
-    - useradd -m -G kvm ranchertest
-    - tar c --owner=ranchertest.ranchertest . | tar x --directory=/home/ranchertest
-    - chown -R ranchertest.ranchertest /home/ranchertest
+    - groupadd --gid $(stat -c '%g' /dev/kvm) kvm
+    - useradd --create-home --groups kvm ranchertest
+    - tar c --owner=ranchertest . | tar x --directory=/home/ranchertest
+    - chown -R ranchertest:ranchertest /home/ranchertest
 
   install_deps_script: |
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg lsb-core \
                     libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     export DISTRO="$(lsb_release --short --codename)"
-    curl -sLf -o /dev/null "https://deb.nodesource.com/${NODE_VERSION}/dists/${DISTRO}/Release"
-    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
+    curl --silent --location --fail --output /dev/null "https://deb.nodesource.com/${NODE_VERSION}/dists/${DISTRO}/Release"
+    curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
     echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
     echo "deb-src [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
     apt-get update 
     apt-get install --yes nodejs 
     node --version && npm --version
 
+  # Info about Cirrus CI caching - After the last script instruction for the task succeeds, Cirrus CI will calculate checksum of the cached folder
+  # (note that it's unrelated to fingerprint_script or fingerprint_key fields) and re-upload the cache if it finds any changes.
+  # Heads up: to avoid a time-costly re-upload, remove volatile files from the cache (for example, in the last script instruction of a task).
   node_modules_cache:
     folder: /home/ranchertest/node_modules
     fingerprint_script: cat package-lock.json
     populate_script:
-      - sudo -iu ranchertest DEBUG=pw:install npm ci
-      - sudo -iu ranchertest ./node_modules/.bin/playwright install-deps
+      # Passing DEBUG=pw:install in order to verify if all Playwright deps were installed properly
+      - sudo --login --user=ranchertest DEBUG=pw:install npm ci
+      - sudo --login --user=ranchertest ranchertest ./node_modules/.bin/playwright install-deps
 
   test_script:
     - export KUBECONFIG=/home/ranchertest/.kube/config
-    - sudo -iu ranchertest CI=1 xvfb-run --auto-servernum -- npm run test:e2e
+    - sudo --login --user=ranchertest CI=1 xvfb-run --auto-servernum -- npm run test:e2e
 
   on_failure: 
     # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,16 +5,24 @@ task:
   container:
     image: ubuntu:21.04
     kvm: true # required for E2E/Integrations tests
-    cpu: 4
-    memory: 8G
+    cpu: 6
+    memory: 12G
   env:
     DEBIAN_FRONTEND: noninteractive
     CI: true
-    FORCE_COLOR: 1 # force terminal color
     CIRRUS_CLONE_DEPTH: 0 # Required to get app version
+    FORCE_COLOR: 1 # force terminal color
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
     KEYRING: /usr/share/keyrings/nodesource.gpg
     NODE_VERSION: node_14.x # set node version e.g: "node_16.x" for Node 16 LTS
+
+  # Setting up a non-root user
+  prepare_user_script:
+    - groupadd -f -g $(stat -c '%g' /dev/kvm) kvm
+    - useradd -m -G kvm ranchertest
+    - tar c --owner=ranchertest.ranchertest . | tar x --directory=/home/ranchertest
+    - chown -R ranchertest.ranchertest /home/ranchertest
+
   install_deps_script: |
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gcc g++ curl git golang openssh-client make netcat sudo vim gpg lsb-core \
@@ -25,15 +33,8 @@ task:
     echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
     echo "deb-src [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
     apt-get update 
-    apt-get install --yes  nodejs 
+    apt-get install --yes nodejs 
     node --version && npm --version
-
-  # Tests should run as non-root user - setting up a test user
-  prepare_user_script:
-    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
-    - useradd -m -G kvm ranchertest
-    - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
-    - chown -R ranchertest.ranchertest /home/ranchertest
 
   node_modules_cache:
     folder: /home/ranchertest/node_modules

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
   install_deps_script: |
     apt-get update
-    apt-get install -y --no-install-recommends golang openssh-client netcat sudo vim
+    apt-get install -y --no-install-recommends golang openssh-client netcat sudo vim curl
     apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && apt-get install -y nodejs && node -v && npm -v
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,6 @@ task:
 
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |
-    groupadd -g $(stat -c '%g' /dev/kvm) kvm
     useradd -m -G kvm ranchertest
     cp -rf . /home/ranchertest
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,6 @@ task:
 
   # Tests should run as non-root user - setting up a test user
   prepare_user_script:
-    - groupadd -g $(stat -c '%g' /dev/kvm) kvm
     - useradd -m -G kvm ranchertest
     - tar c --owner=ranchertest:ranchertest . | tar x --directory=/home/ranchertest
     - chown -R ranchertest.ranchertest /home/ranchertest

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ task:
   name: E2E/Integration Tests
   timeout_in: 45
   container:
-    image: node:14.18.2
+    image: ubuntu:21.04
     kvm: true # required for E2E/Integrations tests
     cpu: 4
     memory: 8G
@@ -17,11 +17,10 @@ task:
     apt-get update
     apt-get install -y --no-install-recommends golang openssh-client netcat sudo vim
     apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-    node --version && npm -v
+    curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash - && apt-get install -y nodejs && node -v && npm -v
 
   # Tests should run as non-root user - setting up a test user
   prepate_user_script: |
-    cp /bin/tar /usr/bin/tar
     groupadd -g $(stat -c '%g' /dev/kvm) kvm
     useradd -m -G kvm ranchertest
     cp -rf . /home/ranchertest


### PR DESCRIPTION
### Changes
1. Set up cirrus ci workflow
2. Manual trigger only

Note: The workflow has `manual trigger` and it will be shown as a grey `neutral` task on git hub checking. It won't affect your PR status or even block you to merge it in main.

![Screen Shot 2021-12-08 at 12 32 26 PM](https://user-images.githubusercontent.com/37411123/145264199-36b0083c-a929-4220-a21a-5ccac2240861.png)

Updated 
* https://cirrus-ci.com/task/5241162284924928
* ~~https://cirrus-ci.com/task/6352946311987200~~
* ~~https://cirrus-ci.com/task/6247811351052288~~
* ~~https://cirrus-ci.com/task/6542483011141632~~

#### The problem
Why not GHA?
* GHA does not support KVM on their runners, making it impossible to run our integration tests in CI
* Even though, GHA have their [runners](https://github.com/actions/virtual-environments/blob/1678e31616b0153040fd82249570929344a96959/images/win/windows2022.json#L18) on top of `Dsv4-series` Azure machines, the feature is disabled by security reasons (applied for Windows and Linux runners).
* Windows runners does not have `WSL2` installed, only `WSL1`.

#### Solution - 01
[Cirrus CI ](https://github.com/marketplace/cirrus-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45OTA=#pricing-and-setup)has linux runners with KVM feature embedded, it being possible to execute our E2E/Integration tests in CI. Lima already uses Cirrus pipelines and it seems very reliable.
Unfortunately, it won't be possible to run our test suite cross-platform due Windows and macOS runners does not have KVM support. 

#### Solution - 02
* Create/host our own self-hosted public CI pipelines (we can use GHA, Argo Workflows or another self-hosted CI provider)

#### Challenges
* Hosting our own CI Pipelines for a public repository could be risky - see more [here](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories)
* It will bring costs to maintain the pipelines working (infrastructure + internal resources)