### PR TITLE
Bump alpine-iso and wsl-distro to bump to nerdctl 0.22.0 and cri-dockerd to 0.2.3

### DIFF
--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -7,12 +7,12 @@ import path from 'path';
 import { download, getResource } from '../lib/download.mjs';
 
 const limaRepo = 'https://github.com/rancher-sandbox/lima-and-qemu';
-const limaTag = 'v1.23';
+const limaTag = 'v1.24';
 
 const alpineLimaRepo = 'https://github.com/lima-vm/alpine-lima';
-const alpineLimaTag = 'v0.2.16';
+const alpineLimaTag = 'v0.2.18';
 const alpineLimaEdition = 'rd';
-const alpineLimaVersion = '3.15.4';
+const alpineLimaVersion = '3.16.0';
 
 async function getLima(platform) {
   const url = `${ limaRepo }/releases/download/${ limaTag }/lima-and-qemu.${ platform }.tar.gz`;

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -9,7 +9,7 @@ import path from 'path';
 import { download } from '../lib/download.mjs';
 
 export default async function main() {
-  const v = '0.24';
+  const v = '0.25';
 
   await download(
     `https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/releases/download/v${ v }/distro-${ v }.tar`,

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -175,9 +175,9 @@ interface SudoCommand {
 const console = Logging.lima;
 const DEFAULT_DOCKER_SOCK_LOCATION = '/var/run/docker.sock';
 const MACHINE_NAME = '0';
-const IMAGE_VERSION = '0.2.16';
+const IMAGE_VERSION = '0.2.18';
 const ALPINE_EDITION = 'rd';
-const ALPINE_VERSION = '3.15.4';
+const ALPINE_VERSION = '3.16.0';
 
 const ETC_RANCHER_DESKTOP_DIR = '/etc/rancher/desktop';
 const CREDENTIAL_FORWARDER_SETTINGS_PATH = path.join(ETC_RANCHER_DESKTOP_DIR, 'credfwd');

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -68,7 +68,7 @@ enum Action {
 }
 
 /** The version of the WSL distro we expect. */
-const DISTRO_VERSION = '0.24';
+const DISTRO_VERSION = '0.25';
 
 /**
  * The list of directories that are in the data distribution (persisted across


### PR DESCRIPTION
Also bumps lima-and-qemu to 0.25 to support Alpine 3.16 and get the latest dns.go fixes.