### PR TITLE
Do separate tests for readability of `this.limactl`

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -312,7 +312,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       // Normally, `file` command returns "... executable arm64" or "... executable x86_64"
       // But if there are problems reading the file, `file' follows the POSIX spec, writes its
       // error message to stdout, and returns exit code 0 (overridable with a `-E` flag on newer
-      // versions of macos. Best to do our own check before invoking `file':
+      // versions of macos). Best to do our own check before invoking `file':
       try {
         await fs.promises.access(this.limactl, fs.constants.R_OK);
       } catch (err: any) {


### PR DESCRIPTION
See `man 1 file` and search for `-E` to learn about POSIX behavior. The `-E` flag is defined on macOS Catalina, but not supported. It works on newer versions. Don't know about older versions. So we'll do our own checks.

Signed-off-by: Eric Promislow <epromislow@suse.com>