### PR TITLE
Don't delete the specific routes for the rd0 vmnet interface

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -44,18 +44,6 @@ provision:
   script: |
     #!/bin/sh
     sed -i 's/host.lima.internal.*/host.lima.internal host.rancher-desktop.internal host.docker.internal/' /etc/hosts
-- # Delete specific route(s) for vmnet interface rd0, so the default route for slirp is used for all egress
-  mode: system
-  script: |
-    #!/bin/sh
-    set -o errexit -o nounset -o xtrace -o pipefail
-    while true; do
-      ROUTE="$(ip route | grep "rd0 scope link" | head -1)"
-      if [ -z "${ROUTE}" ]; then
-        exit
-      fi
-      ip route del ${ROUTE}
-    done
 - # Clean up filesystems
   mode: system
   script: |


### PR DESCRIPTION
It breaks incoming connections from outside the VM.

Not deleting the route means outgoing connections to local resources will go through `rd0`, with the known slowdown compared to using slirp. 😢 