### PR TITLE
Cirrus CI: Fix uploading logs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,13 @@ task:
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 # disable auto-browser download
     KEYRING: /usr/share/keyrings/nodesource.gpg
     NODE_VERSION: node_16.x # set node version e.g: "node_17.x" for Node 17 LTS
-    SUDO_NON_ROOT_CMD: sudo --login --user=ranchertest /usr/bin/env --chdir=/home/ranchertest/src
+    SUDO_NON_ROOT_CMD: >-
+      sudo --login --user=ranchertest /usr/bin/env --chdir=/home/ranchertest/src
+      CI=${CI} CIRRUS_CI=${CIRRUS_CI} CONTINUOUS_INTEGRATION=${CONTINUOUS_INTEGRATION}
+      CIRRUS_BASE_BRANCH=${CIRRUS_BASE_BRANCH} CIRRUS_BASE_SHA=${CIRRUS_BASE_SHA}
+      CIRRUS_BRANCH=${CIRRUS_BRANCH} CIRRUS_PR=${CIRRUS_PR} CIRRUS_TAG=${CIRRUS_TAG}
+      CIRRUS_REPO_NAME=${CIRRUS_REPO_NAME} CIRRUS_REPO_OWNER=${CIRRUS_REPO_OWNER}
+      CIRRUS_REPO_FULL_NAME=${CIRRUS_REPO_FULL_NAME}
 
   # Setting up a non-root user
   prepare_user_script:
@@ -62,7 +68,7 @@ task:
 
   test_script:
     - export KUBECONFIG=/home/ranchertest/.kube/config
-    - ${SUDO_NON_ROOT_CMD} CI=1 xvfb-run --auto-servernum -- npm run test:e2e
+    - ${SUDO_NON_ROOT_CMD} xvfb-run --auto-servernum -- npm run test:e2e
 
   on_failure:
     # custom_script workaround for cirrus bug: https://github.com/cirruslabs/cirrus-ci-agent/issues/197

--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -34,7 +34,10 @@ export class NavPage {
     // Wait until progress bar show up. It takes roughly ~60s to start in CI
     await this.progressBar.waitFor({ state: 'visible', timeout: 200_000 });
     // Wait until progress bar be detached. With that we can make sure the services were started
-    await this.progressBar.waitFor({ state: 'detached', timeout: 120_000 });
+    // This seems to sometimes return too early; actually check the result.
+    while (await this.progressBar.count() > 0) {
+      await this.progressBar.waitFor({ state: 'detached', timeout: 120_000 });
+    }
   }
 
   /**

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -65,11 +65,14 @@ export function reportAsset(testPath: string, type: 'trace' | 'log' = 'trace') {
 
 export async function packageLogs(testPath: string) {
   if (!process.env.CIRRUS_CI) {
+    console.log('Skipping packaging logs, not running in Cirrus CI');
+
     return;
   }
   const logDir = reportAsset(testPath, 'log');
   const outputPath = path.join(__dirname, '..', 'reports', `${ path.basename(testPath) }-logs.tar`);
 
+  console.log(`Packaging logs to ${ outputPath }...`);
   await childProcess.spawnFile('tar', ['cf', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
 }
 


### PR DESCRIPTION
We broke uploading logs, because `CIRRUS_CI` was never passed down to the playwright process (because we use `sudo` to execute it, so the environment variables we should have gotten were missing).

This also contains a fix to ensure that `progressBecomesReady` works as intended — sometimes it seems to return before the progress bar is removed.