### PR TITLE
E2E: Try to use correct tar on Windows.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -66,8 +66,13 @@ export function reportAsset(testPath: string, type: 'trace' | 'log' = 'trace') {
 export async function packageLogs(testPath: string) {
   const logDir = reportAsset(testPath, 'log');
   const outputPath = path.join(__dirname, '..', 'reports', `${ path.basename(testPath) }-logs.tar`);
+  let tar = 'tar';
 
-  await childProcess.spawnFile('tar', ['cf', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
+  if (os.platform() === 'win32') {
+    tar = path.join(process.env.SystemRoot ?? '', 'system32', 'tar.exe');
+  }
+
+  await childProcess.spawnFile(tar, ['cf', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
 }
 
 /**


### PR DESCRIPTION
On Windows, if we end up using the wrong `tar` executable, it will fail to understand Windows-style paths and end up interpreting `C:\...` paths as referring to a remote machine named `C`.  Force use of the `tar.exe` bundled with Windows to avoid the issue.
