### PR TITLE
Ensure nerdctl script exits with failure code when Rancher Desktop is not running

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -9,6 +9,7 @@ scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
 if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
+  exit 1
 else
   LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" shell 0 sudo --preserve-env=CONTAINERD_ADDRESS nerdctl "$@"
 fi

--- a/resources/linux/bin/nerdctl
+++ b/resources/linux/bin/nerdctl
@@ -12,6 +12,7 @@ else
 
   if ! LIMA_HOME="${limaloc}/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
     echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
+    exit 1
   else
     LIMA_HOME="${limaloc}/lima" "${scriptdir}/../lima/bin/limactl" shell 0 sudo --preserve-env=CONTAINERD_ADDRESS nerdctl "$@"
   fi


### PR DESCRIPTION
This PR implements the proposed solution in #1112.

Closes #1112 