### PR TITLE
Bumping the version of Helm to the latest

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -132,7 +132,7 @@ export default async function main(platform) {
   }
 
   // Download Helm. It is a tar.gz file that needs to be expanded and file moved.
-  const helmVersion = '3.7.2';
+  const helmVersion = '3.8.1';
   const helmURL = `https://get.helm.sh/helm-v${ helmVersion }-${ kubePlatform }-${ cpu }.tar.gz`;
 
   await downloadTarGZ(helmURL, path.join(binDir, exeName('helm')), {


### PR DESCRIPTION
This version includes generally available support for
charts in OCI registries