### PR TITLE
Update @types/node to 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@types/jest": "^24.9.1",
         "@types/lodash": "^4.14.168",
         "@types/marked": "^4.0.1",
-        "@types/node": "^14.16.0",
+        "@types/node": "^16.11.19",
         "@types/node-fetch": "^2.5.10",
         "@types/node-forge": "^0.9.7",
         "@types/semver": "^7.3.4",
@@ -5178,9 +5178,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.4.tgz",
-      "integrity": "sha512-swe3lD4izOJWHuxvsZdDFRq6S9i6koJsXOnQKYekhSO5JTizMVirUFgY/bUsaOJQj8oSD4oxmRYPBM/0b6jpdw=="
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -10432,6 +10432,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "14.18.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
+      "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+      "dev": true
     },
     "node_modules/electron/node_modules/debug": {
       "version": "2.6.9",
@@ -33023,9 +33029,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.4.tgz",
-      "integrity": "sha512-swe3lD4izOJWHuxvsZdDFRq6S9i6koJsXOnQKYekhSO5JTizMVirUFgY/bUsaOJQj8oSD4oxmRYPBM/0b6jpdw=="
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -37109,6 +37115,12 @@
         "extract-zip": "^1.0.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "14.18.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
+          "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A==",
+          "dev": true
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.168",
     "@types/marked": "^4.0.1",
-    "@types/node": "^14.16.0",
+    "@types/node": "^16.11.19",
     "@types/node-fetch": "^2.5.10",
     "@types/node-forge": "^0.9.7",
     "@types/semver": "^7.3.4",

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -1,5 +1,5 @@
 import {
-  spawn, CommonOptions, MessagingOptions, StdioOptions, StdioNull, StdioPipe
+  spawn, CommonOptions, IOType, MessagingOptions, StdioOptions, StdioNull, StdioPipe
 } from 'child_process';
 import stream from 'stream';
 
@@ -14,7 +14,7 @@ export {
 /* eslint-disable no-redeclare */
 
 interface SpawnOptionsWithStdioLog<
-  Stdio extends 'pipe' | 'ignore' | 'inherit' | Log
+  Stdio extends IOType | Log
   > extends SpawnOptionsLog {
   stdio: Stdio
 }
@@ -32,7 +32,12 @@ interface SpawnError extends Error {
   stderr?: string;
 }
 
-type StdioOptionsLog = 'pipe' | 'ignore' | 'inherit' | Log | Array<('pipe' | 'ignore' | 'inherit' | stream.Stream | Log | number | null | undefined)>;
+/**
+ * A StdioElementType is the type of a single element in a stdio 3-tuple.
+ */
+type StdioElementType = IOType | stream.Stream | Log | number | null | undefined;
+
+type StdioOptionsLog = IOType | Log | Array<StdioElementType>;
 
 interface CommonSpawnOptionsLog extends CommonOptions, MessagingOptions {
   argv0?: string;
@@ -55,7 +60,7 @@ interface SpawnOptionsWithStdioTuple<
   stdio: [Stdin, Stdout, Stderr];
 }
 
-function isLog(it: 'pipe' | 'ignore' | 'inherit' | stream.Stream | Log | number | null | undefined): it is Log {
+function isLog(it: StdioElementType): it is Log {
   return (typeof it === 'object') && !!it && 'fdStream' in it;
 }
 


### PR DESCRIPTION
We are now building against Node 16, so we should update the TypeScript definitions so it can pick up things like obsolete API usage.  This would have aided in #1198.