### PR TITLE
networking: Don't import expired CA certs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "mac-ca": "^1.0.6",
         "marked": "^4.0.8",
         "node-fetch": "^2.6.1",
+        "node-forge": "^1.2.1",
         "semver": "^7.3.5",
         "socks-proxy-agent": "^6.0.0",
         "sudo-prompt": "^9.2.1",
@@ -17435,6 +17436,14 @@
         "node-forge": "^0.10.0"
       }
     },
+    "node_modules/linux-ca/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -17603,6 +17612,14 @@
       "integrity": "sha512-uuCaT+41YtIQlDDvbigP1evK1iUk97zRirP9+8rZJz8x0eIQZG8Z7YQegMTsCiMesLPb6LBgCS95uyAvVA1tmg==",
       "dependencies": {
         "node-forge": "^0.10.0"
+      }
+    },
+    "node_modules/mac-ca/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/make-dir": {
@@ -18276,11 +18293,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -27249,6 +27266,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/win-ca/node_modules/node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -41141,6 +41166,13 @@
       "requires": {
         "event-stream": "^4.0.1",
         "node-forge": "^0.10.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        }
       }
     },
     "loader-runner": {
@@ -41292,6 +41324,13 @@
       "integrity": "sha512-uuCaT+41YtIQlDDvbigP1evK1iUk97zRirP9+8rZJz8x0eIQZG8Z7YQegMTsCiMesLPb6LBgCS95uyAvVA1tmg==",
       "requires": {
         "node-forge": "^0.10.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        }
       }
     },
     "make-dir": {
@@ -41833,9 +41872,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-gyp-build": {
       "version": "4.3.0",
@@ -48954,6 +48993,11 @@
           "requires": {
             "pify": "^3.0.0"
           }
+        },
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "mac-ca": "^1.0.6",
     "marked": "^4.0.8",
     "node-fetch": "^2.6.1",
+    "node-forge": "^1.2.1",
     "semver": "^7.3.5",
     "socks-proxy-agent": "^6.0.0",
     "sudo-prompt": "^9.2.1",

