### PR TITLE
WSL: fix WSL paths in different distributions.

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -58,7 +58,7 @@ var dockerproxyServeCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Fatalf("could not initialize options: %w", err)
+		logrus.Fatalf("could not initialize options: %s", err)
 	}
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -58,7 +58,7 @@ var dockerproxyServeCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Fatalf("could not initialize options: %s", err)
+		logrus.Warnf("could not initialize options: %s", err)
 	}
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -58,7 +58,7 @@ var dockerproxyServeCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Warnf("could not initialize options: %s", err)
+		logrus.Fatalf("could not initialize options: %s", err)
 	}
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -55,8 +56,12 @@ var dockerproxyServeCmd = &cobra.Command{
 }
 
 func init() {
+	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
+	if err != nil {
+		logrus.Fatalf("could not initialize options: %w", err)
+	}
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
-	dockerproxyServeCmd.Flags().String("proxy-endpoint", dockerproxy.DefaultProxyEndpoint, "Endpoint dockerd is listening on")
+	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")
 	dockerproxyServeViper.AutomaticEnv()
 	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyServeCmd)

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -43,7 +43,7 @@ var dockerproxyStartCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Warnf("could not initialize options: %s", err)
+		logrus.Fatalf("could not initialize options: %s", err)
 	}
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -43,7 +43,7 @@ var dockerproxyStartCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Fatalf("could not initialize options: %s", err)
+		logrus.Warnf("could not initialize options: %s", err)
 	}
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -19,6 +19,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -40,8 +41,12 @@ var dockerproxyStartCmd = &cobra.Command{
 }
 
 func init() {
+	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
+	if err != nil {
+		logrus.Fatalf("could not initialize options: %w", err)
+	}
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
-	dockerproxyStartCmd.Flags().String("endpoint", dockerproxy.DefaultProxyEndpoint, "Dockerd socket endpoint")
+	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")
 	dockerproxyStartViper.AutomaticEnv()
 	dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyStartCmd)

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -43,7 +43,7 @@ var dockerproxyStartCmd = &cobra.Command{
 func init() {
 	defaultProxyEndpoint, err := dockerproxy.GetDefaultProxyEndpoint()
 	if err != nil {
-		logrus.Fatalf("could not initialize options: %w", err)
+		logrus.Fatalf("could not initialize options: %s", err)
 	}
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -53,8 +53,9 @@ import (
 // Note that all persisted info needs to live on disk; it's possible to run
 // containers while restarting the docker proxy (or indeed the machine).
 
-// mountRoot is where we can keep our temporary mounts.
-const mountRoot = "/mnt/wsl/rancher-desktop/run/docker-mounts"
+// mountRoot is where we can keep our temporary mounts, relative to the WSL
+// mount root (typically /mnt/wsl).
+const mountRoot = "rancher-desktop/run/docker-mounts"
 
 // contextKey is the key used to locate the bind manager in the request/response
 // context.  This only lasts for a single request/response pair.
@@ -91,8 +92,13 @@ func newBindManager() (*bindManager, error) {
 		return nil, err
 	}
 
+	mountPoint, err := platform.GetWSLMountPoint()
+	if err != nil {
+		return nil, err
+	}
+
 	result := bindManager{
-		mountRoot: mountRoot,
+		mountRoot: path.Join(mountPoint, mountRoot),
 		entries:   make(map[string]bindManagerEntry),
 		statePath: statePath,
 	}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
 )
 
 func TestNewBindManager(t *testing.T) {
@@ -41,9 +42,11 @@ func TestNewBindManager(t *testing.T) {
 	// We're not testing loading the state here; if it happens to fail, we'll
 	// just have to skip the test.
 	if err != nil {
-		t.SkipNow()
+		t.Skip(fmt.Sprintf("skipping test, got error %s", err))
 	} else {
-		assert.Equal(t, path.Join("/mnt/wsl", mountRoot), bindManager.mountRoot)
+		mountPoint, err := platform.GetWSLMountPoint()
+		assert.NoError(t, err)
+		assert.Equal(t, path.Join(mountPoint, mountRoot), bindManager.mountRoot)
 		assert.Equal(t, "docker-binds.json", path.Base(bindManager.statePath))
 	}
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -43,7 +43,7 @@ func TestNewBindManager(t *testing.T) {
 	if err != nil {
 		t.SkipNow()
 	} else {
-		assert.Equal(t, mountRoot, bindManager.mountRoot)
+		assert.Equal(t, path.Join("/mnt/wsl", mountRoot), bindManager.mountRoot)
 		assert.Equal(t, "docker-binds.json", path.Base(bindManager.statePath))
 	}
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
@@ -20,9 +20,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Get the WSL mount point; typically, this is /mnt/wsl.
+// If we fail to find one, we will use /mnt/wsl instead.
 func GetWSLMountPoint() (string, error) {
 	buf, err := ioutil.ReadFile("/proc/self/mountinfo")
 	if err != nil {
@@ -40,5 +43,6 @@ func GetWSLMountPoint() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("could not find WSL mount root")
+	logrus.Warnf("Could not find WSL mount root, falling back to /mnt/wsl")
+	return "/mnt/wsl", nil
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Get the WSL mount point; typically, this is /mnt/wsl.
+func GetWSLMountPoint() (string, error) {
+	buf, err := ioutil.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return "", fmt.Errorf("error reading mounts: %w", err)
+	}
+	for _, line := range strings.Split(string(buf), "\n") {
+		if !strings.Contains(line, " - tmpfs ") {
+			// Skip the line if the filesystem type isn't "tmpfs"
+			continue
+		}
+		fields := strings.Split(line, " ")
+		if len(fields) >= 5 {
+			return fields[4], nil
+		}
+	}
+	return "", fmt.Errorf("could not find WSL mount root")
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
@@ -35,7 +35,9 @@ func GetWSLMountPoint() (string, error) {
 		}
 		fields := strings.Split(line, " ")
 		if len(fields) >= 5 {
-			return fields[4], nil
+			if strings.HasSuffix(fields[4], "/wsl") {
+				return fields[4], nil
+			}
 		}
 	}
 	return "", fmt.Errorf("could not find WSL mount root")

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -35,8 +35,9 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/util"
 )
 
-// DefaultProxyEndpoint is the path on which dockerd should listen on.
-const DefaultProxyEndpoint = "/mnt/wsl/rancher-desktop/run/docker.sock"
+// defaultProxyEndpoint is the path on which dockerd should listen on, relative
+// to the WSL mount point.
+const defaultProxyEndpoint = "rancher-desktop/run/docker.sock"
 
 // waitForFileToExist will block until the given path exists.  If the given
 // timeout is reached, an error will be returned.
@@ -65,6 +66,14 @@ func waitForFileToExist(path string, timeout time.Duration) error {
 		expired = true
 		return fmt.Errorf("timed out waiting for %s to exist", path)
 	}
+}
+
+func GetDefaultProxyEndpoint() (string, error) {
+	mountPoint, err := platform.GetWSLMountPoint()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(mountPoint, defaultProxyEndpoint), nil
 }
 
 // Start the dockerd process within this WSL distribution on the given vsock

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -71,9 +71,7 @@ func waitForFileToExist(path string, timeout time.Duration) error {
 func GetDefaultProxyEndpoint() (string, error) {
 	mountPoint, err := platform.GetWSLMountPoint()
 	if err != nil {
-		// Note that we still return a string here; this is for use with
-		// testing on real Linux machines.
-		return path.Join("/mnt/wsl", defaultProxyEndpoint), err
+		return "", err
 	}
 	return path.Join(mountPoint, defaultProxyEndpoint), nil
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -71,7 +71,9 @@ func waitForFileToExist(path string, timeout time.Duration) error {
 func GetDefaultProxyEndpoint() (string, error) {
 	mountPoint, err := platform.GetWSLMountPoint()
 	if err != nil {
-		return "", err
+		// Note that we still return a string here; this is for use with
+		// testing on real Linux machines.
+		return path.Join("/mnt/wsl", defaultProxyEndpoint), err
 	}
 	return path.Join(mountPoint, defaultProxyEndpoint), nil
 }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -80,6 +80,12 @@ type execOptions = childProcess.CommonOptions & {
   logStream?: stream.Writable;
 };
 
+/** Execution options for commands running in a WSL distribution. */
+type wslExecOptions = execOptions & {
+  /** WSL distribution; defaults to the INSTANCE_NAME. */
+  distro?: string;
+};
+
 function defined<T>(input: T | undefined | null): input is T {
   return typeof input !== 'undefined' && input !== null;
 }
@@ -647,8 +653,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * - Changes \s to /s
    * - Figures out what the /mnt/DRIVE-LETTER path should be
    */
-  protected async wslify(windowsPath: string): Promise<string> {
-    return (await this.captureCommand('wslpath', '-a', '-u', windowsPath)).trimEnd();
+  protected async wslify(windowsPath: string, distro?: string): Promise<string> {
+    return (await this.captureCommand({ distro }, 'wslpath', '-a', '-u', windowsPath)).trimEnd();
   }
 
   protected async killStaleProcesses() {
@@ -868,10 +874,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * @param command The command to execute.
    */
   protected async execCommand(...command: string[]): Promise<void>;
-  protected async execCommand(options: execOptions, ...command: string[]): Promise<void>;
-  protected async execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
-  protected async execCommand(optionsOrArg: execOptions | string, ...command: string[]): Promise<void | string> {
-    let options: execOptions = {};
+  protected async execCommand(options: wslExecOptions, ...command: string[]): Promise<void>;
+  protected async execCommand(options: wslExecOptions & { capture: true }, ...command: string[]): Promise<string>;
+  protected async execCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<void | string> {
+    let options: wslExecOptions = {};
 
     if (typeof optionsOrArg === 'string') {
       command = [optionsOrArg].concat(command);
@@ -885,7 +891,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       // Print a slightly different message if execution fails.
       return await this.execWSL({
         encoding: 'utf-8', ...options, expectFailure: true
-      }, '--distribution', INSTANCE_NAME, '--exec', ...command);
+      }, '--distribution', options.distro ?? INSTANCE_NAME, '--exec', ...command);
     } catch (ex) {
       if (!expectFailure) {
         console.log(`WSL: executing: ${ command.join(' ') }: ${ ex }`);
@@ -902,8 +908,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * @returns The output of the command.
    */
   protected async captureCommand(...command: string[]): Promise<string>;
-  protected async captureCommand(options: execOptions, ...command: string[]): Promise<string>;
-  protected async captureCommand(optionsOrArg: execOptions | string, ...command: string[]): Promise<string> {
+  protected async captureCommand(options: wslExecOptions, ...command: string[]): Promise<string>;
+  protected async captureCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<string> {
     if (typeof optionsOrArg === 'string') {
       return await this.execCommand({ capture: true }, optionsOrArg, ...command);
     }
@@ -1425,16 +1431,14 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   /**
    * Return the Linux path to the WSL helper executable.
    */
-  protected getWSLHelperPath(): Promise<string> {
+  protected getWSLHelperPath(distro?: string): Promise<string> {
     // We need to get the Linux path to our helper executable; it is easier to
     // just get WSL to do the transformation for us.
-    return this.wslify(resources.get('linux', 'wsl-helper'));
+    return this.wslify(resources.get('linux', 'wsl-helper'), distro);
   }
 
   async listIntegrations(): Promise<Record<string, boolean | string>> {
     const result: Record<string, boolean | string> = {};
-
-    const executable = await this.getWSLHelperPath();
 
     for (const distro of await this.registeredDistros()) {
       if (DISTRO_BLACKLIST.includes(distro)) {
@@ -1442,18 +1446,18 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
 
       try {
+        const executable = await this.getWSLHelperPath(distro);
         const kubeconfigPath = await this.k3sHelper.findKubeConfigToUpdate('rancher-desktop');
-        const stdout = await this.execWSL(
+        const stdout = await this.captureCommand(
           {
-            capture:  true,
-            encoding: 'utf-8',
+            distro,
             env:      {
               ...process.env,
               KUBECONFIG: kubeconfigPath,
               WSLENV:     `${ process.env.WSLENV }:KUBECONFIG/up`,
             },
           },
-          '--distribution', distro, '--exec', executable, 'kubeconfig', '--show');
+          executable, 'kubeconfig', '--show');
 
         if (['true', 'false'].includes(stdout.trim())) {
           result[distro] = stdout.trim() === 'true';
@@ -1477,7 +1481,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   // Set up the background process for integrating with a different WSL
   // distribution to proxy the dockerd socket.
   protected async setupIntegrationProcess(distro: string) {
-    const executable = await this.getWSLHelperPath();
+    const executable = await this.getWSLHelperPath(distro);
 
     this.mobySocketProxyProcesses[distro] ??= new BackgroundProcess(this, `${ distro } socket proxy`,
       async() => {
@@ -1505,21 +1509,20 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
       return 'Unknown distribution';
     }
-    const executable = await this.getWSLHelperPath();
-
     try {
+      const executable = await this.getWSLHelperPath(distro);
       const kubeconfigPath = await this.k3sHelper.findKubeConfigToUpdate('rancher-desktop');
 
-      await this.execWSL(
+      await this.execCommand(
         {
-          encoding: 'utf-8',
+          distro,
           env:      {
             ...process.env,
             KUBECONFIG: kubeconfigPath,
             WSLENV:     `${ process.env.WSLENV }:KUBECONFIG/up`,
           },
         },
-        '--distribution', distro, '--exec', executable, 'kubeconfig', `--enable=${ state }`,
+        executable, 'kubeconfig', `--enable=${ state }`,
       );
       if (state) {
         await this.setupIntegrationProcess(distro);
@@ -1537,25 +1540,24 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected async manageDockerCompose(distro: string, state: boolean) {
-    const srcPath = await this.wslify(resources.get('linux', 'bin', 'docker-compose'));
+    const srcPath = await this.wslify(resources.get('linux', 'bin', 'docker-compose'), distro);
     const destDir = '$HOME/.docker/cli-plugins';
     const destPath = `${ destDir }/docker-compose`;
 
     // Update only the distro -- the current
     if (state) {
-      await this.execWSL('--distribution', distro, '/bin/sh', '-c', `mkdir -p "${ destDir }"`);
-      await this.execWSL('--distribution', distro, '/bin/sh', '-c', `if [ ! -e "${ destPath }" -a ! -L "${ destPath }" ] ; then ln -s "${ srcPath }" "${ destPath }" ; fi`);
+      await this.execCommand({ distro }, '/bin/sh', '-c', `mkdir -p "${ destDir }"`);
+      await this.execCommand({ distro }, '/bin/sh', '-c', `if [ ! -e "${ destPath }" -a ! -L "${ destPath }" ] ; then ln -s "${ srcPath }" "${ destPath }" ; fi`);
       await this.updateDockerComposeLocally();
     } else {
       try {
         // This is preferred to doing the readlink and rm in one long /bin/sh statement because
         // then we rely on the distro's readlink supporting the -n option. Gnu/linux readlink supports -f,
         // On macOS the -f means something else (not that we're likely to see macos WSLs).
-        const targetPath = (await this.execWSL({ capture: true, encoding: 'utf-8' },
-          '--distribution', distro, 'readlink', '-f', destPath)).trimEnd();
+        const targetPath = (await this.captureCommand({ distro }, 'readlink', '-f', destPath)).trimEnd();
 
         if (targetPath === srcPath) {
-          await this.execWSL('--distribution', distro, 'rm', destPath);
+          await this.execCommand({ distro }, 'rm', destPath);
         }
       } catch (err) {
         console.log(`Failed to readlink/rm ${ destPath }`, err);


### PR DESCRIPTION
The mapping of Windows paths to Linux paths in WSL can be different per distribution (due to the ability to have different [root paths](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#automount-settings)); this change ensures we look it up per distribution.

Fixes #1377.