### PR TITLE
make vtunnel configurable 1/2

### DIFF
--- a/src/go/vtunnel/go.mod
+++ b/src/go/vtunnel/go.mod
@@ -18,5 +18,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/src/go/vtunnel/go.sum
+++ b/src/go/vtunnel/go.sum
@@ -26,6 +26,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=

--- a/src/go/vtunnel/pkg/config/config.go
+++ b/src/go/vtunnel/pkg/config/config.go
@@ -1,0 +1,49 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Tunnel struct {
+	HandshakePort         uint32 `yaml:"handshake-port"`
+	VsockHostPort         uint32 `yaml:"vsock-host-port"`
+	PeerAddress           string `yaml:"peer-address"`
+	PeerPort              int    `yaml:"peer-port"`
+	UpstreamServerAddress string `yaml:"upstream-server-address"`
+}
+type Config struct {
+	Tunnel []Tunnel `yaml:"tunnel"`
+}
+
+func NewConfig(path string) (*Config, error) {
+	conf := &Config{}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	d := yaml.NewDecoder(file)
+	if err := d.Decode(&conf); err != nil {
+		return nil, err
+	}
+
+	return conf, nil
+}

--- a/src/go/vtunnel/pkg/vmsock/conn_windows.go
+++ b/src/go/vtunnel/pkg/vmsock/conn_windows.go
@@ -156,7 +156,7 @@ func (h *HostConnector) handshake(vmGuid hvsock.GUID, found chan<- hvsock.GUID, 
 				logrus.Errorf("hosthandshake closing connection: %v", err)
 			}
 			if seed == SeedPhrase {
-				logrus.Infof("successfully estabilished a handshake with a peer: %s", vmGuid.String())
+				logrus.Infof("successfully estabilished a handshake with a peer: %s on port: %v", vmGuid.String(), h.PeerHandshakePort)
 				found <- vmGuid
 				return
 			}


### PR DESCRIPTION
This makes vtunnel configurable which allows us to add any number of tunnels with configuration only and no code change required. 

Please note there will be a follow-up PR 2/2 which includes additional changes (integration code into Rancher Desktop).


Signed-off-by: Nino Kodabande <nkodabande@suse.com>