### PR TITLE
Windows: Add certificates from the "CA" store.

### DIFF
--- a/src/main/networking/index.ts
+++ b/src/main/networking/index.ts
@@ -28,7 +28,7 @@ export default function setupNetworking() {
 
   if (os.platform().startsWith('win')) {
     // Inject the Windows certs.
-    WinCA({ inject: '+' });
+    WinCA({ store: ['root', 'ca'], inject: '+' });
   }
 
   // Set up certificate handling for system certificates on Windows and macOS
@@ -80,7 +80,9 @@ export async function *getSystemCertificates(): AsyncIterable<string> {
 
   if (platform.startsWith('win')) {
     // On Windows, be careful of the new lines.
-    for await (const cert of WinCA({ format: WinCA.der2.pem, generator: true })) {
+    for await (const cert of WinCA({
+      format: WinCA.der2.pem, generator: true, store: ['root', 'ca']
+    })) {
       yield cert.replace(/\r/g, '');
     }
   } else if (platform === 'darwin') {


### PR DESCRIPTION
The certificate stores have confusing names, and IT administrators are likely to put trusted CAs in either "ca" or "root" stores.  Trust both.

Fixes #1572.

This is based on #1487, so filing this one as draft until that gets merged.