### PR TITLE
WSL: Add `host.docker.internal` and `host.minikube.internal` to containers.

### DIFF
--- a/src/assets/scripts/service-wsl-dockerd.initd
+++ b/src/assets/scripts/service-wsl-dockerd.initd
@@ -10,7 +10,7 @@ description="Starts dockerd for Rancher Desktop"
 
 supervisor=supervise-daemon
 command="'${WSL_HELPER_BINARY:-/usr/local/bin/wsl-helper}'"
-command_args="docker-proxy start"
+command_args="docker-proxy start -- ${dockerd_args:-}"
 
 DOCKER_LOGFILE="${DOCKER_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
 output_log="'${DOCKER_LOGFILE}'"

--- a/src/assets/scripts/wsl-data.conf
+++ b/src/assets/scripts/wsl-data.conf
@@ -1,0 +1,14 @@
+# This is the /etc/wsl.conf for use with rancher-desktop-data
+# As we do not have an actual data distribution, this file is included as part
+# of the application and written out at runtime.
+
+[automount]
+# Prevent processing /etc/fstab, since it doesn't exist.
+mountFsTab = false
+# Prevent running ldconfig, since that doesn't exist.
+ldconfig = false
+# Needed for compatibility with some `npm install` scenarios.
+options = metadata
+
+# We _do_ want to generate `/etc/hosts` here, so that it can be used by the main
+# distribution.

--- a/src/k8s-engine/progressTracker.ts
+++ b/src/k8s-engine/progressTracker.ts
@@ -65,6 +65,8 @@ export default class ProgressTracker {
 
   /**
    * Register an action.
+   * @param description Descriptive text for the action, to be shown to the user.
+   * @param priority Only the action with the largest priority will be shown among concurrent actions.
    * @returns A promise that will be resolved when the passed-in promise resolves.
    */
   action<T>(description: string, priority: number, promise: Promise<T>): Promise<T>;

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -21,6 +21,7 @@ import LOGROTATE_K3S_SCRIPT from '@/assets/scripts/logrotate-k3s';
 import SERVICE_BUILDKITD_INIT from '@/assets/scripts/buildkit.initd';
 import SERVICE_BUILDKITD_CONF from '@/assets/scripts/buildkit.confd';
 import INSTALL_WSL_HELPERS_SCRIPT from '@/assets/scripts/install-wsl-helpers';
+import SCRIPT_DATA_WSL_CONF from '@/assets/scripts/wsl-data.conf';
 import mainEvents from '@/main/mainEvents';
 import * as childProcess from '@/utils/childProcess';
 import Logging from '@/utils/logging';
@@ -414,12 +415,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           try {
             // Create a distro archive from the main distro.
             // WSL seems to require a working /bin/sh for initialization.
+            const OVERRIDE_FILES = { 'etc/wsl.conf': SCRIPT_DATA_WSL_CONF };
             const REQUIRED_FILES = [
               '/bin/busybox', // Base tools
               '/bin/mount', // Required for WSL startup
               '/bin/sh', // WSL requires a working shell to initialize
               '/lib', // Dependencies for busybox
-              '/etc/wsl.conf', // WSL configuration for minimal startup
               '/etc/passwd', // So WSL can spawn programs as a user
             ];
             const archivePath = path.join(workdir, 'distro.tar');
@@ -444,6 +445,20 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
             await this.execCommand('tar', '-cf', await this.wslify(archivePath),
               '-C', '/', ...extraFiles, ...DISTRO_DATA_DIRS);
+
+            // The tar-stream package doesn't handle appends well (needs to
+            // stream to a temporary file), and busybox tar doesn't support
+            // append either.  Luckily Windows shipes with a bsdtar that
+            // supports it, though it only supports short options.
+            for (const [relPath, contents] of Object.entries(OVERRIDE_FILES)) {
+              const absPath = path.join(workdir, 'tar', relPath);
+
+              await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+              await fs.promises.writeFile(absPath, contents);
+            }
+            await childProcess.spawnFile('tar.exe',
+              ['-r', '-f', archivePath, '-C', path.join(workdir, 'tar'), ...Object.keys(OVERRIDE_FILES)]);
+            await this.execCommand('tar', '-tvf', await this.wslify(archivePath));
             await this.execWSL('--import', DATA_INSTANCE_NAME, paths.wslDistroData, archivePath, '--version', '2');
           } catch (ex) {
             console.log(`Error registering data distribution: ${ ex }`);


### PR DESCRIPTION
This partially fixes #893.  This forces dockerd to write out `/etc/hosts` in the containers for `host.docker.internal` and `host.minikube.internal`, so that they can contact the host (tested by attempting to make an ssh connection and verifying the host key).

Note that this will _not_ help with things from the host side (from within Windows, or a different WSL distribution); doing so will require administrative privileges to update `/etc/hosts` as seem from Windows.