### PR TITLE
Bump Alpine ISO and WSL distro to include flannel and loopback CNI plugins

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.21';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.7';
+const alpineLimaTag = 'v0.2.8';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.14.3';
 

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.16';
+  const v = '0.17';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -150,7 +150,7 @@ interface SPNetworkDataType {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.7';
+const IMAGE_VERSION = '0.2.8';
 const ALPINE_EDITION = 'rd';
 const ALPINE_VERSION = '3.14.3';
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -60,7 +60,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.15';
+const DISTRO_VERSION = '0.17';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
Changes CNI plugin install location from `/usr/local/libexec/cni` to `/usr/libexec/cni`.

Also fixes a bug from #1628 which didn't bump the distro version number in `wsl.ts`.