### PR TITLE
Use vmnet interface only for ingress

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -44,20 +44,18 @@ provision:
   script: |
     #!/bin/sh
     sed -i 's/host.lima.internal.*/host.lima.internal host.rancher-desktop.internal host.docker.internal/' /etc/hosts
-- # Make sure interface rd0 takes priority over eth0
+- # Delete specific route(s) for vmnet interface rd0, so the default route for slirp is used for all egress
   mode: system
   script: |
     #!/bin/sh
-    set -o errexit -o nounset -o xtrace
-    RD0="$(ip route | grep "^default.* dev rd0 ")"
-    if [ -z "${RD0}" ]; then
-      exit 0
-    fi
-    ETH0="$(ip route | grep "^default.* dev eth0 ")"
-    IP="$(echo "$RD0" | awk '{print $3}')"
-    METRIC="$(echo "$ETH0" | awk '{print $NF}')"
-    ip route del default via "$IP" dev rd0
-    ip route add default via "$IP" dev rd0 metric $((METRIC - 1))
+    set -o errexit -o nounset -o xtrace -o pipefail
+    while true; do
+      ROUTE="$(ip route | grep "rd0 scope link" | head -1)"
+      if [ -z "${ROUTE}" ]; then
+        exit
+      fi
+      ip route del ${ROUTE}
+    done
 - # Clean up filesystems
   mode: system
   script: |

--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -23,7 +23,7 @@ start_pre() {
 supervisor=supervise-daemon
 name=k3s
 command=/usr/local/bin/k3s
-command_args="server --https-listen-port ${PORT}"
+command_args="server --https-listen-port ${PORT} ${ADDITIONAL_ARGS:-}"
 if [ "${ENGINE}" == "moby" ]; then
   command_args="${command_args} --docker"
 fi

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -478,7 +478,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     if (os.platform() === 'darwin') {
       config.networks = [
         {
-          lima:      'shared',
+          lima:      'bridged',
           interface: 'rd0',
         },
       ];
@@ -986,8 +986,9 @@ ${ commands.join('\n') }
   protected async writeServiceScript() {
     await this.writeFile('/etc/init.d/k3s', SERVICE_K3S_SCRIPT, 0o755);
     await this.writeConf('k3s', {
-      PORT:   this.desiredPort.toString(),
-      ENGINE: this.#currentContainerEngine,
+      PORT:            this.desiredPort.toString(),
+      ENGINE:          this.#currentContainerEngine,
+      ADDITIONAL_ARGS: '--flannel-iface rd0',
     });
     await this.writeFile('/etc/logrotate.d/k3s', LOGROTATE_K3S_SCRIPT);
   }


### PR DESCRIPTION
Throughput is almost an order of magnitude lower on the `vmnet` interface then via `slirp`. It is unknown if this is related to using `libvdeplug`, or to `vde_vmnet` itself.

This commit also changes the network mode to "bridged" so that the routable IP address also works outside the host itself.

Fixes #1070 
Fixes #1079