### PR TITLE
Create a Rancher Desktop tab wrapper component

### DIFF
--- a/src/components/ImageAddTabs.vue
+++ b/src/components/ImageAddTabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <tabbed
+  <rd-tabbed
     v-bind="$attrs"
     default-tab="pull"
     class="action-tabs"
@@ -17,19 +17,20 @@
       :weight="1"
     />
     <slot></slot>
-  </tabbed>
+  </rd-tabbed>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import Tabbed from '@/components/Tabbed/index.vue';
+
+import RdTabbed from '@/components/Tabbed/RdTabbed.vue';
 import Tab from '@/components/Tabbed/Tab.vue';
 
 export default Vue.extend({
   name: 'image-add-tabs',
 
   components: {
-    Tabbed,
+    RdTabbed,
     Tab
   },
 
@@ -45,36 +46,3 @@ export default Vue.extend({
   }
 });
 </script>
-
-<style lang="scss" scoped>
-  .action-tabs::v-deep li.tab {
-    margin-right: 0;
-    padding-right: 0;
-    border-bottom: 1px solid;
-    border-color: var(--border);
-    padding-bottom: 7px;
-
-    A {
-      color: var(--muted);
-    }
-  }
-
-  .action-tabs::v-deep .tabs .tab.active {
-    border-color: var(--primary);
-    background-color: transparent;
-
-    A {
-      color: var(--link);
-    }
-  }
-
-  .action-tabs::v-deep ul {
-    border-bottom: 1px solid;
-    border-color: var(--border);
-  }
-
-  .action-tabs::v-deep .tab-container {
-    background-color: transparent;
-    margin-top: 1rem;
-  }
-</style>

--- a/src/components/Preferences/BodyApplication.vue
+++ b/src/components/Preferences/BodyApplication.vue
@@ -81,6 +81,10 @@ export default Vue.extend({
 
     ::v-deep .tabs {
       border-bottom: 1px solid var(--border);
+
+      a {
+        text-decoration: none;
+      }
     }
 
     ::v-deep .tab-container {
@@ -94,16 +98,13 @@ export default Vue.extend({
       padding-right: 0;
       border-bottom: 1px solid var(--border);
 
-      A {
-        color: var(--muted);
-      }
-
       &.active {
         border-color: var(--primary);
         background-color: transparent;
 
-        A {
+        a {
           color: var(--link);
+          text-decoration: none;
         }
       }
     }

--- a/src/components/Preferences/BodyApplication.vue
+++ b/src/components/Preferences/BodyApplication.vue
@@ -3,8 +3,8 @@ import Vue from 'vue';
 import { mapGetters } from 'vuex';
 import type { PropType } from 'vue';
 
-import Tabbed from '@/components/Tabbed/index.vue';
 import Tab from '@/components/Tabbed/Tab.vue';
+import RdTabbed from '@/components/Tabbed/RdTabbed.vue';
 import PreferencesApplicationBehavior from '@/components/Preferences/ApplicationBehavior.vue';
 import PreferencesApplicationEnvironment from '@/components/Preferences/ApplicationEnvironment.vue';
 import { Settings } from '@/config/settings';
@@ -12,7 +12,7 @@ import { Settings } from '@/config/settings';
 export default Vue.extend({
   name:       'preferences-body-application',
   components: {
-    Tabbed,
+    RdTabbed,
     Tab,
     PreferencesApplicationBehavior,
     PreferencesApplicationEnvironment,
@@ -36,23 +36,25 @@ export default Vue.extend({
 </script>
 
 <template>
-  <tabbed
+  <rd-tabbed
     v-if="!isPlatformWindows"
     v-bind="$attrs"
     class="action-tabs"
     :no-content="true"
     @changed="tabSelected"
   >
-    <tab
-      label="Environment"
-      name="environment"
-      :weight="1"
-    />
-    <tab
-      label="Behavior"
-      name="behavior"
-      :weight="2"
-    />
+    <template #tabs>
+      <tab
+        label="Environment"
+        name="environment"
+        :weight="1"
+      />
+      <tab
+        label="Behavior"
+        name="behavior"
+        :weight="2"
+      />
+    </template>
     <div class="application-content">
       <component
         :is="`preferences-application-${ activeTab }`"
@@ -60,7 +62,7 @@ export default Vue.extend({
         v-on="$listeners"
       />
     </div>
-  </tabbed>
+  </rd-tabbed>
   <div v-else class="application-content">
     <preferences-application-behavior
       :preferences="preferences"
@@ -72,41 +74,5 @@ export default Vue.extend({
 <style lang="scss" scoped>
   .application-content {
     padding: var(--preferences-content-padding);
-  }
-
-  .action-tabs {
-    display: flex;
-    flex-direction: column;
-    max-height: 100%;
-
-    ::v-deep .tabs {
-      border-bottom: 1px solid var(--border);
-
-      a {
-        text-decoration: none;
-      }
-    }
-
-    ::v-deep .tab-container {
-      max-height: 100%;
-      overflow: auto;
-      background-color: transparent;
-    }
-
-    ::v-deep li.tab {
-      margin-right: 0;
-      padding-right: 0;
-      border-bottom: 1px solid var(--border);
-
-      &.active {
-        border-color: var(--primary);
-        background-color: transparent;
-
-        a {
-          color: var(--link);
-          text-decoration: none;
-        }
-      }
-    }
   }
 </style>

--- a/src/components/Tabbed/RdTabbed.vue
+++ b/src/components/Tabbed/RdTabbed.vue
@@ -1,0 +1,60 @@
+<script lang="ts">
+import Vue from 'vue';
+
+import Tabbed from '@/components/Tabbed/index.vue';
+
+export default Vue.extend({
+  name:       'rd-tabbed',
+  components: { Tabbed }
+});
+</script>
+
+<template>
+  <tabbed
+    v-bind="$attrs"
+    class="action-tabs"
+    :no-content="true"
+    v-on="$listeners"
+  >
+    <slot name="tabs"></slot>
+    <slot></slot>
+  </tabbed>
+</template>
+
+<style lang="scss" scoped>
+  .action-tabs {
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+
+    ::v-deep .tabs {
+      border-bottom: 1px solid var(--border);
+
+      a {
+        text-decoration: none;
+      }
+    }
+
+    ::v-deep .tab-container {
+      max-height: 100%;
+      overflow: auto;
+      background-color: transparent;
+    }
+
+    ::v-deep li.tab {
+      margin-right: 0;
+      padding-right: 0;
+      border-bottom: 1px solid var(--border);
+
+      &.active {
+        border-color: var(--primary);
+        background-color: transparent;
+
+        a {
+          color: var(--link);
+          text-decoration: none;
+        }
+      }
+    }
+  }
+</style>

--- a/src/pages/images/add.vue
+++ b/src/pages/images/add.vue
@@ -110,6 +110,7 @@ export default {
     display: flex;
     align-items: center;
     gap: 16px;
+    padding-top: 0.5rem;
   }
 
   .image-input::v-deep .labeled-input {


### PR DESCRIPTION
This creates a tab wrapper component specifically for Rancher Desktop so that styles can be consistently applied for tabs in multiple places.

closes #2545 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>