### PR TITLE
Replace `confirm` and `alert` with electron equivalent 

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -598,7 +598,13 @@ Electron.ipcMain.on('get-app-version', async(event) => {
   event.reply('get-app-version', await getVersion());
 });
 
-Electron.ipcMain.handle('show-message-box', (event, options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> => {
+Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBoxOptions, modal = false): Promise<Electron.MessageBoxReturnValue> => {
+  const preferences = window.getWindow('preferences');
+
+  if (modal && preferences) {
+    return Electron.dialog.showMessageBox(preferences, options);
+  }
+
   return Electron.dialog.showMessageBox(options);
 });
 

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -231,6 +231,9 @@ images:
       references: References
 k8s: 
   title: Kubernetes Settings
+  dialog:
+    ok: OK
+    cancel: Cancel
 portForwarding:
   title: Port Forwarding
 general:

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -307,7 +307,7 @@ export default {
 
       const confirm = await this.confirm(`${ consequence }\n\nDo you want to proceed?`);
 
-      if (confirm.response !== 1) {
+      if (!confirm.response) {
         for (const key in this.notifications) {
           this.handleNotification('info', key, '');
         }
@@ -334,7 +334,7 @@ export default {
 
         const confirm = await this.confirm(confirmationMessage);
 
-        if (confirm.response !== 1) {
+        if (!confirm.response) {
           ipcRenderer.invoke('settings-write', { kubernetes: { version: event.target.value } })
             .then(() => this.restart());
         } else {
@@ -349,7 +349,7 @@ export default {
 
         const confirm = await this.confirm(confirmationMessage);
 
-        if (confirm.response !== 1) {
+        if (!confirm.response) {
           try {
             await ipcRenderer.invoke('settings-write', { kubernetes: { containerEngine: desiredEngine } });
             this.restart();
@@ -381,7 +381,7 @@ export default {
 
         const confirm = await this.confirm(confirmationMessage);
 
-        if (confirm.response !== 1) {
+        if (!confirm.response) {
           try {
             await ipcRenderer.invoke('settings-write', { kubernetes: { enabled: value } });
             this.restart();
@@ -415,7 +415,7 @@ export default {
 
       const confirm = await this.confirm(confirmationMessage);
 
-      if (confirm.response === 1) {
+      if (!confirm.response) {
         return;
       }
 

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -219,27 +219,11 @@ export default {
     if (this.hasSystemPreferences) {
       // We don't configure WSL metrics, so don't bother making these checks on Windows.
       if (this.settings.kubernetes.memoryInGB > this.availMemoryInGB) {
-        ipcRenderer.invoke(
-          'show-message-box',
-          {
-            message: `Reducing memory size from ${ this.settings.kubernetes.memoryInGB } to ${ this.availMemoryInGB }`,
-            type:    'info',
-            title:   'Rancher Desktop - Kubernetes Settings'
-          },
-          true
-        );
+        this.alert(`Reducing memory size from ${ this.settings.kubernetes.memoryInGB } to ${ this.availMemoryInGB }`);
         this.settings.kubernetes.memoryInGB = this.availMemoryInGB;
       }
       if (this.settings.kubernetes.numberCPUs > this.availNumCPUs) {
-        ipcRenderer.invoke(
-          'show-message-box',
-          {
-            message: `Reducing # of CPUs from ${ this.settings.kubernetes.numberCPUs } to ${ this.availNumCPUs }`,
-            type:    'info',
-            title:   'Rancher Desktop - Kubernetes Settings'
-          },
-          true
-        );
+        this.alert(`Reducing # of CPUs from ${ this.settings.kubernetes.numberCPUs } to ${ this.availNumCPUs }`);
         this.settings.kubernetes.numberCPUs = this.availNumCPUs;
       }
     }
@@ -321,17 +305,7 @@ export default {
         false: 'Resetting Kubernetes will delete all workloads and configuration.',
       }[wipe];
 
-      const confirm = await ipcRenderer.invoke(
-        'show-message-box',
-        {
-          message:  `${ consequence }\n\nDo you want to proceed?`,
-          type:     'question',
-          title:    'Rancher Desktop - Kubernetes Settings',
-          buttons:  ['Ok', 'Cancel'],
-          cancelId: 1
-        },
-        true
-      );
+      const confirm = await this.confirm(`${ consequence }\n\nDo you want to proceed?`);
 
       if (confirm.response !== 1) {
         for (const key in this.notifications) {
@@ -358,31 +332,13 @@ export default {
         }
         confirmationMessage += '\n\nDo you want to proceed?';
 
-        const confirm = await ipcRenderer.invoke(
-          'show-message-box',
-          {
-            message:  confirmationMessage,
-            type:     'question',
-            title:    'Rancher Desktop - Kubernetes Settings',
-            buttons:  ['Ok', 'Cancel'],
-            cancelId: 1
-          },
-          true
-        );
+        const confirm = await this.confirm(confirmationMessage);
 
         if (confirm.response !== 1) {
           ipcRenderer.invoke('settings-write', { kubernetes: { version: event.target.value } })
             .then(() => this.restart());
         } else {
-          ipcRenderer.invoke(
-            'show-message-box',
-            {
-              message: 'The Kubernetes Version was not changed.',
-              type:    'info',
-              title:   'Rancher Desktop - Kubernetes Settings'
-            },
-            true
-          );
+          this.alert('The Kubernetes Version was not changed.');
         }
       }
     },
@@ -391,17 +347,7 @@ export default {
         const confirmationMessage = [`Changing container engines from ${ this.containerEngineNames[this.currentEngine] } to ${ this.containerEngineNames[desiredEngine] } will require a restart of Kubernetes.`,
           '\n\nDo you want to proceed?'].join('');
 
-        const confirm = await ipcRenderer.invoke(
-          'show-message-box',
-          {
-            message:  confirmationMessage,
-            type:     'question',
-            title:    'Rancher Desktop - Kubernetes Settings',
-            buttons:  ['Ok', 'Cancel'],
-            cancelId: 1
-          },
-          true
-        );
+        const confirm = await this.confirm(confirmationMessage);
 
         if (confirm.response !== 1) {
           try {
@@ -433,17 +379,7 @@ export default {
           '\n\nDo you want to proceed?'
         ].join('');
 
-        const confirm = await ipcRenderer.invoke(
-          'show-message-box',
-          {
-            message:  confirmationMessage,
-            type:     'question',
-            title:    'Rancher Desktop - Kubernetes Settings',
-            buttons:  ['Ok', 'Cancel'],
-            cancelId: 1
-          },
-          true
-        );
+        const confirm = await this.confirm(confirmationMessage);
 
         if (confirm.response !== 1) {
           try {
@@ -477,17 +413,7 @@ export default {
 
       const confirmationMessage = `Kubernetes will restart after ${ value ? 'enabling' : 'disabling' } Traefik. \n\nDo you want to proceed?`;
 
-      const confirm = await ipcRenderer.invoke(
-        'show-message-box',
-        {
-          message:  confirmationMessage,
-          type:     'question',
-          title:    'Rancher Desktop - Kubernetes Settings',
-          buttons:  ['Ok', 'Cancel'],
-          cancelId: 1
-        },
-        true
-      );
+      const confirm = await this.confirm(confirmationMessage);
 
       if (confirm.response === 1) {
         return;
@@ -520,6 +446,30 @@ export default {
     handleError(key, message) {
       this.handleNotification('error', key, message);
     },
+    confirm(message) {
+      return ipcRenderer.invoke(
+        'show-message-box',
+        {
+          message,
+          type:     'question',
+          title:    'Rancher Desktop - Kubernetes Settings',
+          buttons:  ['Ok', 'Cancel'],
+          cancelId: 1
+        },
+        true
+      );
+    },
+    alert(message) {
+      return ipcRenderer.invoke(
+        'show-message-box',
+        {
+          message,
+          type:    'info',
+          title:   'Rancher Desktop - Kubernetes Settings'
+        },
+        true
+      );
+    }
   },
 };
 </script>

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -45,7 +45,7 @@ export const restoreWindow = (window: Electron.BrowserWindow | null): window is 
 /**
  * Return an existing window of the given ID.
  */
-function getWindow(name: string): Electron.BrowserWindow | null {
+export function getWindow(name: string): Electron.BrowserWindow | null {
   return (name in windowMapping) ? BrowserWindow.fromId(windowMapping[name]) : null;
 }
 


### PR DESCRIPTION
This replaces all browser implementations of `confirm` and `alert` in `K8s.vue` with the electron equivalent by making use of the ipc `show-message-box` event. 

This also adds a new argument to `show-message-box` so that we can make the message box behave as a modal. Doing this will help to keep the UI functioning similar to how it did before.

### macOS 1.3.0

<img width="1052" alt="Screen Shot 2022-06-07 at 4 35 18 PM" src="https://user-images.githubusercontent.com/835961/172501384-d3021e13-b3e1-43ac-b00a-d597dbd458fd.png">

### macOS PR #2336 

<img width="1052" alt="Screen Shot 2022-06-07 at 5 34 28 PM" src="https://user-images.githubusercontent.com/835961/172506687-b6c09368-8cd7-47ec-a573-a39247fb9843.png">

### Linux 1.3.0

![image](https://user-images.githubusercontent.com/835961/172501654-547edaf2-b812-4e4e-beda-202ca4c39a9b.png)

### Linux PR #2336 

![image](https://user-images.githubusercontent.com/835961/172501875-8ef8758e-2871-49c5-a9cd-d28260f2e088.png)

### Windows 1.3.0

![image](https://user-images.githubusercontent.com/835961/172507395-524adda3-e895-4f2b-9aaa-b0dda001e3a1.png)

### Windows PR #2336 

![image](https://user-images.githubusercontent.com/835961/172507717-a6b3454a-df42-410b-8ad1-5193b0abba37.png)

Closes #1865 