### PR TITLE
Lima: Gracefully fall back on lack of sudo permissions.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -174,6 +174,18 @@ function defined<T>(input: T | null | undefined): input is T {
   return input !== null && typeof input !== 'undefined';
 }
 
+/**
+ * LimaBackend implements all the Lima-specific functionality for Rancher
+ * Desktop.  This is used on macOS and Linux.
+ */
+// Implementation note: some of the methods of this class do not need to modify
+// the instance; these have an explicit this parameter [1] to narrow their view
+// of the class instance.  Typically, they use Readonly<LimaBackend> to prevent
+// writing to the instance; however, as that drops all non-public fields [2] we
+// sometimes have to use Readonly<LimaBackend> & LimaBackend to pick them up
+// (though this loses the type guarantees around it not modifying the instance).
+// [1]: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
+// [2]: https://github.com/microsoft/TypeScript/issues/46802
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
   constructor(arch: K8s.Architecture) {
     super();

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -664,7 +664,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /**
    * Run `limactl` with the given arguments.
    */
-  protected async lima(...args: string[]): Promise<void> {
+  protected async lima(this: Readonly<this>, ...args: string[]): Promise<void> {
     args = this.debug ? ['--debug'].concat(args) : args;
     try {
       await childProcess.spawnFile(LimaBackend.limactl, args,
@@ -679,7 +679,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /**
    * Run `limactl` with the given arguments, and return stdout.
    */
-  protected async limaWithCapture(...args: string[]): Promise<string> {
+  protected async limaWithCapture(this: Readonly<this>, ...args: string[]): Promise<string> {
     args = this.debug ? ['--debug'].concat(args) : args;
     const { stdout } = await childProcess.spawnFile(LimaBackend.limactl, args,
       { env: LimaBackend.limaEnv, stdio: ['ignore', 'pipe', console] });
@@ -730,7 +730,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return Math.random().toString().substring(2, desiredLength + 2);
   }
 
-  protected async showSudoReason(explanations: Array<string>): Promise<void> {
+  /**
+   * Show the dialog box describing why sudo is required.
+   */
+  protected async showSudoReason(this: unknown, explanations: Array<string>): Promise<void> {
     const bullet = '* ';
     const suffix = explanations.length > 1 ? 's' : '';
     const options: Electron.MessageBoxOptions = {
@@ -745,8 +748,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   /**
-   * Install the vde_vmnet binaries in to /opt/rancher-desktop if required.
-   * Note that this may request the root password.
+   * Run the various commands that require privileged access after prompting the
+   * user about the details.
+   *
+   * @note This may request the root password.
    */
   protected async installToolsWithSudo() {
     const randomTag = LimaBackend.calcRandomTag(8);
@@ -791,7 +796,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
-  protected async installVDETools(commands: Array<string>, explanations: Array<string>): Promise<void> {
+  protected async installVDETools(this: Readonly<this>, commands: Array<string>, explanations: Array<string>): Promise<void> {
     const sourcePath = path.join(paths.resources, os.platform(), 'lima', 'vde');
     const installedPath = VDE_DIR;
     const walk = async(dir: string): Promise<[string[], string[]]> => {
@@ -919,7 +924,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     explanations.push(VDE_DIR);
   }
 
-  protected async createLimaSudoersFile(commands: Array<string>, explanations: Array<string>, randomTag: string): Promise<void> {
+  protected async createLimaSudoersFile(this: Readonly<this> & this, commands: Array<string>, explanations: Array<string>, randomTag: string): Promise<void> {
     const haveFiles: Record<string, boolean> = {};
 
     for (const path of [PREVIOUS_LIMA_SUDOERS_LOCATION, LIMA_SUDOERS_LOCATION]) {
@@ -957,7 +962,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
-  protected async ensureRunLimaLocation(commands: Array<string>, explanations: Array<string>): Promise<void> {
+  protected async ensureRunLimaLocation(this: Readonly<this>, commands: Array<string>, explanations: Array<string>): Promise<void> {
     const limaRunLocation: string = NETWORKS_CONFIG.paths.varRun;
     let dirInfo: fs.Stats | null;
 
@@ -984,7 +989,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     explanations.push(limaRunLocation);
   }
 
-  protected async configureDockerSocket(commands: Array<string>, explanations: Array<string>): Promise<void> {
+  protected async configureDockerSocket(this: Readonly<this> & this, commands: Array<string>, explanations: Array<string>): Promise<void> {
     if (this.#currentContainerEngine !== ContainerEngine.MOBY) {
       return;
     }
@@ -999,7 +1004,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     explanations.push(DEFAULT_DOCKER_SOCK_LOCATION);
   }
 
-  protected async evalSymlink(path: string): Promise<string> {
+  protected async evalSymlink(this: Readonly<this>, path: string): Promise<string> {
     // Use lstat.isSymbolicLink && readlink(path) to walk symlinks,
     // instead of fs.readlink(file) to show both where a symlink is
     // supposed to point, whether or not the referent exists right now.
@@ -1023,7 +1028,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    * Use the sudo-prompt library to run the script as root
    * @param command: Path to an executable file
    */
-  protected async sudoExec(command: string) {
+  protected async sudoExec(this: unknown, command: string) {
     await new Promise<void>((resolve, reject) => {
       const iconPath = path.join(paths.resources, 'icons', 'logo-square-512.png');
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -650,7 +650,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return path.join(paths.resources, os.platform(), 'lima', 'bin', 'limactl');
   }
 
-  protected get limaEnv() {
+  protected static get limaEnv() {
     const binDir = path.join(paths.resources, os.platform(), 'lima', 'bin');
     const vdeDir = path.join(VDE_DIR, 'bin');
     const pathList = (process.env.PATH || '').split(path.delimiter);
@@ -668,7 +668,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     args = this.debug ? ['--debug'].concat(args) : args;
     try {
       await childProcess.spawnFile(LimaBackend.limactl, args,
-        { env: this.limaEnv, stdio: console });
+        { env: LimaBackend.limaEnv, stdio: console });
     } catch (ex) {
       console.error(`+ limactl ${ args.join(' ') }`);
       console.error(ex);
@@ -682,7 +682,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected async limaWithCapture(...args: string[]): Promise<string> {
     args = this.debug ? ['--debug'].concat(args) : args;
     const { stdout } = await childProcess.spawnFile(LimaBackend.limactl, args,
-      { env: this.limaEnv, stdio: ['ignore', 'pipe', console] });
+      { env: LimaBackend.limaEnv, stdio: ['ignore', 'pipe', console] });
 
     return stdout;
   }
@@ -694,7 +694,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     args = ['shell', '--workdir=.', MACHINE_NAME].concat(args);
     args = this.debug ? ['--debug'].concat(args) : args;
 
-    return spawnWithSignal(LimaBackend.limactl, args, { env: this.limaEnv });
+    return spawnWithSignal(LimaBackend.limactl, args, { env: LimaBackend.limaEnv });
   }
 
   protected async ssh(...args: string[]): Promise<void> {
@@ -1292,7 +1292,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       LimaBackend.limactl,
       args,
       {
-        env:   this.limaEnv,
+        env:   LimaBackend.limaEnv,
         stdio: ['ignore', await Logging.k3s.fdStream, await Logging.k3s.fdStream],
       },
     );
@@ -1489,7 +1489,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
                   args = this.debug ? ['--debug'].concat(args) : args;
                   await childProcess.spawnFile(LimaBackend.limactl, args,
-                    { env: this.limaEnv, stdio: 'ignore' });
+                    { env: LimaBackend.limaEnv, stdio: 'ignore' });
                   break;
                 } catch (ex) {
                   console.log('Configuration /etc/rancher/k3s/k3s.yaml not present in lima vm; will check again...');

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -220,9 +220,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /** True if start() was called with k3s enabled, false if it wasn't. */
   #enabledK3s = true;
 
-  /** The name of the shared lima interface from the config file */
-  #externalInterfaceName = '';
-
   /** An explanation of the last run command */
   #lastCommandComment = '';
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -315,20 +315,20 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       // error message to stdout, and returns exit code 0 (overridable with a `-E` flag on newer
       // versions of macos). Best to do our own check before invoking `file':
       try {
-        await fs.promises.access(this.limactl, fs.constants.R_OK);
+        await fs.promises.access(LimaBackend.limactl, fs.constants.R_OK);
       } catch (err: any) {
         switch (err.code) {
         case 'ENOENT':
-          throw new K8s.KubernetesError('Fatal Error', `File ${ this.limactl } doesn't exist.`, true);
+          throw new K8s.KubernetesError('Fatal Error', `File ${ LimaBackend.limactl } doesn't exist.`, true);
         case 'EACCES':
-          throw new K8s.KubernetesError('Fatal Error', `File ${ this.limactl } isn't readable.`, true);
+          throw new K8s.KubernetesError('Fatal Error', `File ${ LimaBackend.limactl } isn't readable.`, true);
         default:
-          throw new K8s.KubernetesError('Fatal Error', `Error trying to analyze file ${ this.limactl }: ${ err }`, true);
+          throw new K8s.KubernetesError('Fatal Error', `Error trying to analyze file ${ LimaBackend.limactl }: ${ err }`, true);
         }
       }
       const expectedArch = this.arch === 'aarch64' ? 'arm64' : this.arch;
       const { stdout } = await childProcess.spawnFile(
-        'file', [this.limactl],
+        'file', [LimaBackend.limactl],
         { stdio: ['inherit', 'pipe', console] });
 
       if (!stdout.includes(`executable ${ expectedArch }`)) {
@@ -646,7 +646,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     })();
   }
 
-  protected get limactl() {
+  protected static get limactl() {
     return path.join(paths.resources, os.platform(), 'lima', 'bin', 'limactl');
   }
 
@@ -667,7 +667,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected async lima(...args: string[]): Promise<void> {
     args = this.debug ? ['--debug'].concat(args) : args;
     try {
-      await childProcess.spawnFile(this.limactl, args,
+      await childProcess.spawnFile(LimaBackend.limactl, args,
         { env: this.limaEnv, stdio: console });
     } catch (ex) {
       console.error(`+ limactl ${ args.join(' ') }`);
@@ -681,7 +681,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    */
   protected async limaWithCapture(...args: string[]): Promise<string> {
     args = this.debug ? ['--debug'].concat(args) : args;
-    const { stdout } = await childProcess.spawnFile(this.limactl, args,
+    const { stdout } = await childProcess.spawnFile(LimaBackend.limactl, args,
       { env: this.limaEnv, stdio: ['ignore', 'pipe', console] });
 
     return stdout;
@@ -694,7 +694,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     args = ['shell', '--workdir=.', MACHINE_NAME].concat(args);
     args = this.debug ? ['--debug'].concat(args) : args;
 
-    return spawnWithSignal(this.limactl, args, { env: this.limaEnv });
+    return spawnWithSignal(LimaBackend.limactl, args, { env: this.limaEnv });
   }
 
   protected async ssh(...args: string[]): Promise<void> {
@@ -1289,7 +1289,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
     args = this.debug ? ['--debug'].concat(args) : args;
     this.logProcess = childProcess.spawn(
-      this.limactl,
+      LimaBackend.limactl,
       args,
       {
         env:   this.limaEnv,
@@ -1488,7 +1488,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
                     'ls', '/etc/rancher/k3s/k3s.yaml'];
 
                   args = this.debug ? ['--debug'].concat(args) : args;
-                  await childProcess.spawnFile(this.limactl, args,
+                  await childProcess.spawnFile(LimaBackend.limactl, args,
                     { env: this.limaEnv, stdio: 'ignore' });
                   break;
                 } catch (ex) {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1461,11 +1461,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           this.progressTracker.action('Installing CA certificates', 50, this.installCACerts()),
         ]);
 
-        if (os.platform() === 'darwin') {
-          this.lastCommandComment = 'Installing tools';
-          await this.progressTracker.action(this.lastCommandComment, 30, this.installToolsWithSudo());
-        }
-
         if (this.currentAction !== Action.STARTING) {
           // User aborted
           return;


### PR DESCRIPTION
This makes it so if sudo permissions are not available, RD will still run with reduced functionality:
- Docker socket forwarding will not work. (We will need a follow-up to forward it at a different address, plus instruct users on using it.)
- `vde_vmnet` is not available on macOS; it will be difficult to connect to the VM.

This helps with #1226 but that shouldn't be closed until we have proper UI to notify the user.

I recommend reviewing by commit; only the last commit is larger.

---
Note that we have a bit of an annoying dependency:
- In order to check if we need sudo, we need to ask limactl if the sudoers configuration is correct.
- In order for limactl to do that, it needs a VM configuration to know what networks it needs.
- But if sudo access is required but not granted, we need to regenerate the VM configuration to drop the networking.