### PR TITLE
Restore port forwarding on mac/linux

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -434,10 +434,6 @@ Electron.ipcMain.on('k8s-progress', () => {
   window.send('k8s-progress', k8smanager.progress);
 });
 
-Electron.ipcMain.handle('k8s-supports-port-forwarding', () => {
-  return !!k8smanager.portForwarder;
-});
-
 Electron.ipcMain.handle('service-fetch', (event, namespace) => {
   return k8smanager.listServices(namespace);
 });

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1557,7 +1557,15 @@ ${ commands.join('\n') }
   }
 
   get portForwarder() {
-    return null;
+    return this;
+  }
+
+  async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
+    return await this.client?.forwardPort(namespace, service, port);
+  }
+
+  async cancelForward(namespace: string, service: string, port: number | string): Promise<void> {
+    await this.client?.cancelForwardPort(namespace, service, port);
   }
 
   async listIntegrations(): Promise<Record<string, boolean | string>> {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -83,7 +83,7 @@ export default {
   data() {
     return {
       routes: [
-        '/General', '/K8s', '/Integrations', '/Images', '/Troubleshooting'
+        '/General', '/K8s', '/Integrations', '/PortForwarding', '/Images', '/Troubleshooting'
       ],
       isChild: false
     };
@@ -113,14 +113,6 @@ export default {
         this.isChild = current.path.lastIndexOf('/') > 0;
       }
     }
-  },
-
-  mounted() {
-    ipcRenderer.invoke('k8s-supports-port-forwarding').then((supported) => {
-      if (supported) {
-        this.$data.routes = ['/General', '/K8s', '/Integrations', '/PortForwarding', '/Images', '/Troubleshooting'];
-      }
-    });
   },
 
   methods: {

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -63,7 +63,6 @@ interface IpcMainEvents {
  */
 interface IpcMainInvokeEvents {
   'settings-write': (arg: RecursivePartial<import('@/config/settings').Settings>) => void;
-  'k8s-supports-port-forwarding': () => boolean;
   'service-fetch': (namespace?: string) => import('@/k8s-engine/k8s').ServiceEntry[];
   'service-forward': (service: {namespace: string, name: string, port: string | number}, state: boolean) => void;
   'get-app-version': () => string;


### PR DESCRIPTION
The change to remove the port forwarding was part of the feature
to automatically forward ports from the VM to the host. We
realized on the Windows side that forwarding internal services
(e.g., the database for a site that's not exposed) should be
available all the time. So, this wasn't removed from Windows. It
should have been restored to mac and linux earlier. Noticed while
doing docs.

Closes #1305