### PR TITLE
Lima: fix log file name.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1014,7 +1014,7 @@ ${ commands.join('\n') }
       this.logProcess?.kill('SIGTERM');
     } catch (ex) { }
     let args = ['shell', '--workdir=.', MACHINE_NAME,
-      '/usr/bin/tail', '-n+1', '-F', '/var/log/k3s'];
+      '/usr/bin/tail', '-n+1', '-F', '/var/log/k3s.log'];
 
     args = this.debug ? ['--debug'].concat(args) : args;
     this.logProcess = childProcess.spawn(


### PR DESCRIPTION
The log file used for k3s was changed in 719b5b98e3d4 but lima was never fixed to use the new file name.

Fixes #1109 — the problem wasn't that we didn't retry, it was that we're looking for the wrong file.