### PR TITLE
Bump go version to support winipcfg/wireguard pkg

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,8 @@ jobs:
         python-version: '2.x'
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        stable: 'false' # Remove once RC suffix is removed
+        go-version: '1.18.0-rc1'
     - name: Install Windows dependencies
       if: startsWith(matrix.os, 'windows-')
       shell: powershell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,8 @@ jobs:
         node-version: '16.x'
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        stable: 'false' # Remove once RC suffix is removed
+        go-version: '1.18.0-rc1'
     - run: npm ci
     - run: npm run lint:nofix
     - run: npm test


### PR DESCRIPTION
This bumps up our go version to 1.18rc1 although this is an RC version it allows us to have access to the wireguard winifcfg package which is essential for the issue-1325.  