### PR TITLE
Make auto-sizing dialogs more consistent

### DIFF
--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -47,6 +47,9 @@ export default Vue.extend({
   html {
     height: initial;
   }
+  body {
+    overflow: hidden;
+  }
   :root[data-flex~="width"] #__layout > .wrapper[data-loaded] {
     width: 100vw;
   }

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -50,12 +50,6 @@ export default Vue.extend({
   body {
     overflow: hidden;
   }
-  :root[data-flex~="width"] #__layout > .wrapper[data-loaded] {
-    width: 100vw;
-  }
-  :root[data-flex~="height"] #__layout > .wrapper[data-loaded] {
-    height: 100vh;
-  }
 </style>
 
 <style lang="scss" scoped>

--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="container">
     <div class="page-body">
       <div class="error-header">
         <img id="logo" src="../../resources/icons/logo-square-red@2x.png" />
@@ -94,6 +94,10 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+  .container {
+    min-width: 52rem;
+  }
+
   .error-header {
     display: flex;
     gap: 0.75rem;

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -4,7 +4,7 @@ import { ipcRenderer } from 'electron';
 import paths from '@/utils/paths';
 
 export default Vue.extend({
-  layout:     'dialog',
+  layout:   'dialog',
   computed: {
     oldIntegrationPath() {
       return paths.oldIntegration;
@@ -22,7 +22,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
+  <div class="container">
     <h3>{{ t('legacyIntegrations.title') }}</h3>
     <p>
       {{ t('legacyIntegrations.messageFirstPart') }}
@@ -50,9 +50,14 @@ export default Vue.extend({
 </template>
 
 <style lang="scss" scoped>
+  .container {
+    min-width: 32rem;
+  }
+
   .button-area {
     align-self: flex-end;
   }
+
   code {
     user-select: text;
     cursor: text;

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -58,6 +58,11 @@ export default Vue.extend({
     align-self: flex-end;
   }
 
+  summary {
+    user-select: none;
+    cursor: pointer;
+  }
+
   code {
     user-select: text;
     cursor: text;

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -75,9 +75,6 @@ export default Vue.extend({
     };
   },
   mounted() {
-    ipcRenderer.on('dialog/size', (event, size: {width: number, height: number}) => {
-      this.checkSize(size);
-    });
     ipcRenderer.on('dialog/populate', (event, explanations: Partial<Record<SudoReason, string[]>>) => {
       this.explanations = explanations;
     });
@@ -87,31 +84,6 @@ export default Vue.extend({
     (this.$refs.accept as HTMLButtonElement)?.focus();
   },
   methods: {
-    /**
-     * checkSize is triggered when the window's preferred size changes; we use
-     * this in response to the user opening one of the <details> disclosures to
-     * ensure the whole text is visible.
-     */
-    checkSize(size: {width: number, height: number}) {
-      if (!this.sized) {
-        // Initial window layout isn't done yet, don't do any sizing.
-        // Check the window size again (in a timeout) to give the window time to
-        // change sizes.
-        setTimeout(() => {
-          this.sized ||= size.width === window.outerWidth && size.height === window.outerHeight;
-        }, 0);
-
-        return;
-      }
-
-      // Because increasing the width can reduce the height requirement, we
-      // should do the resizing in two steps to get the minimum size.
-      if (size.width > window.outerWidth) {
-        window.resizeTo(size.width, window.outerHeight);
-      } else if (size.height > window.outerHeight) {
-        window.resizeTo(window.outerWidth, size.height);
-      }
-    },
     close() {
       // Manually send the result, because we won't get an event here.
       ipcRenderer.send('sudo-prompt/closed', this.suppress);

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -103,20 +103,30 @@ export default Vue.extend({
   .contents {
     padding: 2em;
   }
+
+  summary {
+    user-select: none;
+    cursor: pointer;
+  }
+
   li, p {
     margin: 0.5em;
   }
+
   ul.reasons {
     list-style-type: none;
     padding-left: 0;
   }
+
   li.monospace {
     /* font-family is set in _typography.scss */
     white-space: pre;
   }
+
   #suppress {
     margin: 1em;
   }
+
   .primary-action {
     align-self: flex-end;
   }

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -6,7 +6,7 @@ import Logging from '@/utils/logging';
 import { IpcRendererEvents } from '@/typings/electron-ipc';
 import * as K8s from '@/k8s-engine/k8s';
 
-// const console = Logging.background;
+const console = Logging.background;
 
 /**
  * A mapping of window key (which is our own construct) to a window ID (which is

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -258,9 +258,6 @@ export async function openLegacyIntegrations(): Promise<void> {
     {
       title:          'Rancher Desktop - Legacy Integrations',
       frame:          true,
-      width:          500,
-      height:         240,
-      webPreferences: { enablePreferredSizeMode: false },
       parent:         getWindow('preferences') ?? undefined,
     }
   );

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -127,6 +127,7 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
       autoHideMenuBar: !app.isPackaged,
       show:            false,
       modal:           true,
+      resizable:       false,
       ...opts ?? {},
       webPreferences:  {
         devTools:                !app.isPackaged,

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import Electron, { BrowserWindow, app, shell } from 'electron';
 import _ from 'lodash';
 
@@ -148,17 +149,23 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
   });
 
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
-    const preferences = getWindow('preferences');
-    const { x: prefX, y: prefY, width: prefWidth } = preferences?.getBounds() || {
-      x: 0, y: 0, width: 0, height: 0
-    };
-    const centered = prefX + Math.round((prefWidth / 2) - (width / 2));
+    if (os.platform() === 'linux') {
+      const preferences = getWindow('preferences');
+      const { x: prefX, y: prefY, width: prefWidth } = preferences?.getBounds() || {
+        x: 0, y: 0, width: 0, height: 0
+      };
+      const centered = prefX + Math.round((prefWidth / 2) - (width / 2));
 
-    window.setContentBounds(
-      {
-        x: centered, y: prefY, width, height
-      }
-    );
+      window.setContentBounds(
+        {
+          x: centered, y: prefY, width, height
+        }
+      );
+
+      return;
+    }
+
+    window.setContentSize(width, height, true);
   });
 
   return window;

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -147,36 +147,18 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
     }
   });
 
-  const preferences = getWindow('preferences');
-
-  const [_initX, initY] = window.getPosition();
-
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
+    const preferences = getWindow('preferences');
     const { x: prefX, y: prefY, width: prefWidth } = preferences?.getBounds() || {
       x: 0, y: 0, width: 0, height: 0
     };
-    // window.setContentSize(width, height, true);
-    const newPos = prefX + Math.round((prefWidth / 2) - (width / 2));
+    const centered = prefX + Math.round((prefWidth / 2) - (width / 2));
 
-    window.setBounds(
+    window.setContentBounds(
       {
-        x: newPos, y: prefY, width, height
+        x: centered, y: prefY, width, height
       }
     );
-
-    // window.setPosition(x, y);
-    // window.setSize(width, height);
-
-    // window.setContentBounds(
-    //   {
-    //     x, y, width, height
-    //   },
-    //   true
-    // );
-
-    // const [windowWidth, windowHeight] = window.getSize();
-
-    // window.setMinimumSize(windowWidth, windowHeight);
   });
 
   return window;

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -116,7 +116,6 @@ export function openPreferences() {
  * @param window Electron Browser Window that needs to be resized
  * @param width Width of the browser window
  * @param height Height of the browser window
- * @returns void
  */
 function resizeWindow(window: Electron.BrowserWindow, width: number, height: number): void {
   const parent = window.getParentWindow();
@@ -207,7 +206,7 @@ export async function openKubernetesErrorMessageWindow(titlePart: string, mainMe
     width:  800,
     height: 494,
     parent: getWindow('preferences') ?? undefined,
-    frame:  true
+    frame:  true,
   });
 
   window.webContents.on('ipc-message', (event, channel) => {


### PR DESCRIPTION
This attempts to make auto-sizing of dialogs more consistent through the following:

1. Some scenarios would cause the buttons to be cut off by a few pixels. This seemed to be related to the pattern where we stop watching for resize events after we've determined that a window was `sized`
2. Dialogs that expand details would shift position downward by about 20px on linux. This seems to be rooted in some inconsistencies with how electron reports window positioning

closes #2111
