### PR TITLE
No need to switch contexts globally.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -73,7 +73,7 @@ export async function tool(tool: string, ...args: string[]): Promise<string> {
  * @example await kubectl('version')
  */
 export async function kubectl(...args: string[] ): Promise<string> {
-  return await tool('kubectl', ...args);
+  return await tool('kubectl', '--context', 'rancher-desktop', ...args);
 }
 
 /**

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -82,5 +82,5 @@ export async function kubectl(...args: string[] ): Promise<string> {
  * @example await helm('version')
  */
 export async function helm(...args: string[] ): Promise<string> {
-  return await tool('helm', ...args);
+  return await tool('helm', '--kube-context', 'rancher-desktop', ...args);
 }

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -634,14 +634,6 @@ export default class K3sHelper extends events.EventEmitter {
         writeStream.end(userYAML, 'utf-8');
       });
       await safeRename(workPath, userPath);
-
-      // The config file we modified might not be the top level one.
-      // Update the current context.
-      console.log('Setting default context...');
-
-      await childProcess.spawnFile(
-        resources.executable('kubectl'), ['config', 'use-context', contextName],
-        { stdio: console });
     } finally {
       await fs.promises.rm(workDir, {
         recursive: true, force: true, maxRetries: 10


### PR DESCRIPTION
Always specify an explicit context when calling kubectl.

Fixes #622