### PR TITLE
Rename Factory Reset option to "Keep cached kubernetes images"

### DIFF
--- a/src/go/rdctl/cmd/factoryReset.go
+++ b/src/go/rdctl/cmd/factoryReset.go
@@ -34,7 +34,7 @@ var factoryResetCmd = &cobra.Command{
 	Use:   "factory-reset",
 	Short: "Clear all the Rancher Desktop state and shut it down.",
 	Long: `Clear all the Rancher Desktop state and shut it down.
-Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached system images.`,
+Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached Kubernetes images.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := cobra.NoArgs(cmd, args)
 		if err != nil {
@@ -58,5 +58,5 @@ Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached system 
 
 func init() {
 	rootCmd.AddCommand(factoryResetCmd)
-	factoryResetCmd.Flags().BoolVar(&removeKubernetesCache, "remove-kubernetes-cache", false, "If specified, also removes the cached system images.")
+	factoryResetCmd.Flags().BoolVar(&removeKubernetesCache, "remove-kubernetes-cache", false, "If specified, also removes the cached Kubernetes images.")
 }

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -57,7 +57,7 @@
             data-test="factoryResetButton"
             label="Factory Reset"
             value="auto"
-            :options="[{id: 'keepImages', label: 'Keep Container System Images'}]"
+            :options="[{id: 'keepImages', label: 'Keep cached Kubernetes images'}]"
             @input="factoryReset"
           />
         </div>


### PR DESCRIPTION
because "Container System Images" is kind of abstract? What are they, and why would you or wouldn't you want to keep them?

See also https://github.com/rancher-sandbox/rancher-desktop/issues/2494#issuecomment-1189536627