--- a/src/main/networking/cert-parse.ts
+++ b/src/main/networking/cert-parse.ts
@@ -70,7 +70,7 @@ const x509CertificateValidityValidator = {
         tagClass:    asn1.Class.UNIVERSAL,
         type:        asn1.Type.INTEGER,
         constructed: false,
-      }]
+      }],
     }, {
       name:        'Certificate.TBSCertificate.serialNumber',
       tagClass:    asn1.Class.UNIVERSAL,
@@ -90,13 +90,13 @@ const x509CertificateValidityValidator = {
         name:     'Certificate.TBSCertificate.signature.parameters',
         tagClass: asn1.Class.UNIVERSAL,
         optional: true,
-      }]
+      }],
     }, {
       name:        'Certificate.TBSCertificate.issuer',
       tagClass:    asn1.Class.UNIVERSAL,
       type:        asn1.Type.SEQUENCE,
       constructed: true,
-      captureAsn1: 'issuerEncoded'
+      captureAsn1: 'issuerEncoded',
     }, {
       name:        'Certificate.TBSCertificate.validity',
       tagClass:    asn1.Class.UNIVERSAL,
@@ -113,31 +113,31 @@ const x509CertificateValidityValidator = {
         type:        asn1.Type.UTCTIME,
         constructed: false,
         optional:    true,
-        capture:     'validityUTC1'
+        capture:     'validityUTC1',
       }, {
         name:        'Certificate.TBSCertificate.validity.notBefore (generalized)',
         tagClass:    asn1.Class.UNIVERSAL,
         type:        asn1.Type.GENERALIZEDTIME,
         constructed: false,
         optional:    true,
-        capture:     'validityGeneralized1'
+        capture:     'validityGeneralized1',
       }, {
         name:        'Certificate.TBSCertificate.validity.notAfter (utc)',
         tagClass:    asn1.Class.UNIVERSAL,
         type:        asn1.Type.UTCTIME,
         constructed: false,
         optional:    true,
-        capture:     'validityUTC2'
+        capture:     'validityUTC2',
       }, {
         name:        'Certificate.TBSCertificate.validity.notAfter (generalized)',
         tagClass:    asn1.Class.UNIVERSAL,
         type:        asn1.Type.GENERALIZEDTIME,
         constructed: false,
         optional:    true,
-        capture:     'validityGeneralized2'
-      }]
-    }]
-  }]
+        capture:     'validityGeneralized2',
+      }],
+    }],
+  }],
 };
 
 /**
@@ -179,7 +179,7 @@ function convertDate(val: string | undefined, fn: 'utcTimeToDate' | 'generalized
 }
 
 /**
- * Check a given PEM ceritificate to ensure it is within the valid date range.
+ * Check a given PEM certificate to ensure it is within the valid date range.
  * This does _not_ do any other checking of the certificate.
  */
 export default function checkCertValidity(pem: string): boolean {

--- a/src/main/networking/cert-parse.ts
+++ b/src/main/networking/cert-parse.ts
@@ -1,0 +1,249 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some code is derived from node-forge:
+
+New BSD License (3-clause)
+Copyright (c) 2010, Digital Bazaar, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Digital Bazaar, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DIGITAL BAZAAR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+import forge, { asn1 } from 'node-forge';
+
+import Logging from '@/utils/logging';
+
+const console = Logging.background;
+
+const x509CertificateValidityValidator = {
+  name:        'Certificate',
+  tagClass:    asn1.Class.UNIVERSAL,
+  type:        asn1.Type.SEQUENCE,
+  constructed: true,
+  value:       [{
+    name:        'Certificate.TBSCertificate',
+    tagClass:    asn1.Class.UNIVERSAL,
+    type:        asn1.Type.SEQUENCE,
+    constructed: true,
+    value:       [{
+      name:        'Certificate.TBSCertificate.version',
+      tagClass:    asn1.Class.CONTEXT_SPECIFIC,
+      type:        0,
+      constructed: true,
+      optional:    true,
+      value:       [{
+        name:        'Certificate.TBSCertificate.version.integer',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.INTEGER,
+        constructed: false,
+      }]
+    }, {
+      name:        'Certificate.TBSCertificate.serialNumber',
+      tagClass:    asn1.Class.UNIVERSAL,
+      type:        asn1.Type.INTEGER,
+      constructed: false,
+    }, {
+      name:        'Certificate.TBSCertificate.signature',
+      tagClass:    asn1.Class.UNIVERSAL,
+      type:        asn1.Type.SEQUENCE,
+      constructed: true,
+      value:       [{
+        name:        'Certificate.TBSCertificate.signature.algorithm',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.OID,
+        constructed: false,
+      }, {
+        name:     'Certificate.TBSCertificate.signature.parameters',
+        tagClass: asn1.Class.UNIVERSAL,
+        optional: true,
+      }]
+    }, {
+      name:        'Certificate.TBSCertificate.issuer',
+      tagClass:    asn1.Class.UNIVERSAL,
+      type:        asn1.Type.SEQUENCE,
+      constructed: true,
+      captureAsn1: 'issuerEncoded'
+    }, {
+      name:        'Certificate.TBSCertificate.validity',
+      tagClass:    asn1.Class.UNIVERSAL,
+      type:        asn1.Type.SEQUENCE,
+      constructed: true,
+      // The spec only specifies that there will be two times, each of which may
+      // be either UTC or generalized.  We can't guarantee that both times are
+      // even in the same format; so we alternate reading UTC and generalized,
+      // twice, and only determine the actual value based on what we managed to
+      // read out.
+      value:       [{
+        name:        'Certificate.TBSCertificate.validity.notBefore (utc)',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.UTCTIME,
+        constructed: false,
+        optional:    true,
+        capture:     'validityUTC1'
+      }, {
+        name:        'Certificate.TBSCertificate.validity.notBefore (generalized)',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.GENERALIZEDTIME,
+        constructed: false,
+        optional:    true,
+        capture:     'validityGeneralized1'
+      }, {
+        name:        'Certificate.TBSCertificate.validity.notAfter (utc)',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.UTCTIME,
+        constructed: false,
+        optional:    true,
+        capture:     'validityUTC2'
+      }, {
+        name:        'Certificate.TBSCertificate.validity.notAfter (generalized)',
+        tagClass:    asn1.Class.UNIVERSAL,
+        type:        asn1.Type.GENERALIZEDTIME,
+        constructed: false,
+        optional:    true,
+        capture:     'validityGeneralized2'
+      }]
+    }]
+  }]
+};
+
+/**
+ * parseIssuer decodes the ASN.1 encoded issuer and returns a map describing it.
+ * @param encoded ASN.1 encoded issuer data.
+ */
+function parseIssuer(encoded: any): Record<string, string> {
+  const decoded: {
+        type: string;
+        value: string;
+        name?: string;
+        shortName?: string;
+    }[] = (forge.pki as any).RDNAttributesAsArray(encoded);
+  const result: Record<string, string> = Object.create({}, {
+    toString: {
+      enumerable: false,
+      value() {
+        return this.CN || this.OU || JSON.stringify(this);
+      }
+    }
+  });
+
+  for (const item of decoded) {
+    result[item.shortName ?? item.name ?? item.type] = item.value;
+  }
+
+  return result;
+}
+
+function defined<T>(input: T | undefined | null): input is T {
+  return typeof input !== 'undefined' && input !== null;
+}
+
+/**
+ * Convert the given value to a Date using the given forge.asn1 method.
+ */
+function convertDate(val: string | undefined, fn: 'utcTimeToDate' | 'generalizedTimeToDate') {
+  return val ? (forge.asn1 as any)[fn](val) as Date : undefined;
+}
+
+/**
+ * Check a given PEM ceritificate to ensure it is within the valid date range.
+ * This does _not_ do any other checking of the certificate.
+ */
+export default function checkCertValidity(pem: string): boolean {
+  // Node-forge chokes on non-RSA certificates; so we will need to parse it
+  // manually.  Code is based on BSD-3 licensed node-forge (lib/x509.js).
+
+  console.debug('Checking certificate for expiry...');
+  const msg = forge.pem.decode(pem)[0];
+
+  if (!msg.type.endsWith('CERTIFICATE')) {
+    console.warn(`Skipping certificate with unknown type ${ msg.type }`);
+
+    return false;
+  }
+  if (msg.procType?.type === 'ENCRYPTED') {
+    console.warn('Skipping encrypted certificate');
+
+    return false;
+  }
+  const obj = forge.asn1.fromDer(msg.body);
+  const capture: {
+        validityUTC1?: string;
+        validityGeneralized1?: string;
+        validityUTC2?: string;
+        validityGeneralized2?: string;
+        issuerEncoded?: any;
+    } = {};
+  const errors: string[] = [];
+  // @types/node-forge is missing many methods, so we need to cast as any.
+  const valid = (forge.asn1 as any).validate(obj, x509CertificateValidityValidator, capture, errors);
+  const now = new Date();
+
+  if (!valid) {
+    console.warn(`Rejecting invalid certificate: encountered errors:`, errors);
+
+    return false;
+  }
+
+  const certInfo = {
+    issuer:   parseIssuer(capture.issuerEncoded),
+    validity: [
+      convertDate(capture.validityUTC1, 'utcTimeToDate'),
+      convertDate(capture.validityGeneralized1, 'generalizedTimeToDate'),
+      convertDate(capture.validityUTC2, 'utcTimeToDate'),
+      convertDate(capture.validityGeneralized2, 'generalizedTimeToDate'),
+    ].filter(defined)
+  };
+
+  console.debug('Inspecting certificate', certInfo);
+
+  if (certInfo.validity.length !== 2) {
+    console.warn(`Certificate has unexpected validity dates:`, certInfo);
+
+    return false;
+  }
+  // We don't care about notBefore; just check that notAfter is valid.
+  if (certInfo.validity[1] < now) {
+    console.warn([
+      `Rejected cert expired on ${ certInfo.validity[1].toUTCString() }`,
+      `issued by ${ certInfo.issuer }`,
+    ].join(' '));
+
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
We appear to have issues where people have expired CA certs on their machine, leading to errors verifying otherwise valid server certificates that can either chain to a valid (unexpired) CA or an expired CA.  Try to avoid importing already expired CAs in hopes of fixing the issue.

It was not possible to use `forge.pki.certificateFromPem` directly as that rejects non-RSA certificates (even though we do nothing with the public key), so we have to copy some code over to be able to parse the certificate manually from PEM just enough to see the validity period.

Hopefully fixes #804.