### PR TITLE
Implement list-settings and (PUT) shutdown command.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -20,7 +20,7 @@ import Logging, { setLogLevel } from '@/utils/logging';
 import * as childProcess from '@/utils/childProcess';
 import Latch from '@/utils/latch';
 import paths from '@/utils/paths';
-import HttpCommandServer from '@/main/httpCommandServer';
+import { CommandWorkerInterface, HttpCommandServer } from '@/main/httpCommandServer';
 import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
@@ -79,7 +79,7 @@ mainEvents.on('settings-update', (newSettings) => {
 
 Electron.app.whenReady().then(async() => {
   try {
-    await httpCommandServer.init();
+    await httpCommandServer.init(new BackgroundCommandWorker());
     setupNetworking();
     cfg = settings.init();
     mainEvents.emit('settings-update', cfg);
@@ -745,4 +745,14 @@ function newK8sManager() {
   });
 
   return mgr;
+}
+
+class BackgroundCommandWorker implements CommandWorkerInterface {
+  getSettings() {
+    return JSON.stringify(cfg, undefined, 2);
+  }
+
+  requestShutdown() {
+    Electron.app.quit();
+  }
 }

--- a/background.ts
+++ b/background.ts
@@ -752,7 +752,7 @@ function newK8sManager() {
  * These methods should be thin wrappers around existing functionality in the rest of the backend.
  * Getters normally return strings, either JSON strings or scalars.
  * Setters normally return either `true | false`, or possibly `true | error`.
- * The `requestShutdown` is a special case that never returns .
+ * The `requestShutdown` is a special case that never returns.
  */
 class BackgroundCommandWorker implements CommandWorkerInterface {
   getSettings() {

--- a/background.ts
+++ b/background.ts
@@ -747,6 +747,13 @@ function newK8sManager() {
   return mgr;
 }
 
+/**
+ * Implement the methods the HttpCommandServer needs to service its requests.
+ * These methods should be thin wrappers around existing functionality in the rest of the backend.
+ * Getters normally return strings, either JSON strings or scalars.
+ * Setters normally return either `true | false`, or possibly `true | error`.
+ * The `requestShutdown` is a special case that never returns .
+ */
 class BackgroundCommandWorker implements CommandWorkerInterface {
   getSettings() {
     return JSON.stringify(cfg, undefined, 2);

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -59,13 +59,13 @@ export class HttpCommandServer {
 
         return;
       }
-      const method = request.method;
+      const method = request.method ?? 'GET';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
       const path = url.pathname;
       const pathParts = path.split('/');
       const commandName = pathParts[0] || pathParts[1];
-      // TODO: Further processing of path parts, query parameters, and -d payload to be done later.
-      const command = this.lookupCommand(method ?? 'GET', commandName);
+      // TODO: Further processing of path parts, query parameters, and request body to be done later.
+      const command = this.lookupCommand(method, commandName);
 
       if (!command) {
         response.writeHead(404, { 'Content-Type': 'text/plain' });

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -115,10 +115,7 @@ export class HttpCommandServer {
   }
 
   protected lookupCommand(version: string, method: string, commandName: string) {
-    const versionTable = this.dispatchTable[version];
-    const commandsForMethod = versionTable && versionTable[method];
-
-    return commandsForMethod && commandsForMethod[commandName];
+    return this.dispatchTable[version]?.[method]?.[commandName];
   }
 
   listSettings(request: http.IncomingMessage, response: http.ServerResponse) {

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -73,7 +73,7 @@ export class HttpCommandServer {
 
         return;
       }
-      command(request, response);
+      command.call(this, request, response);
     } catch (err) {
       console.log(`Error handling ${ request.url }: ${ err }`);
       response.writeHead(500, { 'Content-Type': 'text/plain' });
@@ -110,9 +110,8 @@ export class HttpCommandServer {
 
   protected lookupCommand(method: string, commandName: string) {
     const commandsForMethod = this.dispatchTable[method];
-    const command = commandsForMethod ? commandsForMethod[commandName] : undefined;
 
-    return command && command.bind(this);
+    return commandsForMethod ? commandsForMethod[commandName] : undefined;
   }
 
   listSettings(request: http.IncomingMessage, response: http.ServerResponse) {

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -147,6 +147,12 @@ export class HttpCommandServer {
   }
 }
 
+/**
+ * Description of the methods which the HttpCommandServer uses to interact with the backend.
+ * There's no need to use events because the server and the core backend run in the same process.
+ * The HttpCommandServer is passed an instance of this interface, and calls the methods on it
+ * in order to carry out the business logic for the requests it receives.
+ */
 export interface CommandWorkerInterface {
   getSettings: () => string;
   requestShutdown: () => void;

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -130,10 +130,10 @@ export class HttpCommandServer {
   wrapShutdown(request: http.IncomingMessage, response: http.ServerResponse) {
     response.writeHead(202, { 'Content-Type': 'text/plain' });
     response.write('Shutting down.');
-    setTimeout(() => {
+    setImmediate(() => {
       this.shutdown();
       this.commandWorker?.requestShutdown();
-    }, 1);
+    });
   }
 
   shutdown() {


### PR DESCRIPTION
Fixes #1754

- Add a dispatch table to match incoming URL command-name parts to functions.
- Use a Worker class to do the actual work. The server has very little business logic.
- Add a general catch block in the main handler to return 500s.

Signed-off-by: Eric Promislow <epromislow@suse.com>