### PR TITLE
Update README.md to reflect existence of `rancherdesktop.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm run test:e2e
 
 ## Building
 
-Rancher can be built from source on macOS, Windows or Linux.
+Rancher can be built from source on Windows, macOS or Linux.
 Cross-compilation is currently not supported.
 
 
@@ -78,18 +78,18 @@ with an existing Windows installation.
    `Windows PowerShell`).
 3. Run the [automated setup script]:
 
-  ```powershell
-  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-  iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
-  ```
+   ```powershell
+   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+   iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
+   ```
 
 4. Close the privileged PowerShell prompt.
 5. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
    
-  ```
-  npm config set msvs_version <visual-studio-version-number>
-  npm config set msbuild_path <path/to/MSBuild.exe>
-  ```
+   ```
+   npm config set msvs_version <visual-studio-version-number>
+   npm config set msbuild_path <path/to/MSBuild.exe>
+   ```
 
 You are now ready to clone the repository and run `npm install`.
 
@@ -107,10 +107,10 @@ You are now ready to clone the repository and run `npm install`.
 5. Install Visual Studio 2017 or higher. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
 6. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
 
-  ```
-  npm config set msvs_version <visual-studio-version-number>
-  npm config set msbuild_path <path/to/MSBuild.exe>
-  ```
+   ```
+   npm config set msvs_version <visual-studio-version-number>
+   npm config set msbuild_path <path/to/MSBuild.exe>
+   ```
 
 [Scoop]: https://scoop.sh/
 [Visual Studio docs]: https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio?view=vs-2022

--- a/README.md
+++ b/README.md
@@ -11,25 +11,73 @@ please see [docs.rancherdesktop.io][docs].
 [docs]: https://docs.rancherdesktop.io
 
 
-## Installing
+## Setup
 
-In order to work with Rancher Desktop, you need a few things:
+### Windows
 
-- [Node.js][Node.js] v16
-- [Go][Go] 1.16 or later (required only for Windows)
+There are two options for building from source on Windows: with a
+[Development VM Setup](#development-vm-setup) or
+[Manual Development Environment Setup](#manual-development-environment-setup)
+with an existing Windows installation.
 
-Once you have these things, you need to install Rancher Desktop's
-dependencies:
+
+#### Development VM Setup
+
+1. Download a Microsoft Windows 10 [development virtual machine].
+2. Open a PowerShell prompt (hit Windows Key + `X` and open
+   `Windows PowerShell`).
+3. Run the [automated setup script]:
+
+   ```powershell
+   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+   iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
+   ```
+
+4. Close the privileged PowerShell prompt.
+5. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
+   
+   ```
+   npm config set msvs_version <visual-studio-version-number>
+   npm config set msbuild_path <path/to/MSBuild.exe>
+   ```
+
+You can now clone the repository and run `npm install`.
+
+[development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
+[automated setup script]: ./scripts/windows-setup.ps1
+
+
+#### Manual Development Environment Setup
+
+1. Install [Windows Subsystem for Linux (WSL)] on your machine. Skip this step, if WSL is already installed.
+2. Open a PowerShell prompt (hit Windows Key + `X` and open `Windows PowerShell`).
+3. Install [Scoop] via `iwr -useb get.scoop.sh | iex`.
+4. Install git, go, nvm, and unzip via `scoop install git go nvm python unzip`.
+   Check node version with `nvm list`. If node v16 is not installed or set as the current version, then install using `nvm install 16` and set as current using `nvm use 16.xx.xx`.
+5. Install Visual Studio 2017 or higher. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
+6. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
+
+   ```
+   npm config set msvs_version <visual-studio-version-number>
+   npm config set msbuild_path <path/to/MSBuild.exe>
+   ```
+
+You can now clone the repository and run `npm install`.
+
+[Scoop]: https://scoop.sh/
+[Visual Studio docs]: https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio?view=vs-2022
+[Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
+
+
+### macOS and Linux
+
+Install [Node.js][Node.js] v16. Then you can install dependencies with:
 
 ```
 npm run install
 ```
 
-This step should be repeated after every pull of new code, since
-dependencies change frequently.
-
 [Node.js]: https://nodejs.org/
-[Go]: https://go.dev/
 
 
 ## Running
@@ -63,67 +111,13 @@ Rancher can be built from source on Windows, macOS or Linux.
 Cross-compilation is currently not supported.
 
 
-### Windows
-
-There are two options for building from source on Windows: with a
-[Development VM Setup](#development-vm-setup) or
-[Manual Development Environment Setup](#manual-development-environment-setup)
-with an existing Windows installation.
-
-
-#### Development VM Setup
-
-1. Download a Microsoft Windows 10 [development virtual machine].
-2. Open a PowerShell prompt (hit Windows Key + `X` and open
-   `Windows PowerShell`).
-3. Run the [automated setup script]:
-
-   ```powershell
-   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-   iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
-   ```
-
-4. Close the privileged PowerShell prompt.
-5. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
-   
-   ```
-   npm config set msvs_version <visual-studio-version-number>
-   npm config set msbuild_path <path/to/MSBuild.exe>
-   ```
-
-You are now ready to clone the repository and run `npm install`.
-
-[development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
-[automated setup script]: ./scripts/windows-setup.ps1
-
-
-#### Manual Development Environment Setup
-
-1. Install [Windows Subsystem for Linux (WSL)] on your machine. Skip this step, if WSL is already installed.
-2. Open a PowerShell prompt (hit Windows Key + `X` and open `Windows PowerShell`).
-3. Install [Scoop] via `iwr -useb get.scoop.sh | iex`.
-4. Install git, go, nvm, and unzip via `scoop install git go nvm python unzip`.
-   Check node version with `nvm list`. If node v16 is not installed or set as the current version, then install using `nvm install 16` and set as current using `nvm use 16.xx.xx`.
-5. Install Visual Studio 2017 or higher. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
-6. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
-
-   ```
-   npm config set msvs_version <visual-studio-version-number>
-   npm config set msbuild_path <path/to/MSBuild.exe>
-   ```
-
-[Scoop]: https://scoop.sh/
-[Visual Studio docs]: https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio?view=vs-2022
-[Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
-
-
-### macOS
-
-Simply run:
+### Windows and macOS
 
 ```
 npm run build
 ```
+
+The build output goes to `dist/`.
 
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -16,48 +16,40 @@ Rancher can be built from source on macOS, Windows or Linux.  Cross-compilation 
 currently not supported.  The following provides some detail on building.
 
 
-### Prerequisites
-
-Rancher Desktop is an [Electron] and [Node.js] application. Node.js v16 is 
-recommended to build the source.  On Windows, [Go] is also required. On Linux,
-[QEMU] is required at runtime.
-
-[Electron]: https://www.electronjs.org/
-[Node.js]: https://nodejs.org/
-[Go]: https://golang.org/
-[QEMU]: https://www.qemu.org/
-
-#### Windows
+### Building on Windows
 
 There are two options for building from source on Windows: with a
 [Development VM Setup](#development-vm-setup) or
 [Manual Development Environment Setup](#manual-development-environment-setup)
 with an existing Windows installation.
-##### Development VM Setup
+
+#### Development VM Setup
 
 1. Download a Microsoft Windows 10 [development virtual machine].
 2. Open a PowerShell prompt (hit Windows Key + `X` and open
    `Windows PowerShell`).
 3. Run the [automated setup script]:
-   ```powershell
-   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 
-   iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
-   ```
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+  iwr -useb 'https://github.com/rancher-sandbox/rancher-desktop/raw/main/scripts/windows-setup.ps1' | iex
+  ```
+
 4. Close the privileged PowerShell prompt.
 5. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
    
