### PR TITLE
Get rid of checkbox for duplicate feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,10 +20,3 @@ body:
     description: "Add any other context/information about the problem here."
   validations:
     required: false
-- type: checkboxes
-  attributes:
-    label: Preflight Checklist
-    description: "Please ensure you've completed the following:"
-    options:
-      - label: I have searched the [issue tracker](https://github.com/rancher-sandbox/rancher-desktop/issues) for a feature request that matches the one I want to file, without success.
-        required: true


### PR DESCRIPTION
It doesn't seem to really cut down on duplicate requests, and it misleading to have each new issue listed with "1 task completed".

People mostly seem to treat this the same as "Click here to prove you are not a 🤖 ".
