### PR TITLE
Create a .docker/config.json to use the r-d credentials helper.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -22,6 +22,7 @@ import Latch from '@/utils/latch';
 import paths from '@/utils/paths';
 import getCommandLineArgs from '@/utils/commandLine';
 import { CommandWorkerInterface, HttpCommandServer } from '@/main/commandServer/httpCommandServer';
+import { HttpCredentialServer } from '@/main/credentialServer/httpCredentialServer';
 import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
@@ -65,6 +66,7 @@ let pendingRestart = false;
 const protocolRegistered = Latch();
 
 let httpCommandServer: HttpCommandServer|null = null;
+const httpCredentialServer = new HttpCredentialServer();
 
 if (!Electron.app.requestSingleInstanceLock()) {
   gone = true;
@@ -107,6 +109,7 @@ Electron.app.whenReady().then(async() => {
 
     httpCommandServer = new HttpCommandServer(new BackgroundCommandWorker());
     await httpCommandServer.init();
+    await httpCredentialServer.init();
     await setupNetworking();
     cfg = settings.load();
 
@@ -322,6 +325,7 @@ function isK8sError(object: any): object is K8sError {
 
 Electron.app.on('before-quit', async(event) => {
   httpCommandServer?.closeServer();
+  httpCredentialServer.closeServer();
   if (gone) {
     return;
   }

--- a/background.ts
+++ b/background.ts
@@ -22,7 +22,7 @@ import Latch from '@/utils/latch';
 import paths from '@/utils/paths';
 import getCommandLineArgs from '@/utils/commandLine';
 import { CommandWorkerInterface, HttpCommandServer } from '@/main/commandServer/httpCommandServer';
-import { HttpCredentialServer } from '@/main/credentialServer/httpCredentialServer';
+import { HttpCredentialHelperServer } from '@/main/credentialServer/httpCredentialHelperServer';
 import setupNetworking from '@/main/networking';
 import setupUpdate from '@/main/update';
 import setupTray from '@/main/tray';
@@ -66,7 +66,7 @@ let pendingRestart = false;
 const protocolRegistered = Latch();
 
 let httpCommandServer: HttpCommandServer|null = null;
-const httpCredentialServer = new HttpCredentialServer();
+const httpCredentialHelperServer = new HttpCredentialHelperServer();
 
 if (!Electron.app.requestSingleInstanceLock()) {
   gone = true;
@@ -109,7 +109,7 @@ Electron.app.whenReady().then(async() => {
 
     httpCommandServer = new HttpCommandServer(new BackgroundCommandWorker());
     await httpCommandServer.init();
-    await httpCredentialServer.init();
+    await httpCredentialHelperServer.init();
     await setupNetworking();
     cfg = settings.load();
 
@@ -324,12 +324,12 @@ function isK8sError(object: any): object is K8sError {
 }
 
 Electron.app.on('before-quit', async(event) => {
-  httpCommandServer?.closeServer();
-  httpCredentialServer.closeServer();
   if (gone) {
     return;
   }
   event.preventDefault();
+  httpCommandServer?.closeServer();
+  httpCredentialHelperServer.closeServer();
 
   try {
     await k8smanager?.stop();
@@ -820,6 +820,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   }
 
   async requestShutdown() {
+    httpCommandServer?.closeServer();
+    httpCredentialHelperServer.closeServer();
     await k8smanager.stop();
     Electron.app.quit();
   }

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -21,6 +21,8 @@ limitations under the License.
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
+import util from 'util';
 import { spawnSync } from 'child_process';
 
 import { expect, test } from '@playwright/test';
@@ -68,21 +70,30 @@ describeWithCreds('Credentials server', () => {
   let ipaddr: string|undefined = '';
   let initialArgs: string[] = [];
 
-  async function doRequest(path: string, body = '') {
+  async function setVars() {
     if (!ipaddr) {
+      if (!authString) {
+        throw new Error("Trying to set up the args but still haven't set authString");
+      }
       if (os.platform() === 'win32') {
         command = 'wsl';
         ipaddr = await wslHostIPv4Address();
         if (!ipaddr) {
           throw new Error('Failed to get the WSL IP address');
         }
+        // arguments for wsl
         initialArgs = ['--distribution', 'rancher-desktop', '--exec', 'curl'];
       } else {
         command = 'curl';
         ipaddr = 'localhost';
       }
-      initialArgs = initialArgs.concat(['--silent', '--user', authString, '--request', 'POST']);
     }
+    // common arguments for curl
+    initialArgs = initialArgs.concat(['--silent', '--user', authString, '--request', 'POST']);
+  }
+
+  async function doRequest(path: string, body = '') {
+    await setVars();
     const args = initialArgs.concat([`http://${ ipaddr }:${ serverState.port }/${ path }`]);
 
     if (body.length) {
@@ -93,6 +104,42 @@ describeWithCreds('Credentials server', () => {
     expect(stderr).toEqual('');
 
     return stdout;
+  }
+
+  function rdctlPath() {
+    return path.join(appPath, 'resources', os.platform(), 'bin', os.platform() === 'win32' ? 'rdctl.exe' : 'rdctl');
+  }
+
+  async function rdctlCred(...commandArgs: string[]): Promise<{ stdout: string, stderr: string, error?: any }> {
+    await setVars();
+    try {
+      const args = ['shell', '/bin/sh', '-ex', '/usr/local/bin/docker-credential-rancher-desktop'].concat(commandArgs);
+
+      return await spawnFile(rdctlPath(), args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err: any) {
+      return {
+        stdout: err?.stdout ?? '',
+        stderr: err?.stderr ?? '',
+        error:  err
+      };
+    }
+  }
+
+  async function rdctlCredWithStdin(command: string, ...commandArgs: string[]): Promise<{ stdout: string, stderr: string, error?: any }> {
+    await setVars();
+    try {
+      const input = commandArgs[0] ?? '';
+      const body = stream.Readable.from(input);
+      const args = ['shell', '/usr/local/bin/docker-credential-rancher-desktop'].concat([command]);
+
+      return await spawnFile(rdctlPath(), args, { stdio: [body, 'pipe', 'pipe'] });
+    } catch (err: any) {
+      return {
+        stdout: err?.stdout ?? '',
+        stderr: err?.stderr ?? '',
+        error:  err
+      };
+    }
   }
 
   test.describe.configure({ mode: 'serial' });
@@ -182,6 +229,97 @@ describeWithCreds('Credentials server', () => {
     expect(stdout).toContain('credentials not found in native keychain');
 
     stdout = await doRequest('erase', bobsURL);
+    expect(stdout).toContain('The specified item could not be found in the keychain');
+  });
+
+  test('should be able to use the script', async() => {
+    const bobsURL = 'https://bobs.fish/tackle';
+    const bobsFirstSecret = 'loblaw';
+    const bobsSecondSecret = 'shoppers with spaces and % and \' and &s and even a 😱';
+
+    const body = {
+      ServerURL: bobsURL,
+      Username:  'bob',
+      Secret:    bobsFirstSecret
+    };
+
+    // TODO: Replace this with `rdctl status... something something RUNNING` once it's available
+    await util.promisify(setTimeout)(50_000);
+    let { stdout } = await rdctlCred('list');
+
+    if (JSON.parse(stdout)[bobsURL]) {
+      ({ stdout } = await rdctlCred('erase', bobsURL));
+      expect(stdout).toEqual('');
+    }
+
+    ({ stdout } = await rdctlCred('store', JSON.stringify(body)));
+    expect(stdout).toEqual('');
+
+    ({ stdout } = await rdctlCred('list'));
+    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' });
+
+    ({ stdout } = await rdctlCred('get', bobsURL));
+    expect(JSON.parse(stdout)).toMatchObject(body);
+
+    // Verify we can store and retrieve passwords with wacky characters in them.
+    body.Secret = bobsSecondSecret;
+    ({ stdout } = await rdctlCred('store', JSON.stringify(body)));
+    expect(stdout).toBe('');
+
+    ({ stdout } = await rdctlCred('get', bobsURL));
+    expect(JSON.parse(stdout)).toMatchObject(body);
+
+    ({ stdout } = await rdctlCred('erase', bobsURL));
+    expect(stdout).toBe('');
+
+    ({ stdout } = await rdctlCred('get', bobsURL));
+    expect(stdout).toContain('credentials not found in native keychain');
+
+    ({ stdout } = await rdctlCred('erase', bobsURL));
+    expect(stdout).toContain('The specified item could not be found in the keychain');
+  });
+
+  test('should be able to use the script with stdin', async() => {
+    const bobsURL = 'https://bobs.fish/tackle';
+    const bobsFirstSecret = 'loblaw';
+    const bobsSecondSecret = 'shoppers with spaces and % and \' and &s and even a 😱';
+
+    const body = {
+      ServerURL: bobsURL,
+      Username:  'bob',
+      Secret:    bobsFirstSecret
+    };
+    let { stdout } = await rdctlCredWithStdin('list');
+
+    if (JSON.parse(stdout)[bobsURL]) {
+      ({ stdout } = await rdctlCredWithStdin('erase', bobsURL));
+      expect(stdout).toEqual('');
+    }
+
+    ({ stdout } = await rdctlCredWithStdin('store', JSON.stringify(body)));
+    expect(stdout).toEqual('');
+
+    ({ stdout } = await rdctlCredWithStdin('list'));
+    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' });
+
+    ({ stdout } = await rdctlCredWithStdin('get', bobsURL));
+    expect(JSON.parse(stdout)).toMatchObject(body);
+
+    // Verify we can store and retrieve passwords with wacky characters in them.
+    body.Secret = bobsSecondSecret;
+    ({ stdout } = await rdctlCredWithStdin('store', JSON.stringify(body)));
+    expect(stdout).toBe('');
+
+    ({ stdout } = await rdctlCredWithStdin('get', bobsURL));
+    expect(JSON.parse(stdout)).toMatchObject(body);
+
+    ({ stdout } = await rdctlCredWithStdin('erase', bobsURL));
+    expect(stdout).toBe('');
+
+    ({ stdout } = await rdctlCredWithStdin('get', bobsURL));
+    expect(stdout).toContain('credentials not found in native keychain');
+
+    ({ stdout } = await rdctlCredWithStdin('erase', bobsURL));
     expect(stdout).toContain('The specified item could not be found in the keychain');
   });
 });

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -70,7 +70,7 @@ test.describe('Credentials server', () => {
       `Authorization: Basic ${ authString }`,
       `http://localhost:${ serverState.port }/${ path }`,
       '-X',
-      'GET',
+      'POST',
     ];
 
     if (body.length) {

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -30,7 +30,7 @@ import fetch from 'node-fetch';
 import { createDefaultSettings, playwrightReportAssets } from './utils/TestUtils';
 import paths from '@/utils/paths';
 import { ServerState } from '@/main/commandServer/httpCommandServer';
-import { getWSLAddr } from '@/main/credentialServer/httpCredentialHelperServer';
+import { wslHostIPv4Address } from '@/utils/networks';
 import { spawnFile } from '@/utils/childProcess';
 import { findHomeDir } from '@/config/findHomeDir';
 
@@ -72,7 +72,7 @@ describeWithCreds('Credentials server', () => {
     if (!ipaddr) {
       if (os.platform() === 'win32') {
         command = 'wsl';
-        ipaddr = await getWSLAddr();
+        ipaddr = await wslHostIPv4Address();
         if (!ipaddr) {
           throw new Error('Failed to get the WSL IP address');
         }

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -65,7 +65,7 @@ describeWithCreds('Credentials server', () => {
   // Assign these values on first request once we have an authString
   // And we can't assign to ipaddr on Windows here because we need an async context.
   let command = '';
-  let ipaddr = '';
+  let ipaddr: string|undefined = '';
   let initialArgs: string[] = [];
 
   async function doRequest(path: string, body = '') {
@@ -73,6 +73,9 @@ describeWithCreds('Credentials server', () => {
       if (os.platform() === 'win32') {
         command = 'wsl';
         ipaddr = await getWSLAddr();
+        if (!ipaddr) {
+          throw new Error('Failed to get the WSL IP address');
+        }
         initialArgs = ['--distribution', 'rancher-desktop', '--exec', 'curl'];
       } else {
         command = 'curl';

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -1,0 +1,149 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * This file includes end-to-end testing for the HTTP control interface
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { expect, test } from '@playwright/test';
+import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright';
+
+import fetch, { RequestInit } from 'node-fetch';
+import { createDefaultSettings, playwrightReportAssets } from './utils/TestUtils';
+import paths from '@/utils/paths';
+import { ServerState } from '@/main/commandServer/httpCommandServer';
+import { spawnFile } from '@/utils/childProcess';
+
+test.describe('Credentials server', () => {
+  let electronApp: ElectronApplication;
+  let context: BrowserContext;
+  let serverState: ServerState;
+  let authString: string;
+  let page: Page;
+  const appPath = path.join(__dirname, '../');
+  const curl = os.platform() === 'win32' ? path.join(process.env['SYSTEM_ROOT'] ?? 'c:\\windows', 'system32', 'curl.exe') : 'curl';
+
+  async function doRequest(path: string, body = '') {
+    const args = [
+      '-s',
+      '-H',
+      `Authorization: Basic ${ authString }`,
+      `http://localhost:${ serverState.port }/${ path }`,
+      '-X',
+      'GET',
+    ];
+
+    if (body.length) {
+      args.push('-d', body);
+    }
+    const { stdout, stderr } = await spawnFile(curl, args, { stdio: 'pipe' });
+
+    if (stderr) {
+      throw new Error(stderr);
+    }
+
+    return stdout;
+  }
+
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(async() => {
+    createDefaultSettings();
+    electronApp = await _electron.launch({
+      args: [
+        appPath,
+        '--disable-gpu',
+        '--whitelisted-ips=',
+        // See src/utils/commandLine.ts before changing the next item.
+        '--disable-dev-shm-usage',
+        '--no-modal-dialogs',
+      ]
+    });
+    context = electronApp.context();
+
+    await context.tracing.start({
+      screenshots: true,
+      snapshots:   true
+    });
+    page = await electronApp.firstWindow();
+  });
+
+  test.afterAll(async() => {
+    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await electronApp.close();
+  });
+
+  test('should emit connection information', async() => {
+    const dataPath = path.join(paths.appHome, 'credential-server.json');
+    const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
+
+    serverState = JSON.parse(dataRaw);
+    expect(typeof serverState.user).toBe('string');
+    expect(typeof serverState.password).toBe('string');
+    expect(typeof serverState.port).toBe('number');
+    expect(typeof serverState.pid).toBe('number');
+    authString = Buffer.from(`${ serverState.user }:${ serverState.password }`).toString('base64');
+  });
+
+  test('should require authentication', async() => {
+    const url = `http://127.0.0.1:${ serverState.port }/list`;
+    const resp = await fetch(url);
+
+    expect(resp.ok).toBeFalsy();
+    expect(resp.status).toEqual(401);
+  });
+
+  test('should be able to use the API', async() => {
+    const bobsURL = 'https://bobs.fish/tackle';
+    const bobsFirstSecret = 'loblaw';
+    const bobsSecondSecret = 'shoppers';
+    let stdout: string = await doRequest('list');
+
+    if (JSON.parse(stdout)[bobsURL]) {
+      stdout = await doRequest('erase', bobsURL);
+      expect(stdout).toEqual('');
+    }
+
+    stdout = await doRequest('store', `{"ServerURL": "${ bobsURL }", "Username":"bob", "Secret":"${ bobsFirstSecret }"}`);
+    expect(stdout).toEqual('');
+
+    stdout = await doRequest('list');
+    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' } );
+
+    stdout = await doRequest('get', bobsURL);
+    expect(JSON.parse(stdout)).toMatchObject({
+      ServerURL: bobsURL, Username: 'bob', Secret: bobsFirstSecret
+    } );
+
+    stdout = await doRequest('store', `{"ServerURL": "${ bobsURL }", "Username":"bob", "Secret":"${ bobsSecondSecret }"}`);
+    expect(stdout).toBe('');
+
+    stdout = await doRequest('get', bobsURL);
+    expect(JSON.parse(stdout)).toMatchObject({
+      ServerURL: bobsURL, Username: 'bob', Secret: bobsSecondSecret
+    } );
+
+    stdout = await doRequest('erase', bobsURL);
+    expect(stdout).toBe('');
+
+    stdout = await doRequest('get', bobsURL);
+    expect(stdout).toBe('Error: Command failed: docker-credential-osxkeychain get');
+  });
+});

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -34,7 +34,7 @@ import { getWSLAddr } from '@/main/credentialServer/httpCredentialHelperServer';
 import { spawnFile } from '@/utils/childProcess';
 import { findHomeDir } from '@/config/findHomeDir';
 
-function haveDockerCredentialAssistant(): boolean {
+function haveCredentialServerHelper(): boolean {
   // Not using the code from `httpCredentialServer.ts` because we can't use async code at top-level here.
   const dockerConfigPath = path.join(findHomeDir() ?? '', '.docker', 'config.json');
 
@@ -53,7 +53,7 @@ function haveDockerCredentialAssistant(): boolean {
   }
 }
 
-const describeWithCreds = haveDockerCredentialAssistant() ? test.describe : test.skip;
+const describeWithCreds = haveCredentialServerHelper() ? test.describe : test.skip;
 
 describeWithCreds('Credentials server', () => {
   let electronApp: ElectronApplication;

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -183,7 +183,8 @@ describeWithCreds('Credentials server', () => {
   });
 
   test('should require authentication', async() => {
-    const url = `http://127.0.0.1:${ serverState.port }/list`;
+    const ipaddr = os.platform() === 'win32' ? await wslHostIPv4Address() : 'localhost';
+    const url = `http://${ ipaddr }:${ serverState.port }/list`;
     const resp = await fetch(url);
 
     expect(resp.ok).toBeFalsy();

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -65,16 +65,14 @@ test.describe('Credentials server', () => {
 
   async function doRequest(path: string, body = '') {
     const args = [
-      '-s',
-      '-H',
-      `Authorization: Basic ${ authString }`,
+      '--silent',
+      '--user', authString,
       `http://localhost:${ serverState.port }/${ path }`,
-      '-X',
-      'POST',
+      '--request', 'POST',
     ];
 
     if (body.length) {
-      args.push('-d', body);
+      args.push('--data', body);
     }
     const { stdout, stderr } = await spawnFile(curl, args, { stdio: 'pipe' });
 
@@ -122,7 +120,7 @@ test.describe('Credentials server', () => {
     expect(typeof serverState.password).toBe('string');
     expect(typeof serverState.port).toBe('number');
     expect(typeof serverState.pid).toBe('number');
-    authString = Buffer.from(`${ serverState.user }:${ serverState.password }`).toString('base64');
+    authString = `${ serverState.user }:${ serverState.password }`;
   });
 
   testWithCreds('should require authentication', async() => {

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -53,9 +53,9 @@ function haveDockerCredentialAssistant(): boolean {
   }
 }
 
-const testWithCreds = haveDockerCredentialAssistant() ? test : test.skip;
+const describeWithCreds = haveDockerCredentialAssistant() ? test.describe : test.skip;
 
-test.describe('Credentials server', () => {
+describeWithCreds('Credentials server', () => {
   let electronApp: ElectronApplication;
   let context: BrowserContext;
   let serverState: ServerState;
@@ -87,9 +87,7 @@ test.describe('Credentials server', () => {
     }
     const { stdout, stderr } = await spawnFile(command, args, { stdio: 'pipe' });
 
-    if (stderr) {
-      throw new Error(stderr);
-    }
+    expect(stderr).toEqual('');
 
     return stdout;
   }
@@ -122,7 +120,7 @@ test.describe('Credentials server', () => {
     await electronApp.close();
   });
 
-  testWithCreds('should emit connection information', async() => {
+  test('should emit connection information', async() => {
     const dataPath = path.join(paths.appHome, 'credential-server.json');
     const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
 
@@ -134,7 +132,7 @@ test.describe('Credentials server', () => {
     authString = `${ serverState.user }:${ serverState.password }`;
   });
 
-  testWithCreds('should require authentication', async() => {
+  test('should require authentication', async() => {
     const url = `http://127.0.0.1:${ serverState.port }/list`;
     const resp = await fetch(url);
 
@@ -142,7 +140,7 @@ test.describe('Credentials server', () => {
     expect(resp.status).toEqual(401);
   });
 
-  testWithCreds('should be able to use the API', async() => {
+  test('should be able to use the API', async() => {
     const bobsURL = 'https://bobs.fish/tackle';
     const bobsFirstSecret = 'loblaw';
     const bobsSecondSecret = 'shoppers with spaces and % and \' and &s and even a 😱';

--- a/src/assets/scripts/docker-credential-rancher-desktop
+++ b/src/assets/scripts/docker-credential-rancher-desktop
@@ -29,4 +29,5 @@ case $command in
     ;;
 esac
 
-curl -u "$CREDFWD_AUTH" -d "${arg}" --noproxy '*' --fail-with-body "$CREDFWD_URL/$command" 2>/dev/null
+curl --user "$CREDFWD_AUTH"  --data "${arg}" --noproxy '*' --fail-with-body "$CREDFWD_URL/$command" 2>/dev/null
+

--- a/src/assets/scripts/docker-credential-rancher-desktop
+++ b/src/assets/scripts/docker-credential-rancher-desktop
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+command=
+validCommands="list | get URL | store '{ ServerURL: URL, user: USER, secret: SECRET }' | erase URL "
+
+usage() {
+  echo "Usage: $0 $validCommands"
+  exit 1
+}
+
+case $# in
+  0) usage ;;
+  *) command=$1 ; shift ;;
+esac
+
+source /etc/rancher/desktop/credfwd
+case $command in
+  list) arg=""
+    ;;
+  get|store|erase) case $# in
+    0) arg=$(cat) ;;
+    1) arg=$1 ;;
+    *) echo "Usage: $0 get URL - too many arguments specified ($*)" ; exit 1 ;;
+    esac
+    ;;
+  *) echo "Unrecognized command '$command'." ; usage
+    ;;
+esac
+
+curl -u "$CREDFWD_AUTH" -d "${arg}" --noproxy '*' --fail-with-body "$CREDFWD_URL/$command" 2>/dev/null

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1756,9 +1756,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           this.progressTracker.action('Installing image scanner', 50, this.installTrivy()),
           this.progressTracker.action('Installing CA certificates', 50, this.installCACerts()),
         ]);
-        console.log(`QQQ: -installCredentialHelper`);
         await this.progressTracker.action('Installing credential helper', 50, this.installCredentialHelper());
-        console.log(`QQQ: +installCredentialHelper`);
 
         if (this.currentAction !== Action.STARTING) {
           // User aborted

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2001,10 +2001,16 @@ CREDFWD_URL="http://${ hostIPAddr }:${ stateInfo.port }"
 `;
       const credfwdDir = '/etc/rancher/desktop';
       const credfwdFile = `${ credfwdDir }/credfwd`;
+      const configContents = `{
+  "credsStore": "rancher-desktop"
+}
+`;
 
       await this.ssh('sudo', 'mkdir', '-p', credfwdDir);
       await this.writeFile(credfwdFile, fileContents, 0o644);
       await this.writeFile('/usr/local/bin/docker-credential-rancher-desktop', DOCKER_CREDENTIAL_SCRIPT, 0o755);
+      await this.ssh('sudo', 'mkdir', '/root/.docker');
+      await this.writeFile('/root/.docker/config.json', configContents, 0o644);
     } catch (err: any) {
       console.log(`Error trying to create the credfwd file: ${ err }`);
     }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1984,7 +1984,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       return fields[2];
     } catch (err: any) {
-      console.log(`QQQ ip route failed: ${ err }`, err);
+      console.log(`ip route failed: ${ err }`, err);
       throw err;
     }
   }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1978,11 +1978,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   protected async getHostIPAddr(): Promise<string> {
-    console.log(`QQQ: getHostIPAddr: -ip route`);
     try {
       const lines = (await this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME, 'ip', 'route', 'list', 'eth0')).split(/\n/);
-
-      console.log(`QQQ: getHostIPAddr: +ip route`);
       const fields = lines[0].split(/\s+/);
 
       return fields[2];

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -870,23 +870,17 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     const nerdctlPath = await this.wslify(windowsNerdctlPath);
 
     await this.runInstallScript(INSTALL_WSL_HELPERS_SCRIPT, 'install-wsl-helpers', nerdctlPath);
-
-    console.log(`QQQ: -installCredentialHelper`);
     await this.installCredentialHelper();
-    console.log(`QQQ: +installCredentialHelper`);
   }
 
   protected async getHostIPAddr(): Promise<string> {
-    console.log(`QQQ: getHostIPAddr: -ip route`);
     try {
       const lines = (await this.execCommand({ capture: true }, '/sbin/ip', 'route', 'list', 'eth0')).split(/\n/);
-
-      console.log(`QQQ: getHostIPAddr: +ip route`);
       const fields = lines[0].split(/\s+/);
 
       return fields[2];
     } catch (err: any) {
-      console.log(`QQQ ip route failed: ${ err }`, err);
+      console.log(`ip route failed: ${ err }`, err);
       throw err;
     }
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -34,6 +34,7 @@ import * as childProcess from '@/utils/childProcess';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 import { findHomeDir } from '@/config/findHomeDir';
+import { wslHostIPv4Address } from '@/utils/networks';
 import { ContainerEngine, Settings } from '@/config/settings';
 import resources from '@/utils/resources';
 import { getImageProcessor } from '@/k8s-engine/images/imageFactory';
@@ -1008,9 +1009,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
   /** Get the IPv4 address of the WSL (VM) host interface, assuming it's already up. */
   get hostIPAddress(): string | undefined {
-    const iface = os.networkInterfaces()['vEthernet (WSL)'];
-
-    return (iface ?? []).find(addr => addr.family === 'IPv4')?.address;
+    return wslHostIPv4Address();
   }
 
   async getBackendInvalidReason(): Promise<K8s.KubernetesError | null> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -899,10 +899,16 @@ CREDFWD_URL="http://${ hostIPAddr }:${ stateInfo.port }"
 `;
       const credfwdDir = '/etc/rancher/desktop';
       const credfwdFile = `${ credfwdDir }/credfwd`;
+      const configContents = `{
+  "credsStore": "rancher-desktop"
+}
+`;
 
       await this.execCommand('mkdir', '-p', credfwdDir);
       await this.writeFile(credfwdFile, fileContents, { permissions: 0o644 });
       await this.writeFile('/usr/local/bin/docker-credential-rancher-desktop', DOCKER_CREDENTIAL_SCRIPT, { permissions: 0o755 });
+      await this.execCommand('mkdir', '/root/.docker');
+      await this.writeFile('/root/.docker/config.json', configContents, { permissions: 0o644 });
     } catch (err: any) {
       console.log(`Error trying to create the credfwd file: ${ err }`);
     }

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -182,7 +182,6 @@ export class HttpCommandServer {
    * The incoming payload is expected to be a subset of the settings.Settings object
    */
   async updateSettings(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
-    const chunks: Buffer[] = [];
     let values: Record<string, any> = {};
     let result = '';
     const [data, payloadError] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
@@ -199,8 +198,10 @@ export class HttpCommandServer {
         console.log(`updateSettings: error processing JSON request block\n${ data }\n`, err);
         error = 'error processing JSON request block';
       }
+    } else {
+      error = payloadError;
     }
-    if (!payloadError && !error) {
+    if (!error) {
       [result, error] = await this.commandWorker.updateSettings(values);
     }
 

--- a/src/main/credentialServer/README.md
+++ b/src/main/credentialServer/README.md
@@ -1,0 +1,75 @@
+# Credential Helper Server protocol
+
+This server isn't intended to be used publicly;
+it's for other tools that we use in order to find docker credentials.
+But here is the protocol:
+
+There are 4 endpoints.
+All four endpoints use the POST method,
+even the ones that only retrieve information.
+They all expect to find their input parameters via the request body.
+A body template of `''` indicates
+that no input is needed (but the `POST` protocol still needs to be specified).
+
+The actions carried out by each endpoint should be self-explanatory based on its name.
+More attention should be paid
+to the input argument each endpoint takes,
+as they are inconsistent with one another
+(but are consistent with the API of the underlying credential helpers).
+
+```
+/list -d ''
+
+RETURNS:
+
+HTTP Code 200
+
+Body:
+{
+  "URL1": "USER1",
+  "URL2": "USER2",
+  ...
+}
+```
+
+```
+/get -d URL1
+
+RETURNS:
+
+HTTP Code 200
+
+Body:
+{
+   "ServerURL": "URL1",
+   "Username": "USER1",
+   "Secret": "SECRET1"
+}
+```
+
+```
+/store -d { "ServerURL": "URLx", "Username": "USERx", "Secret": "SECRETx"}
+
+RETURNS:
+
+HTTP Code 200
+
+Body: <EMPTY STRING>
+```
+
+It is not an error to store a new username or secret with an existing `ServerURL`.
+
+Only one `Username` may be associated with a particular `ServerURL` (this is a requirement
+of the underlying API). So for example, if you have multiple login IDs with a particular registry,
+you can store the login details in, say, a keychain, for only one of those IDs.
+
+
+```
+/erase -d URL1
+
+RETURNS:
+
+HTTP Code 200
+
+Body: <EMPTY STRING>
+```

--- a/src/main/credentialServer/README.md
+++ b/src/main/credentialServer/README.md
@@ -48,7 +48,7 @@ Body:
 ```
 
 ```
-/store -d { "ServerURL": "URLx", "Username": "USERx", "Secret": "SECRETx"}
+/store -d '{ "ServerURL": "URLx", "Username": "USERx", "Secret": "SECRETx"}'
 
 RETURNS:
 

--- a/src/main/credentialServer/__tests__/httpCredentialHelperServer.spec.ts
+++ b/src/main/credentialServer/__tests__/httpCredentialHelperServer.spec.ts
@@ -1,0 +1,12 @@
+import { HttpCredentialHelperServer } from '../httpCredentialHelperServer';
+
+const subject = new HttpCredentialHelperServer();
+
+describe(HttpCredentialHelperServer, () => {
+  describe('server', () => {
+    it("should complain when the named helper utility doesn't exist", async() => {
+      await expect(subject['runWithInput']('', 'no-such-helper', ['list'])).rejects
+        .toHaveProperty('stderr', 'Error: spawn no-such-helper ENOENT');
+    });
+  });
+});

--- a/src/main/credentialServer/__tests__/httpCredentialHelperServer.spec.ts
+++ b/src/main/credentialServer/__tests__/httpCredentialHelperServer.spec.ts
@@ -5,8 +5,9 @@ const subject = new HttpCredentialHelperServer();
 describe(HttpCredentialHelperServer, () => {
   describe('server', () => {
     it("should complain when the named helper utility doesn't exist", async() => {
-      await expect(subject['runWithInput']('', 'no-such-helper', ['list'])).rejects
-        .toHaveProperty('stderr', 'Error: spawn no-such-helper ENOENT');
+      await expect(() => subject['runWithInput']('', 'no-such-helper', ['list']))
+        .rejects.toHaveProperty('code', 'ENOENT');
+      // Skip testing for prop.path == 'no-such-helper' and prop.syscall == 'spawn no-such-helper'
     });
   });
 });

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -51,7 +51,7 @@ export function getServerCredentialsPath(): string {
 }
 
 export class HttpCredentialHelperServer {
-  protected servers = isWindows ? [http.createServer(), http.createServer()] : [http.createServer()];
+  protected server = http.createServer();
   protected password = serverHelper.randomStr();
   protected stateInfo: ServerState = {
     user:     SERVER_USERNAME,
@@ -206,9 +206,7 @@ export class HttpCredentialHelperServer {
   }
 
   closeServer() {
-    for (const server of this.servers) {
-      server.close();
-    }
+    this.server.close();
   }
 
   protected async runWithInput(data: string, command: string, args: string[]): Promise<string> {

--- a/src/main/credentialServer/httpCredentialServer.ts
+++ b/src/main/credentialServer/httpCredentialServer.ts
@@ -54,7 +54,7 @@ export class HttpCredentialServer {
   };
 
   protected dispatchTable: Record<string, Record<string, dispatchFunctionType>> = {
-    GET: {
+    POST: {
       get:   this.get,
       store: this.store,
       erase: this.erase,
@@ -84,7 +84,7 @@ export class HttpCredentialServer {
         return;
       }
       const helperName = `docker-credential-${ await this.getCredentialHelperName() }`;
-      const method = request.method ?? 'GET';
+      const method = request.method ?? 'POST';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
       const path = url.pathname;
       const pathParts = path.split('/');

--- a/src/main/credentialServer/httpCredentialServer.ts
+++ b/src/main/credentialServer/httpCredentialServer.ts
@@ -1,0 +1,160 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { URL } from 'url';
+import childProcess from 'child_process';
+
+import Logging from '@/utils/logging';
+import paths from '@/utils/paths';
+import * as serverHelper from '@/main/serverHelper';
+import { findHomeDir } from '@/config/findHomeDir';
+
+export type ServerState = {
+  user: string;
+  password: string;
+  port: number;
+  pid: number;
+}
+
+const console = Logging.server;
+const SERVER_PORT = 6109;
+const SERVER_USERNAME = 'user';
+const SERVER_FILE_BASENAME = 'credential-server.json';
+const MAX_REQUEST_BODY_LENGTH = 2048;
+
+export class HttpCredentialServer {
+  protected server = http.createServer();
+  protected password = serverHelper.randomStr();
+  protected stateInfo: ServerState = {
+    user:     SERVER_USERNAME,
+    password: this.password,
+    port:     SERVER_PORT,
+    pid:      process.pid,
+  };
+
+  protected dispatchTable: Record<string, Record<string, boolean>> = {
+    GET: {
+      get:   true,
+      store: true,
+      erase: true,
+      list:  true,
+    },
+  };
+
+  async init() {
+    const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
+
+    await fs.promises.writeFile(statePath,
+      JSON.stringify(this.stateInfo, undefined, 2),
+      { mode: 0o600 });
+    this.server.on('request', this.handleRequest.bind(this));
+    this.server.on('error', (err) => {
+      console.log(`Error: ${ err }`);
+    });
+    this.server.listen(SERVER_PORT, '127.0.0.1');
+    console.log('Credentials server is now ready.');
+  }
+
+  protected async handleRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+    try {
+      if (!serverHelper.basicAuth(SERVER_USERNAME, this.password, request.headers.authorization ?? '')) {
+        response.writeHead(401, { 'Content-Type': 'text/plain' });
+
+        return;
+      }
+      const helperName = `docker-credential-${ await this.getCredentialHelperName() }`;
+      const method = request.method ?? 'GET';
+      const url = new URL(request.url as string, `http://${ request.headers.host }`);
+      const path = url.pathname;
+      const pathParts = path.split('/');
+      const [data, error] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
+
+      if (error) {
+        console.debug(`${ path }: write back status 400, error: ${ error }`);
+        response.writeHead(400, { 'Content-Type': 'text/plain' });
+        response.write(error);
+
+        return;
+      }
+      console.debug(`Processing request ${ method } ${ path }`);
+      if (pathParts.shift()) {
+        response.writeHead(400, { 'Content-Type': 'text/plain' });
+        response.write(`Unexpected data before first / in URL ${ path }`);
+      }
+      if (!this.lookupCommand(method, pathParts[0])) {
+        console.log(`404: No handler for URL ${ method } ${ path }.`);
+        response.writeHead(404, { 'Content-Type': 'text/plain' });
+        response.write(`Unknown command: ${ method } ${ path }`);
+
+        return;
+      }
+      await this.doNamedCommand(helperName, pathParts[0], data, request, response);
+    } catch (err) {
+      console.log(`Error handling ${ request.url }`, err);
+      response.writeHead(500, { 'Content-Type': 'text/plain' });
+      response.write('Error processing request.');
+    } finally {
+      response.end();
+    }
+  }
+
+  protected lookupCommand(method: string, commandName: string) {
+    if (commandName) {
+      return this.dispatchTable[method]?.[commandName];
+    }
+
+    return undefined;
+  }
+
+  protected async doNamedCommand(helperName: string, commandName: string, data: string, request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+    let stdout = '';
+    let stderr: string;
+
+    try {
+      ( { stdout, stderr } = this.runSyncInput(data, helperName, [commandName]));
+      if (!stderr) {
+        response.writeHead(200, { 'Content-Type': 'text/plain' });
+        response.write(stdout);
+
+        return await Promise.resolve();
+      }
+    } catch (err: any) {
+      stderr = err.stderr?.toString() || err.stdout?.toString();
+    }
+    console.debug(`credentialServer: ${ commandName }: writing back status 400, error: ${ stderr || '' }`);
+    response.writeHead(400, { 'Content-Type': 'text/plain' });
+    response.write(stderr);
+
+    return await Promise.resolve();
+  }
+
+  // Caller is responsible for catching exceptions if this file doesn't exist
+  protected async getCredentialHelperName(): Promise<string> {
+    const home = findHomeDir();
+    const dockerConfig = path.join(home ?? '', '.docker', 'config.json');
+    const contents = JSON.parse((await fs.promises.readFile(dockerConfig, { encoding: 'utf-8' })).toString());
+    const credStore = contents['credsStore'];
+
+    if (!credStore) {
+      throw new Error(`No credStore field in ${ dockerConfig }`);
+    }
+
+    return credStore;
+  }
+
+  closeServer() {
+    this.server.close();
+  }
+
+  protected runSyncInput(data: string, command: string, args: string[]): { stdout: string, stderr: string } {
+    try {
+      // Only the *Sync methods in childProcess that run an external command take a string
+      // directly as input. Setting up a readable stream around a string is a lot more work.
+      const stdout = childProcess.execFileSync(command, args, { input: data });
+
+      return { stdout: stdout.toString(), stderr: '' };
+    } catch (err: any) {
+      return { stdout: '', stderr: err.toString() };
+    }
+  }
+}

--- a/src/main/serverHelper.ts
+++ b/src/main/serverHelper.ts
@@ -1,0 +1,71 @@
+import http from 'http';
+import Logging from '@/utils/logging';
+
+const console = Logging.server;
+
+export function basicAuth(expectedUser: string, expectedPassword: string, authString: string): boolean {
+  if (!authString) {
+    console.log('Auth failure: no username+password given');
+
+    return false;
+  }
+  const m = /^Basic\s+(.*)/.exec(authString);
+
+  if (!m) {
+    console.log('Auth failure: only Basic auth is supported');
+
+    return false;
+  }
+  const [user, ...passwordParts] = base64Decode(m[1]).split(':');
+  const password = passwordParts.join(':');
+
+  if (user !== expectedUser || password !== expectedPassword) {
+    console.log(`Auth failure: user/password validation failure for attempted login of user ${ user }`);
+
+    return false;
+  }
+
+  return true;
+}
+
+function base64Decode(value: string): string {
+  return Buffer.from(value, 'base64').toString('utf-8');
+}
+
+export async function getRequestBody(request: http.IncomingMessage, maxPayloadSize: number): Promise<[string, string]> {
+  const chunks: Buffer[] = [];
+  let error = '';
+  let dataSize = 0;
+
+  // Read in the request body
+  for await (const chunk of request) {
+    dataSize += chunk.toString().length;
+    if (dataSize > maxPayloadSize) {
+      error = `request body is too long, request body size exceeds ${ maxPayloadSize }`;
+      break;
+    }
+    chunks.push(chunk);
+  }
+  const data = Buffer.concat(chunks).toString();
+
+  return [data, error];
+}
+
+// There's a `randomStr` in utils/string.ts but it's only usable from the UI side
+// because it depends on access to the `window` object.
+// And trying to use `cryptoRandomString()` from crypto-random-string gives an error message
+// indicating that it pulls in some `require` statements where `import` is required.
+
+export function randomStr(length = 16) {
+  const alpha = 'abcdefghijklmnopqrstuvwxyz';
+  const num = '0123456789';
+  const charSet = alpha + alpha.toUpperCase() + num;
+  const charSetLength = charSet.length;
+  const chars = [];
+
+  while (length-- > 0) {
+    chars.push(charSet[Math.floor(Math.random() * charSetLength)]);
+  }
+
+  return chars.join('');
+}

--- a/src/main/serverHelper.ts
+++ b/src/main/serverHelper.ts
@@ -9,7 +9,7 @@ export function basicAuth(expectedUser: string, expectedPassword: string, authSt
 
     return false;
   }
-  const m = /^Basic\s+(.*)/.exec(authString);
+  const m = /^Basic\s+(.*)/i.exec(authString);
 
   if (!m) {
     console.log('Auth failure: only Basic auth is supported');
@@ -32,6 +32,15 @@ function base64Decode(value: string): string {
   return Buffer.from(value, 'base64').toString('utf-8');
 }
 
+/**
+ * Reads in the input from the request body (which is done by calling `for await (const chunk of result)`),
+ * verifies it hasn't exceeded the max-allowed size,
+ * and returns it as a string.
+ *
+ * @param request
+ * @param maxPayloadSize
+ * @return [value: string, error: string]
+ */
 export async function getRequestBody(request: http.IncomingMessage, maxPayloadSize: number): Promise<[string, string]> {
   const chunks: Buffer[] = [];
   let error = '';
@@ -39,7 +48,7 @@ export async function getRequestBody(request: http.IncomingMessage, maxPayloadSi
 
   // Read in the request body
   for await (const chunk of request) {
-    dataSize += chunk.toString().length;
+    dataSize += chunk.length;
     if (dataSize > maxPayloadSize) {
       error = `request body is too long, request body size exceeds ${ maxPayloadSize }`;
       break;

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -1,0 +1,7 @@
+import os from 'os';
+
+export function wslHostIPv4Address(): string | undefined {
+  const iface = os.networkInterfaces()['vEthernet (WSL)'];
+
+  return (iface ?? []).find(addr => addr.family === 'IPv4')?.address;
+}


### PR DESCRIPTION
Fixes #2202

Currently needs manual testing. One way to do this:
1. Choose nerdctl containerEngine and restart
2. `nerdctl logout`
3. Create an image. Let's call it `beaker/my-web-server:v1`.
4. Try to push it:
```
$ nerdctl push beaker/my-web-server:v1
# Should give an error message like:
server message: insufficient_scope: authorization failed
```
5. Manually add your credentials to your local keychain. On osx this would be
```
echo '{"ServerURL":"https://index.docker.io/v1/", "User":"MYUSERNAME", "Secret:"MYPASSWORD"}' | docker-credential-osxkeychain store
```
6. Repeat the `nerdctl push` command. It should succeed. 

It seems like we're not testing this PR, but I added log statements to `httpCredentialHelperServer.ts` and saw that it was handling requests to get the credentials.