### PR TITLE
Explicitly invoke showAboutPanel when clicking About

### DIFF
--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -40,8 +40,15 @@ function getEditMenu(isMac: boolean): MenuItem {
 function getHelpMenu(isMac: boolean): MenuItem {
   const helpMenuItems: Array<MenuItemConstructorOptions> = [
     ...(!isMac ? [
-      { role: 'about', label: `&About ${ Electron.app.name }` } as MenuItemConstructorOptions,
-      { type: 'separator' } as MenuItemConstructorOptions] : []),
+      {
+        role:  'about',
+        label: `&About ${ Electron.app.name }`,
+        click() {
+          Electron.app.showAboutPanel();
+        }
+      } as MenuItemConstructorOptions,
+      { type: 'separator' } as MenuItemConstructorOptions
+    ] : []),
     {
       label: 'Get &Help',
       click() {


### PR DESCRIPTION
This shows the about panel by explicitly invoking `Electron.app.showAboutPanel()` when clicking on About. 

Spent some time researching why the existing implementation might not be working Linux vs. Windows. Unfortunately, I came up empty-handed in my search. Will do some testing in Windows to see if it's affected as well..

closes #738 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>