### PR TITLE
Fix commands for installing go binaries

### DIFF
--- a/src/assets/specs/README.md
+++ b/src/assets/specs/README.md
@@ -9,7 +9,7 @@
 * opai-codegen: To install:
 
 ```bash
-go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen
+go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
 ```
 
 ### To generate documentation:

--- a/src/go/wsl-helper/pkg/dockerproxy/generate.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/generate.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/go-swagger/go-swagger"
 )
 
-//go:generate -command swagger go run github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
+//go:generate go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
 //go:generate swagger generate server --skip-validation --config-file swagger-configuration.yaml --server-package models --spec swagger.yaml
 
 func init() {


### PR DESCRIPTION
I was having trouble with `npm test` on the go portion because `go get` doesn't download anything to `GOPATH` with modern versions of Go. This uses `go install` instead, which is the recommended method.