### PR TITLE
Restart kubernetes after traefik toggle

### DIFF
--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -63,7 +63,7 @@
         :disabled="!settings.kubernetes.enabled"
         class="feature"
         label="Enable Traefik"
-        @input="handleUpdateFeatures('traefik', $event)"
+        @input="handleUpdateTraefik"
       />
     </div>
     <engine-selector
@@ -391,6 +391,24 @@ export default {
       this.settings.kubernetes.port = value;
       ipcRenderer.invoke('settings-write',
         { kubernetes: { port: value } });
+    },
+    handleUpdateTraefik(value) {
+      if (value === this.settings.kubernetes.options.traefik) {
+        return;
+      }
+
+      const confirmationMessage = `Kubernetes will restart after ${ value ? 'enabling' : 'disabling' } Traefik. \n\nDo you want to proceed?`;
+
+      if (!confirm(confirmationMessage)) {
+        return;
+      }
+
+      try {
+        this.handleUpdateFeatures('traefik', value);
+        this.restart();
+      } catch (err) {
+        console.error('invoke settings-write failed: ', err);
+      }
     },
     handleUpdateFeatures(feature, value) {
       this.settings.kubernetes.options[feature] = value;


### PR DESCRIPTION
This restarts kubernetes after toggling the traefik setting. 

We discussed the approach of raising a confirmation dialog to accomplish this, and turned out to the most straightforward way to resolve the issue without focusing on a refactor of our patterns for applying settings.

closes #1866 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>