### PR TITLE
Improve the error message we get from a failure calling `file`.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -312,10 +312,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       /* The `file` command returns "... executable arm64" or "... executable x86_64" */
       const expectedArch = this.arch === 'aarch64' ? 'arm64' : this.arch;
       const { stdout } = await childProcess.spawnFile(
-        'file', [this.limactl],
+        'file', ['-E', this.limactl],
         { stdio: ['inherit', 'pipe', console] });
 
-      if (!stdout.trim().match(`executable ${ expectedArch }$`)) {
+      if (!stdout.includes(`executable ${ expectedArch }`)) {
         /* Using 'aarch64' and 'x86_64' in the error because that's what we use for the DMG suffix, e.g. "Rancher Desktop.aarch64.dmg" */
         const otherArch = { aarch64: 'x86_64', x86_64: 'aarch64' }[this.arch];
 


### PR DESCRIPTION
The problem is that `file (1)' writes its error messages to stdout,
so if there's any kind of failure, the code assumes its due to an
arch mismatch. By adding a `-E' flag, the command exits with a non-zero
status on failure, and we surface the error to the user.

There is no point trying to recover from this error -- it's a severe
internal error.

Signed-off-by: Eric Promislow <epromislow@suse.com>