### PR TITLE
When `rdctl start` is treated as `rdctl set` and goes wrong, treat it like `rdctl start`.

### DIFF
--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -90,7 +90,7 @@ func doSetCommand(cmd *cobra.Command) error {
 	}
 
 	if !changedSomething {
-		return fmt.Errorf("set command: no settings to change were given")
+		return fmt.Errorf("%s command: no settings to change were given", cmd.Name())
 	}
 	cmd.SilenceUsage = true
 	jsonBuffer, err := json.Marshal(currentSettings)

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -67,8 +67,13 @@ func doStartOrSetCommand(cmd *cobra.Command) error {
 			// `--path | -p` is not a valid option for `rdctl set...`
 			return fmt.Errorf("--path %s specified but Rancher Desktop is already running", applicationPath)
 		}
-		return doSetCommand(cmd)
+		err = doSetCommand(cmd)
+		if err == nil || cmd.Name() == "set" {
+			return err
+		}
 	}
+	// If `set...` failed, try running the original `start` command, if only to give
+	// an error message from the point of view of `start` rather than `set`.
 	cmd.SilenceUsage = true
 	return doStartCommand(cmd)
 }


### PR DESCRIPTION
Fixes #2159

The simplest way is to ignore the error from `set...` and rerun it as a `start` command,
and report any errors through that route.

Signed-off-by: Eric Promislow <epromislow@suse.com>