### PR TITLE
WSL-Helper: Display error if kubeconfig is empty.

### DIFF
--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -45,10 +45,14 @@ var kubeconfigCmd = &cobra.Command{
 		enable := kubeconfigViper.GetBool("enable")
 		show := kubeconfigViper.GetBool("show")
 
+		if configPath == "" {
+			return errors.New("Windows kubeconfig not supplied")
+		}
+
 		_, err := os.Stat(configPath)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("Could not open Windows kubeconfig: %w", err)
+				return fmt.Errorf("could not open Windows kubeconfig: %w", err)
 			}
 			return err
 		}

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -51,10 +51,7 @@ var kubeconfigCmd = &cobra.Command{
 
 		_, err := os.Stat(configPath)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("could not open Windows kubeconfig: %w", err)
-			}
-			return err
+			return fmt.Errorf("could not open Windows kubeconfig: %w", err)
 		}
 		cmd.SilenceUsage = true
 


### PR DESCRIPTION
This produces a less misleading error message.

This is spawned from #772 but wouldn't fix it — there's a problem elsewhere (likely in the TypeScript code).