### PR TITLE
Roll back aliases and bump @playwright/test from 1.17.0 to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@nuxtjs/router-extras": "^1.1.1",
         "@nuxtjs/style-resources": "^1.2.1",
         "@octokit/rest": "^18.0.12",
-        "@playwright/test": "^1.17.0",
+        "@playwright/test": "^1.18.0",
         "@types/dompurify": "^2.2.2",
         "@types/jest": "^24.9.1",
         "@types/lodash": "^4.14.168",
@@ -1459,6 +1459,25 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
+      "integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4727,9 +4746,9 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.17.1.tgz",
-      "integrity": "sha512-mMZS5OMTN/vUlqd1JZkFoAk2FsIZ4/E/00tw5it2c/VF4+3z/aWO+PPd8ShEGzYME7B16QGWNPjyFpDQI1t4RQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.18.0.tgz",
+      "integrity": "sha512-ceu4DqerPlyRsdNfke4IUyWH1WccRuBokngFdPAzc5CRzlGmSTT59NBkJyn8Fg/F01CziaMFgNRrHQIMSd4g5A==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
@@ -4748,20 +4767,23 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-transform-modules-commonjs": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/preset-typescript": "^7.14.5",
-        "colors": "^1.4.0",
+        "babel-plugin-module-resolver": "^4.1.0",
+        "colors": "1.4.0",
         "commander": "^8.2.0",
         "debug": "^4.1.1",
         "expect": "=27.2.5",
         "jest-matcher-utils": "=27.2.5",
         "jpeg-js": "^0.4.2",
+        "json5": "^2.2.0",
         "mime": "^2.4.6",
         "minimatch": "^3.0.3",
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
-        "playwright-core": "=1.17.1",
+        "playwright-core": "=1.18.0",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.4.18",
@@ -6949,6 +6971,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -20784,6 +20822,79 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.18.0.tgz",
@@ -20801,36 +20912,6 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.17.1.tgz",
-      "integrity": "sha512-C3c8RpPiC3qr15fRDN6dx6WnUkPLFmST37gms2aoHPDRvp7EaGDPMMZPpqIm/QWB5J40xDrQCD4YYHz2nBTojQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^8.2.0",
-        "debug": "^4.1.1",
-        "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "jpeg-js": "^0.4.2",
-        "mime": "^2.4.6",
-        "pngjs": "^5.0.0",
-        "progress": "^2.0.3",
-        "proper-lockfile": "^4.1.1",
-        "proxy-from-env": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "socks-proxy-agent": "^6.1.0",
-        "stack-utils": "^2.0.3",
-        "ws": "^7.4.6",
-        "yauzl": "^2.10.0",
-        "yazl": "^2.5.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/playwright/node_modules/playwright-core": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.18.0.tgz",
       "integrity": "sha512-JTRlCVpfAFcC1nth+XIE07w6M5m6C8PaEoClv7wGWF97cyDMcHIij0xIVEKMKli7IG5N0mqjLDFc/akXSbMZ1g==",
@@ -23254,6 +23335,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
       "dev": true
     },
     "node_modules/reserved-words": {
@@ -29971,6 +30058,19 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz",
+      "integrity": "sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/plugin-syntax-jsx": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
@@ -32626,9 +32726,9 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@playwright/test": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.17.1.tgz",
-      "integrity": "sha512-mMZS5OMTN/vUlqd1JZkFoAk2FsIZ4/E/00tw5it2c/VF4+3z/aWO+PPd8ShEGzYME7B16QGWNPjyFpDQI1t4RQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.18.0.tgz",
+      "integrity": "sha512-ceu4DqerPlyRsdNfke4IUyWH1WccRuBokngFdPAzc5CRzlGmSTT59NBkJyn8Fg/F01CziaMFgNRrHQIMSd4g5A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
@@ -32647,20 +32747,23 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-transform-modules-commonjs": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/preset-typescript": "^7.14.5",
-        "colors": "^1.4.0",
+        "babel-plugin-module-resolver": "^4.1.0",
+        "colors": "1.4.0",
         "commander": "^8.2.0",
         "debug": "^4.1.1",
         "expect": "=27.2.5",
         "jest-matcher-utils": "=27.2.5",
         "jpeg-js": "^0.4.2",
+        "json5": "^2.2.0",
         "mime": "^2.4.6",
         "minimatch": "^3.0.3",
         "ms": "^2.1.2",
         "open": "^8.3.0",
         "pirates": "^4.0.1",
         "pixelmatch": "^5.2.1",
-        "playwright-core": "=1.17.1",
+        "playwright-core": "=1.18.0",
         "pngjs": "^5.0.0",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.4.18",
@@ -34546,6 +34649,19 @@
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-module-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz",
+      "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
+      "dev": true,
+      "requires": {
+        "find-babel-config": "^1.2.0",
+        "glob": "^7.1.6",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.0.0",
+        "resolve": "^1.13.1"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -45567,6 +45683,60 @@
         }
       }
     },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "playwright": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.18.0.tgz",
