### PR TITLE
Fix /usr/local updates for Alpine ISO updates

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -19,7 +19,7 @@ provision:
     mount --bind / /bootfs
     # /bootfs/etc is empty on first boot because it has been moved to /mnt/data/etc by lima
     if [ -f /bootfs/etc/os-release ] && ! diff -q /etc/os-release /bootfs/etc/os-release; then
-      cp /etc/machine-id /bootfs/machine-id
+      cp /etc/machine-id /bootfs/etc
       cp /etc/ssh/ssh_host* /bootfs/etc/ssh/
       mkdir -p /etc/docker /etc/rancher
       cp -pr /etc/docker /bootfs/etc

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -10,6 +10,7 @@ containerd:
 # Provisioning scripts run on every boot, not just initial VM provisioning.
 provision:
 - # When the ISO image is updated, only preserve selected data from /etc but otherwise use the new files.
+  # Update files in /usr/local on the data volume from the new versions on the ISO.
   mode: system
   script: |
     #!/bin/sh
@@ -28,6 +29,9 @@ provision:
       mkdir /mnt/data/etc.prev
       mv /etc/* /mnt/data/etc.prev
       mv /bootfs/etc/* /etc
+
+      # install updated files from /usr/local, e.g. nerdctl, buildkit, cni plugins
+      cp -pr /bootfs/usr/local /usr
 
       # lima has applied changes while the "old" /etc was in place; restart to apply them to the updated one.
       reboot


### PR DESCRIPTION
Since /usr/local is moved to the data volume during first boot, any updates need to be copied over to the data volume as well.

Fixes #1474

PR also contains a bug fix to preserve /etc/machine-id across Alpine updates.