### PR TITLE
README: improve macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,22 @@ You can now clone the repository and run `npm install`.
 [Windows Subsystem for Linux (WSL)]: https://docs.microsoft.com/en-us/windows/wsl/install
 
 
-### macOS and Linux
+### macOS
+
+Install Node.js v16 and Go, for example via [Homebrew](https://brew.sh/):
+
+```
+brew install node@16
+brew link node@16
+brew install go
+```
+
+Then you can install dependencies with:
+```
+npm install
+```
+
+### Linux
 
 Install [Node.js][Node.js] v16. Then you can install dependencies with:
 


### PR DESCRIPTION
Go was not explicitly mentioned but it is required. Instructions were added to install node 16 (build fails on node 17 currently).

Signed-off-by: Silvio Moioli <silvio@moioli.net>