### PR TITLE
WSL: Write out any configuration before provisioning.

### DIFF
--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1313,7 +1313,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
             if (!this.cfg?.options.flannel) {
               console.log(`Disabling flannel and network policy`);
-              k3sConf.ADDITIONAL_ARGS += '--flannel-backend=none --disable-network-policy';
+              k3sConf.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';
             }
 
             await this.writeConf('k3s', k3sConf);


### PR DESCRIPTION
This is required for provisioning to be able to change any configuration.

(This means that we shouldn't ever write out the config at the same time as starting the service; therefore the extra argument to `startService` has been removed.)