### PR TITLE
Add `kubernetes.enabled` to the e2e tests.

### DIFF
--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -67,6 +67,7 @@ test.describe.serial('Main App Test', () => {
     await expect(k8sPage.port).toBeVisible();
     await expect(k8sPage.resetButton).toBeVisible();
     await expect(k8sPage.engineRuntime).toBeVisible();
+    await expect(k8sPage.enableKubernetes).toBeVisible();
   });
 
   /**

--- a/e2e/pages/k8s-page.ts
+++ b/e2e/pages/k8s-page.ts
@@ -6,6 +6,7 @@ export class K8sPage {
     readonly resetButton: Locator;
     readonly cpuSlider: Locator;
     readonly port: Locator;
+    readonly enableKubernetes: Locator;
 
     constructor(page: Page) {
       this.page = page;
@@ -14,5 +15,6 @@ export class K8sPage {
       this.cpuSlider = page.locator('[id="numCPUWrapper"]');
       this.engineRuntime = page.locator('.engine-selector');
       this.port = page.locator('[data-test="portConfig"]');
+      this.enableKubernetes = page.locator('[data-test="enableKubernetes"]');
     }
 }

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -55,6 +55,7 @@
         :value="settings.kubernetes.enabled"
         :disabled="cannotReset"
         class="kubernetes"
+        data-test="enableKubernetes"
         @input="handleDisableKubernetesCheckbox"
       />
       <checkbox


### PR DESCRIPTION
Fixes #1589

No point doing more unit tests for this feature until we start doing more unit tests for all the settings. 

Signed-off-by: Eric Promislow <epromislow@suse.com>