### PR TITLE
Restore app menu items

### DIFF
--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -92,7 +92,7 @@ function getMacApplicationMenu(): Array<MenuItem> {
       submenu: [
         { role: 'about' },
         { type: 'separator' },
-        getPreferencesMenuItem(),
+        ...getPreferencesMenuItem(),
         { role: 'services' },
         { type: 'separator' },
         { role: 'hide' },
@@ -134,7 +134,7 @@ function getWindowsApplicationMenu(): Array<MenuItem> {
       label:   '&File',
       role:    'fileMenu',
       submenu: [
-        getPreferencesMenuItem(),
+        ...getPreferencesMenuItem(),
         {
           role:  'quit',
           label: 'E&xit'
@@ -167,14 +167,23 @@ function getWindowsApplicationMenu(): Array<MenuItem> {
  * Gets the preferences menu item for all supported platforms
  * @returns MenuItemConstructorOptions: The preferences menu item object
  */
-function getPreferencesMenuItem(): MenuItemConstructorOptions {
-  return {
-    label:               'Preferences',
-    visible:             process.env.RD_MODAL_PREFERENCES === '1',
-    registerAccelerator: process.env.RD_MODAL_PREFERENCES === '1',
-    accelerator:         'CmdOrCtrl+,',
-    click() {
-      send('preferences-open');
-    }
-  };
+function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
+  const preferencesEnabled = process.env.RD_MODAL_PREFERENCES === '1';
+
+  if (!preferencesEnabled) {
+    return [];
+  }
+
+  return [
+    {
+      label:               'Preferences',
+      visible:             true,
+      registerAccelerator: true,
+      accelerator:         'CmdOrCtrl+,',
+      click() {
+        send('preferences-open');
+      }
+    },
+    { type: 'separator' }
+  ];
 }

--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -89,9 +89,17 @@ function getMacApplicationMenu(): Array<MenuItem> {
   return [
     new MenuItem({
       label:   Electron.app.name,
-      role:    'appMenu',
       submenu: [
-        getPreferencesMenuItem()
+        { role: 'about' },
+        { type: 'separator' },
+        getPreferencesMenuItem(),
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
       ]
     }),
     new MenuItem({


### PR DESCRIPTION
This restores the app menu items by explicitly defining each submenu role. 

### Testing notes

Make sure to validate that the menu item renders as expected both with and without `RD_MODAL_PREFERENCES=1 npm run dev`

### Before

![image](https://user-images.githubusercontent.com/835961/177665356-c84dc254-0028-4218-bdd6-fee5b8ca19b2.png)

### After (`npm run dev`)

<img width="274" alt="Screen Shot 2022-07-06 at 5 20 53 PM" src="https://user-images.githubusercontent.com/835961/177665070-8f753f2f-8ec3-44b9-b7f0-dd1add8ab6f0.png">

### After (`RD_MODAL_PREFERENCES=1 npm run dev`)

<img width="271" alt="Screen Shot 2022-07-06 at 5 27 41 PM" src="https://user-images.githubusercontent.com/835961/177665089-d587817b-f3d5-48af-8bae-cc1eeb31a7da.png">

closes #2502 