### PR TITLE
Bump Node.js to 16.x in GHA

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -25,8 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
-
+          node-version: '16.x'
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - uses: actions/setup-python@v2
       with:
         python-version: '2.x'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-node@v2
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.16'


### PR DESCRIPTION
#994 #438
@mook-as 