### PR TITLE
rdctl: add HTTP API testing.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -1,0 +1,107 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * This file includes end-to-end testing for the HTTP control interface
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { expect, test } from '@playwright/test';
+import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright';
+
+import fetch from 'node-fetch';
+import { createDefaultSettings, kubectl, playwrightReportAssets } from './utils/TestUtils';
+import { NavPage } from './pages/nav-page';
+import paths from '@/utils/paths';
+import { ServerState } from '@/main/httpCommandServer';
+
+test.describe('HTTP control interface', () => {
+  let electronApp: ElectronApplication;
+  let context: BrowserContext;
+  let serverState: ServerState;
+  let page: Page;
+
+  async function doRequest(path: string, method = 'GET') {
+    const url = `http://127.0.0.1:${ serverState.port }/${ path.replace(/^\/*/, '') }`;
+    const auth = `${ serverState.user }:${ serverState.password }`;
+
+    return await fetch(url, {
+      method,
+      headers: { Authorization: `Basic ${ Buffer.from(auth).toString('base64') }` },
+    });
+  }
+
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(async() => {
+    createDefaultSettings();
+
+    electronApp = await _electron.launch({
+      args: [
+        path.join(__dirname, '../'),
+        '--disable-gpu',
+        '--whitelisted-ips=',
+        '--disable-dev-shm-usage',
+      ]
+    });
+    context = electronApp.context();
+
+    await context.tracing.start({ screenshots: true, snapshots: true });
+    page = await electronApp.firstWindow();
+  });
+
+  test.afterAll(async() => {
+    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await electronApp.close();
+  });
+
+  test('should load Kubernetes API', async() => {
+    const navPage = new NavPage(page);
+
+    await navPage.progressBecomesReady();
+    await expect(navPage.progressBar).toBeHidden();
+
+    expect(await kubectl('cluster-info')).toContain('is running at');
+  });
+
+  test('should emit connection information', async() => {
+    const dataPath = path.join(paths.appHome, 'rd-engine.json');
+    const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
+
+    serverState = JSON.parse(dataRaw);
+    expect(typeof serverState.user).toBe('string');
+    expect(typeof serverState.password).toBe('string');
+    expect(typeof serverState.port).toBe('number');
+    expect(typeof serverState.pid).toBe('number');
+  });
+
+  test('should require authentication', async() => {
+    const url = `http://127.0.0.1:${ serverState.port }/v0/list-settings`;
+    const resp = await fetch(url);
+
+    expect(resp.ok).toBeFalsy();
+    expect(resp.status).toEqual(401);
+  });
+
+  test('should be able to get settings', async() => {
+    const resp = await doRequest('/v0/list-settings');
+
+    expect(resp.ok).toBeTruthy();
+    expect(await resp.json()).toHaveProperty('kubernetes');
+  });
+});

--- a/src/main/httpCommandServer.ts
+++ b/src/main/httpCommandServer.ts
@@ -6,7 +6,7 @@ import { URL } from 'url';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 
-type ServerState = {
+export type ServerState = {
   user: string;
   password: string;
   port: number;
@@ -37,7 +37,7 @@ export class HttpCommandServer {
       GET: { 'list-settings': this.listSettings },
       PUT: { shutdown: this.wrapShutdown },
     }
-  }
+  };
 
   async init(commandWorker: CommandWorkerInterface) {
     const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);


### PR DESCRIPTION
We can't test shutdown here, as trying to shut down causes the test to die.

I noticed that the HTTP authorization header was case-sensitive (I had `basic` instead of `Basic`); that's probably fine.