### PR TITLE
Rework GHA package.yaml and linux-release.yaml

### DIFF
--- a/.github/workflows/linux-release.sh
+++ b/.github/workflows/linux-release.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Get the tag in the two forms it's needed.
-withV=${GITHUB_REF#"refs/tags/"}
-withoutV=${GITHUB_REF#"refs/tags/v"}
-
-mkdir dist
-
-cd dist && curl -L -O https://github.com/rancher-sandbox/rancher-desktop/releases/download/${withV}/rancher-desktop-${withoutV}-linux.zip

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -33,15 +33,15 @@ jobs:
         mkdir -p dist
         curl -L -o "dist/${release_zip_name}" "https://github.com/rancher-sandbox/rancher-desktop/releases/download/${version_with_v}/${release_zip_name}"
       env:
-        version_with_v: env.version_with_v
-        release_zip_name: env.release_zip_name
+        version_with_v: ${{ env.version_with_v }}
+        release_zip_name: ${{ env.release_zip_name }}
     - name: Copy .zip file to s3
       uses: prewk/s3-cp-action@v2
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: format('./dist/{0}', env.release_zip_name)
-        dest: format('s3://rancher-desktop-assets-for-obs/{0}', env.s3_zip_name)
+        source: ${{ format('./dist/{0}', env.release_zip_name) }}
+        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.s3_zip_name) }}
     - name: Trigger OBS services
       uses: distributhor/workflow-webhook@v2
       env:

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -1,4 +1,4 @@
-name: Upload the Linux .zip file to S3 so it can be downloaded by OBS
+name: Upload Linux release
 on:
   release:
     types:

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -27,6 +27,7 @@ jobs:
         # make variables available in subsequent steps
         echo "version_with_v=$version_with_v" >> $GITHUB_ENV
         echo "release_zip_name=$release_zip_name" >> $GITHUB_ENV
+        echo "major_minor=$major_minor" >> $GITHUB_ENV
         echo "s3_zip_name=$s3_zip_name" >> $GITHUB_ENV
     - name: Fetch the .zip file from release
       run: |
@@ -42,9 +43,11 @@ jobs:
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         source: ${{ format('./dist/{0}', env.release_zip_name) }}
         dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.s3_zip_name) }}
-    - name: Trigger OBS services
-      uses: distributhor/workflow-webhook@v2
+    - name: Trigger OBS services for relevant package in stable channel
+      run: |
+        curl -X POST \
+          -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
+          "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-${MAJOR_MINOR}"
       env:
-        webhook_type: 'form-urlencoded'
-        webhook_url: ${{ secrets.OBS_WEBHOOK_URL_RELEASE }}
-        webhook_secret: ${{ secrets.OBS_WEBHOOK_TOKEN_RELEASE }}
+        MAJOR_MINOR: ${{ env.major_minor }}
+        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -1,8 +1,12 @@
-# Used to upload the release asset to S3 for Linux
+name: Upload the Linux .zip file to S3 so it can be downloaded by OBS
 on:
   release:
     types:
       - published
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   linux-release:
@@ -12,20 +16,32 @@ jobs:
       with:
         persist-credentials: false
         fetch-depth: 0
