### PR TITLE
Separate title section and body

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -168,8 +168,12 @@ export default {
     display: grid;
     grid-area: body;
     grid-template-rows: auto 1fr;
-    padding: 20px;
+    padding: 0 20px 20px 20px;
     overflow: auto;
+  }
+
+  .title {
+    padding: 20px 20px 0 20px;
   }
 
   .title-top{

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -2,55 +2,55 @@
   <div class="wrapper">
     <Header class="header" />
     <Nav class="nav" :items="routes" />
-    <main class="body">
-      <section class="title">
-        <section class="title-top">
-          <transition-group
-            name="fade-group"
-            class="title-group"
-            appear
-          >
-            <button
-              v-if="isChild"
-              key="back-btn"
-              data-test="back-btn"
-              class="btn role-link btn-sm btn-back fade-group-item"
-              type="button"
-              @click="routeBack"
-            >
-              <span
-                class="icon icon-chevron-left"
-              />
-            </button>
-            <h1
-              key="mainTitle"
-              data-test="mainTitle"
-              class="fade-group-item"
-            >
-              {{ title }}
-            </h1>
-          </transition-group>
-          <transition
-            name="fade"
-            appear
-          >
-            <section
-              v-if="action"
-              key="actions"
-              class="actions fade-actions"
-            >
-              <component :is="action" />
-            </section>
-          </transition>
-        </section>
-        <hr>
-        <section
-          v-show="description"
-          class="description"
+    <section class="title">
+      <section class="title-top">
+        <transition-group
+          name="fade-group"
+          class="title-group"
+          appear
         >
-          {{ description }}
-        </section>
+          <button
+            v-if="isChild"
+            key="back-btn"
+            data-test="back-btn"
+            class="btn role-link btn-sm btn-back fade-group-item"
+            type="button"
+            @click="routeBack"
+          >
+            <span
+              class="icon icon-chevron-left"
+            />
+          </button>
+          <h1
+            key="mainTitle"
+            data-test="mainTitle"
+            class="fade-group-item"
+          >
+            {{ title }}
+          </h1>
+        </transition-group>
+        <transition
+          name="fade"
+          appear
+        >
+          <section
+            v-if="action"
+            key="actions"
+            class="actions fade-actions"
+          >
+            <component :is="action" />
+          </section>
+        </transition>
       </section>
+      <hr>
+      <section
+        v-show="description"
+        class="description"
+      >
+        {{ description }}
+      </section>
+    </section>
+    <main class="body">
       <Nuxt />
     </main>
     <BackendProgress class="progress" />
@@ -139,6 +139,7 @@ export default {
   display: grid;
   grid-template:
     "header   header"
+    "nav      title"
     "nav      body"    1fr
     "progress body"
     / var(--nav-width) 1fr;

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -136,12 +136,5 @@ export default {
       }
     }
   }
-
 };
 </script>
-
-<style scoped>
-.content {
-  padding: 20px;
-}
-</style>


### PR DESCRIPTION
This resolves an issue with the scroll bar overlapping actions by separating the title from the body area. 

This approach allows for the title's width to be sized relative to its parent, independent of the body. I'd like to point out that this changes introduces some modified behavior; the title is now outside of the scrollable area, making it a fixed to the page, so it won't scroll with the rest of the body. I understand that this could not be desirable with the limited real-estate available with the default window height, so I attempted to get back some space by removing extra padding that was applied to the images table.