### PR TITLE
scripts: generate moby OpenAPI in postinstall

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -172,6 +172,10 @@ jobs:
       if: startsWith(matrix.os, 'windows-')
       shell: powershell
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
+    - uses: actions/setup-go@v2
+      with:
+        stable: 'false' # Remove once RC suffix is removed
+        go-version: '1.18.0-rc1'
     - run: npm ci
     - uses: actions/download-artifact@v2
       if: startsWith(matrix.os, 'windows-')

--- a/scripts/download/moby-openapi.mjs
+++ b/scripts/download/moby-openapi.mjs
@@ -1,5 +1,5 @@
-// This downloads the moby openAPI specification (for WSL-helper).  It is
-// used by `go generate` in .../src/go/wsl-helper/pkg/dockerproxy.
+// This downloads the moby openAPI specification (for WSL-helper) and generates
+// ./src/go/wsl-helper/pkg/dockerproxy/models/...
 
 import { spawnSync } from 'child_process';
 import fs from 'fs';
@@ -15,6 +15,6 @@ export default async function run() {
 
   await download(url, outPath, { access: fs.constants.W_OK });
 
-  spawnSync('go', ['generate', '-x', './...'], { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
+  spawnSync('go', ['generate', '-x', 'pkg/dockerproxy/generate.go'], { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
   console.log('Moby API swagger models generated.');
 }

--- a/scripts/download/moby-openapi.mjs
+++ b/scripts/download/moby-openapi.mjs
@@ -1,6 +1,7 @@
 // This downloads the moby openAPI specification (for WSL-helper).  It is
 // used by `go generate` in .../src/go/wsl-helper/pkg/dockerproxy.
 
+import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { download } from '../lib/download.mjs';
@@ -13,4 +14,7 @@ export default async function run() {
   const outPath = path.join(process.cwd(), 'src', 'go', 'wsl-helper', 'pkg', 'dockerproxy', 'swagger.yaml');
 
   await download(url, outPath, { access: fs.constants.W_OK });
+
+  spawnSync('go', ['generate', '-x', './...'], { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
+  console.log('Moby API swagger models generated.');
 }

--- a/scripts/download/moby-openapi.mjs
+++ b/scripts/download/moby-openapi.mjs
@@ -1,9 +1,9 @@
 // This downloads the moby openAPI specification (for WSL-helper) and generates
 // ./src/go/wsl-helper/pkg/dockerproxy/models/...
 
-import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import buildUtils from '../lib/build-utils.mjs';
 import { download } from '../lib/download.mjs';
 
 // The version of the moby API we support
@@ -15,6 +15,6 @@ export default async function run() {
 
   await download(url, outPath, { access: fs.constants.W_OK });
 
-  spawnSync('go', ['generate', '-x', 'pkg/dockerproxy/generate.go'], { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
+  await buildUtils.spawn('go', 'generate', '-x', 'pkg/dockerproxy/generate.go', { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
   console.log('Moby API swagger models generated.');
 }

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -129,16 +129,6 @@ export default async function main(platform) {
     const managedKubectlPath = path.join(kuberlrDir, exeName(`kubectl${ kubeVersion.replace(/^v/, '') }`));
 
     await download(kubectlURL, managedKubectlPath, { expectedChecksum: kubectlSHA });
-
-    // Download go-swagger (build tool, for host only)
-    const goSwaggerVersion = 'v0.28.0';
-    const goSwaggerURLBase = `https://github.com/go-swagger/go-swagger/releases/download/${ goSwaggerVersion }`;
-    const goSwaggerExecutable = exeName(`swagger_${ kubePlatform }_amd64`);
-    const goSwaggerURL = `${ goSwaggerURLBase }/${ goSwaggerExecutable }`;
-    const goSwaggerPath = path.join(process.cwd(), 'resources', 'host', exeName('swagger'));
-    const goSwaggerSHA = await findChecksum(`${ goSwaggerURLBase }/sha256sum.txt`, goSwaggerExecutable);
-
-    await download(goSwaggerURL, goSwaggerPath, { expectedChecksum: goSwaggerSHA });
   }
 
   // Download Helm. It is a tar.gz file that needs to be expanded and file moved.

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -233,9 +233,10 @@ export default {
       });
     };
 
-    await this.spawn('go', 'generate', '-x', './...', { cwd: path.join(this.srcDir, 'src', 'go', 'wsl-helper') });
-    await buildPlatform('linux');
-    await buildPlatform('win32');
+    await this.wait(
+      buildPlatform.bind(this, 'linux'),
+      buildPlatform.bind(this, 'win32'),
+    );
   },
 
   /**

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -2,15 +2,13 @@ import { execFileSync } from 'child_process';
 import os from 'os';
 
 async function runScripts() {
+  await (await import('./download/moby-openapi.mjs')).default();
   switch (os.platform()) {
   case 'linux':
     await (await import('./download/tools.mjs')).default('linux');
     await (await import('./download/lima.mjs')).default();
-    // The moby OpenAPI spec is needed for unit tests only.
-    await (await import('./download/moby-openapi.mjs')).default();
     break;
   case 'darwin':
-    await (await import('./download/moby-openapi.mjs')).default();
     await (await import('./download/tools.mjs')).default('darwin');
     await (await import('./download/lima.mjs')).default();
     break;
@@ -18,7 +16,6 @@ async function runScripts() {
     await (await import('./download/tools.mjs')).default('win32');
     await (await import('./download/tools.mjs')).default('linux');
     await (await import('./download/wsl.mjs')).default();
-    await (await import('./download/moby-openapi.mjs')).default();
     break;
   }
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/generate.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/generate.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/go-swagger/go-swagger"
 )
 
-//go:generate -command swagger ../../../../../resources/host/swagger
+//go:generate -command swagger go run github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
 //go:generate swagger generate server --skip-validation --config-file swagger-configuration.yaml --server-package models --spec swagger.yaml
 
 func init() {


### PR DESCRIPTION
Most of the time, we do not need to regenerate the Moby OpenAPI models. Do that in `npm run poinstall` instead, so that we only have to that once instead of every time we run `npm run dev` / `npm run build`.