### PR TITLE
Bump alpine-lima iso 0.2.13 → 0.2.14

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -10,7 +10,7 @@ const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
 const limaTag = 'v1.23';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.13';
+const alpineLimaTag = 'v0.2.14';
 const alpineLimaEdition = 'rd';
 const alpineLimaVersion = '3.15.4';
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -171,7 +171,7 @@ interface SudoCommand {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.13';
+const IMAGE_VERSION = '0.2.14';
 const ALPINE_EDITION = 'rd';
 const ALPINE_VERSION = '3.15.4';
 


### PR DESCRIPTION
It includes the openssh-sftp-server package that is needed for `limactl copy` with newer versions of `scp`.

Fixes #2139