### PR TITLE
WSL: Fix `docker run --mount`

### DIFF
--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.8';
+  const v = '0.9';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/go/wsl-helper/cmd/root.go
+++ b/src/go/wsl-helper/cmd/root.go
@@ -27,10 +27,7 @@ var rootCmd = &cobra.Command{
 	Short: "Rancher Desktop WSL2 integration helper",
 	Long:  `This command handles various WSL2 integration tasks for Rancher Desktop.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if viper.GetBool("verbose") {
-			logrus.SetLevel(logrus.TraceLevel)
-		}
-		logrus.SetLevel(logrus.TraceLevel)
+		logrus.SetLevel(logrus.InfoLevel + logrus.Level(viper.GetInt("verbose")))
 	},
 }
 
@@ -41,12 +38,12 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().Bool("verbose", false, "enable extra logging")
-	viper.BindPFlags(rootCmd.Flags())
+	rootCmd.PersistentFlags().Count("verbose", "enable extra logging")
 	cobra.OnInitialize(initConfig)
 }
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
+	viper.BindPFlags(rootCmd.Flags())
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -53,8 +53,8 @@ import (
 // Note that all persisted info needs to live on disk; it's possible to run
 // containers while restarting the docker proxy (or indeed the machine).
 
-// mountDir is where we can keep our temporary mounts.
-const mountDir = "/mnt/wsl/rancher-desktop/run/docker-mounts"
+// mountRoot is where we can keep our temporary mounts.
+const mountRoot = "/mnt/wsl/rancher-desktop/run/docker-mounts"
 
 // contextKey is the key used to locate the bind manager in the request/response
 // context.  This only lasts for a single request/response pair.
@@ -62,6 +62,9 @@ var contextKey = struct{}{}
 
 // bindManager manages the binding data (but does not do binding itself)
 type bindManager struct {
+	// mountRoot is where we can keep our temporary mounts.
+	mountRoot string
+
 	// Recorded entries, keyed by the random mount point string (the leaf name
 	// of the bind host location, as reported to dockerd).  Each entry is only
 	// used by one container; multiple entries may map to the same host path.
@@ -187,7 +190,7 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 
 		bindKey := b.makeMount()
 		binds[bindKey] = host
-		host = path.Join(mountDir, bindKey)
+		host = path.Join(b.mountRoot, bindKey)
 		modified = true
 		if options == "" {
 			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s", host, container)
@@ -209,7 +212,7 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 
 		bindKey := b.makeMount()
 		binds[bindKey] = mount.Source
-		mount.Source = path.Join(mountDir, bindKey)
+		mount.Source = path.Join(b.mountRoot, bindKey)
 		// Unlike .HostConfig.Binds, the source for .HostConfig.Mounts must
 		// exist at container create time.
 		if err = os.MkdirAll(mount.Source, 0o700); err != nil {
@@ -306,7 +309,7 @@ func (b *bindManager) mungeContainersStartRequest(req *http.Request, contextValu
 
 	// Do bind mounts
 	for bindKey, target := range mapping {
-		mountDir := path.Join(mountDir, bindKey)
+		mountDir := path.Join(b.mountRoot, bindKey)
 		logEntry := logrus.WithFields(logrus.Fields{
 			"container": templates["id"],
 			"bind":      mountDir,
@@ -341,7 +344,7 @@ func (b *bindManager) mungeContainersStartResponse(req *http.Response, contextVa
 	}
 
 	for bindKey := range *binds {
-		mountDir := path.Join(mountDir, bindKey)
+		mountDir := path.Join(b.mountRoot, bindKey)
 		logEntry := logrus.WithFields(logrus.Fields{
 			"container": templates["id"],
 			"bind":      mountDir,

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -65,7 +65,7 @@ type bindManager struct {
 	// Recorded entries, keyed by the random mount point string (the leaf name
 	// of the bind host location, as reported to dockerd).  Each entry is only
 	// used by one container; multiple entries may map to the same host path.
-	entries map[string]bindManagerEntry `json:",omitempty"`
+	entries map[string]bindManagerEntry
 
 	// Name of the file we use for persisting data.
 	statePath string
@@ -172,14 +172,14 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 	if err != nil {
 		return err
 	}
-	logrus.WithField("body", fmt.Sprintf("%+v", body)).Debug("read body")
+	logrus.WithField("body", fmt.Sprintf("%+v", body)).Trace("read body")
 
 	// The list of bindings
 	binds := make(map[string]string)
 
 	modified := false
 	for bindIndex, bind := range body.HostConfig.Binds {
-		logrus.WithField(fmt.Sprintf("bind %d", bindIndex), bind).Debug("got bind")
+		logrus.WithField(fmt.Sprintf("bind %d", bindIndex), bind).Trace("got bind")
 		host, container, options, isPath := platform.ParseBindString(bind)
 		if !isPath {
 			continue
@@ -208,7 +208,7 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 	req.Body = io.NopCloser(bytes.NewBuffer(buf))
 	req.ContentLength = int64(len(buf))
 	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(buf)))
-	logrus.WithField("binds", binds).Debug("modified binds")
+	logrus.WithField("binds", fmt.Sprintf("%+v", binds)).Debug("modified binds")
 
 	return nil
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
@@ -33,32 +33,72 @@ import (
 )
 
 func TestContainersCreate(t *testing.T) {
-	ctx := context.Background()
-	bindPath := t.TempDir()
-	body := containersCreateBody{
-		HostConfig: models.HostConfig{
-			Binds: []string{
-				fmt.Sprintf("%s:/host", bindPath),
+	t.Run("bind", func(t *testing.T) {
+		ctx := context.Background()
+		bindPath := t.TempDir()
+		body := containersCreateBody{
+			HostConfig: models.HostConfig{
+				Binds: []string{
+					fmt.Sprintf("%s:/host", bindPath),
+				},
 			},
-		},
-	}
-	buf, err := json.Marshal(&body)
-	require.NoError(t, err)
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"http://nowhere.invalid/",
-		io.NopCloser(bytes.NewReader(buf)))
-	require.NoError(t, err)
-	contextValue := &dockerproxy.RequestContextValue{}
-	templates := make(map[string]string)
-	err = mungeContainersCreate(req, contextValue, templates)
-	require.NoError(t, err)
+		}
+		buf, err := json.Marshal(&body)
+		require.NoError(t, err)
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			"http://nowhere.invalid/",
+			io.NopCloser(bytes.NewReader(buf)))
+		require.NoError(t, err)
+		contextValue := &dockerproxy.RequestContextValue{}
+		templates := make(map[string]string)
+		err = mungeContainersCreate(req, contextValue, templates)
+		require.NoError(t, err)
 
-	err = readRequestBodyJSON(req, &body)
-	assert.NoError(t, err)
-	slashPath, err := platform.TranslatePathFromClient(bindPath)
-	assert.NoError(t, err)
-	expectedBind := fmt.Sprintf("%s:/host", slashPath)
-	assert.Equal(t, []string{expectedBind}, body.HostConfig.Binds)
+		err = readRequestBodyJSON(req, &body)
+		assert.NoError(t, err)
+		slashPath, err := platform.TranslatePathFromClient(bindPath)
+		assert.NoError(t, err)
+		expectedBind := fmt.Sprintf("%s:/host", slashPath)
+		assert.Equal(t, []string{expectedBind}, body.HostConfig.Binds)
+	})
+
+	t.Run("mount", func(t *testing.T) {
+		ctx := context.Background()
+		bindPath := t.TempDir()
+		mount := models.Mount{
+			Consistency: "cached",
+			Source:      bindPath,
+			Target:      "/host",
+			Type:        "bind",
+		}
+		body := containersCreateBody{
+			HostConfig: models.HostConfig{
+				Mounts: []*models.Mount{&mount},
+			},
+		}
+		buf, err := json.Marshal(&body)
+		require.NoError(t, err)
+		req, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			"http://nowhere.invalid/",
+			io.NopCloser(bytes.NewReader(buf)))
+		require.NoError(t, err)
+		contextValue := &dockerproxy.RequestContextValue{}
+		templates := make(map[string]string)
+		err = mungeContainersCreate(req, contextValue, templates)
+		require.NoError(t, err)
+
+		err = readRequestBodyJSON(req, &body)
+		assert.NoError(t, err)
+		expected := mount
+		slashPath, err := platform.TranslatePathFromClient(bindPath)
+		expected.Source = slashPath
+		assert.NoError(t, err)
+		require.NotEmpty(t, body.HostConfig.Mounts)
+		require.NotNil(t, body.HostConfig.Mounts[0])
+		assert.Equal(t, expected, *body.HostConfig.Mounts[0])
+	})
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
@@ -71,7 +71,7 @@ func Listen(endpoint string) (net.Listener, error) {
 			if err = os.Remove(filepath); err != nil {
 				logrus.WithError(err).WithField("path", filepath).Debug("could not remove dead socket, ignoring.")
 			}
-		} else {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			logrus.WithError(err).Debug("unexpected error connecting to existing socket, ignoring.")
 		}
 	} else {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -55,7 +55,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.8';
+const DISTRO_VERSION = '0.9';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
This adds support for `docker run --mount=…`; there are two places the moby API supports volume mounts.

This requires https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/pull/18 to land first (and the distro to be tagged as 0.9).  The tagging is complete, and CI is currently building the new distribution.

Fixes #1077.