### PR TITLE
Update docs that explain Linux development versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ the versions of Rancher Desktop available from the `dev` repositories.
 The versions are in the format:
 
 ```
-<priority>.<branch>.<commit>
+<priority>.<branch>.<commit_time>.<commit>
 ```
 
 where:
@@ -181,6 +181,8 @@ branch priority over versions built from the `release-*` branches when updating.
 
 `branch` is the branch name; dashes are removed due to constraints imposed by
 package formats.
+
+`commit_time` is the UNIX timestamp on the commit.
 
 `commit` is the shortened hash of the commit used to make the build.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ branch priority over versions built from the `release-*` branches when updating.
 `branch` is the branch name; dashes are removed due to constraints imposed by
 package formats.
 
-`commit_time` is the UNIX timestamp on the commit.
+`commit_time` is the UNIX timestamp of the commit used to make the build.
 
 `commit` is the shortened hash of the commit used to make the build.
 


### PR DESCRIPTION
As per Tomas' request, I changed the version format of development packages built by OBS so that they include the timestamp. Now when he is doing his weekly testing, he can do `zypper up` in order to update RD to the build that corresponds to the latest commit on `main`.

Closes #2123. Changes have already been made to OBS.