### PR TITLE
Bump WSL distro to 0.19 to include docker-cli

### DIFF
--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.18';
+  const v = '0.19';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -62,7 +62,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.18';
+const DISTRO_VERSION = '0.19';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
This is required to `docker load` the airgap images in /etc/init.d/k3s.

Fixes #1651 (and maybe #1650)