### PR TITLE
Support API passwords that contain embedded colons.

### DIFF
--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -110,8 +110,8 @@ export class HttpCommandServer {
 
       return false;
     }
-    const [user, password] = base64Decode(m[1])
-      .split(':', 2);
+    const [user, ...passwordParts] = base64Decode(m[1]).split(':');
+    const password = passwordParts.join(':');
 
     if (user !== SERVER_USERNAME || password !== this.password) {
       console.log(`Auth failure: user/password validation failure for attempted login of user ${ user }`);


### PR DESCRIPTION
No existing issue.

Not an existing bug. Right now the password is hardwired to a string
of 16 alphanumeric characters, but chances are we'll allow users to
set the password, and we need to allow it to contain ':' characters.

Bug caused by the fact that in JS

`a:b:c`.split(':', 2)` => `['a', 'b']` and the rest is discarded.

Signed-off-by: Eric Promislow <epromislow@suse.com>