### PR TITLE
K8s: Be more exhaustive on if restarts are needed.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -472,7 +472,7 @@ async function doK8sReset(arg: 'fast' | 'wipe' | 'fullRestart'): Promise<void> {
 }
 
 async function doK8sRestartRequired() {
-  const restartRequired = (await k8smanager?.requiresRestartReasons()) ?? {};
+  const restartRequired = (await k8smanager?.requiresRestartReasons(cfg.kubernetes)) ?? {};
 
   window.send('k8s-restart-required', restartRequired);
 }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -107,6 +107,30 @@ interface KubernetesBackendEvents {
   'kim-builder-uninstalled': () => void;
 }
 
+/**
+ * Settings that KubernetesBackend can access.
+ */
+type BackendSettings = Settings['kubernetes'];
+
+/**
+ * Details about why the backend must be restarted.  Normally returns as part
+ * of a `Record<string, RestartReason>` from `requiresRestartReasons()`.
+ */
+export type RestartReason = {
+  /**
+   * The currently active value.
+   */
+  currentValue: any;
+  /**
+   * The desired value (which is probably different from the active value).
+   */
+  desiredValue: any;
+  /**
+   * Whether to display this reason to the user.
+   */
+  visible: boolean;
+};
+
 export interface KubernetesBackend extends events.EventEmitter {
   /** The name of the Kubernetes backend */
   readonly backend: 'wsl' | 'lima' | 'mock';
@@ -154,7 +178,7 @@ export interface KubernetesBackend extends events.EventEmitter {
    * Start the Kubernetes cluster.  If it is already started, it will be
    * restarted.
    */
-  start(config: Settings['kubernetes']): Promise<void>;
+  start(config: BackendSettings): Promise<void>;
 
   /** Stop the Kubernetes cluster.  If applicable, shut down the VM. */
   stop(): Promise<void>;
@@ -163,7 +187,7 @@ export interface KubernetesBackend extends events.EventEmitter {
   del(): Promise<void>;
 
   /** Reset the Kubernetes cluster, removing all workloads. */
-  reset(config: Settings['kubernetes']): Promise<void>;
+  reset(config: BackendSettings): Promise<void>;
 
   /**
    * Reset the cluster, completely deleting any user configuration.  This does
@@ -177,7 +201,7 @@ export interface KubernetesBackend extends events.EventEmitter {
    * because of that reason, or an empty tuple.
    * @returns Reasons to restart; values are tuple of (existing value, desired value).
    */
-  requiresRestartReasons(): Promise<Record<string, [any, any] | []>>;
+  requiresRestartReasons(settings: BackendSettings): Promise<Record<string, RestartReason | undefined>>;
 
   /**
    * Get the external IP address where the services would be listening on, if

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -95,7 +95,7 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
 
   noModalDialogs = true;
 
-  requiresRestartReasons(): Promise<Record<string, [any, any] | []>> {
+  requiresRestartReasons(settings: Settings['kubernetes']): Promise<Record<string, undefined>> {
     return Promise.resolve({});
   }
 

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -248,8 +248,8 @@ export default {
       this.containerEngineChangePending = false;
       for (const key in required) {
         console.log(`restart-required`, key, required[key]);
-        if (required[key].length > 0) {
-          const message = `The cluster must be reset for ${ key } change from ${ required[key][0] } to ${ required[key][1] }.`;
+        if (required[key]?.visible) {
+          const message = `The cluster must be reset for ${ key } change from ${ required[key].currentValue } to ${ required[key].desiredValue }.`;
 
           this.handleNotification('info', `restart-${ key }`, message);
           if (key === 'containerEngine') {

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -90,7 +90,7 @@ export interface IpcRendererEvents {
   'k8s-check-state': (state: import('@/k8s-engine/k8s').State) => void;
   'k8s-current-engine': (engine: import('@/config/settings').ContainerEngine) => void;
   'k8s-current-port': (port: number) => void;
-  'k8s-restart-required': (required: Record<string, [any, any] | []>) => void;
+  'k8s-restart-required': (required: Awaited<ReturnType<import('@/k8s-engine/k8s').KubernetesBackend['requiresRestartReasons']>>) => void;
   'k8s-versions': (versions: import('@/k8s-engine/k8s').VersionEntry[]) => void;
   'k8s-integrations': (integrations: Record<string, boolean | string>) => void;
   'service-changed': (services: import('@/k8s-engine/k8s').ServiceEntry[]) => void;


### PR DESCRIPTION
Change the `KubernetesBackend.requiresRestartReasons` methods to report back on more reasons on why we might need to restart; this adds a flag to not show the reason to the user (which will be obsolete once we always apply all changes at once).

This is so we can use this to later decide if we need to restart at the end of starting (as the user may have changed more settings during the starting process).

This is for #2390.