### PR TITLE
HttpCommandServer: Add CORS support.

### DIFF
--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -87,8 +87,29 @@ export class HttpCommandServer {
     return false;
   }
 
+  /**
+   * Calculate the headers needed for CORS, and sets them on the response.
+   * @returns true if the request has been completely handled.
+   */
+  protected handleCORS(request: http.IncomingMessage, response: http.ServerResponse): boolean {
+    response.setHeader('Access-Control-Allow-Headers', 'Authorization');
+    response.setHeader('Access-Control-Allow-Methods', 'GET, PUT');
+    response.setHeader('Access-Control-Allow-Origin', '*');
+
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204);
+
+      return true;
+    }
+
+    return false;
+  }
+
   protected async handleRequest(request: http.IncomingMessage, response: http.ServerResponse) {
     try {
+      if (this.handleCORS(request, response)) {
+        return;
+      }
       const userType = this.checkAuth(request);
 
       if (!userType) {


### PR DESCRIPTION
This adds CORS support, including adding the extra headers as well as supporting HTTP OPTIONS requests.  Currently we just blindly allow everything.

Fixes #2509 