### PR TITLE
Lima: Set up docker contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/src/config/emptyStubForJSLinter.js",
+      "^@/assets/": "<rootDir>/src/config/emptyStubForJSLinter.js",
       "^@/(.*)$": "<rootDir>/src/$1"
     },
     "preset": "ts-jest/presets/js-with-babel",

--- a/src/k8s-engine/__tests__/lima.spec.ts
+++ b/src/k8s-engine/__tests__/lima.spec.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import net from 'net';
+import os from 'os';
+import path from 'path';
+
+import K3sHelper from '../k3sHelper';
+import LimaBackend from '../lima';
+
+jest.mock('../k3sHelper');
+jest.mock('electron', () => ({}));
+
+describe('LimaBackend', () => {
+  describe('updateDockerContext', () => {
+    /** The instance of LimaBackend under test. */
+    let subj: LimaBackend;
+    /** A directory we can use for scratch files during the test. */
+    let workdir: string;
+    /** Path to the docker config file (in workdir). */
+    let configPath: string;
+    /** Path to the docker context metadata file (in workdir). */
+    let metaPath: string;
+    /** Path to a secondary docker context metadata file, for existing contexts. */
+    let altMetaPath: string;
+    /** Path to the docker socket Rancher Desktop is providing. */
+    let sockPath: string;
+    /** Path to a secondary docker socket, for existing contexts. */
+    let altSockPath: string;
+
+    beforeAll(() => {
+      jest.spyOn(K3sHelper.prototype, 'initialize').mockResolvedValue();
+      jest.spyOn(K3sHelper.prototype, 'on').mockImplementation();
+      jest.spyOn(os, 'homedir').mockImplementation(() => workdir);
+    });
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    beforeEach(async() => {
+      await expect((async() => {
+        subj = new LimaBackend('x86_64');
+        workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rancher-desktop-lima-test-'));
+        configPath = path.join(workdir, '.docker', 'config.json');
+        metaPath = path.join(workdir, '.docker', 'contexts', 'meta',
+          'b547d66a5de60e5f0843aba28283a8875c2ad72e99ba076060ef9ec7c09917c8',
+          'meta.json');
+        altMetaPath = path.join(workdir, '.docker', 'contexts', 'meta',
+          '43999461d22f67840fcd9b8824293eaa4f18146e57b2c651bcd925e3b3e4e429',
+          'meta.json');
+        sockPath = path.join(workdir, 'docker.sock');
+        altSockPath = path.join(workdir, 'pikachu.sock');
+      })()).resolves.toBeUndefined();
+    });
+    afterEach(async() => {
+      await fs.promises.rm(workdir, { recursive: true });
+    });
+
+    it('should generate additional docker context', async() => {
+      await expect(subj['updateDockerContext'](sockPath, undefined, true)).resolves.toBeUndefined();
+      const result = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
+
+      expect(result).toEqual({
+        Endpoints: {
+          docker: {
+            Host:          `unix://${ sockPath }`,
+            SkipTLSVerify: false,
+          }
+        },
+        Metadata: { Description: 'Rancher Desktop moby context' },
+        Name:     'rancher-desktop',
+      });
+    });
+
+    it('should clear context when default', async() => {
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+      await expect(subj['updateDockerContext'](sockPath, undefined, true)).resolves.toBeUndefined();
+      expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toEqual({});
+
+      const spy = jest.spyOn(fs.promises, 'writeFile');
+
+      await subj['updateDockerContext'](sockPath, undefined, true);
+      expect(spy).toHaveBeenCalledWith(metaPath, expect.anything());
+      expect(spy).not.toHaveBeenCalledWith(configPath, expect.anything());
+    });
+
+    it('should not touch working unix socket', async() => {
+      const server = net.createServer();
+
+      try {
+        await new Promise<void>(resolve => server.listen(altSockPath, resolve));
+        await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+        await fs.promises.mkdir(path.dirname(altMetaPath), { recursive: true });
+        await fs.promises.writeFile(altMetaPath, JSON.stringify({
+          Name:      'pikachu',
+          Endpoints: { docker: { Host: `unix://${ altSockPath }` } },
+        }));
+        await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+
+        expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'pikachu');
+      } finally {
+        server.close();
+      }
+    });
+
+    it('should update missing socket', async() => {
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+      await fs.promises.mkdir(path.dirname(altMetaPath), { recursive: true });
+      await fs.promises.writeFile(altMetaPath, JSON.stringify({
+        Name:      'pikachu',
+        Endpoints: { docker: { Host: `unix://${ altSockPath }` } },
+      }));
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+
+      expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'rancher-desktop');
+    });
+
+    it('should update invalid socket', async() => {
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+      await fs.promises.mkdir(path.dirname(altMetaPath), { recursive: true });
+      await fs.promises.writeFile(altMetaPath, JSON.stringify({
+        Name:      'pikachu',
+        Endpoints: { docker: { Host: `unix://${ altSockPath }` } },
+      }));
+      await fs.promises.writeFile(altSockPath, '');
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+
+      expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'rancher-desktop');
+    });
+
+    it('should not touch tcp socket', async() => {
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+      await fs.promises.mkdir(path.dirname(altMetaPath), { recursive: true });
+      await fs.promises.writeFile(altMetaPath, JSON.stringify({
+        Name:      'pikachu',
+        Endpoints: { docker: { Host: `tcp://server.test:1234` } },
+      }));
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+
+      expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'pikachu');
+    });
+
+    it('should update kubernetes endpoint', async() => {
+      const kubeURL = 'http://kubernetes.test:2345';
+
+      await expect(subj['updateDockerContext'](sockPath, kubeURL, false)).resolves.toBeUndefined();
+
+      const result = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
+
+      expect(result).toHaveProperty('Name', 'rancher-desktop');
+      expect(result).toHaveProperty('Endpoints.kubernetes.Host', kubeURL);
+    });
+
+    it('should allow for existing invalid configuration', async() => {
+      const metaDir = path.join(workdir, '.docker', 'contexts', 'meta');
+
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
+      await fs.promises.mkdir(path.join(metaDir, 'invalid-context', 'meta.json'), { recursive: true });
+      await fs.promises.writeFile(path.join(metaDir, 'invalid-context-two'), '');
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+    });
+
+    it('should throw errors reading config.json', async() => {
+      await fs.promises.mkdir(configPath, { recursive: true });
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).rejects.toThrow('EISDIR');
+    });
+  });
+});

