### PR TITLE
Bundle docker credential helpers

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -312,35 +312,39 @@ async function downloadRancherDashboard() {
   fs.rmSync(rancherDashboardPath, { maxRetries: 10 });
 }
 
-async function downloadDockerProvidedCredHelpers(platform, destDir) {
+function downloadDockerProvidedCredHelpers(platform, destDir) {
   const version = '0.6.4';
   const arch = 'amd64';
   const extension = platform.startsWith('win') ? 'zip' : 'tar.gz';
   const downloadFunc = platform.startsWith('win') ? downloadZip : downloadTarGZ;
   const credHelperNames = {
-    linux: ['docker-credential-secretservice', 'docker-credential-pass'],
+    linux:  ['docker-credential-secretservice', 'docker-credential-pass'],
     darwin: ['docker-credential-osxkeychain'],
-    win32: ['docker-credential-wincred'],
+    win32:  ['docker-credential-wincred'],
   }[platform];
   const promises = [];
   const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+
   for (const baseName of credHelperNames) {
-    const sourceUrl = `${baseUrl}/v${version}/${baseName}-v${version}-${arch}.${extension}`;
-    const binName = platform.startsWith('win') ? `${baseName}.exe` : baseName;
+    const sourceUrl = `${ baseUrl }/v${ version }/${ baseName }-v${ version }-${ arch }.${ extension }`;
+    const binName = platform.startsWith('win') ? `${ baseName }.exe` : baseName;
     const destPath = path.join(destDir, binName);
+
     promises.push(downloadFunc(sourceUrl, destPath));
   }
+
   return Promise.all(promises);
 }
 
-async function downloadECRCredHelper(platform, destDir) {
+function downloadECRCredHelper(platform, destDir) {
   const version = '0.6.0';
   const arch = 'amd64';
   const ecrLoginPlatform = platform.startsWith('win') ? 'windows' : platform;
   const baseName = 'docker-credential-ecr-login';
   const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
-  const binName = platform.startsWith('win') ? `${baseName}.exe` : baseName;
-  const sourceUrl = `${baseUrl}/${version}/${ecrLoginPlatform}-${arch}/${binName}`;
+  const binName = platform.startsWith('win') ? `${ baseName }.exe` : baseName;
+  const sourceUrl = `${ baseUrl }/${ version }/${ ecrLoginPlatform }-${ arch }/${ binName }`;
   const destPath = path.join(destDir, binName);
-  return download(sourceUrl, destPath)
+
+  return download(sourceUrl, destPath);
 }

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -312,6 +312,7 @@ async function downloadDockerCredentialHelpers(platform, destDir) {
   const dockerCredHelperVersion = '0.6.4';
   const arch = 'amd64';
   const promises = [];
+  const ecrLoginPlatform = 'windows' ? platform.startsWith('win') : platform;
 
   // download from docker repo
   switch (platform) {
@@ -321,7 +322,19 @@ async function downloadDockerCredentialHelpers(platform, destDir) {
       break;
     case 'darwin':
       // download osxkeychain
+      const baseName = 'docker-credential-osxkeychain';
+      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
+      const destPath = path.join(destDir, baseName);
+      promises.push(downloadTarGZ(sourceUrl, destPath));
+
       // download ecr login
+      const baseName = 'docker-credential-ecr-login';
+      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
+      const destPath = path.join(destDir, baseName);
+      promises.push(download(sourceUrl, destPath))
+
       break;
     case 'win32':
       // download wincred
@@ -334,7 +347,7 @@ async function downloadDockerCredentialHelpers(platform, destDir) {
       // download ecr login
       const baseName = 'docker-credential-ecr-login';
       const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
-      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${platform}-${arch}/${baseName}.exe`;
+      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}.exe`;
       const destPath = path.join(destDir, `${baseName}.exe`);
       promises.push(download(sourceUrl, destPath))
 

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -306,3 +306,41 @@ async function downloadRancherDashboard() {
 
   fs.rmSync(rancherDashboardPath, { maxRetries: 10 });
 }
+
+async function downloadDockerCredentialHelpers(platform, destDir) {
+  const ecrLoginVersion = '0.6.0';
+  const dockerCredHelperVersion = '0.6.4';
+  const arch = 'amd64';
+  const promises = [];
+
+  // download from docker repo
+  switch (platform) {
+    case 'linux':
+      // download secretservice and pass
+      // download ecr login
+      break;
+    case 'darwin':
+      // download osxkeychain
+      // download ecr login
+      break;
+    case 'win32':
+      // download wincred
+      const baseName = 'docker-credential-wincred';
+      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.zip`;
+      const destPath = path.join(destDir, `${baseName}.exe`);
+      promises.push(downloadZip(sourceUrl, destPath));
+
+      // download ecr login
+      const baseName = 'docker-credential-ecr-login';
+      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${platform}-${arch}/${baseName}.exe`;
+      const destPath = path.join(destDir, `${baseName}.exe`);
+      promises.push(download(sourceUrl, destPath))
+
+      break;
+    default:
+      throw new Error(`platform ${platform} is not supported`);
+  }
+  await Promise.all(promises);
+}

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -312,6 +312,12 @@ async function downloadRancherDashboard() {
   fs.rmSync(rancherDashboardPath, { maxRetries: 10 });
 }
 
+/**
+ * Download the docker-provided credential helpers for a specific platform.
+ * @param {string} platform The platform we're downloading for.
+ * @param {string} destDir The directory to place downloaded cred helpers in.
+ * @returns {Promise<string[]>}
+ */
 function downloadDockerProvidedCredHelpers(platform, destDir) {
   const version = '0.6.4';
   const arch = 'amd64';
@@ -336,6 +342,12 @@ function downloadDockerProvidedCredHelpers(platform, destDir) {
   return Promise.all(promises);
 }
 
+/**
+ * Download the version of docker-credential-ecr-login for a specific platform.
+ * @param {string} platform The platform we're downloading for.
+ * @param {string} destDir The directory to place downloaded cred helper in.
+ * @returns {Promise<void>}
+ */
 function downloadECRCredHelper(platform, destDir) {
   const version = '0.6.0';
   const arch = 'amd64';

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -224,6 +224,7 @@ export default async function main(platform) {
     });
 
   downloadRancherDashboard();
+  await downloadDockerCredentialHelpers(platform, binDir);
 }
 
 /**
@@ -312,55 +313,59 @@ async function downloadDockerCredentialHelpers(platform, destDir) {
   const dockerCredHelperVersion = '0.6.4';
   const arch = 'amd64';
   const promises = [];
-  const ecrLoginPlatform = 'windows' ? platform.startsWith('win') : platform;
+  const ecrLoginPlatform = platform.startsWith('win') ? 'windows' : platform;
+  let baseName = '';
+  let baseUrl = '';
+  let sourceUrl = '';
+  let destPath = '';
 
   switch (platform) {
     case 'linux':
       // download secretservice and pass
-      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
-      for (const baseName of ['docker-credential-secretservice', 'docker-credential-pass']) {
-        const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
-        const destPath = path.join(destDir, baseName);
+      baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      for (let baseName of ['docker-credential-secretservice', 'docker-credential-pass']) {
+        sourceUrl = `${baseUrl}/v${dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
+        destPath = path.join(destDir, baseName);
         promises.push(downloadTarGZ(sourceUrl, destPath));
       }
 
       // download ecr login
-      const baseName = 'docker-credential-ecr-login';
-      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
-      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
-      const destPath = path.join(destDir, baseName);
+      baseName = 'docker-credential-ecr-login';
+      baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
+      destPath = path.join(destDir, baseName);
       promises.push(download(sourceUrl, destPath))
 
       break;
     case 'darwin':
       // download osxkeychain
-      const baseName = 'docker-credential-osxkeychain';
-      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
-      const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
-      const destPath = path.join(destDir, baseName);
+      baseName = 'docker-credential-osxkeychain';
+      baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      sourceUrl = `${baseUrl}/v${dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
+      destPath = path.join(destDir, baseName);
       promises.push(downloadTarGZ(sourceUrl, destPath));
 
       // download ecr login
-      const baseName = 'docker-credential-ecr-login';
-      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
-      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
-      const destPath = path.join(destDir, baseName);
+      baseName = 'docker-credential-ecr-login';
+      baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
+      destPath = path.join(destDir, baseName);
       promises.push(download(sourceUrl, destPath))
 
       break;
     case 'win32':
       // download wincred
-      const baseName = 'docker-credential-wincred';
-      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
-      const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.zip`;
-      const destPath = path.join(destDir, `${baseName}.exe`);
+      baseName = 'docker-credential-wincred';
+      baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      sourceUrl = `${baseUrl}/v${dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.zip`;
+      destPath = path.join(destDir, `${baseName}.exe`);
       promises.push(downloadZip(sourceUrl, destPath));
 
       // download ecr login
-      const baseName = 'docker-credential-ecr-login';
-      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
-      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}.exe`;
-      const destPath = path.join(destDir, `${baseName}.exe`);
+      baseName = 'docker-credential-ecr-login';
+      baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}.exe`;
+      destPath = path.join(destDir, `${baseName}.exe`);
       promises.push(download(sourceUrl, destPath))
 
       break;

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -320,7 +320,7 @@ async function downloadRancherDashboard() {
  */
 function downloadDockerProvidedCredHelpers(platform, destDir) {
   const version = '0.6.4';
-  const arch = 'amd64';
+  const arch = process.env.M1 ? 'arm64' : 'amd64';
   const extension = platform.startsWith('win') ? 'zip' : 'tar.gz';
   const downloadFunc = platform.startsWith('win') ? downloadZip : downloadTarGZ;
   const credHelperNames = {
@@ -350,7 +350,7 @@ function downloadDockerProvidedCredHelpers(platform, destDir) {
  */
 function downloadECRCredHelper(platform, destDir) {
   const version = '0.6.0';
-  const arch = 'amd64';
+  const arch = process.env.M1 ? 'arm64' : 'amd64';
   const ecrLoginPlatform = platform.startsWith('win') ? 'windows' : platform;
   const baseName = 'docker-credential-ecr-login';
   const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -314,11 +314,23 @@ async function downloadDockerCredentialHelpers(platform, destDir) {
   const promises = [];
   const ecrLoginPlatform = 'windows' ? platform.startsWith('win') : platform;
 
-  // download from docker repo
   switch (platform) {
     case 'linux':
       // download secretservice and pass
+      const baseUrl = 'https://github.com/docker/docker-credential-helpers/releases/download';
+      for (const baseName of ['docker-credential-secretservice', 'docker-credential-pass']) {
+        const sourceUrl = `${baseUrl}/v{dockerCredHelperVersion}/${baseName}-v${dockerCredHelperVersion}-${arch}.tar.gz`;
+        const destPath = path.join(destDir, baseName);
+        promises.push(downloadTarGZ(sourceUrl, destPath));
+      }
+
       // download ecr login
+      const baseName = 'docker-credential-ecr-login';
+      const baseUrl = 'https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com';
+      const sourceUrl = `${baseUrl}/${ecrLoginVersion}/${ecrLoginPlatform}-${arch}/${baseName}`;
+      const destPath = path.join(destDir, baseName);
+      promises.push(download(sourceUrl, destPath))
+
       break;
     case 'darwin':
       // download osxkeychain


### PR DESCRIPTION
Closes #1699.

Adds code to `postinstall` script to download things like `docker-credential-secretservice` and `docker-credential-ecr-login`. Has not been tested on macOS, so if someone could do that, that would be great.