### PR TITLE
Align dialog buttons to the right

### DIFF
--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -29,7 +29,7 @@
         </div>
       </div>
     </div>
-    <button data-test="accept-btn" class="role-primary accept-button" @click="close">
+    <button data-test="accept-btn" class="role-primary primary-action" @click="close">
       Close
     </button>
   </div>
@@ -144,7 +144,7 @@ export default Vue.extend({
     }
   }
 
-  .accept-button {
+  .primary-action {
     align-self: flex-end;
   }
 </style>

--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -29,13 +29,9 @@
         </div>
       </div>
     </div>
-    <footer class="page-footer">
-      <div class="button-area">
-        <button data-test="accept-btn" class="role-primary" @click="close">
-          Close
-        </button>
-      </div>
-    </footer>
+    <button data-test="accept-btn" class="role-primary accept-button" @click="close">
+      Close
+    </button>
   </div>
 </template>
 
@@ -148,13 +144,7 @@ export default Vue.extend({
     }
   }
 
-  .button-area {
-    max-height: 4rem;
-    float: left;
-    margin-left: 1rem;
-  }
-
-  .page-footer {
-    min-height: 60px;
+  .accept-button {
+    align-self: flex-end;
   }
 </style>

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -33,7 +33,7 @@
       v-model="suppress"
       label="Always run without administrative access"
     />
-    <button ref="accept" class="role-primary accept-button" @click="close">
+    <button ref="accept" class="role-primary primary-action" @click="close">
       OK
     </button>
   </div>
@@ -145,7 +145,7 @@ export default Vue.extend({
   #suppress {
     margin: 1em;
   }
-  .accept-button {
+  .primary-action {
     align-self: flex-end;
   }
 </style>

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -33,7 +33,7 @@
       v-model="suppress"
       label="Always run without administrative access"
     />
-    <button ref="accept" class="role-primary" @click="close">
+    <button ref="accept" class="role-primary accept-button" @click="close">
       OK
     </button>
   </div>
@@ -144,5 +144,8 @@ export default Vue.extend({
   }
   #suppress {
     margin: 1em;
+  }
+  .accept-button {
+    align-self: flex-end;
   }
 </style>


### PR DESCRIPTION
This provides consistency in our dialogs by aligning primary buttons for both Kubernetes Errors and Sudo Prompt to the right.

closes #2041