### PR TITLE
WSL: Add provisioning scripts

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1347,16 +1347,16 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       (async() => {
         const linuxPath = await this.wslify(provisioningPath);
 
-        // Run the provisioning job. We need to clobber /etc/init.d as
+        // Run the provisioning job. We need to clobber /etc/local.d as
         // /etc/init.d/local has no options to use a different directory.
+        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
         await this.execCommand('/bin/rm', '-r', '-f', '/etc/local.d');
         await this.execCommand('/bin/ln', '-s', '-f', '-T', linuxPath, '/etc/local.d');
         await this.execCommand(
           '/bin/sh',
           '-c',
-          `for f in '${ linuxPath }'/*.start; do [ -e "\${f}" ] && chmod a+x "\${f}"; done`);
+          `for f in '${ linuxPath }'/*.start '${ linuxPath }'/*.stop; do [ -f "\${f}" ] && chmod a+x "\${f}"; done`);
         // This should not be running (because we tore down init), but to be safe...
-        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
         await this.execCommand('/usr/local/bin/wsl-service', 'local', 'start');
       })(),
     ]);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1349,17 +1349,30 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       (async() => {
         const linuxPath = await this.wslify(provisioningPath);
 
-        // Run the provisioning job. We need to clobber /etc/local.d as
-        // /etc/init.d/local has no options to use a different directory.
-        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
-        await this.execCommand('/bin/rm', '-r', '-f', '/etc/local.d');
-        await this.execCommand('/bin/ln', '-s', '-f', '-T', linuxPath, '/etc/local.d');
-        await this.execCommand(
-          '/bin/sh',
-          '-c',
-          `for f in '${ linuxPath }'/*.start '${ linuxPath }'/*.stop; do [ -f "\${f}" ] && chmod a+x "\${f}"; done`);
-        // This should not be running (because we tore down init), but to be safe...
-        await this.execCommand('/usr/local/bin/wsl-service', 'local', 'start');
+        await this.execCommand('/bin/sh', '-c', `
+          set -o errexit -o nounset
+
+          # Stop the service if it's already running for some reason.
+          # This should never be the case (because we tore down init).
+          /usr/local/bin/wsl-service --ifstarted local stop
+
+          # Clobber /etc/local.d and replace it with a symlink to our desired
+          # path.  This is needed as /etc/init.d/local does not support
+          # overriding the script directory.
+          rm -r -f /etc/local.d
+          ln -s -f -T "${ linuxPath }" /etc/local.d
+
+          # Ensure all scripts are executable; Windows mounts are unlikely to
+          # have it set by default.
+          for f in "${ linuxPath }"/*.start "${ linuxPath }"/*.stop; do
+              if [ -f "\${f}" ]; then
+                  chmod a+x "\${f}"
+              fi
+          done
+
+          # Run the script.
+          exec /usr/local/bin/wsl-service local start
+        `.replace(/\r/g, ''));
       })(),
     ]);
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1166,13 +1166,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         this.lastCommandComment = 'Running provisioning scripts';
         await this.progressTracker.action(this.lastCommandComment, 100, this.runProvisioningScripts());
 
-        await this.progressTracker.action('Starting k3s', 100, this.startService('k3s', {
-          PORT:                   this.#desiredPort.toString(),
-          LOG_DIR:                await this.wslify(paths.logs),
-          'export IPTABLES_MODE': 'legacy',
-          ENGINE:                 this.#currentContainerEngine,
-          ADDITIONAL_ARGS:        this.cfg?.options.traefik ? '' : '--disable traefik',
-        }));
+        await this.progressTracker.action('Starting k3s', 100,
+          this.startService('k3s', {
+            PORT:                   this.#desiredPort.toString(),
+            LOG_DIR:                await this.wslify(paths.logs),
+            'export IPTABLES_MODE': 'legacy',
+            ENGINE:                 this.#currentContainerEngine,
+            ADDITIONAL_ARGS:        this.cfg?.options.traefik ? '' : '--disable traefik',
+          }));
 
         if (this.currentAction !== Action.STARTING) {
           // User aborted
@@ -1333,13 +1334,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         try {
           await fs.promises.access(ReadmePath, fs.constants.F_OK);
         } catch {
-          const contents = `
+          const contents = `${ `
             Any files named '*.start' in this directory will be executed
             sequentially on Rancher Desktop startup, before the main services.
-            Files are processed in lexical order, and will delay startup until
-            they are complete. Similaryly, any files named '*.stop' will be
-            executed on shutdown, after the main services have exited.
-            `.replace(/\s*\n\s*/g, '\n').trim();
+            Files are processed in lexical order, and startup will be delayed
+            until they have all run to completion. Similaryly, any files named
+            '*.stop' will be executed on shutdown, after the main services have
+            exited, and delay shutdown until they have run to completion.
+            `.replace(/\s*\n\s*/g, '\n').trim() }\n`;
 
           await fs.promises.writeFile(ReadmePath, contents, { encoding: 'utf-8' });
         }


### PR DESCRIPTION
With this PR, users can write provisioning scripts in `C:\Users\<user>\AppData\Roaming\rancher-desktop\*.start` that will be executed before we start k3s (and its dependencies), but under `/sbin/init`.

This means the user can do something like:
```sh
#!/bin/sh
echo 'K3S_EXEC="--disable local-storage"' > /etc/environment
```
(Note that we write out `/etc/conf.d/k3s` afterwards, so overwriting it wouldn't work.)

Fixes #1142.

Tagging Jan for review to check if the overall logic / timing makes sense; we can find somebody to do a code-level review afterwards if necessary.