### PR TITLE
Add missing check for linux or darwin when removing legacy symlinks

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -159,13 +159,15 @@ Electron.app.whenReady().then(async() => {
       await window.openPathUpdate();
     }
 
-    try {
-      await removeLegacySymlinks(paths.oldIntegration);
-    } catch (error) {
-      if (error instanceof PermissionError) {
-        await window.openLegacyIntegrations();
-      } else {
-        throw error;
+    if (os.platform() === 'linux' || os.platform() === 'darwin') {
+      try {
+        await removeLegacySymlinks(paths.oldIntegration);
+      } catch (error) {
+        if (error instanceof PermissionError) {
+          await window.openLegacyIntegrations();
+        } else {
+          throw error;
+        }
       }
     }
 


### PR DESCRIPTION
As Guna said on Slack:

> Hi Adam, Good morning
I am testing the latest main build on WINDOWS,... I ran into an app launch issue.. After installation, the app doesn't start.. I see below error message in the background.log
```
2022-04-22T15:36:46.856Z: Error starting up: Error: Internal error: oldIntegration path not available for Windows
    at x.get oldIntegration [as oldIntegration] (C:\Users\GunasekharMatamalam\AppData\Local\Programs\Rancher Desktop\resources\app.asar\dist\app\background.js:17:136124)
    at C:\Users\GunasekharMatamalam\AppData\Local\Programs\Rancher Desktop\resources\app.asar\dist\app\background.js:29:86500
```

The problem was that we were trying to run `await removeLegacySymlinks(paths.oldIntegration);` on Windows.