### PR TITLE
Run the kim builder depending on the current engine.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -23,7 +23,6 @@ import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
 import setupPaths from '@/main/paths';
 import buildApplicationMenu from '@/main/mainmenu';
-import { ContainerEngine } from '@/config/settings';
 
 Electron.app.setName('Rancher Desktop');
 

--- a/background.ts
+++ b/background.ts
@@ -620,6 +620,11 @@ function handleFailure(payload: any) {
   if (payload instanceof K8s.KubernetesError) {
     ({ name: titlePart, message } = payload);
   } else if (payload instanceof K8s.KimBuilderInstallError) {
+    if (k8smanager?.state !== K8s.State.STARTED) {
+      // Most likely we're shutting down or switching container engines before
+      // kim builder (u)install has finished.
+      return;
+    }
     titlePart = 'Attempting to install a buildkit pod failed';
     message = `${ payload.message }\nA Kubernetes reset is needed only to support building images.\n
 Full error messages are in images.log.`;

--- a/background.ts
+++ b/background.ts
@@ -619,6 +619,10 @@ function handleFailure(payload: any) {
 
   if (payload instanceof K8s.KubernetesError) {
     ({ name: titlePart, message } = payload);
+  } else if (payload instanceof K8s.KimBuilderInstallError) {
+    titlePart = 'Attempting to install a buildkit pod failed';
+    message = `${ payload.message }\nA Kubernetes reset is needed only to support building images.\n
+Full error messages are in images.log.`;
   } else if (payload instanceof Error) {
     message += `: ${ payload }`;
   } else if (typeof payload === 'number') {
@@ -635,6 +639,8 @@ function handleFailure(payload: any) {
     }
   })();
 }
+
+mainEvents.on('handle-failure', handleFailure);
 
 function newK8sManager() {
   const arch = (Electron.app.runningUnderRosettaTranslation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -530,7 +530,7 @@ export class KubeClient extends events.EventEmitter {
       return [];
     }
 
-    return this.services.list(namespace).flatMap((service) => {
+    return this.services.list(namespace)?.flatMap((service) => {
       return (service.spec?.ports || []).map((port) => {
         const namespace = service.metadata?.namespace;
         const name = service.metadata?.name || '';

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -539,7 +539,7 @@ export abstract class ImageProcessor extends EventEmitter {
       console.log('Waiting for the kubernetes backend to start using the newest nodes.');
       if ((Date.now() - startTime) > maxWaitTime) {
         console.log(`Waited more than ${ maxWaitTime / 1000 } secs; Probably a reset is needed to build images.`);
-        break;
+        throw new K8s.KimBuilderInstallError(`Attempt to run 'kim install builder' failed: Timed out waiting for ${ maxWaitTime / 1000 } secs`);
       }
       await util.promisify(setTimeout)(waitTime);
     }
@@ -561,9 +561,8 @@ export abstract class ImageProcessor extends EventEmitter {
   /**
    * Uninstall the kim backend builder, not needed for moby
    * @param backend API to communicate with Kubernetes.
-   * @param address For the kim image processor, the end point address.
    */
-  async uninstallKimBuilder(backend: K8s.KubernetesBackend, address?: string) {
+  async uninstallKimBuilder(backend: K8s.KubernetesBackend) {
     const services = backend.listServices('kube-image');
 
     if (!services?.length) {
@@ -572,10 +571,6 @@ export abstract class ImageProcessor extends EventEmitter {
       return;
     }
     const args = ['builder', 'uninstall'];
-
-    if (address) {
-      args.push('--endpoint-addr', address);
-    }
 
     console.log(`Uninstalling kim: kim ${ args.join(' ') }`);
 

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -515,7 +515,7 @@ export abstract class ImageProcessor extends EventEmitter {
     // this is treated as a fatal but non-terminating error -- the user is advised that they might
     // need to reset kubernetes in order to build images with nerdctl.
     //
-    // Once it can successfully run `docker builder install`, it moves to the next loop.
+    // Once it can successfully run `kim builder install`, it moves to the next loop.
     // Otherwise it fails on a timeout, again with a logged suggestion to reset kubernetes.
     while (true) {
       try {

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -16,6 +16,7 @@ import mainEvents from '@/main/mainEvents';
 import Logging from '@/utils/logging';
 import resources from '@/resources';
 import LimaBackend from '@/k8s-engine/lima';
+import { KimBuilderInstallError } from '@/k8s-engine/k8s';
 
 const REFRESH_INTERVAL = 5 * 1000;
 const APP_NAME = 'rancher-desktop';
@@ -531,8 +532,7 @@ export abstract class ImageProcessor extends EventEmitter {
         if (!e.stderr?.includes('Error: container runtime `docker` not supported')) {
           console.error(`Attempt to run 'kim install builder' => error: '${ e.stderr }'`);
           console.error('A reset might be necessary to support building images.');
-
-          return;
+          throw new K8s.KimBuilderInstallError(`Attempt to run 'kim install builder' failed`);
         }
       }
 
@@ -547,7 +547,7 @@ export abstract class ImageProcessor extends EventEmitter {
     // And now wait for the builder to be ready
     while (true) {
       if (await backend.isServiceReady('kube-image', 'builder')) {
-        console.log('Image-building support is now installed and running');
+        console.debug('Image-building support is now installed and running');
         break;
       }
       if ((Date.now() - startTime) > maxWaitTime) {
@@ -567,7 +567,7 @@ export abstract class ImageProcessor extends EventEmitter {
     const services = backend.listServices('kube-image');
 
     if (!services?.length) {
-      console.log(`No services: ${ services }`);
+      console.debug(`No services: typeof services: ${ typeof services }`);
 
       return;
     }

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -530,7 +530,7 @@ export abstract class ImageProcessor extends EventEmitter {
         console.error(`Failed to restart the kim builder: ${ e.message }.`);
         if (e.stderr?.includes('Error: container runtime `docker` not supported')) {
           console.log(`Ignoring 'kim install builder' error message: '${ e.stderr }'`);
-          console.log('This problem should be resolved shortly.')
+          console.log('This problem should be resolved shortly.');
         } else {
           console.error(`Attempt to run 'kim install builder' => error: '${ e.stderr }'`);
           console.error('A reset might be necessary to support building images.');

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -20,12 +20,17 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
       }
       // There's no need to install kim when using moby, so don't.
       this.isK8sReady = mgr.state === K8s.State.STARTED;
-      this.updateWatchStatus();
-      if (this.isK8sReady) {
-        // On an upgrade it's possible that the builder pod is running from a previous run, so uninstall it
-        // This can also happen if someone changes the preferred engine setting from 'containerd' to 'moby'
-        // and then restarts the app.
-        await this.uninstallKimBuilder(this.k8sManager as K8s.KubernetesBackend);
+      try {
+        this.updateWatchStatus();
+        if (this.isK8sReady) {
+          // On an upgrade it's possible that the builder pod is running from a previous run, so uninstall it
+          // This can also happen if someone changes the preferred engine setting from 'containerd' to 'moby'
+          // and then restarts the app.
+          await this.uninstallKimBuilder(this.k8sManager as K8s.KubernetesBackend);
+        }
+      } catch (e) {
+        // No need to relay this to the user via a dialog box
+        console.log('Uninstalling buildkit failed', e);
       }
     });
   }

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -26,11 +26,11 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
           // On an upgrade it's possible that the builder pod is running from a previous run, so uninstall it
           // This can also happen if someone changes the preferred engine setting from 'containerd' to 'moby'
           // and then restarts the app.
-          await this.uninstallKimBuilder(this.k8sManager as K8s.KubernetesBackend);
+          await this.uninstallKimBuilder(mgr);
         }
       } catch (e) {
         // No need to relay this to the user via a dialog box
-        console.log('Uninstalling buildkit failed', e);
+        console.error('Uninstalling buildkit failed', e);
       }
     });
   }

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -1,12 +1,10 @@
 import { spawn } from 'child_process';
-import os from 'os';
 import path from 'path';
 
 import Logging from '@/utils/logging';
 import resources from '@/resources';
 import * as imageProcessor from '@/k8s-engine/images/imageProcessor';
 import mainEvents from '@/main/mainEvents';
-import paths from '@/utils/paths';
 import * as K8s from '@/k8s-engine/k8s';
 import * as window from '@/window';
 
@@ -27,7 +25,6 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
         // On an upgrade it's possible that the builder pod is running from a previous run, so uninstall it
         // This can also happen if someone changes the preferred engine setting from 'containerd' to 'moby'
         // and then restarts the app.
-        console.log(`QQQ: -uninstallKimBuilder...`);
         await this.uninstallKimBuilder(this.k8sManager as K8s.KubernetesBackend);
       }
     });

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -38,7 +38,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
           if (mgr.state !== K8s.State.STARTED) {
             console.debug(`Ignoring KimBuilderInstallError ${ e } during state ${ mgr.state }`);
           } else {
-            mainEvents.emit('handle-failure', e.name, e.message, e.fatal);
+            mainEvents.emit('handle-failure', e.name, e.message);
           }
         } else {
           console.error('Error trying to install kim builder: ', e);

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -19,18 +19,22 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
         return;
       }
       this.isK8sReady = mgr.state === K8s.State.STARTED;
-      this.updateWatchStatus();
-      if (this.isK8sReady) {
-        let endpoint: string | undefined;
+      try {
+        this.updateWatchStatus();
+        if (this.isK8sReady) {
+          let endpoint: string | undefined;
 
-        // XXX temporary hack: use a fixed address for kim endpoint
-        if (mgr.backend === 'lima') {
-          endpoint = '127.0.0.1';
+          // XXX temporary hack: use a fixed address for kim endpoint
+          if (mgr.backend === 'lima') {
+            endpoint = '127.0.0.1';
+          }
+
+          const needsForce = !(await this.isInstallValid(mgr, endpoint));
+
+          await this.installKimBuilder(mgr, needsForce, endpoint);
         }
-
-        const needsForce = !(await this.isInstallValid(mgr, endpoint));
-
-        await this.installKimBuilder(mgr, needsForce, endpoint);
+      } catch (e) {
+        mainEvents.emit('handle-failure', e);
       }
     });
   }

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -30,7 +30,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
 
         const needsForce = !(await this.isInstallValid(mgr, endpoint));
 
-        await this.install(mgr, needsForce, endpoint);
+        await this.installKimBuilder(mgr, needsForce, endpoint);
       }
     });
   }

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -34,7 +34,15 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
           await this.installKimBuilder(mgr, needsForce, endpoint);
         }
       } catch (e) {
-        mainEvents.emit('handle-failure', e);
+        if (e instanceof K8s.KimBuilderInstallError) {
+          if (mgr.state !== K8s.State.STARTED) {
+            console.debug(`Ignoring KimBuilderInstallError ${ e } during state ${ mgr.state }`);
+          } else {
+            mainEvents.emit('handle-failure', e.name, e.message, e.fatal);
+          }
+        } else {
+          console.error('Error trying to install kim builder: ', e);
+        }
       }
     });
   }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -30,11 +30,9 @@ export class KubernetesError extends Error {
 }
 
 export class KimBuilderInstallError extends Error {
-  readonly fatal: boolean;
   constructor(titlePart: string, message: string) {
     super(message);
     this.name = titlePart;
-    this.fatal = false;
   }
 }
 

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -29,7 +29,14 @@ export class KubernetesError extends Error {
   readonly fatal: boolean;
 }
 
