### PR TITLE
WSL: Work around Win11 deleting /etc/resolv.conf

### DIFF
--- a/src/assets/scripts/wsl-init
+++ b/src/assets/scripts/wsl-init
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This script is used to launch (busybox) init on WSL2.  This is necessary as
+# we need to do some mount namespace shenanigans, since we store the data on the
+# WSL shared mount (/mnt/wsl/rancher/desktop/) and that can have issues with
+# lingering tmpfs mounts after we exit.  This means we need to run this script
+# under unshare (to get a private mount namespace), and then we can mark various
+# mount points as shared (for kim / buildkit).  Kubelet will internally do some
+# tmpfs mounts for volumes (secrets, etc.), which will stay private and go away
+# once k3s exits, so that we can delete the data as necessary.
+
+set -o errexit -o nounset -o xtrace
+
+if [ $$ -ne "1" ]; then
+    # This is not running as PID 1; this means that this is a normal invocation
+    # from WSL.  Set up the namespaces, and try again.
+    echo $$ > /run/wsl-init.pid
+    exec /usr/bin/unshare --pid --mount-proc --fork --propagation slave "${0}"
+fi
+
+# Mark directories that we will need to bind mount as shared mounts.
+(
+    IFS=:
+    for dir in / ${DISTRO_DATA_DIRS}; do
+        mount --make-shared "${dir}"
+    done
+)
+
+if [ -f /var/lib/resolv.conf ]; then
+    ln -s -f /var/lib/resolv.conf /etc/resolv.conf
+fi
+
+# Run init (which never exits).
+exec /sbin/init

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1091,7 +1091,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         await this.execCommand({ expectFailure: true }, 'test', '-s', PID_FILE);
         break;
       } catch (e) {
-        console.log(`Error testing for wsl-init.pid: ${ e }`, e);
+        console.debug(`Error testing for wsl-init.pid: ${ e } (will retry)`);
       }
       if (Date.now() - startTime > maxWaitTime) {
         throw new Error(`Timed out after waiting for /var/run/wsl-init.pid: ${ maxWaitTime / waitTime } secs`);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -23,6 +23,7 @@ import LOGROTATE_K3S_SCRIPT from '@/assets/scripts/logrotate-k3s';
 import SERVICE_BUILDKITD_INIT from '@/assets/scripts/buildkit.initd';
 import SERVICE_BUILDKITD_CONF from '@/assets/scripts/buildkit.confd';
 import INSTALL_WSL_HELPERS_SCRIPT from '@/assets/scripts/install-wsl-helpers';
+import WSL_INIT_SCRIPT from '@/assets/scripts/wsl-init';
 import SCRIPT_DATA_WSL_CONF from '@/assets/scripts/wsl-data.conf';
 import mainEvents from '@/main/mainEvents';
 import * as childProcess from '@/utils/childProcess';
@@ -605,7 +606,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             'resolv-file':    '/etc/dnsmasq.d/data-resolv-conf',
             'listen-address': await this.ipAddress,
           }).map(([k, v]) => `${ k }=${ v }\n`).join('')),
-        this.writeFile('/etc/resolv.conf', `nameserver ${ await this.ipAddress }\n`),
+        // We can't write to /etc/resolv.conf directly due to Win11 issues, see
+        // https://github.com/rancher-sandbox/rancher-desktop/issues/1702
+        // Instead, we write to a different file and make a symlink when we run init.
+        this.writeFile('/var/lib/resolv.conf', `nameserver ${ await this.ipAddress }\n`, { distro: DATA_INSTANCE_NAME }),
         this.writeConf('dnsmasq', { DNSMASQ_OPTS: '--user=dnsmasq --group=dnsmasq' }),
       ]));
   }
@@ -1050,6 +1054,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       await this.execCommand('rm', '-f', PID_FILE);
     } catch {
     }
+
+    await this.writeFile('/usr/local/bin/wsl-init', WSL_INIT_SCRIPT, { permissions: 0o755 });
 
     // The process should already be gone by this point, but make sure.
     this.process?.kill('SIGTERM');

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -782,21 +782,23 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   /**
-   * Write the given contents to a given file name in the RD WSL distribution.
+   * Write the given contents to a given file name in the given WSL distribution.
    * @param filePath The destination file path, in the WSL distribution.
    * @param fileContents The contents of the file.
-   * @param permissions The file permissions.
+   * @param [options.permissions=0o644] The file permissions.
+   * @param [options.distro=INSTANCE_NAME] WSL distribution to write to.
    */
-  protected async writeFile(filePath: string, fileContents: string, permissions: fs.Mode = 0o644) {
+  protected async writeFile(filePath: string, fileContents: string, options?: Partial<{permissions: fs.Mode, distro: typeof INSTANCE_NAME | typeof DATA_INSTANCE_NAME}>) {
+    const distro = options?.distro ?? INSTANCE_NAME;
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `rd-${ path.basename(filePath) }-`));
 
     try {
       const scriptPath = path.join(workdir, path.basename(filePath));
-      const wslScriptPath = await this.wslify(scriptPath);
+      const wslScriptPath = await this.wslify(scriptPath, distro);
 
       await fs.promises.writeFile(scriptPath, fileContents.replace(/\r/g, ''), 'utf-8');
-      await this.execCommand('cp', wslScriptPath, filePath);
-      await this.execCommand('chmod', permissions.toString(8), filePath);
+      await this.execCommand({ distro }, 'busybox', 'cp', wslScriptPath, filePath);
+      await this.execCommand({ distro }, 'busybox', 'chmod', (options?.permissions ?? 0o644).toString(8), filePath);
     } finally {
       await fs.promises.rm(workdir, { recursive: true });
     }
@@ -1220,19 +1222,19 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             const rotateConf = LOGROTATE_K3S_SCRIPT.replace(/\r/g, '')
               .replace('/var/log', logPath);
 
-            await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, 0o755);
-            await this.writeFile('/etc/logrotate.d/k3s', rotateConf, 0o644);
+            await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, { permissions: 0o755 });
+            await this.writeFile('/etc/logrotate.d/k3s', rotateConf);
             await this.execCommand('mkdir', '-p', '/etc/cni/net.d');
-            await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST, 0o644);
-            await this.writeFile('/etc/containerd/config.toml', CONTAINERD_CONFIG, 0o644);
+            await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
+            await this.writeFile('/etc/containerd/config.toml', CONTAINERD_CONFIG);
             await this.writeConf('containerd', { log_owner: 'root' });
-            await this.writeFile('/etc/init.d/docker', SERVICE_SCRIPT_DOCKERD, 0o755);
+            await this.writeFile('/etc/init.d/docker', SERVICE_SCRIPT_DOCKERD, { permissions: 0o755 });
             await this.writeConf('docker', {
               WSL_HELPER_BINARY: await this.getWSLHelperPath(),
               LOG_DIR:           logPath,
             });
-            await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, 0o755);
-            await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF, 0o644);
+            await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, { permissions: 0o755 });
+            await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF);
             await this.execCommand('mkdir', '-p', '/var/lib/misc');
 
             await this.runInit();


### PR DESCRIPTION
It appears that Windows 11 will delete `/etc/resolv.conf` when a distribution initially starts up (i.e. after `wsl --terminate` or new boot), even if it is not configured to generate the file.

This works around the issue by creating the file in `/var/lib` instead, and creating a symlink to it just before we run init (in the `wsl-init` shell script, so within the same run).

Note that I'm copying `wsl-init` over from `rancher-desktop-wsl-distro` to ease backporting; we can drop it from the distro later.

Fixes #1702 (hopefully).