### PR TITLE
Use a more specific test for the presence of a file or symlink.

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1431,7 +1431,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     // Update only the distro -- the current
     if (state) {
       await this.execWSL('--distribution', distro, '/bin/sh', '-c', `mkdir -p "${ destDir }"`);
-      await this.execWSL('--distribution', distro, '/bin/sh', '-c', `if [ ! -f "${ destPath }" ] ; then ln -s "${ srcPath }" "${ destPath }" ; fi`);
+      await this.execWSL('--distribution', distro, '/bin/sh', '-c', `if [ ! -e "${ destPath }" -a ! -L "${ destPath }" ] ; then ln -s "${ srcPath }" "${ destPath }" ; fi`);
       await this.updateDockerComposeLocally();
     } else {
       try {


### PR DESCRIPTION
`! -f GOOD_SYMLINK` returns true when the symlink exists but its referent doesn't.

We want to create a symlink only when there's no real file with that name in the directory,
and no symlink.

So we need to test for both any file (the `-e`) and symlinks (the `-L`).

Signed-off-by: Eric Promislow <epromislow@suse.com>