### PR TITLE
Support disabling flannel in rancher-desktop via rdctl

### DIFF
--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -89,6 +89,8 @@ components:
               properties:
                 traefik:
                   type: boolean
+                flannel:
+                  type: boolean
         portForwarding:
           type: object
           properties:

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -45,7 +45,7 @@ export const defaultSettings = {
     checkForExistingKimBuilder: false,
     enabled:                    true,
     WSLIntegrations:            {} as Record<string, string|boolean>,
-    options:                    { traefik: true },
+    options:                    { traefik: true, flannel: true },
     suppressSudo:               false,
   },
   portForwarding:  { includeKubernetesServices: false },

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,9 @@ type serverSettings struct {
 		ContainerEngine *string `json:"containerEngine,omitempty"`
 		Enabled         *bool   `json:"enabled,omitempty"`
 		Version         *string `json:"version,omitempty"`
+		Options         struct {
+			Flannel *bool `json:"flannel,omitempty"`
+		} `json:"options,omitempty"`
 	} `json:"kubernetes,omitempty"`
 }
 
@@ -35,6 +39,7 @@ var specifiedSettings struct {
 	ContainerEngine string
 	Enabled         bool
 	Version         string
+	Flannel         bool
 }
 
 // setCmd represents the set command
@@ -55,6 +60,7 @@ func init() {
 	setCmd.Flags().StringVar(&specifiedSettings.ContainerEngine, "container-engine", "", "Set engine to containerd or moby (aka docker).")
 	setCmd.Flags().BoolVar(&specifiedSettings.Enabled, "kubernetes-enabled", false, "Control whether kubernetes runs in the backend.")
 	setCmd.Flags().StringVar(&specifiedSettings.Version, "kubernetes-version", "", "Choose which version of kubernetes to run.")
+	setCmd.Flags().BoolVar(&specifiedSettings.Flannel, "flannel-enabled", true, "Control whether flannel is enabled. Use to disable flannel so you can install your own CNI.")
 }
 
 func doSetCommand(cmd *cobra.Command) error {
@@ -71,6 +77,10 @@ func doSetCommand(cmd *cobra.Command) error {
 	}
 	if cmd.Flags().Changed("kubernetes-version") {
 		currentSettings.Kubernetes.Version = &specifiedSettings.Version
+		changedSomething = true
+	}
+	if cmd.Flags().Changed("flannel-enabled") {
+		currentSettings.Kubernetes.Options.Flannel = &specifiedSettings.Flannel
 		changedSomething = true
 	}
 


### PR DESCRIPTION
Fully fixes #1967 and gets back to the behavior of rancher-desktop  v1.1.1 by preventing the creation of the flannel CNI configuration file.

PR is based on #1975 which fixes using CNI with dockerd in general.
