### PR TITLE
Detach preferences from main window

### DIFF
--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -113,12 +113,12 @@ export function openMain(showPreferencesModal = false) {
   app.dock?.show();
 
   if (showPreferencesModal) {
-    openPreferences(window);
+    openPreferences();
   }
 
   window.webContents.on('ipc-message', (_event, channel) => {
     if (channel === 'app-ready' && showPreferencesModal) {
-      openPreferences(window);
+      openPreferences();
     }
   });
 }

--- a/src/window/preferences.ts
+++ b/src/window/preferences.ts
@@ -6,16 +6,14 @@ let isDirty = false;
 /**
  * Open the main window; if it is already open, focus it.
  */
-export function openPreferences(parent: Electron.BrowserWindow) {
+export function openPreferences() {
   const webRoot = getWebRoot();
 
   const window = createWindow('preferences', `${ webRoot }/index.html#preferences`, {
-    parent,
     title:           'Rancher Desktop - Preferences',
     width:           768,
     height:          512,
     autoHideMenuBar: true,
-    modal:           true,
     resizable:       false,
     minimizable:     false,
     show:            false,


### PR DESCRIPTION
We came to the conclusion that preferences does not need to be modal or attached to the parent window during a design review.

closes #2524 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>