### PR TITLE
Add the actual message when there is no builder endpoint

### DIFF
--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -386,9 +386,13 @@ export abstract class ImageProcessor extends EventEmitter {
 
         return false;
       }
-    } catch (ex) {
+    } catch (ex: any) {
       if (this.isK8sResponse(ex) && ex.statusCode === 404) {
         console.log('Existing kim install invalid: missing endpoint');
+
+        return false;
+      } else if (ex.response?.body?.message === 'endpoints "builder" not found') {
+        console.log(`No builder found`);
 
         return false;
       }


### PR DESCRIPTION
No associated error, but after the changes made to work with Node 16.13, the code could no longer determine when the builder wasn't running. There's probably a better way to do this (which is why I added Mark as a reviewer).

Signed-off-by: Eric Promislow <epromislow@suse.com>