-    - name: Fetch the release asset
-      run: .github/workflows/linux-release.sh
-    - name: Copy linux zip to release for tags
-      uses: canastro/copy-file-action@0.0.2
-      with:
-        source: "dist/rancher-desktop*.zip"
-        target: "dist/rancher-desktop-release.zip"
-    - name: Copy release to s3
+    - name: Populate necessary env vars
+      run: |
+        # get the env vars
+        version_with_v=${GITHUB_REF#"refs/tags/"}
+        release_zip_name="rancher-desktop-${version_with_v}.zip"
+        major_minor=$(echo ${version_with_v} | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+.*/\1/g')
+        s3_zip_name="rancher-desktop-${major_minor}.zip"
+
+        # make variables available in subsequent steps
+        echo "version_with_v=$version_with_v" >> $GITHUB_ENV
+        echo "release_zip_name=$release_zip_name" >> $GITHUB_ENV
+        echo "s3_zip_name=$s3_zip_name" >> $GITHUB_ENV
+    - name: Fetch the .zip file from release
+      run: |
+        mkdir -p dist
+        curl -L -o "dist/${release_zip_name}" "https://github.com/rancher-sandbox/rancher-desktop/releases/download/${version_with_v}/${release_zip_name}"
+      env:
+        version_with_v: env.version_with_v
+        release_zip_name: env.release_zip_name
+    - name: Copy .zip file to s3
       uses: prewk/s3-cp-action@v2
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: './dist/rancher-desktop-release.zip'
-        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-release.zip'
+        source: format('./dist/{0}', env.release_zip_name)
+        dest: format('s3://rancher-desktop-assets-for-obs/{0}', env.s3_zip_name)
     - name: Trigger OBS services
       uses: distributhor/workflow-webhook@v2
       env:

--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -20,9 +20,9 @@ jobs:
       run: |
         # get the env vars
         version_with_v=${GITHUB_REF#"refs/tags/"}
-        release_zip_name="rancher-desktop-${version_with_v}.zip"
+        release_zip_name="rancher-desktop-linux-${version_with_v}.zip"
         major_minor=$(echo ${version_with_v} | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+.*/\1/g')
-        s3_zip_name="rancher-desktop-${major_minor}.zip"
+        s3_zip_name="rancher-desktop-linux-${major_minor}.zip"
 
         # make variables available in subsequent steps
         echo "version_with_v=$version_with_v" >> $GITHUB_ENV

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,8 +24,6 @@ jobs:
         - windows-2019
         - ubuntu-latest
     runs-on: ${{ matrix.os }}
-    env:
-      dev_zip_name: ${{ format('rancher-desktop-dev-{0}.zip', github.ref_name) }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -111,18 +109,21 @@ jobs:
         name: Rancher Desktop-win.zip
         path: dist/Rancher Desktop-*-win.zip
         if-no-files-found: error
-    - name: Upload zip as artifact with dev in name
+    - name: set zip_name env var
+      run: |
+        if [ "$GITHUB_REF_TYPE" = 'branch' ]; then
+          # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge"
+          no_slash_ref_name=$(echo $GITHUB_REF_NAME | sed -E 's/\//-/g')
+          zip_name="rancher-desktop-dev-${no_slash_ref_name}.zip"
+        elif [ "$GITHUB_REF_TYPE" = 'tag' ]; then
+          zip_name="rancher-desktop-${GITHUB_REF_NAME}.zip"
+        fi
+        echo "zip_name=$zip_name" >> $GITHUB_ENV
+    - name: Upload zip as workflow artifact
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
-        name: ${{ env.dev_zip_name }}
-        path: dist/rancher-desktop*.zip
-        if-no-files-found: error
-    - name: Upload zip as artifact ready for inclusion in release
-      uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag'
-      with:
-        name: ${{ format('rancher-desktop-{0}.zip', github.ref_name) }}
+        name: ${{ env.zip_name }}
         path: dist/rancher-desktop*.zip
         if-no-files-found: error
     - name: Ensure linux zip file has a known name
@@ -130,7 +131,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
         source: "dist/rancher-desktop*.zip"
-        target: ${{ format('dist/{0}', env.dev_zip_name) }}
+        target: ${{ format('dist/{0}', env.zip_name) }}
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true
@@ -144,8 +145,8 @@ jobs:
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: ${{ format('./dist/{0}', env.dev_zip_name) }}
-        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.dev_zip_name) }}
+        source: ${{ format('./dist/{0}', env.zip_name) }}
+        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.zip_name) }}
     - name: Trigger OBS services
       if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
       run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -111,13 +111,10 @@ jobs:
         if-no-files-found: error
     - name: set zip_name env var
       run: |
