### PR TITLE
Bugfix/2145 kubernetes version

### DIFF
--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -151,6 +151,8 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
     // src/pages/FirstRun.vue.
     `${ webRoot }/index.html#${ id }`,
     {
+      width:           100,
+      height:          100,
       autoHideMenuBar: !app.isPackaged,
       show:            false,
       modal:           true,

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -169,16 +169,17 @@ function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions)
 
   window.menuBarVisible = false;
 
+  window.webContents.on('ipc-message', (_event, channel) => {
+    if (channel === 'dialog/ready') {
+      window.show();
+    }
+  });
+
   window.webContents.on('preferred-size-changed', (_event, { width, height }) => {
     if (os.platform() === 'linux') {
       resizeWindow(window, width, height);
     } else {
       window.setContentSize(width, height, true);
-    }
-
-    if (!window.isVisible()) {
-      window.show();
-      window.focus();
     }
   });
 


### PR DESCRIPTION
This reintroduces showing dialog windows on the `dialog/ready` event. By doing this, we introduce a delay to rendering the first run window until the list of k8s versions is populated. The tradeoff with this approach is that we no longer have the ability to show our window after we first settle on the actual window size via `preferred-size-changed` event. To resolve this, I set a default dialog window size of 100 x 100. This size is arbitrary, but produces a "growing" effect on first render.

I think this solution is a temporary one, and it would be a better pattern to introduce a splash screen that indicates we're waiting for something on first run.. I have noted a range of 8-30+ seconds spent waiting for the k8s version list to populate across platforms.