### PR TITLE
Windows: fix factory reset

### DIFF
--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -221,7 +221,7 @@ export default {
      */
     const buildPlatform = async(platform) => {
       const exeName = platform === 'win32' ? 'wsl-helper.exe' : 'wsl-helper';
-      const outFile = path.join(this.srcDir, 'resources', platform, 'bin', exeName);
+      const outFile = path.join(this.srcDir, 'resources', platform, exeName);
 
       await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', outFile, '.', {
         cwd: path.join(this.srcDir, 'src', 'go', 'wsl-helper'),

--- a/src/go/wsl-helper/cmd/factoryreset.go
+++ b/src/go/wsl-helper/cmd/factoryreset.go
@@ -1,0 +1,63 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/reset"
+)
+
+var factoryResetViper = viper.New()
+
+// factoryResetCmd represents the `wsl-helper factory-reset`
+var factoryResetCmd = &cobra.Command{
+	Use:    "factory-reset",
+	Short:  "Commands for interacting with k3s in WSL",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pid := factoryResetViper.GetUint32("wait-pid")
+		if pid != 0 {
+			if err := process.WaitPid(pid); err != nil {
+				return err
+			}
+		}
+		if err := reset.FactoryReset(); err != nil {
+			return err
+		}
+		launch := factoryResetViper.GetString("launch")
+		if launch != "" {
+			if err := process.Launch(launch); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	factoryResetCmd.Flags().Uint32("wait-pid", 0, "Wait for given process to exit before starting")
+	factoryResetCmd.Flags().String("launch", "", "Launch process when done")
+	factoryResetViper.AutomaticEnv()
+	factoryResetViper.BindPFlags(factoryResetCmd.Flags())
+	rootCmd.AddCommand(factoryResetCmd)
+}

--- a/src/go/wsl-helper/cmd/root.go
+++ b/src/go/wsl-helper/cmd/root.go
@@ -28,8 +28,9 @@ var rootCmd = &cobra.Command{
 	Long:  `This command handles various WSL2 integration tasks for Rancher Desktop.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if viper.GetBool("verbose") {
-			logrus.SetLevel(logrus.DebugLevel)
+			logrus.SetLevel(logrus.TraceLevel)
 		}
+		logrus.SetLevel(logrus.TraceLevel)
 	},
 }
 

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package process
 
 import (

--- a/src/go/wsl-helper/pkg/process/run_windows.go
+++ b/src/go/wsl-helper/pkg/process/run_windows.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package process
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func Launch(executable string, args ...string) error {
+	err := exec.Command(executable, args...).Start()
+	if err != nil {
+		return fmt.Errorf("failed to start %s: %w", executable, err)
+	}
+	return nil
+}

--- a/src/go/wsl-helper/pkg/process/wait_windows.go
+++ b/src/go/wsl-helper/pkg/process/wait_windows.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package process
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32Dll = windows.MustLoadDLL("Kernel32.dll")
+)
+
+// WaitPid waits for the process with the given PID to exit before returning.
+func WaitPid(pid uint32) error {
+	logEntry := logrus.WithField("pid", pid)
+	logEntry.Trace("trying to wait for process")
+	openProcess, err := kernel32Dll.FindProc("OpenProcess")
+	if err != nil {
+		return fmt.Errorf("could not find OpenProcess: %w", err)
+	}
+	hProcRaw, _, err := openProcess.Call(
+		windows.SYNCHRONIZE,
+		0,
+		uintptr(pid),
+	)
+	if hProcRaw == 0 {
+		return fmt.Errorf("could not get handle to process %d: %w", pid, err)
+	}
+	hProc := windows.Handle(hProcRaw)
+	defer windows.CloseHandle(hProc)
+
+	logEntry.Trace("waiting for process")
+	result, err := windows.WaitForSingleObject(hProc, windows.INFINITE)
+	if err != nil {
+		return fmt.Errorf("failed to wait for process %d: %w", pid, err)
+	}
+	logEntry.WithField("result", result).Trace("finished waiting for process")
+	return nil
+}

--- a/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
+++ b/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reset implements factory reset for Windows.
+package reset
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	appName = "rancher-desktop"
+)
+
+// Factory reset deletes any Rancher Desktop user data.
+func FactoryReset() error {
+	appData, err := getKnownFolder(windows.FOLDERID_RoamingAppData)
+	if err != nil {
+		return fmt.Errorf("could not get AppData folder: %w", err)
+	}
+	localAppData, err := getKnownFolder(windows.FOLDERID_LocalAppData)
+	if err != nil {
+		return fmt.Errorf("could not get LocalAppData folder: %w", err)
+	}
+	for _, dir := range []string{
+		// Ordered from least important to most, so that if delete fails we
+		// still keep some of the useful data.
+		path.Join(localAppData, fmt.Sprintf("%s-updater", appName)),
+		path.Join(localAppData, appName),
+		path.Join(appData, appName),
+	} {
+		logrus.WithField("path", dir).Trace("Removing directory")
+		if err := os.RemoveAll(dir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("could not remove %s: %w", dir, err)
+			}
+		}
+	}
+	return nil
+}
+
+var (
+	ole32Dll   = windows.MustLoadDLL("Ole32.dll")
+	shell32Dll = windows.MustLoadDLL("Shell32.dll")
+)
+
+// getKnownFolder gets a Windows known folder.  See https://git.io/JMpgD
+func getKnownFolder(folder *windows.KNOWNFOLDERID) (string, error) {
+	SHGetKnownFolderPath, err := shell32Dll.FindProc("SHGetKnownFolderPath")
+	if err != nil {
+		return "", fmt.Errorf("could not find SHGetKnownFolderPath: %w", err)
+	}
+	CoTaskMemFree, err := ole32Dll.FindProc("CoTaskMemFree")
+	if err != nil {
+		return "", fmt.Errorf("could not find CoTaskMemFree: %w", err)
+	}
+	var result uintptr
+	hr, _, _ := SHGetKnownFolderPath.Call(
+		uintptr(unsafe.Pointer(folder)),
+		0,
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(&result)),
+	)
+	// SHGetKnownFolderPath documentation says we _must_ free the result with
+	// CoTaskMemFree, even if the call failed.
+	defer CoTaskMemFree.Call(result)
+	if hr != 0 {
+		return "", windows.Errno(hr)
+	}
+
+	// result at this point containers the path, as a PWSTR
+	// Note that `go vet` has a false positive here on "misuse of Pointer".
+	return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(result))), nil
+}

--- a/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
+++ b/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
@@ -88,7 +88,7 @@ func getKnownFolder(folder *windows.KNOWNFOLDERID) (string, error) {
 		return "", windows.Errno(hr)
 	}
 
-	// result at this point containers the path, as a PWSTR
+	// result at this point contains the path, as a PWSTR
 	// Note that `go vet` has a false positive here on "misuse of Pointer".
 	return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(result))), nil
 }

--- a/src/go/wsl-helper/pkg/reset/factory_reset_windows_test.go
+++ b/src/go/wsl-helper/pkg/reset/factory_reset_windows_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package reset
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestGetKnownFolder(t *testing.T) {
+	t.Run("AppData", func(t *testing.T) {
+		expected := os.Getenv("APPDATA")
+		actual, err := getKnownFolder(windows.FOLDERID_RoamingAppData)
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected, actual)
+		}
+	})
+	t.Run("LocalAppData", func(t *testing.T) {
+		expected := os.Getenv("LOCALAPPDATA")
+		actual, err := getKnownFolder(windows.FOLDERID_LocalAppData)
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected, actual)
+		}
+	})
+	t.Run("invalid folder", func(t *testing.T) {
+		zeroGuid := windows.KNOWNFOLDERID{}
+		_, err := getKnownFolder(&zeroGuid)
+		if assert.Error(t, err) {
+			notFound := 0x80070002 // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+			assert.Equal(t, windows.Errno(notFound), err)
+		}
+	})
+}

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -192,7 +192,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
     this.mobySocketProxyProcesses = {
       [INTEGRATION_HOST]: new BackgroundProcess(this, 'Win32 socket proxy', async() => {
-        const exe = resources.get('win32', 'bin', 'wsl-helper.exe');
+        const exe = resources.executable('wsl-helper');
         const stream = await Logging['wsl-helper'].fdStream;
 
         return childProcess.spawn(exe, ['docker-proxy', 'serve'], {
@@ -1209,7 +1209,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected getWSLHelperPath(): Promise<string> {
     // We need to get the Linux path to our helper executable; it is easier to
     // just get WSL to do the transformation for us.
-    return this.wslify(resources.get('linux', 'bin', 'wsl-helper'));
+    return this.wslify(resources.get('linux', 'wsl-helper'));
   }
 
   async listIntegrations(): Promise<Record<string, boolean | string>> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1143,19 +1143,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   async factoryReset(): Promise<void> {
+    // The main application data directories will be deleted by a helper
+    // application; we only need to unregister the WSL data.
     await this.del();
-    await Promise.all([paths.cache, paths.config].map(
-      dir => fs.promises.rm(dir, { recursive: true })));
-
-    try {
-      await fs.promises.rmdir(paths.logs, { recursive: true });
-    } catch (error) {
-      // On Windows, we will probably fail to delete the directory as the log
-      // files are held open; we should ignore that error.
-      if (error.code !== 'ENOTEMPTY') {
-        throw error;
-      }
-    }
   }
 
   listServices(namespace?: string): K8s.ServiceEntry[] {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -47,6 +47,7 @@ export class DarwinPaths implements Paths {
 
 /**
  * Win32Paths implements paths for Windows.
+ * Note that this should be kept in sync with .../src/go/wsl-helper/pkg/reset.
  */
 export class Win32Paths implements Paths {
   protected readonly appData = process.env['APPDATA'] || path.join(os.homedir(), 'AppData', 'Roaming');


### PR DESCRIPTION
This changes factory reset on Windows to use wsl-helper as a secondary executable, so we don't have to worry about deleting files that are in use.

Fixes #1075; fixes #1061.