### PR TITLE
Bump lima-and-qemu to v1.18

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.17';
+const limaTag = 'v1.19';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.5';


### PR DESCRIPTION
* Default for `mounts.sshfs.cache` has been reverted to `true`.
* The Linux tarball no longer includes `libgmodule` to fix Fedora 35 compatibility issues.
* The macOS `aarch64` release has been updated to the same lima version as the `x86_64` one (this was broken in v1.17).

Fixes #1269 
Fixes #1349 
Fixes #1356 
Fixes #1403 
