### PR TITLE
rdctl start: don't wait for the app to exit.

### DIFF
--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -131,7 +131,7 @@ func launchApp(applicationPath string, commandLineArgs []string) error {
 	cmd := exec.Command(commandName, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return cmd.Start()
 }
 
 func moveToParent(fullPath string, numberTimes int) string {


### PR DESCRIPTION
`rdctl start ...` shouldn't wait for the main Rancher Desktop process to exit; that's typically long-running, and the user likely wants to be able to actually interact with that instance in the mean time (via other
rdctl commands).

I'm not changing where the output goes, because the user may still want to read any errors.