-   ```
-   npm config set msvs_version <visual-studio-version-number>
-   npm config set msbuild_path <path/to/MSBuild.exe>
-   ```
+  ```
+  npm config set msvs_version <visual-studio-version-number>
+  npm config set msbuild_path <path/to/MSBuild.exe>
+  ```
 
 You are now ready to clone the repository and run `npm install`.
 
 [development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
 [automated setup script]: ./scripts/windows-setup.ps1
 
-##### Manual Development Environment Setup
+
+#### Manual Development Environment Setup
 
 1. Install [Windows Subsystem for Linux (WSL)] on your machine. Skip this step, if WSL is already installed.
 2. Open a PowerShell prompt (hit Windows Key + `X` and open `Windows PowerShell`).
@@ -67,14 +59,25 @@ You are now ready to clone the repository and run `npm install`.
 5. Install Visual Studio 2017 or higher. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
 6. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
 
-   ```
-   npm config set msvs_version <visual-studio-version-number>
-   npm config set msbuild_path <path/to/MSBuild.exe>
-   ```
+  ```
+  npm config set msvs_version <visual-studio-version-number>
+  npm config set msbuild_path <path/to/MSBuild.exe>
+  ```
 
 [Scoop]: https://scoop.sh/
 [Visual Studio docs]: https://docs.microsoft.com/en-us/visualstudio/install/modify-visual-studio?view=vs-2022
 [Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
+
+
+### Prerequisites
+
+Rancher Desktop is an [Electron] and [Node.js] application. Node.js v16 is 
+recommended to build the source.  On Windows, [Go] is also required.
+
+[Electron]: https://www.electronjs.org/
+[Node.js]: https://nodejs.org/
+[Go]: https://golang.org/
+
 
 ### How To Run
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ The build output goes to `dist/`.
 On Linux it is not possible to completely build Rancher Desktop from
 the development environment. This is because [Open Build Service][OBS]
 is used to build the application package into a variety of Linux
-package formats. However, you can access development builds for Linux
-- see below.
+package formats. However, you can access development builds for Linux.
+To learn how see below.
 
 [OBS]: https://build.opensuse.org/
 

--- a/README.md
+++ b/README.md
@@ -128,3 +128,96 @@ is used to build the application package into a variety of Linux
 package formats.
 
 [OBS]: https://build.opensuse.org/
+
+
+## Development Builds
+
+### Windows and macOS
+
+Each commit triggers a GitHub actions run that results in application bundles
+(`.exes`, `.dmgs`) being uploaded as artifacts. This can be useful if you
+want to test the latest build of Rancher Desktop as it comes out of the build
+system. You can download these artifacts from the Summary page of completed actions.
+
+### Linux
+
+Like with Windows and macOS, Linux builds of Rancher Desktop are made from
+each commit. However, only part of the process is done by GitHub Actions.
+The final part of it is done by [Open Build Service][OBS].
+
+There are two channels of the Rancher Desktop repositories: `dev` and `stable`.
+`stable` is the channel that most users use - it serves only released versions of
+Rancher Desktop. `dev` is the channel that we are interested in here: it contains
+builds created from the latest commit made on the `main` branch, and on any branches
+that match the format `release-*`. To learn how to install the development
+repositories, see below.
+
+One more important note on the format of the versions of Rancher Desktop available
+from the `dev` repositories: The versions are in the format:
+
+```
+<priority>.<branch>.<commit>
+```
+
+where:
+
+`priority`: a meaningless number that exists to give versions built from the `main`
+            branch priority over versions built from the `release-*` branches
+`branch`: the branch name; dashes are removed due to constraints imposed by
+          package formats
+`commit`: the shortened hash of the commit used to make the build
+
+[OBS]: https://build.opensuse.org/
+
+
+#### `.deb` Development Repository
+
+You can add the repo with the following steps:
+
+```
+curl -s https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | gpg --dearmor | sudo dd status=none of=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-stable.list
+sudo apt update
+```
+
+You can see available versions with:
+
+```
+apt list -a rancher-desktop
+```
+
+Once you find the version you want to install you can install it with:
+
+```
+sudo apt install rancher-desktop=<version>
+```
+
+This works even if you already have a version of Rancher Desktop installed.
+
+
+#### `.rpm` Development Repository
+
+You can add the repo with:
+
+```
+sudo zypper addrepo https://download.opensuse.org/repositories/isv:/Rancher:/dev/rpm/isv:Rancher:dev.repo
+sudo zypper refresh
+```
+
+You can see available versions with:
+
+```
+zypper search -s rancher-desktop
+```
+
+Finally, install the version you want with:
+
+```
+zypper install rancher-desktop=<version>
+```
+
+Note that you may have to do `zypper install --oldpackage rancher-desktop=<version>`
+if you are doing a downgrade.
+
+
+#### Development AppImages

--- a/README.md
+++ b/README.md
@@ -230,3 +230,13 @@ This works even if you already have a version of Rancher Desktop installed.
 
 There are no repositories for AppImages, but you can access the latest development
 AppImage builds [here](https://download.opensuse.org/repositories/isv:/Rancher:/dev/AppImage/).
+
+
+## Contributing
+
+Please see [the document about contributing](CONTRIBUTING.md).
+
+
+## Further Reading
+
+Please see the [docs](docs/) directory for further developer documentation.

--- a/README.md
+++ b/README.md
@@ -1,76 +1,20 @@
 # Rancher Desktop
 
-Rancher Desktop is an open-source project to bring Kubernetes and container management to the desktop.
-Windows, macOS and Linux versions of Rancher Desktop are available for download, though do note that 
-the Linux version is considered a tech preview.
+Rancher Desktop is an open-source project that brings Kubernetes and
+container management to the desktop. It runs on Windows, macOS and
+Linux. For information not related to the development of Rancher
+Desktop, please see [rancherdesktop.io][home]. For documentation,
+please see [docs.rancherdesktop.io][docs].
 
-## Features
+[home]: https://rancherdesktop.io
+[docs]: https://docs.rancherdesktop.io
 
-Rancher Desktop provides the following features in the form of a desktop application:
-
-- The version of Kubernetes you choose
-- Ability to test upgrading Kubernetes to a new version and see how your workloads respond
-- Run containers, and build, push, and pull images (powered by [nerdctl])
-- Expose an application in Kubernetes for local access
-
-All of this is wrapped in an open-source application.
-
-[nerdctl]: https://github.com/containerd/nerdctl
-
-## Get The App
-
-You can download the application for macOS, Windows and Linux on the [releases page].
-
-[releases page]: https://github.com/rancher-sandbox/rancher-desktop/releases
-
-Running on Windows requires [Windows Subsystem for Linux (WSL2)]. This will be
-installed automatically during Rancher Desktop installation.
-
-[Windows Subsystem for Linux (WSL2)]:
-https://docs.microsoft.com/en-us/windows/wsl/install-win10
-
-Note, [development builds] are available from the CI system. Development builds
-are not signed.
-
-[development builds]:
-https://github.com/rancher-sandbox/rancher-desktop/actions/workflows/package.yaml?query=branch%3Amain
-
-For Linux, you will find both .DEB and .RPM packages attached as an asset for the most recent version.
-
-
-## System Requirements
-Recommended
-| **OS** | **Memory** | **CPU** |
-| :--- | :---: | :---: |
-| macOS | 8GB | 4CPU |
-| Windows | 8GB | 4CPU |
-| Linux | 8GB | 4CPU |
-
-OS versions we're currently using for development/testing:
-| **OS** | **Version**
-| :--- | :---: |
-| macOS | Catalina 10.15 or higher |
-| Windows | Home build 1909  or higher |
-| Ubuntu | Ubuntu 20.04 or higher |
-| openSUSE | Leap 15.3 or higher |
-| Fedora | Fedora 33 or higher |
-
-**Note:**
-Feel free to use a different OS version that haven't been listed.
-We are currently developing/testing Rancher Desktop on the listed OS and you can use it as a reference.
-
-## Base Design Details
-
-Rancher Desktop is an Electron application with the primary business logic
-written in TypeScript and JavaScript.  It leverages several other pieces of
-technology to provide the platform elements which include k3s, kubectl, nerdctl
-WSL, qemu, and more. The application wraps numerous pieces of technology to
-provide one cohesive application.
 
 ## Building The Source
 
 Rancher can be built from source on macOS, Windows or Linux.  Cross-compilation is
 currently not supported.  The following provides some detail on building.
+
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ please see [docs.rancherdesktop.io][docs].
 In order to work with Rancher Desktop, you need a few things:
 
 - [Node.js][Node.js] v16
-- [Go][Go] (Windows only)
+- [Go][Go] 1.16 or later (required only for Windows)
 
 Once you have these things, you need to install Rancher Desktop's
 dependencies:
@@ -117,14 +117,20 @@ You are now ready to clone the repository and run `npm install`.
 [Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
 
 
-## Other Stuff
+### macOS
 
-To build the distributable (application bundle on macOS, installer on Windows),
-run `npm run build`.
+Simply run:
 
-On Linux `npm run build` produces a zip file including the built binaries. To build the 
-distributable artifacts (RPM, Deb or AppImage) the [Open Build Service] is used.
-OBS makes use of the packaging recipes under `packaging/linux` folder of this
-repository together with the zip file including all built binaries.
+```
+npm run build
+```
 
-[Open Build Service]: https://build.opensuse.org/
+
+### Linux
+
+On Linux it is not possible to completely build Rancher Desktop from
+the development environment. This is because [Open Build Service][OBS]
+is used to build the application package into a variety of Linux
+package formats.
+
+[OBS]: https://build.opensuse.org/

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ package formats.
 You can add the repo with the following steps:
 
 ```
-curl -s https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | gpg --dearmor | sudo dd status=none of=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg
-echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-stable.list
+curl -s https://download.opensuse.org/repositories/isv:/Rancher:/dev/deb/Release.key | gpg --dearmor | sudo dd status=none of=/usr/share/keyrings/isv-rancher-dev-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-dev-archive-keyring.gpg] https://download.opensuse.org/repositories/isv:/Rancher:/dev/deb/ ./' | sudo dd status=none of=/etc/apt/sources.list.d/isv-rancher-dev.list
 sudo apt update
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ For user-oriented documentation, please see [docs.rancherdesktop.io][docs].
 [docs]: https://docs.rancherdesktop.io
 
 
+## Overview
+
+Rancher Desktop is an Electron application with the primary business logic
+written in TypeScript and JavaScript.  It leverages several other pieces of
+technology to provide the platform elements which include k3s, kubectl, nerdctl
+WSL, QEMU, and more. The application wraps numerous pieces of technology to
+provide one cohesive application.
+
+
 ## Setup
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ please see [docs.rancherdesktop.io][docs].
 [docs]: https://docs.rancherdesktop.io
 
 
-## Prerequisites
+## Installing
 
 In order to work with Rancher Desktop, you need a few things:
 
@@ -28,8 +28,11 @@ npm run install
 This step should be repeated after every pull of new code, since
 dependencies change frequently.
 
+[Node.js]: https://nodejs.org/
+[Go]: https://go.dev/
 
-## Running a Development Version
+
+## Running
 
 Once you have your dependencies installed you can run a development version
 of Rancher Desktop with:
@@ -39,13 +42,17 @@ npm run dev
 ```
 
 
-## Running Tests
+## Tests
 
-The first command runs the unit tests; the second command runs the
-integration tests:
+To run the unit tests:
 
 ```
 npm test
+```
+
+To run the integration tests:
+
+```
 npm run test:e2e
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ with an existing Windows installation.
 #### Development VM Setup
 
 1. Download a Microsoft Windows 10 [development virtual machine].
+   All of the following steps should be done in that virtual machine.
 2. Open a PowerShell prompt (hit Windows Key + `X` and open
    `Windows PowerShell`).
 3. Run the [automated setup script]:

--- a/README.md
+++ b/README.md
@@ -117,27 +117,13 @@ npm run test:e2e
 ## Building
 
 Rancher can be built from source on Windows, macOS or Linux.
-Cross-compilation is currently not supported.
-
-
-### Windows and macOS
+Cross-compilation is currently not supported. To run a build do:
 
 ```
 npm run build
 ```
 
 The build output goes to `dist/`.
-
-
-### Linux
-
-On Linux it is not possible to completely build Rancher Desktop from
-the development environment. This is because [Open Build Service][OBS]
-is used to build the application package into a variety of Linux
-package formats. However, you can access development builds for Linux.
-To learn how see below.
-
-[OBS]: https://build.opensuse.org/
 
 
 ## Development Builds
@@ -153,7 +139,7 @@ actions.
 
 ### Linux
 
-Like with Windows and macOS, Linux builds of Rancher Desktop are made from each
+Similar to Windows and macOS, Linux builds of Rancher Desktop are made from each
 commit. However on Linux, only part of the process is done by GitHub Actions.
 The final part of it is done by [Open Build Service][OBS].
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Rancher Desktop is an open-source project that brings Kubernetes and
 container management to the desktop. It runs on Windows, macOS and
-Linux. For information not related to the development of Rancher
+Linux. The below documentation pertains to the development of Rancher
+Desktop. For information not related to the development of Rancher
 Desktop, please see [rancherdesktop.io][home]. For documentation,
 please see [docs.rancherdesktop.io][docs].
 
@@ -10,18 +11,58 @@ please see [docs.rancherdesktop.io][docs].
 [docs]: https://docs.rancherdesktop.io
 
 
-## Building The Source
+## Prerequisites
 
-Rancher can be built from source on macOS, Windows or Linux.  Cross-compilation is
-currently not supported.  The following provides some detail on building.
+In order to work with Rancher Desktop, you need a few things:
+
+- [Node.js][Node.js] v16
+- [Go][Go] (Windows only)
+
+Once you have these things, you need to install Rancher Desktop's
+dependencies:
+
+```
+npm run install
+```
+
+This step should be repeated after every pull of new code, since
+dependencies change frequently.
 
 
-### Building on Windows
+## Running a Development Version
+
+Once you have your dependencies installed you can run a development version
+of Rancher Desktop with:
+
+```
+npm run dev
+```
+
+
+## Running Tests
+
+The first command runs the unit tests; the second command runs the
+integration tests:
+
+```
+npm test
+npm run test:e2e
+```
+
+
+## Building
+
+Rancher can be built from source on macOS, Windows or Linux.
+Cross-compilation is currently not supported.
+
+
+### Windows
 
 There are two options for building from source on Windows: with a
 [Development VM Setup](#development-vm-setup) or
 [Manual Development Environment Setup](#manual-development-environment-setup)
 with an existing Windows installation.
+
 
 #### Development VM Setup
 
@@ -69,25 +110,7 @@ You are now ready to clone the repository and run `npm install`.
 [Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
 
 
-### Prerequisites
-
-Rancher Desktop is an [Electron] and [Node.js] application. Node.js v16 is 
-recommended to build the source.  On Windows, [Go] is also required.
-
-[Electron]: https://www.electronjs.org/
-[Node.js]: https://nodejs.org/
-[Go]: https://golang.org/
-
-
-### How To Run
-
-Use the following commands. The former is needed the first time or after an
-update is pulled from upstream. The latter is needed for follow-up starts.
-
-```
-npm install
-npm run dev
-```
+## Other Stuff
 
 To build the distributable (application bundle on macOS, installer on Windows),
 run `npm run build`.
@@ -98,12 +121,3 @@ OBS makes use of the packaging recipes under `packaging/linux` folder of this
 repository together with the zip file including all built binaries.
 
 [Open Build Service]: https://build.opensuse.org/
-
-### How To Test
-
-Use the following commands to run unit tests and e2e tests.
-
-```
-npm test
-npm run test:e2e
-```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Rancher Desktop is an open-source project that brings Kubernetes and
 container management to the desktop. It runs on Windows, macOS and
-Linux. The below documentation pertains to the development of Rancher
-Desktop. For information not related to the development of Rancher
-Desktop, please see [rancherdesktop.io][home]. For documentation,
-please see [docs.rancherdesktop.io][docs].
+Linux. This README pertains to the development of Rancher Desktop.
+For user-oriented information about Rancher Desktop, please see [rancherdesktop.io][home].
+For user-oriented documentation, please see [docs.rancherdesktop.io][docs].
 
 [home]: https://rancherdesktop.io
 [docs]: https://docs.rancherdesktop.io
@@ -125,7 +124,8 @@ The build output goes to `dist/`.
 On Linux it is not possible to completely build Rancher Desktop from
 the development environment. This is because [Open Build Service][OBS]
 is used to build the application package into a variety of Linux
-package formats.
+package formats. However, you can access development builds for Linux
+- see below.
 
 [OBS]: https://build.opensuse.org/
 
@@ -134,26 +134,30 @@ package formats.
 
 ### Windows and macOS
 
-Each commit triggers a GitHub actions run that results in application bundles
-(`.exes`, `.dmgs`) being uploaded as artifacts. This can be useful if you
-want to test the latest build of Rancher Desktop as it comes out of the build
-system. You can download these artifacts from the Summary page of completed actions.
+Each commit triggers a GitHub Actions run that results in application bundles
+(`.exe`s and `.dmg`s) being uploaded as artifacts. This can be useful if you
+want to test the latest build of Rancher Desktop as built by the build system.
+You can download these artifacts from the Summary page of completed `package`
+actions.
+
 
 ### Linux
 
-Like with Windows and macOS, Linux builds of Rancher Desktop are made from
-each commit. However, only part of the process is done by GitHub Actions.
+Like with Windows and macOS, Linux builds of Rancher Desktop are made from each
+commit. However on Linux, only part of the process is done by GitHub Actions.
 The final part of it is done by [Open Build Service][OBS].
 
 There are two channels of the Rancher Desktop repositories: `dev` and `stable`.
-`stable` is the channel that most users use - it serves only released versions of
-Rancher Desktop. `dev` is the channel that we are interested in here: it contains
-builds created from the latest commit made on the `main` branch, and on any branches
-that match the format `release-*`. To learn how to install the development
-repositories, see below.
+`stable` is the channel that most users use. It is the one that users are
+instructed to add in the official [documentation][docs], and the one that contains
+builds that are created from official releases. `dev` is the channel that we are
+interested in here: it contains builds created from the latest commit made on
+the `main` branch, and on any branches that match the format `release-*`. To
+learn how to install the development repositories, see below.
 
-One more important note on the format of the versions of Rancher Desktop available
-from the `dev` repositories: The versions are in the format:
+When using the `dev` repositories, it is important to understand the format of
+the versions of Rancher Desktop available from the `dev` repositories.
+The versions are in the format:
 
 ```
 <priority>.<branch>.<commit>
@@ -161,12 +165,15 @@ from the `dev` repositories: The versions are in the format:
 
 where:
 
-`priority`: a meaningless number that exists to give versions built from the `main`
-            branch priority over versions built from the `release-*` branches
-`branch`: the branch name; dashes are removed due to constraints imposed by
-          package formats
-`commit`: the shortened hash of the commit used to make the build
+`priority` is a meaningless number that exists to give versions built from the `main`
+branch priority over versions built from the `release-*` branches when updating.
 
+`branch` is the branch name; dashes are removed due to constraints imposed by
+package formats.
+
+`commit` is the shortened hash of the commit used to make the build.
+
+[docs]: https://docs.rancherdesktop.io
 [OBS]: https://build.opensuse.org/
 
 
@@ -213,11 +220,13 @@ zypper search -s rancher-desktop
 Finally, install the version you want with:
 
 ```
-zypper install rancher-desktop=<version>
+zypper install --oldpackage rancher-desktop=<version>
 ```
 
-Note that you may have to do `zypper install --oldpackage rancher-desktop=<version>`
-if you are doing a downgrade.
+This works even if you already have a version of Rancher Desktop installed.
 
 
 #### Development AppImages
+
+There are no repositories for AppImages, but you can access the latest development
+AppImage builds [here](https://download.opensuse.org/repositories/isv:/Rancher:/dev/AppImage/).

--- a/README.md
+++ b/README.md
@@ -239,4 +239,4 @@ Please see [the document about contributing](CONTRIBUTING.md).
 
 ## Further Reading
 
-Please see the [docs](docs/) directory for further developer documentation.
+Please see the [docs](docs/development/) directory for further developer documentation.


### PR DESCRIPTION
Closes #1464.
Closes #1345.

I should add, since it might not be obvious, that this PR also adds instructions for installing the `dev` OBS repos (this is for #1345). I figured I'd kill two birds with one stone while I was at it.