### PR TITLE
Bug template - Improved version placeholders

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,14 +34,14 @@ body:
   attributes:
     label: Rancher Desktop Version
     description: "What version of Rancher Desktop are you using?"
-    placeholder: 1.0.1
+    placeholder: "e.g. 1.1.1"
   validations:
     required: true
 - type: input
   attributes:
     label: Rancher Desktop K8s Version
     description: "What version of Kubernetes are you using?"
-    placeholder: "e.g. 1.22.6"
+    placeholder: "e.g. 1.99.9"
   validations:
     required: true
 - type: dropdown


### PR DESCRIPTION
In order to mitigate some confusions during the bug report filling, added more information in the `placeholder` field (generic app and k8s version).