### PR TITLE
Lima & WSL: Write out fallback version.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -453,6 +453,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }
 
       console.error(`Could not use saved version ${ version.raw }, not in ${ availableVersions }`);
+      this.writeSetting({ version: availableVersions[0].version });
 
       return availableVersions[0];
     })();

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -248,6 +248,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
 
       console.error(`Could not use saved version ${ version.raw }, not in ${ availableVersions }`);
+      this.writeSetting({ version: availableVersions[0].version });
 
       return availableVersions[0];
     })();


### PR DESCRIPTION
If we couldn't find the stored version (and fall back to the newest), write out the used version in the settings.  This ensures that our settings match the actually in-use version.

This is needed when we later compare the version to the current state.