### PR TITLE
Credential Server E2E tests: don't use WSL on Windows.

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -139,6 +139,7 @@ describeWithCreds('Credentials server', () => {
       screenshots: true,
       snapshots:   true
     });
+    await electronApp.firstWindow();
   });
 
   test.afterAll(async() => {


### PR DESCRIPTION
All supported versions of Windows ship curl; we should just use that for the E2E API tests, instead of running curl within the WSL distribution. This avoids issues with the firewall depending on the system.

This does not affect the main application, as that uses an `af_vsock` based tunnel for the traffic (and therefore bypassing the firewall).