### PR TITLE
E2E tests: fix races when navigating to page.

### DIFF
--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -46,7 +46,7 @@ export class NavPage {
 
     async navigateTo(tab: keyof typeof pageConstructors) {
       await this.page.click(`.nav li[item="/${ tab }"] a`);
-      await this.page.waitForNavigation({ url: `**/${ tab }`, timeout: 60_000 });
+      await this.page.waitForURL(`**/${ tab }`, { timeout: 60_000 });
 
       return pageConstructors[tab](this.page);
     }


### PR DESCRIPTION
`waitForNavigation` will get stuck forever if we're already on the desired page (because it only examines navigation events).  Use `waitForURL` instead, which handles this case.

Fixes #1482.