### PR TITLE
rdctl: don't fail on missing or bad config file until we need it.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -281,7 +281,7 @@ test.describe('Command server', () => {
           try {
             await spawnFile(mvCommand, [backupPath, configFilePath]);
           } catch (err) {
-            console.log(`Error trying to ${ mvCommand } ${ configFilePath } ${ backupPath }: `, err);
+            console.log(`Error trying to ${ mvCommand } ${ backupPath } ${ configFilePath }: `, err);
             expect(err).toBeUndefined();
           }
         });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -268,12 +268,12 @@ test.describe('Command server', () => {
           serverState = JSON.parse(dataRaw);
           parameters = [`--password=${ serverState.password }`,
             `--port=${ serverState.port }`,
-            `--user=${serverState.user }`,
+            `--user=${ serverState.user }`,
           ];
           try {
             await spawnFile(mvCommand, [configFilePath, backupPath]);
           } catch (err) {
-            console.log(`Error trying to ${ mvCommand } ${ configFilePath} ${ backupPath }: `, err);
+            console.log(`Error trying to ${ mvCommand } ${ configFilePath } ${ backupPath }: `, err);
             expect(err).toBeUndefined();
           }
         });
@@ -281,7 +281,7 @@ test.describe('Command server', () => {
           try {
             await spawnFile(mvCommand, [backupPath, configFilePath]);
           } catch (err) {
-            console.log(`Error trying to ${ mvCommand } ${ configFilePath} ${ backupPath }: `, err);
+            console.log(`Error trying to ${ mvCommand } ${ configFilePath } ${ backupPath }: `, err);
             expect(err).toBeUndefined();
           }
         });
@@ -325,7 +325,7 @@ test.describe('Command server', () => {
             while (i < 100) {
               try {
                 await fs.promises.access(badConfigFile, fs.constants.R_OK);
-                badConfigFile += "x";
+                badConfigFile += 'x';
                 i += 1;
               } catch {
                 break;

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -496,7 +496,7 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
               expect(error).toBeDefined();
-              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null });
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' });
               expect(stderr).not.toContain('Usage:');
               expect(stderr).toContain('no settings specified in the request');
             });
@@ -506,7 +506,7 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
               expect(error).toBeDefined();
-              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request', documentation_url: null } );
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
               expect(stderr).not.toContain('Usage:');
               expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
             });
@@ -519,7 +519,7 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
         expect(error).toBeDefined();
-        expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found', documentation_url: null });
+        expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found' });
         expect(stderr).not.toContain('Usage:');
         expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
       });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -269,50 +269,61 @@ test.describe('Command server', () => {
             `--port=${ serverState.port }`,
             `--user=${ serverState.user }`,
           ];
-          try {
-            await expect(fs.promises.rename(configFilePath, backupPath)).resolves.toEqual(undefined);
-          } catch (err) {
-            console.log(`Error trying to rename ${ configFilePath } ${ backupPath }: `, err);
-            expect(err).toBeUndefined();
-          }
+          await expect(fs.promises.rename(configFilePath, backupPath)).resolves.toBeUndefined();
         });
         test.afterAll(async() => {
-          try {
-            await expect(fs.promises.rename(backupPath, configFilePath)).resolves.toEqual(undefined);
-          } catch (err) {
-            console.log(`Error trying to rename ${ backupPath } ${ configFilePath }: `, err);
-            expect(err).toBeUndefined();
-          }
+          await expect(fs.promises.rename(backupPath, configFilePath)).resolves.toBeUndefined();
         });
 
         test('it complains with no parameters,', async() => {
           const { stdout, stderr, error } = await rdctl(['list-settings']);
 
-          expect(error).toBeDefined();
-          expect(stderr).toContain(`Error: open ${ configFilePath }: no such file or directory`);
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  expect.any(Error),
+            stderr: expect.stringContaining(`Error: open ${ configFilePath }: no such file or directory`),
+            stdout: ''
+          });
           expect(stderr).not.toContain('Usage:');
-          expect(stdout).toEqual('');
         });
 
         test('it works with all parameters,', async() => {
           const { stdout, stderr, error } = await rdctl(parameters.concat(['list-settings']));
 
-          expect(error).toBeUndefined();
-          expect(stderr).toEqual('');
-          expect(stdout).toMatch(/"kubernetes":/);
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  undefined,
+            stderr: '',
+            stdout: expect.stringContaining('"kubernetes":'),
+          });
           const settings = JSON.parse(stdout);
 
