### PR TITLE
WSL: Exclude WSL1 distributions from integration.

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -396,7 +396,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async registeredDistros({ runningOnly = false } = {}): Promise<string[]> {
     const stdout = await this.execWSL({ capture: true }, '--list', '--verbose');
     // As wsl.exe may be localized, don't check state here.
-    const parser = /^[\s\*]+(?<name>.*?)\s+\w+\s+(?<version>\d+)\s*$/;
+    const parser = /^[\s*]+(?<name>.*?)\s+\w+\s+(?<version>\d+)\s*$/;
 
     let result = stdout.trim()
       .split(/[\r\n]+/)


### PR DESCRIPTION
We do not support integrating with WSL1 distributions; don't show them in the list to avoid confusing users.

This should help alleviate some of the issues leading to #1468 (where users try to enable integration for WSL1 distributions).