### PR TITLE
Update the way we access a row

### DIFF
--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -21,16 +21,16 @@
       </template>
       <template #row-actions="{row}">
         <button
-          v-if="row.listenPort"
+          v-if="row.row.listenPort"
           class="btn btn-sm role-tertiary"
-          @click="update(false, row)"
+          @click="update(false, row.row)"
         >
           Cancel
         </button>
         <button
           v-else
           class="btn btn-sm role-tertiary"
-          @click="update(true, row)"
+          @click="update(true, row.row)"
         >
           Forward
         </button>


### PR DESCRIPTION
This fixes a bug in port forwarding where clicking on forward would do nothing. While investigating, I found that any properties we tried to access for a port were `undefined`. Looking at the `row` object for the port forwarding table unveiled that the service data we need to access are nested under a `row` property, meaning that we need to access a row via `row.row`..

This is regression introduced in #2200. It looks like the sortable table component updated its public interface for the `row` slot prop somewhere along the way since we last updated..

closes #2244

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>