### PR TITLE
De-emphasize preferences button

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -46,11 +46,14 @@ export default Vue.extend({
     flex: 1;
     height: 40px;
     z-index: 2;
-
-        img {
-            height: 40px;
-        }
+      img {
+        height: 40px;
+      }
     }
 
+    .header-actions {
+      display: flex;
+      align-items: center;
+    }
   }
 </style>

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -12,7 +12,7 @@ export default Vue.extend({
 
 <template>
   <button
-    class="btn role-fab preferences-button ripple"
+    class="btn role-fab ripple"
     @click="openPreferences"
   >
     <span

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -22,6 +22,9 @@ export default Vue.extend({
 </template>
 
 <style lang="scss" scoped>
+  // We make use of the term Floating Action Button (fab) here because the
+  // design of this button is reminiscent of floating actions buttons from
+  // Material Design
   button.role-fab {
     all: revert;
     cursor: pointer;

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
     border: 0;
     padding: 0.5rem;
     background: none;
-    color: var(--primary-text);
+    color: var(--body-text);
     transition: background 400ms;
     border-radius: 50%;
   }
@@ -41,11 +41,11 @@ export default Vue.extend({
   }
 
   .ripple:hover {
-    background: var(--primary-hover-bg) radial-gradient(circle, transparent 1%, var(--primary-hover-bg) 1%) center/15000%;
+    background: var(--tooltip-bg) radial-gradient(circle, transparent 1%, var(--tooltip-bg) 1%) center/15000%;
   }
 
   .ripple:active {
-    background-color: var(--primary);
+    background-color: var(--default);
     background-size: 100%;
     transition: background 0s;
   }

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -11,26 +11,31 @@ export default Vue.extend({
 </script>
 
 <template>
-  <span
-    class="icon icon-gear ripple"
-    aria-label="Open Preferences"
-    role="button"
+  <button
+    class="btn role-fab preferences-button ripple"
     @click="openPreferences"
-    @keydown.enter="openPreferences"
-    @keydown.space="openPreferences"
-  />
+  >
+    <span
+      class="icon icon-gear"
+    />
+  </button>
 </template>
 
 <style lang="scss" scoped>
-  .icon-gear {
+  button.role-fab {
+    all: revert;
     cursor: pointer;
     font-size: 1.875rem;
+    line-height: 0;
+    border: 0;
     padding: 0.5rem;
+    background: none;
+    color: var(--primary-text);
     transition: background 400ms;
     border-radius: 50%;
   }
 
-  .ripple {
+  button.ripple {
     background-position: center;
     transition: background 0.8s;
   }

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -25,7 +25,6 @@ export default Vue.extend({
   .icon-gear {
     cursor: pointer;
     font-size: 1.875rem;
-    // line-height: 2.25rem;
     padding: 0.5rem;
     transition: background 400ms;
     border-radius: 50%;

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -11,37 +11,38 @@ export default Vue.extend({
 </script>
 
 <template>
-  <button
-    class="btn role-secondary btn-sm"
-    type="button"
+  <span
+    class="icon icon-gear ripple"
     aria-label="Open Preferences"
+    role="button"
     @click="openPreferences"
-  >
-    <i class="icon icon-gear" />
-  </button>
+    @keydown.enter="openPreferences"
+    @keydown.space="openPreferences"
+  />
 </template>
 
 <style lang="scss" scoped>
-  button.btn {
-    background: none;
-    border: none;
-    box-shadow: none;
-    .icon {
-      background: var(--primary);
-      color: var(--primary-text);
-      width: 32px;
-      height: 32px;
-      border-radius: 50%;
-      padding-top: 5px;
-      &::before {
-        font-size: 22px;
-        margin-left: 1px;
-      }
-    }
-    &:focus {
-      .icon {
-        outline: var(--outline-width) dashed var(--primary-active-bg);
-      }
-    }
+  .icon-gear {
+    cursor: pointer;
+    font-size: 1.875rem;
+    // line-height: 2.25rem;
+    padding: 0.5rem;
+    transition: background 400ms;
+    border-radius: 50%;
+  }
+
+  .ripple {
+    background-position: center;
+    transition: background 0.8s;
+  }
+
+  .ripple:hover {
+    background: var(--primary-hover-bg) radial-gradient(circle, transparent 1%, var(--primary-hover-bg) 1%) center/15000%;
+  }
+
+  .ripple:active {
+    background-color: var(--primary);
+    background-size: 100%;
+    transition: background 0s;
   }
 </style>

--- a/src/components/__tests__/PreferencesButton.spec.ts
+++ b/src/components/__tests__/PreferencesButton.spec.ts
@@ -5,7 +5,7 @@ describe('Preferences/ButtonOpen.vue', () => {
   it(`renders a button`, () => {
     const wrapper = shallowMount(PreferencesButton, {});
 
-    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-secondary', 'btn-sm']);
+    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-fab', 'ripple']);
   });
 
   it(`emits 'open-preferences' on click`, () => {


### PR DESCRIPTION
This removes emphasis from the preferences button in its default state by removing a lot of the button styles originally associated with it. As an alternative to always displaying a background color, I opted to add a background on hover along with a ripple effect on click to add some feedback to different button states. 

closes #2525 