### PR TITLE
Settings: Allow setting all values.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -38,6 +38,7 @@ test.describe('Command server', () => {
   let context: BrowserContext;
   let serverState: ServerState;
   let page: Page;
+  const ENOENTMessage = os.platform() === 'win32' ? 'The system cannot find the file specified' : 'no such file or directory';
   const appPath = path.join(__dirname, '../');
 
   async function doRequest(path: string, body = '', method = 'GET') {
@@ -286,7 +287,7 @@ test.describe('Command server', () => {
             stdout, stderr, error
           }).toEqual({
             error:  expect.any(Error),
-            stderr: expect.stringContaining(`Error: open ${ configFilePath }: no such file or directory`),
+            stderr: expect.stringContaining(`Error: open ${ configFilePath }: ${ ENOENTMessage }`),
             stdout: ''
           });
           expect(stderr).not.toContain('Usage:');
@@ -324,7 +325,7 @@ test.describe('Command server', () => {
               stdout, stderr, error
             }).toEqual({
               error:  expect.any(Error),
-              stderr: expect.stringContaining(`Error: open ${ configFilePath }: no such file or directory`),
+              stderr: expect.stringContaining(`Error: open ${ configFilePath }: ${ ENOENTMessage }`),
               stdout: ''
             });
             expect(stderr).not.toContain('Usage:');
@@ -343,7 +344,7 @@ test.describe('Command server', () => {
                 stdout, stderr, error
               }).toEqual({
                 error:  expect.any(Error),
-                stderr: expect.stringContaining(`Error: open ${ configFile }: no such file or directory`),
+                stderr: expect.stringContaining(`Error: open ${ configFile }: ${ ENOENTMessage }`),
                 stdout: ''
               });
               expect(stderr).not.toContain('Usage:');

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -218,9 +218,17 @@ test.describe('Command server', () => {
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
     const body = resp2.body.read().toString();
+    const expectedWSL = {
+      win32:  "Proposed field kubernetes.WSLIntegrations should be an object, got <ceci n'est pas un objet>.",
+      lima:  "Changing field kubernetes.WSLIntegrations via the API isn't supported.",
+    }[os.platform() === 'win32' ? 'win32' : 'lima'];
+    const expectedMemory = {
+      win32: "Changing field kubernetes.memoryInGB via the API isn't supported.",
+      lima:  'Invalid value for kubernetes.memoryInGB: <"carl">',
+    }[os.platform() === 'win32' ? 'win32' : 'lima'];
     const expectedLines = [
-      "Proposed field kubernetes.WSLIntegrations should be an object, got <ceci n'est pas un objet>.",
-      "Changing field kubernetes.memoryInGB via the API isn't supported.",
+      expectedWSL,
+      expectedMemory,
       `Invalid value for kubernetes.containerEngine: <{"status":"should be a scalar"}>; must be 'containerd', 'docker', or 'moby'`,
       'Setting portForwarding should wrap an inner object, but got <bob>.',
       'Invalid value for telemetry: <{"oops":15}>',

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -45,7 +45,7 @@ export const defaultSettings = {
     containerEngine:            ContainerEngine.CONTAINERD,
     checkForExistingKimBuilder: false,
     enabled:                    true,
-    WSLIntegrations:            {} as Record<string, string|boolean>,
+    WSLIntegrations:            {} as Record<string, boolean>,
     options:                    { traefik: true, flannel: true },
     suppressSudo:               false,
     /**

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -419,7 +419,7 @@ describe(SettingsValidator, () => {
         kubernetes: {
           containerEngine: { expected: 'a string' } as unknown as settings.ContainerEngine,
           version:         { expected: 'a string' } as unknown as string,
-          WSLIntegrations: "ceci n'est pas un objet" as unknown as Record<string, boolean>,
+          options:         "ceci n'est pas un objet" as unknown as Record<string, boolean>,
         }
       });
       expect(needToUpdate).toBeFalsy();
@@ -427,7 +427,7 @@ describe(SettingsValidator, () => {
       expect(errors).toEqual([
         "Invalid value for kubernetes.containerEngine: <[object Object]>; must be 'containerd', 'docker', or 'moby'",
         'Kubernetes version "[object Object]" not found.',
-        "Proposed field kubernetes.WSLIntegrations should be an object, got <ceci n'est pas un objet>.",
+        "Setting kubernetes.options should wrap an inner object, but got <ceci n'est pas un objet>.",
       ]);
     });
 

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -131,13 +131,13 @@ describe(SettingsValidator, () => {
 
             switch (typeof defaultSettings[key]) {
             case 'boolean':
-              newValue = !_.get(cfg, keyPath);
+              newValue = !defaultSettings[key];
               break;
             case 'number':
-              newValue = _.get(cfg, keyPath) + 1;
+              newValue = defaultSettings[key] + 1;
               break;
             case 'string':
-              newValue = `${ _.get(cfg, keyPath) }!`;
+              newValue = `${ defaultSettings[key] }!`;
               break;
             default:
               expect(['boolean', 'number', 'string']).toContain(typeof defaultSettings[key]);

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -78,6 +78,8 @@ describe(SettingsValidator, () => {
         'kubernetes.suppressSudo':             'linux',
       };
 
+      const spyValidateSettings = jest.spyOn(subject, 'validateSettings');
+
       function checkSetting(path: string[], defaultSettings: any) {
         const prefix = path.length === 0 ? '' : `${ path.join('.') }.`;
         const props = [];
@@ -192,6 +194,10 @@ describe(SettingsValidator, () => {
       }
 
       checkSetting([], cfg);
+
+      it('should have validated at least one setting', () => {
+        expect(spyValidateSettings).toHaveBeenCalled();
+      });
     });
 
     describe('kubernetes.containerEngine', () => {

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -164,7 +164,7 @@ describe(SettingsValidator, () => {
 
             expect({ needToUpdate, errors }).toEqual({
               needToUpdate: false,
-              errors:       [`Invalid value for ${ prefix }${ key }: <${ invalidValue }>`],
+              errors:       [`Invalid value for ${ prefix }${ key }: <${ JSON.stringify(invalidValue) }>`],
             });
           });
 
@@ -227,7 +227,7 @@ describe(SettingsValidator, () => {
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <>;')],
+          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <"">;')],
         });
       });
 
@@ -251,7 +251,7 @@ describe(SettingsValidator, () => {
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <pikachu>;')],
+          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <"pikachu">;')],
         });
       });
     });
@@ -425,7 +425,7 @@ describe(SettingsValidator, () => {
       expect(needToUpdate).toBeFalsy();
       expect(errors).toHaveLength(3);
       expect(errors).toEqual([
-        "Invalid value for kubernetes.containerEngine: <[object Object]>; must be 'containerd', 'docker', or 'moby'",
+        `Invalid value for kubernetes.containerEngine: <{"expected":"a string"}>; must be 'containerd', 'docker', or 'moby'`,
         'Kubernetes version "[object Object]" not found.',
         "Setting kubernetes.options should wrap an inner object, but got <ceci n'est pas un objet>.",
       ]);

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -102,9 +102,6 @@ describe(SettingsValidator, () => {
     describe('should complain about all unchangeable fields', () => {
       const valuesToChange: [string, RecursivePartial<settings.Settings>][] = [
         ['version', { version: cfg.version + 1 }],
-        ['kubernetes.memoryInGB', { kubernetes: { memoryInGB: cfg.kubernetes.memoryInGB + 1 } }],
-        ['kubernetes.numberCPUs', { kubernetes: { numberCPUs: cfg.kubernetes.numberCPUs + 1 } }],
-        ['kubernetes.port', { kubernetes: { port: cfg.kubernetes.port + 1 } }],
         ['kubernetes.checkForExistingKimBuilder', { kubernetes: { checkForExistingKimBuilder: !cfg.kubernetes.checkForExistingKimBuilder } }],
         ['kubernetes.WSLIntegrations', { kubernetes: { WSLIntegrations: { stuff: 'here' } } }],
         ['kubernetes.WSLIntegrations', {
@@ -114,7 +111,6 @@ describe(SettingsValidator, () => {
             }
           }
         }],
-        ['images.namespace', { images: { namespace: '*g0rni9la7tz*' } }],
       ];
 
       test.each(valuesToChange)('%s', (fullQualifiedPreferenceName, specifiedSettingSegment) => {
@@ -135,6 +131,7 @@ describe(SettingsValidator, () => {
         ['kubernetes', 'WSLIntegrations'],
         ['kubernetes', 'version'],
         ['pathManagementStrategy'],
+        ['version'],
       ];
 
       function checkSetting(path: string[], defaultSettings: any) {

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -394,7 +394,7 @@ describe(SettingsValidator, () => {
     });
 
     it('should complain about unchangeable fields', () => {
-      const unchanableFieldsAndValues = {
+      const unchangeableFieldsAndValues = {
         'kubernetes.checkForExistingKimBuilder': !cfg.kubernetes.checkForExistingKimBuilder,
         version:                                 -1
       };
@@ -402,7 +402,7 @@ describe(SettingsValidator, () => {
       // Check that we _don't_ ask for update when we  have errors.
       const input = { telemetry: !cfg.telemetry };
 
-      for (const [path, value] of Object.entries(unchanableFieldsAndValues)) {
+      for (const [path, value] of Object.entries(unchangeableFieldsAndValues)) {
         _.set(input, path, value);
       }
 
@@ -410,7 +410,7 @@ describe(SettingsValidator, () => {
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: false,
-        errors:       Object.keys(unchanableFieldsAndValues).map(key => `Changing field ${ key } via the API isn't supported.`),
+        errors:       Object.keys(unchangeableFieldsAndValues).map(key => `Changing field ${ key } via the API isn't supported.`),
       });
     });
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -11,9 +11,10 @@ type settingsLike = Record<string, any>;
  * @param desiredValue The new value that the user is setting.
  * @param errors An array that any validation errors should be appended to.
  * @param fqname The fully qualified name of the setting, for formatting in error messages.
+ * @returns Whether the setting has changed.
  */
 type ValidatorFunc<C, D> =
-  (currentValue: C, desiredValue: D, errors: string[], fqname: string) => void;
+  (currentValue: C, desiredValue: D, errors: string[], fqname: string) => boolean;
 
 /**
  * SettingsValidationMapEntry describes validators that are valid for some

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -235,6 +235,13 @@ export default class SettingsValidator {
 
       return false;
     }
+
+    if (desiredValue === PathManagementStrategy.NotSet) {
+      errors.push(`${ fqname }: "${ desiredValue }" is not a valid strategy`);
+
+      return false;
+    }
+
     if (desiredValue !== currentValue) {
       return true;
     }

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -47,9 +47,9 @@ export default class SettingsValidator {
       version:    this.checkUnchanged,
       kubernetes: {
         version:                    this.checkKubernetesVersion,
-        memoryInGB:                 this.checkUnchanged,
-        numberCPUs:                 this.checkUnchanged,
-        port:                       this.checkUnchanged,
+        memoryInGB:                 this.checkNumber(0, Number.POSITIVE_INFINITY),
+        numberCPUs:                 this.checkNumber(0, Number.POSITIVE_INFINITY),
+        port:                       this.checkNumber(1, 65535),
         containerEngine:            this.checkContainerEngine,
         checkForExistingKimBuilder: this.checkUnchanged, // Should only be set internally
         enabled:                    this.checkBoolean,
@@ -61,7 +61,7 @@ export default class SettingsValidator {
       portForwarding: { includeKubernetesServices: this.checkBoolean },
       images:         {
         showAll:   this.checkBoolean,
-        namespace:  this.checkUnchanged,
+        namespace: this.checkString,
       },
       telemetry:              this.checkBoolean,
       updater:                this.checkBoolean,
@@ -137,6 +137,33 @@ export default class SettingsValidator {
    */
   protected checkBoolean(currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
     if (typeof desiredValue !== 'boolean') {
+      errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+      return false;
+    }
+
+    return currentValue !== desiredValue;
+  }
+
+  protected checkNumber(min: number, max: number) {
+    return (currentValue: number, desiredValue: number, errors: string[], fqname: string) => {
+      if (typeof desiredValue !== 'number') {
+        errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+        return false;
+      }
+      if (desiredValue < min || desiredValue > max) {
+        errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+        return false;
+      }
+
+      return currentValue !== desiredValue;
+    };
+  }
+
+  protected checkString(currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
+    if (typeof desiredValue !== 'string') {
       errors.push(this.invalidSettingMessage(fqname, desiredValue));
 
       return false;


### PR DESCRIPTION
This expands the `POST /v1/settings` endpoint to allow changing any of the settings we have.  Generally, we just set boolean/number/string as appropriate, with a few (pre-existing) special checks.

- Some things can only be set on a given platform (e.g. changing WSL integrations on Linux is not allowed).
- We test most of the settings based on the type (in the default settings).
- Update the `Settings` type to clarify that the only valid stored value is boolean (the string is only possible at runtime, as a result of checking what the current integration state is).

Fixes #2370