### PR TITLE
Remove legacy symlinks on macOS

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -136,8 +136,7 @@ Electron.app.whenReady().then(async() => {
       await removeLegacySymlinks(paths.oldIntegration);
     } catch (error) {
       if (error instanceof PermissionError) {
-        const msg = `Rancher Desktop detected legacy tool symlinks in ${paths.integration}, but did not have the required permissions to remove them. Please remove them at your earliest convenience.\n\nThe legacy tools are:\none\ntwo\nthree`;
-        alert(msg);
+        await window.openLegacyIntegrations();
       } else {
         throw error;
       }

--- a/background.ts
+++ b/background.ts
@@ -132,16 +132,6 @@ Electron.app.whenReady().then(async() => {
     installDevtools();
     setupProtocolHandler();
 
-    try {
-      await removeLegacySymlinks(paths.oldIntegration);
-    } catch (error) {
-      if (error instanceof PermissionError) {
-        await window.openLegacyIntegrations();
-      } else {
-        throw error;
-      }
-    }
-
     await integrationManager.enforce();
     await doFirstRun();
 
@@ -166,6 +156,16 @@ Electron.app.whenReady().then(async() => {
     // Path management strategy will need to be selected after an upgrade
     if (!os.platform().startsWith('win') && cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
       await window.openPathUpdate();
+    }
+
+    try {
+      await removeLegacySymlinks(paths.oldIntegration);
+    } catch (error) {
+      if (error instanceof PermissionError) {
+        await window.openLegacyIntegrations();
+      } else {
+        throw error;
+      }
     }
 
     await startBackend(cfg);

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -278,11 +278,10 @@ pathManagement:
   accept: Accept
 
 legacyIntegrations:
-  title: Rancher Desktop - Legacy Integrations Found
+  title: Legacy Integrations Found
   messageFirstPart: Rancher Desktop detected legacy tool symlinks in
-  messageSecondPart: >
-    but did not have the required permissions to remove them.
-    Please remove them at your earliest convenience.
+  messageSecondPart: but did not have the required permissions to remove them.
+  messageThirdPart: Please remove them at your earliest convenience.
   ok: Ok
 
 accountAndKeys:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -279,17 +279,17 @@ pathManagement:
 
 legacyIntegrations:
   title: Legacy Integrations Found
-  tooltip: >
-    Rancher Desktop creates symlinks from bundled tools, such as kubectl and docker,
-    to a directory in order to make them usable. This directory changed in Rancher Desktop
-    1.3.0. If you're seeing this message, Rancher Desktop was unable to remove the symlinks
-    from the old directory automatically. You should remove them manually to prevent future
-    path conflicts.
   messageFirstPart: Rancher Desktop detected legacy tool symlinks in
   messageSecondPart: but did not have the permissions required to remove them.
   messageThirdPart: >
     Legacy symlinks have the potential to cause path conflicts.
     Please remove them at your earliest convenience.
+  details: >
+    Rancher Desktop creates symlinks from bundled tools, such as kubectl and docker,
+    to a directory in order to make them usable. This directory changed in Rancher Desktop
+    1.3.0. If you are seeing this message, Rancher Desktop was unable to remove the symlinks
+    from the old directory automatically. You should remove them manually to prevent future
+    path conflicts.
   ok: Ok
 
 accountAndKeys:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -277,6 +277,14 @@ pathManagement:
       description: 'Rancher Desktop does not change your PATH configuration; add <code>~/.rd/bin</code> to your path manually.'
   accept: Accept
 
+legacyIntegrations:
+  title: Rancher Desktop - Legacy Integrations Found
+  messageFirstPart: Rancher Desktop detected legacy tool symlinks in
+  messageSecondPart: >
+    but did not have the required permissions to remove them.
+    Please remove them at your earliest convenience.
+  ok: Ok
+
 accountAndKeys:
   title: Account and API Keys
   account:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -279,9 +279,17 @@ pathManagement:
 
 legacyIntegrations:
   title: Legacy Integrations Found
+  tooltip: >
+    Rancher Desktop creates symlinks from bundled tools, such as kubectl and docker,
+    to a directory in order to make them usable. This directory changed in Rancher Desktop
+    1.3.0. If you're seeing this message, Rancher Desktop was unable to remove the symlinks
+    from the old directory automatically. You should remove them manually to prevent future
+    path conflicts.
   messageFirstPart: Rancher Desktop detected legacy tool symlinks in
-  messageSecondPart: but did not have the required permissions to remove them.
-  messageThirdPart: Please remove them at your earliest convenience.
+  messageSecondPart: but did not have the permissions required to remove them.
+  messageThirdPart: >
+    Legacy symlinks have the potential to cause path conflicts.
+    Please remove them at your earliest convenience.
   ok: Ok
 
 accountAndKeys:

--- a/src/integrations/__tests__/legacy.spec.ts
+++ b/src/integrations/__tests__/legacy.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import removeLegacySymlinks from '@/integrations/legacy';
+import { removeLegacySymlinks } from '@/integrations/legacy';
 
 const TMPDIR_PREFIX = 'rdtest-';
 

--- a/src/integrations/legacy.ts
+++ b/src/integrations/legacy.ts
@@ -11,6 +11,7 @@ const LEGACY_INTEGRATION_NAMES = [
   'nerdctl',
   'steve',
   'trivy',
+  'rdctl',
 ];
 
 type EaccesError = {

--- a/src/integrations/legacy.ts
+++ b/src/integrations/legacy.ts
@@ -33,13 +33,14 @@ export class PermissionError {
 // of managing integrations. Ensures a clean transition to the new
 // strategy. Idempotent.
 export async function removeLegacySymlinks(legacyIntegrationDir: string): Promise<void> {
-  const settledPromises = await Promise.allSettled(LEGACY_INTEGRATION_NAMES.map(async(name) => {
-      const linkPath = path.join(legacyIntegrationDir, name);
+  const settledPromises = await Promise.allSettled(LEGACY_INTEGRATION_NAMES.map((name) => {
+    const linkPath = path.join(legacyIntegrationDir, name);
 
-      return manageSymlink('', linkPath, false);
+    return manageSymlink('', linkPath, false);
   }));
 
   const permissionErrors = [];
+
   for (const settledPromise of settledPromises) {
     if (settledPromise.status === 'rejected') {
       if (settledPromise.reason.code === 'EACCES') {

--- a/src/integrations/legacy.ts
+++ b/src/integrations/legacy.ts
@@ -13,13 +13,43 @@ const LEGACY_INTEGRATION_NAMES = [
   'trivy',
 ];
 
+type EaccesError = {
+  errno: number;
+  code: string;
+  syscall: string;
+  path: string;
+}
+
+export class PermissionError {
+  errors: EaccesError[] = [];
+
+  constructor(errors: EaccesError[]) {
+    this.errors = errors;
+  }
+}
+
 // Removes any symlinks that may remain from the previous strategy
 // of managing integrations. Ensures a clean transition to the new
 // strategy. Idempotent.
-export default async function removeLegacySymlinks(legacyIntegrationDir: string): Promise<void> {
-  await Promise.all(LEGACY_INTEGRATION_NAMES.map(async(name) => {
-    const linkPath = path.join(legacyIntegrationDir, name);
+export async function removeLegacySymlinks(legacyIntegrationDir: string): Promise<void> {
+  const settledPromises = await Promise.allSettled(LEGACY_INTEGRATION_NAMES.map(async(name) => {
+      const linkPath = path.join(legacyIntegrationDir, name);
 
-    await manageSymlink('', linkPath, false);
+      return manageSymlink('', linkPath, false);
   }));
+
+  const permissionErrors = [];
+  for (const settledPromise of settledPromises) {
+    if (settledPromise.status === 'rejected') {
+      if (settledPromise.reason.code === 'EACCES') {
+        permissionErrors.push(settledPromise.reason);
+      } else {
+        throw settledPromise.reason;
+      }
+    }
+  }
+
+  if (permissionErrors.length > 0) {
+    throw new PermissionError(permissionErrors);
+  }
 }

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -25,7 +25,7 @@ export default Vue.extend({
   <div>
     <h3>
       {{ t('legacyIntegrations.title') }}
-      <i v-tooltip="'this is a tooltip'" class="icon icon-info icon-lg" />
+      <i v-tooltip="t('legacyIntegrations.tooltip')" class="icon icon-info icon-lg" />
     </h3>
     <p>
       {{ t('legacyIntegrations.messageFirstPart') }}

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
     ipcRenderer.send('dialog/ready');
   },
   methods: {
-    async close() {
+    close() {
       window.close();
     }
   },

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -1,0 +1,48 @@
+<script lang="ts">
+import Vue from 'vue';
+import { ipcRenderer } from 'electron';
+import paths from '@/utils/paths';
+
+export default Vue.extend({
+  layout:     'dialog',
+  computed: {
+    oldIntegrationPath() {
+      return paths.oldIntegration;
+    },
+  },
+  mounted() {
+    ipcRenderer.send('dialog/ready');
+  },
+  methods: {
+    async close() {
+      window.close();
+    }
+  },
+});
+</script>
+
+<template>
+  <div>
+    <h3>{{ t('app.name') }}</h3>
+    <p>
+      Rancher Desktop detected legacy tool symlinks in {{ oldIntegrationPath }},
+      but did not have the required permissions to remove them. Please remove
+      them at your earliest convenience.
+    </p>
+    <div class="button-area">
+      <button
+        data-test="accept-btn"
+        class="role-primary"
+        @click="close"
+      >
+        Ok
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .button-area {
+    align-self: flex-end;
+  }
+</style>

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -29,6 +29,9 @@ export default Vue.extend({
       <code>{{ oldIntegrationPath }}</code>
       {{ t('legacyIntegrations.messageSecondPart') }}
     </p>
+    <p>
+      {{ t('legacyIntegrations.messageThirdPart') }}
+    </p>
     <div class="button-area">
       <button
         data-test="accept-btn"

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -23,11 +23,11 @@ export default Vue.extend({
 
 <template>
   <div>
-    <h3>{{ t('app.name') }}</h3>
+    <h3>{{ t('legacyIntegrations.title') }}</h3>
     <p>
-      Rancher Desktop detected legacy tool symlinks in {{ oldIntegrationPath }},
-      but did not have the required permissions to remove them. Please remove
-      them at your earliest convenience.
+      {{ t('legacyIntegrations.messageFirstPart') }}
+      <code>{{ oldIntegrationPath }}</code>
+      {{ t('legacyIntegrations.messageSecondPart') }}
     </p>
     <div class="button-area">
       <button
@@ -35,7 +35,7 @@ export default Vue.extend({
         class="role-primary"
         @click="close"
       >
-        Ok
+        {{ t('legacyIntegrations.ok') }}
       </button>
     </div>
   </div>
@@ -44,5 +44,10 @@ export default Vue.extend({
 <style lang="scss" scoped>
   .button-area {
     align-self: flex-end;
+  }
+  code {
+    user-select: text;
+    cursor: text;
+    padding: 2px;
   }
 </style>

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -23,7 +23,10 @@ export default Vue.extend({
 
 <template>
   <div>
-    <h3>{{ t('legacyIntegrations.title') }}</h3>
+    <h3>
+      {{ t('legacyIntegrations.title') }}
+      <i v-tooltip="'this is a tooltip'" class="icon icon-info icon-lg" />
+    </h3>
     <p>
       {{ t('legacyIntegrations.messageFirstPart') }}
       <code>{{ oldIntegrationPath }}</code>

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -23,10 +23,7 @@ export default Vue.extend({
 
 <template>
   <div>
-    <h3>
-      {{ t('legacyIntegrations.title') }}
-      <i v-tooltip="t('legacyIntegrations.tooltip')" class="icon icon-info icon-lg" />
-    </h3>
+    <h3>{{ t('legacyIntegrations.title') }}</h3>
     <p>
       {{ t('legacyIntegrations.messageFirstPart') }}
       <code>{{ oldIntegrationPath }}</code>
@@ -35,6 +32,11 @@ export default Vue.extend({
     <p>
       {{ t('legacyIntegrations.messageThirdPart') }}
     </p>
+    <details>
+      <summary>More Info</summary>
+      <br>
+      <p>{{ t('legacyIntegrations.details') }}</p>
+    </details>
     <div class="button-area">
       <button
         data-test="accept-btn"

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -256,14 +256,12 @@ export async function openLegacyIntegrations(): Promise<void> {
   const window = openDialog(
     'LegacyIntegrationNotification',
     {
-      title:  'Rancher Desktop - Legacy Integrations',
-      frame:  true,
-      width:  500,
-      height: 240,
-      webPreferences: {
-        enablePreferredSizeMode: false,
-      },
-      parent: getWindow('preferences') ?? undefined,
+      title:          'Rancher Desktop - Legacy Integrations',
+      frame:          true,
+      width:          500,
+      height:         240,
+      webPreferences: { enablePreferredSizeMode: false },
+      parent:         getWindow('preferences') ?? undefined,
     }
   );
 

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -256,7 +256,7 @@ export async function openLegacyIntegrations(): Promise<void> {
   const window = openDialog(
     'LegacyIntegrationNotification',
     {
-      title:  'This is the title',
+      title:  'Rancher Desktop - Legacy Integrations',
       frame:  true,
       parent: getWindow('preferences') ?? undefined,
     }

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -258,6 +258,11 @@ export async function openLegacyIntegrations(): Promise<void> {
     {
       title:  'Rancher Desktop - Legacy Integrations',
       frame:  true,
+      width:  500,
+      height: 200,
+      webPreferences: {
+        enablePreferredSizeMode: false,
+      },
       parent: getWindow('preferences') ?? undefined,
     }
   );

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -259,7 +259,7 @@ export async function openLegacyIntegrations(): Promise<void> {
       title:  'Rancher Desktop - Legacy Integrations',
       frame:  true,
       width:  500,
-      height: 200,
+      height: 240,
       webPreferences: {
         enablePreferredSizeMode: false,
       },

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -238,7 +238,7 @@ export async function openSudoPrompt(explanations: Record<string, string[]>): Pr
   return result;
 }
 
-export async function openPathUpdate() {
+export async function openPathUpdate(): Promise<void> {
   const window = openDialog(
     'PathUpdate',
     {
@@ -246,6 +246,21 @@ export async function openPathUpdate() {
       frame:  true,
       parent: getWindow('preferences') ?? undefined,
     });
+
+  await (new Promise<void>((resolve) => {
+    window.on('closed', resolve);
+  }));
+}
+
+export async function openLegacyIntegrations(): Promise<void> {
+  const window = openDialog(
+    'LegacyIntegrationNotification',
+    {
+      title: 'This is the title',
+      frame: true,
+      parent: getWindow('preferences') ?? undefined,
+    }
+  );
 
   await (new Promise<void>((resolve) => {
     window.on('closed', resolve);

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -256,8 +256,8 @@ export async function openLegacyIntegrations(): Promise<void> {
   const window = openDialog(
     'LegacyIntegrationNotification',
     {
-      title: 'This is the title',
-      frame: true,
+      title:  'This is the title',
+      frame:  true,
       parent: getWindow('preferences') ?? undefined,
     }
   );


### PR DESCRIPTION
Closes #1984.

The idea here is to try to remove legacy symlinks if we can. But if we can't due to a permissions error (which is the expected case on macOS, where the old integration directory is `/usr/local/bin/`, which is owned by root), we want to make a popup that explains that legacy symlinks are there, and that the user should remove them manually.

I haven't tested this on macOS, since I don't have a machine that runs it. However I did test it on my Linux machine and it worked fine.

Finally, I had to do a bit of UI work for this, and I'm not sure I did it right. I think we should provide an answer to the question, "what is a legacy tool symlink?" However, I'm not sure what the best place to put this would be. A tooltip? Just have two paragraphs? @rak-phillip maybe you have a better idea.