### PR TITLE
Ensure that cirrus ci will automatically triggers tasks when invoked by cron

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,14 @@
 task:
-  trigger_type: manual
+  # On Cirrus CI, cron tasks does not start if it has
+  # manual trigger type enabled - expected behaviour
+  # see: https://github.com/cirruslabs/cirrus-ci-docs/discussions/949#discussioncomment-1853964
+  matrix:
+    # Keep manual trigger for all pushes (prs and merges)
+    - trigger_type: manual
+      only_if: $CIRRUS_CRON == ''
+    # Only trigger task automatically if it's a cron and main branch
+    - trigger_type: automatic
+      only_if: $CIRRUS_CRON != '' && $BRANCH == "main"
   name: E2E/Integration Tests
   timeout_in: 45
   container:


### PR DESCRIPTION
### Changes
1. Implemented cron/manual trigger matrix. It will ensure that cirrus will automatically trigger a cron task when invoked by cron.

Remark:
The Cirrus CI pipelines is activated only on my forked [repository](https://github.com/evertonlperes/rancher-desktop) for now. @gunamata and I decided to keep it enabled only on my forked, to collect data and ensure the pipeline is stable enough and then, enable at the upstream repository.

Old PR: https://github.com/rancher-sandbox/rancher-desktop/pull/1145