### PR TITLE
Give sudo dialog more space

### DIFF
--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -101,7 +101,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
   .contents {
-    padding: 1rem;
+    padding: 0.75rem;
     min-width: 32rem;
   }
 
@@ -110,8 +110,10 @@ export default Vue.extend({
     cursor: pointer;
   }
 
-  li, p {
-    margin: 0.5em;
+  li {
+    &, p {
+      margin: 0.5em;
+    }
   }
 
   ul.reasons {

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -101,7 +101,8 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
   .contents {
-    padding: 2em;
+    padding: 1rem;
+    min-width: 32rem;
   }
 
   summary {
@@ -115,7 +116,8 @@ export default Vue.extend({
 
   ul.reasons {
     list-style-type: none;
-    padding-left: 0;
+    padding: 0;
+    margin: 0;
   }
 
   li.monospace {
@@ -124,7 +126,7 @@ export default Vue.extend({
   }
 
   #suppress {
-    margin: 1em;
+    margin: 0.5rem;
   }
 
   .primary-action {


### PR DESCRIPTION
This gives the sudo dialog more space to display content by setting a min width and dialing back some margins and padding around contents.

### Before

![Screen Shot 2022-05-05 at 2 36 54 PM](https://user-images.githubusercontent.com/835961/167029915-0a4f5f11-50a1-45f8-9d43-056179f52ca7.png)

### After

![Screen Shot 2022-05-05 at 2 33 47 PM](https://user-images.githubusercontent.com/835961/167029932-d691bcb9-81ae-452c-9ef3-df97b3e2d593.png)

closes #2149 
