### PR TITLE
Add bulk deletion for images

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -187,7 +187,7 @@ images:
         placeholder: 'registry.example.com/repo/image:tag'
         button: Build
     table:
-      label: Show all images
+      label: All images
       header:
         imageName: Image
         tag: Tag
@@ -4661,3 +4661,7 @@ legacy:
   project:
     label: Project
     select: "Use the Project/Namespace filter at the top of the page to select a Project in order to see legacy Project features."
+
+harvester:
+  tableHeaders:
+    actions: Actions

--- a/src/components/ActionDropdown.vue
+++ b/src/components/ActionDropdown.vue
@@ -59,7 +59,7 @@ export default {
 <template>
   <div class="dropdown-button-group">
     <div
-      class="dropdown-button bg-primary"
+      class="dropdown-button bg-primary btn-role-primary"
       :class="{'one-action':!dualAction, [buttonSize]:true, 'disabled': disableButton}"
     >
       <v-popover

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -183,10 +183,11 @@ export default {
                 icon:    'icon icon-upload',
               },
               {
-                label:   this.t('images.manager.table.action.delete'),
-                action:  'deleteImage',
-                enabled: this.isDeletable(image),
-                icon:    'icon icon-delete',
+                label:    this.t('images.manager.table.action.delete'),
+                action:   'deleteImage',
+                enabled:  this.isDeletable(image),
+                icon:     'icon icon-delete',
+                bulkable: true,
               },
               {
                 label:   this.t('images.manager.table.action.scan'),

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -273,17 +273,9 @@ export default {
     },
     async deleteImages() {
       const message = `Delete ${ this.imagesToDelete.length } ${ this.imagesToDelete.length > 1 ? 'images' : 'image' }?`;
-      const detail = this.imagesToDelete.reduce((prev, curr) => {
-        if (!this.isDeletable(curr)) {
-          return prev;
-        }
-
-        if (!prev) {
-          return `${ curr.imageName }:${ curr.tag }`;
-        }
-
-        return `${ prev }\n${ curr.imageName }:${ curr.tag }`;
-      }, '');
+      const detail = this.imagesToDelete
+        .map(image => `${ image.imageName }:${ image.tag }`)
+        .join('\n');
 
       const options = {
         message,

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -7,11 +7,11 @@
       <SortableTable
         ref="imagesTable"
         class="imagesTable"
-        :headers="headers"
-        :rows="rows"
         key-field="_key"
         default-sort-by="imageName"
-        :table-actions="false"
+        :headers="headers"
+        :rows="rows"
+        :table-actions="true"
         :paging="true"
       >
         <template #header-left>

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -202,7 +202,7 @@ export default {
                 enabled:    this.isDeletable(image),
                 icon:       'icon icon-delete',
                 bulkable:   true,
-                bulkAction: 'deleteImagesDebounced',
+                bulkAction: 'deleteImages',
               },
               {
                 label:   this.t('images.manager.table.action.scan'),
@@ -220,8 +220,8 @@ export default {
           if (!image.deleteImage) {
             image.deleteImage = this.deleteImage.bind(this, image);
           }
-          if (!image.deleteImagesDebounced) {
-            image.deleteImagesDebounced = this.deleteImagesDebounced.bind(this, image);
+          if (!image.deleteImages) {
+            image.deleteImages = this.deleteImages.bind(this, image);
           }
           if (!image.scanImage) {
             image.scanImage = this.scanImage.bind(this, image);
@@ -272,15 +272,7 @@ export default {
     startRunningCommand(command) {
       this.imageOutputCuller = getImageOutputCuller(command);
     },
-    deleteImagesDebounced: _.debounce(async function(obj) {
-      if (this.selected.length) {
-        await this.deleteImages(this.selected);
-
-        return;
-      }
-      await this.deleteImage(obj);
-    }, 50),
-    async deleteImages() {
+    deleteImages: _.debounce(async function() {
       const message = `Delete ${ this.imagesToDelete.length } ${ this.imagesToDelete.length > 1 ? 'images' : 'image' }?`;
       const detail = this.imagesToDelete.reduce((prev, curr) => {
         if (!this.isDeletable(curr)) {
@@ -315,7 +307,7 @@ export default {
       this.startRunningCommand('delete');
       ipcRenderer.send('do-image-deletion-batch', this.imageIdsToDelete);
       this.startImageManagerOutput();
-    },
+    }, 50),
     async deleteImage(obj) {
       const options = {
         message:   `Delete image ${ obj.imageName }:${ obj.tag }?`,

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -81,7 +81,6 @@
 <script>
 import { ipcRenderer } from 'electron';
 
-import _ from 'lodash';
 import Card from '@/components/Card.vue';
 import SortableTable from '@/components/SortableTable';
 import Checkbox from '@/components/form/Checkbox';
@@ -272,7 +271,7 @@ export default {
     startRunningCommand(command) {
       this.imageOutputCuller = getImageOutputCuller(command);
     },
-    deleteImages: _.debounce(async function() {
+    async deleteImages() {
       const message = `Delete ${ this.imagesToDelete.length } ${ this.imagesToDelete.length > 1 ? 'images' : 'image' }?`;
       const detail = this.imagesToDelete.reduce((prev, curr) => {
         if (!this.isDeletable(curr)) {
@@ -307,7 +306,7 @@ export default {
       this.startRunningCommand('delete');
       ipcRenderer.send('do-image-deletion-batch', this.imageIdsToDelete);
       this.startImageManagerOutput();
-    }, 50),
+    },
     async deleteImage(obj) {
       const options = {
         message:   `Delete image ${ obj.imageName }:${ obj.tag }?`,

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -197,11 +197,12 @@ export default {
                 icon:    'icon icon-upload',
               },
               {
-                label:    this.t('images.manager.table.action.delete'),
-                action:   'deleteImagesDebounced',
-                enabled:  this.isDeletable(image),
-                icon:     'icon icon-delete',
-                bulkable: true,
+                label:      this.t('images.manager.table.action.delete'),
+                action:     'deleteImage',
+                enabled:    this.isDeletable(image),
+                icon:       'icon icon-delete',
+                bulkable:   true,
+                bulkAction: 'deleteImagesDebounced',
               },
               {
                 label:   this.t('images.manager.table.action.scan'),
@@ -215,6 +216,9 @@ export default {
           // on the rows directly.
           if (!image.doPush) {
             image.doPush = this.doPush.bind(this, image);
+          }
+          if (!image.deleteImage) {
+            image.deleteImage = this.deleteImage.bind(this, image);
           }
           if (!image.deleteImagesDebounced) {
             image.deleteImagesDebounced = this.deleteImagesDebounced.bind(this, image);
@@ -270,7 +274,6 @@ export default {
     },
     deleteImagesDebounced: _.debounce(async function(obj) {
       if (this.selected.length) {
-        console.debug('DELETE IMAGE', { selected: this.selected });
         await this.deleteImages(this.selected);
 
         return;

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -13,6 +13,7 @@
         :rows="rows"
         :table-actions="true"
         :paging="true"
+        @selection="updateSelection"
       >
         <template #header-left>
           <div v-if="supportsNamespaces">
@@ -146,6 +147,7 @@ export default {
       keepImageManagerOutputWindowOpen: false,
       imageOutputCuller:                null,
       mainWindowScroll:                 -1,
+      selected:                         []
     };
   },
   computed: {
@@ -225,6 +227,9 @@ export default {
   },
 
   methods: {
+    updateSelection(val) {
+      this.selected = val;
+    },
     startImageManagerOutput() {
       this.keepImageManagerOutputWindowOpen = true;
       this.scrollToOutputWindow();

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -15,23 +15,28 @@
         :paging="true"
         @selection="updateSelection"
       >
-        <template #header-left>
-          <div v-if="supportsNamespaces">
-            <label>Image Namespace:</label>
-            <select class="select-namespace" :value="selectedNamespace" @change="handleChangeNamespace($event)">
-              <option v-for="item in imageNamespaces" :key="item" :value="item" :selected="item === selectedNamespace">
-                {{ item }}
-              </option>
-            </select>
-          </div>
-        </template>
         <template #header-middle>
-          <Checkbox
-            :value="showAll"
-            :label="t('images.manager.table.label')"
-            :disabled="!supportsShowAll"
-            @input="handleShowAllCheckbox"
-          />
+          <div class="header-middle">
+            <Checkbox
+              class="all-images"
+              :value="showAll"
+              :label="t('images.manager.table.label')"
+              :disabled="!supportsShowAll"
+              @input="handleShowAllCheckbox"
+            />
+            <div v-if="supportsNamespaces">
+              <label>Namespace</label>
+              <select
+                class="select-namespace"
+                :value="selectedNamespace"
+                @change="handleChangeNamespace($event)"
+              >
+                <option v-for="item in imageNamespaces" :key="item" :value="item" :selected="item === selectedNamespace">
+                  {{ item }}
+                </option>
+              </select>
+            </div>
+          </div>
         </template>
         <!-- The SortableTable component puts the Filter box goes in the #header-right slot
              Too bad, because it means we can't use a css grid to manage the relative
@@ -390,25 +395,25 @@ export default {
     }
   }
 
-  .imagesTable::v-deep tr.highlightFade {
-    animation: highlightFade 1s;
-  }
-
-  .imagesTable::v-deep div.search {
-    margin-top: 12px;
-  }
-
-  .imagesTable::v-deep .sortable-table-header .fixed-header-actions {
-    align-items: end;
-  }
-
-  .imagesTable::v-deep .sortable-table-header .fixed-header-actions .middle {
-    align-self: start;
-    margin-top: 17px;
-    padding-top: 11px;
-  }
-
   .select-namespace {
     max-width: 24rem;
+    min-width: 8rem;
+  }
+
+  .header-middle {
+    display: flex;
+    align-items: end;
+    gap: 1rem;
+  }
+
+  .all-images {
+    margin-bottom: 11px;
+  }
+
+  .imagesTable::v-deep .search-box {
+    align-self: end;
+  }
+  .imagesTable::v-deep .bulk {
+    align-self: end;
   }
 </style>

--- a/src/components/SortableTable/index.vue
+++ b/src/components/SortableTable/index.vue
@@ -732,9 +732,18 @@ export default {
                 <i v-if="act.icon" :class="act.icon" />
                 <span v-html="act.label" />
               </button>
-              <ActionDropdown :class="bulkActionsDropdownClass" class="bulk-actions-dropdown" :disable-button="!selectedRows.length" size="sm">
+              <ActionDropdown
+                :class="bulkActionsDropdownClass"
+                class="bulk-actions-dropdown"
+                :disable-button="!selectedRows.length"
+                size="sm"
+              >
                 <template #button-content>
-                  <button ref="actionDropDown" class="btn bg-primary mr-0" :disabled="!selectedRows.length">
+                  <button
+                    ref="actionDropDown"
+                    class="btn btn-role-primary bg-primary mr-0"
+                    :disabled="!selectedRows.length"
+                  >
                     <i class="icon icon-gear" />
                     <span>{{ t('harvester.tableHeaders.actions') }}</span>
                     <i class="ml-10 icon icon-chevron-down" />

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -379,7 +379,7 @@ export abstract class ImageProcessor extends EventEmitter {
 
   abstract deleteImage(imageID: string): Promise<childResultType>;
 
-  abstract deleteImages(images: string[]): Promise<childResultType>;
+  abstract deleteImages(imageIDs: string[]): Promise<childResultType>;
 
   abstract pullImage(taggedImageName: string): Promise<childResultType>;
 

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -379,6 +379,8 @@ export abstract class ImageProcessor extends EventEmitter {
 
   abstract deleteImage(imageID: string): Promise<childResultType>;
 
+  abstract deleteImages(images: string[]): Promise<childResultType>;
+
   abstract pullImage(taggedImageName: string): Promise<childResultType>;
 
   abstract pushImage(taggedImageName: string): Promise<childResultType>;

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -46,8 +46,8 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
     return await this.runImagesCommand(['rmi', imageID]);
   }
 
-  async deleteImages(images: string[]): Promise<imageProcessor.childResultType> {
-    return await this.runImagesCommand(['rmi', ...images]);
+  async deleteImages(imageIDs: string[]): Promise<imageProcessor.childResultType> {
+    return await this.runImagesCommand(['rmi', ...imageIDs]);
   }
 
   async pullImage(taggedImageName: string): Promise<imageProcessor.childResultType> {

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -46,6 +46,10 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
     return await this.runImagesCommand(['rmi', imageID]);
   }
 
+  async deleteImages(images: string[]): Promise<imageProcessor.childResultType> {
+    return await this.runImagesCommand(['rmi', ...images]);
+  }
+
   async pullImage(taggedImageName: string): Promise<imageProcessor.childResultType> {
     return await this.runImagesCommand(['pull', taggedImageName]);
   }

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -88,8 +88,8 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
     return await this.runImagesCommand(['rmi', imageID]);
   }
 
-  async deleteImages(images: string[]): Promise<imageProcessor.childResultType> {
-    return await this.runImagesCommand(['rmi', ...images]);
+  async deleteImages(imageIDs: string[]): Promise<imageProcessor.childResultType> {
+    return await this.runImagesCommand(['rmi', ...imageIDs]);
   }
 
   async pullImage(taggedImageName: string): Promise<imageProcessor.childResultType> {

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -88,6 +88,10 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
     return await this.runImagesCommand(['rmi', imageID]);
   }
 
+  async deleteImages(images: string[]): Promise<imageProcessor.childResultType> {
+    return await this.runImagesCommand(['rmi', ...images]);
+  }
+
   async pullImage(taggedImageName: string): Promise<imageProcessor.childResultType> {
     return await this.runImagesCommand(['pull', taggedImageName]);
   }

--- a/src/main/imageEvents.ts
+++ b/src/main/imageEvents.ts
@@ -69,14 +69,14 @@ export class ImageEventHandler {
       }
     });
 
-    Electron.ipcMain.on('do-image-deletion-batch', async(event, images) => {
+    Electron.ipcMain.on('do-image-deletion-batch', async(event, imageIDs) => {
       try {
-        await this.imageProcessor.deleteImages(images);
+        await this.imageProcessor.deleteImages(imageIDs);
         await this.imageProcessor.refreshImages();
         event.reply('images-process-ended', 0);
       } catch (err) {
         await Electron.dialog.showMessageBox({
-          message: `Error trying to delete images ${ images }`,
+          message: `Error trying to delete images ${ imageIDs }`,
           type:    'error',
         });
         event.reply('images-process-ended', 1);

--- a/src/main/imageEvents.ts
+++ b/src/main/imageEvents.ts
@@ -69,6 +69,20 @@ export class ImageEventHandler {
       }
     });
 
+    Electron.ipcMain.on('do-image-deletion-batch', async(event, images) => {
+      try {
+        await this.imageProcessor.deleteImages(images);
+        await this.imageProcessor.refreshImages();
+        event.reply('images-process-ended', 0);
+      } catch (err) {
+        await Electron.dialog.showMessageBox({
+          message: `Error trying to delete images ${ images }`,
+          type:    'error',
+        });
+        event.reply('images-process-ended', 1);
+      }
+    });
+
     Electron.ipcMain.on('do-image-build', async(event, taggedImageName) => {
       const options: any = {
         title:      'Pick the build directory',

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script>
+import _ from 'lodash';
 import { ipcRenderer } from 'electron';
 import { mapGetters } from 'vuex';
 import Images from '@/components/Images.vue';
@@ -69,7 +70,12 @@ export default {
 
   mounted() {
     ipcRenderer.on('images-changed', (event, images) => {
-      this.$data.images = images;
+      if (_.isEqual(images, this.images)) {
+        return;
+      }
+
+      this.images = images;
+
       if (this.supportsNamespaces && this.imageNamespaces.length === 0) {
         // This happens if the user clicked on the Images panel before data was ready,
         // so no namespaces were available when it initially asked for them.
@@ -91,9 +97,8 @@ export default {
       this.$data.settings = settings;
       this.checkSelectedNamespace();
     });
-    (async() => {
-      this.$data.images = await ipcRenderer.invoke('images-mounted', true);
-    })();
+
+    ipcRenderer.invoke('images-mounted', true);
 
     ipcRenderer.on('images-namespaces', (event, namespaces) => {
       // TODO: Use a specific message to indicate whether messages are supported or not.

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -98,7 +98,9 @@ export default {
       this.checkSelectedNamespace();
     });
 
-    ipcRenderer.invoke('images-mounted', true);
+    (async() => {
+      this.$data.images = await ipcRenderer.invoke('images-mounted', true);
+    })();
 
     ipcRenderer.on('images-namespaces', (event, namespaces) => {
       // TODO: Use a specific message to indicate whether messages are supported or not.

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -114,6 +114,8 @@ export default {
   },
   beforeDestroy() {
     ipcRenderer.invoke('images-mounted', false);
+    ipcRenderer.removeAllListeners('images-mounted');
+    ipcRenderer.removeAllListeners('images-changed');
   },
 
   methods: {


### PR DESCRIPTION
This adds a bulk deletion option to images that have the delete option available by making use of the `bulkable` and `bulkActions` properties for `availableActions`.

closes #1912 

### Examples

#### Images with a Delete Action, None Selected

![Screen Shot 2022-05-12 at 4 34 33 PM](https://user-images.githubusercontent.com/835961/168184087-fd3c5e21-afaf-46ee-b65c-7d55c7d847e9.png)

#### Images with a Delete Action, All Selected

![Screen Shot 2022-05-12 at 4 34 45 PM](https://user-images.githubusercontent.com/835961/168184090-fa0025f6-20f7-4b13-9578-71e5b9712361.png)

#### Images with a Delete Action, One Selected

![Screen Shot 2022-05-12 at 4 34 55 PM](https://user-images.githubusercontent.com/835961/168184091-70fbed38-aaf4-47c7-b669-5447ae5b4f08.png)

#### Delete Action Available for a Subset of Images

![Screen Shot 2022-05-12 at 4 35 17 PM](https://user-images.githubusercontent.com/835961/168184093-ac29ebd9-7fc7-4a3c-b72f-13595ea97845.png)

