### PR TITLE
wsl-helper: linux docker-proxy: fix mount root

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -92,6 +92,7 @@ func newBindManager() (*bindManager, error) {
 	}
 
 	result := bindManager{
+		mountRoot: mountRoot,
 		entries:   make(map[string]bindManagerEntry),
 		statePath: statePath,
 	}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -36,6 +36,18 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
 )
 
+func TestNewBindManager(t *testing.T) {
+	bindManager, err := newBindManager()
+	// We're not testing loading the state here; if it happens to fail, we'll
+	// just have to skip the test.
+	if err != nil {
+		t.SkipNow()
+	} else {
+		assert.Equal(t, mountRoot, bindManager.mountRoot)
+		assert.Equal(t, "docker-binds.json", path.Base(bindManager.statePath))
+	}
+}
+
 func TestBindManagerPersist(t *testing.T) {
 	original := &bindManager{
 		mountRoot: t.TempDir(),


### PR DESCRIPTION
When creating a bind manager for /containers/create, we need to specify the mount root so that it can generate the paths for bind mounting correctly.
Fixes #1173; fixes #1186