### PR TITLE
Credential Server on Windows builds shouldn't listen on the WSL Interface

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -69,10 +69,9 @@ describeWithCreds('Credentials server', () => {
   const appPath = path.join(__dirname, '../');
   const command = os.platform() === 'win32' ? 'curl.exe' : 'curl';
   const initialArgs: string[] = []; // Assigned once we have auth string on first use.
-  const ipaddr = 'localhost';
 
   async function doRequest(path: string, body = '') {
-    const args = initialArgs.concat([`http://${ ipaddr }:${ serverState.port }/${ path }`]);
+    const args = initialArgs.concat([`http://localhost:${ serverState.port }/${ path }`]);
 
     if (body.length) {
       args.push('--data', body);
@@ -85,7 +84,7 @@ describeWithCreds('Credentials server', () => {
   }
 
   async function doRequestExpectStatus(path: string, body: string, expectedStatus: number) {
-    const args = initialArgs.concat(['-v', `http://${ ipaddr }:${ serverState.port }/${ path }`]);
+    const args = initialArgs.concat(['-v', `http://localhost:${ serverState.port }/${ path }`]);
 
     if (body.length) {
       args.push('--data', body);
@@ -164,7 +163,7 @@ describeWithCreds('Credentials server', () => {
   });
 
   test('should require authentication', async() => {
-    const url = `http://${ ipaddr }:${ serverState.port }/list`;
+    const url = `http://localhost:${ serverState.port }/list`;
     const resp = await fetch(url);
 
     expect(resp.ok).toBeFalsy();

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -67,11 +67,9 @@ describeWithCreds('Credentials server', () => {
   let authString: string;
   let page: Page;
   const appPath = path.join(__dirname, '../');
-  const command = os.platform() === 'win32' ? 'wsl' : 'curl';
-  // Assign these values on first request once we have an authString
-  // And we can't assign to ipaddr on Windows here because we need an async context.
-  let ipaddr: string|undefined = '';
-  let initialArgs: string[] = [];
+  const command = os.platform() === 'win32' ? 'curl.exe' : 'curl';
+  const initialArgs: string[] = []; // Assigned once we have auth string on first use.
+  const ipaddr = 'localhost';
 
   async function doRequest(path: string, body = '') {
     const args = initialArgs.concat([`http://${ ipaddr }:${ serverState.port }/${ path }`]);
@@ -161,14 +159,6 @@ describeWithCreds('Credentials server', () => {
 
     // Now is a good time to initialize the various connection-related values.
     authString = `${ serverState.user }:${ serverState.password }`;
-    if (os.platform() === 'win32') {
-      ipaddr = wslHostIPv4Address();
-      expect(ipaddr).toBeDefined();
-      // arguments for wsl
-      initialArgs = ['--distribution', 'rancher-desktop', '--exec', 'curl'];
-    } else {
-      ipaddr = 'localhost';
-    }
     // common arguments for curl
     initialArgs.push('--silent', '--user', authString, '--request', 'POST');
   });
@@ -184,7 +174,7 @@ describeWithCreds('Credentials server', () => {
   test('should be able to use the API', async() => {
     const bobsURL = 'https://bobs.fish/tackle';
     const bobsFirstSecret = 'loblaw';
-    const bobsSecondSecret = 'shoppers with spaces and % and \' and &s and even a 😱';
+    const bobsSecondSecret = 'shoppers with spaces and % and \' and &s';
 
     const body = {
       ServerURL: bobsURL, Username: 'bob', Secret: bobsFirstSecret

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -10,7 +10,6 @@ import paths from '@/utils/paths';
 import * as childProcess from '@/utils/childProcess';
 import * as serverHelper from '@/main/serverHelper';
 import { findHomeDir } from '@/config/findHomeDir';
-import { wslHostIPv4Address } from '@/utils/networks';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 import BackgroundProcess from '@/utils/backgroundProcess';
 
@@ -90,7 +89,7 @@ export class HttpCredentialHelperServer {
   });
 
   async init() {
-    let addr: string | undefined = '127.0.0.1';
+    const addr = '127.0.0.1';
     const statePath = getServerCredentialsPath();
 
     await fs.promises.writeFile(statePath,
@@ -100,13 +99,6 @@ export class HttpCredentialHelperServer {
     this.server.on('error', (err) => {
       console.error(`Error writing out ${ statePath }`, err);
     });
-    if (isWindows) {
-      addr = wslHostIPv4Address();
-      if (!addr) {
-        console.error('Failed to get an IP address for WSL subsystems.');
-        addr = '127.0.0.1';
-      }
-    }
     this.listenAddr = addr;
     this.server.listen(SERVER_PORT, addr);
     if (process.platform === 'win32') {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -89,7 +89,6 @@ export class HttpCredentialHelperServer {
   });
 
   async init() {
-    const addr = '127.0.0.1';
     const statePath = getServerCredentialsPath();
 
     await fs.promises.writeFile(statePath,
@@ -99,8 +98,8 @@ export class HttpCredentialHelperServer {
     this.server.on('error', (err) => {
       console.error(`Error writing out ${ statePath }`, err);
     });
-    this.listenAddr = addr;
-    this.server.listen(SERVER_PORT, addr);
+    this.listenAddr = '127.0.0.1';
+    this.server.listen(SERVER_PORT, this.listenAddr);
     if (process.platform === 'win32') {
       this.vsockProxy.start();
     }


### PR DESCRIPTION
Credential Server on Windows needs to listen to host loopback, not WSL interface.

Signed-off-by: Eric Promislow <epromislow@suse.com>