### PR TITLE
Use bundled credential helpers by default, bundle `docker-credential-pass` on Linux, and always manage docker.config `credsStore` field

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -166,6 +166,8 @@ Electron.app.whenReady().then(async() => {
     setupTray();
     window.openPreferences();
 
+    dockerDirManager.ensureCredHelperConfigured();
+
     // Path management strategy will need to be selected after an upgrade
     if (!os.platform().startsWith('win') && cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
       if (!noModalDialogs) {

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -43,7 +43,9 @@ BuildRequires:  ImageMagick
 %if 0%{?debian}
 Requires: qemu-utils
 Requires: qemu-system-x86
+Requires: pass
 Requires: openssh-client
+Requires: gnupg
 Requires: libasound2
 Requires: libatk1.0-0
 Requires: libatk-bridge2.0-0
@@ -73,7 +75,9 @@ Requires: libxkbcommon0
 Requires: libxrandr2
 %else
 Requires: qemu
+Requires: password-store
 Requires: openssh-clients
+Requires: gpg2
 Requires: glibc
 Requires: desktop-file-utils
 Requires: libX11-6

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -324,8 +324,7 @@ function downloadDockerProvidedCredHelpers(platform, destDir) {
   const extension = platform.startsWith('win') ? 'zip' : 'tar.gz';
   const downloadFunc = platform.startsWith('win') ? downloadZip : downloadTarGZ;
   const credHelperNames = {
-    // we can add "docker-credential-pass" to this list if we need it
-    linux:  ['docker-credential-secretservice'],
+    linux:  ['docker-credential-secretservice', 'docker-credential-pass'],
     darwin: ['docker-credential-osxkeychain'],
     win32:  ['docker-credential-wincred'],
   }[platform];

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -310,7 +310,7 @@ export function factory(arch: Architecture, dockerDirManager: DockerDirManager):
   case 'darwin':
     return new LimaBackend(arch, dockerDirManager);
   case 'win32':
-    return new WSLBackend(dockerDirManager);
+    return new WSLBackend();
   default:
     throw new Error(`OS "${ platform }" is not supported.`);
   }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1757,7 +1757,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           this.emit('kim-builder-uninstalled');
         }
         if (this.#currentContainerEngine === ContainerEngine.MOBY) {
-          await this.dockerDirManager.ensureDockerConfig(
+          await this.dockerDirManager.ensureDockerContextConfigured(
             this.#allowSudo,
             path.join(paths.altAppHome, 'docker.sock'),
             k3sEndpoint);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -40,7 +40,6 @@ import resources from '@/utils/resources';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 import { getImageProcessor } from '@/k8s-engine/images/imageFactory';
 import { getServerCredentialsPath, ServerState } from '@/main/credentialServer/httpCredentialHelperServer';
-import DockerDirManager from '@/utils/dockerDirManager';
 
 const console = Logging.wsl;
 const INSTANCE_NAME = 'rancher-desktop';
@@ -214,9 +213,8 @@ class BackgroundProcess {
 }
 
 export default class WSLBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor(dockerDirManager: DockerDirManager) {
+  constructor() {
     super();
-    this.dockerDirManager = dockerDirManager;
     this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
     this.k3sHelper.initialize().catch((err) => {
       console.log('k3sHelper.initialize failed: ', err);
@@ -249,8 +247,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   protected cfg: Settings['kubernetes'] | undefined;
-
-  protected dockerDirManager: DockerDirManager;
 
   /**
    * Reference to the _init_ process in WSL.  All other processes should be
@@ -1456,9 +1452,6 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         }
         if (this.#currentContainerEngine === ContainerEngine.CONTAINERD) {
           await this.execCommand('/usr/local/bin/wsl-service', '--ifnotstarted', 'buildkitd', 'start');
-        } else if (this.#currentContainerEngine === ContainerEngine.MOBY) {
-          await this.dockerDirManager.ensureDockerConfig(true);
-        }
 
         this.setState(enabledK3s ? K8s.State.STARTED : K8s.State.DISABLED);
       } catch (ex) {
@@ -1649,7 +1642,6 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     // The main application data directories will be deleted by a helper
     // application; we only need to unregister the WSL data.
     await this.del();
-    await this.dockerDirManager.clearDockerContext();
   }
 
   listServices(namespace?: string): K8s.ServiceEntry[] {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1452,6 +1452,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         }
         if (this.#currentContainerEngine === ContainerEngine.CONTAINERD) {
           await this.execCommand('/usr/local/bin/wsl-service', '--ifnotstarted', 'buildkitd', 'start');
+        }
 
         this.setState(enabledK3s ? K8s.State.STARTED : K8s.State.DISABLED);
       } catch (ex) {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -12,6 +12,7 @@ import * as serverHelper from '@/main/serverHelper';
 import { findHomeDir } from '@/config/findHomeDir';
 import { wslHostIPv4Address } from '@/utils/networks';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
+import resources from '@/utils/resources';
 
 export type ServerState = {
   user: string;
@@ -166,7 +167,7 @@ export class HttpCredentialHelperServer {
     request: http.IncomingMessage,
     response: http.ServerResponse): Promise<void> {
     let stderr: string;
-    const helperPath = path.join(paths.integration, helperName);
+    const helperPath = resources.executable(helperName);
 
     try {
       const body = stream.Readable.from(data);

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -196,13 +196,13 @@ export class HttpCredentialHelperServer {
     const home = findHomeDir();
     const dockerConfig = path.join(home ?? '', '.docker', 'config.json');
     const contents = JSON.parse((await fs.promises.readFile(dockerConfig, { encoding: 'utf-8' })).toString());
-    const credStore = contents['credsStore'];
+    const credsStore = contents['credsStore'];
 
-    if (!credStore) {
-      throw new Error(`No credStore field in ${ dockerConfig }`);
+    if (!credsStore) {
+      throw new Error(`No credsStore field in ${ dockerConfig }`);
     }
 
-    return credStore;
+    return credsStore;
   }
 
   closeServer() {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -166,10 +166,11 @@ export class HttpCredentialHelperServer {
     request: http.IncomingMessage,
     response: http.ServerResponse): Promise<void> {
     let stderr: string;
+    const helperPath = path.join(paths.integration, helperName);
 
     try {
       const body = stream.Readable.from(data);
-      const { stdout } = await spawnFile(helperName, [commandName], { stdio: [body, 'pipe', console] });
+      const { stdout } = await spawnFile(helperPath, [commandName], { stdio: [body, 'pipe', console] });
 
       if (outputChecker(stdout)) {
         response.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -2,11 +2,8 @@ import fs from 'fs';
 import net from 'net';
 import os from 'os';
 import path from 'path';
-import stream from 'stream';
 
-import * as childProcess from '@/utils/childProcess';
 import DockerDirManager from '@/utils/dockerDirManager';
-import { Log } from '@/utils/logging';
 
 const itUnix = os.platform() === 'win32' ? it.skip : it;
 const itLinux = os.platform() === 'linux' ? it : it.skip;
@@ -374,39 +371,6 @@ describe('DockerDirManager', () => {
       await fs.promises.writeFile(metaPath, 'irrelevant');
 
       await expect(subj['clearDockerContext']()).resolves.toBeUndefined();
-    });
-  });
-
-  describe('credHelperWorking', () => {
-    let spawnMock: jest.SpiedFunction<typeof childProcess.spawnFile>;
-    const commonCredHelperExpectations: (...args: Parameters<typeof childProcess.spawnFile>) => void = (command, args, options) => {
-      expect(command).toEqual('docker-credential-mockhelper');
-      expect(args[0]).toEqual('list');
-      expect(options.stdio[0]).toBeInstanceOf(stream.Readable);
-      expect(options.stdio[1]).toBe('pipe');
-      expect(options.stdio[2]).toBeInstanceOf(Log);
-    };
-
-    afterEach(() => {
-      spawnMock.mockRestore();
-    });
-    it('should return false when cred helper is not working', async() => {
-      spawnMock = jest.spyOn(childProcess, 'spawnFile')
-        .mockImplementation((command, args, options) => {
-          commonCredHelperExpectations(command, args, options);
-
-          return Promise.reject(new Error('not a valid cred-helper'));
-        });
-      await expect(subj['credHelperWorking']('mockhelper')).resolves.toBeFalsy();
-    });
-    it('should return true when cred helper is working', async() => {
-      spawnMock = jest.spyOn(childProcess, 'spawnFile')
-        .mockImplementation((command, args, options) => {
-          commonCredHelperExpectations(command, args, options);
-
-          return Promise.resolve({});
-        });
-      await expect(subj['credHelperWorking']('mockhelper')).resolves.toBeTruthy();
     });
   });
 

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -80,7 +80,7 @@ describe('DockerDirManager', () => {
     });
   });
 
-  describeUnix('ensureDockerContext', () => {
+  describeUnix('ensureDockerContextFile', () => {
     /** Path to the docker context metadata file (in workdir). */
     let metaPath: string;
     /** Path to the docker socket Rancher Desktop is providing. */
@@ -94,7 +94,7 @@ describe('DockerDirManager', () => {
     });
 
     it('should create additional docker context if none exists', async() => {
-      await expect(subj['ensureDockerContext'](sockPath, undefined)).resolves.toBeUndefined();
+      await expect(subj['ensureDockerContextFile'](sockPath, undefined)).resolves.toBeUndefined();
       const result = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
 
       expect(result).toEqual({
@@ -113,7 +113,7 @@ describe('DockerDirManager', () => {
     it('should add a kubernetes section if kubernetesEndpoint is not undefined', async() => {
       const kubernetesEndpoint = 'some-endpoint';
 
-      await expect(subj['ensureDockerContext'](sockPath, kubernetesEndpoint)).resolves.toBeUndefined();
+      await expect(subj['ensureDockerContextFile'](sockPath, kubernetesEndpoint)).resolves.toBeUndefined();
       const result = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
 
       expect(result).toEqual({
@@ -135,7 +135,7 @@ describe('DockerDirManager', () => {
     });
   });
 
-  describe('ensureDockerConfig', () => {
+  describe('ensureDockerContextConfigured', () => {
     /** Path to the docker config file (in workdir). */
     let configPath: string;
     /** Path to the docker context metadata file (in workdir). */
@@ -171,14 +171,11 @@ describe('DockerDirManager', () => {
           Name:      'pikachu',
           Endpoints: { docker: { Host: `unix://${ altSockPath }` } },
         }));
-        await expect(subj.ensureDockerConfig(false, sockPath, undefined)).resolves.toBeUndefined();
+        await expect(subj.ensureDockerContextConfigured(false, sockPath, undefined)).resolves.toBeUndefined();
 
         expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'pikachu');
         expect(consoleMock).toHaveBeenCalledWith(
           expect.stringMatching(`Read existing docker config.*`),
-          expect.anything());
-        expect(consoleMock).toHaveBeenCalledWith(
-          expect.stringMatching(`Writing modified docker config.*`),
           expect.anything());
       } finally {
         server.close();
@@ -194,7 +191,7 @@ describe('DockerDirManager', () => {
         Endpoints: { docker: { Host: `unix://${ altSockPath }` } },
       }));
 
-      await expect(subj.ensureDockerConfig(false, sockPath, undefined)).resolves.toBeUndefined();
+      await expect(subj.ensureDockerContextConfigured(false, sockPath, undefined)).resolves.toBeUndefined();
 
       expect(consoleMock).toHaveBeenCalledWith(
         expect.stringMatching(`Could not read existing docker socket.*${ workdir }.*pikachu.*ENOENT`),
@@ -213,7 +210,7 @@ describe('DockerDirManager', () => {
       }));
       await fs.promises.writeFile(altSockPath, '');
 
-      await expect(subj.ensureDockerConfig(false, sockPath, undefined)).resolves.toBeUndefined();
+      await expect(subj.ensureDockerContextConfigured(false, sockPath, undefined)).resolves.toBeUndefined();
 
       expect(consoleMock).toHaveBeenCalledWith(
         expect.stringMatching(`Invalid existing context.*pikachu.*${ workdir }`),
@@ -230,31 +227,28 @@ describe('DockerDirManager', () => {
         Name:      'pikachu',
         Endpoints: { docker: { Host: `tcp://server.test:1234` } },
       }));
-      await expect(subj.ensureDockerConfig(false, sockPath, undefined)).resolves.toBeUndefined();
+      await expect(subj.ensureDockerContextConfigured(false, sockPath, undefined)).resolves.toBeUndefined();
 
       expect(JSON.parse(await fs.promises.readFile(configPath, 'utf-8'))).toHaveProperty('currentContext', 'pikachu');
       expect(consoleMock).toHaveBeenCalledWith(
         expect.stringMatching(`Read existing docker config.*`),
-        expect.anything());
-      expect(consoleMock).toHaveBeenCalledWith(
-        expect.stringMatching(`Writing modified docker config.*`),
         expect.anything());
     });
 
     itUnix('should update kubernetes endpoint', async() => {
       const kubeURL = 'http://kubernetes.test:2345';
 
-      await expect(subj.ensureDockerConfig(false, sockPath, kubeURL)).resolves.toBeUndefined();
+      await expect(subj.ensureDockerContextConfigured(false, sockPath, kubeURL)).resolves.toBeUndefined();
 
       const result = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
 
       expect(result).toHaveProperty('Name', 'rancher-desktop');
       expect(result).toHaveProperty('Endpoints.kubernetes.Host', kubeURL);
       expect(consoleMock).toHaveBeenCalledWith(
-        expect.stringMatching(`Read existing docker config.*`),
+          expect.stringMatching(`No docker config file found`),
         expect.anything());
       expect(consoleMock).toHaveBeenCalledWith(
-        expect.stringMatching(`Writing modified docker config.*`),
+        expect.stringMatching(`Wrote docker config.*`),
         expect.anything());
     });
 
@@ -272,7 +266,7 @@ describe('DockerDirManager', () => {
         await fs.promises.writeFile(configPath, JSON.stringify({ currentContext: 'pikachu' }));
         await fs.promises.mkdir(path.join(metaDir, 'invalid-context', 'meta.json'), { recursive: true });
         await fs.promises.writeFile(path.join(metaDir, 'invalid-context-two'), '');
-        await expect(subj.ensureDockerConfig(false, sockPath, undefined)).resolves.toBeUndefined();
+        await expect(subj.ensureDockerContextConfigured(false, sockPath, undefined)).resolves.toBeUndefined();
 
         expect(consoleMock).toHaveBeenCalledWith(
           expect.stringMatching(`Failed to read context.*invalid-context.*EISDIR`),
@@ -288,14 +282,24 @@ describe('DockerDirManager', () => {
       }
     });
 
+  });
+
+  describe('ensureCredHelperConfigured', () => {
+    /** Path to the docker config file (in workdir). */
+    let configPath: string;
+
+    beforeEach(() => {
+      configPath = path.join(workdir, '.docker', 'config.json');
+    });
+
     it('should throw errors reading config.json', async() => {
       await fs.promises.mkdir(configPath, { recursive: true });
-      await expect(subj.ensureDockerConfig(false, sockPath, undefined)).rejects.toThrow('EISDIR');
+      await expect(subj.ensureCredHelperConfigured()).rejects.toThrow('EISDIR');
       expect(consoleMock).not.toHaveBeenCalled();
     });
 
     it('should set credsStore to default when empty', async() => {
-      await subj.ensureDockerConfig(true, 'notrelevant', undefined);
+      await subj.ensureCredHelperConfigured();
       const rawConfig = await fs.promises.readFile(configPath, 'utf-8');
       const newConfig = JSON.parse(rawConfig);
 
@@ -309,7 +313,7 @@ describe('DockerDirManager', () => {
       try {
         await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
         await fs.promises.writeFile(configPath, JSON.stringify({ credsStore: 'desktop' }));
-        await subj.ensureDockerConfig(true, 'notrelevant', undefined);
+        await subj.ensureCredHelperConfigured();
         const rawConfig = await fs.promises.readFile(configPath, 'utf-8');
         const newConfig = JSON.parse(rawConfig);
 
@@ -326,7 +330,7 @@ describe('DockerDirManager', () => {
       try {
         await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
         await fs.promises.writeFile(configPath, JSON.stringify({ credsStore: 'desktop' }));
-        await subj.ensureDockerConfig(true, 'notrelevant', undefined);
+        await subj.ensureCredHelperConfigured();
         const rawConfig = await fs.promises.readFile(configPath, 'utf-8');
         const newConfig = JSON.parse(rawConfig);
 
@@ -339,7 +343,7 @@ describe('DockerDirManager', () => {
     it('should not change any irrelevant keys in config.json', async() => {
       await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
       await fs.promises.writeFile(configPath, JSON.stringify({ otherKey: 'otherValue' }));
-      await subj.ensureDockerConfig(true, 'notrelevant', undefined);
+      await subj.ensureCredHelperConfigured();
       const newConfig = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
 
       expect(newConfig).toHaveProperty('otherKey', 'otherValue');
@@ -365,7 +369,6 @@ describe('DockerDirManager', () => {
 
       await expect(subj['clearDockerContext']()).resolves.toBeUndefined();
       await expect(fs.promises.lstat(path.dirname(metaPath))).rejects.toThrowError('ENOENT');
-      expect(consoleMock).not.toHaveBeenCalled();
     });
 
     it('should unset docker context as needed', async() => {
@@ -376,7 +379,6 @@ describe('DockerDirManager', () => {
       const contents = JSON.parse(await fs.promises.readFile(configPath, 'utf-8')) ?? {};
 
       expect(contents).not.toHaveProperty('currentContext');
-      expect(consoleMock).not.toHaveBeenCalled();
     });
 
     it('should not unset unrelated docker context', async() => {
@@ -389,7 +391,6 @@ describe('DockerDirManager', () => {
       const contents = JSON.parse(await fs.promises.readFile(configPath, 'utf-8')) ?? {};
 
       expect(contents).toHaveProperty('currentContext', context);
-      expect(consoleMock).not.toHaveBeenCalled();
     });
 
     it('should not fail if docker config is missing', async() => {
@@ -397,7 +398,6 @@ describe('DockerDirManager', () => {
       await fs.promises.writeFile(metaPath, 'irrelevant');
 
       await expect(subj['clearDockerContext']()).resolves.toBeUndefined();
-      expect(consoleMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -245,7 +245,7 @@ describe('DockerDirManager', () => {
       expect(result).toHaveProperty('Name', 'rancher-desktop');
       expect(result).toHaveProperty('Endpoints.kubernetes.Host', kubeURL);
       expect(consoleMock).toHaveBeenCalledWith(
-          expect.stringMatching(`No docker config file found`),
+        expect.stringMatching(`No docker config file found`),
         expect.anything());
       expect(consoleMock).toHaveBeenCalledWith(
         expect.stringMatching(`Wrote docker config.*`),
@@ -281,7 +281,6 @@ describe('DockerDirManager', () => {
         statMock.mockRestore();
       }
     });
-
   });
 
   describe('ensureCredHelperConfigured', () => {

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -70,7 +70,9 @@ export default class DockerDirManager {
       const rawConfig = await fs.promises.readFile(this.dockerConfigPath, { encoding: 'utf-8' });
 
       const config = JSON.parse(rawConfig);
+
       console.log(`Read existing docker config: ${ JSON.stringify(config) }`);
+
       return config;
     } catch (error: any) {
       if (error.code !== 'ENOENT') {

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -70,8 +70,8 @@ export default class DockerDirManager {
       const rawConfig = await fs.promises.readFile(this.dockerConfigPath, { encoding: 'utf-8' });
 
       const config = JSON.parse(rawConfig);
-      console.log(`Read docker config: ${ JSON.stringify(config) }`);
-      return JSON.parse(config);
+      console.log(`Read existing docker config: ${ JSON.stringify(config) }`);
+      return config;
     } catch (error: any) {
       if (error.code !== 'ENOENT') {
         throw error;
@@ -224,9 +224,9 @@ export default class DockerDirManager {
    * @param socketPath Path to the rancher-desktop specific docker socket.
    * @param kubernetesEndpoint Path to rancher-desktop Kubernetes endpoint.
    */
-  protected async ensureDockerContext(socketPath: string, kubernetesEndpoint?: string): Promise<void> {
+  protected async ensureDockerContextFile(socketPath: string, kubernetesEndpoint?: string): Promise<void> {
     if (os.platform().startsWith('win')) {
-      throw new Error('ensureDockerContext is not on Windows');
+      throw new Error('ensureDockerContextFile is not on Windows');
     }
     const contextContents = {
       Name:      this.contextName,
@@ -291,7 +291,7 @@ export default class DockerDirManager {
     const platform = os.platform();
 
     if ((platform === 'darwin' || platform === 'linux') && socketPath) {
-      await this.ensureDockerContext(socketPath, kubernetesEndpoint);
+      await this.ensureDockerContextFile(socketPath, kubernetesEndpoint);
     }
     newConfig.currentContext = await this.getDesiredDockerContext(weOwnDefaultSocket, currentConfig.currentContext);
 

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -318,7 +318,7 @@ export default class DockerDirManager {
     const newConfig = JSON.parse(JSON.stringify(currentConfig));
 
     // ensure we are using one of our preferred credential helpers
-    newConfig.credsStore = this.getCredsStoreFor(currentConfig.credsStore?);
+    newConfig.credsStore = this.getCredsStoreFor(currentConfig.credsStore);
 
     // write config if modified
     if (JSON.stringify(newConfig) !== JSON.stringify(currentConfig)) {

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -69,11 +69,9 @@ export default class DockerDirManager {
     try {
       const rawConfig = await fs.promises.readFile(this.dockerConfigPath, { encoding: 'utf-8' });
 
-      const config = JSON.parse(rawConfig);
+      console.log(`Read existing docker config: ${ rawConfig }`);
 
-      console.log(`Read existing docker config: ${ JSON.stringify(config) }`);
-
-      return config;
+      return JSON.parse(rawConfig);
     } catch (error: any) {
       if (error.code !== 'ENOENT') {
         throw error;
@@ -181,27 +179,6 @@ export default class DockerDirManager {
     }
 
     return this.contextName;
-  }
-
-  /**
-   * Determines whether the passed credential helper is working.
-   * @param helperName The cred helper name, without the "docker-credential-" prefix.
-   */
-  protected async credHelperWorking(helperName: string): Promise<boolean> {
-    const helperBin = `docker-credential-${ helperName }`;
-
-    try {
-      // Provide input in case the helper always reads from stdin regardless of argument (harmless if it doesn't).
-      const body = stream.Readable.from('');
-
-      await spawnFile(helperBin, ['list'], { stdio: [body, 'pipe', console] });
-
-      return true;
-    } catch (err) {
-      console.log(`Credential helper "${ helperBin }" is not functional: ${ err }`);
-
-      return false;
-    }
   }
 
   /**


### PR DESCRIPTION
Closes #2297.
Closes #2305.

I did a number of things in this PR:

1. A small refactor of `DockerDirManager` to separate what was previously `ensureDockerConfig` into two separate methods. These methods are concerned with configuring two separate things: docker contexts, and credential helpers. We'll see if this is a good idea in the future, but at the moment it makes sense because the credential helper part of the config needs to be configured right at the start of a run, whereas the context part of the config has to be configured once we have a couple of details that only `LimaBackend` knows about (so near the end). The context configuration also doesn't apply on Windows.

2. Made some changes to the way `credsStore` is set. It will now always be changed to the platform default, except on Linux when `credsStore` is equal to `secretservice`, in which case it remains the same.

3. Added the necessary dependencies to the deb and rpm packages to install `pass` and `gpg` (and friends), which are needed for `docker-credential-pass` on Linux. We will need to document manual installation of these programs for the AppImage.

4. Added code to tool download script to allow for bundling `docker-credential-pass` on Linux in addition to `docker-credential-secretservice`.

5. Made the calls to the configured credential helper by the credential helper server use the absolute path to the credential helper, so that there are no problems due to programs the helper calls not being in the `PATH`. Originally we were going to modify the `PATH` env var for the credential helper so that it could find `pass`, which we were planning on bundling, but due to security/robustness concerns we decided to rely on the versions of `pass` and `gpg` provided by the OS. This allows for the use of absolute paths, which is probably simpler. This can be changed if desired, however.