### PR TITLE
Make childproces.spawnFile always hide Windows console.

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -641,7 +641,7 @@ export default class K3sHelper extends events.EventEmitter {
 
       await childProcess.spawnFile(
         resources.executable('kubectl'), ['config', 'use-context', contextName],
-        { stdio: console, windowsHide: true });
+        { stdio: console });
     } finally {
       await fs.promises.rm(workDir, {
         recursive: true, force: true, maxRetries: 10

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -734,7 +734,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           ...options,
           encoding:    options.encoding ?? 'utf16le',
           stdio:       ['ignore', 'pipe', stream],
-          windowsHide: true,
         });
 
         return stdout;
@@ -744,7 +743,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         ...options,
         encoding:    options.encoding ?? 'utf16le',
         stdio:       ['ignore', stream, stream],
-        windowsHide: true,
       });
     } catch (ex) {
       if (!options.expectFailure) {
@@ -1334,7 +1332,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         return childProcess.spawn('wsl.exe',
           ['--distribution', distro, '--user', 'root', '--exec', executable,
             'docker-proxy', 'serve', ...this.debugArg('--verbose')],
-          { stdio: ['ignore', logStream, logStream] }
+          { stdio: ['ignore', logStream, logStream], windowsHide: true }
         );
       },
       async(child: childProcess.ChildProcess) => {

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -63,7 +63,8 @@ function isLog(it: StdioElementType): it is Log {
 }
 
 /**
- * Wrapper around child_process.spawn() to promisify it.
+ * Wrapper around child_process.spawn() to promisify it.  On Windows, we never
+ * spawn a new command prompt window.
  * @param command The executable to spawn.
  * @param args Any arguments to the executable.
  * @param options Options to child_process.spawn();
@@ -181,7 +182,11 @@ export async function spawnFile(
 
   // Spawn the child, overriding options.stdio.  This is necessary to support
   // transcoding the output.
-  const child = spawn(command, args || [], { ...options, stdio: mungedStdio });
+  const child = spawn(command, args || [], {
+    windowsHide: true,
+    ...options,
+    stdio:       mungedStdio,
+  });
   const resultMap: Record<number, 'stdout' | 'stderr'> = { 1: 'stdout', 2: 'stderr' };
   const result: { stdout?: string, stderr?: string } = {};
 


### PR DESCRIPTION
We never want to show the console to the user.  Also, add `windowsHide: true` to any direct `child_process.spawn()` calls.

I thought we didn't need to do this (because it seemed fine when I tried things); turns out that was just because I was using `npm run dev`, so the process already had a console.

Fixes #1248.