### PR TITLE
Open only a single Dashboard window

### DIFF
--- a/src/window/dashboard.ts
+++ b/src/window/dashboard.ts
@@ -1,5 +1,5 @@
 import { BrowserView, BrowserWindow } from 'electron';
-import { windowMapping, tryRestoreWindow } from '.';
+import { windowMapping, restoreWindow } from '.';
 
 const dashboardURL = 'http://127.0.0.1:9080/dashboard/c/local/explorer';
 
@@ -8,7 +8,7 @@ const getDashboardWindow = () => ('dashboard' in windowMapping) ? BrowserWindow.
 export function openDashboard() {
   let window = getDashboardWindow();
 
-  if (tryRestoreWindow(window)) {
+  if (restoreWindow(window)) {
     return window;
   }
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -27,7 +27,7 @@ function getWebRoot() {
  * @param window The Electron Browser window to show or restore
  * @returns Boolean: True if the browser window is shown or restored
  */
-export const tryRestoreWindow = (window: Electron.BrowserWindow | null): window is Electron.BrowserWindow => {
+export const restoreWindow = (window: Electron.BrowserWindow | null): window is Electron.BrowserWindow => {
   if (window) {
     if (!window.isFocused()) {
       if (window.isMinimized()) {
@@ -52,7 +52,7 @@ export const tryRestoreWindow = (window: Electron.BrowserWindow | null): window 
 function createWindow(name: string, url: string, options: Electron.BrowserWindowConstructorOptions) {
   let window = (name in windowMapping) ? BrowserWindow.fromId(windowMapping[name]) : null;
 
-  if (tryRestoreWindow(window)) {
+  if (restoreWindow(window)) {
     return window;
   }
 


### PR DESCRIPTION
This limits the number of open dashboard windows to 1 by checking if a dashboard window already exists in the window mapping. 

closes #1787 