### PR TITLE
Fix hanging process by allowing docker-credential-HELPER to read from standard input.

### DIFF
--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -403,9 +403,9 @@ describe('DockerDirManager', () => {
 
   describe('credHelperWorking', () => {
     let spawnMock: jest.SpiedFunction<typeof childProcess.spawnFile>;
-    const commonCredHelperExpectations = (command: any, args: any, options: any) => {
+    const commonCredHelperExpectations: (...args: Parameters<typeof childProcess.spawnFile>) => void = (command, args, options) => {
       expect(command).toEqual('docker-credential-mockhelper');
-      expect((args as Array<string>)[0]).toEqual('list');
+      expect(args[0]).toEqual('list');
       expect(options.stdio[0]).toBeInstanceOf(stream.Readable);
       expect(options.stdio[1]).toBe('pipe');
       expect(options.stdio[2]).toBeInstanceOf(Log);
@@ -419,7 +419,7 @@ describe('DockerDirManager', () => {
         .mockImplementation((command, args, options) => {
           commonCredHelperExpectations(command, args, options);
 
-          return Promise.reject();
+          return Promise.reject(new Error('not a valid cred-helper'));
         });
       await expect(subj['credHelperWorking']('mockhelper')).resolves.toBeFalsy();
     });

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -400,34 +400,8 @@ describe('DockerDirManager', () => {
   });
 
   describe('credHelperWorking', () => {
-    let fakeProcess: childProcess.ChildProcess;
-    let spawnMock: jest.SpiedFunction<typeof childProcess.spawn>;
-
-    beforeAll(() => {
-      spawnMock = jest.spyOn(childProcess, 'spawn')
-        .mockImplementation(() => {
-          fakeProcess = new childProcess.ChildProcess();
-
-          return fakeProcess;
-        });
-    });
-
-    afterAll(() => {
-      spawnMock.mockRestore();
-    });
-
-    it('should return false when cred helper is not working', async() => {
-      const testPromise = expect(subj['credHelperWorking']('mockhelper')).resolves.toBeFalsy();
-
-      fakeProcess.emit('exit', 1);
-      await testPromise;
-    });
-
-    it('should return true when cred helper is working', async() => {
-      const testPromise = expect(subj['credHelperWorking']('mockhelper')).resolves.toBeTruthy();
-
-      fakeProcess.emit('exit', 0);
-      await testPromise;
+    it('should return false when cred helper is not working', () => {
+      expect(subj['credHelperWorking']('no -*- such -*- program/on/this -*- system')).resolves.toBeFalsy();
     });
   });
 });

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -281,6 +281,7 @@ export default class DockerDirManager {
     const currentConfig = await this.readDockerConfig();
 
     console.log(`Read existing docker config: ${ JSON.stringify(currentConfig) }`);
+    // Deep-copy the JSON object
     const newConfig = JSON.parse(JSON.stringify(currentConfig));
 
     // ensure docker context is set as we want

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -1,9 +1,12 @@
-import { spawn } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
 import yaml from 'yaml';
+
+import { spawnFile } from '@/utils/childProcess';
 import Logging from '@/utils/logging';
+import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 
 const console = Logging.background;
 
@@ -81,7 +84,7 @@ export default class DockerDirManager {
    * @param config An object that is the config we want to write.
    */
   protected async writeDockerConfig(config: PartialDockerConfig): Promise<void> {
-    const rawConfig = JSON.stringify(config);
+    const rawConfig = jsonStringifyWithWhiteSpace(config);
 
     await fs.promises.mkdir(this.dockerDirPath, { recursive: true });
     await fs.promises.writeFile(this.dockerConfigPath, rawConfig, { encoding: 'utf-8' });
@@ -178,28 +181,21 @@ export default class DockerDirManager {
    * Determines whether the passed credential helper is working.
    * @param helperName The cred helper name, without the "docker-credential-" prefix.
    */
-  protected credHelperWorking(helperName: string): Promise<boolean> {
+  protected async credHelperWorking(helperName: string): Promise<boolean> {
     const helperBin = `docker-credential-${ helperName }`;
-    const logMsg = `Credential helper "${ helperBin }" is not functional`;
-    let proc: any;
 
     try {
-      proc = spawn(helperBin, ['list']);
-    } catch {
-      console.log(logMsg);
+      // Provide input in case the helper always reads from stdin regardless of argument (harmless if it doesn't).
+      const body = stream.Readable.from('');
 
-      return Promise.resolve(false);
+      await spawnFile(helperBin, ['list'], { stdio: [body, 'pipe', console] });
+
+      return true;
+    } catch (err) {
+      console.log(`Credential helper "${ helperBin }" is not functional: ${ err }`);
+
+      return false;
     }
-
-    return new Promise( (resolve) => {
-      proc.on('exit', (code: number | null, signal: string | null) => {
-        if (code || signal) {
-          console.log(logMsg);
-          resolve(false);
-        }
-        resolve(true);
-      });
-    });
   }
 
   /**


### PR DESCRIPTION
Fixed #2291 

This handles the case where an existing `~/.docker/config.json` file has a `credsStore` field set to `HELPER` that refers to a non-existent or failing `docker-credential-HELPER` executable. It currently causes RD to hang in the `Starting Backend` section.

Also simplify code:
* use utils/child_process.SpawnFile instead of process-based processing
* which removes the need for a mock spawn object

True, we're no longer unit-testing a working instance, but that's harder to do now
that so much code has been removed, and I'll say there's less of a need for it.

Signed-off-by: Eric Promislow <epromislow@suse.com>