### PR TITLE
Introduce vuex modules for k8s & image manager state

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -63,7 +63,7 @@
 import os from 'os';
 
 import { ipcRenderer } from 'electron';
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import ActionMenu from '@/components/ActionMenu.vue';
 import Header from '@/components/Header.vue';
 import Nav from '@/components/Nav.vue';
@@ -83,7 +83,12 @@ export default {
   data() {
     return {
       routes: [
-        '/General', '/K8s', '/Integrations', '/PortForwarding', '/Images', '/Troubleshooting'
+        '/General',
+        '/K8s',
+        '/Integrations',
+        '/PortForwarding',
+        '/Images',
+        '/Troubleshooting'
       ],
       isChild: false
     };
@@ -113,6 +118,12 @@ export default {
         this.isChild = current.path.lastIndexOf('/') > 0;
       }
     }
+  },
+
+  beforeMount() {
+    ipcRenderer.on('k8s-check-state', (event, state) => {
+      this.$store.dispatch('k8sManager/setK8sState', state);
+    });
   },
 
   methods: {

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -41,7 +41,6 @@ export default {
       }
 
       return this.imageManagerState ? 'READY' : 'IMAGE_MANAGER_UNREADY';
-      // return 'READY';
     },
     ...mapGetters('k8sManager', { k8sState: 'getK8sState' }),
     ...mapGetters('imageManager', { imageManagerState: 'getImageManagerState' })

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -50,12 +50,12 @@ export default {
   watch: {
     imageManagerState: {
       handler(state) {
-        if (!state) {
-          this.$store.dispatch(
-            'page/setHeader',
-            { title: this.t('images.title') }
-          );
+        this.$store.dispatch(
+          'page/setHeader',
+          { title: this.t('images.title') }
+        );
 
+        if (!state) {
           return;
         }
 

--- a/src/store/imageManager.js
+++ b/src/store/imageManager.js
@@ -1,0 +1,19 @@
+export const state = () => ({ imageManagerState: false });
+
+export const mutations = {
+  SET_IMAGE_MANAGER_STATE(state, imageManagerState) {
+    state.imageManagerState = imageManagerState;
+  },
+};
+
+export const actions = {
+  setImageManagerState({ commit }, imageManagerState) {
+    commit('SET_IMAGE_MANAGER_STATE', imageManagerState);
+  }
+};
+
+export const getters = {
+  getImageManagerState({ imageManagerState }) {
+    return imageManagerState;
+  }
+};

--- a/src/store/k8sManager.js
+++ b/src/store/k8sManager.js
@@ -1,0 +1,21 @@
+import { ipcRenderer } from 'electron';
+
+export const state = () => ({ k8sState: ipcRenderer.sendSync('k8s-state') });
+
+export const mutations = {
+  SET_K8S_STATE(state, k8sState) {
+    state.k8sState = k8sState;
+  },
+};
+
+export const actions = {
+  setK8sState({ commit }, k8sState) {
+    commit('SET_K8S_STATE', k8sState);
+  }
+};
+
+export const getters = {
+  getK8sState({ k8sState }) {
+    return k8sState;
+  }
+};


### PR DESCRIPTION
This resolves an issue where "Waiting for image manager to be ready" is briefly flashed on the images page for each render by storing values for K8S and Image Manager state in vuex. 

### Before (Routing back to Images generates the text in question)

https://user-images.githubusercontent.com/835961/160496204-55c201ce-608c-4634-b697-02ed0dbf0433.mp4

### After

https://user-images.githubusercontent.com/835961/160496198-0767cbf3-54fa-41a3-9b53-9fea18357bc8.mp4

closes #1915

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>