### PR TITLE
Write to separate host-resolver log files

### DIFF
--- a/src/assets/scripts/service-host-resolver.initd
+++ b/src/assets/scripts/service-host-resolver.initd
@@ -29,6 +29,6 @@ supervisor=supervise-daemon
 command="'${RESOLVER_PEER_BINARY:-/usr/local/bin/host-resolver}'"
 command_args="vsock-peer -a $(eth0_addr)"
 
-RESOLVER_PEER_LOGFILE="${RESOLVER_PEER_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
+RESOLVER_PEER_LOGFILE="${RESOLVER_PEER_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}-peer.log}"
 output_log="'${RESOLVER_PEER_LOGFILE}'"
 error_log="'${RESOLVER_PEER_LOGFILE}'"

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -243,7 +243,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     };
     this.resolverHostProcess = new BackgroundProcess(this, 'host-resolver vsock host', async() => {
       const exe = path.join(paths.resources, 'win32', 'internal', 'host-resolver.exe');
-      const stream = await Logging['host-resolver'].fdStream;
+      const stream = await Logging['host-resolver-host'].fdStream;
 
       return childProcess.spawn(exe, ['vsock-host',
         '--built-in-hosts',


### PR DESCRIPTION
Both host-resolver vsock host and vsock peer write to the same log file. One effectively overwrites the other.