### PR TITLE
Configure cgroups mounts as shared and mount bpffs by default

### DIFF
--- a/src/assets/lima-config.yaml
+++ b/src/assets/lima-config.yaml
@@ -77,6 +77,16 @@ provision:
     . /mnt/lima-cidata/lima.env
     set -o xtrace
     usermod --append --groups docker "${LIMA_CIDATA_USER}"
+- # mount bpffs to allow containers to leverage bpf, and make both bpffs and
+  # cgroupfs shared mounts so the pods can mount them correctly
+  mode: system
+  script: |
+    #!/bin/sh
+    set -o errexit
+
+    mount bpffs -t bpf /sys/fs/bpf
+    mount --make-shared /sys/fs/bpf
+    mount --make-shared /sys/fs/cgroup
 portForwards:
 - guestPortRange: [1, 65535]
   guestIPMustBeZero: true

--- a/src/assets/scripts/wsl-init
+++ b/src/assets/scripts/wsl-init
@@ -26,6 +26,12 @@ fi
     done
 )
 
+# mount bpffs to allow containers to leverage bpf, and make both bpffs and
+# cgroupfs shared mounts so the pods can mount them correctly
+mount bpffs -t bpf /sys/fs/bpf
+mount --make-shared /sys/fs/bpf
+mount --make-shared /sys/fs/cgroup
+
 if [ -f /var/lib/resolv.conf ]; then
     ln -s -f /var/lib/resolv.conf /etc/resolv.conf
 fi


### PR DESCRIPTION
Provides compatibility with containers mounting cgroupfs or containers that leverage bpf.