### PR TITLE
Lima: Use a copy of settings when running.

### DIFF
--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import * as settings from '../settings';
+import clone from '@/utils/clone';
 import { PathManagementStrategy } from '@/integrations/pathManager';
 
 describe('updateFromCommandLine', () => {
@@ -38,7 +39,7 @@ describe('updateFromCommandLine', () => {
       debug:                  true,
       pathManagementStrategy: PathManagementStrategy.NotSet,
     };
-    origPrefs = JSON.parse(JSON.stringify(prefs));
+    origPrefs = clone(prefs);
   });
 
   describe('getUpdatableNode', () => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'path';
 
 import _ from 'lodash';
 
+import clone from '@/utils/clone';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 import { PathManagementStrategy } from '@/integrations/pathManager';
@@ -88,7 +89,7 @@ function loadFromDisk(): Settings {
   }
 
   // clone settings because we check to see if the returned value is different
-  const cfg = updateSettings(JSON.parse(JSON.stringify(settings)));
+  const cfg = updateSettings(clone(settings));
 
   if (!Object.values(ContainerEngine).map(String).includes(cfg.kubernetes.containerEngine)) {
     console.warn(`Replacing unrecognized saved container engine pref of '${ cfg.kubernetes.containerEngine }' with ${ ContainerEngine.CONTAINERD }`);

--- a/src/integrations/windowsIntegrationManager.ts
+++ b/src/integrations/windowsIntegrationManager.ts
@@ -9,6 +9,7 @@ import { State } from '@/k8s-engine/k8s';
 import mainEvents from '@/main/mainEvents';
 import BackgroundProcess from '@/utils/backgroundProcess';
 import { spawn, spawnFile } from '@/utils/childProcess';
+import clone from '@/utils/clone';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 import resources from '@/utils/resources';
@@ -56,7 +57,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   constructor() {
     mainEvents.on('settings-update', (settings) => {
       this.wslHelperDebugArgs = settings.debug ? ['--verbose'] : [];
-      this.settings = JSON.parse(JSON.stringify(settings));
+      this.settings = clone(settings);
       this.sync();
     });
     mainEvents.on('k8s-check-state', (mgr) => {

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -2,7 +2,7 @@
  * Clone a given object, returning a disconnected copy.
  *
  * @note This should be replaced via StructuredClone in NodeJS 18.
- * @note This only supports primative objects (array, object, string, etc.)
+ * @note This only supports primitive objects (array, object, string, etc.)
  */
 export default function clone<T>(input: T): T {
   return JSON.parse(JSON.stringify(input));

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -1,0 +1,9 @@
+/**
+ * Clone a given object, returning a disconnected copy.
+ *
+ * @note This should be replaced via StructuredClone in NodeJS 18.
+ * @note This only supports primative objects (array, object, string, etc.)
+ */
+export default function clone<T>(input: T): T {
+  return JSON.parse(JSON.stringify(input));
+}

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import stream from 'stream';
 import yaml from 'yaml';
 
 import paths from './paths';
 import { spawnFile } from '@/utils/childProcess';
+import clone from '@/utils/clone';
 import Logging from '@/utils/logging';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 
@@ -354,7 +354,7 @@ export default class DockerDirManager {
     const currentConfig = await this.readDockerConfig();
 
     // Deep-copy the JSON object
-    const newConfig = JSON.parse(JSON.stringify(currentConfig));
+    const newConfig = clone(currentConfig);
 
     // ensure docker context is set as we want
     const platform = os.platform();
@@ -378,7 +378,7 @@ export default class DockerDirManager {
     const currentConfig = await this.readDockerConfig();
 
     // Deep-copy the JSON object
-    const newConfig = JSON.parse(JSON.stringify(currentConfig));
+    const newConfig = clone(currentConfig);
 
     // ensure we are using one of our preferred credential helpers
     newConfig.credsStore = await this.getCredsStoreFor(currentConfig.credsStore);

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -10,6 +10,14 @@ export type RecursivePartial<T> = {
       T[P];
 }
 
+export type RecursiveReadonly<T> = {
+  readonly [P in keyof T]:
+  T[P] extends (infer U)[] ? readonly RecursiveReadonly<U>[] :
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  T[P] extends object ? RecursiveReadonly<T[P]> :
+  T[P];
+}
+
 /** UpperAlpha is the set of upper-case alphabets. */
 type UpperAlpha =
   'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' |


### PR DESCRIPTION
This makes us duplicate the settings object in Lima, so that it would not be affected by changes from elsewhere.  This ensures that we can later move to a model where we apply all changes at once.

Fixes #2266.

This will probably make the next release, but that's okay.