### PR TITLE
Display app version and platform in kubernetes error dialog

### DIFF
--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -3,9 +3,12 @@
     <div class="page-body">
       <div class="error-header">
         <img id="logo" src="../../resources/icons/logo-square-red@2x.png" />
-        <h2 data-test="k8s-error-header">
-          Kubernetes Error
-        </h2>
+        <span>
+          <h2 data-test="k8s-error-header">
+            Kubernetes Error
+          </h2>
+          <h5>Rancher Desktop {{ appVersion }} - {{ platform }}</h5>
+        </span>
       </div>
       <div class="k8s-error">
         <div class="error-part">

--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-
+import os from 'os';
 import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
@@ -49,13 +49,23 @@ export default Vue.extend({
       mainMessage:        '',
       lastCommand:        '',
       lastCommandComment: '',
-      lastLogLines:           [],
+      lastLogLines:       [],
+      appVersion:         '',
     };
   },
   computed: {
     joinedLastLogLines(): string {
       return this.lastLogLines.join('\n');
+    },
+    platform(): string {
+      return os.platform();
     }
+  },
+  beforeMount() {
+    ipcRenderer.on('get-app-version', (_event, version) => {
+      this.appVersion = version;
+    });
+    ipcRenderer.send('get-app-version');
   },
   mounted() {
     ipcRenderer.on('dialog/populate', (event, titlePart, mainMessage, failureDetails) => {
@@ -84,6 +94,7 @@ export default Vue.extend({
       margin-top: 0.25rem;
     }
   }
+
   img#logo {
     height: 32px;
     width: 32px;

--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -7,7 +7,7 @@
           <h2 data-test="k8s-error-header">
             Kubernetes Error
           </h2>
-          <h5>Rancher Desktop {{ appVersion }} - {{ platform }}</h5>
+          <h5>{{ versionString }}</h5>
         </span>
       </div>
       <div class="k8s-error">
@@ -62,6 +62,14 @@ export default Vue.extend({
     },
     platform(): string {
       return os.platform();
+    },
+    arch(): string {
+      const arch = os.arch();
+
+      return arch === 'arm64' ? 'aarch64' : arch;
+    },
+    versionString(): string {
+      return `Rancher Desktop ${ this.appVersion } - ${ this.platform } (${ this.arch })`;
     }
   },
   beforeMount() {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -190,6 +190,7 @@ export async function openFirstRun() {
  */
 export async function openKubernetesErrorMessageWindow(titlePart: string, mainMessage: string, failureDetails: K8s.FailureDetails) {
   const window = openDialog('KubernetesError', {
+    title:  `Rancher Desktop - Kubernetes Error`,
     width:  800,
     height: 494,
     parent: getWindow('preferences') ?? undefined,


### PR DESCRIPTION
This displays the app version and platform as a description below the header in the kubernetes error dialog.

closes #1933 