-export class KimBuilderInstallError extends Error { }
+export class KimBuilderInstallError extends Error {
+  readonly fatal: boolean;
+  constructor(titlePart: string, message: string) {
+    super(message);
+    this.name = titlePart;
+    this.fatal = false;
+  }
+}
 
 export type KubernetesProgress = {
   /** The current progress; valid values are 0 to max. */

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -29,6 +29,8 @@ export class KubernetesError extends Error {
   readonly fatal: boolean;
 }
 
+export class KimBuilderInstallError extends Error { }
+
 export type KubernetesProgress = {
   /** The current progress; valid values are 0 to max. */
   current: number,

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -81,6 +81,7 @@ interface IpcMainInvokeEvents {
  */
 export interface IpcRendererEvents {
   'settings-update': (settings: import('@/config/settings').Settings) => void;
+  'handle-failure': (err: Error) => void;
   'settings-read': (settings: import('@/config/settings').Settings) => void;
   'get-app-version': (version: string) => void;
   'update-state': (state: import('@/main/update').UpdateState) => void;

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -81,7 +81,7 @@ interface IpcMainInvokeEvents {
  */
 export interface IpcRendererEvents {
   'settings-update': (settings: import('@/config/settings').Settings) => void;
-  'handle-failure': (err: Error) => void;
+  'handle-failure': (titlePart: string, message: string, fatal?: boolean) => void;
   'settings-read': (settings: import('@/config/settings').Settings) => void;
   'get-app-version': (version: string) => void;
   'update-state': (state: import('@/main/update').UpdateState) => void;

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -81,7 +81,7 @@ interface IpcMainInvokeEvents {
  */
 export interface IpcRendererEvents {
   'settings-update': (settings: import('@/config/settings').Settings) => void;
-  'handle-failure': (titlePart: string, message: string, fatal?: boolean) => void;
+  'handle-failure': (titlePart: string, message: string) => void;
   'settings-read': (settings: import('@/config/settings').Settings) => void;
   'get-app-version': (version: string) => void;
   'update-state': (state: import('@/main/update').UpdateState) => void;


### PR DESCRIPTION
When using the containerd container engine, we need to install
`kim builder` in order to support building images.

When using moby, we can tear down the kubernetes resources that
`kim builder install` installs.` Best way to do this is to run
`kim builder uninstall`.

Now the main gotcha here is that when we change engines, it takes
some time for kubernetes to report that it's using the correct
engine with the command

    kubectl get node -o jsonpath={.items[].status.nodeInfo.containerRuntimeVersion}

A second gotcha is that if we want to see if we need to run `kim builder uninstall`,
using existing code, we need to tell it not to wait for a particular kubernetes state
if we're okay if that state can't be met. So we end up passing a parameter called
`waitForSubsets` (default value `true` to reflect current behavior) through a
several layers of function calls.

Signed-off-by: Eric Promislow <epromislow@suse.com>