### PR TITLE
Tolerate failing to run tmutil

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -582,7 +582,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await fs.promises.mkdir(path.dirname(this.CONFIG_PATH), { recursive: true });
       await fs.promises.writeFile(this.CONFIG_PATH, yaml.stringify(config));
       if (os.platform().startsWith('darwin')) {
-        await childProcess.spawnFile('tmutil', ['addexclusion', paths.lima]);
+        try {
+          await childProcess.spawnFile('tmutil', ['addexclusion', paths.lima]);
+        } catch (ex) {
+          console.log('Failed to add exclusion to TimeMachine', ex);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #1337

Apparently the call to `tmutil` is purely an administrative hint to `Time Machine`, and thus while it's fine to log the failure, there's really no reason to die when it fails.