### PR TITLE
Fix E2E CI tests

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -29,7 +29,7 @@ import { expect, test } from '@playwright/test';
 import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright';
 
 import fetch from 'node-fetch';
-import { createDefaultSettings, playwrightReportAssets } from './utils/TestUtils';
+import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
 import paths from '@/utils/paths';
 import { ServerState } from '@/main/commandServer/httpCommandServer';
 import { wslHostIPv4Address } from '@/utils/networks';
@@ -128,7 +128,11 @@ describeWithCreds('Credentials server', () => {
         // See src/utils/commandLine.ts before changing the next item.
         '--disable-dev-shm-usage',
         '--no-modal-dialogs',
-      ]
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
     });
     context = electronApp.context();
 
@@ -140,7 +144,8 @@ describeWithCreds('Credentials server', () => {
   });
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -1,10 +1,8 @@
 import path from 'path';
-import {
-  ElectronApplication, BrowserContext, _electron, Page, Locator
-} from 'playwright';
+import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 import { test, expect } from '@playwright/test';
 import {
-  createDefaultSettings, kubectl, helm, tearDownHelm, playwrightReportAssets
+  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, packageLogs
 } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
 
@@ -25,7 +23,11 @@ test.describe.serial('Helm Deployment Test', () => {
         // See src/utils/commandLine.ts before changing the next item as the final option.
         '--disable-dev-shm-usage',
         '--no-modal-dialogs',
-      ]
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
     });
     context = electronApp.context();
 
@@ -41,7 +43,8 @@ test.describe.serial('Helm Deployment Test', () => {
   test.afterAll(tearDownHelm);
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/e2e/kubectl.e2e.spec.ts
+++ b/e2e/kubectl.e2e.spec.ts
@@ -3,7 +3,7 @@ import {
   ElectronApplication, BrowserContext, _electron, Page, Locator
 } from 'playwright';
 import { test, expect } from '@playwright/test';
-import { createDefaultSettings, kubectl, playwrightReportAssets } from './utils/TestUtils';
+import { createDefaultSettings, kubectl, packageLogs, reportAsset } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
 
 let page: Page;
@@ -23,7 +23,11 @@ test.describe.serial('K8s Deployment Test', () => {
         // See src/utils/commandLine.ts before changing the next item as the final option.
         '--disable-dev-shm-usage',
         '--no-modal-dialogs',
-      ]
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
     });
     context = electronApp.context();
 
@@ -32,7 +36,8 @@ test.describe.serial('K8s Deployment Test', () => {
   });
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 import { test, expect } from '@playwright/test';
-import { createDefaultSettings, playwrightReportAssets } from './utils/TestUtils';
+import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
 
 let page: Page;
@@ -26,7 +26,11 @@ test.describe.serial('Main App Test', () => {
         // See src/utils/commandLine.ts before changing the next item as the final option.
         '--disable-dev-shm-usage',
         '--no-modal-dialogs',
-      ]
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
     });
     context = electronApp.context();
 
@@ -35,7 +39,8 @@ test.describe.serial('Main App Test', () => {
   });
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -27,7 +27,7 @@ import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright
 
 import fetch, { RequestInit } from 'node-fetch';
 import _ from 'lodash';
-import { createDefaultSettings, kubectl, playwrightReportAssets } from './utils/TestUtils';
+import { createDefaultSettings, kubectl, packageLogs, reportAsset } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
 import paths from '@/utils/paths';
 import { spawnFile } from '@/utils/childProcess';
@@ -102,7 +102,11 @@ test.describe('Command server', () => {
         // See src/utils/commandLine.ts before changing the next item.
         '--disable-dev-shm-usage',
         '--no-modal-dialogs',
-      ]
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
     });
     context = electronApp.context();
 
@@ -114,7 +118,8 @@ test.describe('Command server', () => {
   });
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -7,8 +7,8 @@ import path from 'path';
 
 import { expect } from '@playwright/test';
 
-import paths from '../../src/utils/paths';
-import * as childProcess from '../../src/utils/childProcess';
+import paths from '@/utils/paths';
+import * as childProcess from '@/utils/childProcess';
 import { defaultSettings } from '@/config/settings';
 import { PathManagementStrategy } from '@/integrations/pathManager';
 
@@ -49,12 +49,25 @@ function createSettingsFile(settingsDir: string) {
 }
 
 /**
- * Create playwright trace package based on the spec file name.
- * @returns path string along with spec file
- * @example main.e2e.spec.ts-pw-trace.zip
+ * Calculate the path of an asset that should be attached to a test run.
+ * @param testPath The path to the test file.
+ * @param type What kind of asset this is.
  */
