### PR TITLE
Allow for ServerURL-Specific docker-credential-helpers.

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -319,7 +319,7 @@ describeWithCreds('Credentials server', () => {
       args.splice(postIndex - 1, 2);
     }
     await expect(spawnFile(command, args, { stdio: 'pipe' })).resolves.toMatchObject({
-      stdout: 'Expecting a POST method for the credential-server list request, received GET',
+      stdout: expect.stringContaining('Expecting a POST method for the credential-server list request, received GET'),
       stderr: '',
     });
   });
@@ -360,10 +360,17 @@ describeWithCreds('Credentials server', () => {
     if (credStore !== 'pass') {
       // See above comment discussing the consequences of `echo ARG | docker-credential-pass get` never failing.
       await expect(rdctlCredWithStdin('erase', bobsURL)).resolves.toMatchObject({ stdout: '' });
-      await expect(rdctlCredWithStdin('get', bobsURL)).rejects.toMatchObject({
-        stdout: expect.stringContaining('credentials not found in native keychain'),
-        stderr: expect.stringContaining('Error: exit status 22'),
-      });
+      if (credStore === 'none') {
+        await expect(rdctlCredWithStdin('get', bobsURL)).resolves.toMatchObject({
+          stdout: expect.stringContaining('credentials not found in native keychain'),
+          stderr: '',
+        });
+      } else {
+        await expect(rdctlCredWithStdin('get', bobsURL)).rejects.toMatchObject({
+          stdout: expect.stringContaining('credentials not found in native keychain'),
+          stderr: expect.stringContaining('Error: exit status 22'),
+        });
+      }
     }
   });
 

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -213,7 +213,7 @@ export class HttpCredentialHelperServer {
     response: http.ServerResponse): Promise<void> {
     try {
       const serverAndUsernameInfo: Record<string, string> = JSON.parse(await this.runCommand(`docker-credential-${ thisHelperInfo.credsStore }`, 'list', '', request));
-      const names = _.uniq(Object.values(thisHelperInfo.credHelpers));
+      const names = _.uniq(Object.values(thisHelperInfo.credHelpers ?? {}));
 
       for (const name of names) {
         try {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import stream from 'stream';
 import { URL } from 'url';
 
+import _ from 'lodash';
+
 import { findHomeDir } from '@/config/findHomeDir';
 import { getVtunnelInstance } from '@/main/networking/vtunnel';
 import * as serverHelper from '@/main/serverHelper';
@@ -25,6 +27,11 @@ const console = Logging.server;
 const SERVER_USERNAME = 'user';
 const SERVER_FILE_BASENAME = 'credential-server.json';
 const MAX_REQUEST_BODY_LENGTH = 4194304; // 4MiB
+
+type credHelperInfo = {
+  credsStore: string;
+  credHelpers: Record<string, string>
+};
 
 type checkerFnType = (stdout: string) => boolean;
 
@@ -91,10 +98,18 @@ export class HttpCredentialHelperServer {
 
         return;
       }
-      const helperName = `docker-credential-${ await this.getCredentialHelperName() }`;
       const url = new URL(request.url ?? '', `http://${ request.headers.host }`);
       const path = url.pathname;
       const pathParts = path.split('/');
+
+      console.debug(`Processing request ${ request.method } ${ path }`);
+      if (pathParts.shift()) {
+        response.writeHead(400, { 'Content-Type': 'text/plain' });
+        response.write(`Unexpected data before first / in URL ${ path }`);
+
+        return;
+      }
+      const commandName = pathParts[0];
       const [data, error, errorCode] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
 
       if (error) {
@@ -104,12 +119,12 @@ export class HttpCredentialHelperServer {
 
         return;
       }
-      console.debug(`Processing request ${ request.method } ${ path }`);
-      if (pathParts.shift()) {
-        response.writeHead(400, { 'Content-Type': 'text/plain' });
-        response.write(`Unexpected data before first / in URL ${ path }`);
+      const helperInfo = await this.getCredentialHelperName(commandName, data);
+
+      if (commandName === 'list') {
+        await this.doListCommand(helperInfo, request, response);
       } else {
-        await this.doRequest(helperName, pathParts[0], data, request, response);
+        await this.runCommandProcessOutput(helperInfo.credsStore, commandName, data, request, response);
       }
     } catch (err) {
       console.log(`Error handling ${ request.url }`, err);
@@ -120,13 +135,29 @@ export class HttpCredentialHelperServer {
     }
   }
 
-  protected async doRequest(
-    helperName: string,
+  protected async runCommandProcessOutput(helperName: string,
     commandName: string,
     data: string,
     request: http.IncomingMessage,
     response: http.ServerResponse): Promise<void> {
-    let stderr: string;
+    try {
+      const stdout = await this.runCommand(helperName, commandName, data, request);
+
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.write(stdout);
+    } catch (err: any) {
+      const stderr = (err.stderr || err.stdout) ?? err;
+
+      console.debug(`credentialServer: ${ commandName }: writing back status 400, error: ${ stderr }`);
+      response.writeHead(400, { 'Content-Type': 'text/plain' });
+      response.write(stderr);
+    }
+  }
+
+  protected async runCommand(helperName: string,
+    commandName: string,
+    data: string,
+    request: http.IncomingMessage): Promise<string> {
     let requestCheckError: any = null;
     const checkers: Record<string, checkerFnType> = {
       list:  requireJSONOutput,
@@ -142,43 +173,72 @@ export class HttpCredentialHelperServer {
       requestCheckError = `Unknown credential action '${ commandName }' for the credential-server, must be one of [${ Object.keys(checkers).sort().join('|') }]`;
     }
     if (requestCheckError) {
-      response.writeHead(400, { 'Content-Type': 'text/plain' });
-      response.write(requestCheckError);
+      throw new Error(requestCheckError);
+    }
+
+    const platform = os.platform();
+    let pathVar = process.env.PATH ?? '';
+
+    // The PATH needs to contain our resources directory (on macOS that would
+    // not be in the application's PATH), as well as /usr/local/bin.
+    // NOTE: This needs to match DockerDirManager.
+    pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
+    if (platform === 'darwin') {
+      pathVar += `${ path.delimiter }/usr/local/bin`;
+    }
+
+    const body = stream.Readable.from(data);
+    const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
+      env:   { ...process.env, PATH: pathVar },
+      stdio: [body, 'pipe', console],
+    });
+
+    if (!checkerFn(stdout)) {
+      throw new Error(`Invalid output for ${ commandName } command.`);
+    }
+
+    return stdout;
+  }
+
+  /**
+   * For the LIST command, there are multiple possible sources of information that need to be merged into a simple
+   * { ServerURL: Username } hash.
+   * The first source is the credsStore.
+   * Then if any helper credsStores are identified in the `credHelpers` section, get the full { ServerURL: Username }
+   * from each of them, and keep only those ServerURLs that point to that credsStore.
+   */
+  protected async doListCommand(
+    thisHelperInfo: credHelperInfo,
+    request: http.IncomingMessage,
+    response: http.ServerResponse): Promise<void> {
+    try {
+      const serverAndUsernameInfo: Record<string, string> = JSON.parse(await this.runCommand(`docker-credential-${ thisHelperInfo.credsStore }`, 'list', '', request));
+      const names = _.uniq(Object.values(thisHelperInfo.credHelpers));
+
+      for (const name of names) {
+        try {
+          const otherInfo = JSON.parse(await this.runCommand(`docker-credential-${ name }`, 'list', '', request));
+
+          for (const [serverURL, username] of Object.entries(otherInfo)) {
+            if (thisHelperInfo.credHelpers[serverURL] === name) {
+              serverAndUsernameInfo[serverURL] = username as string;
+            }
+          }
+        } catch (err) {
+          console.debug(`Failed to get credential list for helper ${ name }`);
+        }
+      }
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.write(JSON.stringify(serverAndUsernameInfo));
 
       return;
-    }
-
-    try {
-      const platform = os.platform();
-      let pathVar = process.env.PATH ?? '';
-
-      // The PATH needs to contain our resources directory (on macOS that would
-      // not be in the application's PATH), as well as /usr/local/bin.
-      // NOTE: This needs to match DockerDirManager.
-      pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
-      if (platform === 'darwin') {
-        pathVar += `${ path.delimiter }/usr/local/bin`;
-      }
-
-      const body = stream.Readable.from(data);
-      const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
-        env:   { ...process.env, PATH: pathVar },
-        stdio: [body, 'pipe', console],
-      });
-
-      if (checkerFn(stdout)) {
-        response.writeHead(200, { 'Content-Type': 'text/plain' });
-        response.write(stdout);
-
-        return;
-      }
-      stderr = stdout;
     } catch (err: any) {
-      stderr = (err.stderr || err.stdout) ?? err;
+      const stderr = err.stderr || err.stdout || err.toString();
+
+      console.debug(`credentialServer: list: writing back status 400, error: ${ stderr }`);
+      response.writeHead(400, { 'Content-Type': 'text/plain' });
+      response.write(stderr);
     }
-    console.debug(`credentialServer: ${ commandName }: writing back status 400, error: ${ stderr }`);
-    response.writeHead(400, { 'Content-Type': 'text/plain' });
-    response.write(stderr);
   }
 
   /**
@@ -187,17 +247,33 @@ export class HttpCredentialHelperServer {
    * Note that callers are responsible for catching exceptions, which usually happens if the
    * `$HOME/docker/config.json` doesn't exist, its JSON is corrupt, or it doesn't have a `credsStore` field.
    */
-  protected async getCredentialHelperName(): Promise<string> {
+  protected async getCredentialHelperName(command: string, payload: string): Promise<credHelperInfo> {
     const home = findHomeDir();
     const dockerConfig = path.join(home ?? '', '.docker', 'config.json');
     const contents = JSON.parse((await fs.promises.readFile(dockerConfig, { encoding: 'utf-8' })).toString());
-    const credsStore = contents['credsStore'];
+    const credHelpers = contents.credHelpers;
+    const credsStore = contents.credsStore;
 
-    if (!credsStore) {
-      throw new Error(`No credsStore field in ${ dockerConfig }`);
+    if (credHelpers) {
+      let entry = '';
+
+      switch (command) {
+      case 'erase':
+      case 'get':
+        entry = credHelpers[payload.trim()];
+        break;
+      case 'store': {
+        const obj = JSON.parse(payload);
+
+        entry = obj.ServerURL ? credHelpers[obj.ServerURL] : '';
+      }
+      }
+      if (entry) {
+        return { credsStore: entry, credHelpers: { } };
+      }
     }
 
-    return credsStore;
+    return { credsStore, credHelpers };
   }
 
   closeServer() {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -135,6 +135,7 @@ export class HttpCredentialHelperServer {
     }
   }
 
+
   protected async runCommandProcessOutput(helperName: string,
     commandName: string,
     data: string,
@@ -201,11 +202,13 @@ export class HttpCredentialHelperServer {
   }
 
   /**
-   * For the LIST command, there are multiple possible sources of information that need to be merged into a simple
-   * { ServerURL: Username } hash.
+   * For the LIST command, there are multiple possible sources of information
+   * that need to be merged into a simple
+   *    { ServerURL: Username } hash.
    * The first source is the credsStore.
-   * Then if any helper credsStores are identified in the `credHelpers` section, get the full { ServerURL: Username }
-   * from each of them, and keep only those ServerURLs that point to that credsStore.
+   * Then if any helper credsStores are identified in the `credHelpers` section,
+   * get the full { ServerURL: Username } from each of them,
+   * and keep only those ServerURLs that point to that credsStore.
    */
   protected async doListCommand(
     thisHelperInfo: credHelperInfo,

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -182,7 +182,7 @@ export class HttpCredentialHelperServer {
 
     // The PATH needs to contain our resources directory (on macOS that would
     // not be in the application's PATH), as well as /usr/local/bin.
-    // NOTE: This needs to match DockerDirManager.
+    // NOTE: This needs to match DockerDirManager.spawnFileWithExtraPath
     pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
     if (platform === 'darwin') {
       pathVar += `${ path.delimiter }/usr/local/bin`;
@@ -209,6 +209,8 @@ export class HttpCredentialHelperServer {
    * Then if any helper credsStores are identified in the `credHelpers` section,
    * get the full { ServerURL: Username } from each of them,
    * and keep only those ServerURLs that point to that credsStore.
+   *
+   * Modeled after https://github.com/docker/cli/blob/d0bd373986b6678bfe1a0eb6989ce13907247a85/cli/config/configfile/file.go#L285
    */
   protected async doListCommand(
     thisHelperInfo: credHelperInfo,

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -241,3 +241,10 @@ export function ensureRegex(strOrRegex, exact = true) {
 export function nlToBr(value) {
   return escapeHtml(value || '').replace(/(\r\n|\r|\n)/g, '<br/>\n');
 }
+
+export function ensureEndsWithNewline(s, newlineNotNeededForEmptyString= true) {
+  if (!s && newlineNotNeededForEmptyString) {
+    return s;
+  }
+  return /\n$/.test(s) ? s : `${ s }\n`;
+}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -242,9 +242,10 @@ export function nlToBr(value) {
   return escapeHtml(value || '').replace(/(\r\n|\r|\n)/g, '<br/>\n');
 }
 
-export function ensureEndsWithNewline(s, newlineNotNeededForEmptyString= true) {
+export function ensureEndsWithNewline(s, newlineNotNeededForEmptyString = true) {
   if (!s && newlineNotNeededForEmptyString) {
     return s;
   }
+
   return /\n$/.test(s) ? s : `${ s }\n`;
 }


### PR DESCRIPTION
Fixes #2321

Done by processing the `credHelpers` field in .docker/config.json

Signed-off-by: Eric Promislow <epromislow@suse.com>