### PR TITLE
Incrementing internal version to 1.1.0 for next minor release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rancher-desktop",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rancher-desktop",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rancher-desktop",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "SUSE",
     "email": "containers@suse.com"


### PR DESCRIPTION
Once 1.0.1 has been released this change will stop the updater
from trying to downgrade a system running a dev build.