### PR TITLE
Add versioning to rdctl.

### DIFF
--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -42,7 +42,7 @@ var (
 )
 
 const clientVersion = "1.0.0"
-const serverVersion = "v0"
+const apiVersion = "v0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -85,7 +85,7 @@ func doRequest(method string, command string)  error {
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-  req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, serverVersion, command), nil)
+  req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, apiVersion, command), nil)
   if err != nil {
     return nil, err
   }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -41,6 +41,9 @@ var (
   password string
 )
 
+const clientVersion = "1.0.0"
+const serverVersion = "v0"
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "rdctl",
@@ -82,7 +85,7 @@ func doRequest(method string, command string)  error {
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-  req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/v0/%s", host, port, command), nil)
+  req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, serverVersion, command), nil)
   if err != nil {
     return nil, err
   }

--- a/src/go/rdctl/cmd/version.go
+++ b/src/go/rdctl/cmd/version.go
@@ -27,7 +27,7 @@ var showVersionCmd = &cobra.Command{
 	Short: "Shows the CLI version.",
 	Long: `Shows the CLI version.`,
   RunE: func(cmd *cobra.Command, args []string) error {
-    _, err := fmt.Printf("rdctl client version: %s, server version: %s\n", clientVersion, apiVersion)
+    _, err := fmt.Printf("rdctl client version: %s, targeting server version: %s\n", clientVersion, apiVersion)
     return err
   },
 }

--- a/src/go/rdctl/cmd/version.go
+++ b/src/go/rdctl/cmd/version.go
@@ -27,7 +27,7 @@ var showVersionCmd = &cobra.Command{
 	Short: "Shows the CLI version.",
 	Long: `Shows the CLI version.`,
   RunE: func(cmd *cobra.Command, args []string) error {
-    _, err := fmt.Printf("rdctl client version: %s, server version: %s\n", clientVersion, serverVersion)
+    _, err := fmt.Printf("rdctl client version: %s, server version: %s\n", clientVersion, apiVersion)
     return err
   },
 }

--- a/src/go/rdctl/cmd/version.go
+++ b/src/go/rdctl/cmd/version.go
@@ -1,0 +1,37 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+  "fmt"
+  "github.com/spf13/cobra"
+)
+
+// showVersionCmd represents the showVersion command
+var showVersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Shows the CLI version.",
+	Long: `Shows the CLI version.`,
+  RunE: func(cmd *cobra.Command, args []string) error {
+    _, err := fmt.Printf("rdctl client version: %s, server version: %s\n", clientVersion, serverVersion)
+    return err
+  },
+}
+
+func init() {
+	rootCmd.AddCommand(showVersionCmd)
+}

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -71,7 +71,7 @@ export default async function pathConflict(targetDir: string, binaryName: string
   }
   const notes: Array<string> = [];
   const paths: Array<string> = process.env.PATH?.split(path.delimiter) ?? [];
-  let sawCurrentDir = false;
+  let sawTargetDir = false;
 
   targetDir = path.resolve(targetDir);
   for (const currentDir of paths) {
@@ -80,7 +80,7 @@ export default async function pathConflict(targetDir: string, binaryName: string
     // we need to accommodate any irregularities.
     // path.normalize doesn't remove a trailing slash, path.resolve does.
     if (path.resolve(currentDir) === targetDir) {
-      sawCurrentDir = true;
+      sawTargetDir = true;
       continue;
     }
     const currentPath = path.join(currentDir, binaryName);
@@ -94,13 +94,13 @@ export default async function pathConflict(targetDir: string, binaryName: string
     // For kubectl, don't bother comparing versions, just existence is enough of a problem
     // if it occurs earlier in the path, because our kubectl is actually a symlink to kuberlr
     if (binaryName === 'kubectl') {
-      if (!sawCurrentDir) {
+      if (!sawTargetDir) {
         notes.push(`Existing instance of ${ binaryName } in ${ currentDir } interferes with internal linking of kubectl to kuberlr.`);
       }
       continue;
     }
     if (isUnversioned) {
-      if (!sawCurrentDir) {
+      if (!sawTargetDir) {
         notes.push(`Existing instance of ${ binaryName } in ${ currentDir } shadows a linked instance.`);
       }
       continue;
@@ -116,7 +116,7 @@ export default async function pathConflict(targetDir: string, binaryName: string
 
     // complain about all earlier instances in the path if the version is different
     // complain about later instances only if they're newer
-    if (!sawCurrentDir) {
+    if (!sawTargetDir) {
       if (!semver.eq(currentVersion, proposedVersion)) {
         notes.push(`Existing instance of ${ binaryName } in ${ currentDir } has version ${ currentVersion }, shadows linked version ${ proposedVersion }.`);
       }

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -13,7 +13,7 @@ const flags: Record<string, string> = {
   docker:  '-v',
   helm:    'version',
   kubectl: 'version',
-  rdctl: 'version',
+  rdctl:   'version',
 };
 const regexes: Record<string, RegExp> = {
   docker:  /version\s+(\S+?),/,
@@ -22,13 +22,13 @@ const regexes: Record<string, RegExp> = {
   // older:   Client: &version.Version{SemVer:"v2.16.12", ...
   helm:    /Version.*:.*?"v(.+?)"/,
   kubectl: /Client Version.*?GitVersion:"v(.+?)"/,
-  rdctl: /rdctl client version:\s*([\d\.]+)/,
+  rdctl:   /rdctl client version:\s*([\d\.]+)/,
 };
 const referenceVersions: Record<string, semver.SemVer|null> = {
   docker:  null,
   helm:    null,
   kubectl: null,
-  rdctl: null,
+  rdctl:   null,
 };
 
 /**

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -13,6 +13,7 @@ const flags: Record<string, string> = {
   docker:  '-v',
   helm:    'version',
   kubectl: 'version',
+  rdctl: 'version',
 };
 const regexes: Record<string, RegExp> = {
   docker:  /version\s+(\S+?),/,
@@ -21,11 +22,13 @@ const regexes: Record<string, RegExp> = {
   // older:   Client: &version.Version{SemVer:"v2.16.12", ...
   helm:    /Version.*:.*?"v(.+?)"/,
   kubectl: /Client Version.*?GitVersion:"v(.+?)"/,
+  rdctl: /rdctl client version:\s*([\d\.]+)/,
 };
 const referenceVersions: Record<string, semver.SemVer|null> = {
   docker:  null,
   helm:    null,
   kubectl: null,
+  rdctl: null,
 };
 
 /**


### PR DESCRIPTION
Fixes #1838

We're not doing much with the versions now,
but this is just to have *something* in place. Later the
CLI can ask the server what version it's running, and refuse
if there's a version mismatch. Or something. Right now I
just want the CLI to have a version.

And move "/v0" into a constant, so it's more obvious.

Signed-off-by: Eric Promislow <epromislow@suse.com>