### PR TITLE
Bump lima-and-qemu to 1.17

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.16';
+const limaTag = 'v1.17';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.5';


### PR DESCRIPTION
* DNS and proxy settings are collected from first interface with an IPv4 address
* sshfs cache option is now configurable in lima.yaml
