### PR TITLE
E2E: when archiving logs, follow symlinks.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -74,7 +74,7 @@ export async function packageLogs(testPath: string) {
   const outputPath = path.join(__dirname, '..', 'reports', `${ path.basename(testPath) }-logs.tar`);
 
   console.log(`Packaging logs to ${ outputPath }...`);
-  await childProcess.spawnFile('tar', ['cf', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
+  await childProcess.spawnFile('tar', ['cfh', outputPath, '.'], { cwd: logDir, stdio: 'inherit' });
 }
 
 /**


### PR DESCRIPTION
This is necessary for the log files from CI to be useful.