### PR TITLE
K3s-helper: Set default context if it didn't exist.

### DIFF
--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -625,6 +625,7 @@ export default class K3sHelper extends events.EventEmitter {
       merge(userConfig.contexts, workConfig.contexts);
       merge(userConfig.users, workConfig.users);
       merge(userConfig.clusters, workConfig.clusters);
+      userConfig.currentContext ??= contextName;
       const userYAML = this.ensureContentsAreYAML(userConfig.exportConfig());
       const writeStream = fs.createWriteStream(workPath, { mode: 0o600 });
 


### PR DESCRIPTION
Kuberlr gets unhappy if we have a kubeconfig without any default context set at all.
