### PR TITLE
Kubernetes backend: add endpoint to propose settings.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -780,6 +780,19 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   protected k8sVersions: string[] = [];
   protected settingsValidator = new SettingsValidator();
 
+  /**
+   * Use the settings validator to validate settings after doing any
+   * initialization.
+   */
+  protected async validateSettings(...args: Parameters<SettingsValidator['validateSettings']>) {
+    if (this.k8sVersions.length === 0) {
+      this.k8sVersions = (await k8smanager.availableVersions).map(entry => entry.version.version);
+      this.settingsValidator.k8sVersions = this.k8sVersions;
+    }
+
+    return this.settingsValidator.validateSettings(...args);
+  }
+
   getSettings() {
     return jsonStringifyWithWhiteSpace(cfg);
   }
@@ -800,11 +813,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
    * @returns [{string} description of final state if no error, {string} error message]
    */
   async updateSettings(context: CommandWorkerInterface.CommandContext, newSettings: RecursivePartial<settings.Settings>): Promise<[string, string]> {
-    if (this.k8sVersions.length === 0) {
-      this.k8sVersions = (await k8smanager.availableVersions).map(entry => entry.version.version);
-      this.settingsValidator.k8sVersions = this.k8sVersions;
-    }
-    const [needToUpdate, errors] = this.settingsValidator.validateSettings(cfg, newSettings);
+    const [needToUpdate, errors] = await this.validateSettings(cfg, newSettings);
 
     if (errors.length > 0) {
       return ['', `errors in attempt to update settings:\n${ errors.join('\n') }`];
@@ -830,14 +839,21 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     }
   }
 
+  async proposeSettings(context: CommandWorkerInterface.CommandContext, newSettings: RecursivePartial<settings.Settings>): Promise<[string, string]> {
+    const [needToUpdate, errors] = await this.validateSettings(cfg, newSettings);
+
+    if (errors.length > 0) {
+      return ['', `errors in proposed settings:\n${ errors.join('\n') }`];
+    }
+    const result = await k8smanager?.requiresRestartReasons(newSettings?.kubernetes ?? {}) ?? {};
+
+    return [JSON.stringify(result), ''];
+  }
+
   async requestShutdown() {
     httpCommandServer?.closeServer();
     httpCredentialHelperServer.closeServer();
     await k8smanager.stop();
     Electron.app.quit();
-  }
-
-  async testBackendRestartReasons() {
-    return await k8smanager?.requiresRestartReasons(cfg.kubernetes) ?? {};
   }
 }

--- a/background.ts
+++ b/background.ts
@@ -418,7 +418,6 @@ function writeSettings(arg: RecursivePartial<settings.Settings>) {
   _.merge(cfg, arg);
   settings.save(cfg);
   mainEvents.emit('settings-update', cfg);
-  Electron.ipcMain.emit('k8s-restart-required');
 }
 
 Electron.ipcMain.handle('settings-write', (event, arg) => {
@@ -500,16 +499,6 @@ async function doK8sReset(arg: 'fast' | 'wipe' | 'fullRestart', context: Command
     }
   }
 }
