### PR TITLE
cirrus CI: Enable all automatic builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,4 @@
 task:
-  # On Cirrus CI, cron tasks does not start if it has
-  # manual trigger type enabled - expected behaviour
-  # see: https://github.com/cirruslabs/cirrus-ci-docs/discussions/949#discussioncomment-1853964
-  matrix:
-    # Keep manual trigger for all pushes (prs and merges)
-    - trigger_type: manual
-      only_if: $CIRRUS_CRON == ''
-    # Only trigger task automatically if it's a cron and main branch
-    - trigger_type: automatic
-      only_if: $CIRRUS_CRON != '' && $BRANCH == "main"
   name: E2E/Integration Tests
   timeout_in: 45
   container:
@@ -50,8 +40,8 @@ task:
     curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor > "$KEYRING"
     echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
     echo "deb-src [signed-by=${KEYRING}] https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
-    apt-get update 
-    apt-get install --yes nodejs 
+    apt-get update
+    apt-get install --yes nodejs
     node --version && npm --version
   # Info about Cirrus CI caching see: https://cirrus-ci.org/guide/writing-tasks/#cache-instruction
   node_modules_cache:
@@ -70,7 +60,7 @@ task:
     - export KUBECONFIG=/home/ranchertest/.kube/config
     - ${SUDO_NON_ROOT_CMD} CI=1 xvfb-run --auto-servernum -- npm run test:e2e
 
-  on_failure: 
+  on_failure:
     # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197
     # Still broken after cirrus fix, addressing a new issue to them. (Jan.06 2022)
     custom_script: |


### PR DESCRIPTION
Agreed upon in the 1.2.[01] release retro.
