### PR TITLE
[#1165] Fix ENOENT K3s downloads

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -431,9 +431,8 @@ export default class K3sHelper extends events.EventEmitter {
         console.log('Error verifying checksums after download', error);
         throw error;
       }
-      await safeRename(workDir, path.join(cacheDir, version.raw));
     } finally {
-      await fs.promises.rmdir(workDir, { recursive: true, maxRetries: 3 });
+      await safeRename(workDir, path.join(cacheDir, version.raw));
     }
   }
 

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -431,8 +431,11 @@ export default class K3sHelper extends events.EventEmitter {
         console.log('Error verifying checksums after download', error);
         throw error;
       }
-    } finally {
       await safeRename(workDir, path.join(cacheDir, version.raw));
+    } finally {
+      await fs.promises.rm(workDir, {
+        recursive: true, maxRetries: 3, force: true
+      });
     }
   }
 


### PR DESCRIPTION
Resolves: #1165
Unblock @rak-phillip PR: https://github.com/rancher-sandbox/rancher-desktop/pull/1199
### Changes
~~1. Removed unnecessary delete k3s tmp directory action.~~
1. Replaced deprecated `rmdir` to `rm({recursive: true, maxRetries: 3, force: true})`.


### How to replicate the issue
The issue can be replicated (with accuracy), after deleting `k3s` local cache folder. If you have any version locally that matches with you k8s selection (RD K8s version), it won't fail.