-        if [ "$GITHUB_REF_TYPE" = 'branch' ]; then
-          # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge"
-          no_slash_ref_name=$(echo $GITHUB_REF_NAME | sed -E 's/\//-/g')
-          zip_name="rancher-desktop-dev-${no_slash_ref_name}.zip"
-        elif [ "$GITHUB_REF_TYPE" = 'tag' ]; then
-          zip_name="rancher-desktop-${GITHUB_REF_NAME}.zip"
-        fi
+        # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge";
+        # remove slashes since they aren't valid in filenames
+        no_slash_ref_name=$(echo $GITHUB_REF_NAME | sed -E 's/\//-/g')
+        zip_name="rancher-desktop-linux-${no_slash_ref_name}.zip"
         echo "zip_name=$zip_name" >> $GITHUB_ENV
     - name: Upload zip as workflow artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -116,19 +116,19 @@ jobs:
         no_slash_ref_name=$(echo $GITHUB_REF_NAME | sed -E 's/\//-/g')
         zip_name="rancher-desktop-linux-${no_slash_ref_name}.zip"
         echo "zip_name=$zip_name" >> $GITHUB_ENV
-    - name: Upload zip as workflow artifact
-      uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
-      with:
-        name: ${{ env.zip_name }}
-        path: dist/rancher-desktop*.zip
-        if-no-files-found: error
     - name: Ensure linux zip file has a known name
       uses: canastro/copy-file-action@0.0.2
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
         source: "dist/rancher-desktop*.zip"
         target: ${{ format('dist/{0}', env.zip_name) }}
+    - name: Upload zip as workflow artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
+      with:
+        name: Rancher Desktop-linux.zip
+        path: ${{ format('dist/{0}', env.zip_name) }}
+        if-no-files-found: error
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,6 +24,8 @@ jobs:
         - windows-2019
         - ubuntu-latest
     runs-on: ${{ matrix.os }}
+    env:
+      dev_zip_name: ${{ format('rancher-desktop-dev-{0}.zip', github.ref_name) }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -109,35 +111,43 @@ jobs:
         name: Rancher Desktop-win.zip
         path: dist/Rancher Desktop-*-win.zip
         if-no-files-found: error
-    - uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'ubuntu-')
+    - name: Upload zip as artifact with dev in name
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
-        name: Rancher Desktop-linux.zip
+        name: env.dev_zip_name
         path: dist/rancher-desktop*.zip
         if-no-files-found: error
-    - name: Copy linux zip to canary for main
+    - name: Upload zip as artifact ready for inclusion in release
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag'
+      with:
+        name: format('rancher-desktop-{0}.zip', github.ref_name)
+        path: dist/rancher-desktop*.zip
+        if-no-files-found: error
+    - name: Ensure linux zip file has a known name
       uses: canastro/copy-file-action@0.0.2
-      if: ${{ startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main' }}
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
         source: "dist/rancher-desktop*.zip"
-        target: "dist/rancher-desktop-canary.zip"
+        target: format('dist/{0}', env.dev_zip_name)
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true
-      if: startsWith(matrix.os, 'ubuntu-') && github.ref_name == 'main'
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       run: '[[ -n "${key}" ]]'
       env:
         key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    - name: Copy canary to s3
+    - name: Copy zip file to S3
       uses: prewk/s3-cp-action@v2
-      if: steps.has_s3.outcome == 'success'
+      if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: './dist/rancher-desktop-canary.zip'
-        dest: 's3://rancher-desktop-assets-for-obs/rancher-desktop-canary.zip'
+        source: format('./dist/{0}', env.dev_zip_name)
+        dest: format('s3://rancher-desktop-assets-for-obs/{0}', env.dev_zip_name)
     - name: Trigger OBS services
-      if: steps.has_s3.outcome == 'success'
+      if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
       run: |
         curl -X POST \
           -H "Authorization: Token ${WEBHOOK_SECRET}" \

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - release-*
     tags:
       - '*'
   workflow_dispatch: {}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -132,27 +132,26 @@ jobs:
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true
-      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
+      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
       run: '[[ -n "${key}" ]]'
       env:
         key: ${{ secrets.AWS_ACCESS_KEY_ID }}
     - name: Copy zip file to S3
       uses: prewk/s3-cp-action@v2
-      if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
+      if: steps.has_s3.outcome == 'success'
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         source: ${{ format('./dist/{0}', env.zip_name) }}
         dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.zip_name) }}
