### PR TITLE
Ensure e2e tests run with `kubernetes.enabled` set to true.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -25,6 +25,19 @@ function createSettingsFile(settingsDir: string) {
     fs.mkdirSync(settingsDir, { recursive: true });
     fs.writeFileSync(path.join(settingsDir, fileSettingsName), settingsJson);
     console.log('Default settings file successfully created on: ', `${ settingsDir }/${ fileSettingsName }`);
+  } else {
+    try {
+      const contents = fs.readFileSync(settingsFullPath, { encoding: 'utf-8' });
+      const settings = JSON.parse(contents.toString());
+
+      if (settings.kubernetes?.enabled === false) {
+        console.log(`Warning: updating settings.kubernetes.enabled to true.`);
+        settings.kubernetes.enabled = true;
+        fs.writeFileSync(settingsFullPath, JSON.stringify(settings), { encoding: 'utf-8' });
+      }
+    } catch (err) {
+      console.log(`Failed to process ${ settingsFullPath }: ${ err }`);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1663 

Note that I tried doing this from `e2e.mjs` to avoid race conditions if the subsidiary tests are ever run in parallel, but ran into js/ts problems trying to access `settings.ts`. So doing it this way. Also not bothering restore the config, issuing a warning message instead.

I think these compromises are ok because most of the time these tests are run in CI on a green field, so the problem doesn't apply. It occurs only in the rarer circumstances where devs run the tests manually.

Signed-off-by: Eric Promislow <epromislow@suse.com>