### PR TITLE
KubernetesBackend: require new settings to check for restart reasons.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -472,7 +472,7 @@ async function doK8sReset(arg: 'fast' | 'wipe' | 'fullRestart'): Promise<void> {
 }
 
 async function doK8sRestartRequired() {
-  const restartRequired = (await k8smanager?.requiresRestartReasons()) ?? {};
+  const restartRequired = (await k8smanager?.requiresRestartReasons(cfg.kubernetes)) ?? {};
 
   window.send('k8s-restart-required', restartRequired);
 }

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import util from 'util';
 import semver from 'semver';
 
-import { KubernetesBackend, KubernetesError, State } from './k8s';
+import { KubernetesBackend, KubernetesError, State, RestartReason } from './k8s';
 import ProgressTracker from './progressTracker';
 import { Settings } from '@/config/settings';
 import Logging from '@/utils/logging';
@@ -95,7 +95,7 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
 
   noModalDialogs = true;
 
-  requiresRestartReasons(): Promise<Record<string, [any, any] | []>> {
+  requiresRestartReasons(): Promise<Record<string, RestartReason | undefined>> {
     return Promise.resolve({});
   }
 

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -248,8 +248,8 @@ export default {
       this.containerEngineChangePending = false;
       for (const key in required) {
         console.log(`restart-required`, key, required[key]);
-        if (required[key].length > 0) {
-          const message = `The cluster must be reset for ${ key } change from ${ required[key][0] } to ${ required[key][1] }.`;
+        if (required[key]) {
+          const message = `The cluster must be reset for ${ key } change from ${ required[key].current } to ${ required[key].desired }.`;
 
           this.handleNotification('info', `restart-${ key }`, message);
           if (key === 'containerEngine') {
@@ -404,9 +404,9 @@ export default {
         { kubernetes: { numberCPUs: value } });
     },
     handleUpdatePort(value) {
-      this.settings.kubernetes.port = value;
+      this.settings.kubernetes.port = parseInt(value, 10);
       ipcRenderer.invoke('settings-write',
-        { kubernetes: { port: value } });
+        { kubernetes: { port: parseInt(value, 10) } });
     },
     async handleUpdateTraefik(value) {
       if (value === this.settings.kubernetes.options.traefik) {

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -90,7 +90,7 @@ export interface IpcRendererEvents {
   'k8s-check-state': (state: import('@/k8s-engine/k8s').State) => void;
   'k8s-current-engine': (engine: import('@/config/settings').ContainerEngine) => void;
   'k8s-current-port': (port: number) => void;
-  'k8s-restart-required': (required: Record<string, [any, any] | []>) => void;
+  'k8s-restart-required': (required: Record<string, import('@/k8s-engine/k8s').RestartReason | undefined>) => void;
   'k8s-versions': (versions: import('@/k8s-engine/k8s').VersionEntry[]) => void;
   'k8s-integrations': (integrations: Record<string, boolean | string>) => void;
   'service-changed': (services: import('@/k8s-engine/k8s').ServiceEntry[]) => void;


### PR DESCRIPTION
Modify `requiresRestartReasons()` to take settings to compare against. This is necessary as the backends are now using a copy of the settings internally, so we can't just compare the settings they have against the settings that have been applied (as they would mostly be equal).

This is part of #2403 but limited to only fixing the currently-used reasons; this does _not_ add any of the other reasons.  As such, this should be easier to review.

To confirm the fix: in the Kubernetes Settings view, change the port number (from the default of 6443); it should pop up a notification on the bottom describing the need to restart. (You may need to resize the window to get rid of the scroll bars.)