-    - name: Trigger OBS services
-      if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
+    - name: Trigger OBS services for relevant package in dev channel
+      if: steps.has_s3.outcome == 'success'
       run: |
         curl -X POST \
-          -H "Authorization: Token ${WEBHOOK_SECRET}" \
-          "${WEBHOOK_URL}"
+          -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
+          "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:dev&package=rancher-desktop-${GITHUB_REF_NAME}"
       env:
-        WEBHOOK_URL: ${{ secrets.OBS_WEBHOOK_URL_CANARY }}
-        WEBHOOK_SECRET: ${{ secrets.OBS_WEBHOOK_TOKEN_CANARY }}
+        OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
 
   sign:
     name: Test Signing

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -115,14 +115,14 @@ jobs:
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
-        name: env.dev_zip_name
+        name: ${{ env.dev_zip_name }}
         path: dist/rancher-desktop*.zip
         if-no-files-found: error
     - name: Upload zip as artifact ready for inclusion in release
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'tag'
       with:
-        name: format('rancher-desktop-{0}.zip', github.ref_name)
+        name: ${{ format('rancher-desktop-{0}.zip', github.ref_name) }}
         path: dist/rancher-desktop*.zip
         if-no-files-found: error
     - name: Ensure linux zip file has a known name
@@ -130,7 +130,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
       with:
         source: "dist/rancher-desktop*.zip"
-        target: format('dist/{0}', env.dev_zip_name)
+        target: ${{ format('dist/{0}', env.dev_zip_name) }}
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true
@@ -144,8 +144,8 @@ jobs:
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: format('./dist/{0}', env.dev_zip_name)
-        dest: format('s3://rancher-desktop-assets-for-obs/{0}', env.dev_zip_name)
+        source: ${{ format('./dist/{0}', env.dev_zip_name) }}
+        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.dev_zip_name) }}
     - name: Trigger OBS services
       if: steps.has_s3.outcome == 'success' && github.ref_type == 'branch'
       run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -124,7 +124,7 @@ jobs:
         target: ${{ format('dist/{0}', env.zip_name) }}
     - name: Upload zip as workflow artifact
       uses: actions/upload-artifact@v2
-      if: startsWith(matrix.os, 'ubuntu-') && github.ref_type == 'branch'
+      if: startsWith(matrix.os, 'ubuntu-')
       with:
         name: Rancher Desktop-linux.zip
         path: ${{ format('dist/{0}', env.zip_name) }}


### PR DESCRIPTION
This pull request makes a couple of changes to the way that the Linux part of package.yaml and linux-release.yaml work:

- The webhook action (distributhor/workflow-webhook@v2) is replaced by a curl call, which enables us to put the URL for the HTTP request directly in the github action. This makes it easier to understand what is going on. It also enables us to use one token, rather than multiple tokens, for all stages, and to eliminate the `OBS_WEBHOOK_URL_*` secrets (which I believe weren't actually "secrets" in the first place).

- We now have .zip files of the format `rancher-desktop-linux-<branch>.zip` uploaded to S3. These can be grabbed by services in packages, where there is one package per branch, so that we can have a development build for each branch. This should come in handy when testing release branches. The branch names must be in the format `main`, or `release-*`. This applies to the dev channel only.

- I introduced some logic in linux-release.yaml to facilitate a scheme to provide multiple versions of RD in the stable channel. This scheme is similar to how the dev channel works (see above), except instead of the OBS package names being of the form `rancher-desktop-linux-<branch>`, the package names are of the form `rancher-desktop-<major_minor>`, where `major_minor` is the major and minor part of the semantic version (for example `0.7` or `1.0`). All that needs to be done to use this in a release is to upload the .zip file from the artifacts in the GHA workflow run that you want to release - linux-release.yaml should take care of everything else.