### PR TITLE
Project board automation

### DIFF
--- a/.github/workflows/board-automation.yaml
+++ b/.github/workflows/board-automation.yaml
@@ -1,0 +1,17 @@
+name: Stripey
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: skeet70/default-project-board-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          project: 1

--- a/.github/workflows/board-automation.yaml
+++ b/.github/workflows/board-automation.yaml
@@ -9,7 +9,7 @@ jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
-      - uses: skeet70/default-project-board-action@v1
+      - uses: skeet70/default-project-board-action@b1f4d447074827722eb1f0258c3741dd8e156b66
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/.github/workflows/board-automation.yaml
+++ b/.github/workflows/board-automation.yaml
@@ -7,14 +7,13 @@ on:
       - reopened
 permissions:
     issues: write
-    repository-projects: write
 jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
       - uses: skeet70/default-project-board-action@b1f4d447074827722eb1f0258c3741dd8e156b66
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           repository: ${{ github.repository }}
           issue: ${{ github.event.issue.number }}
           project: 1

--- a/.github/workflows/board-automation.yaml
+++ b/.github/workflows/board-automation.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
       - reopened
+permissions:
+    issues: write
+    repository-projects: write
 jobs:
   add_to_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/board-automation.yaml
+++ b/.github/workflows/board-automation.yaml
@@ -7,6 +7,7 @@ on:
       - reopened
 permissions:
     issues: write
+    repository-projects: write
 jobs:
   add_to_project:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changes
1. Implemented a GHA workflow to auto assign Project  in `opened/reopened`  issues

#### How it works?
The workflow will detect any new or reopened issues and will trigger the GHA runner. We don't need to create or edit the existing issues templates, the automation will use the existing ones.

<img width="857" alt="Screen Shot 2022-01-28 at 1 52 22 PM" src="https://user-images.githubusercontent.com/37411123/151588264-3373d9cb-3ee1-4b83-8b57-a490ff0bef3d.png">
.