### PR TITLE
WSL: Fix logging with spaces in path.

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -17,7 +17,7 @@ depend() {
 
 start_pre() {
   rm -f /tmp/k3s.*
-  checkpath --file --mode 0644 --owner root "${output_log}" "${error_log}"
+  checkpath --file --mode 0644 --owner root "${output_log_unquoted}" "${error_log_unquoted}"
 }
 
 supervisor=supervise-daemon
@@ -29,8 +29,10 @@ if [ "${ENGINE}" == "moby" ]; then
 fi
 command_args="${command_args} ${K3S_EXEC:-}"
 K3S_LOGFILE="${K3S_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
-output_log="${K3S_OUTFILE:-${K3S_LOGFILE}}"
-error_log="${K3S_ERRFILE:-${K3S_LOGFILE}}"
+output_log_unquoted="${K3S_OUTFILE:-${K3S_LOGFILE}}"
+output_log="'${output_log_unquoted}'"
+error_log_unquoted="${K3S_ERRFILE:-${K3S_LOGFILE}}"
+error_log="'${error_log_unquoted}'"
 
 pidfile="/var/run/k3s.pid"
 respawn_delay=5

--- a/src/assets/scripts/service-wsl-dockerd.initd
+++ b/src/assets/scripts/service-wsl-dockerd.initd
@@ -13,8 +13,8 @@ command="'${WSL_HELPER_BINARY:-/usr/local/bin/wsl-helper}'"
 command_args="docker-proxy start"
 
 DOCKER_LOGFILE="${DOCKER_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
-output_log="${DOCKER_LOGFILE}"
-error_log="${DOCKER_LOGFILE}"
+output_log="'${DOCKER_LOGFILE}'"
+error_log="'${DOCKER_LOGFILE}'"
 
 rc_ulimit="${DOCKER_ULIMIT:--c unlimited -n 1048576 -u unlimited}"
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -688,7 +688,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       options = optionsOrArg;
     }
     try {
-      const stream = await Logging['wsl.exec'].fdStream;
+      const stream = await Logging['wsl-exec'].fdStream;
 
       // We need two separate calls so TypeScript can resolve the return values.
       if (options.capture) {


### PR DESCRIPTION
The [script that OpenRC uses to launch supervise-daemon](https://github.com/OpenRC/openrc/blob/0.44.9/sh/supervise-daemon.sh#L27) doesn't correctly quote the variables; this means that it will get passed unquoted, so if the log path contains spaces it will be split as separate arguments and the second part (and later) will be taken as the command.  Fix that by quoting things manually.

Note that this means when we use the variables internally (e.g. passing to checkpath), we need to use the correct quoting.

Fixes #1082.

Tested with a user named `Jöé Smîth`.