### PR TITLE
Modify ~/.bash_profile as well as ~/.bashrc when using Automatic `PATH` management

### DIFF
--- a/src/integrations/__tests__/pathManager.spec.ts
+++ b/src/integrations/__tests__/pathManager.spec.ts
@@ -2,8 +2,9 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { RcFilePathManager } from '@/integrations/pathManager';
+import { START_LINE, END_LINE } from '@/integrations/manageLinesInFile';
 
-const testUnix = os.platform() === 'win32' ? test.skip : test;
+const describeUnix = os.platform() === 'win32' ? describe.skip : describe;
 let testDir = '';
 const savedEnv = process.env;
 
@@ -20,35 +21,115 @@ function readdirRecursive(dirPath: string): string[] {
   return files.flat();
 }
 
-beforeEach(async() => {
-  testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rdtest-'));
-  const spy = jest.spyOn(os, 'homedir');
+describeUnix('RcFilePathManager', () => {
+  let pathManager: RcFilePathManager;
 
-  spy.mockReturnValue(testDir);
-  process.env = { ...process.env, XDG_CONFIG_HOME: path.join(testDir, '.config') };
-});
+  beforeEach(async() => {
+    pathManager = new RcFilePathManager();
+    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rdtest-'));
+    const spy = jest.spyOn(os, 'homedir');
 
-afterEach(async() => {
-  process.env = savedEnv;
-  const spy = jest.spyOn(os, 'homedir');
-
-  spy.mockRestore();
-  await fs.promises.rm(testDir, { recursive: true, force: true });
-});
-
-testUnix('Ensure that RcFilePathManager enforce and remove methods work', async() => {
-  const pathManager = new RcFilePathManager();
-
-  await pathManager.enforce();
-  let fileBlob = readdirRecursive(testDir).join(os.EOL);
-  const rcNames = ['bash_profile', 'bashrc', 'zshrc', 'cshrc', 'tcshrc', 'config.fish'];
-
-  rcNames.forEach((rcName) => {
-    expect(fileBlob).toMatch(rcName);
+    spy.mockReturnValue(testDir);
+    process.env = { ...process.env, XDG_CONFIG_HOME: path.join(testDir, '.config') };
   });
-  await pathManager.remove();
-  fileBlob = readdirRecursive(testDir).join(os.EOL);
-  rcNames.forEach((rcName) => {
-    expect(fileBlob).not.toMatch(rcName);
+
+  afterEach(async() => {
+    process.env = savedEnv;
+    const spy = jest.spyOn(os, 'homedir');
+
+    spy.mockRestore();
+    await fs.promises.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('enforce', () => {
+    let bashProfilePath: string;
+    let bashLoginPath: string;
+    let profilePath: string;
+
+    beforeEach(() => {
+      bashProfilePath = path.join(testDir, '.bash_profile');
+      bashLoginPath = path.join(testDir, '.bash_login');
+      profilePath = path.join(testDir, '.profile');
+    });
+
+    it('should create rc files if they do not exist', async() => {
+      const rcNames = ['bashrc', 'zshrc', 'cshrc', 'tcshrc', 'config.fish'];
+
+      await pathManager.enforce();
+      let fileBlob = readdirRecursive(testDir).join(os.EOL);
+      rcNames.forEach((rcName) => {
+        expect(fileBlob).toMatch(rcName);
+      });
+      await pathManager.remove();
+      fileBlob = readdirRecursive(testDir).join(os.EOL);
+      rcNames.forEach((rcName) => {
+        expect(fileBlob).not.toMatch(rcName);
+      });
+    });
+
+    it('should create .bash_profile if it, .profile or .bash_login does not exist', async() => {
+      await pathManager.enforce();
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).rejects.toThrow();
+    });
+
+    it('should modify .bash_profile if it, .bash_login and .profile exist', async() => {
+      await fs.promises.writeFile(bashProfilePath, '');
+      await fs.promises.writeFile(bashLoginPath, '');
+      await fs.promises.writeFile(profilePath, '');
+
+      await pathManager.enforce();
+
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
+    });
+
+    it('should modify .bash_login if only it and/or .profile (and not .bash_profile) exist', async() => {
+      await fs.promises.writeFile(bashLoginPath, '');
+      await fs.promises.writeFile(profilePath, '');
+
+      await pathManager.enforce();
+
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
+    });
+
+    it('should modify .profile if only it (and not .bash_profile or .bash_login) exists', async() => {
+      await fs.promises.writeFile(profilePath, '');
+
+      await pathManager.enforce();
+
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+    });
+
+    it('should remove lines from bash login shell files if they exist', async() => {
+      const managedContent = 'managed content';
+      const unmanagedContent = 'should not be touched';
+      const content = [
+        unmanagedContent,
+        START_LINE,
+        managedContent,
+        END_LINE,
+      ].join(os.EOL);
+      await fs.promises.writeFile(bashProfilePath, content);
+      await fs.promises.writeFile(bashLoginPath, content);
+      await fs.promises.writeFile(profilePath, content);
+
+      await pathManager.remove();
+
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.not.toMatch(managedContent);
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch(unmanagedContent);
+
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.not.toMatch(managedContent);
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.toMatch(unmanagedContent);
+
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch(managedContent);
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.toMatch(unmanagedContent);
+    });
   });
 });

--- a/src/integrations/__tests__/pathManager.spec.ts
+++ b/src/integrations/__tests__/pathManager.spec.ts
@@ -41,7 +41,7 @@ testUnix('Ensure that RcFilePathManager enforce and remove methods work', async(
 
   await pathManager.enforce();
   let fileBlob = readdirRecursive(testDir).join(os.EOL);
-  const rcNames = ['bashrc', 'zshrc', 'cshrc', 'tcshrc', 'config.fish'];
+  const rcNames = ['bash_profile', 'bashrc', 'zshrc', 'cshrc', 'tcshrc', 'config.fish'];
 
   rcNames.forEach((rcName) => {
     expect(fileBlob).toMatch(rcName);

--- a/src/integrations/__tests__/pathManager.spec.ts
+++ b/src/integrations/__tests__/pathManager.spec.ts
@@ -71,8 +71,8 @@ describeUnix('RcFilePathManager', () => {
     it('should create .bash_profile if it, .profile or .bash_login does not exist', async() => {
       await pathManager.enforce();
       await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
-      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
-      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow(/ENOENT/);
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).rejects.toThrow(/ENOENT/);
     });
 
     it('should modify .bash_profile if it, .bash_login and .profile exist', async() => {
@@ -93,7 +93,7 @@ describeUnix('RcFilePathManager', () => {
 
       await pathManager.enforce();
 
-      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow(/ENOENT/);
       await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
       await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin');
     });
@@ -103,8 +103,8 @@ describeUnix('RcFilePathManager', () => {
 
       await pathManager.enforce();
 
-      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
-      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow(/ENOENT/);
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow(/ENOENT/);
       await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
     });
 

--- a/src/integrations/__tests__/pathManager.spec.ts
+++ b/src/integrations/__tests__/pathManager.spec.ts
@@ -57,6 +57,7 @@ describeUnix('RcFilePathManager', () => {
 
       await pathManager.enforce();
       let fileBlob = readdirRecursive(testDir).join(os.EOL);
+
       rcNames.forEach((rcName) => {
         expect(fileBlob).toMatch(rcName);
       });
@@ -69,7 +70,7 @@ describeUnix('RcFilePathManager', () => {
 
     it('should create .bash_profile if it, .profile or .bash_login does not exist', async() => {
       await pathManager.enforce();
-      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
       await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
       await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).rejects.toThrow();
     });
@@ -81,9 +82,9 @@ describeUnix('RcFilePathManager', () => {
 
       await pathManager.enforce();
 
-      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
-      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
-      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin');
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin');
     });
 
     it('should modify .bash_login if only it and/or .profile (and not .bash_profile) exist', async() => {
@@ -93,8 +94,8 @@ describeUnix('RcFilePathManager', () => {
       await pathManager.enforce();
 
       await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
-      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
-      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.not.toMatch('.rd/bin');
     });
 
     it('should modify .profile if only it (and not .bash_profile or .bash_login) exists', async() => {
@@ -104,7 +105,7 @@ describeUnix('RcFilePathManager', () => {
 
       await expect(fs.promises.readFile(bashProfilePath, { encoding: 'utf-8' })).rejects.toThrow();
       await expect(fs.promises.readFile(bashLoginPath, { encoding: 'utf-8' })).rejects.toThrow();
-      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin')
+      await expect(fs.promises.readFile(profilePath, { encoding: 'utf-8' })).resolves.toMatch('.rd/bin');
     });
 
     it('should remove lines from bash login shell files if they exist', async() => {
@@ -116,6 +117,7 @@ describeUnix('RcFilePathManager', () => {
         managedContent,
         END_LINE,
       ].join(os.EOL);
+
       await fs.promises.writeFile(bashProfilePath, content);
       await fs.promises.writeFile(bashLoginPath, content);
       await fs.promises.writeFile(profilePath, content);

--- a/src/integrations/pathManager.ts
+++ b/src/integrations/pathManager.ts
@@ -72,8 +72,7 @@ export class RcFilePathManager implements PathManager {
    */
   protected async managePosix(desiredPresent: boolean): Promise<void> {
     const pathLine = `export PATH="${ paths.integration }:$PATH"`;
-    // Note: order is important here. Only the first one that is present
-    // is executed for a bash login shell.
+    // Note: order is important here. Only the first one that is present is modified.
     const bashLoginShellFiles = [
       '.bash_profile',
       '.bash_login',
@@ -84,7 +83,7 @@ export class RcFilePathManager implements PathManager {
     if (desiredPresent) {
       let linesAdded = false;
 
-      // Write the first file that exists
+      // Write the first file that exists, if any
       for (const fileName of bashLoginShellFiles) {
         const filePath = path.join(os.homedir(), fileName);
 

--- a/src/integrations/pathManager.ts
+++ b/src/integrations/pathManager.ts
@@ -102,7 +102,7 @@ export class RcFilePathManager implements PathManager {
 
       // If none of the files exist, write .bash_profile
       if (!linesAdded) {
-        const filePath = path.join(os.homedir(), '.bash_profile');
+        const filePath = path.join(os.homedir(), bashLoginShellFiles[0]);
 
         await manageLinesInFile(filePath, [pathLine], desiredPresent);
       }

--- a/src/integrations/pathManager.ts
+++ b/src/integrations/pathManager.ts
@@ -68,7 +68,10 @@ export class RcFilePathManager implements PathManager {
   protected async managePosix(desiredPresent: boolean): Promise<void> {
     const pathLine = `export PATH="${ paths.integration }:$PATH"`;
 
-    await Promise.all(['.bashrc', '.zshrc'].map((rcName) => {
+    // We change both .bash_profile and .bashrc because either one, or both,
+    // may run, depending on whether bash is run as a login shell. Having
+    // the RD bin directory in the PATH twice is ugly, but not a problem.
+    await Promise.all(['.bash_profile', '.bashrc', '.zshrc'].map((rcName) => {
       const rcPath = path.join(os.homedir(), rcName);
 
       return manageLinesInFile(rcPath, [pathLine], desiredPresent);


### PR DESCRIPTION
Closes #2229.

Signed-off-by: Adam Pickering <adamkpickering@gmail.com>