### PR TITLE
Fix the case of the name we're importing.

### DIFF
--- a/src/plugins/tooltip.js
+++ b/src/plugins/tooltip.js
@@ -1,4 +1,4 @@
 import Vue from 'vue';
-import VTooltip from 'v-tooltip';
+import vTooltip from 'v-tooltip';
 
-Vue.use(VTooltip);
+Vue.use(vTooltip);


### PR DESCRIPTION
It should be the same as the default exported name, respecting case.

Signed-off-by: Eric Promislow <epromislow@suse.com>