### PR TITLE
WSL-Helper: make Linux vsock connection non-blocking.

### DIFF
--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-swagger/go-swagger v0.28.0
 	github.com/google/uuid v1.1.2
 	github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/vsock_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/vsock_linux.go
@@ -1,0 +1,158 @@
+package platform
+
+// This file contains extensions to vsock handling on Linux.  This is derived
+// from github.com/linuxkit/virtsock/pkg/vsock.
+
+/**
+ * Copyright 2016-2017 The authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/linuxkit/virtsock/pkg/vsock"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// Convert a generic unix.Sockaddr to a Addr
+func sockaddrToVsock(sa unix.Sockaddr) *vsock.Addr {
+	switch sa := sa.(type) {
+	case *unix.SockaddrVM:
+		return &vsock.Addr{CID: sa.CID, Port: sa.Port}
+	}
+	return nil
+}
+
+// ListenVsockNonBlocking returns a net.Listener which can accept connections on the given port, returning non-blocking connections.
+func ListenVsockNonBlocking(cid, port uint32) (net.Listener, error) {
+	fd, err := syscall.Socket(unix.AF_VSOCK, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	sa := &unix.SockaddrVM{CID: cid, Port: port}
+	if err = unix.Bind(fd, sa); err != nil {
+		return nil, errors.Wrapf(err, "bind() to %08x.%08x failed", cid, port)
+	}
+
+	err = syscall.Listen(fd, syscall.SOMAXCONN)
+	if err != nil {
+		return nil, errors.Wrapf(err, "listen() on %08x.%08x failed", cid, port)
+	}
+	return &vsockListener{fd, vsock.Addr{CID: cid, Port: port}}, nil
+}
+
+type vsockListener struct {
+	fd    int
+	local vsock.Addr
+}
+
+// Accept accepts an incoming call and returns the new connection.
+func (v *vsockListener) Accept() (net.Conn, error) {
+	fd, sa, err := unix.Accept4(v.fd, unix.SOCK_NONBLOCK)
+	if err != nil {
+		return nil, err
+	}
+	return newVsockConn(uintptr(fd), &v.local, sockaddrToVsock(sa)), nil
+}
+
+// Close closes the listening connection
+func (v *vsockListener) Close() error {
+	// Note this won't cause the Accept to unblock.
+	return unix.Close(v.fd)
+}
+
+// Addr returns the address the Listener is listening on
+func (v *vsockListener) Addr() net.Addr {
+	return v.local
+}
+
+// a wrapper around FileConn which supports CloseRead and CloseWrite
+type vsockConn struct {
+	vsock  *os.File
+	fd     uintptr
+	local  *vsock.Addr
+	remote *vsock.Addr
+}
+
+func newVsockConn(fd uintptr, local, remote *vsock.Addr) *vsockConn {
+	vsock := os.NewFile(fd, fmt.Sprintf("vsock:%d", fd))
+	return &vsockConn{vsock: vsock, fd: fd, local: local, remote: remote}
+}
+
+// LocalAddr returns the local address of a connection
+func (v *vsockConn) LocalAddr() net.Addr {
+	return v.local
+}
+
+// RemoteAddr returns the remote address of a connection
+func (v *vsockConn) RemoteAddr() net.Addr {
+	return v.remote
+}
+
+// Close closes the connection
+func (v *vsockConn) Close() error {
+	return v.vsock.Close()
+}
+
+// CloseRead shuts down the reading side of a vsock connection
+func (v *vsockConn) CloseRead() error {
+	return syscall.Shutdown(int(v.fd), syscall.SHUT_RD)
+}
+
+// CloseWrite shuts down the writing side of a vsock connection
+func (v *vsockConn) CloseWrite() error {
+	return syscall.Shutdown(int(v.fd), syscall.SHUT_WR)
+}
+
+// Read reads data from the connection
+func (v *vsockConn) Read(buf []byte) (int, error) {
+	return v.vsock.Read(buf)
+}
+
+// Write writes data over the connection
+func (v *vsockConn) Write(buf []byte) (int, error) {
+	return v.vsock.Write(buf)
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection
+func (v *vsockConn) SetDeadline(t time.Time) error {
+	return nil // FIXME
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+func (v *vsockConn) SetReadDeadline(t time.Time) error {
+	return nil // FIXME
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+func (v *vsockConn) SetWriteDeadline(t time.Time) error {
+	return nil // FIXME
+}
+
+// File duplicates the underlying socket descriptor and returns it.
+func (v *vsockConn) File() (*os.File, error) {
+	// This is equivalent to dup(2) but creates the new fd with CLOEXEC already set.
+	r0, _, e1 := syscall.Syscall(syscall.SYS_FCNTL, uintptr(v.vsock.Fd()), syscall.F_DUPFD_CLOEXEC, 0)
+	if e1 != 0 {
+		return nil, os.NewSyscallError("fcntl", e1)
+	}
+	return os.NewFile(r0, v.vsock.Name()), nil
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -31,6 +31,7 @@ import (
 	"github.com/linuxkit/virtsock/pkg/vsock"
 	"golang.org/x/sys/unix"
 
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/util"
 )
 
@@ -111,7 +112,7 @@ func Start(port uint32, dockerSocket string, args []string) error {
 		return err
 	}
 
-	listener, err := vsock.Listen(vsock.CIDAny, port)
+	listener, err := platform.ListenVsockNonBlocking(vsock.CIDAny, port)
 	if err != nil {
 		return fmt.Errorf("could not listen on vsock port %08x: %w", port, err)
 	}


### PR DESCRIPTION
When we pipe the connection between the unix docker socket (`/var/run/docker.sock`) and the vsock socket, we need to open the vsock side as non-blocking so that once the unix side is closed we can close the vsock side properly.  Otherwise the client would not be able to detect the socket should close.

This copies an (Apache-2.0 licensed) file from github.com/linuxkit/virtsock so that we can make the resulting socket non-blocking.  The only relevant change is in `func (v *vsockListener) Accept()` to add `SOCK_NONBLOCK`.

This should fix #1171.