### PR TITLE
Bump Playwright from 1.17.0 to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "js-yaml-loader": "^1.2.2",
         "nan": "^2.15.0",
         "nuxt": "^2.14.12",
-        "playwright": "^1.17.0",
+        "playwright": "^1.18.0",
         "raw-loader": "^4.0.2",
         "sass": "^1.38.2",
         "sass-loader": "^10.1.1",
@@ -20785,13 +20785,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.17.1.tgz",
-      "integrity": "sha512-DisCkW9MblDJNS3rG61p8LiLA2WA7IY/4A4W7DX4BphWe/HuWjKmGQptuk4NVIh5UuSwXpW/jaH2+ZgjHs3GMA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.18.0.tgz",
+      "integrity": "sha512-GOWvcWRtL7o6QCj6tvZCxqHKx2sIhXeEmEJAqQdOZgxzQiCkPe1hnTHab1p8R1bDvHK703fDS2oIbs3mcvg6gw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "=1.17.1"
+        "playwright-core": "=1.18.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -20804,6 +20804,36 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.17.1.tgz",
       "integrity": "sha512-C3c8RpPiC3qr15fRDN6dx6WnUkPLFmST37gms2aoHPDRvp7EaGDPMMZPpqIm/QWB5J40xDrQCD4YYHz2nBTojQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^8.2.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "socks-proxy-agent": "^6.1.0",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yauzl": "^2.10.0",
+        "yazl": "^2.5.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.18.0.tgz",
+      "integrity": "sha512-JTRlCVpfAFcC1nth+XIE07w6M5m6C8PaEoClv7wGWF97cyDMcHIij0xIVEKMKli7IG5N0mqjLDFc/akXSbMZ1g==",
       "dev": true,
       "dependencies": {
         "commander": "^8.2.0",
@@ -45538,12 +45568,38 @@
       }
     },
     "playwright": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.17.1.tgz",
-      "integrity": "sha512-DisCkW9MblDJNS3rG61p8LiLA2WA7IY/4A4W7DX4BphWe/HuWjKmGQptuk4NVIh5UuSwXpW/jaH2+ZgjHs3GMA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.18.0.tgz",
+      "integrity": "sha512-GOWvcWRtL7o6QCj6tvZCxqHKx2sIhXeEmEJAqQdOZgxzQiCkPe1hnTHab1p8R1bDvHK703fDS2oIbs3mcvg6gw==",
       "dev": true,
       "requires": {
-        "playwright-core": "=1.17.1"
+        "playwright-core": "=1.18.0"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.18.0.tgz",
+          "integrity": "sha512-JTRlCVpfAFcC1nth+XIE07w6M5m6C8PaEoClv7wGWF97cyDMcHIij0xIVEKMKli7IG5N0mqjLDFc/akXSbMZ1g==",
+          "dev": true,
+          "requires": {
+            "commander": "^8.2.0",
+            "debug": "^4.1.1",
+            "extract-zip": "^2.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "jpeg-js": "^0.4.2",
+            "mime": "^2.4.6",
+            "pngjs": "^5.0.0",
+            "progress": "^2.0.3",
+            "proper-lockfile": "^4.1.1",
+            "proxy-from-env": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "socks-proxy-agent": "^6.1.0",
+            "stack-utils": "^2.0.3",
+            "ws": "^7.4.6",
+            "yauzl": "^2.10.0",
+            "yazl": "^2.5.1"
+          }
+        }
       }
     },
     "playwright-core": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "js-yaml-loader": "^1.2.2",
     "nan": "^2.15.0",
     "nuxt": "^2.14.12",
-    "playwright": "^1.17.0",
+    "playwright": "^1.18.0",
     "raw-loader": "^4.0.2",
     "sass": "^1.38.2",
     "sass-loader": "^10.1.1",


### PR DESCRIPTION
### Changes
1. Bump Playwright version from `1.17.0` to `1.18.0`