### PR TITLE
Bump lima-and-qemu to v1.15

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.14';
+const limaTag = 'v1.15';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.3';


### PR DESCRIPTION
Lima changes:

* sync clock with host after sleep
* disable caching in sshfs
* use "everyone" instead of "staff" for networking group
* add LIMA_CIDATA_SLIRP_IP_ADDRESS setting to lima.env
* replace localhost in **all** proxy settings with gateway address
* support for symbolic link following in mounts
* improved x86_64 emulation on aarch64

No updates to vde_switch and vde_vmnet

Fixes #839 
