### PR TITLE
Refactor `src/resources.ts`

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -15,7 +15,7 @@ import * as settings from '@/config/settings';
 import * as window from '@/window';
 import { closeDashboard, openDashboard } from '@/window/dashboard';
 import * as K8s from '@/k8s-engine/k8s';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import Logging, { setLogLevel } from '@/utils/logging';
 import * as childProcess from '@/utils/childProcess';
 import Latch from '@/utils/latch';

--- a/background.ts
+++ b/background.ts
@@ -111,7 +111,7 @@ Electron.app.whenReady().then(async() => {
       copyright:          'Copyright © 2021 SUSE LLC', // TODO: Update this to 2021-... as dev progresses
       applicationName:    Electron.app.name,
       applicationVersion: `Version ${ await getVersion() }`,
-      iconPath:           resources.get('icons', 'logo-square-512.png'),
+      iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
     });
 
     setupTray();

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -105,7 +105,9 @@ export default async function main(platform) {
     win32:  'windows',
   }[platform];
   const resourcesDir = path.join(process.cwd(), 'resources', platform);
+  // binDir is for binaries that the user will execute
   const binDir = path.join(resourcesDir, 'bin');
+  // internalDir is for binaries that RD will execute behind the scenes
   const internalDir = path.join(resources, 'internal')
   const onWindows = kubePlatform === 'windows';
   const cpu = process.env.M1 ? 'arm64' : 'amd64';

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -106,6 +106,7 @@ export default async function main(platform) {
   }[platform];
   const resourcesDir = path.join(process.cwd(), 'resources', platform);
   const binDir = path.join(resourcesDir, 'bin');
+  const internalDir = path.join(resources, 'internal')
   const onWindows = kubePlatform === 'windows';
   const cpu = process.env.M1 ? 'arm64' : 'amd64';
 
