### PR TITLE
K8s: Attach the failing command to the exception.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -661,7 +661,7 @@ async function handleFailure(payload: any) {
     // getFailureDetails is going to read from existing log files.
     // Wait 1 second before reading them to allow recent writes to appear in them.
     await util.promisify(setTimeout)(1_000);
-    const failureDetails: K8s.FailureDetails = await k8smanager.getFailureDetails();
+    const failureDetails: K8s.FailureDetails = await k8smanager.getFailureDetails(payload);
 
     if (failureDetails) {
       await window.openKubernetesErrorMessageWindow(titlePart, secondaryMessage || message, failureDetails);

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer';
-import { ChildProcess, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import os from 'os';
 import timers from 'timers';
@@ -8,6 +7,7 @@ import { KubeConfig } from '@kubernetes/client-node/dist/config';
 import * as K8s from '@/k8s-engine/k8s';
 import * as window from '@/window';
 import mainEvents from '@/main/mainEvents';
+import { ChildProcess, ErrorCommand, spawn } from '@/utils/childProcess';
 import Logging from '@/utils/logging';
 import LimaBackend from '@/k8s-engine/lima';
 
@@ -319,11 +319,22 @@ export abstract class ImageProcessor extends EventEmitter {
           }
           resolve({ ...result, code });
         } else if (signal) {
-          reject({
-            ...result, code: -1, signal
-          });
+          reject(Object.create(result, {
+            code:           { value: -1 },
+            signal:         { value: signal },
+            [ErrorCommand]: {
+              enumerable: false,
+              value:      child.spawnargs,
+            }
+          }));
         } else {
-          reject({ ...result, code });
+          reject(Object.create(result, {
+            code:           { value: code },
+            [ErrorCommand]: {
+              enumerable: false,
+              value:      child.spawnargs,
+            }
+          }));
         }
       });
     });

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -45,7 +45,7 @@ export type Architecture = 'x86_64' | 'aarch64';
 
 export type FailureDetails = {
   /** The last lima/wsl command run: */
-  lastCommand: string,
+  lastCommand?: string,
   lastCommandComment: string,
   lastLogLines: Array<string>,
 }
@@ -235,13 +235,10 @@ export interface KubernetesBackend extends events.EventEmitter {
   /**
    * If called after a backend operation fails, this returns a block of data that attempts
    * to give more information about what command was being run when the error happened.
+   *
+   * @param [exception] The associated exception.
    */
-  getFailureDetails(): Promise<FailureDetails>;
-
-  /**
-   * The last command run.
-   */
-  lastCommand: string;
+  getFailureDetails(exception: any): Promise<FailureDetails>;
 
   /**
    * A description of the last backend command, usually displayed by the progress tracker,

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -136,12 +136,6 @@ export class OSNotImplemented extends events.EventEmitter {
     return Promise.reject(new Error('not implemented'));
   }
 
-  get lastCommand() {
-    this.#notified = displayError(this.#notified);
-
-    return '';
-  }
-
   get lastCommandComment() {
     this.#notified = displayError(this.#notified);
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -284,20 +284,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   /** True if start() was called with k3s enabled, false if it wasn't. */
   #enabledK3s = true;
 
-  /** Used for giving better error messages on failure to start or stop
-   * The actual underlying lima command
-   */
-  #lastCommand = '';
-
-  get lastCommand() {
-    return this.#lastCommand;
-  }
-
-  set lastCommand(value: string) {
-    console.log(`Running command ${ value }...`);
-    this.#lastCommand = value;
-  }
-
   /** An explanation of the last run command */
   #lastCommandComment = '';
 
@@ -307,7 +293,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
   set lastCommandComment(value: string) {
     this.#lastCommandComment = value;
-    this.#lastCommand = '';
   }
 
   /** Helper object to manage available K3s versions. */
@@ -883,7 +868,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     } else {
       options = optionsOrArg;
     }
-    this.lastCommand = `wsl ${ args.join(' ') }`;
     try {
       const stream = options.logStream ?? await Logging['wsl-exec'].fdStream;
 
@@ -1790,10 +1774,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     this.#checkedDockerCompose = true;
   }
 
-  async getFailureDetails(): Promise<K8s.FailureDetails> {
+  async getFailureDetails(exception: any): Promise<K8s.FailureDetails> {
     const loglines = (await fs.promises.readFile(console.path, 'utf-8')).split('\n').slice(-10);
     const details: K8s.FailureDetails = {
-      lastCommand:        this.lastCommand,
+      lastCommand:        exception[childProcess.ErrorCommand],
       lastCommandComment: this.lastCommandComment,
       lastLogLines:       loglines,
     };

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -9,6 +9,12 @@ export {
   ChildProcess, CommonOptions, SpawnOptions, exec, spawn
 } from 'child_process';
 
+/**
+ * ErroCommand is a symbol we attach to any exceptions thrown to describe the
+ * command that failed.
+ */
+export const ErrorCommand = Symbol('child-process.command');
+
 /* eslint-disable no-redeclare */
 
 interface SpawnOptionsWithStdioLog<
@@ -141,9 +147,13 @@ export async function spawnFile(
   args?: string[] | SpawnOptionsLog & SpawnOptionsEncoding,
   options: SpawnOptionsLog & SpawnOptionsEncoding = {}
 ): Promise<{ stdout?: string, stderr?: string }> {
+  let finalArgs: string[] = [];
+
   if (args && !Array.isArray(args)) {
     options = args;
-    args = [];
+    finalArgs = [];
+  } else {
+    finalArgs = args ?? [];
   }
 
   const stdio = options.stdio;
@@ -182,7 +192,7 @@ export async function spawnFile(
 
   // Spawn the child, overriding options.stdio.  This is necessary to support
   // transcoding the output.
-  const child = spawn(command, args || [], {
+  const child = spawn(command, finalArgs, {
     windowsHide: true,
     ...options,
     stdio:       mungedStdio,
@@ -227,6 +237,12 @@ export async function spawnFile(
       }
       const error: SpawnError = new Error(message);
 
+      Object.defineProperties(error, {
+        [ErrorCommand]: {
+          enumerable: false,
+          value:      `${ command } ${ finalArgs.join(' ') }`,
+        }
+      });
       if (typeof result.stdout !== 'undefined') {
         error.stdout = result.stdout;
       }

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -10,7 +10,7 @@ export {
 } from 'child_process';
 
 /**
- * ErroCommand is a symbol we attach to any exceptions thrown to describe the
+ * ErrorCommand is a symbol we attach to any exceptions thrown to describe the
  * command that failed.
  */
 export const ErrorCommand = Symbol('child-process.command');


### PR DESCRIPTION
This changes how we track a command that fails; rather than keeping the state with the backend object, instead attach it to the exception thrown when the process exits.

This is to allow a follow-up change that will allow methods spawning child processes to not modify the containing instance.\