### PR TITLE
Prompt for Path Management Strategy when one is not set

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -26,7 +26,7 @@ import setupTray from '@/main/tray';
 import buildApplicationMenu from '@/main/mainmenu';
 import { Steve } from '@/k8s-engine/steve';
 import SettingsValidator from '@/main/commandServer/settingsValidator';
-import { getPathManagerFor, PathManager } from '@/integrations/pathManager';
+import { getPathManagerFor, PathManagementStrategy, PathManager } from '@/integrations/pathManager';
 import { IntegrationManager, getIntegrationManager } from '@/integrations/integrationManager';
 import removeLegacySymlinks from '@/integrations/legacy';
 
@@ -144,6 +144,11 @@ Electron.app.whenReady().then(async() => {
 
     setupTray();
     window.openPreferences();
+
+    // Path management strategy will need to be selected after an upgrade
+    if (cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
+      await window.openPathUpdate();
+    }
 
     await startBackend(cfg);
   } catch (ex) {

--- a/background.ts
+++ b/background.ts
@@ -146,7 +146,7 @@ Electron.app.whenReady().then(async() => {
     window.openPreferences();
 
     // Path management strategy will need to be selected after an upgrade
-    if (cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
+    if (!os.platform().startsWith('win') && cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
       await window.openPathUpdate();
     }
 

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -6,6 +6,8 @@ import fs from 'fs';
 import path from 'path';
 import paths from '../../src/utils/paths';
 import * as childProcess from '../../src/utils/childProcess';
+import { defaultSettings } from '@/config/settings';
+import { PathManagementStrategy } from '@/integrations/pathManager';
 
 /**
  * Create empty default settings to bypass gracefully
@@ -16,7 +18,9 @@ export function createDefaultSettings() {
 }
 
 function createSettingsFile(settingsDir: string) {
-  const settingsData = '{}';
+  const settingsData = defaultSettings;
+
+  settingsData.pathManagementStrategy = PathManagementStrategy.RcFiles;
   const settingsJson = JSON.stringify(settingsData);
   const fileSettingsName = 'settings.json';
   const settingsFullPath = path.join(settingsDir, fileSettingsName);

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -20,7 +20,7 @@ export function createDefaultSettings() {
 function createSettingsFile(settingsDir: string) {
   const settingsData = defaultSettings;
 
-  settingsData.pathManagementStrategy = PathManagementStrategy.RcFiles;
+  settingsData.pathManagementStrategy = PathManagementStrategy.Manual;
   const settingsJson = JSON.stringify(settingsData);
   const fileSettingsName = 'settings.json';
   const settingsFullPath = path.join(settingsDir, fileSettingsName);

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -163,6 +163,10 @@ suffix:
 ##############################
 # Components & Pages
 ##############################
+app:
+  name: Rancher Desktop
+  update: There's one last step to finish updating Rancher Desktop
+
 images:
   title: Images
   state:
@@ -271,6 +275,8 @@ pathManagement:
     manual:
       label: Manual
       description: Rancher Desktop does not change your PATH configuration; add ~/.rd/bin to your path manually.
+  accept: Accept
+
 
 accountAndKeys:
   title: Account and API Keys

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -165,7 +165,7 @@ suffix:
 ##############################
 app:
   name: Rancher Desktop
-  update: There's one last step to finish updating Rancher Desktop
+  update: "There's one last step to finish updating Rancher Desktop"
 
 images:
   title: Images

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4643,4 +4643,3 @@ legacy:
   project:
     label: Project
     select: "Use the Project/Namespace filter at the top of the page to select a Project in order to see legacy Project features."
-  

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -21,13 +21,13 @@ export default Vue.extend({
       await this.$store.dispatch('applicationSettings/commitPathManagementStrategy', this.pathManagementStrategy);
       ipcRenderer.send('window/close');
     }
-  }
+  },
 });
 </script>
 
 <template>
   <div>
-    <div>Rancher Desktop</div>
+    <h3>Rancher Desktop</h3>
     <div>There's one last step to finish updating Rancher Desktop</div>
     <path-management-selector
       :value="pathManagementStrategy"

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -16,6 +16,10 @@ export default Vue.extend({
   methods: {
     setPathManagementStrategy(val: PathManagementStrategy) {
       this.$store.dispatch('applicationSettings/setPathManagementStrategy', val);
+    },
+    async commitStrategy() {
+      await this.$store.dispatch('applicationSettings/commitPathManagementStrategy', this.pathManagementStrategy);
+      ipcRenderer.send('window/close');
     }
   }
 });
@@ -33,7 +37,7 @@ export default Vue.extend({
       <button
         data-test="accept-btn"
         class="role-primary"
-        @click="close"
+        @click="commitStrategy"
       >
         Accept
       </button>

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -25,7 +25,7 @@ export default Vue.extend({
     },
     async commitStrategy() {
       await this.$store.dispatch('applicationSettings/commitPathManagementStrategy', this.pathManagementStrategy);
-      ipcRenderer.send('window/close');
+      window.close();
     }
   },
 });

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -33,8 +33,8 @@ export default Vue.extend({
 
 <template>
   <div>
-    <h3>Rancher Desktop</h3>
-    <div>There's one last step to finish updating Rancher Desktop</div>
+    <h3>{{ t('app.name') }}</h3>
+    <div>{{ t('app.update.description') }}</div>
     <path-management-selector
       :value="pathManagementStrategy"
       @input="setPathManagementStrategy"
@@ -45,7 +45,7 @@ export default Vue.extend({
         class="role-primary"
         @click="commitStrategy"
       >
-        Accept
+        {{ t('pathManagement.accept') }}
       </button>
     </div>
   </div>

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -22,8 +22,27 @@ export default Vue.extend({
 </script>
 
 <template>
-  <path-management-selector
-    :value="pathManagementStrategy"
-    @input="setPathManagementStrategy"
-  />
+  <div>
+    <div>Rancher Desktop</div>
+    <div>There's one last step to finish updating Rancher Desktop</div>
+    <path-management-selector
+      :value="pathManagementStrategy"
+      @input="setPathManagementStrategy"
+    />
+    <div class="button-area">
+      <button
+        data-test="accept-btn"
+        class="role-primary"
+        @click="close"
+      >
+        Accept
+      </button>
+    </div>
+  </div>
 </template>
+
+<style lang="scss" scoped>
+  .button-area {
+    align-self: flex-end;
+  }
+</style>

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+import Vue from 'vue';
+import { ipcRenderer } from 'electron';
+import { mapGetters } from 'vuex';
+import PathManagementSelector from '~/components/PathManagementSelector.vue';
+import { PathManagementStrategy } from '~/integrations/pathManager';
+
+export default Vue.extend({
+  name:       'path-update',
+  components: { PathManagementSelector },
+  layout:     'dialog',
+  computed:   { ...mapGetters('applicationSettings', { pathManagementStrategy: 'getPathManagementStrategy' }) },
+  mounted() {
+    ipcRenderer.send('dialog/ready');
+  },
+  methods: {
+    setPathManagementStrategy(val: PathManagementStrategy) {
+      this.$store.dispatch('applicationSettings/setPathManagementStrategy', val);
+    }
+  }
+});
+</script>
+
+<template>
+  <path-management-selector
+    :value="pathManagementStrategy"
+    @input="setPathManagementStrategy"
+  />
+</template>

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -34,7 +34,7 @@ export default Vue.extend({
 <template>
   <div>
     <h3>{{ t('app.name') }}</h3>
-    <div>{{ t('app.update.description') }}</div>
+    <div>{{ t('app.update', { }, true) }}</div>
     <path-management-selector
       :value="pathManagementStrategy"
       @input="setPathManagementStrategy"

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -10,8 +10,14 @@ export default Vue.extend({
   components: { PathManagementSelector },
   layout:     'dialog',
   computed:   { ...mapGetters('applicationSettings', { pathManagementStrategy: 'getPathManagementStrategy' }) },
+  beforeMount() {
+    window.addEventListener('beforeunload', this.commitStrategy);
+  },
   mounted() {
     ipcRenderer.send('dialog/ready');
+  },
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.commitStrategy);
   },
   methods: {
     setPathManagementStrategy(val: PathManagementStrategy) {

--- a/src/pages/PathUpdate.vue
+++ b/src/pages/PathUpdate.vue
@@ -2,8 +2,8 @@
 import Vue from 'vue';
 import { ipcRenderer } from 'electron';
 import { mapGetters } from 'vuex';
-import PathManagementSelector from '~/components/PathManagementSelector.vue';
-import { PathManagementStrategy } from '~/integrations/pathManager';
+import PathManagementSelector from '@/components/PathManagementSelector.vue';
+import { PathManagementStrategy } from '@/integrations/pathManager';
 
 export default Vue.extend({
   name:       'path-update',

--- a/src/store/applicationSettings.js
+++ b/src/store/applicationSettings.js
@@ -1,3 +1,4 @@
+import { ipcRenderer } from 'electron';
 import * as settings from '@/config/settings';
 import { PathManagementStrategy } from '@/integrations/pathManager';
 
@@ -14,6 +15,13 @@ export const mutations = {
 export const actions = {
   setPathManagementStrategy({ commit }, strategy) {
     commit('SET_PATH_MANAGEMENT_STRATEGY', strategy);
+  },
+  async commitPathManagementStrategy({ commit }, strategy) {
+    commit('SET_PATH_MANAGEMENT_STRATEGY', strategy);
+    await ipcRenderer.invoke(
+      'settings-write',
+      { pathManagementStrategy: strategy }
+    );
   }
 };
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -142,12 +142,14 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
   let windowState: 'hidden' | 'shown' | 'sized' = 'hidden';
 
   window.menuBarVisible = false;
+
   window.webContents.on('ipc-message', (event, channel) => {
     if (channel === 'dialog/ready') {
       window.show();
       windowState = 'shown';
     }
   });
+
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
     if (windowState === 'sized') {
       // Once the window is done sizing, don't do any more automatic resizing.
@@ -232,6 +234,19 @@ export async function openSudoPrompt(explanations: string[]): Promise<boolean> {
   }));
 
   return result;
+}
+
+export async function openPathUpdate() {
+  const window = openDialog(
+    'PathUpdate',
+    {
+      frame:  false,
+      parent: getWindow('preferences') ?? undefined
+    });
+
+  await (new Promise<void>((resolve) => {
+    window.on('closed', resolve);
+  }));
 }
 
 /**

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -245,6 +245,12 @@ export async function openPathUpdate() {
       parent: getWindow('preferences') ?? undefined
     });
 
+  window.webContents.on('ipc-message', (_event, channel) => {
+    if (channel === 'window/close') {
+      window.close();
+    }
+  });
+
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);
   }));

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -245,12 +245,6 @@ export async function openPathUpdate() {
       parent: getWindow('preferences') ?? undefined,
     });
 
-  window.webContents.on('ipc-message', (_event, channel) => {
-    if (channel === 'window/close') {
-      window.close();
-    }
-  });
-
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);
   }));

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -241,8 +241,8 @@ export async function openPathUpdate() {
     'PathUpdate',
     {
       title:  'Rancher Desktop - Welcome',
-      frame:  false,
-      parent: getWindow('preferences') ?? undefined
+      frame:  true,
+      parent: getWindow('preferences') ?? undefined,
     });
 
   window.webContents.on('ipc-message', (_event, channel) => {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -240,6 +240,7 @@ export async function openPathUpdate() {
   const window = openDialog(
     'PathUpdate',
     {
+      title:  'Rancher Desktop - Welcome',
       frame:  false,
       parent: getWindow('preferences') ?? undefined
     });

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -240,7 +240,7 @@ export async function openPathUpdate() {
   const window = openDialog(
     'PathUpdate',
     {
-      title:  'Rancher Desktop - Welcome',
+      title:  'Rancher Desktop - Update',
       frame:  true,
       parent: getWindow('preferences') ?? undefined,
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Node",
     "lib": [
       "ESNext",
-      "ESNext.AsyncIterable",
+      "ESNext.AsyncIterable"
     ],
     "esModuleInterop": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": [
       "ESNext",
       "ESNext.AsyncIterable",
-      "DOM"
     ],
     "esModuleInterop": true,
     "allowJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "Node",
     "lib": [
       "ESNext",
-      "ESNext.AsyncIterable"
+      "ESNext.AsyncIterable",
+      "DOM"
     ],
     "esModuleInterop": true,
     "allowJs": true,


### PR DESCRIPTION
This prompts for a Path Management strategy selection when coming from a version of Rancher Desktop that wouldn't have one set. We do this by raising a modal window after opening the preferences window. Users will not see this if a path management strategy is set.

For this feature, we treat closing of the dialog as an implicit `accept` of the selected strategy, as one should be set.

This PR is a follow-up to https://github.com/rancher-sandbox/rancher-desktop/pull/1970.

closes #1986 