-          expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
+          expect(settings).toMatchObject({
+            version:                expect.anything(),
+            kubernetes:             expect.anything(),
+            portForwarding:         expect.anything(),
+            images:                 expect.anything(),
+            telemetry:              expect.anything(),
+            updater:                expect.anything(),
+            debug:                  expect.anything(),
+            pathManagementStrategy: expect.anything()
+          });
         });
         test("it complains when some parameters aren't specified", async() => {
           for (let idx = 0; idx < parameters.length; idx += 1) {
             const partialParameters = parameters.slice(0, idx).concat(parameters.slice(idx + 1));
             const { stdout, stderr, error } = await rdctl(partialParameters.concat(['list-settings']));
 
-            expect(error).toBeDefined();
-            expect(stderr).toContain(`Error: open ${ configFilePath }: no such file or directory`);
+            expect({
+              stdout, stderr, error
+            }).toEqual({
+              error:  expect.any(Error),
+              stderr: expect.stringContaining(`Error: open ${ configFilePath }: no such file or directory`),
+              stdout: ''
+            });
             expect(stderr).not.toContain('Usage:');
-            expect(stdout).toEqual('');
           }
         });
         test.describe('when a non-existent config file is specified', () => {
@@ -324,12 +335,16 @@ test.describe('Command server', () => {
               // Do not actually create configFile
               const { stdout, stderr, error } = await rdctl(parameters.concat(['list-settings', '--config-path', configFile]));
 
-              expect(error).toBeDefined();
-              expect(stderr).toContain(`Error: open ${ configFile }: no such file or directory`);
+              expect({
+                stdout, stderr, error
+              }).toEqual({
+                error:  expect.any(Error),
+                stderr: expect.stringContaining(`Error: open ${ configFile }: no such file or directory`),
+                stdout: ''
+              });
               expect(stderr).not.toContain('Usage:');
-              expect(stdout).toEqual('');
             } finally {
-              await fs.promises.rmdir(tmpDir, { recursive: true });
+              await fs.promises.rm(tmpDir, { recursive: true });
             }
           });
         });
@@ -338,68 +353,103 @@ test.describe('Command server', () => {
     test('should show settings and nil-update settings', async() => {
       const { stdout, stderr, error } = await rdctl(['list-settings']);
 
-      expect(error).toBeUndefined();
-      expect(stderr).toEqual('');
-      expect(stdout).toMatch(/"kubernetes":/);
+      expect({
+        stdout, stderr, error
+      }).toEqual({
+        error:  undefined,
+        stderr: '',
+        stdout: expect.stringContaining('"kubernetes":'),
+      });
       const settings = JSON.parse(stdout);
 
-      expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
+      expect(settings).toMatchObject({
+        version:                expect.anything(),
+        kubernetes:             expect.anything(),
+        portForwarding:         expect.anything(),
+        images:                 expect.anything(),
+        telemetry:              expect.anything(),
+        updater:                expect.anything(),
+        debug:                  expect.anything(),
+        pathManagementStrategy: expect.anything()
+      });
 
       const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
         `--kubernetes-enabled=${ !!settings.kubernetes.enabled }`,
         '--kubernetes-version', settings.kubernetes.version];
       const result = await rdctl(args);
 
-      expect(result.stderr).toEqual('');
-      expect(result.stdout).toContain('Status: no changes necessary.');
+      expect(result).toMatchObject({
+        stderr: '',
+        stdout: expect.stringContaining('Status: no changes necessary.')
+      });
     });
 
     test.describe('set', () => {
       test('complains when no args are given', async() => {
         const { stdout, stderr, error } = await rdctl(['set']);
 
-        expect(error).toBeDefined();
-        expect(stderr).toContain('Error: set command: no settings to change were given');
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining('Error: set command: no settings to change were given'),
+          stdout: ''
+        });
         expect(stderr).toContain('Usage:');
-        expect(stdout).toEqual('');
       });
 
       test('complains when option value missing', async() => {
         const { stdout, stderr, error } = await rdctl(['set', '--container-engine']);
 
-        expect(error).toBeDefined();
-        expect(stderr).toContain('Error: flag needs an argument: --container-engine');
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining('Error: flag needs an argument: --container-engine'),
+          stdout: ''
+        });
         expect(stderr).toContain('Usage:');
-        expect(stdout).toEqual('');
       });
 
       test('complains when non-boolean option value specified', async() => {
         const { stdout, stderr, error } = await rdctl(['set', '--kubernetes-enabled=gorb']);
 
-        expect(error).toBeDefined();
-        expect(stderr).toContain('Error: invalid argument "gorb" for "--kubernetes-enabled" flag: strconv.ParseBool: parsing "gorb": invalid syntax');
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining('Error: invalid argument "gorb" for "--kubernetes-enabled" flag: strconv.ParseBool: parsing "gorb": invalid syntax'),
+          stdout: ''
+        });
         expect(stderr).toContain('Usage:');
