### PR TITLE
Source /etc/environment early in service-k3s.initd

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -4,6 +4,8 @@
 
 # shellcheck shell=ksh
 
+if [ -f /etc/environment ]; then source /etc/environment; fi
+
 # ENGINE configuration variable is either "moby" or "containerd"
 ENGINE="${ENGINE:-containerd}"
 
@@ -39,4 +41,3 @@ respawn_delay=5
 respawn_max=0
 
 set -o allexport
-if [ -f /etc/environment ]; then source /etc/environment; fi


### PR DESCRIPTION
/etc/environment is updated with env vars from `override.yaml` but they don't take effect early enough for the K8S_EXEC variable to be taken into account.

Related: https://github.com/rancher-sandbox/rancher-desktop/pull/926
Related: https://github.com/rancher-sandbox/rancher-desktop/pull/1097