### PR TITLE
Remove docker symlink on quit if running RD as AppImage

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -277,6 +277,7 @@ Electron.app.on('before-quit', async(event) => {
       // For AppImage these links are only valid for this specific runtime,
       // clear broken links before leaving
       await Promise.all([
+        linkResource('docker', false),
         linkResource('helm', false),
         linkResource('kubectl', false),
         linkResource('nerdctl', false),


### PR DESCRIPTION
The directory that all of the RD files, including the integrations, are located in is different each time RD runs. This can mean that integration symlinks are left in a broken state once it quits. Previously only `kubectl`, `helm` and `nerdctl` were removed when quitting because this code predates the inclusion of moby as an alternative to containerd. This PR adds `docker` to this list, which keeps it from being left dangling and causing problems during later runs.

Note that this is just a band-aid fix that slightly improves things for the 1.1 release. We still need to improve the way integrations are managed.