### PR TITLE
Add Rancher Desktop slider component

### DIFF
--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -169,6 +169,7 @@ export default {
   <div class="system-preferences">
     <rd-slider
       id="memoryInGBWrapper"
+      ref="memory"
       label="Memory (GB)"
       :value="safeMemory"
       :min="safeMinMemory"
@@ -181,6 +182,7 @@ export default {
 
     <rd-slider
       id="numCPUWrapper"
+      ref="cpu"
       label="# CPUs"
       :value="safeCPUs"
       :min="safeMinCPUs"

--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -1,8 +1,8 @@
 <script>
-import VueSlider from 'vue-slider-component';
-import 'vue-slider-component/theme/default.css';
+import RdSlider from '@/components/form/RdSlider.vue';
+
 export default {
-  components: { VueSlider },
+  components: { RdSlider },
   props:      {
     // Memory limits
     memoryInGB: {
@@ -167,90 +167,38 @@ export default {
 
 <template>
   <div class="system-preferences">
-    <div id="memoryInGBWrapper" class="labeled-input">
-      <label>Memory (GB)</label>
-      <section class="slider-container">
-        <input
-          type="number"
-          class="slider-input"
-          :value="safeMemory"
-          @input="updatedVal($event.target.value, 'memory')"
-        />
-        <vue-slider
-          ref="memory"
-          :value="safeMemory"
-          :min="safeMinMemory"
-          :max="availMemoryInGB"
-          :marks="memoryMarks"
-          :tooltip="'none'"
-          :disabled="disableMemory"
-          :process="processMemory"
-          @change="updatedVal($event, 'memory')"
-        />
-      </section>
-    </div>
+    <rd-slider
+      id="memoryInGBWrapper"
+      label="Memory (GB)"
+      :value="safeMemory"
+      :min="safeMinMemory"
+      :max="availMemoryInGB"
+      :marks="memoryMarks"
+      :disabled="disableMemory"
+      :process="processMemory"
+      @change="updatedVal($event, 'memory')"
+    />
 
-    <div id="numCPUWrapper" class="labeled-input">
-      <label># CPUs</label>
-      <section class="slider-container">
-        <input
-          type="number"
-          class="slider-input"
-          :value="safeCPUs"
-          @input="updatedVal($event.target.value, 'cpu')"
-        />
-        <vue-slider
-          ref="cpu"
-          :value="safeCPUs"
-          :min="safeMinCPUs"
-          :max="availNumCPUs"
-          :interval="1"
-          :marks="CPUMarks"
-          :tooltip="'none'"
-          :disabled="disableCPUs"
-          :process="processCPUs"
-          @change="updatedVal($event, 'cpu')"
-        />
-      </section>
-    </div>
+    <rd-slider
+      id="numCPUWrapper"
+      label="# CPUs"
+      :value="safeCPUs"
+      :min="safeMinCPUs"
+      :max="availNumCPUs"
+      :interval="1"
+      :marks="CPUMarks"
+      :disabled="disableCPUs"
+      :process="processCPUs"
+      @change="updatedVal($event, 'cpu')"
+    />
   </div>
 </template>
 
 <style scoped>
-
-.labeled-input .vue-slider {
-  margin: 2em 1em;
-  flex: 1;
-}
-.vue-slider >>> .vue-slider-rail {
-  background-color: var(--progress-bg);
-}
-.vue-slider >>> .vue-slider-mark-step {
-  background-color: var(--checkbox-tick-disabled);
-  opacity: 0.5;
-}
-.vue-slider >>> .vue-slider-dot-handle {
-  background-color: var(--scrollbar-thumb);
-  box-shadow: 0.5px 0.5px 2px 1px var(--darker);
-}
-@media screen and (prefers-color-scheme: dark) {
-  .vue-slider >>> .vue-slider-dot-handle {
-    background-color: var(--checkbox-tick-disabled);
-  }
-}
-.vue-slider >>> .vue-slider-process {
-  background-color: var(--error);
-}
-
-.slider-container {
+.system-preferences {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 1rem;
+  padding-right: 1rem;
 }
-
-.slider-input, .slider-input:focus, .slider-input:hover {
-  max-width: 6rem;
-  border: solid var(--border-width) var(--input-border);
-  padding:10px;
-}
-
 </style>

--- a/src/components/__tests__/SystemPreferences.spec.js
+++ b/src/components/__tests__/SystemPreferences.spec.js
@@ -59,7 +59,6 @@ describe('SystemPreferences.vue', () => {
 
     delete minimalProps.memoryInGB;
     delete minimalProps.numberCPUs;
-    delete minimalProps.noChangesToApply;
     const wrapper = createWrappedPage(minimalProps);
 
     expect(wrapper.props().memoryInGB).toBe(2);

--- a/src/components/__tests__/SystemPreferences.spec.js
+++ b/src/components/__tests__/SystemPreferences.spec.js
@@ -27,14 +27,14 @@ describe('SystemPreferences.vue', () => {
     expect(wrapper.props().availMemoryInGB).toBe(8);
     expect(wrapper.props().availNumCPUs).toBe(6);
 
-    const slider1 = wrapper.find('div#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
+    const slider1 = wrapper.find('#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider1.exists()).toBeFalsy();
-    const slider2 = wrapper.find('div#numCPUWrapper div.vue-slider.vue-slider-disabled');
+    const slider2 = wrapper.find('#numCPUWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider2.exists()).toBeFalsy();
 
-    const div1 = wrapper.find('div#memoryInGBWrapper');
+    const div1 = wrapper.find('#memoryInGBWrapper');
     const span1 = div1.find('div.vue-slider div.vue-slider-dot');
 
     expect(span1.exists()).toBeTruthy();
@@ -42,7 +42,7 @@ describe('SystemPreferences.vue', () => {
     expect(span1.attributes('aria-valuenow')).toEqual('4');
     expect(span1.attributes('aria-valuemax')).toEqual('8');
 
-    const div2 = wrapper.find('div#numCPUWrapper');
+    const div2 = wrapper.find('#numCPUWrapper');
     const span2 = div2.find('div.vue-slider div.vue-slider-dot');
 
     expect(span2.exists()).toBeTruthy();
@@ -64,14 +64,14 @@ describe('SystemPreferences.vue', () => {
 
     expect(wrapper.props().memoryInGB).toBe(2);
     expect(wrapper.props().numberCPUs).toBe(2);
-    const slider1 = wrapper.find('div#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
+    const slider1 = wrapper.find('#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider1.exists()).toBeFalsy();
-    const slider2 = wrapper.find('div#numCPUWrapper div.vue-slider.vue-slider-disabled');
+    const slider2 = wrapper.find('#numCPUWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider2.exists()).toBeFalsy();
 
-    const div1 = wrapper.find('div#memoryInGBWrapper');
+    const div1 = wrapper.find('#memoryInGBWrapper');
     const span1 = div1.find('div.vue-slider div.vue-slider-dot');
 
     expect(span1.exists()).toBe(true);
@@ -79,7 +79,7 @@ describe('SystemPreferences.vue', () => {
     expect(span1.attributes('aria-valuenow')).toEqual('2');
     expect(span1.attributes('aria-valuemax')).toEqual('8');
 
-    const div2 = wrapper.find('div#numCPUWrapper');
+    const div2 = wrapper.find('#numCPUWrapper');
     const span2 = div2.find('div.vue-slider div.vue-slider-dot');
 
     expect(span2.exists()).toBe(true);
@@ -97,12 +97,12 @@ describe('SystemPreferences.vue', () => {
       availNumCPUs:    1,
     };
     const wrapper = createWrappedPage(minimalProps);
-    const slider1 = wrapper.find('div#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
+    const slider1 = wrapper.find('#memoryInGBWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider1.exists()).toBeTruthy();
     expect(slider1.find('div.vue-slider-rail div.vue-slider-dot.vue-slider-dot-disabled').exists()).toBeTruthy();
 
-    const slider2 = wrapper.find('div#numCPUWrapper div.vue-slider.vue-slider-disabled');
+    const slider2 = wrapper.find('#numCPUWrapper div.vue-slider.vue-slider-disabled');
 
     expect(slider2.exists()).toBeTruthy();
     expect(slider2.find('div.vue-slider-rail div.vue-slider-dot.vue-slider-dot-disabled').exists()).toBeTruthy();
@@ -145,7 +145,7 @@ describe('SystemPreferences.vue', () => {
     it('the sliders detect invalid values', async() => {
       const wrapper = createWrappedPage(baseProps);
 
-      const div1 = wrapper.find('div#memoryInGBWrapper');
+      const div1 = wrapper.find('#memoryInGBWrapper');
       const slider1 = div1.find('div.vue-slider');
       const span1 = slider1.find('div.vue-slider-dot');
       const slider1vm = slider1.vm;
@@ -163,7 +163,7 @@ describe('SystemPreferences.vue', () => {
         slider1vm.setValue(baseProps.availMemoryInGB + 1);
       }, '[VueSlider error]: The "value" must be less than or equal to the "max".');
 
-      const div2 = wrapper.find('div#numCPUWrapper');
+      const div2 = wrapper.find('#numCPUWrapper');
       const slider2 = div2.find('div.vue-slider');
       const slider2vm = slider2.vm;
       const span2 = slider2.find('div.vue-slider-dot');
@@ -187,7 +187,7 @@ describe('SystemPreferences.vue', () => {
   it('emits events', async() => {
     const wrapper = createWrappedPage(baseProps);
 
-    const div1 = wrapper.find('div#memoryInGBWrapper');
+    const div1 = wrapper.find('#memoryInGBWrapper');
     const slider1 = div1.find('div.vue-slider');
     const slider1vm = slider1.vm;
 
@@ -202,7 +202,7 @@ describe('SystemPreferences.vue', () => {
     expect(updateMemoryEmitter[0]).toEqual([3]);
     expect(updateMemoryEmitter[1]).toEqual([5]);
 
-    const div2 = wrapper.find('div#numCPUWrapper');
+    const div2 = wrapper.find('#numCPUWrapper');
     const slider2 = div2.find('div.vue-slider');
     const slider2vm = slider2.vm;
 

--- a/src/components/form/RdSlider.vue
+++ b/src/components/form/RdSlider.vue
@@ -123,11 +123,6 @@ export default Vue.extend({
   background-color: var(--error);
 }
 
-.slider-container {
-  display: flex;
-  align-items: center;
-}
-
 .slider-input, .slider-input:focus, .slider-input:hover {
   max-width: 6rem;
   border: solid var(--border-width) var(--input-border);

--- a/src/components/form/RdSlider.vue
+++ b/src/components/form/RdSlider.vue
@@ -1,0 +1,136 @@
+<script lang="ts">
+import Vue from 'vue';
+import VueSlider from 'vue-slider-component';
+import 'vue-slider-component/theme/default.css';
+
+import RdFieldset from '@/components/form/RdFieldset.vue';
+
+export default Vue.extend({
+  name:       'rd-slider',
+  components: { VueSlider, RdFieldset },
+  props:      {
+    label: {
+      type:    String,
+      default: ''
+    },
+    value: {
+      type:     Number,
+      required: true
+    },
+    min: {
+      type:     Number,
+      required: true
+    },
+    max: {
+      type:     Number,
+      required: true
+    },
+    interval: {
+      type:    Number,
+      default: 1
+    },
+    marks: {
+      type:     Array,
+      required: true
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    process: {
+      type:     Function,
+      required: true
+    },
+  },
+  methods: {
+    updatedVal(value: string) {
+      this.$emit('change', value);
+    }
+  }
+});
+</script>
+
+<template>
+  <rd-fieldset
+    :legend-text="label"
+  >
+    <div class="rd-slider">
+      <input
+        type="number"
+        class="slider-input"
+        :value="value"
+        @input="updatedVal($event.target.value)"
+      />
+      <vue-slider
+        ref="memory"
+        class="rd-slider-rail"
+        :value="value"
+        :min="min"
+        :max="max"
+        :interval="interval"
+        :marks="marks"
+        :tooltip="'none'"
+        :disabled="disabled"
+        :process="process"
+        @change="updatedVal($event)"
+      />
+    </div>
+  </rd-fieldset>
+</template>
+
+<style lang="scss" scoped>
+.rd-fieldset {
+  width: 100%;
+}
+
+.rd-slider {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2rem;
+}
+
+.rd-slider-rail {
+  flex-grow: 1;
+}
+
+.labeled-input .vue-slider {
+  margin: 2em 1em;
+  flex: 1;
+}
+
+.vue-slider::v-deep .vue-slider-rail {
+  background-color: var(--progress-bg);
+}
+
+.vue-slider::v-deep .vue-slider-mark-step {
+  background-color: var(--checkbox-tick-disabled);
+  opacity: 0.5;
+}
+
+.vue-slider::v-deep .vue-slider-dot-handle {
+  background-color: var(--scrollbar-thumb);
+  box-shadow: 0.5px 0.5px 2px 1px var(--darker);
+}
+
+@media screen and (prefers-color-scheme: dark) {
+  .vue-slider::v-deep .vue-slider-dot-handle {
+    background-color: var(--checkbox-tick-disabled);
+  }
+}
+
+.vue-slider::v-deep .vue-slider-process {
+  background-color: var(--error);
+}
+
+.slider-container {
+  display: flex;
+  align-items: center;
+}
+
+.slider-input, .slider-input:focus, .slider-input:hover {
+  max-width: 6rem;
+  border: solid var(--border-width) var(--input-border);
+  padding:10px;
+}
+</style>


### PR DESCRIPTION
This adds a rancher desktop-specific slider component so that we can more readily style our sliders without having to build each slider so that each instance has a matching template. 

closes #2464 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>