### PR TITLE
Change missed occurences of `WSL Integration` to `WSL Integrations`

### DIFF
--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -75,7 +75,7 @@ test.describe.serial('Main App Test', () => {
    * Checking WSL and Port Forwarding - Windows Only
    */
   if (os.platform().startsWith('win')) {
-    test('should navigate to WSL Integration and check elements', async() => {
+    test('should navigate to WSL Integrations and check elements', async() => {
       const navPage = new NavPage(page);
       const wslPage = await navPage.navigateTo('WSLIntegrations');
 

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4587,7 +4587,7 @@ troubleshooting:
 ##############################
 integrations: 
   windows:
-    title: WSL Integration
+    title: WSL Integrations
     description: "Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros"
 
 ##############################

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -44,7 +44,7 @@ export default {
       routes: this.$nuxt.$router.getRoutes().reduce((paths, route) => {
         paths[route.path] = route;
         if (route.name === 'Supporting Utilities' && os.platform() === 'win32') {
-          route.name = 'WSL Integration';
+          route.name = 'WSL Integrations';
         }
 
         return paths;


### PR DESCRIPTION
At some point I changed the title of the `WSL Integration` tab to `WSL Integrations`. It seems I did not do this in all the places it was needed though - it was causing the E2E tests to fail on Windows. This is the fix.