### PR TITLE
Fix issue templates auto label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
 name: Bug Report
 description: Report Rancher Desktop issue
-labels: ["bug"]
+labels: ["kind/bug"]
 body:
 - type: input
   attributes:
     label: Rancher Desktop Version
     description: What version of Rancher Desktop are you using?
-    placeholder: 0.6.1
+    placeholder: 0.7.1
   validations:
     required: true
 - type: input
@@ -47,7 +47,8 @@ body:
   attributes:
     label: Windows User Only
     description: Are you using VPN, Proxy, Special Firewall rules, Security Software or custom Activity directory features? if Yes, please describe.
-    placeholder: "e.g. VPN PulseSecure, Kaspersky Total Security 21.2.x, custom proxy configs or activity directory features..."
+    placeholder: "e.g. VPN PulseSecure, Kaspersky Total Security 21.2.x, custom proxy configs, activity directory features or N/A"
+    required: true
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,6 @@ body:
     label: Windows User Only
     description: Are you using VPN, Proxy, Special Firewall rules, Security Software or custom Activity directory features? if Yes, please describe.
     placeholder: "e.g. VPN PulseSecure, Kaspersky Total Security 21.2.x, custom proxy configs, activity directory features or N/A"
-    required: true
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
   attributes:
     label: Windows User Only
     description: Are you using VPN, Proxy, Special Firewall rules, Security Software or custom Activity directory features? if Yes, please describe.
-    placeholder: "e.g. VPN PulseSecure, Kaspersky Total Security 21.2.x, custom proxy configs, activity directory features or N/A"
+    placeholder: "e.g. VPN PulseSecure, Kaspersky Total Security 21.2.x, custom proxy configs, activity directory features, or N/A"
   validations:
     required: false
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a feature or idea to Rancher Desktop
-labels: ["enhancement"]
+labels: ["kind/enhancement"]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
### Changes
1. Fixed label names on issue templates.
2. Minor enhancements 

The auto label append was broken after renaming all existing labels.