### PR TITLE
Credential helper: Try to find the executable

### DIFF
--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -206,7 +206,7 @@ export class HttpCredentialHelperServer {
 
       const body = stream.Readable.from(data);
       const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
-        env: { ...process.env, PATH: pathVar },
+        env:   { ...process.env, PATH: pathVar },
         stdio: [body, 'pipe', console]
       });
 

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -456,16 +456,15 @@ describe('DockerDirManager', () => {
       win32:  'wincred',
     } as Record<string, string>)[os.platform()];
 
+    afterEach(() => {
+      jest.spyOn(subj as any, 'credHelperWorking').mockRestore();
+    });
+
     it('should return existing cred helper if it works', async() => {
       const helperName = 'mock-helper';
 
-      const spy = jest.spyOn(subj as any, 'credHelperWorking').mockResolvedValue(true);
-
-      try {
-        await expect(subj['getCredsStoreFor'](helperName)).resolves.toEqual(helperName);
-      } finally {
-        spy.mockRestore();
-      }
+      jest.spyOn(subj as any, 'credHelperWorking').mockResolvedValue(true);
+      await expect(subj['getCredsStoreFor'](helperName)).resolves.toEqual(helperName);
     });
 
     it('should return the right cred helper for the right platform', async() => {
@@ -473,16 +472,12 @@ describe('DockerDirManager', () => {
     });
 
     it('should return the platform helper if the existing one does not work', async() => {
-      const spy = jest.spyOn(subj as any, 'credHelperWorking').mockResolvedValue(false);
-
-      try {
-        await expect(subj['getCredsStoreFor']('broken-helper')).resolves.toEqual(platformDefaultHelper);
-      } finally {
-        spy.mockRestore();
-      }
+      jest.spyOn(subj as any, 'credHelperWorking').mockResolvedValue(false);
+      await expect(subj['getCredsStoreFor']('broken-helper')).resolves.toEqual(platformDefaultHelper);
     });
 
     itLinux('should return secretservice when that is the current value', async() => {
+      jest.spyOn(subj as any, 'credHelperWorking').mockResolvedValue(false);
       await expect(subj['getCredsStoreFor']('secretservice')).resolves.toEqual('secretservice');
     });
   });

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -2,8 +2,11 @@ import fs from 'fs';
 import net from 'net';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
 
+import * as childProcess from '@/utils/childProcess';
 import DockerDirManager from '@/utils/dockerDirManager';
+import { Log } from '@/utils/logging';
 
 const itUnix = os.platform() === 'win32' ? it.skip : it;
 const itLinux = os.platform() === 'linux' ? it : it.skip;
@@ -371,6 +374,39 @@ describe('DockerDirManager', () => {
       await fs.promises.writeFile(metaPath, 'irrelevant');
 
       await expect(subj['clearDockerContext']()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('credHelperWorking', () => {
+    let spawnMock: jest.SpiedFunction<typeof childProcess.spawnFile>;
+    const commonCredHelperExpectations: (...args: Parameters<typeof childProcess.spawnFile>) => void = (command, args, options) => {
+      expect(command).toEqual('docker-credential-mockhelper');
+      expect(args[0]).toEqual('list');
+      expect(options.stdio[0]).toBeInstanceOf(stream.Readable);
+      expect(options.stdio[1]).toBe('pipe');
+      expect(options.stdio[2]).toBeInstanceOf(Log);
+    };
+
+    afterEach(() => {
+      spawnMock.mockRestore();
+    });
+    it('should return false when cred helper is not working', async() => {
+      spawnMock = jest.spyOn(childProcess, 'spawnFile')
+        .mockImplementation((command, args, options) => {
+          commonCredHelperExpectations(command, args, options);
+
+          return Promise.reject(new Error('not a valid cred-helper'));
+        });
+      await expect(subj['credHelperWorking']('mockhelper')).resolves.toBeFalsy();
+    });
+    it('should return true when cred helper is working', async() => {
+      spawnMock = jest.spyOn(childProcess, 'spawnFile')
+        .mockImplementation((command, args, options) => {
+          commonCredHelperExpectations(command, args, options);
+
+          return Promise.resolve({});
+        });
+      await expect(subj['credHelperWorking']('mockhelper')).resolves.toBeTruthy();
     });
   });
 

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -69,9 +69,11 @@ export default class DockerDirManager {
     try {
       const rawConfig = await fs.promises.readFile(this.dockerConfigPath, { encoding: 'utf-8' });
 
-      console.log(`Read existing docker config: ${ rawConfig }`);
+      const config = JSON.parse(rawConfig);
 
-      return JSON.parse(rawConfig);
+      console.log(`Read existing docker config: ${ JSON.stringify(config) }`);
+
+      return config;
     } catch (error: any) {
       if (error.code !== 'ENOENT') {
         throw error;
@@ -179,6 +181,27 @@ export default class DockerDirManager {
     }
 
     return this.contextName;
+  }
+
+  /**
+   * Determines whether the passed credential helper is working.
+   * @param helperName The cred helper name, without the "docker-credential-" prefix.
+   */
+  protected async credHelperWorking(helperName: string): Promise<boolean> {
+    const helperBin = `docker-credential-${ helperName }`;
+
+    try {
+      // Provide input in case the helper always reads from stdin regardless of argument (harmless if it doesn't).
+      const body = stream.Readable.from('');
+
+      await spawnFile(helperBin, ['list'], { stdio: [body, 'pipe', console] });
+
+      return true;
+    } catch (err) {
+      console.log(`Credential helper "${ helperBin }" is not functional: ${ err }`);
+
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
If the user has a custom docker credential helper configured, try to use it if we can.

This won't be as useful on macOS, but at least on Windows we should find custom helpers if possible.

Partially reverts #2306.