### PR TITLE
Write out server errors in a JSON packet to stdout.

### DIFF
--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -1,0 +1,199 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"github.com/spf13/cobra"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var apiSettings struct {
+	Method       string
+	InputFile    string
+	RawFields    []string
+	CookedFields    []string
+}
+
+// apiCmd represents the api command
+var apiCmd = &cobra.Command{
+	Use:   "api",
+	Short: "Run API endpoints directly",
+	Long: `Runs API endpoints directly.
+Default method is PUT if a body or input file is specified, GET otherwise.
+
+Two ways of specifying a body:
+1. --input FILE: Like the existing preferences file. Does not support interpolation.
+
+2. --raw-field|-f name=value : interpolates value as is into the body
+	 --field|-F name=value: "smartly" interpolates value into the body:
+			 2.1. Strings are wrapped with quotes if not provided;
+			 2.2. Numbers and true/false are interpolated without quotes.
+
+Example type-2 command:
+
+rdctl set -F container-engine=moby -F kubernetes-enabled=true -f 'kubernetes-version="1.22.7"'
+
+A special raw-field name of "body" supports specifying a raw payload:
+
+rdctl set -f body='{"kubernetes": {"engine": "moby", "enabled": true, "version": "1.22.7" } }'
+
+It is an error to specify a regular field named body, or other fields along with body.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doApiCommand(cmd, args)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(apiCmd)
+	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "Method to use")
+	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "","File containing JSON payload to upload")
+	apiCmd.Flags().StringArrayVarP(&apiSettings.RawFields, "raw-field", "f", []string{}, "Inject a string parameter in key=value format to the template")
+	apiCmd.Flags().StringArrayVarP(&apiSettings.CookedFields, "field", "F", []string{}, "Inject a typed parameter in key=value format to the template")
+}
+
+func getNamedBodyTemplate() (string, error) {
+	for _, x := range apiSettings.CookedFields {
+		if strings.HasPrefix(x, "body=") {
+			return "", fmt.Errorf("%s", "only raw fields may contain a body field")
+		}
+	}
+	for _, x := range apiSettings.RawFields {
+		if strings.HasPrefix(x, "body=") {
+			if len(apiSettings.CookedFields) > 0 || len(apiSettings.RawFields) > 1 {
+				return "", fmt.Errorf("%s", "when a body field is specified, no other fields may be specified")
+			}
+			return strings.SplitN(x, "=", 2)[1], nil
+		}
+	}
+	return "", nil
+}
+
+func getBody() (*bytes.Buffer, error) {
+	bodyTemplate, err := getNamedBodyTemplate()
+	if err != nil {
+		return nil, err
+	}
+	if bodyTemplate != "" {
+		return bytes.NewBufferString(bodyTemplate), nil
+	}
+	if len(apiSettings.RawFields) == 0 && len(apiSettings.CookedFields) == 0 {
+		return nil, nil
+	}
+
+	containsNonDigit := regexp.MustCompile(`\D`)
+	for _, s := range apiSettings.CookedFields {
+		parts := strings.SplitN(s, "=", 2)
+		if parts[1] == "true" || parts[1] == "false" || containsNonDigit.FindString(parts[1]) == "" {
+			apiSettings.RawFields = append(apiSettings.RawFields, s)
+		} else if parts[1][0] == '"' && strings.HasSuffix(parts[1], `"`) {
+			apiSettings.RawFields = append(apiSettings.RawFields, s)
+		} else {
+			apiSettings.RawFields = append(apiSettings.RawFields, fmt.Sprintf(`%s="%s"`, parts[0], parts[1]))
+		}
+	}
+
+	bufTemplate := new(bytes.Buffer)
+	bufTemplate.WriteString(`{ "kubernetes": { `)
+	values := make(map[string]interface{})
+	commaOrEmptyString := ""
+
+	for _, s := range apiSettings.RawFields {
+		parts := strings.SplitN(s, "=", 2)
+		canonicalName := ""
+		switch(parts[0]) {
+		case "container-engine":
+			canonicalName = "engine"
+		case "kubernetes-enabled":
+			canonicalName = "enabled"
+		case "kubernetes-version":
+			canonicalName = "version"
+		}
+		if canonicalName == "" {
+			return nil, fmt.Errorf("field name %s not recognized", parts[0])
+		}
+		_, ok := values[canonicalName]
+		if !ok {
+			bufTemplate.WriteString(fmt.Sprintf(`%s "%s": {{ .%s }}`, commaOrEmptyString, canonicalName, canonicalName))
+			commaOrEmptyString = ","
+		}
+		values[canonicalName] = parts[1]
+	}
+
+	bufTemplate.WriteString("} }")
+	t := template.Must(template.New("template").Parse(bufTemplate.String()))
+	buf := new(bytes.Buffer)
+	err = t.Execute(buf, values)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func doApiCommand(cmd *cobra.Command, args []string) error {
+	var result []byte
+	var err error
+
+	if apiSettings.InputFile != "" {
+		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
+			return fmt.Errorf("fields may not be specified when input from a file is specified")
+		}
+		if apiSettings.Method == "" {
+			apiSettings.Method = "PUT"
+		}
+		if len(apiSettings.RawFields) > 0 || len(apiSettings.CookedFields) > 0 {
+			return fmt.Errorf("fields may be specified only with an in-line body template, not input from a file")
+		}
+		contents, err := ioutil.ReadFile(apiSettings.InputFile)
+		if err != nil {
+			return err
+		}
+		result, err = doRequestWithPayload(apiSettings.Method, args[0], bytes.NewBuffer(contents))
+	} else {
+		var template *bytes.Buffer
+
+		template, err = getBody()
+		if err != nil {
+			return err
+		}
+		if template != nil {
+			if apiSettings.Method == "" {
+				apiSettings.Method = "PUT"
+			}
+			result, err = doRequestWithPayload(apiSettings.Method, args[0], template)
+		} else {
+			if apiSettings.Method == "" {
+				apiSettings.Method = "GET"
+			}
+			result, err = doRequest(apiSettings.Method, args[0])
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if len(result) > 0 {
+		fmt.Printf("Status: %s.\n", string(result))
+	} else {
+		fmt.Printf("Operation successfully returned with no output.")
+	}
+	return nil
+}

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -27,7 +27,7 @@ var listSettingsCmd = &cobra.Command{
 	Short: "Lists the current settings.",
 	Long:  `Lists the current settings in JSON format.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := doRequest("GET", "list-settings")
+		result, err := doRequest("GET", versionCommand("", "list-settings"))
 		if err != nil {
 			return err
 		}

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -77,6 +77,20 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&password, "password", "", "overrides the password setting in the config file")
 }
 
+func versionCommand(version string, command string) string {
+	if version == "" {
+		return fmt.Sprintf("%s/%s", apiVersion, command)
+	}
+	return fmt.Sprintf("%s/%s", version, command)
+}
+
+func makeURL(host string, port string, command string) string {
+	if command[0] == '/' {
+		return fmt.Sprintf("http://%s:%s%s", host, port, command)
+	}
+	return fmt.Sprintf("http://%s:%s/%s", host, port, command)
+}
+
 func doRequest(method string, command string) ([]byte, error) {
 	req, err := getRequestObject(method, command)
 	if err != nil {
@@ -86,7 +100,7 @@ func doRequest(method string, command string) ([]byte, error) {
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) ([]byte, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, apiVersion, command), payload)
+	req, err := http.NewRequest(method, makeURL(host, port, command), payload)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +111,7 @@ func doRequestWithPayload(method string, command string, payload *bytes.Buffer) 
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%s/%s/%s", host, port, apiVersion, command), nil)
+	req, err := http.NewRequest(method, makeURL(host, port, command), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +154,6 @@ func doRestOfRequest(req *http.Request) ([]byte, error) {
 	} else if statusMessage != "" {
 		return nil, fmt.Errorf("%s", string(body))
 	}
-
 	return body, nil
 }
 

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -129,9 +129,15 @@ func doRestOfRequest(req *http.Request) ([]byte, error) {
 	}
 	statusMessage := ""
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		statusMessage = response.Status
+		if statusMessage != "" {
+			fmt.Printf(`{
+	"message": "%s"
+}
+`, statusMessage)
+		}
 		switch response.StatusCode {
 		case 400:
-			statusMessage = response.Status
 			// Prefer the error message in the body written by the command-server, not the one from the http server.
 			break
 		case 401:
@@ -152,6 +158,8 @@ func doRestOfRequest(req *http.Request) ([]byte, error) {
 		}
 		return nil, err
 	} else if statusMessage != "" {
+		// Got response.StatusCode = 400, write the raw status message out to stdout,
+		// and return the actual error message in the response.Body (which gets written to stderr)
 		return nil, fmt.Errorf("%s", string(body))
 	}
 	return body, nil

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -81,7 +81,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	result, err := doRequestWithPayload("PUT", "set", bytes.NewBuffer(jsonBuffer))
+	result, err := doRequestWithPayload("PUT", versionCommand("","set"), bytes.NewBuffer(jsonBuffer))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -27,7 +27,7 @@ var shutdownCmd = &cobra.Command{
 	Short: "Shuts down the running Rancher Desktop application",
 	Long:  `Shuts down the running Rancher Desktop application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		result, err := doRequest("PUT", "shutdown")
+		result, err := doRequest("PUT", versionCommand("", "shutdown"))
 		if err != nil {
 			return err
 		}

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -70,6 +70,7 @@ export class HttpCommandServer {
       }
       const method = request.method ?? 'GET';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
+      console.debug(`Processing request.url ${ request.url as string }`);
       const path = url.pathname;
       const pathParts = path.split('/');
 


### PR DESCRIPTION
Fixes #1945

Other error messages, and the usage screen, will continue to be written to stderr.

Signed-off-by: Eric Promislow <epromislow@suse.com>