### PR TITLE
nerdctl-stub: fix mounting files.

### DIFF
--- a/src/go/nerdctl-stub/main_linux.go
+++ b/src/go/nerdctl-stub/main_linux.go
@@ -74,7 +74,7 @@ func cleanupParseArgs() error {
 	for _, entry := range entries {
 		entryPath := filepath.Join(workdir, entry.Name())
 		err = unix.Unmount(entryPath, 0)
-		if err != nil {
+		if err != nil && !errors.Is(err, unix.EINVAL) {
 			log.Printf("Error unmounting %s: %s", entryPath, err)
 		}
 		err = os.Remove(entryPath)


### PR DESCRIPTION
On Linux, we need to mount path arguments; when the target is a file (rather than a directory), we need to not create a directory as the mount target.

Should fix #1060.