@@ -45574,38 +45744,12 @@
       "dev": true,
       "requires": {
         "playwright-core": "=1.18.0"
-      },
-      "dependencies": {
-        "playwright-core": {
-          "version": "1.18.0",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.18.0.tgz",
-          "integrity": "sha512-JTRlCVpfAFcC1nth+XIE07w6M5m6C8PaEoClv7wGWF97cyDMcHIij0xIVEKMKli7IG5N0mqjLDFc/akXSbMZ1g==",
-          "dev": true,
-          "requires": {
-            "commander": "^8.2.0",
-            "debug": "^4.1.1",
-            "extract-zip": "^2.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "jpeg-js": "^0.4.2",
-            "mime": "^2.4.6",
-            "pngjs": "^5.0.0",
-            "progress": "^2.0.3",
-            "proper-lockfile": "^4.1.1",
-            "proxy-from-env": "^1.1.0",
-            "rimraf": "^3.0.2",
-            "socks-proxy-agent": "^6.1.0",
-            "stack-utils": "^2.0.3",
-            "ws": "^7.4.6",
-            "yauzl": "^2.10.0",
-            "yazl": "^2.5.1"
-          }
-        }
       }
     },
     "playwright-core": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.17.1.tgz",
-      "integrity": "sha512-C3c8RpPiC3qr15fRDN6dx6WnUkPLFmST37gms2aoHPDRvp7EaGDPMMZPpqIm/QWB5J40xDrQCD4YYHz2nBTojQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.18.0.tgz",
+      "integrity": "sha512-JTRlCVpfAFcC1nth+XIE07w6M5m6C8PaEoClv7wGWF97cyDMcHIij0xIVEKMKli7IG5N0mqjLDFc/akXSbMZ1g==",
       "dev": true,
       "requires": {
         "commander": "^8.2.0",
@@ -47591,6 +47735,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
       "dev": true
     },
     "reserved-words": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@nuxtjs/router-extras": "^1.1.1",
     "@nuxtjs/style-resources": "^1.2.1",
     "@octokit/rest": "^18.0.12",
-    "@playwright/test": "^1.17.0",
+    "@playwright/test": "^1.18.0",
     "@types/dompurify": "^2.2.2",
     "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.168",

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -3,9 +3,7 @@ import {
 } from 'child_process';
 import stream from 'stream';
 
-// Removed prefix path due an error on
-// playwright/test class - see https://github.com/microsoft/playwright/issues/7121
-import { Log } from '../utils/logging';
+import { Log } from '@/utils/logging';
 
 export {
   ChildProcess, CommonOptions, SpawnOptions, exec, spawn

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -25,9 +25,7 @@ import stream from 'stream';
 
 import Electron from 'electron';
 
-// Removed prefix path due an error on
-// playwright/test class - see https://github.com/microsoft/playwright/issues/7121
-import paths from '../utils/paths';
+import paths from '@/utils/paths';
 
 type consoleKey = 'log' | 'error' | 'info' | 'warn';
 type logLevel = 'debug' | 'info';


### PR DESCRIPTION
### Changes
1. Rolled back import changes (path aliases) on `src/utils/childProcess.ts` and `src/utils/logging.ts` -> more info [here](https://github.com/rancher-sandbox/rancher-desktop/pull/1146/files#diff-0e07a00003db43dce30c641a3a8584a95408101eb80a17dc8f0e6aaf029b77c2L28)
2. Bump test runner plugin `@playwright/test` from 1.17.0 to 1.18.0. 