### PR TITLE
k3s-helper: Log certificate on error.

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -7,12 +7,12 @@ import stream from 'stream';
 import tls from 'tls';
 import util from 'util';
 
-import fetch from 'node-fetch';
 import semver from 'semver';
 import { CustomObjectsApi, KubeConfig, V1ObjectMeta } from '@kubernetes/client-node';
 import { ActionOnInvalid } from '@kubernetes/client-node/dist/config_types';
 import yaml from 'yaml';
 
+import fetch from '@/utils/fetch';
 import Logging from '@/utils/logging';
 import DownloadProgressListener from '@/utils/DownloadProgressListener';
 import safeRename from '@/utils/safeRename';

--- a/src/main/networking/index.ts
+++ b/src/main/networking/index.ts
@@ -53,7 +53,7 @@ export async function *getSystemCertificates(): AsyncIterable<string> {
 }
 
 // Set up certificate handling for system certificates on Windows and macOS
-Electron.app.on('certificate-error', async(event, webContents, url, error, certificate, callback) => {
+Electron.app?.on('certificate-error', async(event, webContents, url, error, certificate, callback) => {
   if (error === 'net::ERR_CERT_INVALID') {
     // If we're getting *this* particular error, it means it's an untrusted cert.
     // Ask the system store.

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -7,9 +7,9 @@ import { newError, CustomPublishOptions } from 'builder-util-runtime';
 import Electron from 'electron';
 import { AppUpdater, Provider, ResolvedUpdateFileInfo, UpdateInfo } from 'electron-updater';
 import { ProviderRuntimeOptions, ProviderPlatform } from 'electron-updater/out/providers/Provider';
-import fetch from 'node-fetch';
 import semver from 'semver';
 
+import fetch from '@/utils/fetch';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -80,7 +80,16 @@ class CustomAgent extends https.Agent {
 let systemCerts: string[];
 
 /**
- * A wrapper for node-fetch to log certificates on error.
+ * Fetch a remote URL, throwing a CertificateVerificationError if there is an
+ * issue with the server certificate.
+ *
+ * This is a wrapper for node-fetch's version of fetch(), except that on
+ * certificate error we throw a CertificateVerificationError that provides
+ * details on the certificate that failed to verify (instead of the default
+ * behaviour where we only get the error string without certificate details).
+ *
+ * Note that, due to an implementation detail, providing a custom HTTP agent may
+ * not work correctly.
  */
 export default async function fetch(url: string, options?: RequestInit) {
   if (!systemCerts) {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,89 @@
+import http from 'http';
+import https from 'https';
+import tls from 'tls';
+
+import _fetch, { RequestInit } from 'node-fetch';
+
+import Logging from '@/utils/logging';
+import { getSystemCertificates } from '@/main/networking';
+
+const console = Logging.fetch;
+
+class CustomAgent extends https.Agent {
+  createConnection(options: http.ClientRequestArgs, ...args: any) {
+    // create the socket, but tell it to _not_ reject unauthorized connections.
+    // We manually raise errors instead; this is required to fetch the offending certificate.
+    const method = (https.Agent.prototype as any).createConnection;
+    const socket = method.call(this, { ...options, rejectUnauthorized: false }, ...args);
+
+    if (socket instanceof tls.TLSSocket) {
+      socket.on('secureConnect', () => {
+        if (socket.authorized) {
+          return;
+        }
+        const cert = socket.getPeerCertificate(true);
+        let error = socket.authorizationError;
+
+        if (typeof error === 'string') {
+          error = new Error(error);
+        }
+        console.error(`Certificate verification failure at ${ new Date() }: ${ error }`, cert);
+        socket.emit('error', error);
+      });
+    }
+
+    return socket;
+  }
+}
+
+let systemCerts: string[];
+
+/**
+ * A wrapper for node-fetch to log certificates on error.
+ */
+export default async function fetch(url: string, options?: RequestInit) {
+  if (!systemCerts) {
+    const certs = [];
+
+    for await (const cert of getSystemCertificates()) {
+      certs.push(cert);
+    }
+    systemCerts = certs;
+  }
+
+  return await _fetch(url, {
+    ...options,
+    agent: (parsedURL) => {
+      // Find the correct agent, given user options and defaults.
+      let agent: http.Agent;
+
+      if (options?.agent) {
+        if (options.agent instanceof http.Agent) {
+          agent = options.agent;
+        } else {
+          agent = options.agent(parsedURL);
+        }
+      } else {
+        agent = http.globalAgent;
+      }
+      if (!parsedURL.protocol.startsWith('https')) {
+        return agent;
+      }
+
+      // Need to construct a custom agent.
+      const secureAgent = agent as https.Agent ?? https.globalAgent;
+      let ca = secureAgent.options.ca ?? [];
+
+      if (!Array.isArray(ca)) {
+        ca = [ca];
+      }
+
+      console.debug(`Creating custom HTTPS agent for ${ parsedURL }`);
+
+      return new CustomAgent({
+        ...secureAgent.options,
+        ca: [...ca, ...systemCerts],
+      });
+    }
+  });
+}

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -108,6 +108,8 @@ export default async function fetch(url: string, options?: RequestInit) {
       ...options,
       agent: (parsedURL) => {
         // Find the correct agent, given user options and defaults.
+        const isSecure = parsedURL.protocol.startsWith('https');
+
         if (options?.agent) {
           if (options.agent instanceof http.Agent) {
             agent = options.agent;
@@ -115,9 +117,9 @@ export default async function fetch(url: string, options?: RequestInit) {
             agent = options.agent(parsedURL);
           }
         } else {
-          agent = http.globalAgent;
+          agent = isSecure ? https.globalAgent : http.globalAgent;
         }
-        if (!parsedURL.protocol.startsWith('https')) {
+        if (!isSecure) {
           return agent;
         }
 


### PR DESCRIPTION
This makes an extra log for certificate details when failing to fetch k3s releases &c; this is meant to troubleshoot user issues.