### PR TITLE
Resolve symlinks in executable path before getting parent directory

### DIFF
--- a/src/go/rdctl/cmd/shell.go
+++ b/src/go/rdctl/cmd/shell.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 )
 
@@ -64,6 +65,10 @@ func doShellCommand(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		execPath, err := os.Executable()
+		if err != nil {
+			return err
+		}
+		execPath, err = filepath.EvalSymlinks(execPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We try to locate `../lima/bin/limactl` from `bin/rdctl`, but that doesn't work if we start from `~/.rd/bin/rdctl` because the lima directory isn't symlinked into `~/.rd`.
