### PR TITLE
Return false if PEM certificate cannot be decoded

### DIFF
--- a/src/main/networking/cert-parse.ts
+++ b/src/main/networking/cert-parse.ts
@@ -202,7 +202,13 @@ export default function checkCertValidity(pem: string): boolean {
   // manually.  Code is based on BSD-3 licensed node-forge (lib/x509.js).
 
   console.debug('Checking certificate for expiry...');
-  const msg = forge.pem.decode(pem)[0];
+  const msg = tryPemDecode(pem);
+
+  if (!msg) {
+    console.warn('Skipping certificate, cannot decode');
+
+    return false;
+  }
 
   if (!msg.type.endsWith('CERTIFICATE')) {
     console.warn(`Skipping certificate with unknown type ${ msg.type }`);

--- a/src/main/networking/cert-parse.ts
+++ b/src/main/networking/cert-parse.ts
@@ -179,6 +179,21 @@ function convertDate(val: string | undefined, fn: 'utcTimeToDate' | 'generalized
 }
 
 /**
+ * Attempts to decode PEM certificate and handle exceptions
+ * @param pem PEM file
+ * @returns Decoded PEM certificate or null on error
+ */
+function tryPemDecode(pem: string) {
+  try {
+    return forge.pem.decode(pem)[0];
+  } catch (e) {
+    console.error(`Rejecting invalid certificate: encountered errors:`, e);
+
+    return null;
+  }
+}
+
+/**
  * Check a given PEM certificate to ensure it is within the valid date range.
  * This does _not_ do any other checking of the certificate.
  */


### PR DESCRIPTION
This resolves an issue that was causing the startup routine to hang on unhandled exceptions for decoding PEM certificates on Linux.

closes #1642 