### PR TITLE
Bump lima, alpine iso, and wsl distro versions

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,12 +7,12 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.22';
+const limaTag = 'v1.23';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.9';
+const alpineLimaTag = 'v0.2.11';
 const alpineLimaEdition = 'rd';
-const alpineLimaVersion = '3.14.3';
+const alpineLimaVersion = '3.15.4';
 
 async function getLima(platform) {
   const url = `${ limaRepo }/releases/download/${ limaTag }/lima-and-qemu.${ platform }.tar.gz`;

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -8,7 +8,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.20';
+  const v = '0.21';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -170,9 +170,9 @@ interface SudoCommand {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.9';
+const IMAGE_VERSION = '0.2.11';
 const ALPINE_EDITION = 'rd';
-const ALPINE_VERSION = '3.14.3';
+const ALPINE_VERSION = '3.15.4';
 
 /** The following files, and their parents up to /, must only be writable by root,
  *  and none of them are allowed to be symlinks (lima-vm requirements).

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -66,7 +66,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.20';
+const DISTRO_VERSION = '0.21';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
lima-and-qemu 1.22 → 1.23
Alpine 3.14.3-0.2.9 → 3.15.4-0.2.11
wsl-distro 0.20 → 0.21

* lima gets experimental 9p support
* iso and distro get nerdctl 0.19.0, and cri-dockerd metrics fixes
* distro adds apk-tools
