### PR TITLE
Move lima files under ~/.rd

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -32,7 +32,7 @@ import { Steve } from '@/k8s-engine/steve';
 import SettingsValidator from '@/main/commandServer/settingsValidator';
 import { getPathManagerFor, PathManagementStrategy, PathManager } from '@/integrations/pathManager';
 import { IntegrationManager, getIntegrationManager } from '@/integrations/integrationManager';
-import { removeLegacySymlinks, PermissionError } from '@/integrations/legacy';
+import { removeLegacySymlinks, migrateLimaFilesToNewLocation, PermissionError } from '@/integrations/legacy';
 import DockerDirManager from '@/utils/dockerDirManager';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 
@@ -190,6 +190,7 @@ Electron.app.whenReady().then(async() => {
           throw error;
         }
       }
+      await migrateLimaFilesToNewLocation();
     }
 
     await startBackend(cfg);

--- a/src/go/rdctl/cmd/shell.go
+++ b/src/go/rdctl/cmd/shell.go
@@ -96,12 +96,7 @@ func doShellCommand(cmd *cobra.Command, args []string) error {
 }
 
 func setupLimaHome() error {
-	var candidatePath string
-	if runtime.GOOS == "linux" {
-		candidatePath = path.Join(os.Getenv("HOME"), ".local", "share", "rancher-desktop", "lima")
-	} else {
-		candidatePath = path.Join(os.Getenv("HOME"), "Library", "Application Support", "rancher-desktop", "lima")
-	}
+	candidatePath := path.Join(os.Getenv("HOME"), ".rd", "lima")
 	stat, err := os.Stat(candidatePath)
 	if err != nil {
 		return fmt.Errorf("can't find the lima-home directory at %q", candidatePath)

--- a/src/integrations/legacy.ts
+++ b/src/integrations/legacy.ts
@@ -74,6 +74,16 @@ export async function migrateLimaFilesToNewLocation() {
   }
 
   try {
+    await fs.promises.rm(paths.lima, { recursive: true });
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      // there is no directory to delete, all good
+    } else {
+      throw new Error(`Can't delete ${ paths.lima }: err`);
+    }
+  }
+
+  try {
     await fs.promises.rename(paths.oldLima, paths.lima);
   } catch (err: any) {
     throw new Error(`Can't migrate lima configuration to ${ paths.lima }: err`);

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -60,6 +60,11 @@ describe('paths', () => {
     },
     lima: {
       win32:  new Error('lima'),
+      linux:  '%HOME%/.rd/lima/',
+      darwin: '%HOME%/.rd/lima/',
+    },
+    oldLima: {
+      win32:  new Error('oldLima'),
       linux:  '%HOME%/.local/share/rancher-desktop/lima/',
       darwin: '%HOME%/Library/Application Support/rancher-desktop/lima/',
     },
@@ -130,11 +135,11 @@ describe('paths', () => {
   });
 
   it('lima should be in one of the main subtrees', () => {
-    const pathsToDelete = [paths.cache, paths.appHome, paths.config, paths.logs];
+    const pathsToDelete = [paths.cache, paths.appHome, paths.altAppHome, paths.config, paths.logs];
     const platform = os.platform();
 
     if (['darwin', 'linux'].includes(platform)) {
-      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toEqual(platform === 'darwin');
+      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toBeTruthy();
       expect(pathsToDelete.some( dir => '/bobs/friendly/llama/farm'.startsWith(dir))).toBeFalsy();
     }
   });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -25,6 +25,8 @@ export interface Paths {
   wslDistroData: string;
   /** Directory holding Lima state (macOS-specific). */
   lima: string;
+  /** Directory that used to hold Lima state (macOS-specific). */
+  oldLima: string;
   /** Directory holding provided binary resources */
   integration: string;
   /** The directory that used to hold provided binary integrations */
@@ -53,7 +55,8 @@ export class DarwinPaths extends ProvidesResources implements Paths {
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
   logs = process.env.RD_LOGS_DIR ?? path.join(os.homedir(), 'Library', 'Logs', APP_NAME);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
-  lima = path.join(this.appHome, 'lima');
+  lima = path.join(this.altAppHome, 'lima');
+  oldLima = path.join(this.appHome, 'lima');
   oldIntegration = '/usr/local/bin';
   integration = path.join(this.altAppHome, 'bin');
 
@@ -85,6 +88,10 @@ export class Win32Paths extends ProvidesResources implements Paths {
     throw new Error('lima not available for Windows');
   }
 
+  get oldLima(): string {
+    throw new Error('lima not available for Windows');
+  }
+
   get oldIntegration(): string {
     throw new Error('Internal error: oldIntegration path not available for Windows');
   }
@@ -106,7 +113,8 @@ export class LinuxPaths extends ProvidesResources implements Paths {
   readonly config = path.join(this.configHome, APP_NAME);
   readonly logs = process.env.RD_LOGS_DIR ?? path.join(this.dataHome, APP_NAME, 'logs');
   readonly cache = path.join(this.cacheHome, APP_NAME);
-  readonly lima = path.join(this.dataHome, APP_NAME, 'lima');
+  readonly lima = path.join(this.altAppHome, 'lima');
+  readonly oldLima = path.join(this.dataHome, APP_NAME, 'lima');
   readonly integration = path.join(this.altAppHome, 'bin');
   readonly oldIntegration = path.join(os.homedir(), '.local', 'bin');
 


### PR DESCRIPTION
👋  Hello Rancher Desktop maintainers! This is my first PR in this, please bear with me!

I am attempting to fix #797. I know the current patch is rough, for now I just wanted to collect your input on whether the overall approach is reasonable or not (hence the Draft status).

Here I am taking the approach suggested in and abusing a "facility" we already had to remove legacy symlinks to move all lima files under `~/.rd`, and simultaneously poiting `LIMA_HOME` over there.

I did not find a good reason to add a symlink back so far.

Comments more than welcome!