### PR TITLE
Correct the incoming synoyms before checking the payload as a whole.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -801,7 +801,6 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       return ['', `errors in attempt to update settings:\n${ errors.join('\n') }`];
     }
     if (needToUpdate) {
-      this.settingsValidator.correctSynonymValues(newSettings);
       writeSettings(newSettings);
       // cfg is a global, and at this point newConfig has been merged into it :(
       window.send('settings-update', cfg);

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -38,7 +38,7 @@ describe(SettingsValidator, () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('should accept and modify valid values that are synonyms', () => {
+    it('should correct and accept near-valid values', () => {
       const newConfig = _.merge({}, cfg, {
         kubernetes:
           {
@@ -66,9 +66,14 @@ describe(SettingsValidator, () => {
       });
 
       subject.correctSynonymValues(newConfig);
-      expect(newConfig.kubernetes.enabled).toBe(desiredEnabledBoolean);
-      expect(newConfig.kubernetes.version).toEqual('1.23.4');
-      expect(newConfig.kubernetes.containerEngine).toEqual('moby');
+      expect(newConfig).toMatchObject({
+        kubernetes:
+          {
+            enabled:         desiredEnabledBoolean,
+            version:         '1.23.4',
+            containerEngine: 'moby'
+          }
+      });
     });
 
     it('should report errors for unchangeable fields', () => {
@@ -131,7 +136,6 @@ describe(SettingsValidator, () => {
       });
 
       expect(needToUpdate).toBeFalsy();
-      expect(errors).toHaveLength(3);
       expect(errors).toEqual([
         'Kubernetes version 1.1.1 not found.',
         "Invalid value for kubernetes.containerEngine: <1.1.2>; must be 'containerd', 'docker', or 'moby'",

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -38,7 +38,7 @@ describe(SettingsValidator, () => {
       expect(errors).toHaveLength(0);
     });
 
-    it('should correct and accept near-valid values', () => {
+    it('should canonicalize and accept near-valid values', () => {
       const newConfig = _.merge({}, cfg, {
         kubernetes:
           {
@@ -65,7 +65,7 @@ describe(SettingsValidator, () => {
           }
       });
 
-      subject.correctSynonymValues(newConfig);
+      subject.canonicalizeSynonyms(newConfig);
       expect(newConfig).toMatchObject({
         kubernetes:
           {


### PR DESCRIPTION
No associated issue

This simplifies the processing -- the equality-checker can work with
the converted values, and most equality-checkers are now just doing
a single line -- but does give some puzzling error messages, like
the EngineChecker saying 'docker' is allowed although it complains if
it is actually specified, because the synonym converter would have
already converted it to 'moby'.

Signed-off-by: Eric Promislow <epromislow@suse.com>