### PR TITLE
Download and install the docker-buildx plugin.

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -167,6 +167,7 @@ export default async function main(platform) {
   const dockerBuildxURL = `${ dockerBuildxURLBase }/${ dockerBuildxExecutable }`;
   const dockerBuildxPath = path.join(binDir, exeName('docker-buildx'));
   const dockerBuildxOptions = {};
+
   if (kubePlatform !== 'darwin') {
     dockerBuildxOptions.expectedChecksum = await findChecksum(`${ dockerBuildxURLBase }/checksums.txt`, dockerBuildxExecutable);
   }
@@ -232,6 +233,7 @@ export default async function main(platform) {
  * Desired: on Windows, .../bin/kubectl.exe is a copy of .../bin/kuberlr.exe
  *          elsewhere: .../bin/kubectl is a symlink to .../bin/kuberlr
  * @param kuberlrPath {string}
+ * @param binKubectlPath {string}
  * @returns {Promise<void>}
  */
 async function bindKubectlToKuberlr(kuberlrPath, binKubectlPath) {

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -160,6 +160,18 @@ export default async function main(platform) {
 
   await download(dockerURL, dockerPath, { expectedChecksum: dockerSHA });
 
+  // Download the Docker-Buildx Plug-In
+  const dockerBuildxVersion = 'v0.7.1';
+  const dockerBuildxURLBase = `https://github.com/docker/buildx/releases/download/${ dockerBuildxVersion }`;
+  const dockerBuildxExecutable = exeName(`buildx-${ dockerBuildxVersion }.${ kubePlatform }-${ cpu }`);
+  const dockerBuildxURL = `${ dockerBuildxURLBase }/${ dockerBuildxExecutable }`;
+  const dockerBuildxPath = path.join(binDir, exeName('docker-buildx'));
+  const dockerBuildxOptions = {};
+  if (kubePlatform !== 'darwin') {
+    dockerBuildxOptions.expectedChecksum = await findChecksum(`${ dockerBuildxURLBase }/checksums.txt`, dockerBuildxExecutable);
+  }
+  await download(dockerBuildxURL, dockerBuildxPath, dockerBuildxOptions);
+
   // Download the Docker-Compose Plug-In
   const dockerComposeVersion = 'v2.2.3';
   const dockerComposeURLBase = `https://github.com/docker/compose/releases/download/${ dockerComposeVersion }`;

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -168,6 +168,8 @@ export default async function main(platform) {
   const dockerBuildxPath = path.join(binDir, exeName('docker-buildx'));
   const dockerBuildxOptions = {};
 
+  // No checksums available on the docker/buildx site for darwin builds
+  // https://github.com/docker/buildx/issues/945
   if (kubePlatform !== 'darwin') {
     dockerBuildxOptions.expectedChecksum = await findChecksum(`${ dockerBuildxURLBase }/checksums.txt`, dockerBuildxExecutable);
   }

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -63,7 +63,8 @@ export default class UnixlikeIntegrations {
       }
       if (name === 'docker') {
         // See function jsdoc for what the integration is updated in `listIntegrations` and not `setIntegration`
-        await this.setDockerComposeIntegration(this.#results[linkPath] === true);
+        await this.setDockerPluginIntegration('docker-compose', this.#results[linkPath] === true);
+        await this.setDockerPluginIntegration('docker-buildx', this.#results[linkPath] === true);
       }
     }
 
@@ -104,14 +105,14 @@ export default class UnixlikeIntegrations {
   /**
    * This function is a combination of listIntegrations (to determine state) and setIntegration
    * (to carry out an action)
-   * because `docker-compose` isn't an independent integration, but depends on `docker`.
+   * because docker plugins aren't independent, but depend on `docker`.
    * This is also why the function is called from listIntegrations and not setIntegration --
    * note that listIntegrations is always called after setIntegrations to show updated state
+   * @param basename - the basename of the plugin to manage
    * @param state - activate integration if true
    * @protected
    */
-  protected async setDockerComposeIntegration(state: boolean): Promise<void> {
-    const basename = 'docker-compose';
+  protected async setDockerPluginIntegration(basename: string, state: boolean): Promise<void> {
     const linkPath = path.join(DOCKER_CLI_PLUGIN_DIR, basename);
     const desiredPath = resources.executable(basename);
 


### PR DESCRIPTION
Not on the backlog (yet - it's an issue), but I wanted to verify the paths before writing them in slack, and as long as I had the paths, it was trivial to add this.

Fixes #1263

Signed-off-by: Eric Promislow <epromislow@suse.com>