### PR TITLE
 K8s: Be more exhaustive on if restarts are needed.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -847,4 +847,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     await k8smanager.stop();
     Electron.app.quit();
   }
+
+  async testBackendRestartReasons() {
+    return await k8smanager?.requiresRestartReasons(cfg.kubernetes) ?? {};
+  }
 }

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -1,0 +1,195 @@
+import os from 'os';
+import path from 'path';
+
+import _ from 'lodash';
+import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
+import { test, expect } from '@playwright/test';
+
+import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
+import { NavPage } from './pages/nav-page';
+import { Settings, ContainerEngine } from '@/config/settings';
+import { spawnFile } from '@/utils/childProcess';
+import { RecursivePartial } from '@/utils/typeUtils';
+
+type KubeSettings = Settings['kubernetes'];
+
+test.describe.serial('KuberentesBackend', () => {
+  let electronApp: ElectronApplication;
+  let context: BrowserContext;
+  let page: Page;
+
+  test.beforeAll(async() => {
+    createDefaultSettings();
+
+    electronApp = await _electron.launch({
+      args: [
+        path.join(__dirname, '../'),
+        '--disable-gpu',
+        '--whitelisted-ips=',
+        // See src/utils/commandLine.ts before changing the next item as the final option.
+        '--disable-dev-shm-usage',
+        '--no-modal-dialogs',
+      ],
+      env: {
+        ...process.env,
+        RD_LOGS_DIR: reportAsset(__filename, 'log'),
+      },
+    });
+    context = electronApp.context();
+
+    await context.tracing.start({ screenshots: true, snapshots: true });
+    page = await electronApp.firstWindow();
+  });
+
+  test.afterAll(async() => {
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
+    await electronApp.close();
+  });
+
+  test('should start loading the background services and hide progress bar', async() => {
+    const navPage = new NavPage(page);
+
+    await navPage.progressBecomesReady();
+    await expect(navPage.progressBar).toBeHidden();
+  });
+
+  test.describe('requiresRestartReasons', () => {
+    const rdctlPath = path.join(path.dirname(__dirname), 'resources', os.platform(), 'bin', os.platform() === 'win32' ? 'rdctl.exe' : 'rdctl');
+
+    async function get(requestPath: string) {
+      const { stdout } = await spawnFile(rdctlPath, ['api', '-X', 'GET', requestPath],
+        { stdio: ['ignore', 'pipe', 'inherit'] });
+
+      return JSON.parse(stdout);
+    }
+
+    /**
+     * getOldSettings returns the subset of settings that are being modified.
+     */
+    function getOldSettings(oldSettings: Settings, newSettings: RecursivePartial<Settings>): RecursivePartial<Settings> {
+      /**
+       * keysDeep returns the list of paths of all elements of the given object.
+       */
+      const keysDeep: (obj: any, path: string[]) => string[][] = (obj, path = []) => {
+        return Object.keys(obj).flatMap((k) => {
+          return _.isObjectLike(obj[k]) ? keysDeep(obj[k], path.concat(k)) : [path.concat(k)];
+        });
+      };
+
+      // The typing for _.pick is incorrect: paths are a (string | string[])[] argument, not a rest argument.
+      return _.pick(oldSettings, keysDeep(newSettings, []) as any);
+    }
+
+    async function putSettings(newSettings: RecursivePartial<Settings>) {
+      await spawnFile(rdctlPath, ['api', '-X', 'PUT', '--body', JSON.stringify(newSettings), '/v0/settings'], { stdio: 'pipe' });
+    }
+
+    test('should not have any reasons to restart', async() => {
+      await expect(get('/v0/testBackendRestartReasons')).resolves.toEqual({});
+    });
+
+    test('should detect port changes', async() => {
+      const currentSettings = (await get('/v0/settings')) as Settings;
+      /**
+       * getAlt returns the setting that isn't the same as the existing setting.
+       */
+      const getAlt = <K extends keyof KubeSettings>(setting: K, altOne: KubeSettings[K], altTwo: KubeSettings[K]) => {
+        return currentSettings.kubernetes[setting] === altOne ? altTwo : altOne;
+      };
+      const getAlt2 = <K1 extends keyof KubeSettings, K2 extends keyof KubeSettings[K1]>(k1: K1, k2: K2, altOne: KubeSettings[K1][K2], altTwo: KubeSettings[K1][K2]) => {
+        return currentSettings.kubernetes[k1][k2] === altOne ? altTwo : altOne;
+      };
+      const newSettings: RecursivePartial<Settings> = {
+        kubernetes: {
+          version:                  getAlt('version', '1.23.6', '1.23.5'),
+          port:                     getAlt('port', 6443, 6444),
+          containerEngine:          getAlt('containerEngine', ContainerEngine.CONTAINERD, ContainerEngine.MOBY),
+          enabled:                  getAlt('enabled', true, false),
+          options:                  {
+            traefik: getAlt2('options', 'traefik', true, false),
+            flannel: getAlt2('options', 'flannel', true, false),
+          }
+        }
+      };
+      const platformSettings: Record<string, RecursivePartial<Settings>> = {
+        win32: { kubernetes: { experimentalHostResolver: getAlt('experimentalHostResolver', true, false) } },
+        lima:  {
+          kubernetes: {
+            numberCPUs:   getAlt('numberCPUs', 1, 2),
+            memoryInGB:   getAlt('memoryInGB', 3, 4),
+            suppressSudo: getAlt('suppressSudo', true, false),
+          },
+        },
+      };
+
+      _.merge(newSettings, platformSettings[os.platform() === 'win32' ? 'win32' : 'lima']);
+      const buildExpected = <K extends keyof Settings['kubernetes']>(setting: K, visible = false) => {
+        return {
+          current: currentSettings.kubernetes[setting],
+          desired: newSettings.kubernetes?.[setting],
+          visible,
+        };
+      };
+      const buildExpected2 = <K1 extends keyof KubeSettings, K2 extends keyof KubeSettings[K1]>(k1: K1, k2: K2, visible = false) => {
+        return {
+          current: currentSettings.kubernetes[k1][k2],
+          desired: (newSettings.kubernetes as KubeSettings)[k1][k2],
+          visible
+        };
+      };
+      const expected = {
+        version:           buildExpected('version'),
+        port:              buildExpected('port'),
+        containerEngine:   buildExpected('containerEngine'),
+        enabled:           buildExpected('enabled'),
+        'options.traefik': buildExpected2('options', 'traefik'),
+        'options.flannel': buildExpected2('options', 'flannel'),
+      };
+
+      if (os.platform() === 'win32') {
+        _.merge(expected, { 'host-resolver': buildExpected('experimentalHostResolver') });
+      } else {
+        _.merge(expected, {
+          sudo:   buildExpected('suppressSudo'),
+          cpu:    buildExpected('numberCPUs', true),
+          memory: buildExpected('memoryInGB', true),
+        });
+      }
+
+      await expect(putSettings(newSettings)).resolves.toBeUndefined();
+      try {
+        await expect(get('/v0/testBackendRestartReasons')).resolves.toEqual(expected);
+      } finally {
+        await expect(putSettings(getOldSettings(currentSettings, newSettings))).resolves.toBeUndefined();
+      }
+    });
+
+    test('should handle WSL integrations', async() => {
+      test.skip(os.platform() !== 'win32', 'WSL integration only supported on Windows');
+      const currentSettings = (await get('/v0/settings')) as Settings;
+      const random = `${ Date.now() }${ Math.random() }`;
+      const newSettings: RecursivePartial<Settings> = {
+        kubernetes: {
+          WSLIntegrations: {
+            [`true-${ random }`]:  true,
+            [`false-${ random }`]: false,
+          }
+        }
+      };
+
+      await expect(putSettings(newSettings)).resolves.toBeUndefined();
+      try {
+        await expect(get('/v0/testBackendRestartReasons')).resolves.toMatchObject({
+          WSLIntegrations: {
+            current: {},
+            desired: newSettings.kubernetes?.WSLIntegrations,
+            visible: false,
+          }
+        });
+      } finally {
+        await expect(putSettings(getOldSettings(currentSettings, newSettings))).resolves.toBeUndefined();
+      }
+    });
+  });
+});

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -86,7 +86,7 @@ test.describe.serial('KuberentesBackend', () => {
     }
 
     test('should not have any reasons to restart', async() => {
-      await expect(get('/v0/testBackendRestartReasons')).resolves.toEqual({});
+      await expect(get('/v0/test_backend_restart_reasons')).resolves.toEqual({});
     });
 
     test('should detect port changes', async() => {
@@ -159,7 +159,7 @@ test.describe.serial('KuberentesBackend', () => {
 
       await expect(putSettings(newSettings)).resolves.toBeUndefined();
       try {
-        await expect(get('/v0/testBackendRestartReasons')).resolves.toEqual(expected);
+        await expect(get('/v0/test_backend_restart_reasons')).resolves.toEqual(expected);
       } finally {
         await expect(putSettings(getOldSettings(currentSettings, newSettings))).resolves.toBeUndefined();
       }
@@ -180,7 +180,7 @@ test.describe.serial('KuberentesBackend', () => {
 
       await expect(putSettings(newSettings)).resolves.toBeUndefined();
       try {
-        await expect(get('/v0/testBackendRestartReasons')).resolves.toMatchObject({
+        await expect(get('/v0/test_backend_restart_reasons')).resolves.toMatchObject({
           WSLIntegrations: {
             current: {},
             desired: newSettings.kubernetes?.WSLIntegrations,

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -91,10 +91,13 @@ test.describe.serial('KubernetesBackend', () => {
     }
 
     /**
-     * getOldSettings returns the subset of settings that are being modified.
+     * getOldSettings returns the subset of oldSettings that also occur in
+     * newSettings.  This can be used to revert the changes caused by newSettings.
+     * @param oldSettings The settings that is a superset of the things to return.
+     * @param newSettings The set that will determine what will be returned.
      */
     function getOldSettings(oldSettings: Settings, newSettings: RecursivePartial<Settings>): RecursivePartial<Settings> {
-      const getOldSettings = <S>(oldObj: S, newObj: RecursivePartial<S>) => {
+      const getOldSettingsSubset = <S>(oldObj: S, newObj: RecursivePartial<S>) => {
         const result: RecursivePartial<S> = {};
 
         for (const key of Object.keys(newObj) as (keyof S)[]) {
@@ -103,7 +106,7 @@ test.describe.serial('KubernetesBackend', () => {
           if (typeof child === 'object' && child !== null) {
             const nonNullChild: RecursivePartial<S[keyof S]> = child as any;
 
-            result[key] = getOldSettings(oldObj[key], nonNullChild) as any;
+            result[key] = getOldSettingsSubset(oldObj[key], nonNullChild) as any;
           } else {
             result[key] = oldObj[key] as any;
           }
@@ -112,7 +115,7 @@ test.describe.serial('KubernetesBackend', () => {
         return result;
       };
 
-      return getOldSettings(oldSettings, newSettings);
+      return getOldSettingsSubset(oldSettings, newSettings);
     }
 
     async function putSettings(newSettings: RecursivePartial<Settings>) {

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -137,7 +137,7 @@ test.describe.serial('KuberentesBackend', () => {
         }
       };
       const platformSettings: Record<string, RecursivePartial<Settings>> = {
-        win32: { kubernetes: { experimentalHostResolver: getAlt('experimentalHostResolver', true, false) } },
+        win32: { kubernetes: { hostResolver: getAlt('hostResolver', true, false) } },
         lima:  {
           kubernetes: {
             numberCPUs:   getAlt('numberCPUs', 1, 2),
@@ -172,7 +172,7 @@ test.describe.serial('KuberentesBackend', () => {
       };
 
       if (os.platform() === 'win32') {
-        _.merge(expected, { 'host-resolver': buildExpected('experimentalHostResolver') });
+        _.merge(expected, { 'host-resolver': buildExpected('hostResolver') });
       } else {
         _.merge(expected, {
           sudo:   buildExpected('suppressSudo'),

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -59,6 +59,15 @@ test.describe.serial('KuberentesBackend', () => {
   test.describe('requiresRestartReasons', () => {
     let serverState: { user: string, password: string, port: string, pid: string };
 
+    test.afterEach(async() => {
+      // Wait for the backend to stop (it's okay to fail to start here though)
+      const navPage = new NavPage(page);
+
+      while (await navPage.progressBar.count() > 0) {
+        await navPage.progressBar.waitFor({ state: 'detached', timeout: 120_000 });
+      }
+    });
+
     test('should emit connection information', async() => {
       const dataPath = path.join(paths.appHome, 'rd-engine.json');
       const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -15,7 +15,7 @@ import { RecursivePartial } from '@/utils/typeUtils';
 
 type KubeSettings = Settings['kubernetes'];
 
-test.describe.serial('KuberentesBackend', () => {
+test.describe.serial('KubernetesBackend', () => {
   let electronApp: ElectronApplication;
   let context: BrowserContext;
   let page: Page;
@@ -122,7 +122,7 @@ test.describe.serial('KuberentesBackend', () => {
       await expect(get('/v0/test_backend_restart_reasons')).resolves.toEqual({});
     });
 
-    test('should detect port changes', async() => {
+    test('should detect changes', async() => {
       const currentSettings = (await get('/v0/settings')) as Settings;
       /**
        * getAlt returns the setting that isn't the same as the existing setting.

--- a/e2e/config/playwright-config.ts
+++ b/e2e/config/playwright-config.ts
@@ -3,12 +3,13 @@ import type { Config, PlaywrightTestOptions } from '@playwright/test';
 
 const outputDir = path.join(__dirname, '..', 'e2e', 'test-results');
 const testDir = path.join(__dirname, '..', '..', 'e2e');
+const timeScale = process.env.CI ? 2 : 1;
 
 const config: Config<PlaywrightTestOptions> = {
   testDir,
   outputDir,
-  timeout:       process.env.CI ? 600_000 : 300_000,
-  globalTimeout: 900_000,
+  timeout:       300_000 * timeScale,
+  globalTimeout: 900_000 * timeScale,
   workers:       1,
   reporter:      'list',
 };

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -772,6 +772,7 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
+            'GET /v0/testBackendRestartReasons',
           ]);
         });
 
@@ -785,6 +786,7 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
+            'GET /v0/testBackendRestartReasons',
           ]);
         });
       });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -772,7 +772,7 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
-            'GET /v0/testBackendRestartReasons',
+            'GET /v0/test_backend_restart_reasons',
           ]);
         });
 
@@ -786,7 +786,7 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
-            'GET /v0/testBackendRestartReasons',
+            'GET /v0/test_backend_restart_reasons',
           ]);
         });
       });

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -16,7 +16,6 @@ import { ActionOnInvalid } from '@kubernetes/client-node/dist/config_types';
 import { Response } from 'node-fetch';
 import yaml from 'yaml';
 
-import { Settings } from '@/config/settings';
 import fetch from '@/utils/fetch';
 import Latch from '@/utils/latch';
 import Logging from '@/utils/logging';

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -992,11 +992,9 @@ export default class K3sHelper extends events.EventEmitter {
    * Helper for implementing KubernetesBackend.requiresRestartReasons
    */
   requiresRestartReasons(
-    settings: {
-      current: Settings['kubernetes'],
-      desired: Settings['kubernetes'],
-      items: Record<string, [boolean, ...string[]]>
-    },
+    currentSettings: K8s.BackendSettings,
+    desiredSettings: K8s.BackendSettings,
+    items: Record<string, [boolean, ...string[]]>,
     quiet = false,
     extras: Record<string, {current: number, desired: number, visible?: boolean}> = {},
   ): Record<string, K8s.RestartReason | undefined> {
@@ -1011,8 +1009,8 @@ export default class K3sHelper extends events.EventEmitter {
      * @param path The path in the Settings['kubeneretes'] object to compare.
      */
     const cmp = (key: string, visible: boolean, ...path: string[]) => {
-      const current = _.get(settings.current, path, NotFound);
-      const desired = _.get(settings.desired, path, NotFound);
+      const current = _.get(currentSettings, path, NotFound);
+      const desired = _.get(desiredSettings, path, NotFound);
 
       if (current === NotFound) {
         throw new Error(`Invalid restart check: path ${ path } not found on current values`);
@@ -1025,7 +1023,7 @@ export default class K3sHelper extends events.EventEmitter {
       };
     };
 
-    for (const [key, [visible, ...path]] of Object.entries(settings.items)) {
+    for (const [key, [visible, ...path]] of Object.entries(items)) {
       cmp(key, visible, ...path);
     }
 

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -1006,7 +1006,7 @@ export default class K3sHelper extends events.EventEmitter {
      * need to restart the backend.
      * @param key The identifier to use for the UI.
      * @param visible Whether to expose the difference to the user.
-     * @param path The path in the Settings['kubeneretes'] object to compare.
+     * @param path The path in the Settings['kubernetes'] object to compare.
      */
     const cmp = (key: string, visible: boolean, ...path: string[]) => {
       const current = _.get(currentSettings, path, NotFound);

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -8,13 +8,15 @@ import stream from 'stream';
 import tls from 'tls';
 import util from 'util';
 
+import type Electron from 'electron';
+import _ from 'lodash';
 import semver from 'semver';
 import { CustomObjectsApi, KubeConfig, V1ObjectMeta } from '@kubernetes/client-node';
 import { ActionOnInvalid } from '@kubernetes/client-node/dist/config_types';
 import { Response } from 'node-fetch';
 import yaml from 'yaml';
 
-import type Electron from 'electron';
+import { Settings } from '@/config/settings';
 import fetch from '@/utils/fetch';
 import Latch from '@/utils/latch';
 import Logging from '@/utils/logging';
@@ -984,6 +986,60 @@ export default class K3sHelper extends events.EventEmitter {
     } catch {
       return true;
     }
+  }
+
+  /**
+   * Helper for implementing KubernetesBackend.requiresRestartReasons
+   */
+  requiresRestartReasons(
+    settings: {
+      current: Settings['kubernetes'],
+      desired: Settings['kubernetes'],
+      items: Record<string, [boolean, ...string[]]>
+    },
+    quiet = false,
+    extras: Record<string, {current: number, desired: number, visible?: boolean}> = {},
+  ): Record<string, K8s.RestartReason | undefined> {
+    const results: Record<string, K8s.RestartReason | undefined> = {};
+    const NotFound = Symbol('not-found');
+
+    /**
+     * Check the given settings against the last-applied settings to see if we
+     * need to restart the backend.
+     * @param key The identifier to use for the UI.
+     * @param visible Whether to expose the difference to the user.
+     * @param path The path in the Settings['kubeneretes'] object to compare.
+     */
+    const cmp = (key: string, visible: boolean, ...path: string[]) => {
+      const current = _.get(settings.current, path, NotFound);
+      const desired = _.get(settings.desired, path, NotFound);
+
+      if (current === NotFound) {
+        throw new Error(`Invalid restart check: path ${ path } not found on current values`);
+      }
+      if (desired === NotFound) {
+        throw new Error(`Invalid restart check: path ${ path } not found on desired values`);
+      }
+      results[key] = _.isEqual(current, desired) ? undefined : {
+        current, desired, visible: visible && !quiet,
+      };
+    };
+
+    for (const [key, [visible, ...path]] of Object.entries(settings.items)) {
+      cmp(key, visible, ...path);
+    }
+
+    for (const [key, { current, desired, visible }] of Object.entries(extras)) {
+      if (_.isEqual(current, desired)) {
+        results[key] = undefined;
+      } else {
+        results[key] = {
+          current, desired, visible: typeof visible === 'undefined' ? true : visible
+        };
+      }
+    }
+
+    return results;
   }
 }
 

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -106,7 +106,7 @@ interface KubernetesBackendEvents {
 /**
  * Settings that KubernetesBackend can access.
  */
-type BackendSettings = RecursiveReadonly<Settings['kubernetes']>;
+export type BackendSettings = RecursiveReadonly<Settings['kubernetes']>;
 
 /**
  * Details about why the backend must be restarted.  Normally returns as part

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2019,18 +2019,16 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     const GiB = 1024 * 1024 * 1024;
 
     return this.k3sHelper.requiresRestartReasons(
+      this.cfg,
+      cfg,
       {
-        current: this.cfg,
-        desired: cfg,
-        items:   {
-          version:           [false, 'version'],
-          port:              [true, 'port'],
-          containerEngine:   [false, 'containerEngine'],
-          enabled:           [false, 'enabled'],
-          'options.traefik': [false, 'options', 'traefik'],
-          'options.flannel': [false, 'options', 'flannel'],
-          sudo:              [false, 'suppressSudo'],
-        }
+        version:           [false, 'version'],
+        port:              [true, 'port'],
+        containerEngine:   [false, 'containerEngine'],
+        enabled:           [false, 'enabled'],
+        'options.traefik': [false, 'options', 'traefik'],
+        'options.flannel': [false, 'options', 'flannel'],
+        sudo:              [false, 'suppressSudo'],
       },
       quiet,
       {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2001,34 +2001,37 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
   }
 
   async requiresRestartReasons(cfg: Settings['kubernetes']): Promise<Record<string, K8s.RestartReason | undefined>> {
-    if (this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR || !this.cfg?.enabled) {
-      // If we're in the middle of starting or stopping, or not using k3s, we don't need to restart.
-      return {};
-    }
+    const limaConfig = await this.getLimaConfig();
 
-    const currentConfig = await this.getLimaConfig();
-
-    const results: Record<string, K8s.RestartReason | undefined> = {};
-    const cmp = (key: string, current: number, desired: number) => {
-      if (typeof current === 'undefined') {
-        results[key] = undefined;
-      } else {
-        results[key] = current === desired ? undefined : {
-          current, desired, visible: true
-        };
-      }
-    };
-
-    if (!currentConfig || !this.cfg) {
+    if (!limaConfig || !this.cfg) {
       return {}; // No need to restart if nothing exists
     }
+
+    // If we're in the middle of something, or if we're in an error state, there
+    // is no need to tell the use about the need to restart.
+    const quiet = this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR;
     const GiB = 1024 * 1024 * 1024;
 
-    cmp('cpu', currentConfig.cpus || 4, cfg.numberCPUs);
-    cmp('memory', Math.round((currentConfig.memory || 4 * GiB) / GiB), cfg.memoryInGB);
-    cmp('port', this.currentPort, cfg.port);
-
-    return results;
+    return this.k3sHelper.requiresRestartReasons(
+      {
+        current: this.cfg,
+        desired: cfg,
+        items:   {
+          version:           [false, 'version'],
+          port:              [true, 'port'],
+          containerEngine:   [false, 'containerEngine'],
+          enabled:           [false, 'enabled'],
+          'options.traefik': [false, 'options', 'traefik'],
+          'options.flannel': [false, 'options', 'flannel'],
+          sudo:              [false, 'suppressSudo'],
+        }
+      },
+      quiet,
+      {
+        cpu:    { current: limaConfig.cpus ?? 2, desired: cfg.numberCPUs },
+        memory: { current: (limaConfig.memory ?? 4) / GiB, desired: cfg.memoryInGB },
+      },
+    );
   }
 
   listServices(namespace?: string): K8s.ServiceEntry[] {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -238,7 +238,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
-      const version = semver.parse(this.cfg?.version) ?? availableVersions[0];
+      const storedVersion = semver.parse(this.cfg?.version);
+      const version = storedVersion ?? availableVersions[0];
 
       if (!version) {
         throw new Error('No version available');
@@ -247,6 +248,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       const matchedVersion = availableVersions.find(v => v.compare(version) === 0);
 
       if (matchedVersion) {
+        if (!storedVersion) {
+          // No (valid) stored version; save the selected one.
+          this.writeSetting({ version: matchedVersion.version });
+        }
+
         return matchedVersion;
       }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1569,6 +1569,9 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     return (await this.client?.isServiceReady(namespace, service)) || false;
   }
 
+  // The WSL implementation of requiresRestartReasons doesn't need to do
+  // anything asynchronously; however, to match the API, we still need to return
+  // a Promise.
   requiresRestartReasons(cfg: Settings['kubernetes']): Promise<Record<string, K8s.RestartReason | undefined>> {
     if (!this.cfg) {
       // No need to restart if nothing exists

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1564,27 +1564,32 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   requiresRestartReasons(cfg: Settings['kubernetes']): Promise<Record<string, K8s.RestartReason | undefined>> {
-    if (this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR || !this.cfg?.enabled) {
-      // If we're in the middle of starting or stopping, we don't need to restart.
-      // If we're in an error state, differences between current and desired could be meaningless
-      // If we aren't running k3s, there are no parameters we care about.
+    if (!this.cfg) {
+      // No need to restart if nothing exists
       return Promise.resolve({});
     }
 
-    return new Promise((resolve) => {
-      const results: Record<string, K8s.RestartReason | undefined> = {};
-      const cmp = (key: string, current: number, desired: number) => {
-        results[key] = current === desired ? undefined : {
-          current, desired, visible: true
-        };
-      };
+    // If we're in the middle of something, or if we're in an error state, there
+    // is no need to tell the use about the need to restart.
+    const quiet = this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR;
 
-      if (!this.cfg) {
-        return resolve({}); // No need to restart if nothing exists
-      }
-      cmp('port', this.currentPort, cfg.port ?? this.currentPort);
-      resolve(results);
-    });
+    return Promise.resolve(this.k3sHelper.requiresRestartReasons(
+      {
+        current: this.cfg,
+        desired: cfg,
+        items:   {
+          version:           [false, 'version'],
+          port:              [true, 'port'],
+          containerEngine:   [false, 'containerEngine'],
+          enabled:           [false, 'enabled'],
+          WSLIntegrations:   [false, 'WSLIntegrations'],
+          'options.traefik': [false, 'options', 'traefik'],
+          'options.flannel': [false, 'options', 'flannel'],
+          'host-resolver':   [false, 'experimentalHostResolver'],
+        },
+      },
+      quiet,
+    ));
   }
 
   async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1580,19 +1580,17 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     const quiet = this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR;
 
     return Promise.resolve(this.k3sHelper.requiresRestartReasons(
+      this.cfg,
+      cfg,
       {
-        current: this.cfg,
-        desired: cfg,
-        items:   {
-          version:           [false, 'version'],
-          port:              [true, 'port'],
-          containerEngine:   [false, 'containerEngine'],
-          enabled:           [false, 'enabled'],
-          WSLIntegrations:   [false, 'WSLIntegrations'],
-          'options.traefik': [false, 'options', 'traefik'],
-          'options.flannel': [false, 'options', 'flannel'],
-          'host-resolver':   [false, 'hostResolver'],
-        },
+        version:           [false, 'version'],
+        port:              [true, 'port'],
+        containerEngine:   [false, 'containerEngine'],
+        enabled:           [false, 'enabled'],
+        WSLIntegrations:   [false, 'WSLIntegrations'],
+        'options.traefik': [false, 'options', 'traefik'],
+        'options.flannel': [false, 'options', 'flannel'],
+        'host-resolver':   [false, 'hostResolver'],
       },
       quiet,
     ));

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1591,7 +1591,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
           WSLIntegrations:   [false, 'WSLIntegrations'],
           'options.traefik': [false, 'options', 'traefik'],
           'options.flannel': [false, 'options', 'flannel'],
-          'host-resolver':   [false, 'experimentalHostResolver'],
+          'host-resolver':   [false, 'hostResolver'],
         },
       },
       quiet,

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import http from 'http';
 import path from 'path';
 import { URL } from 'url';
+import _ from 'lodash';
 
 import type { Settings } from '@/config/settings';
 import mainEvents from '@/main/mainEvents';
@@ -63,6 +64,11 @@ export class HttpCommandServer {
 
   async init() {
     const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
+
+    if (/^(?:test|dev)/.test(process.env.NODE_ENV ?? '')) {
+      // For test & dev runs, add extra testing-only endpoints.
+      _.merge(this.dispatchTable, { v0: { GET: { testBackendRestartReasons: this.testBackendRestartReasons } } });
+    }
 
     await fs.promises.writeFile(statePath,
       jsonStringifyWithWhiteSpace(this.externalState),
@@ -316,6 +322,19 @@ export class HttpCommandServer {
     return Promise.resolve();
   }
 
+  async testBackendRestartReasons(request: http.IncomingMessage, response: http.ServerResponse) {
+    try {
+      const result = await this.commandWorker.testBackendRestartReasons();
+
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.write(JSON.stringify(result));
+    } catch (ex) {
+      response.writeHead(500, 'Internal server error');
+      console.error(ex);
+      response.write(ex);
+    }
+  }
+
   closeServer() {
     this.server.close();
   }
@@ -337,6 +356,11 @@ export interface CommandWorkerInterface {
   getSettings: (context: commandContext) => string;
   updateSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
   requestShutdown: (context: commandContext) => void;
+
+  /**
+   * Testing only: list reasons why the backend requires a restart.
+   */
+   testBackendRestartReasons: () => Promise<Record<string, any>>;
 }
 
 // Extend CommandWorkerInterface to have extra types, as these types are used by

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -67,7 +67,7 @@ export class HttpCommandServer {
 
     if (/^(?:test|dev)/.test(process.env.NODE_ENV ?? '')) {
       // For test & dev runs, add extra testing-only endpoints.
-      _.merge(this.dispatchTable, { v0: { GET: { testBackendRestartReasons: this.testBackendRestartReasons } } });
+      _.merge(this.dispatchTable, { v0: { GET: { test_backend_restart_reasons: this.testBackendRestartReasons } } });
     }
 
     await fs.promises.writeFile(statePath,

--- a/src/pages/K8s.vue
+++ b/src/pages/K8s.vue
@@ -248,7 +248,7 @@ export default {
       this.containerEngineChangePending = false;
       for (const key in required) {
         console.log(`restart-required`, key, required[key]);
-        if (required[key]) {
+        if (required[key]?.visible) {
           const message = `The cluster must be reset for ${ key } change from ${ required[key].current } to ${ required[key].desired }.`;
 
           this.handleNotification('info', `restart-${ key }`, message);


### PR DESCRIPTION
This obsoletes #2403.

This adds more (hidden) reasons to cause restart, such as changing whether sudo is allowed.  This also adds a test (by selectively exposing a new HTTP API endpoint).

We will likely (in a follow-up) adjust that API endpoint for the UI later, but it will be renamed.