### PR TITLE
Bump lima to 0.8.3 and make static hostnames available inside containers

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.19';
+const limaTag = 'v1.20';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.7';

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -43,11 +43,6 @@ provision:
   script: |
     #!/bin/sh
     hostname lima-rancher-desktop
-- # Create host.rancher-desktop.internal, lima-rancher-desktop, and host.docker.internal aliases for host.lima.internal
-  mode: system
-  script: |
-    #!/bin/sh
-    sed -i 's/host.lima.internal.*/host.lima.internal lima-rancher-desktop host.rancher-desktop.internal host.docker.internal/' /etc/hosts
 - # Clean up filesystems
   mode: system
   script: |

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -87,6 +87,9 @@ type LimaConfiguration = {
     script: string;
     hint: string;
   }[];
+  hostResolver?: {
+    hosts?: Record<string, string>;
+  }
   portForwards?: Array<Record<string, any>>;
   networks?: Array<Record<string, string>>;
   paths?: Record<string, string>;
@@ -541,8 +544,17 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         { location: '~', writable: true },
         { location: '/tmp/rancher-desktop', writable: true },
       ],
-      ssh: { localPort: await this.sshPort },
-      k3s: { version: desiredVersion.version },
+      ssh:          { localPort: await this.sshPort },
+      k3s:          { version: desiredVersion.version },
+      hostResolver: {
+        hosts: {
+          // As far as lima is concerned, the instance name is 'lima-0'.
+          // We change the hostname in a provisioning script.
+          'lima-rancher-desktop':          'lima-0',
+          'host.rancher-desktop.internal': 'host.lima.internal',
+          'host.docker.internal':          'host.lima.internal',
+        }
+      }
     });
 
     if (os.platform() === 'darwin') {


### PR DESCRIPTION
Tested manually (ping statistics removed for clarity):

```console
$ rdlima ping -c 1 lima-rancher-desktop
PING lima-rancher-desktop (192.168.5.15): 56 data bytes
64 bytes from 192.168.5.15: seq=0 ttl=42 time=0.157 ms

$ rdlima ping -c 1 host.docker.internal
PING host.docker.internal (192.168.5.2): 56 data bytes
64 bytes from 192.168.5.2: seq=0 ttl=42 time=0.349 ms

$ nerdctl run --rm alpine ping -c 1 lima-rancher-desktop
PING lima-rancher-desktop (192.168.5.15): 56 data bytes
64 bytes from 192.168.5.15: seq=0 ttl=64 time=0.043 ms

$ nerdctl run --rm alpine ping -c 1 host.docker.internal
PING host.docker.internal (192.168.5.2): 56 data bytes
64 bytes from 192.168.5.2: seq=0 ttl=254 time=0.340 ms
```

Fixes #1316
Fixes #1439 