### PR TITLE
Groundwork for allowing user to specify forwarding port

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -541,7 +541,7 @@ Electron.ipcMain.handle('service-fetch', (_, namespace) => {
 
 Electron.ipcMain.handle('service-forward', async(_, service, state) => {
   if (state) {
-    await k8smanager.forwardPort(service.namespace, service.name, service.port);
+    await k8smanager.forwardPort(service.namespace, service.name, service.port, 0);
   } else {
     await k8smanager.cancelForward(service.namespace, service.name, service.port);
   }

--- a/background.ts
+++ b/background.ts
@@ -535,19 +535,15 @@ Electron.ipcMain.on('k8s-progress', () => {
   window.send('k8s-progress', k8smanager.progress);
 });
 
-Electron.ipcMain.handle('service-fetch', (event, namespace) => {
+Electron.ipcMain.handle('service-fetch', (_, namespace) => {
   return k8smanager.listServices(namespace);
 });
 
-Electron.ipcMain.handle('service-forward', async(event, service, state) => {
-  const forwarder = k8smanager?.portForwarder;
-
-  if (forwarder) {
-    if (state) {
-      await forwarder.forwardPort(service.namespace, service.name, service.port);
-    } else {
-      await forwarder.cancelForward(service.namespace, service.name, service.port);
-    }
+Electron.ipcMain.handle('service-forward', async(_, service, state) => {
+  if (state) {
+    await k8smanager.forwardPort(service.namespace, service.name, service.port);
+  } else {
+    await k8smanager.cancelForward(service.namespace, service.name, service.port);
   }
 });
 

--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -41,7 +41,6 @@
 
 <script>
 import { ipcRenderer } from 'electron';
-import $ from 'jquery';
 import SortableTable from '@/components/SortableTable';
 import Checkbox from '@/components/form/Checkbox';
 const K8s = require('../k8s-engine/k8s');

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -544,9 +544,8 @@ export class KubeClient extends events.EventEmitter {
    * @param namespace The namespace to forward to.
    * @param endpoint The endpoint in the namespace to forward to.
    * @param k8sPort The port to forward to on the endpoint.
-   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    */
-  async cancelForwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort: number) {
+  async cancelForwardPort(namespace: string, endpoint: string, k8sPort: number | string) {
     const targetName = this.targetName(namespace, endpoint, k8sPort);
     const server = this.servers.get(namespace, endpoint, k8sPort);
 

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -395,9 +395,44 @@ export class KubeClient extends events.EventEmitter {
     (namespace: string, endpoint: string, port: number | string) => `${ namespace }/${ endpoint }:${ port }`;
 
   /**
-   * Create a port forwarding, listening on localhost.  Note that if the
-   * endpoint isn't ready yet, the port forwarding might not work correctly
-   * until it does.
+   * Given a Pod object, returns its namespace, its name and the port number matching
+   * the passed port name/number.
+   * @param pod The pod to extract the info from.
+   * @param k8sPort The port name or number to get the port number from.
+   * @returns An array containing the pod namespace, the pod name and the port number.
+   */
+  protected getPodDetails(pod: k8s.V1Pod, k8sPort: number | string): [string, string, number] {
+    if (!pod.metadata) {
+      throw new Error('Pod has no metadata');
+    }
+    if (!pod.metadata.name) {
+      throw new Error('Pod has no name');
+    }
+    const podNamespace = pod.metadata.namespace ?? 'default';
+    const podName = pod.metadata.name;
+
+    let portNumber: number;
+
+    if (typeof k8sPort === 'number') {
+      portNumber = k8sPort;
+    } else {
+      if (!pod.spec) {
+        throw new Error(`Pod "${ podName } does not have a spec property`);
+      }
+      const podPorts = pod.spec.containers.flatMap(container => container.ports);
+      const podPort = podPorts.find(port => port?.name === k8sPort);
+      if (!podPort) {
+        throw new Error(`Could not find port number for pod "${ podName }`);
+      }
+      portNumber = podPort.containerPort;
+    }
+
+    return [ podNamespace, podName, portNumber ];
+  }
+
+  /**
+   * Forward a port to a kubernetes service. The port forwarding will not work
+   * until the endpoint is ready.
    * @param namespace The namespace to forward to.
    * @param endpoint The endpoint in the namespace to forward to.
    * @param k8sPort The port to forward to on the endpoint.
@@ -425,48 +460,32 @@ export class KubeClient extends events.EventEmitter {
         const code = isError<ErrorWithStringCode>(error, 'code') ? error.code : 'MISSING';
         const innerError = isError<ErrorWithNestedError>(error, 'error') ? error.error : error;
 
-        if (!['ECONNRESET', 'EPIPE'].includes(code)) {
-          console.log(`Error creating proxy: ${ innerError }`);
-        }
+        console.error(`Error creating proxy for ${ targetName }: code "${ code }" error "${ innerError }"`);
       });
 
-      // Find a working pod
+      // get the details of the pod we are forwarding to
       const endpoints = await this.getEndpointSubsets(namespace, endpoint) ?? [];
+      console.debug(`Got endpoints subsets: ${ JSON.stringify(endpoints) }`);
       const pod = await this.getActivePodFromEndpointSubsets(endpoints);
+      console.debug(`Got active pod: ${ JSON.stringify(pod) }`);
 
       if (!pod) {
-        socket.destroy(new Error(`Port forwarding to ${ targetName } failed; no active pod found`));
-
-        return;
+        throw new Error(`No active pod found`);
       }
+
+      const [podNamespace, podName, portNumber] = this.getPodDetails(pod, k8sPort);
+      console.debug(`Got podNamespace = "${podNamespace}"`);
+      console.debug(`Got podName = "${podName}"`);
+      console.debug(`Got portNumber = "${portNumber}"`);
+
+      // check if server is still valid
       if (!this.servers.has(namespace, endpoint, k8sPort)) {
-        socket.destroy(new Error(`Port forwarding to ${ targetName } was cancelled`));
+        new Error('Server is no longer valid');
+      }
 
-        return;
-      }
-      if (!pod.metadata) {
-        throw new Error(`Active ${ targetName } pod has no metadata`);
-      }
-      if (!pod.metadata.name) {
-        throw new Error(`Active ${ targetName } pod has no name`);
-      }
-      const { metadata:{ namespace: podNamespace, name: podName } } = pod;
-
+      // forward the port
       const stdin = new ErrorSuppressingStdin(socket);
-      let portNumber: number;
-
-      if (typeof k8sPort === 'number') {
-        portNumber = k8sPort;
-      } else {
-        const ports = endpoints.flatMap(endpoint => endpoint.ports).filter(defined);
-
-        portNumber = ports.find(p => p.name === k8sPort)?.port ?? 0;
-        if (portNumber === 0) {
-          throw new Error(`Could not find port number for ${ targetName }`);
-        }
-      }
-
-      this.forwarder.portForward(podNamespace || 'default', podName, [portNumber], socket, null, stdin)
+      this.forwarder.portForward(podNamespace, podName, [portNumber], socket, null, stdin)
         .catch((e) => {
           console.log(`Failed to create web socket for forwarding to ${ targetName }: ${ e?.error || e }`);
           socket.destroy(e);
@@ -495,7 +514,7 @@ export class KubeClient extends events.EventEmitter {
       });
       server.once('listening', resolveOnce);
       server.once('error', rejectOnce);
-      server.listen({ port: hostPort ?? 0, host: 'localhost' });
+      server.listen({ port: hostPort, host: 'localhost' });
     });
     if (this.servers.get(namespace, endpoint, k8sPort) !== server) {
       // The port forwarding has been cancelled, or we've set up a new one.

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -584,19 +584,6 @@ export class KubeClient extends events.EventEmitter {
   }
 
   /**
-   * Get the port for a given forwarding.
-   * @param namespace The namespace to forward to.
-   * @param endpoint The endpoint in the namespace to forward to.
-   * @param port The port to forward to on the endpoint.
-   * @returns The local forwarded port.
-   */
-  getForwardedPort(namespace: string, endpoint: string, port: number): number | null {
-    const address = this.servers.get(namespace, endpoint, port)?.address();
-
-    return address ? (address as net.AddressInfo).port : null;
-  }
-
-  /**
    * Get the cached list of services.
    * @param namespace The namespace to limit fetches to.
    * @returns The services currently in the system.

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -506,15 +506,16 @@ export class KubeClient extends events.EventEmitter {
    * Create a port forward for an endpoint, listening on localhost.
    * @param namespace The namespace containing the end points to forward to.
    * @param endpoint The endpoint to forward to.
-   * @param port The port to forward.
+   * @param k8sPort The port to forward.
+   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
    * @return The port number for the port forward.
    */
-  async forwardPort(namespace: string, endpoint: string, port: number | string): Promise<number | undefined> {
-    const targetName = this.targetName(namespace, endpoint, port);
+  async forwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+    const targetName = this.targetName(namespace, endpoint, k8sPort);
 
-    await this.createForwardingServer(namespace, endpoint, port);
+    await this.createForwardingServer(namespace, endpoint, k8sPort);
 
-    const server = this.servers.get(namespace, endpoint, port);
+    const server = this.servers.get(namespace, endpoint, k8sPort);
 
     if (!server) {
       // Port forwarding was cancelled while we were waiting.
@@ -539,13 +540,14 @@ export class KubeClient extends events.EventEmitter {
    * Ensure that a given port forwarding does not exist; if it did, close it.
    * @param namespace The namespace to forward to.
    * @param endpoint The endpoint in the namespace to forward to.
-   * @param port The port to forward to on the endpoint.
+   * @param k8sPort The port to forward to on the endpoint.
+   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
    */
-  async cancelForwardPort(namespace: string, endpoint: string, port: number | string) {
-    const targetName = this.targetName(namespace, endpoint, port);
-    const server = this.servers.get(namespace, endpoint, port);
+  async cancelForwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort?: number) {
+    const targetName = this.targetName(namespace, endpoint, k8sPort);
+    const server = this.servers.get(namespace, endpoint, k8sPort);
 
-    this.servers.delete(namespace, endpoint, port);
+    this.servers.delete(namespace, endpoint, k8sPort);
     if (server) {
       await new Promise((resolve) => {
         server.close(resolve);

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -401,9 +401,9 @@ export class KubeClient extends events.EventEmitter {
    * @param namespace The namespace to forward to.
    * @param endpoint The endpoint in the namespace to forward to.
    * @param k8sPort The port to forward to on the endpoint.
-   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
+   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    */
-  protected async createForwardingServer(namespace: string, endpoint: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+  protected async createForwardingServer(namespace: string, endpoint: string, k8sPort: number | string, hostPort: number): Promise<void> {
     const targetName = this.targetName(namespace, endpoint, k8sPort);
 
     if (this.servers.get(namespace, endpoint, k8sPort)) {
@@ -510,10 +510,10 @@ export class KubeClient extends events.EventEmitter {
    * @param namespace The namespace containing the end points to forward to.
    * @param endpoint The endpoint to forward to.
    * @param k8sPort The port to forward.
-   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
+   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    * @return The port number for the port forward.
    */
-  async forwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+  async forwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {
     const targetName = this.targetName(namespace, endpoint, k8sPort);
 
     await this.createForwardingServer(namespace, endpoint, k8sPort, hostPort);
@@ -544,9 +544,9 @@ export class KubeClient extends events.EventEmitter {
    * @param namespace The namespace to forward to.
    * @param endpoint The endpoint in the namespace to forward to.
    * @param k8sPort The port to forward to on the endpoint.
-   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
+   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    */
-  async cancelForwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort?: number) {
+  async cancelForwardPort(namespace: string, endpoint: string, k8sPort: number | string, hostPort: number) {
     const targetName = this.targetName(namespace, endpoint, k8sPort);
     const server = this.servers.get(namespace, endpoint, k8sPort);
 

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -174,7 +174,7 @@ export type ServiceEntry = {
   /** The internal port number (or name) of the service. */
   port?: number | string;
   /** The forwarded port on localhost (on the host), if any. */
-  listenPort?:number;
+  listenPort?: number;
 }
 
 /**

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -421,13 +421,14 @@ export class KubeClient extends events.EventEmitter {
       }
       const podPorts = pod.spec.containers.flatMap(container => container.ports);
       const podPort = podPorts.find(port => port?.name === k8sPort);
+
       if (!podPort) {
         throw new Error(`Could not find port number for pod "${ podName }`);
       }
       portNumber = podPort.containerPort;
     }
 
-    return [ podNamespace, podName, portNumber ];
+    return [podNamespace, podName, portNumber];
   }
 
   /**
@@ -462,8 +463,10 @@ export class KubeClient extends events.EventEmitter {
 
       // get the details of the pod we are forwarding to
       const endpoints = await this.getEndpointSubsets(namespace, endpoint) ?? [];
+
       console.debug(`Got endpoints subsets: ${ JSON.stringify(endpoints) }`);
       const pod = await this.getActivePodFromEndpointSubsets(endpoints);
+
       console.debug(`Got active pod: ${ JSON.stringify(pod) }`);
 
       if (!pod) {
@@ -471,9 +474,10 @@ export class KubeClient extends events.EventEmitter {
       }
 
       const [podNamespace, podName, portNumber] = this.getPodDetails(pod, k8sPort);
-      console.debug(`Got podNamespace = "${podNamespace}"`);
-      console.debug(`Got podName = "${podName}"`);
-      console.debug(`Got portNumber = "${portNumber}"`);
+
+      console.debug(`Got podNamespace = "${ podNamespace }"`);
+      console.debug(`Got podName = "${ podName }"`);
+      console.debug(`Got portNumber = "${ portNumber }"`);
 
       // check if server is still valid
       if (!this.servers.has(namespace, endpoint, k8sPort)) {
@@ -482,6 +486,7 @@ export class KubeClient extends events.EventEmitter {
 
       // forward the port
       const stdin = new ErrorSuppressingStdin(socket);
+
       this.forwarder.portForward(podNamespace, podName, [portNumber], socket, null, stdin)
         .catch((e) => {
           console.log(`Failed to create web socket for forwarding to ${ targetName }: ${ e?.error || e }`);
@@ -530,7 +535,6 @@ export class KubeClient extends events.EventEmitter {
 
     if (server) {
       console.log(`Found existing server for ${ targetName }.`);
-
     } else {
       // create server
       console.log(`Setting up new port forwarding to ${ targetName }...`);
@@ -551,6 +555,7 @@ export class KubeClient extends events.EventEmitter {
     }
 
     const address = server.address() as net.AddressInfo;
+
     return address.port;
   }
 

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -24,6 +24,7 @@ import * as K8s from '@/k8s-engine/k8s';
 // const k8s = require('@kubernetes/client-node');
 import { findHomeDir } from '@/config/findHomeDir';
 import { isUnixError } from '@/typings/unix.interface';
+import { KubeClient } from '@/k8s-engine/client';
 
 const console = Logging.k8s;
 
@@ -802,7 +803,7 @@ export default class K3sHelper extends events.EventEmitter {
    * Manually uninstall the K3s-installed copy of Traefik, if it exists.
    * This exists to work around https://github.com/k3s-io/k3s/issues/5103
    */
-  async uninstallTraefik(client: K8s.Client) {
+  async uninstallTraefik(client: KubeClient) {
     try {
       const customApi = client.k8sClient.makeApiClient(CustomObjectsApi);
       const { body: response } = await customApi.listNamespacedCustomObject('helm.cattle.io', 'v1', 'kube-system', 'helmcharts');

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -224,12 +224,6 @@ export interface KubernetesBackend extends events.EventEmitter, KubernetesBacken
   isServiceReady(namespace: string, service: string): Promise<boolean>;
 
   /**
-   * Helper to handle port forwarding for this backend.  This may be null, in
-   * which case port forwarding isn't supported.
-   */
-  readonly portForwarder: KubernetesBackendPortForwarder | null;
-
-  /**
    * If called after a backend operation fails, this returns a block of data that attempts
    * to give more information about what command was being run when the error happened.
    *
@@ -304,16 +298,18 @@ export interface KubernetesBackendPortForwarder {
    * Forward a single service port, returning the resulting local port number.
    * @param namespace The namespace containing the service to forward.
    * @param service The name of the service to forward.
-   * @param port The internal port of the service to forward.
+   * @param k8sPort The internal port of the service to forward.
+   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
    * @returns The port listening on localhost that forwards to the service.
    */
-  forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined>;
+  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined>;
 
   /**
    * Cancel an existing port forwarding.
    * @param namespace The namespace containing the service to forward.
    * @param service The name of the service to forward.
-   * @param port The internal port of the service to forward.
+   * @param k8sPort The internal port of the service to forward.
+   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
    */
-  cancelForward(namespace: string, service: string, port: number | string): Promise<void>;
+  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void>;
 }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -311,5 +311,5 @@ export interface KubernetesBackendPortForwarder {
    * @param k8sPort The internal port of the service to forward.
    * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    */
-  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void>;
+  cancelForward(namespace: string, service: string, k8sPort: number | string): Promise<void>;
 }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -299,17 +299,17 @@ export interface KubernetesBackendPortForwarder {
    * @param namespace The namespace containing the service to forward.
    * @param service The name of the service to forward.
    * @param k8sPort The internal port of the service to forward.
-   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
+   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    * @returns The port listening on localhost that forwards to the service.
    */
-  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined>;
+  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined>;
 
   /**
    * Cancel an existing port forwarding.
    * @param namespace The namespace containing the service to forward.
    * @param service The name of the service to forward.
    * @param k8sPort The internal port of the service to forward.
-   * @param hostPort The host port to listen on for the forwarded port. Leave it undefined to choose a random port.
+   * @param hostPort The host port to listen on for the forwarded port. Pass 0 for a random port.
    */
-  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void>;
+  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void>;
 }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -128,7 +128,7 @@ export type RestartReason = {
   visible: boolean;
 };
 
-export interface KubernetesBackend extends events.EventEmitter {
+export interface KubernetesBackend extends events.EventEmitter, KubernetesBackendPortForwarder {
   /** The name of the Kubernetes backend */
   readonly backend: 'wsl' | 'lima' | 'mock';
 

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -8,7 +8,7 @@ import { ServiceEntry } from './client';
 import { Settings } from '@/config/settings';
 import { RecursiveReadonly } from '@/utils/typeUtils';
 
-export { KubeClient as Client, ServiceEntry } from './client';
+export { ServiceEntry } from './client';
 
 export enum State {
   STOPPED = 0, // The engine is not running.

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2013,11 +2013,11 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     return (await this.client?.isServiceReady(namespace, service)) || false;
   }
 
-  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
     await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
   }
 

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2013,10 +2013,6 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     return (await this.client?.isServiceReady(namespace, service)) || false;
   }
 
-  get portForwarder() {
-    return this;
-  }
-
   async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, port);
   }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2017,8 +2017,8 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
-    await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
+  async cancelForward(namespace: string, service: string, k8sPort: number | string): Promise<void> {
+    await this.client?.cancelForwardPort(namespace, service, k8sPort);
   }
 
   async getFailureDetails(exception: any): Promise<K8s.FailureDetails> {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2013,12 +2013,12 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     return (await this.client?.isServiceReady(namespace, service)) || false;
   }
 
-  async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
-    return await this.client?.forwardPort(namespace, service, port);
+  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+    return this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, port: number | string): Promise<void> {
-    await this.client?.cancelForwardPort(namespace, service, port);
+  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+    await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
   }
 
   async getFailureDetails(exception: any): Promise<K8s.FailureDetails> {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2014,7 +2014,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
   }
 
   async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
-    return this.client?.forwardPort(namespace, service, k8sPort, hostPort);
+    return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
   async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -279,7 +279,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /** Helper object to manage available K3s versions. */
   protected readonly k3sHelper: K3sHelper;
 
-  protected client: K8s.Client | null = null;
+  protected client: KubeClient | null = null;
 
   /** Helper object to manage progress notifications. */
   protected progressTracker;
@@ -1666,7 +1666,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
                 return k3sConfigString;
               }));
 
-          this.client = new K8s.Client();
+          this.client = new KubeClient();
 
           this.lastCommandComment = 'Waiting for services';
           await this.progressTracker.action(
@@ -1747,7 +1747,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         //   - do nothing, and set config.kubernetes.checkForExistingKimBuilder to false (forever)
 
         if (config.checkForExistingKimBuilder && config.enabled) {
-          this.client ??= new K8s.Client();
+          this.client ??= new KubeClient();
           await getImageProcessor(config.containerEngine, this).removeKimBuilder(this.client.k8sClient);
           // No need to remove kim builder components ever again.
           this.writeSetting({ checkForExistingKimBuilder: false });

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -115,7 +115,7 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
     return Promise.resolve(12345);
   }
 
-  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
+  cancelForward(namespace: string, service: string, k8sPort: number | string): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -110,4 +110,12 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
       gamma: 'some error',
     });
   }
+
+  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+    return Promise.resolve(12345);
+  }
+
+  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -111,11 +111,11 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
     });
   }
 
-  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+  forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {
     return Promise.resolve(12345);
   }
 
-  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+  cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
     return Promise.resolve();
   }
 }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1564,11 +1564,11 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
   }
 
-  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
     await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
   }
 

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1564,12 +1564,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
   }
 
-  async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
-    return await this.client?.forwardPort(namespace, service, port);
+  async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
+    return this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, port: number | string): Promise<void> {
-    await this.client?.cancelForwardPort(namespace, service, port);
+  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {
+    await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
   }
 
   /**

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1568,8 +1568,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
-  async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<void> {
-    await this.client?.cancelForwardPort(namespace, service, k8sPort, hostPort);
+  async cancelForward(namespace: string, service: string, k8sPort: number | string): Promise<void> {
+    await this.client?.cancelForwardPort(namespace, service, k8sPort);
   }
 
   /**

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1563,10 +1563,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     });
   }
 
-  get portForwarder() {
-    return this;
-  }
-
   async forwardPort(namespace: string, service: string, port: number | string): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, port);
   }

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -45,6 +45,7 @@ import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 import { getImageProcessor } from '@/k8s-engine/images/imageFactory';
 import { getServerCredentialsPath, ServerState } from '@/main/credentialServer/httpCredentialHelperServer';
 import { getVtunnelConfigPath } from '@/main/networking/vtunnel';
+import { KubeClient } from '@/k8s-engine/client';
 
 const console = Logging.wsl;
 const INSTANCE_NAME = 'rancher-desktop';
@@ -143,7 +144,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    */
   protected resolverHostProcess: BackgroundProcess;
 
-  protected client: K8s.Client | null = null;
+  protected client: KubeClient | null = null;
 
   /** Interval handle to update the progress. */
   // The return type is odd because TypeScript is pulling in some of the DOM
@@ -1279,7 +1280,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             await this.execCommand('busybox', 'rm', '-f', '/etc/cni/net.d/10-flannel.conflist');
           }
 
-          const client = this.client = new K8s.Client();
+          const client = this.client = new KubeClient();
 
           this.lastCommandComment = 'Waiting for services';
           await this.progressTracker.action(

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -1565,7 +1565,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<number | undefined> {
-    return this.client?.forwardPort(namespace, service, k8sPort, hostPort);
+    return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }
 
   async cancelForward(namespace: string, service: string, k8sPort: number | string, hostPort?: number): Promise<void> {


### PR DESCRIPTION
Closes #2349.

Also lays the groundwork for #791. I'm submitting this as a PR now so that it is easier to review. It shouldn't change any of the behaviour of RD, except for fixing the problem described in #2349. Things done in this PR:
- added `hostPort` field to relevant methods to let the user specify the port that the forwarding server listens on
- refactor of `KubeClient.forwardPort` and associated functions
- fixed the issue described in #2349

Things I am aware of, but plan to do in the next PR:
- handling the case where `hostPort` is not a valid port number
- handling the case where `hostPort` is already in use
- UI changes