### PR TITLE
Added the api command.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -412,6 +412,23 @@ test.describe('HTTP control interface', () => {
       expect(stdout).toBe('');
       expect(stderr).toContain('Error: unknown flag: --input-');
     });
+
+    test('api: complains when no body is provided', async() => {
+      const { stdout, stderr } = await rdctl(['api', 'settings', '-X', 'PUT']);
+
+      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+      expect(stderr).not.toContain('Usage:');
+      expect(stderr).toContain('no settings specified in the request');
+    });
+
+    test('api: complains when an invalid setting is specified', async() => {
+      const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
+      const { stdout, stderr } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
+
+      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+      expect(stderr).not.toContain('Usage:');
+      expect(stderr).toMatch(/errors in attempt to update settings:\s+ Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
+    });
   });
 
   // Where is the test that pushes a supported update, you may be wondering?

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -407,6 +407,23 @@ test.describe('HTTP control interface', () => {
       expect(stderr).toContain('Error: unknown flag: --input-');
     });
 
+    test('api: PUT /v0/settings from body', async() => {
+      const settingsFile = path.join(paths.config, 'settings.json');
+      const rdctl = path.join(process.cwd(), 'resources', os.platform(), 'bin', 'rdctl');
+      const settingsBody = await fs.promises.readFile(settingsFile, { encoding: 'utf-8' });
+
+      for (const endpoint of ['settings', '/v0/settings']) {
+        for (const methodSpecs of [[], ['-X', 'PUT'], ['--method', 'PUT']]) {
+          for (const inputOption of ['--body', '-b']) {
+            const { stdout, stderr } = await rdctl(['api', ...methodSpecs, inputOption, settingsBody]);
+
+            expect(stderr).toBe('');
+            expect(stdout).toContain('no changes necessary');
+          }
+        }
+      }
+    });
+
     test('api: complains on invalid endpoint', async() => {
       const endpoint = '/v99/no/such/endpoint';
       const { stdout, stderr } = await rdctl(['api', endpoint]);

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -356,6 +356,14 @@ test.describe('HTTP control interface', () => {
       expect(stdout).toEqual('');
     });
 
+    test('api: empty string endpoint should give an error message', async() => {
+      const { stdout, stderr } = await rdctl(['api', '']);
+
+      expect(stderr).toContain('Error: api command: no endpoint specified');
+      expect(stderr).toContain('Usage:');
+      expect(stdout).toEqual('');
+    });
+
     test('api: complains when more than one arg is given', async() => {
       const endpoints = ['settings', '/v0/settings'];
       const { stdout, stderr } = await rdctl(['api', ...endpoints]);

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -240,7 +240,7 @@ test.describe('HTTP control interface', () => {
       expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
 
       const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
-        `--kubernetes-enabled=${ settings.kubernetes.enabled ? 'true' : 'false' }`,
+        `--kubernetes-enabled=${ !! settings.kubernetes.enabled }`,
         '--kubernetes-version', settings.kubernetes.version];
       const result = await rdctl(args);
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -153,13 +153,13 @@ test.describe('HTTP control interface', () => {
     let resp = await doRequest('/v0/settings');
     const rawSettings = resp.body.read().toString();
 
-    resp = await doRequest('/v0/set', rawSettings, 'PUT');
+    resp = await doRequest('/v0/settings', rawSettings, 'PUT');
     expect(resp.ok).toBeTruthy();
     expect(resp.status).toEqual(202);
     expect(resp.body.read().toString()).toContain('no changes necessary');
   });
 
-  test('should not update values when the /set payload has errors', async() => {
+  test('should not update values when the /settings payload has errors', async() => {
     let resp = await doRequest('/v0/settings');
     const settings = await resp.json();
     const desiredEnabled = !settings.kubernetes.enabled;
@@ -174,7 +174,7 @@ test.describe('HTTP control interface', () => {
           checkForExistingKimBuilder: !settings.kubernetes.checkForExistingKimBuilder, // not supported
         }
     });
-    const resp2 = await doRequest('/v0/set', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v0/settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
@@ -436,7 +436,7 @@ test.describe('HTTP control interface', () => {
 
       expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
       expect(stderr).not.toContain('Usage:');
-      expect(stderr).toMatch(/errors in attempt to update settings:\s+ Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
+      expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
     });
   });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -413,6 +413,15 @@ test.describe('HTTP control interface', () => {
       expect(stderr).toContain('Error: unknown flag: --input-');
     });
 
+    test('api: complains on invalid endpoint', async() => {
+      const endpoint = '/v99/no/such/endpoint';
+      const { stdout, stderr } = await rdctl(['api', endpoint]);
+
+      expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found', documentation_url: null });
+      expect(stderr).not.toContain('Usage:');
+      expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
+    });
+
     test('api: complains when no body is provided', async() => {
       const { stdout, stderr } = await rdctl(['api', 'settings', '-X', 'PUT']);
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -76,7 +76,7 @@ test.describe('HTTP control interface', () => {
 
   async function bash(command: string): Promise< { stdout: string, stderr: string }> {
     try {
-      const { stdout, stderr } = await childProcess.spawnFile('/bin/sh', ['-c', command], { stdio: 'pipe' });
+      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', command], { stdio: 'pipe' });
 
       return { stdout, stderr };
     } catch (err: any) {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -243,7 +243,7 @@ test.describe('HTTP control interface', () => {
       expect(stdout).toMatch(/"kubernetes":/);
       const settings = JSON.parse(stdout);
 
-      expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug']).toMatchObject(Object.keys(settings));
+      expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
 
       const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
         `--kubernetes-enabled=${ settings.kubernetes.enabled ? 'true' : 'false' }`,
@@ -383,7 +383,7 @@ test.describe('HTTP control interface', () => {
           expect(stderr).toEqual('');
           const settings = JSON.parse(stdout);
 
-          expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug']).toMatchObject(Object.keys(settings));
+          expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
         }
       }
     });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -417,10 +417,21 @@ test.describe('HTTP control interface', () => {
           for (const inputOption of ['--body', '-b']) {
             const { stdout, stderr } = await rdctl(['api', ...methodSpecs, inputOption, settingsBody]);
 
-            expect(stderr).toBe('');
+            expect(stderr).toEqual('');
             expect(stdout).toContain('no changes necessary');
           }
         }
+      }
+    });
+
+    test('api: complains when body and input are both specified', async() => {
+      const rdctl = path.join(process.cwd(), 'resources', os.platform(), 'bin', 'rdctl');
+
+      for (const bodyOption of ['--body', '-b']) {
+        const { stdout, stderr } = await rdctl(['api', 'settings', bodyOption, '{ "doctor": { "wu" : "tang" }}', '--input', 'mabels.farm']);
+
+        expect(stdout).toEqual('');
+        expect(stderr).toContain('TODO: fill in message');
       }
     });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -240,7 +240,7 @@ test.describe('HTTP control interface', () => {
       expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
 
       const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
-        `--kubernetes-enabled=${ !! settings.kubernetes.enabled }`,
+        `--kubernetes-enabled=${ !!settings.kubernetes.enabled }`,
         '--kubernetes-version', settings.kubernetes.version];
       const result = await rdctl(args);
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -479,7 +479,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found', documentation_url: null });
+      expect(JSON.parse(stdout)).toEqual({ error: { message: '404 Not Found', documentation_url: null } });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
     });
@@ -488,7 +488,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+      expect(JSON.parse(stdout)).toEqual({ error: { message: '400 Bad Request', documentation_url: null } });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain('no settings specified in the request');
     });
@@ -498,7 +498,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+      expect(JSON.parse(stdout)).toEqual({ error: { message: '400 Bad Request', documentation_url: null } });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
     });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -261,7 +261,7 @@ test.describe('HTTP control interface', () => {
 
       expect(stderr).toContain('Error: flag needs an argument: --container-engine');
       expect(stderr).toContain('Usage:');
-      expect(stdout).toContain('');
+      expect(stdout).toEqual('');
     });
 
     test('set: complains when non-boolean option value specified', async() => {
@@ -269,7 +269,7 @@ test.describe('HTTP control interface', () => {
 
       expect(stderr).toContain('Error: invalid argument "gorb" for "--kubernetes-enabled" flag: strconv.ParseBool: parsing "gorb": invalid syntax');
       expect(stderr).toContain('Usage:');
-      expect(stdout).toContain('');
+      expect(stdout).toEqual('');
     });
 
     test('set: complains when invalid engine specified', async() => {
@@ -279,7 +279,7 @@ test.describe('HTTP control interface', () => {
       expect(stderr).toContain('Error: errors in attempt to update settings:');
       expect(stderr).toContain(`Invalid value for kubernetes.containerEngine: <${ myEngine }>; must be 'containerd', 'docker', or 'moby'`);
       expect(stderr).not.toContain('Usage:');
-      expect(stdout).toContain('');
+      expect(stdout).toEqual('');
     });
 
     test('set: complains when server rejects a proposed version', async() => {
@@ -287,7 +287,7 @@ test.describe('HTTP control interface', () => {
 
       expect(stderr).toMatch(/Error: errors in attempt to update settings:\s+Kubernetes version "karl" not found./);
       expect(stderr).not.toContain('Usage:');
-      expect(stdout).toContain('');
+      expect(stdout).toEqual('');
     });
 
     test('api: set: can read input file as separate argument', async() => {
@@ -332,7 +332,7 @@ test.describe('HTTP control interface', () => {
 
         expect(stderr).toContain(`Error: ${ cmd } command: unrecognized command-line arguments specified: [${ args.join(' ') }]`);
         expect(stderr).toContain('Usage:');
-        expect(stdout).toContain('');
+        expect(stdout).toEqual('');
       }
     });
 
@@ -344,7 +344,7 @@ test.describe('HTTP control interface', () => {
 
         expect(stderr).toContain(`Error: unknown flag: ${ options[0] }`);
         expect(stderr).toContain('Usage:');
-        expect(stdout).toContain('');
+        expect(stdout).toEqual('');
       }
     });
 
@@ -403,7 +403,7 @@ test.describe('HTTP control interface', () => {
       // And complains about a '--input-' flag
       const { stdout, stderr } = await bash(`cat ${ settingsFile } | ${ rdctl } api settings -X PUT --input-`);
 
-      expect(stdout).toBe('');
+      expect(stdout).toEqual('');
       expect(stderr).toContain('Error: unknown flag: --input-');
     });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -38,7 +38,7 @@ test.describe('HTTP control interface', () => {
   let context: BrowserContext;
   let serverState: ServerState;
   let page: Page;
-  let appPath: string;
+  const appPath = path.join(__dirname, '../');
 
   async function doRequest(path: string, body = '', method = 'GET') {
     const url = `http://127.0.0.1:${ serverState.port }/${ path.replace(/^\/*/, '') }`;
@@ -86,8 +86,6 @@ test.describe('HTTP control interface', () => {
 
   test.beforeAll(async() => {
     createDefaultSettings();
-    appPath = path.join(__dirname, '../');
-
     electronApp = await _electron.launch({
       args: [
         appPath,

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -63,12 +63,8 @@ test.describe('HTTP control interface', () => {
   }
 
   async function rdctl(commandArgs: string[]): Promise< { stdout: string, stderr: string }> {
-    const rPath = rdctlPath();
-
     try {
-      const { stdout, stderr } = await spawnFile(rPath, commandArgs, { stdio: 'pipe' });
-
-      return { stdout, stderr };
+      return await spawnFile(rdctlPath(), commandArgs, { stdio: 'pipe' });
     } catch (err: any) {
       return { stdout: err?.stdout ?? '', stderr: err?.stderr ?? '' };
     }

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -19,9 +19,9 @@ limitations under the License.
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
-import os from 'os';
 import { expect, test } from '@playwright/test';
 import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright';
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -439,26 +439,26 @@ test.describe('HTTP control interface', () => {
               expect(stderr).toContain('Error: unknown flag: --input-');
             });
 
-            // test.describe('from body', async() => {
-            //   const settingsFile = path.join(paths.config, 'settings.json');
-            //   const settingsBody = await fs.promises.readFile(settingsFile, { encoding: 'utf-8' });
-            //
-            //   for (const endpoint of ['settings', '/v0/settings']) {
-            //     for (const methodSpecs of [[], ['-X', 'PUT'], ['--method', 'PUT']]) {
-            //       for (const inputOption of ['--body', '-b']) {
-            //         const args = ['api', endpoint, ...methodSpecs, inputOption, settingsBody];
-            //
-            //         test(args.join(' '), async() => {
-            //           const { stdout, stderr, error } = await rdctl(args);
-            //
-            //           expect(error).toBeUndefined();
-            //           expect(stderr).toEqual('');
-            //           expect(stdout).toContain('no changes necessary');
-            //         });
-            //       }
-            //     }
-            //   }
-            // });
+            test.describe('from body', () => {
+              const settingsFile = path.join(paths.config, 'settings.json');
+
+              for (const endpoint of ['settings', '/v0/settings']) {
+                for (const methodSpecs of [[], ['-X', 'PUT'], ['--method', 'PUT']]) {
+                  for (const inputOption of ['--body', '-b']) {
+                    const args = ['api', endpoint, ...methodSpecs, inputOption];
+
+                    test(args.join(' '), async() => {
+                      const settingsBody = await fs.promises.readFile(settingsFile, { encoding: 'utf-8' });
+                      const { stdout, stderr, error } = await rdctl(args.concat(settingsBody));
+
+                      expect(error).toBeUndefined();
+                      expect(stderr).toEqual('');
+                      expect(stdout).toContain('no changes necessary');
+                    });
+                  }
+                }
+              }
+            });
 
             test.describe('complains when body and input are both specified', () => {
               for (const bodyOption of ['--body', '-b']) {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -479,7 +479,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ error: { message: '404 Not Found', documentation_url: null } });
+      expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found', documentation_url: null });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
     });
@@ -488,7 +488,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ error: { message: '400 Bad Request', documentation_url: null } });
+      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain('no settings specified in the request');
     });
@@ -498,7 +498,7 @@ test.describe('HTTP control interface', () => {
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
       expect(error).toBeUndefined();
-      expect(JSON.parse(stdout)).toEqual({ error: { message: '400 Bad Request', documentation_url: null } });
+      expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null } );
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
     });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -86,9 +86,7 @@ test.describe('HTTP control interface', () => {
         stdout: err?.stdout ?? '', stderr: err?.stderr ?? '', error: err
       };
     } finally {
-      if (stream) {
-        stream.close();
-      }
+      stream?.close();
     }
   }
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -33,7 +33,7 @@ import paths from '@/utils/paths';
 import { spawnFile } from '@/utils/childProcess';
 import { ServerState } from '@/main/commandServer/httpCommandServer';
 
-test.describe('HTTP control interface', () => {
+test.describe('Command server', () => {
   let electronApp: ElectronApplication;
   let context: BrowserContext;
   let serverState: ServerState;
@@ -306,7 +306,7 @@ test.describe('HTTP control interface', () => {
       });
     });
 
-    test.describe('all commands:', () => {
+    test.describe('all commands', () => {
       test.describe('complains about unrecognized/extra arguments', () => {
         const badArgs = ['string', 'brucebean'];
 
@@ -340,8 +340,8 @@ test.describe('HTTP control interface', () => {
       });
     });
 
-    test.describe('api:', () => {
-      test.describe('all subcommands:', () => {
+    test.describe('api', () => {
+      test.describe('all subcommands', () => {
         test('complains when no args are given', async() => {
           const { stdout, stderr, error } = await rdctl(['api']);
 
@@ -371,7 +371,7 @@ test.describe('HTTP control interface', () => {
         });
       });
 
-      test.describe('settings:', () => {
+      test.describe('settings', () => {
         test.describe('options:', () => {
           test.describe('GET', () => {
             for (const endpoint of ['settings', '/v0/settings']) {
@@ -474,26 +474,26 @@ test.describe('HTTP control interface', () => {
                 });
               }
             });
+
+            test('complains when no body is provided', async() => {
+              const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
+
+              expect(error).toBeDefined();
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+              expect(stderr).not.toContain('Usage:');
+              expect(stderr).toContain('no settings specified in the request');
+            });
+
+            test('invalid setting is specified', async() => {
+              const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
+              const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
+
+              expect(error).toBeDefined();
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null } );
+              expect(stderr).not.toContain('Usage:');
+              expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
+            });
           });
-        });
-
-        test('invalid setting is specified', async() => {
-          const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
-          const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
-
-          expect(error).toBeDefined();
-          expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null } );
-          expect(stderr).not.toContain('Usage:');
-          expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
-        });
-
-        test('complains when no body is provided', async() => {
-          const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
-
-          expect(error).toBeDefined();
-          expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
-          expect(stderr).not.toContain('Usage:');
-          expect(stderr).toContain('no settings specified in the request');
         });
       });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -478,7 +478,7 @@ test.describe('HTTP control interface', () => {
       const endpoint = '/v99/no/such/endpoint';
       const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
-      expect(error).toBeUndefined();
+      expect(error).toBeDefined();
       expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found', documentation_url: null });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
@@ -487,7 +487,7 @@ test.describe('HTTP control interface', () => {
     test('api: complains when no body is provided', async() => {
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
-      expect(error).toBeUndefined();
+      expect(error).toBeDefined();
       expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toContain('no settings specified in the request');
@@ -497,7 +497,7 @@ test.describe('HTTP control interface', () => {
       const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
       const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
-      expect(error).toBeUndefined();
+      expect(error).toBeDefined();
       expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null } );
       expect(stderr).not.toContain('Usage:');
       expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -1,0 +1,199 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"github.com/spf13/cobra"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var apiSettings struct {
+	Method       string
+	InputFile    string
+	RawFields    []string
+	CookedFields    []string
+}
+
+// apiCmd represents the api command
+var apiCmd = &cobra.Command{
+	Use:   "api",
+	Short: "Run API endpoints directly",
+	Long: `Runs API endpoints directly.
+Default method is PUT if a body or input file is specified, GET otherwise.
+
+Two ways of specifying a body:
+1. --input FILE: Like the existing preferences file. Does not support interpolation.
+
+2. --raw-field|-f name=value : interpolates value as is into the body
+	 --field|-F name=value: "smartly" interpolates value into the body:
+			 2.1. Strings are wrapped with quotes if not provided;
+			 2.2. Numbers and true/false are interpolated without quotes.
+
+Example type-2 command:
+
+rdctl set -F container-engine=moby -F kubernetes-enabled=true -f 'kubernetes-version="1.22.7"'
+
+A special raw-field name of "body" supports specifying a raw payload:
+
+rdctl set -f body='{"kubernetes": {"engine": "moby", "enabled": true, "version": "1.22.7" } }'
+
+It is an error to specify a regular field named body, or other fields along with body.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doApiCommand(cmd, args)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(apiCmd)
+	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "Method to use")
+	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "","File containing JSON payload to upload")
+	apiCmd.Flags().StringArrayVarP(&apiSettings.RawFields, "raw-field", "f", []string{}, "Inject a string parameter in key=value format to the template")
+	apiCmd.Flags().StringArrayVarP(&apiSettings.CookedFields, "field", "F", []string{}, "Inject a typed parameter in key=value format to the template")
+}
+
+func getNamedBodyTemplate() (string, error) {
+	for _, x := range apiSettings.CookedFields {
+		if strings.HasPrefix(x, "body=") {
+			return "", fmt.Errorf("%s", "only raw fields may contain a body field")
+		}
+	}
+	for _, x := range apiSettings.RawFields {
+		if strings.HasPrefix(x, "body=") {
+			if len(apiSettings.CookedFields) > 0 || len(apiSettings.RawFields) > 1 {
+				return "", fmt.Errorf("%s", "when a body field is specified, no other fields may be specified")
+			}
+			return strings.SplitN(x, "=", 2)[1], nil
+		}
+	}
+	return "", nil
+}
+
+func getBody() (*bytes.Buffer, error) {
+	bodyTemplate, err := getNamedBodyTemplate()
+	if err != nil {
+		return nil, err
+	}
+	if bodyTemplate != "" {
+		return bytes.NewBufferString(bodyTemplate), nil
+	}
+	if len(apiSettings.RawFields) == 0 && len(apiSettings.CookedFields) == 0 {
+		return nil, nil
+	}
+
+	containsNonDigit := regexp.MustCompile(`\D`)
+	for _, s := range apiSettings.CookedFields {
+		parts := strings.SplitN(s, "=", 2)
+		if parts[1] == "true" || parts[1] == "false" || containsNonDigit.FindString(parts[1]) == "" {
+			apiSettings.RawFields = append(apiSettings.RawFields, s)
+		} else if parts[1][0] == '"' && strings.HasSuffix(parts[1], `"`) {
+			apiSettings.RawFields = append(apiSettings.RawFields, s)
+		} else {
+			apiSettings.RawFields = append(apiSettings.RawFields, fmt.Sprintf(`%s="%s"`, parts[0], parts[1]))
+		}
+	}
+
+	bufTemplate := new(bytes.Buffer)
+	bufTemplate.WriteString(`{ "kubernetes": { `)
+	values := make(map[string]interface{})
+	commaOrEmptyString := ""
+
+	for _, s := range apiSettings.RawFields {
+		parts := strings.SplitN(s, "=", 2)
+		canonicalName := ""
+		switch(parts[0]) {
+		case "container-engine":
+			canonicalName = "engine"
+		case "kubernetes-enabled":
+			canonicalName = "enabled"
+		case "kubernetes-version":
+			canonicalName = "version"
+		}
+		if canonicalName == "" {
+			return nil, fmt.Errorf("field name %s not recognized", parts[0])
+		}
+		_, ok := values[canonicalName]
+		if !ok {
+			bufTemplate.WriteString(fmt.Sprintf(`%s "%s": {{ .%s }}`, commaOrEmptyString, canonicalName, canonicalName))
+			commaOrEmptyString = ","
+		}
+		values[canonicalName] = parts[1]
+	}
+
+	bufTemplate.WriteString("} }")
+	t := template.Must(template.New("template").Parse(bufTemplate.String()))
+	buf := new(bytes.Buffer)
+	err = t.Execute(buf, values)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func doApiCommand(cmd *cobra.Command, args []string) error {
+	var result []byte
+	var err error
+
+	if apiSettings.InputFile != "" {
+		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
+			return fmt.Errorf("fields may not be specified when input from a file is specified")
+		}
+		if apiSettings.Method == "" {
+			apiSettings.Method = "PUT"
+		}
+		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
+			return fmt.Errorf("fields may be specified only with an in-line body template, not input from a file")
+		}
+		contents, err := ioutil.ReadFile(apiSettings.InputFile)
+		if err != nil {
+			return err
+		}
+		result, err = doRequestWithPayload(apiSettings.Method, args[0], bytes.NewBuffer(contents))
+	} else {
+		var template *bytes.Buffer
+
+		template, err = getBody()
+		if err != nil {
+			return err
+		}
+		if template != nil {
+			if apiSettings.Method == "" {
+				apiSettings.Method = "PUT"
+			}
+			result, err = doRequestWithPayload(apiSettings.Method, args[0], template)
+		} else {
+			if apiSettings.Method == "" {
+				apiSettings.Method = "GET"
+			}
+			result, err = doRequest(apiSettings.Method, args[0])
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if len(result) > 0 {
+		fmt.Printf("Status: %s.\n", string(result))
+	} else {
+		fmt.Printf("Operation successfully returned with no output.")
+	}
+	return nil
+}

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -21,16 +21,14 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"io/ioutil"
+	"os"
 	"regexp"
-	"strings"
-	"text/template"
 )
 
 var apiSettings struct {
-	Method       string
-	InputFile    string
-	RawFields    []string
-	CookedFields []string
+	Method    string
+	InputFile string
+	Body      string
 }
 
 // apiCmd represents the api command
@@ -43,20 +41,7 @@ Default method is PUT if a body or input file is specified, GET otherwise.
 Two ways of specifying a body:
 1. --input FILE: Like the existing preferences file. Does not support interpolation.
 
-2. --raw-field|-f name=value : interpolates value as is into the body
-	 --field|-F name=value: "smartly" interpolates value into the body:
-			 2.1. Strings are wrapped with quotes if not provided;
-			 2.2. Numbers and true/false are interpolated without quotes.
-
-Example type-2 command:
-
-rdctl set -F container-engine=moby -F kubernetes-enabled=true -f 'kubernetes-version="1.22.7"'
-
-A special raw-field name of "body" supports specifying a raw payload:
-
-rdctl set -f body='{"kubernetes": {"engine": "moby", "enabled": true, "version": "1.22.7" } }'
-
-It is an error to specify a regular field named body, or other fields along with body.
+2. --body|-b string: For the 'PUT /settings' endpoint this must be a valid JSON string.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doApiCommand(cmd, args)
@@ -66,134 +51,56 @@ It is an error to specify a regular field named body, or other fields along with
 func init() {
 	rootCmd.AddCommand(apiCmd)
 	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "Method to use")
-	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "", "File containing JSON payload to upload")
-	apiCmd.Flags().StringArrayVarP(&apiSettings.RawFields, "raw-field", "f", []string{}, "Inject a string parameter in key=value format to the template")
-	apiCmd.Flags().StringArrayVarP(&apiSettings.CookedFields, "field", "F", []string{}, "Inject a typed parameter in key=value format to the template")
-}
-
-func getNamedBodyTemplate() (string, error) {
-	for _, x := range apiSettings.CookedFields {
-		if strings.HasPrefix(x, "body=") {
-			return "", fmt.Errorf("%s", "only raw fields may contain a body field")
-		}
-	}
-	for _, x := range apiSettings.RawFields {
-		if strings.HasPrefix(x, "body=") {
-			if len(apiSettings.CookedFields) > 0 || len(apiSettings.RawFields) > 1 {
-				return "", fmt.Errorf("%s", "when a body field is specified, no other fields may be specified")
-			}
-			return strings.SplitN(x, "=", 2)[1], nil
-		}
-	}
-	return "", nil
-}
-
-func getBody() (*bytes.Buffer, error) {
-	bodyTemplate, err := getNamedBodyTemplate()
-	if err != nil {
-		return nil, err
-	}
-	if bodyTemplate != "" {
-		return bytes.NewBufferString(bodyTemplate), nil
-	}
-	if len(apiSettings.RawFields) == 0 && len(apiSettings.CookedFields) == 0 {
-		return nil, nil
-	}
-
-	containsNonDigit := regexp.MustCompile(`\D`)
-	for _, s := range apiSettings.CookedFields {
-		parts := strings.SplitN(s, "=", 2)
-		if parts[1] == "true" || parts[1] == "false" || containsNonDigit.FindString(parts[1]) == "" {
-			apiSettings.RawFields = append(apiSettings.RawFields, s)
-		} else if parts[1][0] == '"' && strings.HasSuffix(parts[1], `"`) {
-			apiSettings.RawFields = append(apiSettings.RawFields, s)
-		} else {
-			apiSettings.RawFields = append(apiSettings.RawFields, fmt.Sprintf(`%s="%s"`, parts[0], parts[1]))
-		}
-	}
-
-	bufTemplate := new(bytes.Buffer)
-	bufTemplate.WriteString(`{ "kubernetes": { `)
-	values := make(map[string]interface{})
-	commaOrEmptyString := ""
-
-	for _, s := range apiSettings.RawFields {
-		parts := strings.SplitN(s, "=", 2)
-		canonicalName := ""
-		switch parts[0] {
-		case "container-engine":
-			canonicalName = "engine"
-		case "kubernetes-enabled":
-			canonicalName = "enabled"
-		case "kubernetes-version":
-			canonicalName = "version"
-		}
-		if canonicalName == "" {
-			return nil, fmt.Errorf("field name %s not recognized", parts[0])
-		}
-		_, ok := values[canonicalName]
-		if !ok {
-			bufTemplate.WriteString(fmt.Sprintf(`%s "%s": {{ .%s }}`, commaOrEmptyString, canonicalName, canonicalName))
-			commaOrEmptyString = ","
-		}
-		values[canonicalName] = parts[1]
-	}
-
-	bufTemplate.WriteString("} }")
-	t := template.Must(template.New("template").Parse(bufTemplate.String()))
-	buf := new(bytes.Buffer)
-	err = t.Execute(buf, values)
-	if err != nil {
-		return nil, err
-	}
-	return buf, nil
+	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "", "File containing JSON payload to upload (- for standard input)")
+	apiCmd.Flags().StringVarP(&apiSettings.Body, "body", "b", "", "JSON payload to upload")
 }
 
 func doApiCommand(cmd *cobra.Command, args []string) error {
 	var result []byte
+	var contents []byte
 	var err error
 
+	if len(args) == 0 {
+		return fmt.Errorf("api command: no endpoint specified")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("api command: too many endpoints specified (%v); exactly one must be specified", args)
+	}
+	endpoint := args[0]
+	if regexp.MustCompile(`^/v\d+/`).FindString(endpoint) == "" {
+		endpoint = fmt.Sprintf("/%s", versionCommand(apiVersion, endpoint))
+	}
+	// No longer emit usage info on errors
+	cmd.SetUsageFunc(func(*cobra.Command) error { return nil })
 	if apiSettings.InputFile != "" {
-		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
-			return fmt.Errorf("fields may not be specified when input from a file is specified")
-		}
 		if apiSettings.Method == "" {
 			apiSettings.Method = "PUT"
 		}
-		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
-			return fmt.Errorf("fields may be specified only with an in-line body template, not input from a file")
-		}
-		contents, err := ioutil.ReadFile(apiSettings.InputFile)
-		if err != nil {
-			return err
-		}
-		result, err = doRequestWithPayload(apiSettings.Method, args[0], bytes.NewBuffer(contents))
-	} else {
-		var template *bytes.Buffer
-
-		template, err = getBody()
-		if err != nil {
-			return err
-		}
-		if template != nil {
-			if apiSettings.Method == "" {
-				apiSettings.Method = "PUT"
-			}
-			result, err = doRequestWithPayload(apiSettings.Method, args[0], template)
+		if apiSettings.InputFile == "-" {
+			contents, err = ioutil.ReadAll(os.Stdin)
 		} else {
-			if apiSettings.Method == "" {
-				apiSettings.Method = "GET"
-			}
-			result, err = doRequest(apiSettings.Method, args[0])
+			contents, err = ioutil.ReadFile(apiSettings.InputFile)
 		}
+		if err != nil {
+			return err
+		}
+		result, err = doRequestWithPayload(apiSettings.Method, endpoint, bytes.NewBuffer(contents))
+	} else if apiSettings.Body != "" {
+		if apiSettings.Method == "" {
+			apiSettings.Method = "PUT"
+		}
+		result, err = doRequestWithPayload(apiSettings.Method, endpoint, bytes.NewBufferString(apiSettings.Body))
+	} else {
+		if apiSettings.Method == "" {
+			apiSettings.Method = "GET"
+		}
+		result, err = doRequest(apiSettings.Method, endpoint)
 	}
 	if err != nil {
 		return err
 	}
 	if len(result) > 0 {
-		fmt.Printf("Status: %s.\n", string(result))
-	} else {
-		fmt.Printf("Operation successfully returned with no output.")
+		fmt.Println(string(result))
 	}
 	return nil
 }

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -19,8 +19,8 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"github.com/spf13/cobra"
+	"io/ioutil"
 	"regexp"
 	"strings"
 	"text/template"
@@ -30,7 +30,7 @@ var apiSettings struct {
 	Method       string
 	InputFile    string
 	RawFields    []string
-	CookedFields    []string
+	CookedFields []string
 }
 
 // apiCmd represents the api command
@@ -66,7 +66,7 @@ It is an error to specify a regular field named body, or other fields along with
 func init() {
 	rootCmd.AddCommand(apiCmd)
 	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "Method to use")
-	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "","File containing JSON payload to upload")
+	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "", "File containing JSON payload to upload")
 	apiCmd.Flags().StringArrayVarP(&apiSettings.RawFields, "raw-field", "f", []string{}, "Inject a string parameter in key=value format to the template")
 	apiCmd.Flags().StringArrayVarP(&apiSettings.CookedFields, "field", "F", []string{}, "Inject a typed parameter in key=value format to the template")
 }
@@ -120,7 +120,7 @@ func getBody() (*bytes.Buffer, error) {
 	for _, s := range apiSettings.RawFields {
 		parts := strings.SplitN(s, "=", 2)
 		canonicalName := ""
-		switch(parts[0]) {
+		switch parts[0] {
 		case "container-engine":
 			canonicalName = "engine"
 		case "kubernetes-enabled":

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -62,7 +62,7 @@ func doApiCommand(cmd *cobra.Command, args []string) error {
 	var err error
 	var errorPacket *APIError
 
-	if len(args) == 0 {
+	if len(args) == 0 || len(args[0]) == 0 {
 		return fmt.Errorf("api command: no endpoint specified")
 	}
 	if len(args) > 1 {

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -72,6 +72,9 @@ func doApiCommand(cmd *cobra.Command, args []string) error {
 	if regexp.MustCompile(`^/v\d+/`).FindString(endpoint) == "" {
 		endpoint = fmt.Sprintf("/%s", versionCommand(apiVersion, endpoint))
 	}
+	if apiSettings.InputFile != "" && apiSettings.Body != "" {
+		return fmt.Errorf("api command: --body and --input options cannot both be specified")
+	}
 	// No longer emit usage info on errors
 	cmd.SetUsageFunc(func(*cobra.Command) error { return nil })
 	if apiSettings.InputFile != "" {

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -40,9 +40,9 @@ var apiCmd = &cobra.Command{
 Default method is PUT if a body or input file is specified, GET otherwise.
 
 Two ways of specifying a body:
-1. --input FILE: Like the existing preferences file. Does not support interpolation.
+1. --input FILE: For example, '--input .../rancher-desktop/settings.json'. Specify '-' for standard input.
 
-2. --body|-b string: For the 'PUT /settings' endpoint this must be a valid JSON string.
+2. --body|-b string: For the 'PUT /settings' endpoint, this must be a valid JSON string.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doApiCommand(cmd, args)

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"regexp"
+
+	"github.com/spf13/cobra"
 )
 
 var apiSettings struct {

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -27,7 +27,7 @@ var listSettingsCmd = &cobra.Command{
 	Short: "Lists the current settings.",
 	Long:  `Lists the current settings in JSON format.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := doRequest("GET", "list-settings")
+		result, err := doRequest("GET", versionCommand("", "list-settings"))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -30,7 +30,7 @@ var listSettingsCmd = &cobra.Command{
 		if len(args) > 0 {
 			return fmt.Errorf("list-settings command: unrecognized command-line arguments specified: %v", args)
 		}
-		result, err := doRequest("GET", versionCommand("", "settings"))
+		result, err := processRequestForUtility(doRequest("GET", versionCommand("", "settings")))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -27,7 +27,10 @@ var listSettingsCmd = &cobra.Command{
 	Short: "Lists the current settings.",
 	Long:  `Lists the current settings in JSON format.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := doRequest("GET", versionCommand("", "list-settings"))
+		if len(args) > 0 {
+			return fmt.Errorf("list-settings command: unrecognized command-line arguments specified: %v", args)
+		}
+		result, err := doRequest("GET", versionCommand("", "settings"))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -146,7 +146,12 @@ func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return nil, pErrorPacket, nil
+	  if pErrorPacket != nil {
+      return nil, pErrorPacket, nil
+    } else {
+      // Only return this error if there is nothing else to report
+      return nil, nil, err
+    }
 	}
 	return body, pErrorPacket, nil
 }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -146,12 +146,12 @@ func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-	  if pErrorPacket != nil {
-      return nil, pErrorPacket, nil
-    } else {
-      // Only return this error if there is nothing else to report
-      return nil, nil, err
-    }
+		if pErrorPacket != nil {
+			return nil, pErrorPacket, nil
+		} else {
+			// Only return this error if there is nothing else to report
+			return nil, nil, err
+		}
 	}
 	return body, pErrorPacket, nil
 }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -90,7 +91,7 @@ func versionCommand(version string, command string) string {
 }
 
 func makeURL(host string, port string, command string) string {
-	if command[0] == '/' {
+	if strings.HasPrefix(command, "/") {
 		return fmt.Sprintf("http://%s:%s%s", host, port, command)
 	}
 	return fmt.Sprintf("http://%s:%s/%s", host, port, command)

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -33,8 +33,10 @@ import (
 )
 
 type APIError struct {
-	Message          *string `json:"message,omitifempty"`
-	DocumentationUrl *string `json:"documentation_url,omitifempty"`
+	Error struct {
+		Message          *string `json:"message,omitifempty"`
+		DocumentationUrl *string `json:"documentation_url,omitifempty"`
+	} `json:"error"`
 }
 
 var (
@@ -139,7 +141,7 @@ func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError
 	errorPacket := APIError{}
 	pErrorPacket := &errorPacket
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		errorPacket.Message = &response.Status
+		errorPacket.Error.Message = &response.Status
 	} else {
 		pErrorPacket = nil
 	}

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -77,6 +77,20 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&password, "password", "", "overrides the password setting in the config file")
 }
 
+func versionCommand(version string, command string) string {
+	if version == "" {
+		return fmt.Sprintf("%s/%s", apiVersion, command)
+	}
+	return fmt.Sprintf("%s/%s", version, command)
+}
+
+func makeURL(host string, port string, command string) string {
+	if command[0] == '/' {
+		return fmt.Sprintf("http://%s:%s%s", host, port, command)
+	}
+	return fmt.Sprintf("http://%s:%s/%s", host, port, command)
+}
+
 func doRequest(method string, command string) ([]byte, error) {
 	req, err := getRequestObject(method, command)
 	if err != nil {
@@ -86,7 +100,7 @@ func doRequest(method string, command string) ([]byte, error) {
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) ([]byte, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, apiVersion, command), payload)
+	req, err := http.NewRequest(method, makeURL(host, port, command), payload)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +111,7 @@ func doRequestWithPayload(method string, command string, payload *bytes.Buffer) 
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, apiVersion, command), nil)
+	req, err := http.NewRequest(method, makeURL(host, port, command), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +154,6 @@ func doRestOfRequest(req *http.Request) ([]byte, error) {
 	} else if statusMessage != "" {
 		return nil, fmt.Errorf("%s", string(body))
 	}
-
 	return body, nil
 }
 

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -102,7 +102,7 @@ func doRequest(method string, command string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	return doRestOfRequest(req)
+  return http.DefaultClient.Do(req)
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) (*http.Response, error) {
@@ -113,7 +113,7 @@ func doRequestWithPayload(method string, command string, payload *bytes.Buffer) 
 	req.SetBasicAuth(user, password)
 	req.Header.Add("Content-Type", "application/json")
 	req.Close = true
-	return doRestOfRequest(req)
+  return http.DefaultClient.Do(req)
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
@@ -125,11 +125,6 @@ func getRequestObject(method string, command string) (*http.Request, error) {
 	req.Header.Add("Content-Type", "text/plain")
 	req.Close = true
 	return req, nil
-}
-
-func doRestOfRequest(req *http.Request) (*http.Response, error) {
-	client := http.Client{}
-	return client.Do(req)
 }
 
 func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError, error) {

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -33,8 +33,8 @@ import (
 )
 
 type APIError struct {
-  Message          *string `json:"message,omitifempty"`
-  DocumentationUrl *string `json:"documentation_url,omitifempty"`
+	Message          *string `json:"message,omitifempty"`
+	DocumentationUrl *string `json:"documentation_url,omitifempty"`
 }
 
 var (

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -102,7 +102,7 @@ func doRequest(method string, command string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-  return http.DefaultClient.Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) (*http.Response, error) {
@@ -113,7 +113,7 @@ func doRequestWithPayload(method string, command string, payload *bytes.Buffer) 
 	req.SetBasicAuth(user, password)
 	req.Header.Add("Content-Type", "application/json")
 	req.Close = true
-  return http.DefaultClient.Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -33,10 +33,8 @@ import (
 )
 
 type APIError struct {
-	Error struct {
-		Message          *string `json:"message,omitifempty"`
-		DocumentationUrl *string `json:"documentation_url,omitifempty"`
-	} `json:"error"`
+  Message          *string `json:"message,omitifempty"`
+  DocumentationUrl *string `json:"documentation_url,omitifempty"`
 }
 
 var (
@@ -141,7 +139,7 @@ func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError
 	errorPacket := APIError{}
 	pErrorPacket := &errorPacket
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		errorPacket.Error.Message = &response.Status
+		errorPacket.Message = &response.Status
 	} else {
 		pErrorPacket = nil
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -83,7 +83,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := doRequestWithPayload("PUT", versionCommand("", "set"), bytes.NewBuffer(jsonBuffer))
+	result, err := incorporateStatusMessage(doRequestWithPayload("PUT", versionCommand("", "settings"), bytes.NewBuffer(jsonBuffer)))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -81,7 +81,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := doRequestWithPayload("PUT", versionCommand("","set"), bytes.NewBuffer(jsonBuffer))
+	result, err := doRequestWithPayload("PUT", versionCommand("", "set"), bytes.NewBuffer(jsonBuffer))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -77,6 +77,8 @@ func doSetCommand(cmd *cobra.Command) error {
 	if !changedSomething {
 		return fmt.Errorf("set command: no settings to change were given")
 	}
+	// No longer emit usage info on errors
+	cmd.SetUsageFunc(func(*cobra.Command) error { return nil })
 	jsonBuffer, err := json.Marshal(currentSettings)
 	if err != nil {
 		return err

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -83,7 +83,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := incorporateStatusMessage(doRequestWithPayload("PUT", versionCommand("", "settings"), bytes.NewBuffer(jsonBuffer)))
+	result, err := doRequestWithPayload("PUT", versionCommand("", "settings"), bytes.NewBuffer(jsonBuffer))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -81,7 +81,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := doRequestWithPayload("PUT", "set", bytes.NewBuffer(jsonBuffer))
+	result, err := doRequestWithPayload("PUT", versionCommand("","set"), bytes.NewBuffer(jsonBuffer))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -83,7 +83,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := doRequestWithPayload("PUT", versionCommand("", "settings"), bytes.NewBuffer(jsonBuffer))
+	result, err := processRequestForUtility(doRequestWithPayload("PUT", versionCommand("", "settings"), bytes.NewBuffer(jsonBuffer)))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -30,7 +30,7 @@ var shutdownCmd = &cobra.Command{
 		if len(args) > 0 {
 			return fmt.Errorf("shutdown command: unrecognized command-line arguments specified: %v", args)
 		}
-		result, err := doRequest("PUT", versionCommand("", "shutdown"))
+		result, err := processRequestForUtility(doRequest("PUT", versionCommand("", "shutdown")))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -27,7 +27,7 @@ var shutdownCmd = &cobra.Command{
 	Short: "Shuts down the running Rancher Desktop application",
 	Long:  `Shuts down the running Rancher Desktop application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := doRequest("PUT", "shutdown")
+		result, err := doRequest("PUT", versionCommand("", "shutdown"))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -27,6 +27,9 @@ var shutdownCmd = &cobra.Command{
 	Short: "Shuts down the running Rancher Desktop application",
 	Long:  `Shuts down the running Rancher Desktop application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf("shutdown command: unrecognized command-line arguments specified: %v", args)
+		}
 		result, err := doRequest("PUT", versionCommand("", "shutdown"))
 		if err != nil {
 			return err

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -137,7 +137,7 @@ describe(SettingsValidator, () => {
 
       expect(needToUpdate).toBeFalsy();
       expect(errors).toEqual([
-        'Kubernetes version 1.1.1 not found.',
+        'Kubernetes version "1.1.1" not found.',
         "Invalid value for kubernetes.containerEngine: <1.1.2>; must be 'containerd', 'docker', or 'moby'",
         'Invalid value for kubernetes.enabled: <1>',
       ]);

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -143,7 +143,7 @@ export class HttpCommandServer {
   }
 
   /**
-   * Handle `PUT /v?/set` requests.
+   * Handle `PUT /v?/settings` requests.
    * Like the other methods, this method creates the request (here by reading the request body),
    * submits it to the provided CommandWorker, and writes back the appropriate status code
    * and data to the response object.

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -70,7 +70,6 @@ export class HttpCommandServer {
       }
       const method = request.method ?? 'GET';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
-      console.debug(`Processing request.url ${ request.url as string }`);
       const path = url.pathname;
       const pathParts = path.split('/');
 

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -35,10 +35,10 @@ export class HttpCommandServer {
 
   protected dispatchTable: Record<string, Record<string, Record<string, DispatchFunctionType>>> = {
     v0: {
-      GET: { 'list-settings': this.listSettings },
+      GET: { settings: this.listSettings },
       PUT: {
         shutdown: this.wrapShutdown,
-        set:      this.updateSettings
+        settings: this.updateSettings
       },
     }
   };

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -70,6 +70,7 @@ export class HttpCommandServer {
       }
       const method = request.method ?? 'GET';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
+      console.debug(`Processing request.url ${ request.url as string }`);
       const path = url.pathname;
       const pathParts = path.split('/');
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -115,7 +115,7 @@ export default class SettingsValidator {
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
     if (!this.k8sVersions.includes(desiredVersion)) {
-      errors.push(`Kubernetes version ${ desiredVersion } not found.`);
+      errors.push(`Kubernetes version "${ desiredVersion }" not found.`);
 
       return false;
     }


### PR DESCRIPTION
Fixes #1903

Currently supports these options:
```
--method | -X method (default PUT when input is specified, GET otherwise)
--input ( FILE | - ) (like the current settings.json file, `-` for stdin)
--body | -b input-body, normally JSON
```

And these endpoints:

```
GET settings
PUT settings <BODY>
PUT shutdown
```

Signed-off-by: Eric Promislow <epromislow@suse.com>