### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/src/integrations/__tests__/legacy.spec.ts
+++ b/src/integrations/__tests__/legacy.spec.ts
@@ -5,6 +5,7 @@ import { removeLegacySymlinks } from '@/integrations/legacy';
 
 const TMPDIR_PREFIX = 'rdtest-';
 
+const testUnix = os.platform() === 'win32' ? test.skip : test;
 const resourcesDir = path.join('resources', os.platform(), 'bin');
 let testDir: string;
 let someOtherDir: string;
@@ -24,7 +25,7 @@ afterEach(async() => {
   }
 });
 
-test('Ensure legacy symlinks are removed properly', async() => {
+testUnix('Ensure legacy symlinks are removed properly', async() => {
   // make managed symlinks (these should be removed)
   const managedLegacySymlinks = ['docker', 'kubectl'];
 

--- a/src/integrations/__tests__/manageLinesInFile.spec.ts
+++ b/src/integrations/__tests__/manageLinesInFile.spec.ts
@@ -29,7 +29,7 @@ test("Create file when true and it doesn't yet exist", async() => {
 ${ TEST_LINE_1 }
 ${ END_LINE }`;
 
-  expect(content).toBe(expectedContents);
+  expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
 });
 
 test('Delete file when false and it contains only the managed lines', async() => {
@@ -53,7 +53,7 @@ ${ START_LINE }
 ${ TEST_LINE_1 }
 ${ END_LINE }`;
 
-  expect(content).toBe(expectedContents);
+  expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
 });
 
 test('Remove lines from file that exists and has content', async() => {
@@ -67,7 +67,7 @@ ${ END_LINE }`;
   await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
   const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
 
-  expect(newContents).toBe(unmanagedContents);
+  expect(newContents.replace(/\r\n/g, '\n')).toBe(unmanagedContents.replace(/\r\n/g, '\n'));
 });
 
 test('Update managed lines', async() => {
@@ -89,7 +89,7 @@ ${ TEST_LINE_2 }
 ${ END_LINE }
 ${ bottomUnmanagedContents }`;
 
-  expect(newContents).toBe(expectedNewContents);
+  expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents.replace(/\r\n/g, '\n'));
 });
 
 test('Remove managed lines from between unmanaged lines', async() => {
@@ -107,7 +107,7 @@ ${ bottomUnmanagedContents }`;
   const expectedNewContents = `${ topUnmanagedContents }
 ${ bottomUnmanagedContents }`;
 
-  expect(newContents).toBe(expectedNewContents);
+  expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents);
 });
 
 test('File mode should not be changed when updating a file', async() => {

--- a/src/integrations/__tests__/pathManager.spec.ts
+++ b/src/integrations/__tests__/pathManager.spec.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { RcFilePathManager } from '@/integrations/pathManager';
 
+const testUnix = os.platform() === 'win32' ? test.skip : test;
 let testDir = '';
 const savedEnv = process.env;
 
@@ -35,7 +36,7 @@ afterEach(async() => {
   await fs.promises.rm(testDir, { recursive: true, force: true });
 });
 
-test('Ensure that RcFilePathManager enforce and remove methods work', async() => {
+testUnix('Ensure that RcFilePathManager enforce and remove methods work', async() => {
   const pathManager = new RcFilePathManager();
 
   await pathManager.enforce();

--- a/src/integrations/__tests__/unixIntegrationManager.spec.ts
+++ b/src/integrations/__tests__/unixIntegrationManager.spec.ts
@@ -6,6 +6,7 @@ import UnixIntegrationManager, { manageSymlink } from '@/integrations/unixIntegr
 const INTEGRATION_DIR_NAME = 'integrationDir';
 const TMPDIR_PREFIX = 'rdtest-';
 
+const testUnix = os.platform() !== 'win32' ? test : test.skip;
 const resourcesDir = path.join('resources', os.platform(), 'bin');
 let testDir: string;
 let integrationDir: string;
@@ -45,7 +46,7 @@ afterEach(async() => {
   }
 });
 
-test('Ensure symlinks and dirs are created properly', async() => {
+testUnix('Ensure symlinks and dirs are created properly', async() => {
   const integrationManager = new UnixIntegrationManager(
     resourcesDir, integrationDir, dockerCliPluginDir);
 
@@ -63,7 +64,7 @@ test('Ensure symlinks and dirs are created properly', async() => {
   }
 });
 
-test('Ensure symlinks and dirs are removed properly', async() => {
+testUnix('Ensure symlinks and dirs are removed properly', async() => {
   await createTestSymlinks(resourcesDir, integrationDir, dockerCliPluginDir);
   const integrationManager = new UnixIntegrationManager(
     resourcesDir, integrationDir, dockerCliPluginDir);
@@ -73,7 +74,7 @@ test('Ensure symlinks and dirs are removed properly', async() => {
   expect(fs.promises.readdir(dockerCliPluginDir)).resolves.toEqual([]);
 });
 
-test('Existing docker CLI plugins should not be overwritten upon .enforce()', async() => {
+testUnix('Existing docker CLI plugins should not be overwritten upon .enforce()', async() => {
   // create existing plugin
   const existingPluginPath = path.join(dockerCliPluginDir, 'docker-compose');
   const existingPluginContents = 'meaningless contents';
@@ -91,7 +92,7 @@ test('Existing docker CLI plugins should not be overwritten upon .enforce()', as
   expect(newContents).toEqual(existingPluginContents);
 });
 
-test('Existing docker CLI plugins should not be removed upon .remove()', async() => {
+testUnix('Existing docker CLI plugins should not be removed upon .remove()', async() => {
   // create existing plugin
   const existingPluginPath = path.join(dockerCliPluginDir, 'docker-compose');
   const existingPluginContents = 'meaningless contents';
@@ -109,7 +110,7 @@ test('Existing docker CLI plugins should not be removed upon .remove()', async()
   expect(newContents).toEqual(existingPluginContents);
 });
 
-test('.enforce() should be idempotent', async() => {
+testUnix('.enforce() should be idempotent', async() => {
   const integrationManager = new UnixIntegrationManager(
     resourcesDir, integrationDir, dockerCliPluginDir);
 
@@ -125,7 +126,7 @@ test('.enforce() should be idempotent', async() => {
   expect(dockerCliDirAfterFirstCall).toEqual(dockerCliDirAfterSecondCall);
 });
 
-test('.remove() should be idempotent', async() => {
+testUnix('.remove() should be idempotent', async() => {
   const integrationManager = new UnixIntegrationManager(
     resourcesDir, integrationDir, dockerCliPluginDir);
 
@@ -146,7 +147,7 @@ test('.remove() should be idempotent', async() => {
   expect(dockerCliDirAfterFirstCall).toEqual(dockerCliDirAfterSecondCall);
 });
 
-test('.removeSymlinksOnly should remove symlinks but not integration directory', async() => {
+testUnix('.removeSymlinksOnly should remove symlinks but not integration directory', async() => {
   await createTestSymlinks(resourcesDir, integrationDir, dockerCliPluginDir);
   const integrationManager = new UnixIntegrationManager(
     resourcesDir, integrationDir, dockerCliPluginDir);
@@ -156,7 +157,7 @@ test('.removeSymlinksOnly should remove symlinks but not integration directory',
   await expect(fs.promises.readdir(dockerCliPluginDir)).resolves.toEqual([]);
 });
 
-test("manageSymlink should create the symlink if it doesn't exist", async() => {
+testUnix("manageSymlink should create the symlink if it doesn't exist", async() => {
   const srcPath = path.join(resourcesDir, 'kubectl');
   const dstPath = path.join(testDir, 'kubectl');
 
@@ -169,7 +170,7 @@ test("manageSymlink should create the symlink if it doesn't exist", async() => {
   return fs.promises.readlink(dstPath);
 });
 
-test('manageSymlink should do nothing if file is correct symlink', async() => {
+testUnix('manageSymlink should do nothing if file is correct symlink', async() => {
   const srcPath = path.join(resourcesDir, 'kubectl');
   const dstPath = path.join(testDir, 'kubectl');
 
@@ -181,7 +182,7 @@ test('manageSymlink should do nothing if file is correct symlink', async() => {
   expect(newTarget).toEqual(srcPath);
 });
 
-test('manageSymlink should correct a symlink with an incorrect target', async() => {
+testUnix('manageSymlink should correct a symlink with an incorrect target', async() => {
   // create a file to target in the bad symlink
   const badSrcDir = path.join(testDir, 'resources', os.platform(), 'bin');
   const badSrcPath = path.join(badSrcDir, 'fakeKubectl');
@@ -198,7 +199,7 @@ test('manageSymlink should correct a symlink with an incorrect target', async() 
   expect(newTarget).toEqual(srcPath);
 });
 
-test("manageSymlink should not touch the file if it isn't a symlink", async() => {
+testUnix("manageSymlink should not touch the file if it isn't a symlink", async() => {
   // create the non-symlink dst file
   const contents = 'these contents should be kept';
   const dstPath = path.join(testDir, 'kubectl');
@@ -212,7 +213,7 @@ test("manageSymlink should not touch the file if it isn't a symlink", async() =>
   expect(newContents).toEqual(contents);
 });
 
-test("manageSymlink should not touch the file if it isn't a symlink we own", async() => {
+testUnix("manageSymlink should not touch the file if it isn't a symlink we own", async() => {
   const oldSrcPath = path.join(testDir, 'fakeKubectl');
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
@@ -226,7 +227,7 @@ test("manageSymlink should not touch the file if it isn't a symlink we own", asy
   expect(newTarget).toEqual(oldSrcPath);
 });
 
-test("manageSymlink should not touch the file if custom string doesn't match", async() => {
+testUnix("manageSymlink should not touch the file if custom string doesn't match", async() => {
   const oldSrcPath = path.join(testDir, 'resources', os.platform(), 'bin', 'fakeKubectl');
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
@@ -239,7 +240,7 @@ test("manageSymlink should not touch the file if custom string doesn't match", a
   expect(newTarget).toEqual(oldSrcPath);
 });
 
-test('manageSymlink should change the file if the custom string matches', async() => {
+testUnix('manageSymlink should change the file if the custom string matches', async() => {
   const customString = path.join('another', 'dir');
   const oldSrcDir = path.join(testDir, customString);
   const oldSrcPath = path.join(oldSrcDir, 'fakeKubectl');
@@ -255,7 +256,7 @@ test('manageSymlink should change the file if the custom string matches', async(
   expect(newTarget).toEqual(srcPath);
 });
 
-test('manageSymlink should delete the file if the target path matches', async() => {
+testUnix('manageSymlink should delete the file if the target path matches', async() => {
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
 
@@ -265,7 +266,7 @@ test('manageSymlink should delete the file if the target path matches', async() 
   return expect(fs.promises.readlink(dstPath)).rejects.toThrow();
 });
 
-test("manageSymlink shouldn't delete the file if the target path doesn't match", async() => {
+testUnix("manageSymlink shouldn't delete the file if the target path doesn't match", async() => {
   const oldSrcPath = path.join(testDir, 'fakeKubectl');
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
@@ -279,7 +280,7 @@ test("manageSymlink shouldn't delete the file if the target path doesn't match",
   expect(newTarget).toEqual(oldSrcPath);
 });
 
-test("manageSymlink shouldn't delete the file if it isn't a symlink", async() => {
+testUnix("manageSymlink shouldn't delete the file if it isn't a symlink", async() => {
   const oldContents = "shouldn't be changed";
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
@@ -292,7 +293,7 @@ test("manageSymlink shouldn't delete the file if it isn't a symlink", async() =>
   expect(newContents).toEqual(oldContents);
 });
 
-test('manageSymlink should do nothing if file is not present', async() => {
+testUnix('manageSymlink should do nothing if file is not present', async() => {
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
 
@@ -305,7 +306,7 @@ test('manageSymlink should do nothing if file is not present', async() => {
   return expect(testDirContentsAfter).toEqual([]);
 });
 
-test("manageSymlink should not remove the file if custom string doesn't match", async() => {
+testUnix("manageSymlink should not remove the file if custom string doesn't match", async() => {
   const oldSrcPath = path.join(testDir, 'resources', os.platform(), 'bin', 'fakeKubectl');
   const dstPath = path.join(testDir, 'kubectl');
   const srcPath = path.join(resourcesDir, 'kubectl');
@@ -318,7 +319,7 @@ test("manageSymlink should not remove the file if custom string doesn't match", 
   expect(newTarget).toEqual(oldSrcPath);
 });
 
-test('manageSymlink should remove the file if the custom string matches', async() => {
+testUnix('manageSymlink should remove the file if the custom string matches', async() => {
   const customString = path.join('another', 'dir');
   const oldSrcPath = path.join(testDir, customString, 'fakeKubectl');
   const dstPath = path.join(testDir, 'kubectl');

--- a/src/k8s-engine/__tests__/lima.spec.ts
+++ b/src/k8s-engine/__tests__/lima.spec.ts
@@ -6,10 +6,12 @@ import path from 'path';
 import K3sHelper from '../k3sHelper';
 import LimaBackend from '../lima';
 
+const describeUnix = os.platform() === 'win32' ? describe.skip : describe;
+
 jest.mock('../k3sHelper');
 jest.mock('electron', () => ({}));
 
-describe('LimaBackend', () => {
+describeUnix('LimaBackend', () => {
   describe('updateDockerContext', () => {
     /** The instance of LimaBackend under test. */
     let subj: LimaBackend;

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -199,7 +199,7 @@ export default class SettingsValidator {
 
       if (k in synonymsTable) {
         if (typeof (synonymsTable[k]) === 'object') {
-          return this.canonicalizeSettings(synonymsTable[k], newSettings[k], fqname);
+          this.canonicalizeSettings(synonymsTable[k], newSettings[k], fqname);
         } else {
           synonymsTable[k].call(this, newSettings, k);
         }


### PR DESCRIPTION
- Don't run Unix tests on Windows (Lima, things needing symlinks, etc.)
- Fix an issue in settings validator — we were not validating things correctly.
- Line ending issues.