### PR TITLE
WSL: Use correct path for wsl-helper.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -537,7 +537,7 @@ Electron.ipcMain.on('factory-reset', async() => {
     // On Windows, we need to use a helper process in order to ensure we
     // delete files in use.  Of course, we can't wait for that process to
     // return - the whole point is for us to not be running.
-    childProcess.spawn(resources.executable('wsl-helper'),
+    childProcess.spawn(path.join(paths.resources, 'win32', 'wsl-helper.exe'),
       ['factory-reset', `--wait-pid=${ process.pid }`, `--launch=${ process.argv0 }`],
       { detached: true, windowsHide: true });
     Electron.app.quit();

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -229,7 +229,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
     this.mobySocketProxyProcesses = {
       [INTEGRATION_HOST]: new BackgroundProcess(this, 'Win32 socket proxy', async() => {
-        const exe = resources.executable('wsl-helper');
+        const exe = path.join(paths.resources, 'win32', 'wsl-helper.exe');
         const stream = await Logging['wsl-helper'].fdStream;
 
         return childProcess.spawn(exe, ['docker-proxy', 'serve', ...this.debugArg('--verbose')], {


### PR DESCRIPTION
`wsl-helper` is not in the bin directory, so we can't use `resources.executable` to locate it.