### PR TITLE
Close all sockets when closing the server

### DIFF
--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -541,7 +541,7 @@ export class KubeClient extends events.EventEmitter {
           .get(targetName)
           ?.forEach(socket => socket.destroy());
 
-        this.sockets.set(targetName, []);
+        this.sockets.delete(targetName);
       });
       this.emit('service-changed', this.listServices());
     }

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -199,6 +199,12 @@ export class KubeClient extends events.EventEmitter {
    * entry exists, then we want to set up port forwarding for it.
    */
   protected servers = new ForwardingMap();
+
+  /**
+   * Collection of active sockets. Used to clean up connections when attempting
+   * to close a server. Keys can be any string, but are formatted as
+   * namespace/endpoint:port to help match sockets to the corresponding server.
+   */
   protected sockets = new Map<string, net.Socket[]>();
 
   protected coreV1API: k8s.CoreV1Api;
@@ -379,6 +385,13 @@ export class KubeClient extends events.EventEmitter {
     return pod?.status?.phase === 'Running';
   }
 
+  /**
+   * Formats the namespace, endpoint, and port as namespace/endpoint:port
+   * @param namespace The namespace to forward to.
+   * @param endpoint The endpoint in the namespace to forward to.
+   * @param port The port to forward to on the endpoint.
+   * @returns A formatted string consisting of the namespace/endpoint:port
+   */
   private targetName =
     (namespace: string, endpoint: string, port: number | string) => `${ namespace }/${ endpoint }:${ port }`
 

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -530,13 +530,18 @@ export class KubeClient extends events.EventEmitter {
    * @param port The port to forward to on the endpoint.
    */
   async cancelForwardPort(namespace: string, endpoint: string, port: number | string) {
+    const targetName = this.targetName(namespace, endpoint, port);
     const server = this.servers.get(namespace, endpoint, port);
 
     this.servers.delete(namespace, endpoint, port);
     if (server) {
       await new Promise((resolve) => {
         server.close(resolve);
-        this.sockets.forEach(socket => socket.destroy());
+        this.sockets
+          .get(targetName)
+          ?.forEach(socket => socket.destroy());
+
+        this.sockets.set(targetName, []);
       });
       this.emit('service-changed', this.listServices());
     }

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -379,6 +379,9 @@ export class KubeClient extends events.EventEmitter {
     return pod?.status?.phase === 'Running';
   }
 
+  private targetName =
+    (namespace: string, endpoint: string, port: number | string) => `${ namespace }/${ endpoint }:${ port }`
+
   /**
    * Create a port forwarding, listening on localhost.  Note that if the
    * endpoint isn't ready yet, the port forwarding might not work correctly
@@ -388,7 +391,7 @@ export class KubeClient extends events.EventEmitter {
    * @param port The port to forward to on the endpoint.
    */
   protected async createForwardingServer(namespace: string, endpoint: string, port: number | string): Promise<void> {
-    const targetName = `${ namespace }/${ endpoint }:${ port }`;
+    const targetName = this.targetName(namespace, endpoint, port);
 
     if (this.servers.get(namespace, endpoint, port)) {
       // We already have a port forwarding server; don't clobber it.
@@ -497,7 +500,7 @@ export class KubeClient extends events.EventEmitter {
    * @return The port number for the port forward.
    */
   async forwardPort(namespace: string, endpoint: string, port: number | string): Promise<number | undefined> {
-    const targetName = `${ namespace }/${ endpoint }:${ port }`;
+    const targetName = this.targetName(namespace, endpoint, port);
 
     await this.createForwardingServer(namespace, endpoint, port);
 


### PR DESCRIPTION
This resolves an issue where the Forward button under the Port Forwarding page would seemingly not switch between `Close` and `Forward` when attempting to close a port. 

### Background

The button would toggle back to `Forward`, it would just take upwards to 3 minutes when there was an active connection. `server.close()` is designed to behave this way and only ever closes after all connections are closed.

### Solution

We keep track of all sockets when creating a connection and destroy each socket after `server.close()` is invoked.  

closes #469 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>