### PR TITLE
Pin trivy version to v0.25.3

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -189,11 +189,8 @@ export default async function main(platform) {
   // https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_checksums.txt
   // https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_macOS-64bit.tar.gz
 
-  const trivyURLBase = 'https://github.com/aquasecurity/trivy/releases';
-  const rawTrivyVersionJSON = spawnSync('curl', ['-k', '-L', '-H', 'Accept: application/json',
-    `${ trivyURLBase }/latest`]).stdout.toString();
-  const trivyVersionJSON = JSON.parse(rawTrivyVersionJSON);
-  const trivyVersionWithV = trivyVersionJSON['tag_name'];
+  const trivyVersionWithV = 'v0.25.3';
+  const trivyURLBase = `https://github.com/aquasecurity/trivy/releases/download/${ trivyVersionWithV }`;
   const trivyVersion = trivyVersionWithV.replace(/^v/, '');
   const trivyOS = cpu === 'amd64' ? 'Linux-64bit' : 'Linux-ARM64';
   const trivyBasename = `trivy_${ trivyVersion }_${ trivyOS }`;

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -190,7 +190,7 @@ export default async function main(platform) {
   // https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_macOS-64bit.tar.gz
 
   const trivyVersionWithV = 'v0.25.3';
-  const trivyURLBase = `https://github.com/aquasecurity/trivy/releases/download/${ trivyVersionWithV }`;
+  const trivyURLBase = `https://github.com/aquasecurity/trivy/releases`;
   const trivyVersion = trivyVersionWithV.replace(/^v/, '');
   const trivyOS = cpu === 'amd64' ? 'Linux-64bit' : 'Linux-ARM64';
   const trivyBasename = `trivy_${ trivyVersion }_${ trivyOS }`;


### PR DESCRIPTION
This pins the trivy version to `v0.25.3`. Updating the trivy version should be an explicit task that we perform.

closes #1206 