### PR TITLE
Update cursor to pointer for sortable column headers

### DIFF
--- a/src/components/SortableTable/THead.vue
+++ b/src/components/SortableTable/THead.vue
@@ -153,6 +153,8 @@ export default {
 
 <style lang="scss" scoped>
    .sortable > SPAN {
+    cursor: pointer;
+    user-select: none;
     display: inline-block;
     white-space: nowrap;
     &:hover,


### PR DESCRIPTION
This also disables text selection for column headers to prevent selection when performing multiple sorts in a row. 

closes #1463 

backport rancher/dashboard#5261

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>