### PR TITLE
WSL-Helper: Force stop process as needed.

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
+
+	// Pull in to register the mungers
+	_ "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/mungers"
+)
+
+var dockerproxyKillViper = viper.New()
+
+// dockerproxyKillCmd is the `wsl-helper docker-proxy kill` command.
+var dockerproxyKillCmd = &cobra.Command{
+	Use:   "kill",
+	Short: "Force stop any instances of the docker socket proxy server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := process.KillOthers("docker-proxy", "serve")
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	dockerproxyKillViper.AutomaticEnv()
+	dockerproxyKillViper.BindPFlags(dockerproxyKillCmd.Flags())
+	dockerproxyCmd.AddCommand(dockerproxyKillCmd)
+}

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -38,7 +38,7 @@ var dockerproxyServeCmd = &cobra.Command{
 		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		proxyEndpoint := dockerproxyServeViper.GetString("proxy-endpoint")
-		err := process.KillOthers()
+		err := process.KillOthers("docker-proxy", "serve")
 		if err != nil {
 			return err
 		}

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -12,13 +12,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// KillOthers will kill any other processes with the same command line.
-func KillOthers() error {
+// KillOthers will kill any other processes with the executable.
+func KillOthers(args ...string) error {
 	selfPid := fmt.Sprintf("%d", os.Getpid())
-	selfCmd, err := ioutil.ReadFile("/proc/self/cmdline")
+	selfFile, err := os.Readlink("/proc/self/exe")
 	if err != nil {
-		logrus.WithError(err).Error("could not read /proc/self/cmdline")
+		logrus.WithError(err).Error("could not read /proc/self/exe")
 		return err
+	}
+	var argsBytes []byte
+	for _, arg := range args {
+		argsBytes = append(argsBytes, []byte(arg)...)
+		argsBytes = append(argsBytes, byte(0))
 	}
 	var pids []int
 	// Read /proc, ignoring errors - any entries we _could_ read are returned.
@@ -27,21 +32,47 @@ func KillOthers() error {
 		if !proc.IsDir() || proc.Name() == selfPid || proc.Name() == "self" {
 			continue
 		}
+		procFile, err := os.Readlink(path.Join("/proc", proc.Name(), "exe"))
+		if err != nil {
+			// pid died, or we don't have permissions, or it's not a pid.
+			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read exe")
+			continue
+		}
+		if selfFile != procFile {
+			logrus.WithFields(logrus.Fields{
+				"pid":                 proc.Name(),
+				"expected executable": selfFile,
+				"executable":          procFile,
+			}).Trace("pid has different executable")
+			continue
+		}
 		procCmd, err := ioutil.ReadFile(path.Join("/proc", proc.Name(), "cmdline"))
 		if err != nil {
 			// pid died, or we don't have permissions, or it's not a pid.
-			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read cmdline")
+			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read command line")
 			continue
 		}
-		if bytes.Compare(selfCmd, procCmd) == 0 {
-			// A different pid has the same command line; kill it.
-			pid, err := strconv.Atoi(proc.Name())
-			if err == nil {
-				pids = append(pids, pid)
-			}
+		procCmd = bytes.ReplaceAll(procCmd, []byte("\x00--verbose\x00"), []byte{0})
+		procArgs := bytes.SplitN(procCmd, []byte{0}, 2)
+		if len(procArgs) < 2 {
+			logrus.WithField("pid", proc.Name()).Trace("pid has no args")
+			continue
+		} else if bytes.Compare(argsBytes, procArgs[1]) != 0 {
+			// pid args are not the expected args
+			logrus.WithFields(logrus.Fields{
+				"pid":           proc.Name(),
+				"expected args": string(argsBytes),
+				"actual args":   string(procArgs[1]),
+			}).Trace("pid has incorrect arguments")
+			continue
+		}
+		pid, err := strconv.Atoi(proc.Name())
+		if err == nil {
+			pids = append(pids, pid)
 		}
 	}
 	for _, pid := range pids {
+		logrus.WithField("pid", pid).Debug("Attempting to kill pid")
 		proc, err := os.FindProcess(pid)
 		if err == nil {
 			err = proc.Signal(syscall.SIGTERM)

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -216,7 +216,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         const exe = resources.executable('wsl-helper');
         const stream = await Logging['wsl-helper'].fdStream;
 
-        return childProcess.spawn(exe, ['docker-proxy', 'serve'], {
+        return childProcess.spawn(exe, ['docker-proxy', 'serve', ...this.debugArg('--verbose')], {
           stdio:       ['ignore', stream, stream],
           windowsHide: true,
         });
@@ -691,6 +691,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
     await this.execCommand('mkdir', '-p', '/var/local/bin');
     await this.wslInstall(trivyExecPath, '/usr/local/bin');
+  }
+
+  /**
+   * debugArg returns the given arguments in an array if the debug flag is
+   * set, else an empty array.
+   */
+  protected debugArg(...args: string[]): string[] {
+    return this.debug ? args : [];
   }
 
   /**
@@ -1272,7 +1280,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         const logStream = await Logging[`wsl-helper.${ distro }`].fdStream;
 
         return childProcess.spawn('wsl.exe',
-          ['--distribution', distro, '--user', 'root', '--exec', executable, 'docker-proxy', 'serve'],
+          ['--distribution', distro, '--user', 'root', '--exec', executable,
+            'docker-proxy', 'serve', ...this.debugArg('--verbose')],
           { stdio: ['ignore', logStream, logStream] }
         );
       },
@@ -1281,8 +1290,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
         child.kill('SIGTERM');
         await this.execWSL({ encoding: 'utf-8', logStream },
-          '--distribution', distro, '--user', 'root',
-          '--exec', executable, 'docker-proxy', 'kill');
+          '--distribution', distro, '--user', 'root', '--exec', executable,
+          'docker-proxy', 'kill', ...this.debugArg('--verbose'));
       });
   }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -104,7 +104,7 @@ class BackgroundProcess {
    */
   protected spawn: () => Promise<childProcess.ChildProcess>;
 
-  /** A fuction which will terminate the process. */
+  /** A function which will terminate the process. */
   protected destroy: (child: childProcess.ChildProcess) => Promise<void>;
 
   /**

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -713,6 +713,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
       // We need two separate calls so TypeScript can resolve the return values.
       if (options.capture) {
+        console.debug(`Capturing output: wsl.exe ${ args.join(' ') }`);
         const { stdout } = await childProcess.spawnFile('wsl.exe', args, {
           ...options,
           encoding:    options.encoding ?? 'utf16le',
@@ -722,6 +723,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
         return stdout;
       }
+      console.debug(`Running: wsl.exe ${ args.join(' ') }`);
       await childProcess.spawnFile('wsl.exe', args, {
         ...options,
         encoding:    options.encoding ?? 'utf16le',

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -71,6 +71,8 @@ type execOptions = childProcess.CommonOptions & {
   encoding?: BufferEncoding;
   /** Expect the command to fail; do not log on error.  Exceptions are still thrown. */
   expectFailure?: boolean;
+  /** A custom log stream to write to; must have a file descriptor. */
+  logStream?: stream.Writable;
 };
 
 function defined<T>(input: T | undefined | null): input is T {
@@ -102,6 +104,9 @@ class BackgroundProcess {
    */
   protected spawn: () => Promise<childProcess.ChildProcess>;
 
+  /** A fuction which will terminate the process. */
+  protected destroy: (child: childProcess.ChildProcess) => Promise<void>;
+
   /**
    * Whether the process should be running.
    */
@@ -112,10 +117,22 @@ class BackgroundProcess {
    */
   protected timer: NodeJS.Timeout | null = null;
 
-  constructor(backend: K8s.KubernetesBackend, name: string, spawn: () => Promise<childProcess.ChildProcess>) {
+  /**
+   *
+   * @param backend The owning Kubernetes backend; this is used to avoid running in an invalid state.
+   * @param name A descriptive name of the process for logging.
+   * @param spawn A function to create the underlying child process.
+   * @param destroy Optional function to stop the underlying child process.
+   */
+  constructor(backend: K8s.KubernetesBackend, name: string, spawn: typeof BackgroundProcess.prototype.spawn, destroy?: typeof BackgroundProcess.prototype.destroy) {
     this.backend = backend;
     this.name = name;
     this.spawn = spawn;
+    this.destroy = destroy ?? ((process) => {
+      process?.kill('SIGTERM');
+
+      return Promise.resolve();
+    });
   }
 
   /**
@@ -133,11 +150,13 @@ class BackgroundProcess {
   protected async restart() {
     if (!this.shouldRun || ![K8s.State.STARTING, K8s.State.STARTED].includes(this.backend.state)) {
       console.debug(`Not restarting ${ this.name }: ${ this.shouldRun } / ${ this.backend.state }`);
-      this.stop();
+      await this.stop();
 
       return;
     }
-    this.process?.kill('SIGTERM');
+    if (this.process) {
+      await this.destroy(this.process);
+    }
     if (this.timer) {
       // Ideally, we should use this.timer.refresh(); however, it does not
       // appear to actually trigger.
@@ -169,13 +188,15 @@ class BackgroundProcess {
   /**
    * Stop the process and do not restart it.
    */
-  stop() {
+  async stop() {
     console.log(`Stopping background process ${ this.name }.`);
     this.shouldRun = false;
     if (this.timer) {
       clearTimeout(this.timer);
     }
-    this.process?.kill('SIGTERM');
+    if (this.process) {
+      await this.destroy(this.process);
+    }
   }
 }
 
@@ -536,8 +557,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     await Promise.all([
       this.execWSL('--terminate', INSTANCE_NAME),
       this.execWSL('--terminate', DATA_INSTANCE_NAME),
+      ...Object.values(this.mobySocketProxyProcesses).map(proc => proc.stop())
     ]);
-    Object.values(this.mobySocketProxyProcesses).forEach(proc => proc.stop());
   }
 
   /**
@@ -688,7 +709,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       options = optionsOrArg;
     }
     try {
-      const stream = await Logging['wsl-exec'].fdStream;
+      const stream = options.logStream ?? await Logging['wsl-exec'].fdStream;
 
       // We need two separate calls so TypeScript can resolve the return values.
       if (options.capture) {
@@ -1010,7 +1031,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
                   await this.setupIntegrationProcess(distro);
                   this.mobySocketProxyProcesses[distro].start();
                 } else {
-                  this.mobySocketProxyProcesses[distro]?.stop();
+                  await this.mobySocketProxyProcesses[distro]?.stop();
                 }
               }
             });
@@ -1105,7 +1126,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'docker', 'stop');
         }
         this.process?.kill('SIGTERM');
-        Object.values(this.mobySocketProxyProcesses).forEach(proc => proc.stop());
+        await Promise.all(Object.values(this.mobySocketProxyProcesses).map(proc => proc.stop()));
         if (await this.isDistroRegistered({ runningOnly: true })) {
           await this.execWSL('--terminate', INSTANCE_NAME);
         }
@@ -1244,17 +1265,23 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async setupIntegrationProcess(distro: string) {
     const executable = await this.getWSLHelperPath();
 
-    this.mobySocketProxyProcesses[distro] ??= new BackgroundProcess(this, `${ distro } socket proxy`, async() => {
-      const stream = await Logging[`wsl-helper.${ distro }`].fdStream;
+    this.mobySocketProxyProcesses[distro] ??= new BackgroundProcess(this, `${ distro } socket proxy`,
+      async() => {
+        const logStream = await Logging[`wsl-helper.${ distro }`].fdStream;
 
-      return childProcess.spawn('wsl.exe',
-        ['--distribution', distro, '--user', 'root', '--exec', executable, 'docker-proxy', 'serve'],
-        {
-          stdio:       ['ignore', stream, stream],
-          windowsHide: true,
-        }
-      );
-    });
+        return childProcess.spawn('wsl.exe',
+          ['--distribution', distro, '--user', 'root', '--exec', executable, 'docker-proxy', 'serve'],
+          { stdio: ['ignore', logStream, logStream] }
+        );
+      },
+      async(child: childProcess.ChildProcess) => {
+        const logStream = await Logging[`wsl-helper.${ distro }`].fdStream;
+
+        child.kill('SIGTERM');
+        await this.execWSL({ encoding: 'utf-8', logStream },
+          '--distribution', distro, '--user', 'root',
+          '--exec', executable, 'docker-proxy', 'kill');
+      });
   }
 
   async setIntegration(distro: string, state: boolean): Promise<string | undefined> {
@@ -1283,7 +1310,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         await this.setupIntegrationProcess(distro);
         this.mobySocketProxyProcesses[distro].start();
       } else {
-        this.mobySocketProxyProcesses[distro]?.stop();
+        await this.mobySocketProxyProcesses[distro]?.stop();
       }
     } catch (error) {
       console.error(`Could not set up kubeconfig integration for ${ distro }:`, error);


### PR DESCRIPTION
It seems like killing the `wsl.exe` process (and therefore the controlling terminal) does not always send `SIGTERM` (or even `SIGHUP`) to the Linux-side process.  This PR implements an extra command on `wsl-helper` to manually find the process and terminate it, instead.

Also includes some fixups to debug logging, which was used to figure out what was going wrong…

Fixes #1059.