### PR TITLE
Add an index to the images key

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -158,11 +158,11 @@ export default {
   computed: {
     keyedImages() {
       return this.images
-        .map((image) => {
+        .map((image, index) => {
           return {
             ...image,
             si:   parseSi(image.size),
-            _key: `${ image.imageID }-${ this.imageTag(image.tag) }`
+            _key: `${ index }-${ image.imageID }-${ this.imageTag(image.tag) }`
           };
         });
     },


### PR DESCRIPTION
Because we treat image tags with `<none>` as `latest`, we don't have a unique key for our tables. The ui crashes when repopulating table data while toggling namespaces because of this key violation. Prefixing the table key with the index does plenty to distinguish duplicate members in the table, but we might want to consider implementing further down the line might be to generate a UUID for each image in the backend, so that that we don't have to generate a key for our images in the UI.

closes #2341 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>