### PR TITLE
WSL: Use dnsmasq

### DIFF
--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.12.1';
+  const v = '0.14';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/assets/scripts/wsl-data.conf
+++ b/src/assets/scripts/wsl-data.conf
@@ -1,0 +1,14 @@
+# This is the /etc/wsl.conf for use with rancher-desktop-data
+# As we do not have an actual data distribution, this file is included as part
+# of the application and written out at runtime.
+
+[automount]
+# Prevent processing /etc/fstab, since it doesn't exist.
+mountFsTab = false
+# Prevent running ldconfig, since that doesn't exist.
+ldconfig = false
+# Needed for compatibility with some `npm install` scenarios.
+options = metadata
+
+# We _do_ want to generate `/etc/hosts` here, so that it can be used by the main
+# distribution.

--- a/src/k8s-engine/progressTracker.ts
+++ b/src/k8s-engine/progressTracker.ts
@@ -65,6 +65,8 @@ export default class ProgressTracker {
 
   /**
    * Register an action.
+   * @param description Descriptive text for the action, to be shown to the user.
+   * @param priority Only the action with the largest priority will be shown among concurrent actions.
    * @returns A promise that will be resolved when the passed-in promise resolves.
    */
   action<T>(description: string, priority: number, promise: Promise<T>): Promise<T>;

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -60,7 +60,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.12.1';
+const DISTRO_VERSION = '0.14';
 
 /**
  * The list of directories that are in the data distribution (persisted across

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -475,7 +475,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
             // The tar-stream package doesn't handle appends well (needs to
             // stream to a temporary file), and busybox tar doesn't support
-            // append either.  Luckily Windows shipes with a bsdtar that
+            // append either.  Luckily Windows ships with a bsdtar that
             // supports it, though it only supports short options.
             for (const [relPath, contents] of Object.entries(OVERRIDE_FILES)) {
               const absPath = path.join(workdir, 'tar', relPath);
@@ -571,7 +571,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             'resolv-file':    '/etc/dnsmasq.d/data-resolv-conf',
             'listen-address': await this.ipAddress,
           }).map(([k, v]) => `${ k }=${ v }\n`).join('')),
-        this.writeFile( '/etc/resolv.conf', `nameserver ${ await this.ipAddress }`),
+        this.writeFile('/etc/resolv.conf', `nameserver ${ await this.ipAddress }`),
         this.writeConf('dnsmasq', { DNSMASQ_OPTS: '--user=dnsmasq --group=dnsmasq' }),
       ]));
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -534,9 +534,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async writeHostsFile() {
     await this.progressTracker.action('Updating /etc/hosts', 50, async() => {
       const contents = await fs.promises.readFile(`\\\\wsl$\\${ DATA_INSTANCE_NAME }\\etc\\hosts`);
+      const hosts = ['host.rancher-desktop.internal', 'host.docker.internal'];
       const extra = [
         '# BEGIN Rancher Desktop configuration.',
-        `${ this.hostIPAddress } host.docker.internal host.minikube.internal`,
+        `${ this.hostIPAddress } ${ hosts.join(' ') }`,
         '# END Rancher Desktop configuration.',
       ].map(l => `${ l }\n`).join('');
 


### PR DESCRIPTION
This adds dnsmasq on Windows, and uses it for the rancher-desktop WSL distribution.  It mostly forwards to the normal nameserver (by reading the `resolv.conf` from the data distribution), but additionally interprets `/etc/hosts` where we add the fake hostnames `host.docker.internal` and `host.minikube.internal`.

Requires https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/pull/23.
Fixes #893.