-        expect(stdout).toEqual('');
       });
 
       test('complains when invalid engine specified', async() => {
         const myEngine = 'giblets';
         const { stdout, stderr, error } = await rdctl(['set', `--container-engine=${ myEngine }`]);
 
-        expect(error).toBeDefined();
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining(`Invalid value for kubernetes.containerEngine: <${ myEngine }>; must be 'containerd', 'docker', or 'moby'`),
+          stdout: ''
+        });
         expect(stderr).toContain('Error: errors in attempt to update settings:');
-        expect(stderr).toContain(`Invalid value for kubernetes.containerEngine: <${ myEngine }>; must be 'containerd', 'docker', or 'moby'`);
         expect(stderr).not.toContain('Usage:');
-        expect(stdout).toEqual('');
       });
 
       test('complains when server rejects a proposed version', async() => {
         const { stdout, stderr, error } = await rdctl(['set', '--kubernetes-version=karl']);
 
-        expect(error).toBeDefined();
-        expect(stderr).toMatch(/Error: errors in attempt to update settings:\s+Kubernetes version "karl" not found./);
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringMatching(/Error: errors in attempt to update settings:\s+Kubernetes version "karl" not found./),
+          stdout: ''
+        });
         expect(stderr).not.toContain('Usage:');
-        expect(stdout).toEqual('');
       });
     });
 
@@ -413,10 +463,14 @@ test.describe('Command server', () => {
           test(args.join(' '), async() => {
             const { stdout, stderr, error } = await rdctl(args);
 
-            expect(error).toBeDefined();
-            expect(stderr).toContain(`Error: unknown command "string" for "rdctl ${ cmd }"`);
+            expect({
+              stdout, stderr, error
+            }).toEqual({
+              error:  expect.any(Error),
+              stderr: expect.stringContaining(`Error: unknown command "string" for "rdctl ${ cmd }"`),
+              stdout: ''
+            });
             expect(stderr).toContain('Usage:');
-            expect(stdout).toEqual('');
           });
         }
       });
@@ -428,10 +482,14 @@ test.describe('Command server', () => {
           test(args.join(' '), async() => {
             const { stdout, stderr, error } = await rdctl(args);
 
-            expect(error).toBeDefined();
-            expect(stderr).toContain(`Error: unknown flag: ${ args[1] }`);
+            expect({
+              stdout, stderr, error
+            }).toEqual({
+              error:  expect.any(Error),
+              stderr: expect.stringContaining(`Error: unknown flag: ${ args[1] }`),
+              stdout: ''
+            });
             expect(stderr).toContain('Usage:');
-            expect(stdout).toEqual('');
           });
         }
       });
@@ -442,29 +500,41 @@ test.describe('Command server', () => {
         test('complains when no args are given', async() => {
           const { stdout, stderr, error } = await rdctl(['api']);
 
-          expect(error).toBeDefined();
-          expect(stderr).toContain('Error: api command: no endpoint specified');
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  expect.any(Error),
+            stderr: expect.stringContaining('Error: api command: no endpoint specified'),
+            stdout: ''
+          });
           expect(stderr).toContain('Usage:');
-          expect(stdout).toEqual('');
         });
 
         test('empty string endpoint should give an error message', async() => {
           const { stdout, stderr, error } = await rdctl(['api', '']);
 
-          expect(error).toBeDefined();
-          expect(stderr).toContain('Error: api command: no endpoint specified');
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  expect.any(Error),
+            stderr: expect.stringContaining('Error: api command: no endpoint specified'),
+            stdout: ''
+          });
           expect(stderr).toContain('Usage:');
-          expect(stdout).toEqual('');
         });
 
         test('complains when more than one endpoint is given', async() => {
           const endpoints = ['settings', '/v0/settings'];
           const { stdout, stderr, error } = await rdctl(['api', ...endpoints]);
 
-          expect(error).toBeDefined();
-          expect(stderr).toContain(`Error: api command: too many endpoints specified ([${ endpoints.join(' ') }]); exactly one must be specified`);
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  expect.any(Error),
+            stderr: expect.stringContaining(`Error: api command: too many endpoints specified ([${ endpoints.join(' ') }]); exactly one must be specified`),
+            stdout: ''
+          });
           expect(stderr).toContain('Usage:');
