### PR TITLE
Tick steve version

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -204,7 +204,7 @@ export default async function main(platform) {
   await downloadTarGZ(trivyURL, path.join(actualBinDir, 'trivy'), { expectedChecksum: trivySHA });
 
   // Download Steve
-  const steveVersion = 'v0.1.0-beta6';
+  const steveVersion = 'v0.1.0-beta7';
   const steveURLBase = `https://github.com/rancher-sandbox/rancher-desktop-steve/releases/download/${ steveVersion }`;
   const steveCPU = process.env.M1 ? 'arm64' : 'amd64';
   const steveExecutable = `steve-${ kubePlatform }-${ steveCPU }`;


### PR DESCRIPTION
This ticks the steve version to v0.1.0-beta7, which binds host to 127.0.0.1 in order to remove the Windows Defender Firewall prompt.

closes #1879 

Signed-off-by: phillip_rak <rak.phillip@gmail.com>