### PR TITLE
Import airgap images with --all-platforms option

### DIFF
--- a/src/assets/scripts/service-k3s.initd
+++ b/src/assets/scripts/service-k3s.initd
@@ -37,7 +37,7 @@ start_pre() {
   if [ "${ENGINE}" == "moby" ]; then
     docker load --input /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar
   else
-    nerdctl --address /run/k3s/containerd/containerd.sock --namespace k8s.io load --input /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar
+    nerdctl --address /run/k3s/containerd/containerd.sock --namespace k8s.io load --all-platforms --input /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar
   fi
 }
 


### PR DESCRIPTION
because the coredns image for arm64 specifies the wrong architecture:

```console
$ skopeo inspect --config --raw docker://docker.io/coredns/coredns@sha256:7847ada4d72bc8b479122ad9963fbe073f563f1a982f5b76dbfc872184a4f518 | jq .architecture
"amd64"
```
See also https://github.com/k3s-io/k3s/pull/2198

Fixes #1669