### PR TITLE
Auto-size first run dialog to fit contents without scrolling

### DIFF
--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -43,6 +43,7 @@ export default Vue.extend({
   height: 100%;
   display: flex;
   flex-flow: column;
+  gap: 1rem;
 }
 
 </style>

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -1,9 +1,9 @@
 <!-- This layout is used by dialog boxes that do not want navigation -->
 
 <template>
-  <dialog ref="wrapper" class="wrapper" open>
+  <div ref="wrapper" class="wrapper" open>
     <Nuxt class="body" />
-  </dialog>
+  </div>
 </template>
 
 <script lang="ts">
@@ -33,6 +33,9 @@ export default Vue.extend({
   background-color: var(--body-bg);
   border: none;
   color: var(--body-text);
+  width: 24rem;
+  padding: 1.25rem;
+  margin: 0 auto;
 }
 
 .body {

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -16,18 +16,15 @@ export default Vue.extend({
     // the "dark" part will be a dynamic pref.
     // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
     return { bodyAttrs: { class: 'theme-dark' } };
-  },
-  mounted() {
-    const wrapper = this.$refs.wrapper as HTMLDialogElement;
-
-    // Dynamically resize the window to fit the contents.
-    // We need a bit extra on the width to ensure we don't get scroll bars.
-    window.resizeBy(
-      wrapper.offsetWidth - document.documentElement.offsetWidth + 14,
-      wrapper.offsetHeight - document.documentElement.offsetHeight);
   }
 });
 </script>
+
+<style lang="scss">
+  html {
+    height: initial;
+  }
+</style>
 
 <style lang="scss" scoped>
 @import "@/assets/styles/app.scss";
@@ -36,11 +33,9 @@ export default Vue.extend({
   background-color: var(--body-bg);
   border: none;
   color: var(--body-text);
-  height: 100vh;
 }
 
 .body {
-  height: 100%;
   display: flex;
   flex-flow: column;
   gap: 1rem;

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -149,4 +149,8 @@ export default Vue.extend({
   .button-area {
     align-self: flex-end;
   }
+
+  .select-k8s-version {
+    margin-top: 0.5rem;
+  }
 </style>

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -146,4 +146,7 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+  .button-area {
+    align-self: flex-end;
+  }
 </style>

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -3,46 +3,44 @@
     <h2 data-test="k8s-settings-header">
       Welcome to Rancher Desktop
     </h2>
-    <div class="k8s-settings">
-      <label>
-        Please select a Kubernetes version:
-        <select v-model="settings.kubernetes.version" class="select-k8s-version" @change="onChange">
-          <!--
+    <Checkbox
+      label="Enable Kubernetes"
+      :value="settings.kubernetes.enabled"
+      @input="handleDisableKubernetesCheckbox"
+    />
+    <label>
+      Please select a Kubernetes version:
+      <select v-model="settings.kubernetes.version" class="select-k8s-version" @change="onChange">
+        <!--
             - On macOS Chrome / Electron can't style the <option> elements.
             - We do the best we can by instead using <optgroup> for a recommended section.
             -->
-          <optgroup v-if="recommendedVersions.length > 0" label="Recommended Versions">
-            <option
-              v-for="item in recommendedVersions"
-              :key="item.version.version"
-              :value="item.version.version"
-              :selected="item.version.version === defaultVersion.version.version"
-            >
-              {{ versionName(item) }}
-            </option>
-          </optgroup>
-          <optgroup v-if="nonRecommendedVersions.length > 0" label="Other Versions">
-            <option
-              v-for="item in nonRecommendedVersions"
-              :key="item.version.version"
-              :value="item.version.version"
-              :selected="item.version.version === defaultVersion.version.version"
-            >
-              v{{ item.version.version }}
-            </option>
-          </optgroup>
-        </select>
-      </label>
-      <engine-selector
-        :container-engine="settings.kubernetes.containerEngine"
-        @change="onChangeEngine"
-      />
-      <Checkbox
-        label="Enable Kubernetes"
-        :value="settings.kubernetes.enabled"
-        @input="handleDisableKubernetesCheckbox"
-      />
-    </div>
+        <optgroup v-if="recommendedVersions.length > 0" label="Recommended Versions">
+          <option
+            v-for="item in recommendedVersions"
+            :key="item.version.version"
+            :value="item.version.version"
+            :selected="item.version.version === defaultVersion.version.version"
+          >
+            {{ versionName(item) }}
+          </option>
+        </optgroup>
+        <optgroup v-if="nonRecommendedVersions.length > 0" label="Other Versions">
+          <option
+            v-for="item in nonRecommendedVersions"
+            :key="item.version.version"
+            :value="item.version.version"
+            :selected="item.version.version === defaultVersion.version.version"
+          >
+            v{{ item.version.version }}
+          </option>
+        </optgroup>
+      </select>
+    </label>
+    <engine-selector
+      :container-engine="settings.kubernetes.containerEngine"
+      @change="onChangeEngine"
+    />
     <div class="button-area">
       <button data-test="accept-btn" class="role-primary" @click="close">
         Accept
@@ -148,18 +146,4 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-  .select-k8s-version {
-    margin-top: 0.5rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .button-area {
-    // sass doesn't understand `end` here, and sets up `[dir]` selectors that
-    // will never match anything.  So we need to use `right`, which breaks RTL.
-    text-align: right;
-  }
-
-  .k8s-settings {
-    flex: 1;
-  }
 </style>

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -133,7 +133,7 @@ export async function openFirstRun() {
   });
 
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
-    window.setSize(width, height);
+    window.setContentSize(width, height);
     window.setMinimumSize(width, height);
   });
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -132,9 +132,9 @@ export async function openFirstRun() {
     }
   });
 
-  window.webContents.on('preferred-size-changed', (_event, preferredSize) => {
-    window.setSize(324, preferredSize.height);
-    window.setMinimumSize(324, preferredSize.height);
+  window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
+    window.setSize(width, height);
+    window.setMinimumSize(width, height);
   });
 
   window.menuBarVisible = false;

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -118,6 +118,7 @@ export async function openFirstRun() {
     {
       autoHideMenuBar: !app.isPackaged,
       show:            false,
+      useContentSize:  true,
       webPreferences:  {
         devTools:                !app.isPackaged,
         nodeIntegration:         true,
@@ -134,7 +135,10 @@ export async function openFirstRun() {
 
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
     window.setContentSize(width, height);
-    window.setMinimumSize(width, height);
+
+    const [windowWidth, windowHeight] = window.getSize();
+
+    window.setMinimumSize(windowWidth, windowHeight);
   });
 
   window.menuBarVisible = false;

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -116,16 +116,13 @@ export async function openFirstRun() {
     'first-run',
     `${ webRoot }/index.html#FirstRun`,
     {
-      width:           324,
-      height:          364,
-      minWidth:        324,
-      minHeight:       364,
       autoHideMenuBar: !app.isPackaged,
       show:            false,
       webPreferences:  {
-        devTools:           !app.isPackaged,
-        nodeIntegration:    true,
-        contextIsolation:   false,
+        devTools:                !app.isPackaged,
+        nodeIntegration:         true,
+        contextIsolation:        false,
+        enablePreferredSizeMode: true,
       },
     });
 
@@ -134,6 +131,12 @@ export async function openFirstRun() {
       window.show();
     }
   });
+
+  window.webContents.on('preferred-size-changed', (_event, preferredSize) => {
+    window.setSize(324, preferredSize.height);
+    window.setMinimumSize(324, preferredSize.height);
+  });
+
   window.menuBarVisible = false;
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);


### PR DESCRIPTION
This updates the first run dialog to make use of `enablePreferredSizeMode`, so that the window can automatically resize to the minimum size needed to contain the layout without scrolling.

We want to improve the way the preferences window resizes, because we will soon have to display a varying number of options in the first-run dialog depending on platform. Making resizing seamless will ease the implementation of this future work.

supports #1936 

closes #1949