### PR TITLE
PreferencesButton: Don't inline SVG.

### DIFF
--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -12,44 +12,30 @@ export default Vue.extend({
 
 <template>
   <button
-    class="btn role-primary btn-sm"
+    class="btn role-tertiary btn-sm"
     type="button"
     aria-label="Open Preferences"
     @click="openPreferences"
   >
-    <!--
-      TODO: #2415 Fix off-centered icons in linux.
-      NOTE: Custom svg is the gear icon from IcoMoon, which is used to generate
-      other icons throughout Rancher Desktop.
-    -->
-    <svg
-      class="icon"
-      viewBox="0 0 32 32"
-    >
-      <path
-        class="icon-gear"
-        d="M29.181 19.070c-1.679-2.908-0.669-6.634 2.255-8.328l-3.145-5.447c-0.898 0.527-1.943 0.829-3.058 0.829-3.361 0-6.085-2.742-6.085-6.125h-6.289c0.008 1.044-0.252 2.103-0.811 3.070-1.679 2.908-5.411 3.897-8.339 2.211l-3.144 5.447c0.905 0.515 1.689 1.268 2.246 2.234 1.676 2.903 0.672 6.623-2.241 8.319l3.145 5.447c0.895-0.522 1.935-0.82 3.044-0.82 3.35 0 6.067 2.725 6.084 6.092h6.289c-0.003-1.034 0.259-2.080 0.811-3.038 1.676-2.903 5.399-3.894 8.325-2.219l3.145-5.447c-0.899-0.515-1.678-1.266-2.232-2.226zM16 22.479c-3.578 0-6.479-2.901-6.479-6.479s2.901-6.479 6.479-6.479c3.578 0 6.479 2.901 6.479 6.479s-2.901 6.479-6.479 6.479z"
-      />
-    </svg>
+    <i class="icon icon-gear" />
   </button>
 </template>
 
 <style lang="scss" scoped>
   button.btn {
-    display: flex;
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    align-items:center;
-    justify-content:center;
-  }
-
-  .icon {
-    width: 1rem;
-    height: 1rem;
-  }
-
-  .icon-gear{
-    fill: var(--primary-text)
+    background: none;
+    border: none;
+    .icon {
+      background: var(--primary);
+      color: var(--primary-text);
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      padding-top: 5px;
+      &::before {
+        font-size: 22px;
+        margin-left: 1px;
+      }
+    }
   }
 </style>

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -12,7 +12,7 @@ export default Vue.extend({
 
 <template>
   <button
-    class="btn role-tertiary btn-sm"
+    class="btn role-secondary btn-sm"
     type="button"
     aria-label="Open Preferences"
     @click="openPreferences"
@@ -25,6 +25,7 @@ export default Vue.extend({
   button.btn {
     background: none;
     border: none;
+    box-shadow: none;
     .icon {
       background: var(--primary);
       color: var(--primary-text);
@@ -35,6 +36,11 @@ export default Vue.extend({
       &::before {
         font-size: 22px;
         margin-left: 1px;
+      }
+    }
+    &:focus {
+      .icon {
+        outline: var(--outline-width) dashed var(--primary-active-bg);
       }
     }
   }

--- a/src/components/__tests__/PreferencesButton.spec.ts
+++ b/src/components/__tests__/PreferencesButton.spec.ts
@@ -5,7 +5,7 @@ describe('Preferences/ButtonOpen.vue', () => {
   it(`renders a button`, () => {
     const wrapper = shallowMount(PreferencesButton, {});
 
-    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-primary', 'btn-sm']);
+    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-tertiary', 'btn-sm']);
   });
 
   it(`emits 'open-preferences' on click`, () => {

--- a/src/components/__tests__/PreferencesButton.spec.ts
+++ b/src/components/__tests__/PreferencesButton.spec.ts
@@ -5,7 +5,7 @@ describe('Preferences/ButtonOpen.vue', () => {
   it(`renders a button`, () => {
     const wrapper = shallowMount(PreferencesButton, {});
 
-    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-tertiary', 'btn-sm']);
+    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-secondary', 'btn-sm']);
   });
 
   it(`emits 'open-preferences' on click`, () => {


### PR DESCRIPTION
We have the gear icon available as an icon (from icomoon, same source); instead of inlining the SVG, just use it as an icon like we do elsewhere.

I marked the button as tertiary because it's not a key button on that window (even though the colours are for a primary button).