### PR TITLE
Add socat to Alpine ISO and WSL distro

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.16';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.4';
+const alpineLimaTag = 'v0.2.5';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.14.3';
 

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.11';
+  const v = '0.12';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -146,7 +146,7 @@ interface SPNetworkDataType {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.4';
+const IMAGE_VERSION = '0.2.5';
 const ALPINE_EDITION = 'rd';
 const ALPINE_VERSION = '3.14.3';
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -58,7 +58,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.11';
+const DISTRO_VERSION = '0.12';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
Latest k3s versions drop `socat` because it is no longer needed for port-forwarding with containerd. We still need it though for port-forwarding with docker-shim.

Fixes #1250