### PR TITLE
Iptables rules without address range bind to 0.0.0.0

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,7 +7,7 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.20';
+const limaTag = 'v1.21';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
 const alpineLimaTag = 'v0.2.7';

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.15';
+  const v = '0.16';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -79,4 +79,5 @@ provision:
     usermod --append --groups docker "${LIMA_CIDATA_USER}"
 portForwards:
 - guestPortRange: [1, 65535]
+  guestIPMustBeZero: true
   hostIP: "0.0.0.0"


### PR DESCRIPTION
This commit bumps to lima 0.8.3+ to include the change that implements this.

It also bumps the wsl distro to 0.16, which in turn includes rancher-desktop-agent v0.1.2, which uses the corresponding lima code.

The lima port forwarding rules are modified so that only ports bound to `0.0.0.0` are forwarded to `0.0.0.0` on the host. Ports bound to `127.0.0.1` are forwarded to `127.0.0.1` on the host, and all other interfaces are not forwarded.

This means `docker/nerdctl run ... -p 8080:80` will forward to `0.0.0.0`, but `docker/nerdctl run ... -p 127.0.0.1:8080:80` will forward to `127.0.0.1`.

Similarly for kubernetes, node ports are forwarded to `0.0.0.0`, but cluster ips are forwarded only to `127.0.0.1`.

Fixes #1626