### PR TITLE
Check for updates in the background.

### DIFF
--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -18,6 +18,13 @@ const console = Logging.update;
 const gCachePath = path.join(paths.cache, 'updater-longhorn.json');
 
 /**
+ * If the upgrade responder doesn't have a requestIntervalInMinutes field (or if
+ * it's zero), use this value instead.  Note that the server can still set it to
+ * be less than this value.
+ */
+const defaultUpdateIntervalInMinutes = 60;
+
+/**
  * LonghornProviderOptions specifies the options available for LonghornProvider.
  */
 export interface LonghornProviderOptions extends CustomPublishOptions {
@@ -249,7 +256,8 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
     const responseRaw = await fetch(this.configuration.upgradeServer, requestOptions);
     const response = await responseRaw.json() as LonghornUpgraderResponse;
     const latest = response.versions.find(v => v.Tags.includes('latest'));
-    const requestIntervalInMs = response.requestIntervalInMinutes * 1000 * 60;
+    const requestIntervalInMinutes = response.requestIntervalInMinutes || defaultUpdateIntervalInMinutes;
+    const requestIntervalInMs = requestIntervalInMinutes * 1000 * 60;
     const nextRequestTime = Date.now() + requestIntervalInMs;
 
     if (!latest) {

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -44,6 +44,15 @@ export interface LonghornProviderOptions extends CustomPublishOptions {
   readonly vPrefixedTagName?: boolean
 }
 
+/** LonghornUpdateInfo is an UpdateInfo with additional fields for custom use. */
+export interface LonghornUpdateInfo extends UpdateInfo {
+  /**
+   * The minimum time (milliseconds since Unix epoch) we should next check for
+   * an update.
+   */
+  nextUpdateTime: number;
+}
+
 /**
  * LonghornUpgraderResponse describes the response from the Longhorn upgrade
  * responder service.
@@ -180,7 +189,7 @@ export async function setHasQueuedUpdate(isQueued: boolean): Promise<void> {
  * Note that we do internal caching to avoid issues with being double-counted in
  * the stats.
  */
-export default class LonghornProvider extends Provider<UpdateInfo> {
+export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
   constructor(
     private readonly configuration: CustomPublishOptions,
     private readonly updater: AppUpdater,
@@ -198,7 +207,7 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
    * @param checksumURL The URL to the file containing the checksum.
    * @returns Base64-encoded checksum.
    */
-  async getSha512Sum(checksumURL: string): Promise<string> {
+  protected async getSha512Sum(checksumURL: string): Promise<string> {
     const contents = await (await fetch(checksumURL)).text();
     const buffer = Buffer.from(contents.split(/\s+/)[0], 'hex');
 
@@ -310,22 +319,23 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
     return cache;
   }
 
-  async getLatestVersion(): Promise<UpdateInfo> {
-    const info = await this.checkForUpdates();
+  async getLatestVersion(): Promise<LonghornUpdateInfo> {
+    const cache = await this.checkForUpdates();
 
     return {
       files:   [{
-        url:                   info.file.url,
-        size:                  info.file.size,
-        sha512:                info.file.checksum,
+        url:                   cache.file.url,
+        size:                  cache.file.size,
+        sha512:                cache.file.checksum,
         isAdminRightsRequired: false,
       }],
-      version:      info.release.tag,
+      version:        cache.release.tag,
       path:                     '',
       sha512:                   '',
-      releaseName:  info.release.name,
-      releaseNotes: info.release.notes,
-      releaseDate:  info.release.date,
+      releaseName:    cache.release.name,
+      releaseNotes:   cache.release.notes,
+      releaseDate:    cache.release.date,
+      nextUpdateTime: cache.nextUpdateTime,
     };
   }
 

--- a/src/main/update/index.ts
+++ b/src/main/update/index.ts
@@ -15,11 +15,11 @@ import {
 } from 'electron-updater';
 import yaml from 'yaml';
 
+import LonghornProvider, { hasQueuedUpdate, LonghornUpdateInfo, setHasQueuedUpdate } from './LonghornProvider';
 import { Settings } from '@/config/settings';
 import mainEvent from '@/main/mainEvents';
 import Logging from '@/utils/logging';
 import * as window from '@/window';
-import LonghornProvider, { hasQueuedUpdate, LonghornUpdateInfo, setHasQueuedUpdate } from './LonghornProvider';
 
 const console = Logging.update;
 


### PR DESCRIPTION
This makes update checks in the background, so that we can correctly notify long-running instances about available updates.

Note that we skip checking if we're in the middle of downloading (to avoid triggering parallel downloads); this shouldn't be an issue in the wild as we shouldn't be checking so often that the previous download is still incomplete.

Fixes #1084.