### PR TITLE
Bump alpine-lima ISO and wsl-distro releases

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.23';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.11';
+const alpineLimaTag = 'v0.2.13';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.15.4';
 

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -9,7 +9,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.21';
+  const v = '0.22';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -170,7 +170,7 @@ interface SudoCommand {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.11';
+const IMAGE_VERSION = '0.2.13';
 const ALPINE_EDITION = 'rd';
 const ALPINE_VERSION = '3.15.4';
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -67,7 +67,7 @@ const DISTRO_BLACKLIST = [
 ];
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.21';
+const DISTRO_VERSION = '0.22';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
* Bumps `nerdctl` from 0.19.0 → 0.20.0
* Includes `curl` package for credentials forwarder
* Includes `sudo` in wsl-distro so that `rdctl shell sudo` works everywhere
