### PR TITLE
Render a message if preferences can't load

### DIFF
--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -1,0 +1,51 @@
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({ name: 'empty-state' });
+</script>
+
+<template>
+  <div class="empty-state">
+    <div class="empty-state-icon">
+      <slot name="icon">
+        <span class="icon icon-alert"></span>
+      </slot>
+    </div>
+    <div class="empty-state-heading">
+      <slot name="heading">
+        NOT FAIL
+      </slot>
+    </div>
+    <div class="empty-state-body">
+      <slot name="body">
+        This is some body text that we want to relay to the end user
+      </slot>
+    </div>
+    <slot name="primary-button"></slot>
+    <slot name="secondary-button"></slot>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .empty-state-icon {
+    font-size: 8rem;
+    line-height: 1;
+  }
+
+  .empty-state-heading {
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+  }
+
+  .empty-state-body {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+</style>

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -20,8 +20,6 @@ export default Vue.extend({ name: 'empty-state' });
         This is some body text that we want to relay to the end user
       </slot>
     </div>
-    <slot name="primary-button"></slot>
-    <slot name="secondary-button"></slot>
   </div>
 </template>
 
@@ -31,7 +29,6 @@ export default Vue.extend({ name: 'empty-state' });
     flex-direction: column;
     gap: 0.75rem;
     align-items: center;
-    justify-content: center;
   }
 
   .empty-state-icon {

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -15,7 +15,12 @@ export default Vue.extend({
       type:    String,
       default: 'This is an example of an empty state.'
     }
-  }
+  },
+  computed: {
+    hasPrimaryActionSlot(): boolean {
+      return !!this.$slots['primary-action'];
+    }
+  },
 });
 </script>
 
@@ -35,6 +40,9 @@ export default Vue.extend({
       <slot name="body">
         {{ body }}
       </slot>
+    </div>
+    <div v-if="hasPrimaryActionSlot" class="empty-state-primary-action">
+      <slot name="primary-action"></slot>
     </div>
   </div>
 </template>
@@ -60,5 +68,9 @@ export default Vue.extend({
   .empty-state-body {
     font-size: 1rem;
     line-height: 1.5rem;
+  }
+
+  .empty-state-primary-action {
+    padding-top: 1.5rem;
   }
 </style>

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -1,23 +1,39 @@
 <script lang="ts">
 import Vue from 'vue';
-export default Vue.extend({ name: 'empty-state' });
+export default Vue.extend({
+  name:  'empty-state',
+  props: {
+    icon: {
+      type:    String,
+      default: 'icon-alert'
+    },
+    heading: {
+      type:    String,
+      default: 'Empty state'
+    },
+    body: {
+      type:    String,
+      default: 'This is an example of an empty state.'
+    }
+  }
+});
 </script>
 
 <template>
   <div class="empty-state">
     <div class="empty-state-icon">
       <slot name="icon">
-        <span class="icon icon-alert"></span>
+        <span class="icon" :class="icon"></span>
       </slot>
     </div>
     <div class="empty-state-heading">
       <slot name="heading">
-        NOT FAIL
+        {{ heading }}
       </slot>
     </div>
     <div class="empty-state-body">
       <slot name="body">
-        This is some body text that we want to relay to the end user
+        {{ body }}
       </slot>
     </div>
   </div>

--- a/src/components/Preferences/ModalBody.vue
+++ b/src/components/Preferences/ModalBody.vue
@@ -39,10 +39,12 @@ export default Vue.extend({
 
 <template>
   <div>
-    <component
-      :is="componentFromNavItem"
-      :preferences="preferences"
-      v-on="$listeners"
-    />
+    <slot>
+      <component
+        :is="componentFromNavItem"
+        :preferences="preferences"
+        v-on="$listeners"
+      />
+    </slot>
   </div>
 </template>

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -38,7 +38,7 @@ export default Vue.extend({
 
     ipcRenderer.send('api-get-credentials');
   },
-  computed: { ...mapGetters('preferences', ['getPreferences', 'isPreferencesDirty']) },
+  computed: { ...mapGetters('preferences', ['getPreferences', 'isPreferencesDirty', 'hasError']) },
   methods:  {
     navChanged(tabName: string) {
       this.currentNavItem = tabName;
@@ -80,7 +80,7 @@ export default Vue.extend({
       :preferences="getPreferences"
       v-on="$listeners"
     >
-      <div class="preferences-error">
+      <div v-if="hasError" class="preferences-error">
         <empty-state />
       </div>
     </preferences-body>

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -58,6 +58,9 @@ export default Vue.extend({
         'preferences/fetchPreferences',
         this.credentials
       );
+    },
+    reloadPreferences() {
+      ipcRenderer.send('preferences-reload');
     }
   }
 });
@@ -69,6 +72,7 @@ export default Vue.extend({
       class="preferences-header"
     />
     <preferences-nav
+      v-if="!hasError"
       class="preferences-nav"
       :current-nav-item="currentNavItem"
       :nav-items="navItems"
@@ -81,7 +85,17 @@ export default Vue.extend({
       v-on="$listeners"
     >
       <div v-if="hasError" class="preferences-error">
-        <empty-state />
+        <empty-state
+          icon="icon-warning"
+          heading="Unable to fetch preferences"
+          body="Reload Preferences to try again."
+        >
+          <template #primary-action>
+            <button class="btn role-primary" @click="reloadPreferences">
+              Reload preferences
+            </button>
+          </template>
+        </empty-state>
       </div>
     </preferences-body>
     <preferences-actions

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -8,11 +8,12 @@ import PreferencesHeader from '@/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@/components/Preferences/ModalNav.vue';
 import PreferencesBody from '@/components/Preferences/ModalBody.vue';
 import PreferencesActions from '@/components/Preferences/ModalActions.vue';
+import EmptyState from '@/components/EmptyState.vue';
 
 export default Vue.extend({
   name:       'preferences-modal',
   components: {
-    PreferencesHeader, PreferencesNav, PreferencesBody, PreferencesActions
+    PreferencesHeader, PreferencesNav, PreferencesBody, PreferencesActions, EmptyState
   },
   layout: 'preferences',
   data() {
@@ -78,7 +79,11 @@ export default Vue.extend({
       :current-nav-item="currentNavItem"
       :preferences="getPreferences"
       v-on="$listeners"
-    />
+    >
+      <div class="preferences-error">
+        <empty-state />
+      </div>
+    </preferences-body>
     <preferences-actions
       class="preferences-actions"
       :is-dirty="isPreferencesDirty"
@@ -118,5 +123,15 @@ export default Vue.extend({
       "header header"
       "nav body"
       "actions actions";
+  }
+
+  .preferences-error {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding-bottom: 6rem;
   }
 </style>

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -50,7 +50,7 @@ export const actions: ActionTree<PreferencesState, PreferencesState> = {
         })
       });
 
-    if (response.status !== 200) {
+    if (!response.ok) {
       commit('SET_ERROR', true);
 
       return;

--- a/src/window/preferences.ts
+++ b/src/window/preferences.ts
@@ -28,6 +28,10 @@ export function openPreferences() {
     if (channel === 'preferences/load') {
       window.show();
     }
+
+    if (channel === 'preferences-reload') {
+      window.reload();
+    }
   });
 
   window.on('close', (event) => {


### PR DESCRIPTION
This displays an error message and provides a way for attempting to reload if fetching preferences returns an error.  

### Example

![image](https://user-images.githubusercontent.com/835961/178849177-cce754e8-6f5a-4c30-9dfc-b0ceff2a1eb5.png)

closes #2522 
