### PR TITLE
Remove BrowserView implmentation

### DIFF
--- a/src/window/dashboard.ts
+++ b/src/window/dashboard.ts
@@ -15,30 +15,17 @@ export function openDashboard() {
   window = new BrowserWindow({
     title:  'Rancher Dashboard',
     width:  800,
-    height: 600
+    height: 600,
+    show:   false
   });
 
-  const view = new BrowserView();
-  const windowSize = window.getContentSize();
-
-  window.setBrowserView(view);
-
-  view.setBounds({
-    x:      0,
-    y:      0,
-    width:  windowSize[0],
-    height: windowSize[1],
-  });
-
-  view.setAutoResize({ width: true, height: true });
-
-  view.webContents
-    .loadURL(dashboardURL)
-    .catch((err) => {
-      console.error(`Can't load the dashboard URL ${ dashboardURL }: `, err);
-    });
+  window.loadURL(dashboardURL);
 
   windowMapping['dashboard'] = window.id;
+
+  window.once('ready-to-show', () => {
+    window?.show();
+  })
 }
 
 export function closeDashboard() {

--- a/src/window/dashboard.ts
+++ b/src/window/dashboard.ts
@@ -25,7 +25,7 @@ export function openDashboard() {
 
   window.once('ready-to-show', () => {
     window?.show();
-  })
+  });
 }
 
 export function closeDashboard() {


### PR DESCRIPTION
This removes the `BrowserView` implementation for rendering dashboard content. `BrowserView` was causing some issues on certain Linux DEs where it would not render until resizing the window. 

I attempted to subscribe to several window events that would potentially help with making sure that content would render, but the most simple solution was to remove the `BrowserView`, as it's not needed for the time being.

closes #1969 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>