### PR TITLE
Changes modals text so its more clear that is the VM restarting

### DIFF
--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -363,7 +363,7 @@ export default {
     async handleDisableKubernetesCheckbox(value) {
       if (value !== this.settings.kubernetes.enabled) {
         const confirmationMessage = [
-          `${ value ? 'Enabling' : 'Disabling' } Kubernetes requires a restart. `,
+          `${ value ? 'Enabling' : 'Disabling' } Kubernetes requires a VM restart. `,
           '\n\nDo you want to proceed?'
         ].join('');
 

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -363,7 +363,7 @@ export default {
     async handleDisableKubernetesCheckbox(value) {
       if (value !== this.settings.kubernetes.enabled) {
         const confirmationMessage = [
-          `${ value ? 'Enabling' : 'Disabling' } Kubernetes requires a VM restart. `,
+          `${ value ? 'Enabling' : 'Disabling' } Kubernetes will require restarting the virtual machine `,
           '\n\nDo you want to proceed?'
         ].join('');
 


### PR DESCRIPTION
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/1710

The initial message can indicate something different in MacOS context (as per issue description).
Changed the modal notification so it's more clear that is the VM restarting and not the Application or System.

Signed-off-by: Sorin C <scurescu@suse.com>