--- a/src/k8s-engine/__tests__/lima.spec.ts
+++ b/src/k8s-engine/__tests__/lima.spec.ts
@@ -78,9 +78,21 @@ describe('LimaBackend', () => {
 
       const spy = jest.spyOn(fs.promises, 'writeFile');
 
-      await subj['updateDockerContext'](sockPath, undefined, true);
+      await expect(subj['updateDockerContext'](sockPath, undefined, true)).resolves.toBeUndefined();
       expect(spy).toHaveBeenCalledWith(metaPath, expect.anything());
       expect(spy).not.toHaveBeenCalledWith(configPath, expect.anything());
+    });
+
+    it('should do nothing if context already set', async() => {
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'rancher-desktop' }));
+      const readdirSpy = jest.spyOn(fs.promises, 'readdir');
+      const writeFileSpy = jest.spyOn(fs.promises, 'writeFile').mockClear();
+
+      await expect(subj['updateDockerContext'](sockPath, undefined, false)).resolves.toBeUndefined();
+      expect(readdirSpy).not.toHaveBeenCalled();
+      expect(writeFileSpy).toHaveBeenCalledWith(metaPath, expect.anything());
+      expect(writeFileSpy).not.toHaveBeenCalledWith(configPath, expect.anything());
     });
 
     it('should not touch working unix socket', async() => {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1486,8 +1486,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
                 break;
               }
             } catch (ex) {
-              console.debug(`Failed to read context ${ dir }, skipping: ${ ex }`);
-              continue;
+              console.log(`Failed to read context ${ dir }, skipping: ${ ex }`);
             }
           }
           if (!existingSocket.startsWith('unix://')) {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1501,16 +1501,16 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
             if (stat.isSocket()) {
               return;
             }
-            console.log(`Invalid existing context ${ existingConfig.currentContext }: ${ existingSocket } is not a socket; overriding.`);
+            console.log(`Invalid existing context "${ existingConfig.currentContext }": ${ existingSocket } is not a socket; overriding.`);
           } catch (ex) {
-            console.log(`Could not read existing docker socket ${ existingSocket }, overriding context ${ existingConfig.currentContext }: ${ ex }`);
+            console.log(`Could not read existing docker socket ${ existingSocket }, overriding context "${ existingConfig.currentContext }": ${ ex }`);
           }
         }
         existingConfig.currentContext = contextName;
         await fs.promises.writeFile(configPath, JSON.stringify(existingConfig));
       }
     } catch (ex: any) {
-      if (ex?.errno !== 'ENOENT') {
+      if (ex?.code !== 'ENOENT') {
         throw ex;
       }
       if (!defaultSocket) {
@@ -1518,6 +1518,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         // We need to write a docker config.
         const config = { currentContext: contextName };
 
+        await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
         await fs.promises.writeFile(configPath, JSON.stringify(config));
       }
     }


### PR DESCRIPTION
This configures Lima to set up docker contexts:
- We _always_ set up a `rancher-desktop` context.
- If we have sudo access, we switch the user to the default context (i.e. using `/var/run/docker.sock`).
- Otherwise, only if the user's current context is broken (i.e. has a unix socket path, but there is no such unix socket), we switch the user to the `rancher-desktop` context.

Fixes #910.  This implements the ideas from #1841 (the original revision of the description; this was out of scope for that issue).