### PR TITLE
Handle paths in `nerdctl compose` subcommands

### DIFF
--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -278,9 +278,8 @@ func init() {
 	registerArgHandler("compose", "-f", filePathArgHandler)
 	registerArgHandler("compose", "--project-directory", filePathArgHandler)
 	registerArgHandler("compose", "--env-file", filePathArgHandler)
-	subcommands := []string{"build", "config", "down", "kill", "logs", "ps", "pull", "push", "up"}
-	for _, sc := range subcommands {
-		// No `-f` option because they aren't in the help for any of the `docker compose X` subcommands.:w
+	for _, sc := range []string{"build", "config", "down", "kill", "logs", "ps", "pull", "push", "up"} {
+		// No `-f` option because they aren't in the help for any of the `docker compose X` subcommands.
 		registerArgHandler("compose " + sc, "--file", filePathArgHandler)
 		registerArgHandler("compose " + sc, "--project-directory", filePathArgHandler)
 		registerArgHandler("compose " + sc, "--env-file", filePathArgHandler)

--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -278,6 +278,13 @@ func init() {
 	registerArgHandler("compose", "-f", filePathArgHandler)
 	registerArgHandler("compose", "--project-directory", filePathArgHandler)
 	registerArgHandler("compose", "--env-file", filePathArgHandler)
+	subcommands := []string{"build", "config", "down", "kill", "logs", "ps", "pull", "push", "up"}
+	for _, sc := range subcommands {
+		// No `-f` option because they aren't in the help for any of the `docker compose X` subcommands.:w
+		registerArgHandler("compose " + sc, "--file", filePathArgHandler)
+		registerArgHandler("compose " + sc, "--project-directory", filePathArgHandler)
+		registerArgHandler("compose " + sc, "--env-file", filePathArgHandler)
+	}
 	registerArgHandler("container run", "--cosign-key", filePathArgHandler)
 	registerArgHandler("container run", "--volume", volumeArgHandler)
 	registerArgHandler("container run", "-v", volumeArgHandler)


### PR DESCRIPTION
Some of the commands have a 3-level structure:
`nerdctl COMMAND options.... SUBCOMMAND options...`

This change will WSL-convert paths that appear in the second set
of options.

Signed-off-by: Eric Promislow <epromislow@suse.com>