### PR TITLE
Make final dot optional in MB/s(ec\.)? regex

### DIFF
--- a/src/components/__tests__/UpdateStatus.spec.ts
+++ b/src/components/__tests__/UpdateStatus.spec.ts
@@ -110,7 +110,7 @@ describe('UpdateStatus.vue', () => {
       });
 
       expect(wrapper.findComponent({ ref: 'updateStatus' }).text())
-        .toMatch(/^An update to version v1\.2\.3 is available; downloading... \(12%, 1\.2MB\/s(?:ec\.)?\)$/);
+        .toMatch(/^An update to version v1\.2\.3 is available; downloading... \(12%, 1\.2MB\/s(?:ec\.?)?\)$/);
       expect(wrapper.findComponent({ ref: 'updateReady' }).exists()).toBeFalsy();
     });
   });


### PR DESCRIPTION
On my Catalina system with Canadian locale the output is "MB/sec" without a dot for the abbreviation.
