### PR TITLE
Fix unit test failure in non English languages

### DIFF
--- a/src/components/UpdateStatus.vue
+++ b/src/components/UpdateStatus.vue
@@ -60,6 +60,10 @@ const UpdateStatusProps = Vue.extend({
       type:    Object as PropType<UpdateState | null>,
       default: null,
     },
+    locale: {
+      type:    String,
+      default: undefined,
+    },
     version: {
       type:    String,
       default: '(checking...)',
@@ -109,7 +113,7 @@ class UpdateStatus extends UpdateStatusProps {
     }
 
     const percent = Math.floor(progress.percent);
-    const speed = Intl.NumberFormat(undefined, {
+    const speed = Intl.NumberFormat(this.locale, {
       style:       'unit',
       unit:        'byte-per-second',
       unitDisplay: 'narrow',

--- a/src/components/__tests__/UpdateStatus.spec.ts
+++ b/src/components/__tests__/UpdateStatus.spec.ts
@@ -107,6 +107,7 @@ describe('UpdateStatus.vue', () => {
             transferred:    0
           },
         } as UpdateState,
+        locale: 'en',
       });
 
       expect(wrapper.findComponent({ ref: 'updateStatus' }).text())


### PR DESCRIPTION
This is a result in Japanese environment.

```
> npm test
...
 FAIL  src/components/__tests__/UpdateStatus.spec.ts (11.197 s)
  ● UpdateStatus.vue › update status › shows download progress

    expect(received).toMatch(expected)

    Expected pattern: /^An update to version v1\.2\.3 is available; downloading... \(12%, 1\.2MB\/s(?:ec\.?)?\)$/
    Received string:  "An update to version v1.2.3 is available; downloading... (12%, 123万B/秒)"

      111 |
      112 |       expect(wrapper.findComponent({ ref: 'updateStatus' }).text())
    > 113 |         .toMatch(/^An update to version v1\.2\.3 is available; downloading... \(12%, 1\.2MB\/s(?:ec\.?)?\)$/);
          |          ^
      114 |       expect(wrapper.findComponent({ ref: 'updateReady' }).exists()).toBeFalsy();
      115 |     });
      116 |   });

      at Object.<anonymous> (src/components/__tests__/UpdateStatus.spec.ts:113:10)
...
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>