### PR TITLE
Rename Preferences window to Main

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -164,7 +164,7 @@ Electron.app.whenReady().then(async() => {
     });
 
     setupTray();
-    window.openPreferences();
+    window.openMain();
 
     dockerDirManager.ensureCredHelperConfigured();
 
@@ -317,7 +317,7 @@ Electron.app.on('second-instance', async() => {
   // Someone tried to run another instance of Rancher Desktop,
   // reveal and focus this window instead.
   await protocolRegistered;
-  window.openPreferences();
+  window.openMain();
 });
 
 interface K8sError {
@@ -368,7 +368,7 @@ Electron.app.on('activate', async() => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   await protocolRegistered;
-  window.openPreferences();
+  window.openMain();
 });
 
 Electron.ipcMain.on('settings-read', (event) => {
@@ -599,10 +599,10 @@ Electron.ipcMain.on('get-app-version', async(event) => {
 });
 
 Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBoxOptions, modal = false): Promise<Electron.MessageBoxReturnValue> => {
-  const preferences = window.getWindow('preferences');
+  const mainWindow = window.getWindow('main');
 
-  if (modal && preferences) {
-    return Electron.dialog.showMessageBox(preferences, options);
+  if (modal && mainWindow) {
+    return Electron.dialog.showMessageBox(mainWindow, options);
   }
 
   return Electron.dialog.showMessageBox(options);

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -12,7 +12,7 @@ import { KubeConfig } from '@kubernetes/client-node';
 import * as kubectl from '@/k8s-engine/kubectl';
 import kubeconfig from '@/config/kubeconfig.js';
 import { State } from '@/k8s-engine/k8s';
-import { openPreferences } from '@/window';
+import { openMain } from '@/window';
 import { openDashboard } from '@/window/dashboard';
 import mainEvents from '@/main/mainEvents';
 import { Settings, load } from '@/config/settings';
@@ -57,7 +57,7 @@ export class Tray {
       click() {
         const showPreferencesModal = process.env.RD_MODAL_PREFERENCES === '1';
 
-        openPreferences(showPreferencesModal);
+        openMain(showPreferencesModal);
       },
     },
     {

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -94,12 +94,12 @@ function createWindow(name: string, url: string, options: Electron.BrowserWindow
 }
 
 /**
- * Open the preferences window; if it is already open, focus it.
+ * Open the main window; if it is already open, focus it.
  */
-export function openPreferences(showPreferencesModal = false) {
+export function openMain(showPreferencesModal = false) {
   const webRoot = getWebRoot();
 
-  const window = createWindow('preferences', `${ webRoot }/index.html`, {
+  const window = createWindow('main', `${ webRoot }/index.html`, {
     width:          940,
     height:         600,
     webPreferences: {
@@ -219,7 +219,7 @@ export async function openKubernetesErrorMessageWindow(titlePart: string, mainMe
     title:  `Rancher Desktop - Kubernetes Error`,
     width:  800,
     height: 494,
-    parent: getWindow('preferences') ?? undefined,
+    parent: getWindow('main') ?? undefined,
     frame:  true,
   });
 
@@ -242,7 +242,7 @@ export async function openKubernetesErrorMessageWindow(titlePart: string, mainMe
  *   again.
  */
 export async function openSudoPrompt(explanations: Record<string, string[]>): Promise<boolean> {
-  const window = openDialog('SudoPrompt', { parent: getWindow('preferences') ?? undefined });
+  const window = openDialog('SudoPrompt', { parent: getWindow('main') ?? undefined });
 
   /**
    * The result of the dialog; this is true if the user asked to never be
@@ -270,7 +270,7 @@ export async function openPathUpdate(): Promise<void> {
     {
       title:  'Rancher Desktop - Update',
       frame:  true,
-      parent: getWindow('preferences') ?? undefined,
+      parent: getWindow('main') ?? undefined,
     });
 
   await (new Promise<void>((resolve) => {
@@ -283,7 +283,7 @@ export async function openLegacyIntegrations(): Promise<void> {
     'LegacyIntegrationNotification',
     {
       title:          'Rancher Desktop - Legacy Integrations',
-      parent:         getWindow('preferences') ?? undefined,
+      parent:         getWindow('main') ?? undefined,
     }
   );
 


### PR DESCRIPTION
This renames the `preferences` window to `main` in preparation for creating a dedicated electron window for managing preferences.

contributes to #2448

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>