### PR TITLE
bump go 1.18 to a stable release

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,8 +38,7 @@ jobs:
         python-version: '2.x'
     - uses: actions/setup-go@v2
       with:
-        stable: 'false' # Remove once RC suffix is removed
-        go-version: '1.18.0-rc1'
+        go-version: '^1.18'
     - name: Install Windows dependencies
       if: startsWith(matrix.os, 'windows-')
       shell: powershell
@@ -174,8 +173,7 @@ jobs:
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
     - uses: actions/setup-go@v2
       with:
-        stable: 'false' # Remove once RC suffix is removed
-        go-version: '1.18.0-rc1'
+        go-version: '^1.18'
     - run: npm ci
     - uses: actions/download-artifact@v2
       if: startsWith(matrix.os, 'windows-')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,7 @@ jobs:
         node-version: '16.x'
     - uses: actions/setup-go@v2
       with:
-        stable: 'false' # Remove once RC suffix is removed
-        go-version: '1.18.0-rc1'
+        go-version: '^1.18'
     - run: npm ci
     - run: npm run lint:nofix
     - run: npm test


### PR DESCRIPTION
Signed-off-by: Nino Kodabande <nkodabande@suse.com>