### PR TITLE
Create a flattened list of all vulnerabilities

### DIFF
--- a/src/pages/images/scans/_image-name.vue
+++ b/src/pages/images/scans/_image-name.vue
@@ -90,7 +90,7 @@ export default {
       // TODO: rancher-sandbox/rancher-desktop#2007
       return results
         ?.reduce((prev, curr) => {
-          return [...prev, ...curr.Vulnerabilities];
+          return [...prev, ...curr?.Vulnerabilities || []];
         }, [])
         ?.map(({ PkgName, VulnerabilityID, ...rest }) => {
           return {

--- a/src/pages/images/scans/_image-name.vue
+++ b/src/pages/images/scans/_image-name.vue
@@ -87,9 +87,11 @@ export default {
     vulnerabilities() {
       const results = JSON.parse(this.jsonOutput)?.Results;
 
+      // TODO: rancher-sandbox/rancher-desktop#2007
       return results
-        ?.find((_val, i) => i === 0)
-        ?.Vulnerabilities
+        ?.reduce((prev, curr) => {
+          return [...prev, ...curr.Vulnerabilities];
+        }, [])
         ?.map(({ PkgName, VulnerabilityID, ...rest }) => {
           return {
             id: `${ PkgName }-${ VulnerabilityID }`,


### PR DESCRIPTION
This closes #2002 by getting a collection of all vulnerabilities instead of the first target of the scan.

We can improve upon the experience that we have today by grouping our scans by target, so I created #2007 to address this. 

There's a good test case to be found in #2002 by scanning the `ituv0018/artikel` image.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>