### PR TITLE
Replace fs.watch with watchOnceAndRestart function

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -634,7 +634,6 @@ function newK8sManager() {
         writeSettings({ kubernetes: { version: mgr.version } });
       }
       currentImageProcessor?.relayNamespaces();
-      // TODO: Find the appropriate location to start the Steve API
 
       if (enabledK8s) {
         Steve.getInstance().start();

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -85,6 +85,27 @@ export class Tray {
 
   private readonly trayIconSet = this.isMacOs() ? this.trayIconsMacOs : this.trayIcons;
 
+  private watchOnceAndRestart = (kubeconfigPath: string) => {
+    const watcher = fs.watch(kubeconfigPath);
+
+    watcher.on('error', (err) => {
+      console.error(`Failed to fs.watch ${ kubeconfigPath }:`, err);
+    });
+
+    watcher.on('change', (eventType, _) => {
+      if (eventType === 'rename' && !kubeconfig.hasAccess(kubeconfigPath)) {
+        // File doesn't exist. Wait for it to be recreated
+        return;
+      }
+
+      watcher.close();
+
+      this.buildFromConfig(kubeconfigPath);
+
+      setTimeout(this.watchOnceAndRestart, 1000, kubeconfigPath);
+    });
+  };
+
   constructor() {
     this.settings = load();
     this.trayMenu = new Electron.Tray(this.trayIconSet.starting);
@@ -115,18 +136,8 @@ export class Tray {
       throw new Error('No kubeconfig path found');
     }
     this.buildFromConfig(kubeconfigPath);
-    const watcher = fs.watch(kubeconfigPath);
 
-    watcher.on('error', (err) => {
-      console.error(`Failed to fs.watch ${ kubeconfigPath }:`, err);
-    });
-    watcher.on('change', (eventType, _) => {
-      if (eventType === 'rename' && !kubeconfig.hasAccess(kubeconfigPath)) {
-        // File doesn't exist. Wait for it to be recreated
-        return;
-      }
-      this.buildFromConfig(kubeconfigPath);
-    });
+    this.watchOnceAndRestart(kubeconfigPath);
 
     mainEvents.on('k8s-check-state', (mgr) => {
       this.k8sStateChanged(mgr.state);

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -85,6 +85,11 @@ export class Tray {
 
   private readonly trayIconSet = this.isMacOs() ? this.trayIconsMacOs : this.trayIcons;
 
+  /**
+   * Create a watcher for the provided kubeconfigPath; when the change event is
+   * triggered, close the watcher and restart after a duration (1 second)
+   * @param kubeconfigPath The path to watch for Kubernetes config changes
+   */
   private watchOnceAndRestart = (kubeconfigPath: string) => {
     const watcher = fs.watch(kubeconfigPath);
 


### PR DESCRIPTION
This replaces `fs.watch` with a `watchOnceAndRestart` function in an attempt to resolve an issue where `fs.watch` will trigger at least once and then silently fail. By closing and restarting the watcher, we can more reliably watch for changes in the kubeconfig path.

Issues with `fs.watch` seems to be well circulated, some are [clearly noted in the node docs](https://nodejs.org/docs/latest-v16.x/api/fs.html#caveats). It looks like [Chokidar](https://github.com/paulmillr/chokidar) is a highly recommended replacement for `fs.watch`, but I figured I'd take an attempt at resolving this issue before relying on a new dependency. 

Some considerations

* recursively closing and restarting the watcher might not be an efficient solution
* we have a best-case 1 second delay between closing and restarting the watcher; we can miss events in this duration
* we don't have any means to restart the watcher if it fails like it currently is today

closes #1037 