### PR TITLE
Use "everyone" group instead of "staff"

### DIFF
--- a/src/assets/networks-config.yaml
+++ b/src/assets/networks-config.yaml
@@ -14,7 +14,7 @@ paths:
   vdeVMNet: /opt/rancher-desktop/bin/vde_vmnet
   varRun: /private/var/run/rancher-desktop-lima
   sudoers: /private/etc/sudoers.d/rancher-desktop-lima
-group: staff
+group: everyone
 networks:
   shared:
     mode: shared

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -977,6 +977,10 @@ ${ commands.join('\n') }
       config = NETWORKS_CONFIG;
     }
 
+    if (config.group === 'staff') {
+      config.group = 'everyone';
+    }
+
     for (const key of Object.keys(config.networks)) {
       if (key.startsWith('bridged_')) {
         delete config.networks[key];


### PR DESCRIPTION
Because "staff" includes only local accounts whereas "everyone" also includes external accounts provided by directory services.

Fixes #1152 