### PR TITLE
Suppress network address warnings when networks aren't configured

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1372,7 +1372,9 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         } else {
           const sharedIP = await this.getInterfaceAddr('rd1');
 
-          await this.noBridgedNetworkDialog(sharedIP);
+          if (!this.cfg?.suppressSudo) {
+            await this.noBridgedNetworkDialog(sharedIP);
+          }
           if (sharedIP) {
             config.ADDITIONAL_ARGS += '--flannel-iface rd1';
             console.log(`Using ${ sharedIP } on shared network rd1`);


### PR DESCRIPTION
When sudo is disabled, then no bridged or shared networks are configured, so there is no point in warning about them not having an IP address.

Fixes #2099