@@ -210,7 +211,7 @@ export default async function main(platform) {
   const steveCPU = process.env.M1 ? 'arm64' : 'amd64';
   const steveExecutable = `steve-${ kubePlatform }-${ steveCPU }`;
   const steveURL = `${ steveURLBase }/${ steveExecutable }.tar.gz`;
-  const stevePath = path.join(binDir, exeName('steve'));
+  const stevePath = path.join(internalDir, exeName('steve'));
   const steveSHA = await findChecksum(`${ steveURL }.sha512sum`, steveExecutable);
 
   await downloadTarGZ(

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -108,7 +108,7 @@ export default async function main(platform) {
   // binDir is for binaries that the user will execute
   const binDir = path.join(resourcesDir, 'bin');
   // internalDir is for binaries that RD will execute behind the scenes
-  const internalDir = path.join(resources, 'internal')
+  const internalDir = path.join(resourcesDir, 'internal');
   const onWindows = kubePlatform === 'windows';
   const cpu = process.env.M1 ? 'arm64' : 'amd64';
 

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -196,8 +196,9 @@ export default async function main(platform) {
   const trivyURL = `${ trivyURLBase }/download/${ trivyVersionWithV }/${ trivyBasename }.tar.gz`;
   const trivySHA = await findChecksum(`${ trivyURLBase }/download/${ trivyVersionWithV }/trivy_${ trivyVersion }_checksums.txt`, `${ trivyBasename }.tar.gz`);
 
-  // Grab a linux executable and put it in the linux/bin dir, which will probably need to be created
-  const actualBinDir = path.join(process.cwd(), 'resources', 'linux', 'bin');
+  // Grab a linux executable and put it in the linux/internal dir, which will
+  // probably need to be created
+  const actualBinDir = path.join(process.cwd(), 'resources', 'linux', 'internal');
 
   await fs.promises.mkdir(actualBinDir, { recursive: true });
   // trivy.tgz files are top-level tarballs - not wrapped in a labelled directory :(

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 
 import Logging from '@/utils/logging';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import * as imageProcessor from '@/k8s-engine/images/imageProcessor';
 import mainEvents from '@/main/mainEvents';
 import * as K8s from '@/k8s-engine/k8s';

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -4,13 +4,12 @@ import * as k8s from '@kubernetes/client-node';
 
 import { KubeConfig } from '@kubernetes/client-node/dist/config';
 import Logging from '@/utils/logging';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import * as imageProcessor from '@/k8s-engine/images/imageProcessor';
 import * as childProcess from '@/utils/childProcess';
 import * as K8s from '@/k8s-engine/k8s';
 import mainEvents from '@/main/mainEvents';
 
-const KUBE_CONTEXT = 'rancher-desktop';
 const console = Logging.images;
 
 export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor {

--- a/src/k8s-engine/kubectl.ts
+++ b/src/k8s-engine/kubectl.ts
@@ -1,9 +1,8 @@
 'use strict';
 
 import childProcess, { spawn } from 'child_process';
-import os from 'os';
 import process from 'process';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 
 // The K8s JS library will get the current context but does not have the ability
 // to save the context. The current version of the package targets k8s 1.18 and

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1254,7 +1254,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected async installTrivy() {
-    await this.lima('copy', resources.get('linux', 'bin', 'trivy'), `${ MACHINE_NAME }:./trivy`);
+    const trivyPath = resources.get('linux', 'internal', 'trivy');
+    await this.lima('copy', trivyPath, `${ MACHINE_NAME }:./trivy`);
     await this.ssh('sudo', 'mv', './trivy', '/usr/local/bin/trivy');
   }
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -25,7 +25,7 @@ import { ContainerEngine, Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import DEFAULT_CONFIG from '@/assets/lima-config.yaml';
 import NETWORKS_CONFIG from '@/assets/networks-config.yaml';
 import FLANNEL_CONFLIST from '@/assets/scripts/10-flannel.conflist';

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -483,6 +483,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
   protected get baseDiskImage() {
     const imageName = `alpine-lima-v${ IMAGE_VERSION }-${ ALPINE_EDITION }-${ ALPINE_VERSION }.iso`;
+
     return path.join(paths.resources, os.platform(), imageName);
   }
 
@@ -1009,7 +1010,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected async sudoExec(command: string) {
     await new Promise<void>((resolve, reject) => {
       const iconPath = path.join(paths.resources, 'icons', 'logo-square-512.png');
-      sudo.exec(command, { name: 'Rancher Desktop', icns: iconPath}, (error, stdout, stderr) => {
+
+      sudo.exec(command, { name: 'Rancher Desktop', icns: iconPath }, (error, stdout, stderr) => {
         if (stdout) {
           console.log(`Prompt for sudo: stdout: ${ stdout }`);
         }
@@ -1112,7 +1114,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
         await this.ssh('sudo', 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
       }
-      const profilePath = path.join(paths.resources, 'scripts', 'profile')
+      const profilePath = path.join(paths.resources, 'scripts', 'profile');
+
       await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
     } finally {
       await fs.promises.rm(workdir, { recursive: true });
@@ -1123,7 +1126,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-containerd-install-'));
 
     try {
-      const profilePath = path.join(paths.resources, 'scripts', 'profile')
+      const profilePath = path.join(paths.resources, 'scripts', 'profile');
+
       await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
 
       await this.ssh('sudo', 'mkdir', '-p', '/etc/cni/net.d');
@@ -1255,6 +1259,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
   protected async installTrivy() {
     const trivyPath = path.join(paths.resources, 'linux', 'internal', 'trivy');
+
     await this.lima('copy', trivyPath, `${ MACHINE_NAME }:./trivy`);
     await this.ssh('sudo', 'mv', './trivy', '/usr/local/bin/trivy');
   }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -482,7 +482,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected get baseDiskImage() {
-    return resources.get(os.platform(), `alpine-lima-v${ IMAGE_VERSION }-${ ALPINE_EDITION }-${ ALPINE_VERSION }.iso`);
+    const imageName = `alpine-lima-v${ IMAGE_VERSION }-${ ALPINE_EDITION }-${ ALPINE_VERSION }.iso`;
+    return path.join(paths.resources, os.platform(), imageName);
   }
 
   #sshPort = 0;
@@ -633,7 +634,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected get limaEnv() {
-    const binDir = resources.get(os.platform(), 'lima', 'bin');
+    const binDir = path.join(paths.resources, os.platform(), 'lima', 'bin');
     const vdeDir = path.join(VDE_DIR, 'bin');
     const pathList = (process.env.PATH || '').split(path.delimiter);
     const newPath = [binDir, vdeDir].concat(...pathList).filter(x => x);
@@ -774,7 +775,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected async installVDETools(commands: Array<string>, explanations: Array<string>): Promise<void> {
-    const sourcePath = resources.get(os.platform(), 'lima', 'vde');
+    const sourcePath = path.join(paths.resources, os.platform(), 'lima', 'vde');
     const installedPath = VDE_DIR;
     const walk = async(dir: string): Promise<[string[], string[]]> => {
       const fullPath = path.resolve(sourcePath, dir);
@@ -1007,7 +1008,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    */
   protected async sudoExec(command: string) {
     await new Promise<void>((resolve, reject) => {
-      sudo.exec(command, { name: 'Rancher Desktop', icns: resources.get('icons', 'logo-square-512.png') }, (error, stdout, stderr) => {
+      const iconPath = path.join(paths.resources, 'icons', 'logo-square-512.png');
+      sudo.exec(command, { name: 'Rancher Desktop', icns: iconPath}, (error, stdout, stderr) => {
         if (stdout) {
           console.log(`Prompt for sudo: stdout: ${ stdout }`);
         }
@@ -1110,7 +1112,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
         await this.ssh('sudo', 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
       }
-      await this.lima('copy', resources.get('scripts', 'profile'), `${ MACHINE_NAME }:~/.profile`);
+      const profilePath = path.join(paths.resources, 'scripts', 'profile')
+      await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
     } finally {
       await fs.promises.rm(workdir, { recursive: true });
     }
@@ -1120,11 +1123,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-containerd-install-'));
 
     try {
-      const fixedProfile = path.join(workdir, 'profile');
-      const profileContents = (await fs.promises.readFile(resources.get('scripts', 'profile'), { encoding: 'utf-8' }));
-
-      await fs.promises.writeFile(fixedProfile, profileContents);
-      await this.lima('copy', fixedProfile, `${ MACHINE_NAME }:~/.profile`);
+      const profilePath = path.join(paths.resources, 'scripts', 'profile')
+      await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
 
       await this.ssh('sudo', 'mkdir', '-p', '/etc/cni/net.d');
       await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
@@ -1254,7 +1254,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected async installTrivy() {
-    const trivyPath = resources.get('linux', 'internal', 'trivy');
+    const trivyPath = path.join(paths.resources, 'linux', 'internal', 'trivy');
     await this.lima('copy', trivyPath, `${ MACHINE_NAME }:./trivy`);
     await this.ssh('sudo', 'mv', './trivy', '/usr/local/bin/trivy');
   }

--- a/src/k8s-engine/steve.ts
+++ b/src/k8s-engine/steve.ts
@@ -53,7 +53,7 @@ export class Steve {
         '--context',
         'rancher-desktop',
         '--ui-path',
-        resources.get('rancher-dashboard'),
+        path.join(paths.resources, 'rancher-dashboard'),
         '--offline',
         'true'
       ]

--- a/src/k8s-engine/steve.ts
+++ b/src/k8s-engine/steve.ts
@@ -1,7 +1,6 @@
 import os from 'os';
 import path from 'path';
 import { ChildProcess, spawn } from 'child_process';
-import resources from '@/resources';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 

--- a/src/k8s-engine/steve.ts
+++ b/src/k8s-engine/steve.ts
@@ -46,6 +46,7 @@ export class Steve {
 
     const osSpecificName = /^win/i.test(os.platform()) ? 'steve.exe' : 'steve';
     const stevePath = path.join(paths.resources, os.platform(), 'internal', osSpecificName);
+
     this.process = spawn(
       stevePath,
       [

--- a/src/k8s-engine/steve.ts
+++ b/src/k8s-engine/steve.ts
@@ -1,6 +1,9 @@
+import os from 'os';
+import path from 'path';
 import { ChildProcess, spawn } from 'child_process';
 import resources from '@/resources';
 import Logging from '@/utils/logging';
+import paths from '@/utils/paths';
 
 const console = Logging.steve;
 
@@ -42,8 +45,10 @@ export class Steve {
       return;
     }
 
+    const osSpecificName = /^win/i.test(os.platform()) ? 'steve.exe' : 'steve';
+    const stevePath = path.join(paths.resources, os.platform(), 'internal', osSpecificName);
     this.process = spawn(
-      resources.executable('steve'),
+      stevePath,
       [
         '--context',
         'rancher-desktop',

--- a/src/k8s-engine/unixlikeIntegrations.ts
+++ b/src/k8s-engine/unixlikeIntegrations.ts
@@ -4,7 +4,7 @@ import os from 'os';
 
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import PathConflictManager from '@/main/pathConflictManager';
 import * as window from '@/window';
 import { isNodeError } from '@/typings/unix.interface';

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -829,6 +829,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected async installWSLHelpers() {
     const fwdSlashNerdctlPath = path.join(paths.resources, 'linux', 'bin', 'nerdctl-stub');
     const nerdctlPath = await this.wslify(fwdSlashNerdctlPath);
+
     await this.runInstallScript(INSTALL_WSL_HELPERS_SCRIPT, 'install-wsl-helpers', nerdctlPath);
   }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -32,7 +32,7 @@ import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 import { findHomeDir } from '@/config/findHomeDir';
 import { ContainerEngine, Settings } from '@/config/settings';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import { getImageProcessor } from '@/k8s-engine/images/imageFactory';
 
 const console = Logging.wsl;

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -240,7 +240,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected get distroFile() {
-    return resources.get(os.platform(), `distro-${ DISTRO_VERSION }.tar`);
+    return path.join(paths.resources, os.platform(), `distro-${ DISTRO_VERSION }.tar`);
   }
 
   protected get downloadURL() {
@@ -827,8 +827,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * Install helper tools for WSL (nerdctl integration).
    */
   protected async installWSLHelpers() {
-    await this.runInstallScript(INSTALL_WSL_HELPERS_SCRIPT,
-      'install-wsl-helpers', await this.wslify(resources.get('linux', 'bin', 'nerdctl-stub')));
+    const fwdSlashNerdctlPath = path.join(paths.resources, 'linux', 'bin', 'nerdctl-stub');
+    const nerdctlPath = await this.wslify(fwdSlashNerdctlPath);
+    await this.runInstallScript(INSTALL_WSL_HELPERS_SCRIPT, 'install-wsl-helpers', nerdctlPath);
   }
 
   /**
@@ -840,7 +841,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     // This function moves it into /usr/local/bin/ so when trivy is
     // invoked to run through wsl, it runs faster.
 
-    const trivyExecPath = resources.get('linux', 'internal', 'trivy');
+    const trivyExecPath = path.join(paths.resources, 'linux', 'internal', 'trivy');
 
     await this.execCommand('mkdir', '-p', '/var/local/bin');
     await this.wslInstall(trivyExecPath, '/usr/local/bin');
@@ -1604,7 +1605,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected getWSLHelperPath(distro?: string): Promise<string> {
     // We need to get the Linux path to our helper executable; it is easier to
     // just get WSL to do the transformation for us.
-    return this.wslify(resources.get('linux', 'wsl-helper'), distro);
+
+    return this.wslify(path.join(paths.resources, 'linux', 'wsl-helper'), distro);
   }
 
   async listIntegrations(): Promise<Record<string, boolean | string>> {
@@ -1717,7 +1719,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected async manageDockerCompose(distro: string, state: boolean) {
-    const srcPath = await this.wslify(resources.get('linux', 'bin', 'docker-compose'), distro);
+    const dockerComposePath = path.join(paths.resources, 'linux', 'bin', 'docker-compose');
+    const srcPath = await this.wslify(dockerComposePath, distro);
     const destDir = '$HOME/.docker/cli-plugins';
     const destPath = `${ destDir }/docker-compose`;
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -840,7 +840,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     // This function moves it into /usr/local/bin/ so when trivy is
     // invoked to run through wsl, it runs faster.
 
-    const trivyExecPath = resources.get('linux', 'bin', 'trivy');
+    const trivyExecPath = resources.get('linux', 'internal', 'trivy');
 
     await this.execCommand('mkdir', '-p', '/var/local/bin');
     await this.wslInstall(trivyExecPath, '/usr/local/bin');

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -12,7 +12,6 @@ import { KubeConfig } from '@kubernetes/client-node';
 import * as kubectl from '@/k8s-engine/kubectl';
 import kubeconfig from '@/config/kubeconfig.js';
 import { State } from '@/k8s-engine/k8s';
-import resources from '@/resources';
 import { openPreferences } from '@/window';
 import { openDashboard } from '@/window/dashboard';
 import mainEvents from '@/main/mainEvents';

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -2,7 +2,7 @@
 // lower right on Windows).
 
 import fs from 'fs';
-import pth from 'path';
+import path from 'path';
 import os from 'os';
 
 import Electron from 'electron';
@@ -17,6 +17,7 @@ import { openPreferences } from '@/window';
 import { openDashboard } from '@/window/dashboard';
 import mainEvents from '@/main/mainEvents';
 import { Settings, load } from '@/config/settings';
+import paths from '@/utils/paths';
 
 /**
  * Tray is a class to manage the tray icon for rancher-desktop.
@@ -29,7 +30,7 @@ export class Tray {
       enabled: false,
       label:   'Kubernetes is starting',
       type:    'normal',
-      icon:    resources.get('icons/kubernetes-icon-black.png'),
+      icon:    path.join(paths.resources, 'icons', 'kubernetes-icon-black.png'),
     },
     { type: 'separator' },
     {
@@ -68,26 +69,26 @@ export class Tray {
   };
 
   private readonly trayIconsMacOs = {
-    stopped:  'icons/logo-tray-stopped-Template@2x.png',
-    starting: 'icons/logo-tray-starting-Template@2x.png',
-    started:  'icons/logo-tray-Template@2x.png',
-    stopping: 'icons/logo-tray-stopping-Template@2x.png',
-    error:    'icons/logo-tray-error-Template@2x.png'
+    stopped:  path.join(paths.resources, 'icons', 'logo-tray-stopped-Template@2x.png'),
+    starting: path.join(paths.resources, 'icons', 'logo-tray-starting-Template@2x.png'),
+    started:  path.join(paths.resources, 'icons', 'logo-tray-Template@2x.png'),
+    stopping: path.join(paths.resources, 'icons', 'logo-tray-stopping-Template@2x.png'),
+    error:    path.join(paths.resources, 'icons', 'logo-tray-error-Template@2x.png'),
   };
 
   private readonly trayIcons = {
     stopped:  '',
-    starting: 'icons/logo-square-bw.png',
-    started:  'icons/logo-square.png',
+    starting: path.join(paths.resources, 'icons', 'logo-square-bw.png'),
+    started:  path.join(paths.resources, 'icons', 'logo-square.png'),
     stopping: '',
-    error:    'icons/logo-square-red.png'
+    error:    path.join(paths.resources, 'icons', 'logo-square-red.png'),
   };
 
   private readonly trayIconSet = this.isMacOs() ? this.trayIconsMacOs : this.trayIcons;
 
   constructor() {
     this.settings = load();
-    this.trayMenu = new Electron.Tray(resources.get(this.trayIconSet.starting));
+    this.trayMenu = new Electron.Tray(this.trayIconSet.starting);
     this.trayMenu.setToolTip('Rancher Desktop');
 
     // Discover k8s contexts
@@ -198,12 +199,12 @@ export class Tray {
       [State.ERROR]:      'Kubernetes has encountered an error',
     };
 
-    let icon = resources.get('icons/kubernetes-icon-black.png');
-    let logo = resources.get(this.trayIconSet.starting);
+    let icon = path.join(paths.resources, 'icons', 'kubernetes-icon-black.png');
+    let logo = this.trayIconSet.starting;
 
     if (this.kubernetesState === State.STARTED) {
-      icon = resources.get('/icons/kubernetes-icon-color.png');
-      logo = resources.get(this.trayIconSet.started);
+      icon = path.join(paths.resources, 'icons', 'kubernetes-icon-color.png');
+      logo = this.trayIconSet.started;
       // Update the contexts as a new kubernetes context will be added
       this.updateContexts();
       this.contextMenuItems = this.updateDashboardState(
@@ -213,8 +214,8 @@ export class Tray {
     } else if (this.kubernetesState === State.ERROR) {
       // For licensing reasons, we cannot just tint the Kubernetes logo.
       // Here we're using an icon from GitHub's octicons set.
-      icon = resources.get('/icons/issue-opened-16.png');
-      logo = resources.get(this.trayIconSet.error);
+      icon = path.join(paths.resources, 'icons', 'issue-opened-16.png');
+      logo = this.trayIconSet.error;
     }
 
     const stateMenu = this.contextMenuItems.find(item => item.id === 'state');
@@ -232,11 +233,11 @@ export class Tray {
 
   protected verifyKubeConfig() {
     if (process.env.KUBECONFIG && process.env.KUBECONFIG.length > 0) {
-      const originalFiles = process.env.KUBECONFIG.split(pth.delimiter);
+      const originalFiles = process.env.KUBECONFIG.split(path.delimiter);
       const filteredFiles = originalFiles.filter(kubeconfig.hasAccess);
 
       if (filteredFiles.length < originalFiles.length) {
-        process.env.KUBECONFIG = filteredFiles.join(pth.delimiter);
+        process.env.KUBECONFIG = filteredFiles.join(path.delimiter);
       }
     }
   }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,20 +1,7 @@
 import os from 'os';
 import path from 'path';
-import { app } from 'electron';
 import memoize from 'lodash/memoize';
 import paths from '@/utils/paths';
-
-/**
- * Get the path to a resource file
- * @param pathParts Path relative to the resource directory
- */
-export function get(...pathParts: string[]) {
-  if (app.isPackaged) {
-    return path.join(process.resourcesPath, 'resources', ...pathParts);
-  }
-
-  return path.join(app.getAppPath(), 'resources', ...pathParts);
-}
 
 /**
  * Get the path to an executable binary
@@ -26,4 +13,4 @@ function _executable(name: string) {
 }
 export const executable = memoize(_executable);
 
-export default { get, executable };
+export default executable;

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -2,21 +2,7 @@ import os from 'os';
 import path from 'path';
 import { app } from 'electron';
 import memoize from 'lodash/memoize';
-
-const adjustNameWithDir: Record<string, string> = {
-  docker:            path.join('bin', 'docker'),
-  'docker-buildx':   path.join('bin', 'docker-buildx'),
-  'docker-compose':  path.join('bin', 'docker-compose'),
-  helm:              path.join('bin', 'helm'),
-  kubectl:           path.join('bin', 'kubectl'),
-  nerdctl:           path.join('bin', 'nerdctl'),
-  rdctl:             path.join('bin', 'rdctl'),
-  steve:             path.join('bin', 'steve'),
-};
-
-function fixedSourceName(name: string) {
-  return adjustNameWithDir[name] || name;
-}
+import paths from '@/utils/paths';
 
 /**
  * Get the path to a resource file
@@ -35,9 +21,8 @@ export function get(...pathParts: string[]) {
  * @param name The name of the binary, without file extension.
  */
 function _executable(name: string) {
-  const adjustedName = fixedSourceName(name);
-
-  return get(os.platform(), /^win/i.test(os.platform()) ? `${ adjustedName }.exe` : adjustedName);
+  const osSpecificName = /^win/i.test(os.platform()) ? `${ name }.exe` : name
+  return path.join(paths.resources, os.platform(), 'bin', osSpecificName);
 }
 export const executable = memoize(_executable);
 

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -47,7 +47,7 @@ describe('paths', () => {
       darwin: '/usr/local/bin',
     },
     resources: {
-      win32: new Error('does not apply'),
+      win32:  new Error('does not apply'),
       darwin: new Error('does not apply'),
     }
   };

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -46,6 +46,10 @@ describe('paths', () => {
       win32:  '/usr/local/bin',
       darwin: '/usr/local/bin',
     },
+    resources: {
+      win32: new Error('does not apply'),
+      darwin: new Error('does not apply'),
+    }
   };
 
   const table = Object.entries(cases).flatMap(

--- a/src/utils/pathConflict.ts
+++ b/src/utils/pathConflict.ts
@@ -4,7 +4,7 @@ import semver from 'semver';
 import Logging from '@/utils/logging';
 
 import * as childProcess from '@/utils/childProcess';
-import resources from '@/resources';
+import resources from '@/utils/resources';
 import { isUnixError } from '@/typings/unix.interface';
 
 const console = Logging.background;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -4,6 +4,7 @@
 
 import os from 'os';
 import path from 'path';
+import { app } from 'electron';
 
 const APP_NAME = 'rancher-desktop';
 
@@ -24,6 +25,8 @@ export interface Paths {
   lima: string;
   /** Directory holding provided binary resources */
   integration: string;
+  /** Directory that holds resource files in the RD installation. */
+  resources: string;
 }
 
 /**
@@ -42,6 +45,11 @@ export class DarwinPaths implements Paths {
 
   get wslDistroData(): string {
     throw new Error('wslDistro not available for darwin');
+  }
+
+  get resources(): string {
+    const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+    return path.join(basePath, 'resources');
   }
 }
 
@@ -88,6 +96,11 @@ export class Win32Paths implements Paths {
     // is the location that has been in use.
     // throw new Error('integration path not available for Windows');
   }
+
+  get resources(): string {
+    const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+    return path.join(basePath, 'resources');
+  }
 }
 
 /**
@@ -127,6 +140,11 @@ export class LinuxPaths implements Paths {
 
   get integration(): string {
     return path.join(os.homedir(), '.local', 'bin');
+  }
+
+  get resources(): string {
+    const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+    return path.join(basePath, 'resources');
   }
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -49,6 +49,7 @@ export class DarwinPaths implements Paths {
 
   get resources(): string {
     const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+
     return path.join(basePath, 'resources');
   }
 }
@@ -99,6 +100,7 @@ export class Win32Paths implements Paths {
 
   get resources(): string {
     const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+
     return path.join(basePath, 'resources');
   }
 }
@@ -144,6 +146,7 @@ export class LinuxPaths implements Paths {
 
   get resources(): string {
     const basePath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+
     return path.join(basePath, 'resources');
   }
 }

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -9,7 +9,8 @@ import paths from '@/utils/paths';
  * @param name The name of the binary, without file extension.
  */
 function _executable(name: string) {
-  const osSpecificName = /^win/i.test(os.platform()) ? `${ name }.exe` : name
+  const osSpecificName = /^win/i.test(os.platform()) ? `${ name }.exe` : name;
+
   return path.join(paths.resources, os.platform(), 'bin', osSpecificName);
 }
 export const executable = memoize(_executable);

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -4,7 +4,8 @@ import memoize from 'lodash/memoize';
 import paths from '@/utils/paths';
 
 /**
- * Get the path to an executable binary
+ * Gets the absolute path to an executable. Adds ".exe" to the end
+ * if running on Windows.
  * @param name The name of the binary, without file extension.
  */
 function _executable(name: string) {
@@ -13,4 +14,4 @@ function _executable(name: string) {
 }
 export const executable = memoize(_executable);
 
-export default executable;
+export default { executable };


### PR DESCRIPTION
Closes #1831.

This PR separates binaries that are for RD-internal use only (such as `trivy`) from binaries that users use. This is something that will improve the integration management code. This PR also includes does a refactor of the `src/resources.ts` file. I included the refactor because I found `resources.get` confusing each time I came across it. I felt like creating `paths.resources` and using `path.join` would be clearer for future readers of our code. Let me know what you guys think.