### PR TITLE
Use $HOME instead of ~ in manual PATH instructions

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -270,14 +270,14 @@ containerRuntime:
 
 pathManagement:
   label: Configure PATH
-  tooltip: Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>~/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
   options:
     rcFiles:
       label: Automatic
       description: Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
     manual:
       label: Manual
-      description: 'Rancher Desktop does not change your PATH configuration; add <code>~/.rd/bin</code> to your path manually.'
+      description: 'Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.'
   accept: Accept
 
 legacyIntegrations:


### PR DESCRIPTION
Refs #2416. Putting `~` directly on your PATH can cause issues with programs that are not shells (such as Docker).