-
-async function doK8sRestartRequired() {
-  const restartRequired = (await k8smanager?.requiresRestartReasons(cfg.kubernetes)) ?? {};
-
-  window.send('k8s-restart-required', restartRequired);
-}
-
-Electron.ipcMain.on('k8s-restart-required', async() => {
-  await doK8sRestartRequired();
-});
 
 Electron.ipcMain.on('k8s-restart', async() => {
   if (cfg.kubernetes.port !== k8smanager.desiredPort) {

--- a/background.ts
+++ b/background.ts
@@ -840,7 +840,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   }
 
   async proposeSettings(context: CommandWorkerInterface.CommandContext, newSettings: RecursivePartial<settings.Settings>): Promise<[string, string]> {
-    const [needToUpdate, errors] = await this.validateSettings(cfg, newSettings);
+    const [_, errors] = await this.validateSettings(cfg, newSettings);
 
     if (errors.length > 0) {
       return ['', `errors in proposed settings:\n${ errors.join('\n') }`];

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import _ from 'lodash';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 import { test, expect } from '@playwright/test';
+import semver from 'semver';
 
 import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
 import { NavPage } from './pages/nav-page';
@@ -135,7 +136,7 @@ test.describe.serial('KubernetesBackend', () => {
       _.merge(newSettings, platformSettings[os.platform() === 'win32' ? 'win32' : 'lima']);
 
       const expectedDefinition: Partial<Record<RecursiveKeys<Settings['kubernetes']>, boolean>> = {
-        version:           newSettings.kubernetes?.version === '1.12.5',
+        version:           semver.lt(newSettings.kubernetes?.version ?? '0.0.0', currentSettings.kubernetes.version),
         port:              false,
         containerEngine:   false,
         enabled:           false,

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -772,7 +772,6 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
-            'GET /v0/test_backend_restart_reasons',
           ]);
         });
 
@@ -786,7 +785,6 @@ test.describe('Command server', () => {
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
-            'GET /v0/test_backend_restart_reasons',
           ]);
         });
       });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -769,6 +769,7 @@ test.describe('Command server', () => {
             'GET /',
             'GET /v0',
             'PUT /v0/factory_reset',
+            'PUT /v0/propose_settings',
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',
@@ -782,6 +783,7 @@ test.describe('Command server', () => {
           expect(JSON.parse(stdout)).toEqual([
             'GET /v0',
             'PUT /v0/factory_reset',
+            'PUT /v0/propose_settings',
             'GET /v0/settings',
             'PUT /v0/settings',
             'PUT /v0/shutdown',

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -5,7 +5,7 @@ info:
 paths:
   /v0/factory_reset:
     put:
-      operationId: facotryReset
+      operationId: factoryReset
       summary: Factory reset Rancher Desktop, losing user data
       requestBody:
         description: >-
@@ -24,7 +24,7 @@ paths:
       operationId: proposeSettings
       summary: >-
         Propose some settings and determine if the backend needs to be restarted
-        or reset (losing use data).
+        or reset (losing user data).
       requestBody:
         description: >-
           JSON block consisting of some or all of the current preferences,

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -3,7 +3,64 @@ info:
   title: "Rancher Desktop API"
   version: 0.0.1
 paths:
-  /v0/list-settings:
+  /v0/factory_reset:
+    put:
+      operationId: facotryReset
+      summary: Factory reset Rancher Desktop, losing user data
+      requestBody:
+        description: >-
+          JSON block giving factory reset options.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                keepSystemImages:
+                  type: boolean
+        required: true
+
+  /v0/propose_settings:
+    put:
+      operationId: proposeSettings
+      summary: >-
+        Propose some settings and determine if the backend needs to be restarted
+        or reset (losing use data).
+      requestBody:
+        description: >-
+          JSON block consisting of some or all of the current preferences,
+          with changes applied to any number of settings the backend supports changing this way.
+        content:
+          application/json:
+            schema:
+              "$ref" : "#/components/schemas/preferences"
+        required: true
+      responses:
+        '202':
+          description: >-
+            A description of the effects of the proposed settings on the
+            backend.
+          content:
+            "application/json":
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    current: {}
+                    desired: {}
+                    severity:
+                      type: string
+                      enum: [ restart, reset ]
+        '400':
+          description: >-
+            The proposed settings were not valid.
+          content:
+            "text/plain":
+              schema:
+                type: string
+
+
+  /v0/settings:
     get:
       operationId: listSettings
       summary:  List the current preference settings
@@ -15,8 +72,6 @@ paths:
             application/json:
               schema:
                 "$ref" : "#/components/schemas/preferences"
-
-  /v0/set:
     put:
       operationId: updateSettings
       summary:  Updates the specified preference settings

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -23,7 +23,7 @@ import DownloadProgressListener from '@/utils/DownloadProgressListener';
 import safeRename from '@/utils/safeRename';
 import paths from '@/utils/paths';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
-import { defined } from '@/utils/typeUtils';
+import { defined, RecursiveKeys, RecursivePartial, RecursiveTypes } from '@/utils/typeUtils';
 import * as K8s from '@/k8s-engine/k8s';
 // TODO: Replace with the k8s version after kubernetes-client/javascript/pull/748 lands
 import { findHomeDir } from '@/config/findHomeDir';
@@ -64,6 +64,34 @@ type cacheData = {
   /** Mapping of channel labels to current version (excluding build information). */
   channels: Record<string, string>;
 }
+
+/**
+ * RequiresRestartSeverityChecker is a function that will be used to determine
+ * whether a given settings change will require a reset (i.e. deleting user
+ * workloads).
+ */
+type RequiresRestartSeverityChecker<K extends keyof RecursiveTypes<K8s.BackendSettings>> =
+  (currentValue: RecursiveTypes<K8s.BackendSettings>[K], desiredValue: RecursiveTypes<K8s.BackendSettings>[K]) => 'restart' | 'reset';
+
+/**
+ * RequiresRestartCheckers defines a mapping of settings (in dot-separated form)
+ * to a RequiresRestartSeverityChecker for the given setting.
+ */
+type RequiresRestartCheckers = {
+  [K in keyof RecursiveTypes<K8s.BackendSettings>]?: RequiresRestartSeverityChecker<K>;
+};
+
+/**
+ * ExtraRequiresReasons defines a mapping of settings (in dot-separated form) to
+ * the current value (that does not always match the stored settings) and a
+ * RequiresRestartSeverityChecker for the given setting.
+ */
+type ExtraRequiresReasons = {
+  [K in keyof RecursiveTypes<K8s.BackendSettings>]?: {
+    current: RecursiveTypes<K8s.BackendSettings>[K];
+    severity?: RequiresRestartSeverityChecker<K>;
+  }
+};
 
 /**
  * ChannelMapping is an internal structure to map a channel name to its
@@ -1014,46 +1042,58 @@ export default class K3sHelper extends events.EventEmitter {
    */
   requiresRestartReasons(
     currentSettings: K8s.BackendSettings,
-    desiredSettings: K8s.BackendSettings,
-    items: Record<string, [boolean, ...string[]]>,
-    quiet = false,
-    extras: Record<string, {current: number, desired: number, visible?: boolean}> = {},
-  ): Record<string, K8s.RestartReason | undefined> {
-    const results: Record<string, K8s.RestartReason | undefined> = {};
+    desiredSettings: RecursivePartial<K8s.BackendSettings>,
+    checkers: RequiresRestartCheckers,
+    extras: ExtraRequiresReasons = {},
+  ): K8s.RestartReasons {
+    const results: K8s.RestartReasons = {};
     const NotFound = Symbol('not-found');
 
     /**
      * Check the given settings against the last-applied settings to see if we
      * need to restart the backend.
      * @param key The identifier to use for the UI.
-     * @param visible Whether to expose the difference to the user.
      * @param path The path in the Settings['kubernetes'] object to compare.
      */
-    const cmp = (key: string, visible: boolean, ...path: string[]) => {
-      const current = _.get(currentSettings, path, NotFound);
-      const desired = _.get(desiredSettings, path, NotFound);
+    function cmp<K extends keyof RecursiveTypes<K8s.BackendSettings>>(key: K, checker?: RequiresRestartSeverityChecker<K>) {
+      const fullKey = `kubernetes.${ key }` as keyof K8s.RestartReasons;
+      const current = _.get(currentSettings, key, NotFound);
+      const desired = _.get(desiredSettings, key, NotFound);
 
       if (current === NotFound) {
         throw new Error(`Invalid restart check: path ${ path } not found on current values`);
       }
       if (desired === NotFound) {
-        throw new Error(`Invalid restart check: path ${ path } not found on desired values`);
+        // desiredSettings does not contain the full set.
+        return;
       }
-      results[key] = _.isEqual(current, desired) ? undefined : {
-        current, desired, visible: visible && !quiet,
-      };
-    };
-
-    for (const [key, [visible, ...path]] of Object.entries(items)) {
-      cmp(key, visible, ...path);
+      if (!_.isEqual(current, desired)) {
+        results[fullKey] = {
+          current, desired, severity: checker ? checker(current, desired) : 'restart'
+        };
+      }
     }
 
-    for (const [key, { current, desired, visible }] of Object.entries(extras)) {
-      if (_.isEqual(current, desired)) {
-        results[key] = undefined;
-      } else {
-        results[key] = {
-          current, desired, visible: typeof visible === 'undefined' ? true : visible
+    for (const [key, checker] of Object.entries(checkers)) {
+      // We need the casts here because TypeScript can't match up the key with
+      // its corresponding checker.
+      cmp(key as any, checker as any);
+    }
+
+    for (const [key, entry] of Object.entries(extras)) {
+      if (!entry) {
+        // The list is hard-coded; getting here means a programming error.
+        throw new Error(`Invalid requiresRestartReasons extra key ${ key }`);
+      }
+
+      const desired = _.get(desiredSettings, key);
+      const { current, severity } = entry;
+
+      if (!_.isEqual(current, desired)) {
+        const fullKey = `kubernetes.${ key }` as keyof K8s.RestartReasons;
+
+        results[fullKey] = {
+          current, desired, severity: severity ? (severity as any)(current, desired) : 'restart'
         };
       }
     }

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 import { ServiceEntry } from './client';
 
 import { Settings } from '@/config/settings';
-import { RecursiveReadonly } from '@/utils/typeUtils';
+import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 
 export { ServiceEntry } from './client';
 
@@ -109,10 +109,12 @@ interface KubernetesBackendEvents {
 export type BackendSettings = RecursiveReadonly<Settings['kubernetes']>;
 
 /**
- * Details about why the backend must be restarted.  Normally returns as part
- * of a `Record<string, RestartReason>` from `requiresRestartReasons()`.
+ * Reasons that the backend might need to restart, as returned from
+ * `requiresRestartReasons()`.
+ * @returns A mapping of the preference causing the restart to the changed
+ *          values.
  */
-export type RestartReason = {
+export type RestartReasons = Partial<Record<RecursiveKeys<Settings>, {
   /**
    * The currently active value.
    */
@@ -123,10 +125,11 @@ export type RestartReason = {
    */
   desired: any;
   /**
-   * Whether to display this reason to the user.
+   * The severity of the restart; this may be set to `reset` for some values
+   * indicating that there will be data loss.
    */
-  visible: boolean;
-};
+  severity: 'restart' | 'reset';
+}>>;
 
 export interface KubernetesBackend extends events.EventEmitter, KubernetesBackendPortForwarder {
   /** The name of the Kubernetes backend */
@@ -199,12 +202,9 @@ export interface KubernetesBackend extends events.EventEmitter, KubernetesBacken
   factoryReset(keepSystemImages: boolean): Promise<void>;
 
   /**
-   * For all possible reasons that the cluster might need to restart, return
-   * either a reason that the restart is needed, or `undefined` to signal that
-   * a restart is not needed for this reason.
-   * @returns Reasons to restart.  The mapping key is a name for the reason.
+   * Check if applying the given settings would require the backend to restart.
    */
-  requiresRestartReasons(config: BackendSettings): Promise<Record<string, RestartReason | undefined>>;
+  requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons>;
 
   /**
    * Get the external IP address where the services would be listening on, if

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -2010,34 +2010,36 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     await Promise.all(promises);
   }
 
-  async requiresRestartReasons(cfg: Settings['kubernetes']): Promise<Record<string, K8s.RestartReason | undefined>> {
+  async requiresRestartReasons(cfg: RecursivePartial<K8s.BackendSettings>): Promise<K8s.RestartReasons> {
     const limaConfig = await this.getLimaConfig();
 
     if (!limaConfig || !this.cfg) {
       return {}; // No need to restart if nothing exists
     }
 
-    // If we're in the middle of something, or if we're in an error state, there
-    // is no need to tell the use about the need to restart.
-    const quiet = this.currentAction !== Action.NONE || this.internalState === K8s.State.ERROR;
     const GiB = 1024 * 1024 * 1024;
 
     return this.k3sHelper.requiresRestartReasons(
       this.cfg,
       cfg,
       {
-        version:           [false, 'version'],
-        port:              [true, 'port'],
-        containerEngine:   [false, 'containerEngine'],
-        enabled:           [false, 'enabled'],
-        'options.traefik': [false, 'options', 'traefik'],
-        'options.flannel': [false, 'options', 'flannel'],
-        sudo:              [false, 'suppressSudo'],
+        version: (current: string, desired: string) => {
+          if (semver.gt(current, desired)) {
+            return 'reset';
+          }
+
+          return 'restart';
+        },
+        port:              undefined,
+        containerEngine:   undefined,
+        enabled:           undefined,
+        'options.traefik': undefined,
+        'options.flannel': undefined,
+        suppressSudo:      undefined,
       },
-      quiet,
       {
-        cpu:    { current: limaConfig.cpus ?? 2, desired: cfg.numberCPUs },
-        memory: { current: (limaConfig.memory ?? 4) / GiB, desired: cfg.memoryInGB },
+        numberCPUs: { current: limaConfig.cpus ?? 2 },
+        memoryInGB: { current: (limaConfig.memory ?? 4 * GiB) / GiB },
       },
     );
   }

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import util from 'util';
 import semver from 'semver';
 
-import { KubernetesBackend, KubernetesError, State, RestartReason } from './k8s';
+import { KubernetesBackend, KubernetesError, State, RestartReasons } from './k8s';
 import ProgressTracker from './progressTracker';
 import { Settings } from '@/config/settings';
 import Logging from '@/utils/logging';
@@ -99,7 +99,7 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
 
   noModalDialogs = true;
 
-  requiresRestartReasons(): Promise<Record<string, RestartReason | undefined>> {
+  requiresRestartReasons(): Promise<RestartReasons> {
     return Promise.resolve({});
   }
 

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -50,9 +50,10 @@ export class HttpCommandServer {
     v0: {
       GET: { settings: this.listSettings },
       PUT: {
-        factory_reset: this.factoryReset,
-        shutdown:      this.wrapShutdown,
-        settings:      this.updateSettings
+        factory_reset:    this.factoryReset,
+        shutdown:         this.wrapShutdown,
+        settings:         this.updateSettings,
+        propose_settings: this.proposeSettings,
       },
     }
   };
@@ -80,11 +81,6 @@ export class HttpCommandServer {
       });
     }
     const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
-
-    if (/^(?:test|dev)/.test(process.env.NODE_ENV ?? '')) {
-      // For test & dev runs, add extra testing-only endpoints.
-      _.merge(this.dispatchTable, { v0: { GET: { test_backend_restart_reasons: this.testBackendRestartReasons } } });
-    }
 
     await fs.promises.writeFile(statePath,
       jsonStringifyWithWhiteSpace(this.externalState),
@@ -245,6 +241,33 @@ export class HttpCommandServer {
     });
   }
 
+  protected async readRequestSettings(request: http.IncomingMessage, functionName: string): Promise<[number, string] | RecursivePartial<Settings>> {
+    const [data, payloadError, payloadErrorCode] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
+
+    if (payloadError) {
+      return [payloadErrorCode, payloadError];
+    }
+
+    if (data.length === 0) {
+      return [400, 'no settings specified in the request'];
+    }
+
+    try {
+      const result = JSON.parse(data) ?? {};
+
+      if (typeof result !== 'object') {
+        return [400, 'settings payload is not an object'];
+      }
+
+      return result;
+    } catch (err) {
+      // TODO: Revisit this log stmt if sensitive values (e.g. PII, IPs, creds) can be provided via this command
+      console.log(`${ functionName }: error processing JSON request block\n${ data }\n`, err);
+
+      return [400, 'error processing JSON request block'];
+    }
+  }
+
   /**
    * Handle `PUT /v?/settings` requests.
    * Like the other methods, this method creates the request (here by reading the request body),
@@ -254,29 +277,21 @@ export class HttpCommandServer {
    * The incoming payload is expected to be a subset of the settings.Settings object
    */
   async updateSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
-    let values: Record<string, any> = {};
-    let result = '';
-    const [data, payloadError, payloadErrorCode] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
-    let error = '';
     let errorCode = 400;
+    let error = '';
+    let result = '';
+    const body = await this.readRequestSettings(request, 'updateSettings');
 
-    if (payloadError) {
-      error = payloadError;
-      errorCode = payloadErrorCode;
-    } else if (data.length === 0) {
-      error = 'no settings specified in the request';
+    if (Array.isArray(body)) {
+      [errorCode, error] = body;
     } else {
       try {
-        console.debug(`Request data: ${ data }`);
-        values = JSON.parse(data);
-      } catch (err) {
-        // TODO: Revisit this log stmt if sensitive values (e.g. PII, IPs, creds) can be provided via this command
-        console.log(`updateSettings: error processing JSON request block\n${ data }\n`, err);
-        error = 'error processing JSON request block';
+        [result, error] = await this.commandWorker.updateSettings(context, body);
+      } catch (ex) {
+        console.error(`updateSettings: exception when updating:`, ex);
+        errorCode = 500;
+        error = 'internal error';
       }
-    }
-    if (!error) {
-      [result, error] = await this.commandWorker.updateSettings(context, values);
     }
 
     if (error) {
@@ -286,6 +301,35 @@ export class HttpCommandServer {
     } else {
       console.debug(`updateSettings: write back status 202, result: ${ result }`);
       response.writeHead(202, { 'Content-Type': 'text/plain' });
+      response.write(result);
+    }
+  }
+
+  async proposeSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext) {
+    let errorCode = 400;
+    let error = '';
+    let result = '';
+    const body = await this.readRequestSettings(request, 'updateSettings');
+
+    try {
+      if (Array.isArray(body)) {
+        [errorCode, error] = body;
+      } else {
+        [result, error] = await this.commandWorker.proposeSettings(context, body);
+        console.error(`propose: ${ JSON.stringify(body) } -> ${ result }`);
+      }
+    } catch (ex) {
+      console.error('proposedSettings: internal error:', ex);
+      errorCode = 500;
+      error = 'internal error';
+    }
+    if (error) {
+      console.error(`proposeSettings: write back status ${ errorCode }, error: ${ error }`);
+      response.writeHead(errorCode, { 'Content-Type': 'text/plain' });
+      response.write(error);
+    } else {
+      console.error(`proposeSettings: write back status 200, result: ${ result }`);
+      response.writeHead(200, { 'Content-Type': 'application/json' });
       response.write(result);
     }
   }
@@ -320,7 +364,7 @@ export class HttpCommandServer {
         this.commandWorker.factoryReset(keepSystemImages);
       });
     } else {
-      console.debug(`updateSettings: write back status 400, error: ${ error }`);
+      console.debug(`factoryReset: write back status 400, error: ${ error }`);
       response.writeHead(400, { 'Content-Type': 'text/plain' });
       response.write(error);
     }
@@ -336,19 +380,6 @@ export class HttpCommandServer {
     });
 
     return Promise.resolve();
-  }
-
-  async testBackendRestartReasons(request: http.IncomingMessage, response: http.ServerResponse) {
-    try {
-      const result = await this.commandWorker.testBackendRestartReasons();
-
-      response.writeHead(200, { 'Content-Type': 'application/json' });
-      response.write(JSON.stringify(result));
-    } catch (ex) {
-      response.writeHead(500, 'Internal server error');
-      console.error(ex);
-      response.write(ex);
-    }
   }
 
   closeServer() {
@@ -371,12 +402,8 @@ export interface CommandWorkerInterface {
   factoryReset: (keepSystemImages: boolean) => void;
   getSettings: (context: commandContext) => string;
   updateSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
+  proposeSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
   requestShutdown: (context: commandContext) => void;
-
-  /**
-   * Testing only: list reasons why the backend requires a restart.
-   */
-   testBackendRestartReasons: () => Promise<Record<string, any>>;
 }
 
 // Extend CommandWorkerInterface to have extra types, as these types are used by

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import http from 'http';
 import path from 'path';
 import { URL } from 'url';
-import _ from 'lodash';
 
 import type { Settings } from '@/config/settings';
 import mainEvents from '@/main/mainEvents';
@@ -277,8 +276,8 @@ export class HttpCommandServer {
    * The incoming payload is expected to be a subset of the settings.Settings object
    */
   async updateSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
+    let error: string;
     let errorCode = 400;
-    let error = '';
     let result = '';
     const body = await this.readRequestSettings(request, 'updateSettings');
 
@@ -306,8 +305,8 @@ export class HttpCommandServer {
   }
 
   async proposeSettings(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext) {
+    let error: string;
     let errorCode = 400;
-    let error = '';
     let result = '';
     const body = await this.readRequestSettings(request, 'updateSettings');
 

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -17,7 +17,6 @@ interface IpcMainEvents {
   'k8s-state': () => void;
   'k8s-current-engine': () => void;
   'k8s-current-port': () => void;
-  'k8s-restart-required': () => void;
   'k8s-progress': () => void;
   'k8s-integrations': () => void;
   'k8s-integration-set': (name: string, newState: boolean) => void;
@@ -95,7 +94,6 @@ export interface IpcRendererEvents {
   'k8s-check-state': (state: import('@/k8s-engine/k8s').State) => void;
   'k8s-current-engine': (engine: import('@/config/settings').ContainerEngine) => void;
   'k8s-current-port': (port: number) => void;
-  'k8s-restart-required': (required: Record<string, import('@/k8s-engine/k8s').RestartReason | undefined>) => void;
   'k8s-versions': (versions: import('@/k8s-engine/k8s').VersionEntry[], boolean) => void;
   'k8s-integrations': (integrations: Record<string, boolean | string>) => void;
   'service-changed': (services: import('@/k8s-engine/k8s').ServiceEntry[]) => void;


### PR DESCRIPTION
This adds a `PUT /v0/propose_settings` API endpoint for use by the UI.

It takes the same sort of settings as `PUT /v0/settings`.

It returns a JSON object, where each key is a dot-separated setting name (e.g. `kubernetes.memoryInGB`), and returns an object with three fields:
  - `current`: The existing (active) setting.
  - `desired`: The setting that was submitted.
  - `severity`: Either `restart` or `reset`, depending on whether applying the setting will require removing existing user data.

The UI is expected to use this endpoint to determine what warning to show to the user about applying.

Fixes #2586.