-          expect(stdout).toEqual('');
         });
       });
 
@@ -478,8 +548,13 @@ test.describe('Command server', () => {
                 test(args.join(' '), async() => {
                   const { stdout, stderr, error } = await rdctl(args);
 
-                  expect(error).toBeUndefined();
-                  expect(stderr).toEqual('');
+                  expect({
+                    stdout, stderr, error
+                  }).toEqual({
+                    error:  undefined,
+                    stderr: '',
+                    stdout: expect.stringMatching(/{.+}/s)
+                  });
                   const settings = JSON.parse(stdout);
 
                   expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
@@ -500,9 +575,13 @@ test.describe('Command server', () => {
                     test(args.join(' '), async() => {
                       const { stdout, stderr, error } = await rdctlWithStdin(settingsFile, args);
 
-                      expect(error).toBeUndefined();
-                      expect(stderr).toBe('');
-                      expect(stdout).toContain('no changes necessary');
+                      expect({
+                        stdout, stderr, error
+                      }).toEqual({
+                        error:  undefined,
+                        stderr: '',
+                        stdout: expect.stringContaining('no changes necessary')
+                      });
                     });
                   }
                 }
@@ -519,9 +598,13 @@ test.describe('Command server', () => {
                     test(args.join(' '), async() => {
                       const { stdout, stderr, error } = await rdctl(args);
 
-                      expect(error).toBeUndefined();
-                      expect(stderr).toBe('');
-                      expect(stdout).toContain('no changes necessary');
+                      expect({
+                        stdout, stderr, error
+                      }).toEqual({
+                        error:  undefined,
+                        stderr: '',
+                        stdout: expect.stringContaining('no changes necessary')
+                      });
                     });
                   }
                 }
@@ -531,9 +614,14 @@ test.describe('Command server', () => {
             test('should complain about a "--input-" flag', async() => {
               const { stdout, stderr, error } = await rdctl(['api', '/settings', '-X', 'PUT', '--input-']);
 
-              expect(error).toBeDefined();
-              expect(stdout).toEqual('');
-              expect(stderr).toContain('Error: unknown flag: --input-');
+              expect({
+                stdout, stderr, error
+              }).toEqual({
+                error:  expect.any(Error),
+                stderr: expect.stringContaining('Error: unknown flag: --input-'),
+                stdout: ''
+              });
+              expect(stderr).toContain('Usage:');
             });
 
             test.describe('from body', () => {
@@ -548,9 +636,13 @@ test.describe('Command server', () => {
                       const settingsBody = await fs.promises.readFile(settingsFile, { encoding: 'utf-8' });
                       const { stdout, stderr, error } = await rdctl(args.concat(settingsBody));
 
-                      expect(error).toBeUndefined();
-                      expect(stderr).toEqual('');
-                      expect(stdout).toContain('no changes necessary');
+                      expect({
+                        stdout, stderr, error
+                      }).toEqual({
+                        error:  undefined,
+                        stderr: '',
+                        stdout: expect.stringContaining('no changes necessary')
+                      });
                     });
                   }
                 }
@@ -564,9 +656,13 @@ test.describe('Command server', () => {
                 test(args.join(' '), async() => {
                   const { stdout, stderr, error } = await rdctl(args);
 
-                  expect(error).toBeDefined();
-                  expect(stdout).toEqual('');
-                  expect(stderr).toContain('Error: api command: --body and --input options cannot both be specified');
+                  expect({
+                    stdout, stderr, error
+                  }).toEqual({
+                    error:  expect.any(Error),
+                    stderr: expect.stringContaining('Error: api command: --body and --input options cannot both be specified'),
+                    stdout: ''
+                  });
                   expect(stderr).toContain('Usage:');
                 });
               }
@@ -575,20 +671,30 @@ test.describe('Command server', () => {
             test('complains when no body is provided', async() => {
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
-              expect(error).toBeDefined();
-              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' });
+              expect({
+                stdout, stderr, error
+              }).toEqual({
+                error:  expect.any(Error),
+                stderr: expect.stringContaining('no settings specified in the request'),
+                stdout: expect.stringMatching(/{.*}/s)
+              });
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
               expect(stderr).not.toContain('Usage:');
-              expect(stderr).toContain('no settings specified in the request');
             });
 
             test('invalid setting is specified', async() => {
               const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
-              expect(error).toBeDefined();
-              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
+              expect({
+                stdout, stderr, error
+              }).toEqual({
+                error:  expect.any(Error),
+                stderr: expect.stringMatching(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/),
+                stdout: expect.stringMatching(/{.*}/s)
+              });
               expect(stderr).not.toContain('Usage:');
-              expect(stderr).toMatch(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <beefalo>; must be 'containerd', 'docker', or 'moby'/);
+              expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
             });
           });
         });
@@ -598,10 +704,15 @@ test.describe('Command server', () => {
         const endpoint = '/v99/no/such/endpoint';
         const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
-        expect(error).toBeDefined();
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining(`Unknown command: GET ${ endpoint }`),
+          stdout: expect.stringMatching(/{.*}/s)
+        });
         expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found' });
         expect(stderr).not.toContain('Usage:');
-        expect(stderr).toContain(`Unknown command: GET ${ endpoint }`);
       });
 
       test.describe('getting endpoints', () => {
@@ -635,16 +746,24 @@ test.describe('Command server', () => {
       test('can run echo', async() => {
         const { stdout, stderr, error } = await rdctl(['shell', 'echo', 'abc', 'def']);
 
-        expect(error).toBeUndefined();
-        expect(stderr).toEqual('');
-        expect(stdout.trim()).toEqual('abc def');
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  undefined,
+          stderr: '',
+          stdout: expect.stringContaining('abc def')
+        });
       });
       test('can run a command with a dash-option', async() => {
         const { stdout, stderr, error } = await rdctl(['shell', 'uname', '-a']);
 
-        expect(error).toBeUndefined();
-        expect(stderr).toEqual('');
-        expect(stdout.trim()).not.toEqual('');
+        expect({
+          stdout, stderr, error
+        }).toEqual({
+          error:  undefined,
+          stderr: '',
+          stdout: expect.stringMatching(/\S/)
+        });
       });
       test('can run a shell', async() => {
         const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rdctl-shell-input'));
@@ -654,9 +773,13 @@ test.describe('Command server', () => {
           await fs.promises.writeFile(inputPath, 'echo orate linds chump\n');
           const { stdout, stderr, error } = await rdctlWithStdin(inputPath, ['shell']);
 
-          expect(error).toBeUndefined();
-          expect(stderr).toBe('');
-          expect(stdout).toContain('orate linds chump');
+          expect({
+            stdout, stderr, error
+          }).toEqual({
+            error:  undefined,
+            stderr: '',
+            stdout: expect.stringContaining('orate linds chump')
+          });
         } finally {
           await fs.promises.rm(tmpDir, { recursive: true, force: true });
         }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -19,16 +19,13 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 	"github.com/spf13/cobra"
 )
 
@@ -36,18 +33,6 @@ type APIError struct {
 	Message          *string `json:"message,omitifempty"`
 	DocumentationUrl *string `json:"documentation_url,omitifempty"`
 }
-
-var (
-	// Used for flags and config
-	configDir           string
-	configPath          string
-	defaultConfigPath   string
-	user                string
-	host                string
-	port                string
-	password            string
-	deferredConfigError error
-)
 
 const clientVersion = "1.1.0"
 const apiVersion = "v0"
@@ -69,8 +54,6 @@ func Execute() {
 }
 
 func init() {
-	var err error
-
 	if len(os.Args) > 1 {
 		mainCommand := os.Args[1]
 		if mainCommand == "-h" || mainCommand == "help" || mainCommand == "--help" {
@@ -82,17 +65,8 @@ func init() {
 			return
 		}
 	}
-	cobra.OnInitialize(initConfig)
-	configDir, err = os.UserConfigDir()
-	if err != nil {
-		log.Fatal("Can't get config-dir: ", err)
-	}
-	defaultConfigPath = filepath.Join(configDir, "rancher-desktop", "rd-engine.json")
-	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", fmt.Sprintf("config file (default %s)", defaultConfigPath))
-	rootCmd.PersistentFlags().StringVar(&user, "user", "", "overrides the user setting in the config file")
-	rootCmd.PersistentFlags().StringVar(&host, "host", "", "default is localhost; most useful for WSL")
-	rootCmd.PersistentFlags().StringVar(&port, "port", "", "overrides the port setting in the config file")
-	rootCmd.PersistentFlags().StringVar(&password, "password", "", "overrides the password setting in the config file")
+	cobra.OnInitialize(config.InitConfig)
+	config.DefineGlobalFlags(rootCmd)
 }
 
 func versionCommand(version string, command string) string {
@@ -118,35 +92,33 @@ func doRequest(method string, command string) (*http.Response, error) {
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) (*http.Response, error) {
-	if deferredConfigError != nil && insufficientConnectionInfo() {
-		return nil, deferredConfigError
-	}
-	req, err := http.NewRequest(method, makeURL(host, port, command), payload)
+	err := config.GetPossibleConfigError()
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(user, password)
+	req, err := http.NewRequest(method, makeURL(config.Host, config.Port, command), payload)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(config.User, config.Password)
 	req.Header.Add("Content-Type", "application/json")
 	req.Close = true
 	return http.DefaultClient.Do(req)
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-	if deferredConfigError != nil && insufficientConnectionInfo() {
-		return nil, deferredConfigError
-	}
-	req, err := http.NewRequest(method, makeURL(host, port, command), nil)
+	err := config.GetPossibleConfigError()
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(user, password)
+	req, err := http.NewRequest(method, makeURL(config.Host, config.Port, command), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(config.User, config.Password)
 	req.Header.Add("Content-Type", "text/plain")
 	req.Close = true
 	return req, nil
-}
-
-func insufficientConnectionInfo() bool {
-	return port == "" || user == "" || password == ""
 }
 
 func processRequestForAPI(response *http.Response, err error) ([]byte, *APIError, error) {
@@ -206,42 +178,4 @@ func processRequestForUtility(response *http.Response, err error) ([]byte, error
 		return nil, fmt.Errorf("%s", string(body))
 	}
 	return body, nil
-}
-
-// The CLIConfig struct is used to store the json data read from the config file.
-type CLIConfig struct {
-	User     string
-	Password string
-	Port     int
-}
-
-func initConfig() {
-	if configPath == "" {
-		configPath = defaultConfigPath
-	}
-	if host == "" {
-		host = "localhost"
-	}
-	content, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		deferredConfigError = fmt.Errorf("trying to read config file: %v", err)
-		return
-	}
-
-	var settings CLIConfig
-	err = json.Unmarshal(content, &settings)
-	if err != nil {
-		deferredConfigError = fmt.Errorf("trying to json-load file %s: %v", configPath, err)
-		return
-	}
-
-	if user == "" {
-		user = settings.User
-	}
-	if password == "" {
-		password = settings.Password
-	}
-	if port == "" {
-		port = strconv.Itoa(settings.Port)
-	}
 }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -25,8 +25,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 	"github.com/spf13/cobra"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 )
 
 type APIError struct {
@@ -92,30 +93,30 @@ func doRequest(method string, command string) (*http.Response, error) {
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) (*http.Response, error) {
-	host, port, user, password, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(method, makeURL(host, port, command), payload)
+	req, err := http.NewRequest(method, makeURL(connectionInfo.Host, connectionInfo.Port, command), payload)
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(user, password)
+	req.SetBasicAuth(connectionInfo.User, connectionInfo.Password)
 	req.Header.Add("Content-Type", "application/json")
 	req.Close = true
 	return http.DefaultClient.Do(req)
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-	host, port, user, password, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(method, makeURL(host, port, command), nil)
+	req, err := http.NewRequest(method, makeURL(connectionInfo.Host, connectionInfo.Port, command), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(user, password)
+	req.SetBasicAuth(connectionInfo.User, connectionInfo.Password)
 	req.Header.Add("Content-Type", "text/plain")
 	req.Close = true
 	return req, nil

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -31,8 +31,8 @@ import (
 )
 
 type APIError struct {
-	Message          *string `json:"message,omitifempty"`
-	DocumentationUrl *string `json:"documentation_url,omitifempty"`
+	Message          *string `json:"message,omitempty"`
+	DocumentationUrl *string `json:"documentation_url,omitempty"`
 }
 
 const clientVersion = "1.1.0"
@@ -66,7 +66,6 @@ func init() {
 			return
 		}
 	}
-	cobra.OnInitialize(config.InitConfig)
 	config.DefineGlobalFlags(rootCmd)
 }
 

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -92,30 +92,30 @@ func doRequest(method string, command string) (*http.Response, error) {
 }
 
 func doRequestWithPayload(method string, command string, payload *bytes.Buffer) (*http.Response, error) {
-	err := config.GetPossibleConfigError()
+	host, port, user, password, err := config.GetConnectionInfo()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(method, makeURL(config.Host, config.Port, command), payload)
+	req, err := http.NewRequest(method, makeURL(host, port, command), payload)
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(config.User, config.Password)
+	req.SetBasicAuth(user, password)
 	req.Header.Add("Content-Type", "application/json")
 	req.Close = true
 	return http.DefaultClient.Do(req)
 }
 
 func getRequestObject(method string, command string) (*http.Request, error) {
-	err := config.GetPossibleConfigError()
+	host, port, user, password, err := config.GetConnectionInfo()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(method, makeURL(config.Host, config.Port, command), nil)
+	req, err := http.NewRequest(method, makeURL(host, port, command), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.SetBasicAuth(config.User, config.Password)
+	req.SetBasicAuth(user, password)
 	req.Header.Add("Content-Type", "text/plain")
 	req.Close = true
 	return req, nil

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -1,0 +1,117 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config handles all the config-related parts of rdctl
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// The CLIConfig struct is used to store the json data read from the config file.
+type CLIConfig struct {
+	User     string
+	Password string
+	Port     int
+}
+
+var (
+	User     string
+	Host     string
+	Port     string
+	Password string
+
+	configDir           string
+	configPath          string
+	defaultConfigPath   string
+	deferredConfigError error
+)
+
+// DefineGlobalFlags sets up the global flags, available for all sub-commands
+func DefineGlobalFlags(rootCmd *cobra.Command) {
+	var err error
+
+	configDir, err = os.UserConfigDir()
+	if err != nil {
+		log.Fatal("Can't get config-dir: ", err)
+	}
+	defaultConfigPath = filepath.Join(configDir, "rancher-desktop", "rd-engine.json")
+	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", fmt.Sprintf("config file (default %s)", defaultConfigPath))
+	rootCmd.PersistentFlags().StringVar(&User, "user", "", "overrides the user setting in the config file")
+	rootCmd.PersistentFlags().StringVar(&Host, "host", "", "default is localhost; most useful for WSL")
+	rootCmd.PersistentFlags().StringVar(&Port, "port", "", "overrides the port setting in the config file")
+	rootCmd.PersistentFlags().StringVar(&Password, "password", "", "overrides the password setting in the config file")
+}
+
+// GetPossibleConfigError returns a deferred config-related error if there is one and the user
+// didn't explicitly specify all the connection-related flags
+func GetPossibleConfigError() error {
+	if deferredConfigError != nil && insufficientConnectionInfo() {
+		return deferredConfigError
+	}
+	return nil
+}
+
+// InitConfig is run after all modules are loaded and before the appropriate Execute function is invoked
+func InitConfig() {
+	if configPath == "" {
+		configPath = defaultConfigPath
+	}
+	if Host == "" {
+		Host = "localhost"
+	}
+	content, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		// If the default config file isn't available, it might not have been created yet, so don't complain.
+		// But if the user specified their own --config-path and it's not readable, complain immediately.
+		if configPath != defaultConfigPath {
+			// This code does the same as `log.Fatalf` without emitting the leading timestamp.
+			fmt.Fprintf(os.Stderr, "Error: trying to read config file: %v", err)
+			os.Exit(1)
+		}
+		deferredConfigError = fmt.Errorf("trying to read config file: %v", err)
+		return
+	}
+
+	var settings CLIConfig
+	err = json.Unmarshal(content, &settings)
+	if err != nil {
+		deferredConfigError = fmt.Errorf("trying to json-load file %s: %v", configPath, err)
+		return
+	}
+
+	if User == "" {
+		User = settings.User
+	}
+	if Password == "" {
+		Password = settings.Password
+	}
+	if Port == "" {
+		Port = strconv.Itoa(settings.Port)
+	}
+}
+
+func insufficientConnectionInfo() bool {
+	return Port == "" || User == "" || Password == ""
+}

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -37,10 +37,10 @@ type CLIConfig struct {
 }
 
 var (
-	User     string
-	Host     string
-	Port     string
-	Password string
+	user     string
+	host     string
+	port     string
+	password string
 
 	configDir           string
 	configPath          string
@@ -58,19 +58,19 @@ func DefineGlobalFlags(rootCmd *cobra.Command) {
 	}
 	defaultConfigPath = filepath.Join(configDir, "rancher-desktop", "rd-engine.json")
 	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", fmt.Sprintf("config file (default %s)", defaultConfigPath))
-	rootCmd.PersistentFlags().StringVar(&User, "user", "", "overrides the user setting in the config file")
-	rootCmd.PersistentFlags().StringVar(&Host, "host", "", "default is localhost; most useful for WSL")
-	rootCmd.PersistentFlags().StringVar(&Port, "port", "", "overrides the port setting in the config file")
-	rootCmd.PersistentFlags().StringVar(&Password, "password", "", "overrides the password setting in the config file")
+	rootCmd.PersistentFlags().StringVar(&user, "user", "", "overrides the user setting in the config file")
+	rootCmd.PersistentFlags().StringVar(&host, "host", "", "default is localhost; most useful for WSL")
+	rootCmd.PersistentFlags().StringVar(&port, "port", "", "overrides the port setting in the config file")
+	rootCmd.PersistentFlags().StringVar(&password, "password", "", "overrides the password setting in the config file")
 }
 
-// GetPossibleConfigError returns a deferred config-related error if there is one and the user
-// didn't explicitly specify all the connection-related flags
-func GetPossibleConfigError() error {
+// GetConnectionInfo returns the connection info if it has it, and an error message explaining why
+// it isn't available if it doesn't have it.
+func GetConnectionInfo() (string, string, string, string, error) {
 	if deferredConfigError != nil && insufficientConnectionInfo() {
-		return deferredConfigError
+		return "", "", "", "", deferredConfigError
 	}
-	return nil
+	return host, port, user, password, nil
 }
 
 // InitConfig is run after all modules are loaded and before the appropriate Execute function is invoked
@@ -78,8 +78,8 @@ func InitConfig() {
 	if configPath == "" {
 		configPath = defaultConfigPath
 	}
-	if Host == "" {
-		Host = "localhost"
+	if host == "" {
+		host = "localhost"
 	}
 	content, err := ioutil.ReadFile(configPath)
 	if err != nil {
@@ -101,17 +101,17 @@ func InitConfig() {
 		return
 	}
 
-	if User == "" {
-		User = settings.User
+	if user == "" {
+		user = settings.User
 	}
-	if Password == "" {
-		Password = settings.Password
+	if password == "" {
+		password = settings.Password
 	}
-	if Port == "" {
-		Port = strconv.Itoa(settings.Port)
+	if port == "" {
+		port = strconv.Itoa(settings.Port)
 	}
 }
 
 func insufficientConnectionInfo() bool {
-	return Port == "" || User == "" || Password == ""
+	return port == "" || user == "" || password == ""
 }

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -37,6 +37,7 @@ type CLIConfig struct {
 	Port     int
 }
 
+// ConnectionInfo stores the parameters needed to connect to an HTTP server
 type ConnectionInfo struct {
 	User     string
 	Password string
@@ -73,14 +74,14 @@ func DefineGlobalFlags(rootCmd *cobra.Command) {
 // So if the user runs an `rdctl` command after a factory reset, there is no config file (in the default location),
 // but it might not be necessary. So only use the error message for the missing file if it is actually needed.
 func GetConnectionInfo() (*ConnectionInfo, error) {
-	err, isImmediateError := initConfig()
+	err, isImmediateError := finishConnectionSettings()
 	if err != nil && (isImmediateError || insufficientConnectionInfo()) {
 		return nil, err
 	}
 	return &connectionSettings, nil
 }
 
-func initConfig() (error, bool) {
+func finishConnectionSettings() (error, bool) {
 	if configPath == "" {
 		configPath = defaultConfigPath
 	}
@@ -98,7 +99,7 @@ func initConfig() (error, bool) {
 	var settings CLIConfig
 	err = json.Unmarshal(content, &settings)
 	if err != nil {
-		return fmt.Errorf("error in config file %s: %s", configPath, err), configPath != defaultConfigPath
+		return fmt.Errorf("error in config file %s: %w", configPath, err), configPath != defaultConfigPath
 	}
 
 	if connectionSettings.User == "" {


### PR DESCRIPTION
Fixes #2143 

So the key here is to get the error associated with the command-server config file, but only display the error and fail if we need the information.

There are two cases where this happens:

1. The commands that need to talk to the server: the user specifies settings for all of `--user`, `--password`, and `--port`.

2. The command is `rdctl start` and Rancher Desktop isn't running, so we're going to actually start.
Note that this variant of `rdctl start` fails if RD is running and for some reason the user has deleted `rd-engine.json`, turned off permissions, or changed its contents. In this rare case, the app will try to run `rdctl start`, and then the user will get a message (in background.log?) stating that it's already running.

One complication is that `rdctl start` is a hybrid -- if it has arguments and RD is running, it quietly switches to `rd set` (but still needs to give any error messages from the point of view of someone who typed `rdctl start`).

