### PR TITLE
e2e TestUtils: capture stderr

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -4,6 +4,9 @@
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
+
+import { expect } from '@playwright/test';
+
 import paths from '../../src/utils/paths';
 import * as childProcess from '../../src/utils/childProcess';
 
@@ -69,13 +72,16 @@ export async function tool(tool: string, ...args: string[]): Promise<string> {
 
   try {
     const { stdout } = await childProcess.spawnFile(
-      exe, args, { stdio: ['ignore', 'pipe', 'inherit'] });
+      exe, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
     return stdout;
   } catch (ex:any) {
     console.error(`Error running ${ tool } ${ args.join(' ') }`);
     console.error(`stdout: ${ ex.stdout }`);
     console.error(`stderr: ${ ex.stderr }`);
+    expect({
+      stdout: ex.stdout, stderr: ex.stderr, message: ex.toString()
+    }).toBeUndefined();
     throw ex;
   }
 }

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -79,6 +79,10 @@ export async function tool(tool: string, ...args: string[]): Promise<string> {
     console.error(`Error running ${ tool } ${ args.join(' ') }`);
     console.error(`stdout: ${ ex.stdout }`);
     console.error(`stderr: ${ ex.stderr }`);
+    // This expect(...).toBeUndefined() will always fail; we just want to make
+    // playwright print out the stdout and stderr along with the message.
+    // Normally, it would just print out `ex.toString()`, which mostly just says
+    // "<command> exited with code 1" and doesn't explain _why_ that happened.
     expect({
       stdout: ex.stdout, stderr: ex.stderr, message: ex.toString()
     }).toBeUndefined();


### PR DESCRIPTION
This ensures that we capture the standard error on commands we run, so that we can print it out if things fail.  Also, in the error case, run an assertion that will always fail so we can see all the details.

Sample output (after locally changing the tests to always fail):
```
  ✘  helm.e2e.spec.ts:53:3 › Helm Deployment Test › should check kubernetes API is ready (0ms)
Error running kubectl --context rancher-desktop invalid-option
stdout: 
stderr: Error: flags cannot be placed before plugin name: --context

Error running helm --kube-context rancher-desktop repo remove bitnami
stdout: 
stderr: Error: no repo named "bitnami" found
```
The added (always-failing) assertion:
```
  1) helm.e2e.spec.ts:53:3 › Helm Deployment Test › should check kubernetes API is ready ===========

    Error: expect(received).toBeUndefined()

    Received: {"message": "/…/resources/darwin/bin/helm exited with code 1", "stderr": "Error: no repo named \"bitnami\" found
    ", "stdout": ""}

        at tool (/…/e2e/utils/TestUtils.ts:84:8)
        at helm (/…/e2e/utils/TestUtils.ts:104:10)
        at tearDownHelm (/…/e2e/utils/TestUtils.ts:61:3)
```