### PR TITLE
HTTP API: make it possible to get error dialogs.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -278,7 +278,7 @@ async function startBackend(cfg: settings.Settings) {
 /**
  * Start the backend.
  *
- * @note This may throw without handling the error.
+ * @note Callers are responsible for handling errors thrown from here.
  */
 async function startK8sManager() {
   const changedContainerEngine = currentContainerEngine !== cfg.kubernetes.containerEngine;
@@ -725,7 +725,7 @@ function newK8sManager() {
     if (state === K8s.State.STOPPING) {
       Steve.getInstance().stop();
     }
-    if (pendingRestartContext && !backendIsBusy()) {
+    if (pendingRestartContext !== undefined && !backendIsBusy()) {
       // If we restart immediately the QEMU process in the VM doesn't always respond to a shutdown messages
       setTimeout(doFullRestart, 2_000, pendingRestartContext);
       pendingRestartContext = undefined;

--- a/background.ts
+++ b/background.ts
@@ -15,6 +15,7 @@ import * as window from '@/window';
 import { RecursivePartial } from '@/utils/typeUtils';
 import { closeDashboard, openDashboard } from '@/window/dashboard';
 import * as K8s from '@/k8s-engine/k8s';
+import K8sFactory from '@/k8s-engine/factory';
 import Logging, { setLogLevel } from '@/utils/logging';
 import * as childProcess from '@/utils/childProcess';
 import Latch from '@/utils/latch';
@@ -705,7 +706,7 @@ function doFullRestart(context: CommandWorkerInterface.CommandContext) {
 
 function newK8sManager() {
   const arch = (Electron.app.runningUnderARM64Translation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';
-  const mgr = K8s.factory(arch, dockerDirManager);
+  const mgr = K8sFactory(arch, dockerDirManager);
 
   mgr.on('state-changed', (state: K8s.State) => {
     mainEvents.emit('k8s-check-state', mgr);

--- a/src/k8s-engine/factory.ts
+++ b/src/k8s-engine/factory.ts
@@ -1,0 +1,26 @@
+import os from 'os';
+
+import { Architecture, KubernetesBackend } from './k8s';
+import MockBackend from './mock';
+import LimaBackend from './lima';
+import WSLBackend from './wsl';
+import DockerDirManager from '@/utils/dockerDirManager';
+
+export default function factory(arch: Architecture, dockerDirManager: DockerDirManager): KubernetesBackend {
+  const platform = os.platform();
+
+  if (process.env.RD_MOCK_BACKEND === '1') {
+    return new MockBackend();
+  }
+
+  switch (platform) {
+  case 'linux':
+    return new LimaBackend(arch, dockerDirManager);
+  case 'darwin':
+    return new LimaBackend(arch, dockerDirManager);
+  case 'win32':
+    return new WSLBackend();
+  default:
+    throw new Error(`OS "${ platform }" is not supported.`);
+  }
+}

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -1,16 +1,11 @@
 import events from 'events';
-import os from 'os';
 
 import { EventEmitter } from 'stream';
 import semver from 'semver';
 
 import { ServiceEntry } from './client';
-import LimaBackend from './lima';
-import MockBackend from './mock';
-import WSLBackend from './wsl';
 
 import { Settings } from '@/config/settings';
-import DockerDirManager from '@/utils/dockerDirManager';
 import { RecursiveReadonly } from '@/utils/typeUtils';
 
 export { KubeClient as Client, ServiceEntry } from './client';
@@ -321,23 +316,4 @@ export interface KubernetesBackendPortForwarder {
    * @param port The internal port of the service to forward.
    */
   cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
-}
-
-export function factory(arch: Architecture, dockerDirManager: DockerDirManager): KubernetesBackend {
-  const platform = os.platform();
-
-  if (process.env.RD_MOCK_BACKEND === '1') {
-    return new MockBackend();
-  }
-
-  switch (platform) {
-  case 'linux':
-    return new LimaBackend(arch, dockerDirManager);
-  case 'darwin':
-    return new LimaBackend(arch, dockerDirManager);
-  case 'win32':
-    return new WSLBackend();
-  default:
-    throw new Error(`OS "${ platform }" is not supported.`);
-  }
 }

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -3,10 +3,13 @@ import http from 'http';
 import path from 'path';
 import { URL } from 'url';
 
+import type { Settings } from '@/config/settings';
+import mainEvents from '@/main/mainEvents';
+import * as serverHelper from '@/main/serverHelper';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
-import * as serverHelper from '@/main/serverHelper';
+import { RecursivePartial } from '@/utils/typeUtils';
 
 export type ServerState = {
   user: string;
@@ -15,20 +18,25 @@ export type ServerState = {
   pid: number;
 }
 
-type DispatchFunctionType = (request: http.IncomingMessage, response: http.ServerResponse) => Promise<void>;
+type DispatchFunctionType = (request: http.IncomingMessage, response: http.ServerResponse, context: commandContext) => Promise<void>;
 
 const console = Logging.server;
 const SERVER_PORT = 6107;
-const SERVER_USERNAME = 'user';
 const SERVER_FILE_BASENAME = 'rd-engine.json';
 const MAX_REQUEST_BODY_LENGTH = 2048;
 
 export class HttpCommandServer {
   protected server = http.createServer();
-  protected password = serverHelper.randomStr();
-  protected stateInfo: ServerState = {
-    user:     SERVER_USERNAME,
-    password: this.password,
+  protected readonly externalState: ServerState = {
+    user:     'user',
+    password: serverHelper.randomStr(),
+    port:     SERVER_PORT,
+    pid:      process.pid,
+  };
+
+  protected readonly interactiveState: ServerState = {
+    user:     'interactive-user',
+    password: serverHelper.randomStr(),
     port:     SERVER_PORT,
     pid:      process.pid,
   };
@@ -47,13 +55,16 @@ export class HttpCommandServer {
 
   constructor(commandWorker: CommandWorkerInterface) {
     this.commandWorker = commandWorker;
+    mainEvents.on('api-get-credentials', () => {
+      mainEvents.emit('api-credentials', this.interactiveState);
+    });
   }
 
   async init() {
     const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
 
     await fs.promises.writeFile(statePath,
-      jsonStringifyWithWhiteSpace(this.stateInfo),
+      jsonStringifyWithWhiteSpace(this.externalState),
       { mode: 0o600 });
     this.server.on('request', this.handleRequest.bind(this));
     this.server.on('error', (err) => {
@@ -63,13 +74,29 @@ export class HttpCommandServer {
     console.log('CLI server is now ready.');
   }
 
+  protected checkAuth(request: http.IncomingMessage): userType | false {
+    const authHeader = request.headers.authorization ?? '';
+
+    if (serverHelper.basicAuth(this.externalState.user, this.externalState.password, authHeader)) {
+      return 'api';
+    }
+    if (serverHelper.basicAuth(this.interactiveState.user, this.interactiveState.password, authHeader)) {
+      return 'interactive';
+    }
+
+    return false;
+  }
+
   protected async handleRequest(request: http.IncomingMessage, response: http.ServerResponse) {
     try {
-      if (!serverHelper.basicAuth(SERVER_USERNAME, this.password, request.headers.authorization ?? '')) {
+      const user = this.checkAuth(request);
+
+      if (!user) {
         response.writeHead(401, { 'Content-Type': 'text/plain' });
 
         return;
       }
+
       const method = request.method ?? 'GET';
       const url = new URL(request.url as string, `http://${ request.headers.host }`);
       const path = url.pathname;
@@ -89,7 +116,7 @@ export class HttpCommandServer {
 
         return;
       }
-      await command.call(this, request, response);
+      await command.call(this, request, response, { interactive: user === 'interactive' });
     } catch (err) {
       console.log(`Error handling ${ request.url }`, err);
       response.writeHead(500, { 'Content-Type': 'text/plain' });
@@ -110,8 +137,8 @@ export class HttpCommandServer {
     return undefined;
   }
 
-  protected listSettings(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
-    const settings = this.commandWorker.getSettings();
+  protected listSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
+    const settings = this.commandWorker.getSettings(context);
 
     if (settings) {
       console.debug('listSettings: succeeded 200');
@@ -182,7 +209,7 @@ export class HttpCommandServer {
    *
    * The incoming payload is expected to be a subset of the settings.Settings object
    */
-  async updateSettings(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+  async updateSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
     let values: Record<string, any> = {};
     let result = '';
     const [data, payloadError] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
@@ -203,7 +230,7 @@ export class HttpCommandServer {
       error = payloadError;
     }
     if (!error) {
-      [result, error] = await this.commandWorker.updateSettings(values);
+      [result, error] = await this.commandWorker.updateSettings(context, values);
     }
 
     if (error) {
@@ -217,13 +244,13 @@ export class HttpCommandServer {
     }
   }
 
-  wrapShutdown(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+  wrapShutdown(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
     console.debug('shutdown: succeeded 202');
     response.writeHead(202, { 'Content-Type': 'text/plain' });
     response.write('Shutting down.');
     setImmediate(() => {
       this.closeServer();
-      this.commandWorker.requestShutdown();
+      this.commandWorker.requestShutdown(context);
     });
 
     return Promise.resolve();
@@ -234,6 +261,11 @@ export class HttpCommandServer {
   }
 }
 
+type userType = 'api' | 'interactive';
+interface commandContext {
+  interactive: boolean;
+}
+
 /**
  * Description of the methods which the HttpCommandServer uses to interact with the backend.
  * There's no need to use events because the server and the core backend run in the same process.
@@ -241,7 +273,13 @@ export class HttpCommandServer {
  * in order to carry out the business logic for the requests it receives.
  */
 export interface CommandWorkerInterface {
-  getSettings: () => string;
-  updateSettings: (newSettings: Record<string, any>) => Promise<[string, string]>;
-  requestShutdown: () => void;
+  getSettings: (context: commandContext) => string;
+  updateSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
+  requestShutdown: (context: commandContext) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace -- exporting extra things on interfaces.
+export namespace CommandWorkerInterface {
+  export type CommandContext = commandContext;
+  export type UserType = userType;
 }

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -74,7 +74,7 @@ export class HttpCommandServer {
     console.log('CLI server is now ready.');
   }
 
-  protected checkAuth(request: http.IncomingMessage): userType | false {
+  protected checkAuth(request: http.IncomingMessage): UserType | false {
     const authHeader = request.headers.authorization ?? '';
 
     if (serverHelper.basicAuth(this.externalState.user, this.externalState.password, authHeader)) {
@@ -89,9 +89,9 @@ export class HttpCommandServer {
 
   protected async handleRequest(request: http.IncomingMessage, response: http.ServerResponse) {
     try {
-      const user = this.checkAuth(request);
+      const userType = this.checkAuth(request);
 
-      if (!user) {
+      if (!userType) {
         response.writeHead(401, { 'Content-Type': 'text/plain' });
 
         return;
@@ -116,7 +116,7 @@ export class HttpCommandServer {
 
         return;
       }
-      await command.call(this, request, response, { interactive: user === 'interactive' });
+      await command.call(this, request, response, { interactive: userType === 'interactive' });
     } catch (err) {
       console.log(`Error handling ${ request.url }`, err);
       response.writeHead(500, { 'Content-Type': 'text/plain' });
@@ -261,7 +261,7 @@ export class HttpCommandServer {
   }
 }
 
-type userType = 'api' | 'interactive';
+type UserType = 'api' | 'interactive';
 interface commandContext {
   interactive: boolean;
 }
@@ -278,8 +278,10 @@ export interface CommandWorkerInterface {
   requestShutdown: (context: commandContext) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace -- exporting extra things on interfaces.
+// Extend CommandWorkerInterface to have extra types, as these types are used by
+// things that would need to use the interface.  ESLint doesn't like using
+// namespaces; but in this case we're extending an existing interface.
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CommandWorkerInterface {
   export type CommandContext = commandContext;
-  export type UserType = userType;
 }

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -47,6 +47,19 @@ interface MainEventNames {
     * string if there is an error.
     */
    'integration-update'(state: Record<string, boolean|string>): void;
+
+   /**
+    * Emitted as a request to get the credentials for API access.
+    */
+   'api-get-credentials'(): void;
+   /**
+    * Emitted as a reply to 'api-get-credentials'; the credentials can be used
+    * via HTTP basic auth on localhost.
+    *
+    * @note These credentials are meant for the UI; using them may require user
+    * interaction.
+    */
+   'api-credentials'(credentials: {user: string, password: string, port: number}): void;
 }
 
 interface MainEvents extends EventEmitter {


### PR DESCRIPTION
We want to change the front end to also use the HTTP API for internal use.  However, this means that we need to be able to show the error dialogs in that case (when things are broken), but still suppress them when using `rdctl` / raw HTTP calls.

I've elected to do this by generating a second, internal credential pair; the front end can use this set of credentials instead of the ones we write to disk. (We don't need to write this to disk, as the front end can fetch it directly.)

I also had to move `K8s.factory()` to a new file as there's now an import loop somewhere; moving that to a new file (that only `background.ts` imports) means most users of `k8s.ts` (which only wanted it for the interface definitions) can pick up less code.

Fixes #2500.