### PR TITLE
Fixing handling of filesystem errors

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -23,7 +23,7 @@ import * as K8s from '@/k8s-engine/k8s';
 // TODO: Replace with the k8s version after kubernetes-client/javascript/pull/748 lands
 // const k8s = require('@kubernetes/client-node');
 import { findHomeDir } from '@/config/findHomeDir';
-import { isUnixError } from '@/typings/unix.interface';
+import { isUnixError, isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.k8s;
 
@@ -103,7 +103,7 @@ export default class K3sHelper extends events.EventEmitter {
         }
       }
     } catch (ex) {
-      if (isUnixError(ex) && ex.code !== 'ENOENT') {
+      if (isUnixFsError(ex) && ex.code !== 'ENOENT') {
         throw ex;
       }
     }
@@ -382,7 +382,7 @@ export default class K3sHelper extends events.EventEmitter {
 
         return (await Promise.all(promises)).filter(x => x)[0];
       } catch (ex) {
-        if (isUnixError(ex) && ex.code !== 'ENOENT') {
+        if (isUnixFsError(ex) && ex.code !== 'ENOENT') {
           throw ex;
         }
 
@@ -536,7 +536,7 @@ export default class K3sHelper extends events.EventEmitter {
           return kubeConfigPath;
         }
       } catch (err) {
-        if (isUnixError(err) && err.code !== 'ENOENT') {
+        if (isUnixFsError(err) && err.code !== 'ENOENT') {
           throw err;
         }
       }
@@ -617,7 +617,7 @@ export default class K3sHelper extends events.EventEmitter {
       try {
         userConfig.loadFromFile(userPath, { onInvalidEntry: ActionOnInvalid.FILTER });
       } catch (err) {
-        if (isUnixError(err) && err.code !== 'ENOENT') {
+        if (isUnixFsError(err) && err.code !== 'ENOENT') {
           console.log(`Error trying to load kubernetes config file ${ userPath }:`, err);
         }
         // continue to merge into an empty userConfig == `{ contexts: [], clusters: [], users: [] }`

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -23,7 +23,7 @@ import * as K8s from '@/k8s-engine/k8s';
 // TODO: Replace with the k8s version after kubernetes-client/javascript/pull/748 lands
 // const k8s = require('@kubernetes/client-node');
 import { findHomeDir } from '@/config/findHomeDir';
-import { isUnixError, isUnixFsError } from '@/typings/unix.interface';
+import { isUnixError } from '@/typings/unix.interface';
 
 const console = Logging.k8s;
 
@@ -103,7 +103,7 @@ export default class K3sHelper extends events.EventEmitter {
         }
       }
     } catch (ex) {
-      if (isUnixFsError(ex) && ex.code !== 'ENOENT') {
+      if ((ex as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw ex;
       }
     }
@@ -382,7 +382,7 @@ export default class K3sHelper extends events.EventEmitter {
 
         return (await Promise.all(promises)).filter(x => x)[0];
       } catch (ex) {
-        if (isUnixFsError(ex) && ex.code !== 'ENOENT') {
+        if ((ex as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw ex;
         }
 
@@ -536,7 +536,7 @@ export default class K3sHelper extends events.EventEmitter {
           return kubeConfigPath;
         }
       } catch (err) {
-        if (isUnixFsError(err) && err.code !== 'ENOENT') {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw err;
         }
       }
@@ -617,7 +617,7 @@ export default class K3sHelper extends events.EventEmitter {
       try {
         userConfig.loadFromFile(userPath, { onInvalidEntry: ActionOnInvalid.FILTER });
       } catch (err) {
-        if (isUnixFsError(err) && err.code !== 'ENOENT') {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
           console.log(`Error trying to load kubernetes config file ${ userPath }:`, err);
         }
         // continue to merge into an empty userConfig == `{ contexts: [], clusters: [], users: [] }`

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -35,7 +35,6 @@ import SERVICE_BUILDKITD_INIT from '@/assets/scripts/buildkit.initd';
 import SERVICE_BUILDKITD_CONF from '@/assets/scripts/buildkit.confd';
 import mainEvents from '@/main/mainEvents';
 import UnixlikeIntegrations from '@/k8s-engine/unixlikeIntegrations';
-import { isUnixError } from '@/typings/unix.interface';
 import { getImageProcessor } from '@/k8s-engine/images/imageFactory';
 
 /**
@@ -578,7 +577,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
         return yaml.parse(configRaw) as LimaConfiguration;
       } catch (ex) {
-        if (isUnixError(ex) && ex.code === 'ENOENT') {
+        if ((ex as NodeJS.ErrnoException).code === 'ENOENT') {
           return undefined;
         }
       }
@@ -881,7 +880,7 @@ ${ commands.join('\n') }
       }
     } catch (err) {
       dirInfo = null;
-      if (isUnixError(err) && err.code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         console.log(`Unexpected situation with ${ RUN_LIMA_LOCATION }, stat => error ${ err }`, err);
         throw err;
       }
@@ -922,7 +921,7 @@ ${ commands.join('\n') }
         path = await fs.promises.readlink(path);
       }
     } catch (err) {
-      if (isUnixError(err) && err.code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         console.log(`Error trying to resolve symbolic link ${ path }:`, err);
       }
     }
@@ -973,7 +972,7 @@ ${ commands.join('\n') }
         config = NETWORKS_CONFIG;
       }
     } catch (err) {
-      if (isUnixError(err) && err.code !== 'ENOENT') {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         console.log(`Existing networks.yaml file ${ networkPath } not yaml-parsable, got error ${ err }. It will be replaced.`);
       }
       config = NETWORKS_CONFIG;

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -6,7 +6,7 @@ import paths from '@/utils/paths';
 import resources from '@/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
-import { isUnixError } from '@/typings/unix.interface';
+import { isUnixFsError } from '@/typings/unix.interface';
 
 const INTEGRATIONS = ['docker', 'helm', 'kubectl', 'nerdctl'];
 const console = Logging.background;
@@ -49,9 +49,9 @@ export default class UnixlikeIntegrations {
           this.#results[linkPath] = `Already linked to ${ currentDest }`;
         }
       } catch (error) {
-        if (isUnixError(error) && error.code === 'ENOENT') {
+        if (isUnixFsError(error) && error.code === 'ENOENT') {
           this.#results[linkPath] = false;
-        } else if (isUnixError(error) && error.code === 'EINVAL') {
+        } else if (isUnixFsError(error) && error.code === 'EINVAL') {
           this.#results[linkPath] = `File exists and is not a symbolic link`;
         } else {
           this.#results[linkPath] = `Can't link to ${ linkPath }: ${ error }`;
@@ -73,7 +73,7 @@ export default class UnixlikeIntegrations {
         const message = `Error creating symlink for ${ linkPath }:`;
 
         console.error(message, err);
-        if (isUnixError(err)) {
+        if (isUnixFsError(err)) {
           this.#results[linkPath] = `${ message } ${ err.message }`;
         }
 
@@ -86,7 +86,7 @@ export default class UnixlikeIntegrations {
         const message = `Error unlinking symlink for ${ linkPath }`;
 
         console.error(message, err);
-        if (isUnixError(err)) {
+        if (isUnixFsError(err)) {
           this.#results[linkPath] = `${ message } ${ err.message }`;
         }
 
@@ -113,7 +113,7 @@ export default class UnixlikeIntegrations {
         });
       }
     } catch (error) {
-      if (!(isUnixError(error))) {
+      if (!(isUnixFsError(error))) {
         return;
       }
       switch (error.code) {

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -6,7 +6,7 @@ import paths from '@/utils/paths';
 import resources from '@/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
-import { isUnixFsError } from '@/typings/unix.interface';
+import { isNodeError } from '@/typings/unix.interface';
 
 const INTEGRATIONS = ['docker', 'helm', 'kubectl', 'nerdctl'];
 const console = Logging.background;
@@ -49,9 +49,9 @@ export default class UnixlikeIntegrations {
           this.#results[linkPath] = `Already linked to ${ currentDest }`;
         }
       } catch (error) {
-        if (isUnixFsError(error) && error.code === 'ENOENT') {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
           this.#results[linkPath] = false;
-        } else if (isUnixFsError(error) && error.code === 'EINVAL') {
+        } else if ((error as NodeJS.ErrnoException).code === 'EINVAL') {
           this.#results[linkPath] = `File exists and is not a symbolic link`;
         } else {
           this.#results[linkPath] = `Can't link to ${ linkPath }: ${ error }`;
@@ -73,7 +73,7 @@ export default class UnixlikeIntegrations {
         const message = `Error creating symlink for ${ linkPath }:`;
 
         console.error(message, err);
-        if (isUnixFsError(err)) {
+        if (err instanceof Error) {
           this.#results[linkPath] = `${ message } ${ err.message }`;
         }
 
@@ -86,7 +86,7 @@ export default class UnixlikeIntegrations {
         const message = `Error unlinking symlink for ${ linkPath }`;
 
         console.error(message, err);
-        if (isUnixFsError(err)) {
+        if (err instanceof Error) {
           this.#results[linkPath] = `${ message } ${ err.message }`;
         }
 
@@ -113,7 +113,8 @@ export default class UnixlikeIntegrations {
         });
       }
     } catch (error) {
-      if (!(isUnixFsError(error))) {
+      // if (error typeof NodeJS.ErrnoException) {
+      if (!(isNodeError(error))) {
         return;
       }
       switch (error.code) {

--- a/src/main/pathConflictManager.ts
+++ b/src/main/pathConflictManager.ts
@@ -6,7 +6,7 @@ import * as window from '@/window';
 import pathConflict from '@/utils/pathConflict';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import { isUnixError } from '@/typings/unix.interface';
+import { isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.background;
 const DebounceInterval = 500; // msec
@@ -69,7 +69,7 @@ export default class PathConflictManager {
       try {
         await fs.promises.access(dirName, fs.constants.R_OK);
       } catch (err) {
-        if (isUnixError(err) && err.code !== 'ENOENT') {
+        if (isUnixFsError(err) && err.code !== 'ENOENT') {
           console.log(`error in setupPathWatchersForShadowing:`, err);
         }
         continue;

--- a/src/main/pathConflictManager.ts
+++ b/src/main/pathConflictManager.ts
@@ -6,7 +6,6 @@ import * as window from '@/window';
 import pathConflict from '@/utils/pathConflict';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import { isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.background;
 const DebounceInterval = 500; // msec
@@ -69,7 +68,7 @@ export default class PathConflictManager {
       try {
         await fs.promises.access(dirName, fs.constants.R_OK);
       } catch (err) {
-        if (isUnixFsError(err) && err.code !== 'ENOENT') {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
           console.log(`error in setupPathWatchersForShadowing:`, err);
         }
         continue;

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -12,7 +12,7 @@ import Electron from 'electron';
 
 import Logging from '@/utils/logging';
 import paths, { Paths } from '@/utils/paths';
-import { isUnixFsError } from '@/typings/unix.interface';
+import { isNodeError } from '@/typings/unix.interface';
 
 const console = Logging.background;
 const APP_NAME = 'rancher-desktop';
@@ -114,7 +114,7 @@ function removeEmptyParents(directory: string) {
     try {
       fs.rmdirSync(parent);
     } catch (ex) {
-      if (isUnixFsError(ex) && expectedErrors.includes(ex.code)) {
+      if (isNodeError(ex) && expectedErrors.includes(ex.code)) {
         break;
       }
       throw ex;
@@ -132,7 +132,7 @@ function recursiveRemoveSync(target: string) {
   try {
     fs.rmSync(target, { recursive: true });
   } catch (ex) {
-    if (isUnixFsError(ex) && ex.code === 'ENOENT') {
+    if ((ex as NodeJS.ErrnoException).code === 'ENOENT') {
       return;
     }
     throw ex;
@@ -167,7 +167,7 @@ function tryRename(oldPath: string, newPath: string, info: string, deleteOnFailu
 
     return 'succeeded';
   } catch (ex) {
-    if (isUnixFsError(ex) && ['ENOENT', 'EEXIST'].includes(ex.code)) {
+    if (isNodeError(ex) && ['ENOENT', 'EEXIST'].includes(ex.code)) {
       console.error(`Expected error moving ${ info }: ${ ex }`);
 
       return 'failed';

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -12,7 +12,7 @@ import Electron from 'electron';
 
 import Logging from '@/utils/logging';
 import paths, { Paths } from '@/utils/paths';
-import { isUnixError } from '@/typings/unix.interface';
+import { isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.background;
 const APP_NAME = 'rancher-desktop';
@@ -114,7 +114,7 @@ function removeEmptyParents(directory: string) {
     try {
       fs.rmdirSync(parent);
     } catch (ex) {
-      if (isUnixError(ex) && expectedErrors.includes(ex.code)) {
+      if (isUnixFsError(ex) && expectedErrors.includes(ex.code)) {
         break;
       }
       throw ex;
@@ -132,7 +132,7 @@ function recursiveRemoveSync(target: string) {
   try {
     fs.rmSync(target, { recursive: true });
   } catch (ex) {
-    if (isUnixError(ex) && ex.code === 'ENOENT') {
+    if (isUnixFsError(ex) && ex.code === 'ENOENT') {
       return;
     }
     throw ex;
@@ -167,7 +167,7 @@ function tryRename(oldPath: string, newPath: string, info: string, deleteOnFailu
 
     return 'succeeded';
   } catch (ex) {
-    if (isUnixError(ex) && ['ENOENT', 'EEXIST'].includes(ex.code)) {
+    if (isUnixFsError(ex) && ['ENOENT', 'EEXIST'].includes(ex.code)) {
       console.error(`Expected error moving ${ info }: ${ ex }`);
 
       return 'failed';

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -12,7 +12,7 @@ import semver from 'semver';
 
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import { isUnixError } from '@/typings/unix.interface';
+import { isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.update;
 const gCachePath = path.join(paths.cache, 'updater-longhorn.json');
@@ -147,7 +147,7 @@ export async function hasQueuedUpdate(): Promise<boolean> {
 
     return true;
   } catch (error) {
-    if (isUnixError(error) && error.code !== 'ENOENT') {
+    if (isUnixFsError(error) && error.code !== 'ENOENT') {
       console.error('Could not check for queued update:', error);
     }
   }
@@ -164,7 +164,7 @@ export async function setHasQueuedUpdate(isQueued: boolean): Promise<void> {
     await fs.promises.writeFile(gCachePath, JSON.stringify(cache),
       { encoding: 'utf-8', mode: 0o600 });
   } catch (error) {
-    if (isUnixError(error) && error.code !== 'ENOENT') {
+    if (isUnixFsError(error) && error.code !== 'ENOENT') {
       console.error('Could not check for queued update:', error);
     }
   }
@@ -218,7 +218,7 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
         return cache;
       }
     } catch (error) {
-      if (isUnixError(error) && error.code !== 'ENOENT') {
+      if (isUnixFsError(error) && error.code !== 'ENOENT') {
         // Log the unexpected error, but keep going.
         console.error('Error reading update cache:', error);
       }

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -12,7 +12,6 @@ import semver from 'semver';
 
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import { isUnixFsError } from '@/typings/unix.interface';
 
 const console = Logging.update;
 const gCachePath = path.join(paths.cache, 'updater-longhorn.json');
@@ -147,7 +146,7 @@ export async function hasQueuedUpdate(): Promise<boolean> {
 
     return true;
   } catch (error) {
-    if (isUnixFsError(error) && error.code !== 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.error('Could not check for queued update:', error);
     }
   }
@@ -164,7 +163,7 @@ export async function setHasQueuedUpdate(isQueued: boolean): Promise<void> {
     await fs.promises.writeFile(gCachePath, JSON.stringify(cache),
       { encoding: 'utf-8', mode: 0o600 });
   } catch (error) {
-    if (isUnixFsError(error) && error.code !== 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.error('Could not check for queued update:', error);
     }
   }
@@ -218,7 +217,7 @@ export default class LonghornProvider extends Provider<UpdateInfo> {
         return cache;
       }
     } catch (error) {
-      if (isUnixFsError(error) && error.code !== 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         // Log the unexpected error, but keep going.
         console.error('Error reading update cache:', error);
       }

--- a/src/typings/unix.interface.ts
+++ b/src/typings/unix.interface.ts
@@ -11,3 +11,17 @@ export const isUnixError = (val: any): val is UnixError => {
     'code' in val &&
     'message' in val;
 };
+
+export interface UnixFsError {
+  syscall: string;
+  path: string;
+  code: string;
+  message: string;
+}
+
+export const isUnixFsError = (val: any): val is UnixError => {
+  return 'syscall' in val &&
+    'path' in val &&
+    'code' in val &&
+    'message' in val;
+};

--- a/src/typings/unix.interface.ts
+++ b/src/typings/unix.interface.ts
@@ -12,14 +12,15 @@ export const isUnixError = (val: any): val is UnixError => {
     'message' in val;
 };
 
-export interface UnixFsError {
+export interface NodeError {
   syscall: string;
   path: string;
   code: string;
   message: string;
+  errno: number;
 }
 
-export const isUnixFsError = (val: any): val is UnixError => {
+export const isNodeError = (val: any): val is NodeError => {
   return 'syscall' in val &&
     'path' in val &&
     'code' in val &&


### PR DESCRIPTION
Closes #1239

Errors from the filesystem do not have the properties of UnixError
such as stdout. This adds a second type check for the properties
found on filesystem errors in both mac and linux.