### PR TITLE
Move Reset Kubernetes button to Troubleshooting

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4574,7 +4574,7 @@ troubleshooting:
     title: Kubernetes
     resetKubernetes:
       title: Reset Kubernetes
-      description:  Resetting Kubernetes will delete all workloads and configuration.
+      description: Resetting Kubernetes will delete all workloads and configuration.
       buttonText: Reset Kubernetes
       messageBox:
         title: Rancher Desktop - Reset Kubernetes

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4574,8 +4574,14 @@ troubleshooting:
     title: Kubernetes
     resetKubernetes:
       title: Reset Kubernetes
-      description: Resetting Kubernetes will delete workloads and configuration.
+      description:  Resetting Kubernetes will delete all workloads and configuration.
       buttonText: Reset Kubernetes
+      messageBox:
+        title: Rancher Desktop - Reset Kubernetes
+        message: Reset Kubernetes?
+        checkboxLabel: Delete container images
+        ok: Reset
+        cancel: Cancel
     resetContainer:
       title: 'Reset Kubernetes & Container Images'
       description: All images will be lost and Kubernetes will be reset.

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -28,10 +28,10 @@
         <hr>
         <troubleshooting-line-item>
           <template #title>
-            Reset Kubernetes
+            {{ t('troubleshooting.kubernetes.resetKubernetes.title') }}
           </template>
           <template #description>
-            Resetting Kubernetes to default will delete all workloads and configurations.
+            {{ t('troubleshooting.kubernetes.resetKubernetes.description') }}
           </template>
           <button
             data-test="k8sResetBtn"
@@ -39,7 +39,7 @@
             class="btn btn-xs role-secondary"
             @click="resetKubernetes"
           >
-            Reset Kubernetes
+            {{ t('troubleshooting.kubernetes.resetKubernetes.buttonText') }}
           </button>
         </troubleshooting-line-item>
         <hr>
@@ -128,20 +128,23 @@ export default {
     },
     async resetKubernetes() {
       const cancelPosition = 1;
-      const consequence = 'Resetting Kubernetes will delete all workloads and configuration.';
-
-      const message = `${ consequence }\n\nDo you want to proceed?`;
+      const message = this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.message');
+      const detail = this.t('troubleshooting.kubernetes.resetKubernetes.description');
 
       const confirm = await ipcRenderer.invoke(
         'show-message-box',
         {
           message,
+          detail,
           type:            'question',
-          title:           'Rancher Desktop - Kubernetes Settings',
-          checkboxLabel:   'Delete container images',
+          title:           this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.title'),
+          checkboxLabel:   this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.checkboxLabel'),
           checkboxChecked: false,
-          buttons:         [this.t('k8s.dialog.ok'), this.t('k8s.dialog.cancel')],
-          cancelId:        cancelPosition
+          buttons:         [
+            this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.ok'),
+            this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.cancel')
+          ],
+          cancelId: cancelPosition
         },
         true
       );

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -28,6 +28,23 @@
         <hr>
         <troubleshooting-line-item>
           <template #title>
+            Reset Kubernetes
+          </template>
+          <template #description>
+            Resetting Kubernetes to default will delete all workloads and configurations.
+          </template>
+          <button
+            data-test="k8sResetBtn"
+            type="button"
+            class="btn btn-xs role-secondary"
+            @click="resetKubernetes"
+          >
+            Reset Kubernetes
+          </button>
+        </troubleshooting-line-item>
+        <hr>
+        <troubleshooting-line-item>
+          <template #title>
             {{ t('troubleshooting.general.factoryReset.title') }}
           </template>
           <template #description>
@@ -109,6 +126,34 @@ export default {
     updateDebug(value) {
       ipcRenderer.invoke('settings-write', { debug: value });
     },
+    async resetKubernetes() {
+      const cancelPosition = 1;
+      const consequence = 'Resetting Kubernetes will delete all workloads and configuration.';
+
+      const message = `${ consequence }\n\nDo you want to proceed?`;
+
+      const confirm = await ipcRenderer.invoke(
+        'show-message-box',
+        {
+          message,
+          type:            'question',
+          title:           'Rancher Desktop - Kubernetes Settings',
+          checkboxLabel:   'Delete container images',
+          checkboxChecked: false,
+          buttons:         [this.t('k8s.dialog.ok'), this.t('k8s.dialog.cancel')],
+          cancelId:        cancelPosition
+        },
+        true
+      );
+
+      const { response, checkboxChecked } = confirm;
+
+      if (response === cancelPosition) {
+        return;
+      }
+
+      ipcRenderer.send('k8s-reset', checkboxChecked ? 'wipe' : 'fast');
+    }
   },
 };
 </script>


### PR DESCRIPTION
This moves the Reset Kubernetes button over to the Troubleshooting page in preparation for the new preferences. 

Duplicated buttons will be removed in #2524

closes #2553