### PR TITLE
utils/fetch: support options.agent being a boolean.

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -113,10 +113,10 @@ export default async function fetch(url: string, options?: RequestInit) {
         let agent: http.Agent;
 
         if (options?.agent) {
-          if (options.agent instanceof http.Agent) {
-            agent = options.agent;
-          } else {
+          if (typeof options.agent === 'function') {
             agent = options.agent(parsedURL);
+          } else {
+            agent = options.agent;
           }
         } else {
           agent = isSecure ? https.globalAgent : http.globalAgent;


### PR DESCRIPTION
https://github.com/node-fetch/node-fetch/pull/1502 changed the type of `options.agent` to allow a boolean, which caused issues as we tried to call it.  Flip the condition around and check for function instead, so that this
compiles.

Fixes issue Eric reported over Slack.