### PR TITLE
Revert "Build rdctl for linux"

### DIFF
--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -319,8 +319,7 @@ export default {
       tasks.push(() => this.buildVtunnel('win32'));
       tasks.push(() => this.buildVtunnel('linux'));
     }
-    tasks.push(() => this.buildUtility('rdctl', 'windows'));
-    tasks.push(() => this.buildUtility('rdctl', 'linux'));
+    tasks.push(() => this.buildUtility('rdctl', os.platform()));
     tasks.push(() => this.buildUtility('docker-credential-none', os.platform()));
 
     return this.wait(...tasks);


### PR DESCRIPTION
This reverts commit 94135970aac4f1309da9a434147b1fbb53f16776.

The problem with this commit is it stopped making platform-specific builds for rdctl except on Windows.