### PR TITLE
nerdctl-stub: fix macos tests.

### DIFF
--- a/src/go/nerdctl-stub/main_unsupported.go
+++ b/src/go/nerdctl-stub/main_unsupported.go
@@ -13,6 +13,7 @@ func unhandledArgHandler(arg string) (string, []cleanupFunc, error) {
 var volumeArgHandler = unhandledArgHandler
 var filePathArgHandler = unhandledArgHandler
 var outputPathArgHandler = unhandledArgHandler
+var mountArgHandler = unhandledArgHandler
 
 func spawn(opts spawnOptions) error {
 	panic("Platform is unsupported")


### PR DESCRIPTION
Needs a new stub for the new function.  Fixup for #1616.