### PR TITLE
Replace all instances of fs.rmdir(path, { recursive: true })

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -107,7 +107,7 @@ export function save(cfg: Settings) {
  */
 export async function clear() {
   // The node version packed with electron might not have fs.rm yet.
-  await fs.promises.rmdir(paths.config, { recursive: true, force: true } as any);
+  await fs.promises.rm(paths.config, { recursive: true, force: true } as any);
 }
 
 /**

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -135,7 +135,7 @@ describe(K3sHelper, () => {
       await subject['readCache']();
       expect(subject['versions']).toEqual(versions);
     } finally {
-      await util.promisify(fs.rmdir)(workDir, { recursive: true });
+      await util.promisify(fs.rm)(workDir, { recursive: true, force: true });
     }
   });
 

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -643,7 +643,9 @@ export default class K3sHelper extends events.EventEmitter {
         resources.executable('kubectl'), ['config', 'use-context', contextName],
         { stdio: console, windowsHide: true });
     } finally {
-      await fs.promises.rmdir(workDir, { recursive: true, maxRetries: 10 });
+      await fs.promises.rm(workDir, {
+        recursive: true, force: true, maxRetries: 10
+      });
     }
   }
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1358,7 +1358,7 @@ ${ commands.join('\n') }
         await this.ssh('sudo', 'tar', 'xf', '/tmp/certs.tar', '-C', '/usr/local/share/ca-certificates/');
       }
     } finally {
-      await fs.promises.rmdir(workdir, { recursive: true });
+      await fs.promises.rm(workdir, { recursive: true, force: true });
     }
     await this.ssh('sudo', 'update-ca-certificates');
   }
@@ -1434,7 +1434,7 @@ ${ commands.join('\n') }
       pathsToDelete.push(paths.lima);
     }
     await this.del(true);
-    await Promise.all(pathsToDelete.map(p => fs.promises.rmdir(p, { recursive: true })));
+    await Promise.all(pathsToDelete.map(p => fs.promises.rm(p, { recursive: true, force: true })));
   }
 
   async requiresRestartReasons(): Promise<Record<string, [any, any] | []>> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -473,7 +473,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     } catch (ex) {
       console.log('Error setting up data distribution:', ex);
     } finally {
-      await fs.promises.rmdir(workdir, { recursive: true });
+      await fs.promises.rm(workdir, { recursive: true, force: true });
     }
   }
 
@@ -1113,7 +1113,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           '/usr/local/share/ca-certificates/');
       }));
     } finally {
-      await fs.promises.rmdir(workdir, { recursive: true });
+      await fs.promises.rm(workdir, { recursive: true, force: true });
     }
     await this.execCommand('/usr/sbin/update-ca-certificates');
   }

--- a/src/utils/safeRename.ts
+++ b/src/utils/safeRename.ts
@@ -28,7 +28,9 @@ export default async function safeRename(srcPath: string, destPath: string): Pro
       // This is exactly what we want.
 
       await fsExtra.copy(srcPath, destPath);
-      await fsPromises.rmdir(srcPath, { recursive: true, maxRetries: 2 });
+      await fsPromises.rm(srcPath, {
+        recursive: true, force: true, maxRetries: 2
+      });
     } else {
       await fsPromises.copyFile(srcPath, destPath);
       await fsPromises.unlink(srcPath);


### PR DESCRIPTION
This replaces the deprecated usage of `fs.rmdir(path, { recursive: true })` with recommended `fs.rm(path, { recursive: true, force: true })`, `fs.rmSync(path, { recursive: true, force: true })` or `fs.promises.rm(path, { recursive: true, force: true })`

closes #1198

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>