### PR TITLE
Fix the go module path, so that pkgs can be used

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
@@ -19,10 +19,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/process"
 
 	// Pull in to register the mungers
-	_ "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/mungers"
+	_ "github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/mungers"
 )
 
 var dockerproxyKillViper = viper.New()

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -20,12 +20,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/process"
 
 	// Pull in to register the mungers
-	_ "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/mungers"
+	_ "github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/mungers"
 )
 
 var dockerproxyServeViper = viper.New()

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -19,11 +19,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 
 	// Pull in to register the mungers
-	_ "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/mungers"
+	_ "github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/mungers"
 )
 
 var dockerproxyServeViper = viper.New()

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
 )
 
 var dockerproxyStartViper = viper.New()

--- a/src/go/wsl-helper/cmd/factoryreset.go
+++ b/src/go/wsl-helper/cmd/factoryreset.go
@@ -23,8 +23,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/process"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/reset"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/process"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/reset"
 )
 
 var factoryResetViper = viper.New()

--- a/src/go/wsl-helper/cmd/updatedns.go
+++ b/src/go/wsl-helper/cmd/updatedns.go
@@ -21,7 +21,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dnsupdater"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dnsupdater"
 )
 
 // updatednsCmd represents the update-dns command

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -1,4 +1,4 @@
-module github.com/rancher-sandbox/rancher-desktop/src/wsl-helper
+module github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper
 
 go 1.18
 

--- a/src/go/wsl-helper/main.go
+++ b/src/go/wsl-helper/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package main
 
-import "github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/cmd"
+import "github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/cmd"
 
 func main() {
 	cmd.Execute()

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -32,9 +32,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 )
 
 // For Linux (non-rancher-desktop WSL2 containers), we need to do a little more

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 )
 
 func TestNewBindManager(t *testing.T) {

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 )
 
 type containersCreateBody struct {

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
@@ -25,9 +25,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/go/wsl-helper/pkg/dockerproxy/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve.go
@@ -35,8 +35,8 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/models"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/models"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
 )
 
 // RequestContextValue contains things we attach to incoming requests

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -31,8 +31,8 @@ import (
 	"github.com/linuxkit/virtsock/pkg/vsock"
 	"golang.org/x/sys/unix"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/platform"
-	"github.com/rancher-sandbox/rancher-desktop/src/wsl-helper/pkg/dockerproxy/util"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/platform"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/util"
 )
 
 // defaultProxyEndpoint is the path on which dockerd should listen on, relative


### PR DESCRIPTION
I need this change so I can re-use some of our pkgs in host-resolver. More specifically I'm interested in `util/pipe.go`