### PR TITLE
Properly source /etc/environment in /etc/init.d/k3s

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -4,7 +4,20 @@
 
 # shellcheck shell=ksh
 
-if [ -f /etc/environment ]; then source /etc/environment; fi
+# shellcheck disable=SC2163
+if [ -f /etc/environment ]; then
+    while read -r line; do
+        # pam_env implementation:
+        # - '#' is treated the same as newline; terminates value
+        # - skip leading tabs and spaces
+        # - skip leading "export " prefix (only single space)
+        # - skip leading quote ('\'' or '"') on the value side
+        # - skip trailing quote only if leading quote has been skipped;
+        #   quotes don't need to match; trailing quote may be omitted
+        line="$(echo "$line" | sed -E "s/^[ \\t]*(export )?//; s/#.*//; s/(^[^=]+=)[\"'](.*[^\"'])?[\"']?$/\1\2/")"
+        [ -n "$line" ] && export "$line"
+    done </etc/environment
+fi
 
 # ENGINE configuration variable is either "moby" or "containerd"
 ENGINE="${ENGINE:-containerd}"


### PR DESCRIPTION
/etc/environment does not use shell syntax, so cannot be sourced directly via `source /etc/environment`.

Addresses https://github.com/rancher-sandbox/rancher-desktop/issues/578#issuecomment-1033607536