### PR TITLE
WSL: create state directory needed for dnsmasq

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1233,6 +1233,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             });
             await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, 0o755);
             await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF, 0o644);
+            await this.execCommand('mkdir', '-p', '/var/lib/misc');
 
             await this.runInit();
             if (this.#currentContainerEngine === ContainerEngine.MOBY) {


### PR DESCRIPTION
As /var/lib is mounted from the data distribution, this may not exist for an upgraded install.  Manually create it before we start dnsmasq to avoid errors.

Fixes #1686 