### PR TITLE
Only delete a unique collection of image ids

### DIFF
--- a/src/main/imageEvents.ts
+++ b/src/main/imageEvents.ts
@@ -71,7 +71,9 @@ export class ImageEventHandler {
 
     Electron.ipcMain.on('do-image-deletion-batch', async(event, imageIDs) => {
       try {
-        await this.imageProcessor.deleteImages(imageIDs);
+        const uniqueImageIDs = new Set<string>(imageIDs);
+
+        await this.imageProcessor.deleteImages([...uniqueImageIDs]);
         await this.imageProcessor.refreshImages();
         event.reply('images-process-ended', 0);
       } catch (err) {


### PR DESCRIPTION
This makes sure that we only attempt to delete a unique collection of image IDs. 

We make use of the `rmi` command for deleting images and having duplicate image IDs will generate an error after the first in the collection has been deleted. For example:

`nerdctl rmi de56395ae078 de56395ae078`

closes #2343 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>