### PR TITLE
Load k3s airgap images into container runtime before starting k3s

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -33,6 +33,15 @@ depend() {
 start_pre() {
   rm -f /tmp/k3s.*
   checkpath --file --mode 0644 --owner root "${output_log_unquoted}" "${error_log_unquoted}"
+  ARCH=amd64
+  if [ "$(uname -m)" = "aarch64" ]; then
+    ARCH=arm64
+  fi
+  if [ "${ENGINE}" == "moby" ]; then
+    docker load --input /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar
+  else
+    nerdctl --address /run/k3s/containerd/containerd.sock --namespace k8s.io load --input /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar
+  fi
 }
 
 supervisor=supervise-daemon


### PR DESCRIPTION
Fixes #1139