### PR TITLE
Correct the integration source directory on `UnixIntegrationManager`

### DIFF
--- a/src/integrations/integrationManager.ts
+++ b/src/integrations/integrationManager.ts
@@ -30,14 +30,15 @@ export interface IntegrationManager {
 }
 
 export function getIntegrationManager(): IntegrationManager {
-  const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
   const platform = os.platform();
+  const resourcesBinDir = path.join(paths.resources, platform, 'bin')
+  const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
 
   switch (platform) {
   case 'linux':
-    return new UnixIntegrationManager(paths.resources, paths.integration, dockerCliPluginDir);
+    return new UnixIntegrationManager(resourcesBinDir, paths.integration, dockerCliPluginDir);
   case 'darwin':
-    return new UnixIntegrationManager(paths.resources, paths.integration, dockerCliPluginDir);
+    return new UnixIntegrationManager(resourcesBinDir, paths.integration, dockerCliPluginDir);
   case 'win32':
     return new WindowsIntegrationManager();
   default:


### PR DESCRIPTION
The source directory for integrations was set to `paths.resources`, which meant the directories in that directory were what appeared in `~/.rd/bin/`. This fixes that.