### PR TITLE
Build a standalone docker-credential-none.

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -32,7 +32,6 @@ import fetch from 'node-fetch';
 import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
 import paths from '@/utils/paths';
 import { ServerState } from '@/main/commandServer/httpCommandServer';
-import { wslHostIPv4Address } from '@/utils/networks';
 import { spawnFile } from '@/utils/childProcess';
 import { findHomeDir } from '@/config/findHomeDir';
 
@@ -187,7 +186,7 @@ describeWithCreds('Credentials server', () => {
     await doRequestExpectStatus('store', JSON.stringify(body), 200);
 
     stdout = await doRequest('list');
-    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' } );
+    expect(JSON.parse(stdout)[bobsURL]).toBe('bob');
 
     stdout = await doRequest('get', bobsURL);
     expect(JSON.parse(stdout)).toMatchObject(body);
@@ -233,7 +232,7 @@ describeWithCreds('Credentials server', () => {
     expect(stdout).toEqual('');
 
     ({ stdout } = await rdctlCredWithStdin('list'));
-    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' });
+    expect(JSON.parse(stdout)[bobsURL]).toBe('bob');
 
     ({ stdout } = await rdctlCredWithStdin('get', bobsURL));
     expect(JSON.parse(stdout)).toMatchObject(body);

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -209,7 +209,7 @@ describeWithCreds('Credentials server', () => {
     await doRequestExpectStatus('store', JSON.stringify(body), 200);
 
     stdout = await doRequest('list');
-    expect(JSON.parse(stdout)[bobsURL]).toBe('bob');
+    expect(JSON.parse(stdout)).toMatchObject({ [bobsURL]: 'bob' });
 
     stdout = await doRequest('get', bobsURL);
     expect(JSON.parse(stdout)).toMatchObject(body);
@@ -296,13 +296,16 @@ describeWithCreds('Credentials server', () => {
       expect(stderr).toContain('Error: exit status 22');
     });
 
-    test('it should not complain about other fields', async() => {
+    test('it should not complain about extra fields', async() => {
       const body: Record<string, string> = {
         ServerURL: bobsURL, Username: 'bob', Soup: 'gazpacho'
       };
-      const { stdout, stderr } = await rdctlCredWithStdin('store', JSON.stringify(body));
+      let { stdout, stderr } = await rdctlCredWithStdin('store', JSON.stringify(body));
 
       expect(stdout).toBe('');
+      expect(stderr).toBe('');
+      ({ stdout, stderr } = await rdctlCredWithStdin('get', bobsURL));
+      expect(JSON.parse(stdout)).not.toMatchObject({ Soup: 'gazpacho' });
       expect(stderr).toBe('');
     });
   });

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -272,15 +272,15 @@ export default {
   },
 
   /**
-   * Build the rdctl CLI.
+   * Build a utility for the current OS
    */
-  async buildRdCtl(platform) {
-    const target = platform === 'win32' ? 'rdctl.exe' : 'rdctl';
+  async buildUtility(name, platform) {
+    const target = platform === 'win32' ? `${ name }.exe` : name;
     const parentDir = path.join(this.srcDir, 'resources', platform, 'bin');
     const outFile = path.join(parentDir, target);
 
     await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', outFile, '.', {
-      cwd: path.join(this.srcDir, 'src', 'go', 'rdctl'),
+      cwd: path.join(this.srcDir, 'src', 'go', name),
       env: {
         ...process.env,
         GOOS: this.goOSMapping[platform],
@@ -319,7 +319,8 @@ export default {
       tasks.push(() => this.buildVtunnel('win32'));
       tasks.push(() => this.buildVtunnel('linux'));
     }
-    tasks.push(() => this.buildRdCtl(os.platform()));
+    tasks.push(() => this.buildUtility('rdctl', os.platform()));
+    tasks.push(() => this.buildUtility('docker-credential-none', os.platform()));
 
     return this.wait(...tasks);
   },

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -272,7 +272,7 @@ export default {
   },
 
   /**
-   * Build a utility for the specified platform.
+   * Build a golang-based utility for the specified platform.
    */
   async buildUtility(name, platform) {
     const target = platform === 'win32' ? `${ name }.exe` : name;

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -272,7 +272,7 @@ export default {
   },
 
   /**
-   * Build a utility for the current OS
+   * Build a utility for the specified platform.
    */
   async buildUtility(name, platform) {
     const target = platform === 'win32' ? `${ name }.exe` : name;

--- a/src/go/docker-credential-none/cmd/erase.go
+++ b/src/go/docker-credential-none/cmd/erase.go
@@ -17,13 +17,14 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
 var eraseCmd = &cobra.Command{
 	Use:   "erase",
-	Short: "Update the auths in config.json based on the data written to stdin.",
-	Long:  `Update the auths in config.json based on the data written to stdin.`,
+	Short: fmt.Sprintf("Update the auths in ~/.docker/%s based on the data written to stdin.", configFileName),
+	Long:  fmt.Sprintf(`Update the auths in ~/.docker/%s based on the data written to stdin.`, configFileName),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doErase()
 	},

--- a/src/go/docker-credential-none/cmd/erase.go
+++ b/src/go/docker-credential-none/cmd/erase.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var eraseCmd = &cobra.Command{
+	Use:   "erase",
+	Short: "Update the auths in config.json based on the data written to stdin.",
+	Long:  `Update the auths in config.json based on the data written to stdin.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doErase()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(eraseCmd)
+}
+
+func doErase() error {
+	config, err := getParsedConfig()
+	if err != nil {
+		config = map[string]interface{}{}
+	}
+	url := getStandardInput()
+	authsInterface, ok := config["auths"]
+	if !ok {
+		// Not an error if there's no URL (or auths)
+		return nil
+	}
+	auths := authsInterface.(map[string]interface{})
+	_, ok = auths[url]
+	if !ok {
+		// Not an error if there's no URL (or auths)
+		return nil
+	}
+	delete(auths, url)
+	return saveParsedConfig(&config)
+}

--- a/src/go/docker-credential-none/cmd/get.go
+++ b/src/go/docker-credential-none/cmd/get.go
@@ -1,0 +1,78 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get all the data associated with the URL written to stdin.",
+	Long:  `Get all the data associated with the URL written to stdin.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doGet()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+}
+
+func doGet() error {
+	urlArg := getStandardInput()
+	config, err := getParsedConfig()
+	if err != nil {
+		return err
+	}
+	payload := doGetAux(&config, urlArg)
+	if payload == "" {
+		fmt.Fprintf(os.Stdout, "credentials not found in native keychain")
+	} else {
+		fmt.Fprintln(os.Stdout, payload)
+	}
+	return nil
+}
+
+func doGetAux(config *dockerConfigType, urlArg string) string {
+	authsInterface, ok := (*config)["auths"]
+	if !ok {
+		return ""
+	}
+	auths := authsInterface.(map[string]interface{})
+	authDataForUrl, ok := auths[urlArg]
+	if !ok {
+		return ""
+	}
+	authData, ok := authDataForUrl.(map[string]interface{})["auth"]
+	if !ok {
+		return ""
+	}
+	credentialPair, err := base64.StdEncoding.DecodeString(authData.(string))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return ""
+	}
+	parts := strings.SplitN(string(credentialPair), ":", 2)
+	return jsonPacket(urlArg, parts[0], parts[1])
+}

--- a/src/go/docker-credential-none/cmd/get.go
+++ b/src/go/docker-credential-none/cmd/get.go
@@ -66,16 +66,16 @@ func doGet() error {
 func getRecordForServerURL(config *dockerConfigType, urlArg string) (*credType, error) {
 	authsInterface, ok := (*config)["auths"]
 	if !ok {
-		return nil, URLNotFoundError{}
+		return nil, urlNotFoundError{}
 	}
 	auths := authsInterface.(map[string]interface{})
 	authDataForUrl, ok := auths[urlArg]
 	if !ok {
-		return nil, URLNotFoundError{}
+		return nil, urlNotFoundError{}
 	}
 	authData, ok := authDataForUrl.(map[string]interface{})["auth"]
 	if !ok {
-		return nil, URLNotFoundError{}
+		return nil, urlNotFoundError{}
 	}
 	credentialPair, err := base64.StdEncoding.DecodeString(authData.(string))
 	if err != nil {
@@ -86,7 +86,7 @@ func getRecordForServerURL(config *dockerConfigType, urlArg string) (*credType, 
 		return nil, fmt.Errorf("not a valid base64-encoded pair: <%s>", authData.(string))
 	}
 	if parts[0] == "" {
-		return nil, NoUserForURLError{}
+		return nil, noUserForURLError{}
 	}
 	return &credType{urlArg, parts[0], parts[1]}, nil
 }
@@ -95,18 +95,16 @@ func getRecordForServerURL(config *dockerConfigType, urlArg string) (*credType, 
 // https://github.com/docker/docker-credential-helpers/blob/master/credentials/error.go
 // to ensure consistency with error messages from other helpers
 
-type URLNotFoundError struct {
-	Err error
+type urlNotFoundError struct {
 }
 
-func (e URLNotFoundError) Error() string {
+func (e urlNotFoundError) Error() string {
 	return "credentials not found in native keychain"
 }
 
-type NoUserForURLError struct {
-	Err error
+type noUserForURLError struct {
 }
 
-func (e NoUserForURLError) Error() string {
+func (e noUserForURLError) Error() string {
 	return "no credentials username"
 }

--- a/src/go/docker-credential-none/cmd/list.go
+++ b/src/go/docker-credential-none/cmd/list.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the URLs that have stored associated credentials.",
+	Long:  `List the URLs that have stored associated credentials.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doList()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+func doList() error {
+	config, err := getParsedConfig()
+	if err != nil {
+		return err
+	}
+	var urls []string
+	authsInterface, ok := config["auths"]
+	if ok {
+		auths := authsInterface.(map[string]interface{})
+		for url := range auths {
+			urls = append(urls, url)
+		}
+	}
+	fmt.Printf("[%s]\n", strings.Join(urls, ", "))
+	return nil
+}

--- a/src/go/docker-credential-none/cmd/root.go
+++ b/src/go/docker-credential-none/cmd/root.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const configFileName = "cicd-targeted.config.json"
+
 type dockerConfigType map[string]interface{}
 
 var configFile string
@@ -36,8 +38,8 @@ var configFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "docker-credential-none",
-	Short: "Store docker creds in .docker/config.json.shadow",
-	Long:  `Store docker credentials base64-encoded in .docker/config.json.shadow. This is mostly for testing purposes.`,
+	Short: fmt.Sprintf("Store docker creds in ~/.docker/%s", configFileName),
+	Long:  fmt.Sprintf(`Store docker credentials base64-encoded in ~/.docker/%s. This is mostly for testing purposes.`, configFileName),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -50,7 +52,7 @@ func Execute() {
 }
 
 func init() {
-	configFile = filepath.Join(dockerconfig.Dir(), "config.json.shadow")
+	configFile = filepath.Join(dockerconfig.Dir(), configFileName)
 }
 
 func getParsedConfig() (dockerConfigType, error) {

--- a/src/go/docker-credential-none/cmd/root.go
+++ b/src/go/docker-credential-none/cmd/root.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	dockerconfig "github.com/docker/docker/cli/config"
+	"github.com/spf13/cobra"
+)
+
+type dockerConfigType map[string]interface{}
+
+var configFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "docker-credential-none",
+	Short: "Store docker creds in .docker/config.json.shadow",
+	Long:  `Store docker credentials base64-encoded in .docker/config.json.shadow. This is mostly for testing purposes.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	configFile = filepath.Join(dockerconfig.Dir(), "config.json.shadow")
+}
+
+func getParsedConfig() (dockerConfigType, error) {
+	jsonThing := make(dockerConfigType)
+	contents, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return jsonThing, err
+	}
+	err = json.Unmarshal(contents, &jsonThing)
+	return jsonThing, err
+}
+
+func getStandardInput() string {
+	var chunks []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		chunks = append(chunks, scanner.Text())
+	}
+	return strings.TrimRight(strings.Join(chunks, ""), "\n")
+}
+
+func saveParsedConfig(config *dockerConfigType) error {
+	contents, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(configFile, contents, 0600)
+	return nil
+}
+
+func jsonPacket(urlArg, username, secret string) string {
+	// JSON-encode the individual parts, but use sprintf to lay it out the way other cred-helpers do.
+	b1, err := json.Marshal(urlArg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return ""
+	}
+	b2, err := json.Marshal(username)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return ""
+	}
+	b3, err := json.Marshal(secret)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return ""
+	}
+	return fmt.Sprintf(`{"ServerURL": %s, "Username": %s, "Secret": %s}`, string(b1), string(b2), string(b3))
+}

--- a/src/go/docker-credential-none/cmd/root.go
+++ b/src/go/docker-credential-none/cmd/root.go
@@ -35,9 +35,9 @@ const configFileName = "plaintext-credentials.config.json"
 type dockerConfigType map[string]interface{}
 
 type credType struct {
-  ServerURL string `json:"ServerURL"`
-  Username  string `json:"Username"`
-  Secret    string `json:"Secret"`
+	ServerURL string `json:"ServerURL"`
+	Username  string `json:"Username"`
+	Secret    string `json:"Secret"`
 }
 
 var configFile string

--- a/src/go/docker-credential-none/cmd/root.go
+++ b/src/go/docker-credential-none/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -69,8 +70,7 @@ func getParsedConfig() (dockerConfigType, error) {
 	dockerConfig := make(dockerConfigType)
 	contents, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		pathError, ok := err.(*os.PathError)
-		if ok && pathError.Err == syscall.ENOENT {
+		if errors.Is(err, syscall.ENOENT) {
 			// Time to create a new config (or return no data)
 			return dockerConfig, nil
 		}

--- a/src/go/docker-credential-none/cmd/store.go
+++ b/src/go/docker-credential-none/cmd/store.go
@@ -25,8 +25,8 @@ import (
 
 var storeCmd = &cobra.Command{
 	Use:   "store",
-	Short: "Update the auths in config.json based on the data written to stdin.",
-	Long:  `Update the auths in config.json based on the data written to stdin.`,
+	Short: fmt.Sprintf("Update the auths in ~/.docker/%s based on the data written to stdin.", configFileName),
+	Long:  fmt.Sprintf(`Update the auths in ~/.docker/%s based on the data written to stdin.`, configFileName),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doStore()
 	},

--- a/src/go/docker-credential-none/cmd/store.go
+++ b/src/go/docker-credential-none/cmd/store.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var storeCmd = &cobra.Command{
+	Use:   "store",
+	Short: "Update the auths in config.json based on the data written to stdin.",
+	Long:  `Update the auths in config.json based on the data written to stdin.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doStore()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(storeCmd)
+}
+
+type credType struct {
+	ServerURL string `json:"ServerURL"`
+	Username  string `json:"Username"`
+	Secret    string `json:"Secret"`
+}
+
+func doStore() error {
+	var auths map[string]interface{}
+
+	config, err := getParsedConfig()
+	if err != nil {
+		config = map[string]interface{}{}
+	}
+	jsonPayload := getStandardInput()
+	cred := credType{}
+	err = json.Unmarshal([]byte(jsonPayload), &cred)
+	if err != nil {
+		return err
+	}
+	authsInterface, ok := config["auths"]
+	if !ok {
+		config["auths"] = map[string]interface{}{}
+		auths, ok = config["auths"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("%s", "Can't update config['auths']")
+		}
+	} else {
+		auths = authsInterface.(map[string]interface{})
+	}
+	d := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", cred.Username, cred.Secret)))
+	auths[cred.ServerURL] = map[string]string{"auth": d}
+	return saveParsedConfig(&config)
+}

--- a/src/go/docker-credential-none/go.mod
+++ b/src/go/docker-credential-none/go.mod
@@ -1,0 +1,13 @@
+module github.com/rancher-sandbox/rancher-desktop/src/go/docker-credential-none
+
+go 1.18
+
+require (
+	github.com/docker/docker v20.10.17+incompatible
+	github.com/spf13/cobra v1.4.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/src/go/docker-credential-none/go.sum
+++ b/src/go/docker-credential-none/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=
+github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/src/go/docker-credential-none/main.go
+++ b/src/go/docker-credential-none/main.go
@@ -1,0 +1,13 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+*/
+package main
+
+import (
+	"github.com/rancher-sandbox/rancher-desktop/src/go/docker-credential-none/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/src/go/docker-credential-none/main.go
+++ b/src/go/docker-credential-none/main.go
@@ -1,6 +1,17 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2022 SUSE LLC
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package main
 

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -25,7 +25,6 @@ const SERVER_PORT = 6109;
 const SERVER_USERNAME = 'user';
 const SERVER_FILE_BASENAME = 'credential-server.json';
 const MAX_REQUEST_BODY_LENGTH = 2048;
-const isWindows = os.platform().startsWith('win');
 
 type dispatchFunctionType = (helperName: string, data: string, request: http.IncomingMessage, response: http.ServerResponse) => Promise<void>;
 

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -272,6 +272,9 @@ export default class DockerDirManager {
     if (currentCredsStore && await this.credHelperWorking(currentCredsStore)) {
       return currentCredsStore;
     }
+    if (process.env.CIRRUS_CI && this.credHelperWorking('none')) {
+      return 'none';
+    }
 
     if (platform.startsWith('win')) {
       return 'wincred';

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -272,7 +272,7 @@ export default class DockerDirManager {
     if (currentCredsStore && await this.credHelperWorking(currentCredsStore)) {
       return currentCredsStore;
     }
-    if (process.env.CIRRUS_CI && this.credHelperWorking('none')) {
+    if (process.env.CI && this.credHelperWorking('none')) {
       return 'none';
     }
 

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -272,7 +272,7 @@ export default class DockerDirManager {
     if (currentCredsStore && await this.credHelperWorking(currentCredsStore)) {
       return currentCredsStore;
     }
-    if (process.env.CI && this.credHelperWorking('none')) {
+    if (process.env.CIRRUS_CI && this.credHelperWorking('none')) {
       return 'none';
     }
 


### PR DESCRIPTION
Fixes #2335

It stores the auths in ~/.docker/cicd-targeted.config.json

It can't store them in config.json because the docker CLI
will clear the `auths` hash (because `credsStore` is set).

Signed-off-by: Eric Promislow <epromislow@suse.com>