-export function playwrightReportAssets(fileName: string) {
-  return path.join(__dirname, '..', 'reports', `${ fileName }-pw-trace.zip`);
+export function reportAsset(testPath: string, type: 'trace' | 'log' = 'trace') {
+  const name = {
+    trace: 'pw-trace.zip',
+    log:   'logs'
+  }[type];
+
+  // Note that CirrusCI doesn't upload folders...
+  return path.join(__dirname, '..', 'reports', `${ path.basename(testPath) }-${ name }`);
+}
+
+export async function packageLogs(testPath: string) {
+  const logDir = reportAsset(testPath, 'log');
+  const outputPath = path.join(__dirname, '..', 'reports', `${ path.basename(testPath) }-logs.tar`);
+
+  await childProcess.spawnFile('tar', ['cf', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
 }
 
 /**

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -18,22 +18,18 @@ import { PathManagementStrategy } from '@/integrations/pathManager';
  * FirstPage window.
  */
 export function createDefaultSettings() {
-  createSettingsFile(paths.config);
-}
-
-function createSettingsFile(settingsDir: string) {
   const settingsData = defaultSettings;
 
   settingsData.debug = true;
   settingsData.pathManagementStrategy = PathManagementStrategy.Manual;
   const settingsJson = JSON.stringify(settingsData);
   const fileSettingsName = 'settings.json';
-  const settingsFullPath = path.join(settingsDir, fileSettingsName);
+  const settingsFullPath = path.join(paths.config, fileSettingsName);
 
   if (!fs.existsSync(settingsFullPath)) {
-    fs.mkdirSync(settingsDir, { recursive: true });
-    fs.writeFileSync(path.join(settingsDir, fileSettingsName), settingsJson);
-    console.log('Default settings file successfully created on: ', `${ settingsDir }/${ fileSettingsName }`, settingsData);
+    fs.mkdirSync(paths.config, { recursive: true });
+    fs.writeFileSync(path.join(paths.config, fileSettingsName), settingsJson);
+    console.log('Default settings file successfully created on: ', `${ paths.config }/${ fileSettingsName }`, settingsData);
   } else {
     try {
       const contents = fs.readFileSync(settingsFullPath, { encoding: 'utf-8' });

--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 import { expect, test } from '@playwright/test';
 
-import { createDefaultSettings, playwrightReportAssets } from './utils/TestUtils';
+import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
 import { spawnFile } from '@/utils/childProcess';
 
@@ -161,6 +161,7 @@ test.describe('WSL Integrations', () => {
         RD_TEST_WSL_EXE:    path.join(workdir, 'system32', 'wsl.exe'),
         RD_MOCK_WSL_DATA:   path.join(workdir, 'config.json'),
         RD_MOCK_BACKEND:    '1',
+        RD_LOGS_DIR:      reportAsset(__filename, 'log'),
       },
     });
     context = electronApp.context();
@@ -169,7 +170,8 @@ test.describe('WSL Integrations', () => {
     page = await electronApp.firstWindow();
   });
   test.afterAll(async() => {
-    await context.tracing.stop({ path: playwrightReportAssets(path.basename(__filename)) });
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
     await electronApp.close();
   });
 

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -385,8 +385,7 @@ describe('DockerDirManager', () => {
     const commonCredHelperExpectations: (...args: Parameters<typeof childProcess.spawnFile>) => void = (command, args, options) => {
       expect(command).toEqual('docker-credential-mockhelper');
       expect(args[0]).toEqual('list');
-      expect(options.stdio[0]).toBeInstanceOf(stream.Readable);
-      expect(options.stdio[1]).toBe('pipe');
+      expect(options.stdio[1]).toBe('ignore');
       expect(options.stdio[2]).toBeInstanceOf(Log);
     };
 

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -189,13 +189,14 @@ export default class DockerDirManager {
 
     const platform = os.platform();
     let pathVar = process.env.PATH ?? ''; // This should always be set.
+
     pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
     if (platform === 'darwin') {
-      pathVar += `${path.delimiter}/usr/local/bin`;
+      pathVar += `${ path.delimiter }/usr/local/bin`;
     }
 
     return await spawnFile(command, args, {
-      env: { ...process.env, PATH: pathVar },
+      env:   { ...process.env, PATH: pathVar },
       stdio: [body ?? 'ignore', 'ignore', console],
     });
   }
@@ -206,19 +207,21 @@ export default class DockerDirManager {
    */
   protected async credHelperPassInitialized(): Promise<boolean> {
     try {
-      const timeoutError = Symbol('timeout')
+      const timeoutError = Symbol('timeout');
       const execPromise = this.spawnFileWithExtraPath('pass', ['ls']);
-      const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve(timeoutError), 1_000));
+      const timeoutPromise = new Promise(resolve => setTimeout(() => resolve(timeoutError), 1_000));
       const result = await Promise.any([execPromise, timeoutPromise]);
 
       if (Object.is(result, timeoutError)) {
         console.debug('Timed out waiting for pass');
+
         return false;
       }
 
       return true;
     } catch (ex) {
       console.debug(`The pass command is not working; ignoring docker-credential-pass`);
+
       return false;
     }
   }
@@ -228,17 +231,19 @@ export default class DockerDirManager {
    * @param helperName The cred helper name, without the "docker-credential-" prefix.
    */
   protected async credHelperWorking(helperName: string): Promise<boolean> {
-    const helperBin = `docker-credential-${helperName}`;
+    const helperBin = `docker-credential-${ helperName }`;
 
-    console.debug(`Checking if credential helper ${helperName} is working...`);
+    console.debug(`Checking if credential helper ${ helperName } is working...`);
 
     if (helperName === 'desktop') {
       // Special case docker-credentials-desktop: never use it.
-      console.debug(`Rejecting ${helperName}; blacklisted.`);
+      console.debug(`Rejecting ${ helperName }; blacklisted.`);
+
       return false;
     } else if (helperName === 'pass') {
       if (!await this.credHelperPassInitialized()) {
-        console.debug(`Rejecting ${helperName}; underlying library not intialized.`);
+        console.debug(`Rejecting ${ helperName }; underlying library not intialized.`);
+
         return false;
       }
     }
@@ -248,7 +253,7 @@ export default class DockerDirManager {
       const body = stream.Readable.from('');
 
       await this.spawnFileWithExtraPath(helperBin, ['list'], body);
-      console.debug(`Credential helper ${helperBin} is working.`);
+      console.debug(`Credential helper ${ helperBin } is working.`);
 
       return true;
     } catch (err) {

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -44,7 +44,15 @@ export class Log {
     this.fdPromise = new Promise((resolve) => {
       this.stream.on('open', resolve);
     });
-    this.console = process.env.NODE_ENV === 'test' ? globalThis.console : new Console(this.stream);
+    // If we're running unit tests, output to the console rather than file.
+    // However, _don't_ do so for end-to-end tests in Playwright.
+    // We detect Playwright via the TEST_PARALLEL_INDEX environment variable.
+    // See https://playwright.dev/docs/test-parallel#worker-index-and-parallel-index
+    if (process.env.NODE_ENV === 'test' && !process.env.TEST_PARALLEL_INDEX) {
+      this.console = globalThis.console;
+    } else {
+      this.console = new Console(this.stream);
+    }
   }
 
   /** The path to the log file. */

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -51,7 +51,7 @@ export class DarwinPaths extends ProvidesResources implements Paths {
   appHome = path.join(os.homedir(), 'Library', 'Application Support', APP_NAME);
   altAppHome = path.join(os.homedir(), '.rd');
   config = path.join(os.homedir(), 'Library', 'Preferences', APP_NAME);
-  logs = path.join(os.homedir(), 'Library', 'Logs', APP_NAME);
+  logs = process.env.RD_LOGS_DIR ?? path.join(os.homedir(), 'Library', 'Logs', APP_NAME);
   cache = path.join(os.homedir(), 'Library', 'Caches', APP_NAME);
   lima = path.join(this.appHome, 'lima');
   oldIntegration = '/usr/local/bin';
@@ -76,7 +76,7 @@ export class Win32Paths extends ProvidesResources implements Paths {
   readonly appHome = path.join(this.appData, APP_NAME);
   readonly altAppHome = this.appHome;
   readonly config = path.join(this.appData, APP_NAME);
-  readonly logs = path.join(this.localAppData, APP_NAME, 'logs');
+  readonly logs = process.env.RD_LOGS_DIR ?? path.join(this.localAppData, APP_NAME, 'logs');
   readonly cache = path.join(this.localAppData, APP_NAME, 'cache');
   readonly wslDistro = path.join(this.localAppData, APP_NAME, 'distro');
   readonly wslDistroData = path.join(this.localAppData, APP_NAME, 'distro-data');
@@ -104,7 +104,7 @@ export class LinuxPaths extends ProvidesResources implements Paths {
   readonly appHome = path.join(this.configHome, APP_NAME);
   readonly altAppHome = path.join(os.homedir(), '.rd');
   readonly config = path.join(this.configHome, APP_NAME);
-  readonly logs = path.join(this.dataHome, APP_NAME, 'logs');
+  readonly logs = process.env.RD_LOGS_DIR ?? path.join(this.dataHome, APP_NAME, 'logs');
   readonly cache = path.join(this.cacheHome, APP_NAME);
   readonly lima = path.join(this.dataHome, APP_NAME, 'lima');
   readonly integration = path.join(this.altAppHome, 'bin');


### PR DESCRIPTION
- Check that `pass` is working before using `docker-credential-pass` (because `docker-credential-pass list` doesn't actually check that it works)
- Provide logs in Cirrus CI on E2E tests, for when things fail.
- Log at a debug level when in E2E tests (to track down why things fail)
- When running E2E tests, _don't_ emit logs to stdout (because Playwright hides it). Still emit it to stdout when running unit tests.