### PR TITLE
GitHub Actions: package linux bits on tag too.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -116,7 +116,7 @@ jobs:
         if-no-files-found: error
     - name: Copy linux zip to canary for main
       uses: canastro/copy-file-action@0.0.2
-      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main' }}
+      if: ${{ startsWith(matrix.os, 'ubuntu-') && (github.ref_name == 'main' || github.ref_type == 'tag') }}
       with:
         source: "dist/rancher-desktop*.zip"
         target: "dist/rancher-desktop-canary.zip"


### PR DESCRIPTION
Because we actually want to ship Linux bits too.

Not that this PR is draft to trigger CI so we can at least see syntax issues.