### PR TITLE
Make use of tags and digest to delete images

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -316,7 +316,15 @@ export default {
       this.currentCommand = `delete ${ obj.imageName }:${ obj.tag }`;
       this.mainWindowScroll = this.main.scrollTop;
       this.startRunningCommand('delete');
-      ipcRenderer.send('do-image-deletion', obj.imageName.trim(), obj.imageID.trim());
+
+      ipcRenderer.send(
+        'do-image-deletion',
+        obj.imageName.trim(),
+        obj.imageID.trim(),
+        obj.tag.trim(),
+        obj.digest.trim()
+      );
+
       this.startImageManagerOutput();
     },
     doPush(obj) {

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -179,7 +179,7 @@ export default {
     },
     imageIdsToDelete() {
       return this.imagesToDelete
-        .map(image => image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`);
+        .map(this.getTaggedImage);
     },
     rows() {
       return this.filteredImages
@@ -274,9 +274,7 @@ export default {
     },
     async deleteImages() {
       const message = `Delete ${ this.imagesToDelete.length } ${ this.imagesToDelete.length > 1 ? 'images' : 'image' }?`;
-      const detail = this.imagesToDelete
-        .map(image => image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`)
-        .join('\n');
+      const detail = this.imageIdsToDelete.join('\n');
 
       const options = {
         message,
@@ -318,13 +316,7 @@ export default {
       this.mainWindowScroll = this.main.scrollTop;
       this.startRunningCommand('delete');
 
-      ipcRenderer.send(
-        'do-image-deletion',
-        obj.imageName.trim(),
-        obj.imageID.trim(),
-        obj.tag.trim(),
-        obj.digest.trim()
-      );
+      ipcRenderer.send('do-image-deletion', obj.imageName.trim(), this.getTaggedImage(obj));
 
       this.startImageManagerOutput();
     },
@@ -368,6 +360,9 @@ export default {
       if (!val && this.mainWindowScroll >= 0) {
         this.scrollToTop();
       }
+    },
+    getTaggedImage(image) {
+      return image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`;
     }
   },
 };

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -178,7 +178,8 @@ export default {
       return this.selected.filter(image => this.isDeletable(image));
     },
     imageIdsToDelete() {
-      return this.imagesToDelete.map(image => image.imageID);
+      return this.imagesToDelete
+        .map(image => image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`);
     },
     rows() {
       return this.filteredImages
@@ -274,7 +275,7 @@ export default {
     async deleteImages() {
       const message = `Delete ${ this.imagesToDelete.length } ${ this.imagesToDelete.length > 1 ? 'images' : 'image' }?`;
       const detail = this.imagesToDelete
-        .map(image => `${ image.imageName }:${ image.tag }`)
+        .map(image => image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`)
         .join('\n');
 
       const options = {

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -30,11 +30,11 @@ export interface childResultType {
  * The fields for display in the images table
  */
 export interface imageType {
-  imageName: string,
-  tag: string,
-  imageID: string,
-  size: string,
-  digest: string
+  imageName: string;
+  tag: string;
+  imageID: string;
+  size: string;
+  digest: string;
 }
 
 /**

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -389,7 +389,7 @@ export abstract class ImageProcessor extends EventEmitter {
 
   abstract buildImage(dirPart: string, filePart: string, taggedImageName: string): Promise<childResultType>;
 
-  abstract deleteImage(imageID: string, name: string, tag: string, digest: string): Promise<childResultType>;
+  abstract deleteImage(imageID: string): Promise<childResultType>;
 
   abstract deleteImages(imageIDs: string[]): Promise<childResultType>;
 

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -34,6 +34,7 @@ export interface imageType {
   tag: string,
   imageID: string,
   size: string,
+  digest: string
 }
 
 /**
@@ -246,13 +247,17 @@ export abstract class ImageProcessor extends EventEmitter {
   }
 
   protected parse(data: string): imageType[] {
-    const results = data.trimEnd().split(/\r?\n/).slice(1).map((line) => {
-      const [imageName, tag, imageID, size] = line.split(/\s+/);
+    const results = data
+      .trimEnd()
+      .split(/\r?\n/)
+      .slice(1)
+      .map((line) => {
+        const [imageName, tag, digest, imageID, _created, _platform, size, _blobSize] = line.split(/\s+/);
 
-      return {
-        imageName, tag, imageID, size
-      };
-    });
+        return {
+          imageName, tag, imageID, size, digest
+        };
+      });
 
     return results;
   }

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -389,7 +389,7 @@ export abstract class ImageProcessor extends EventEmitter {
 
   abstract buildImage(dirPart: string, filePart: string, taggedImageName: string): Promise<childResultType>;
 
-  abstract deleteImage(imageID: string): Promise<childResultType>;
+  abstract deleteImage(imageID: string, name: string, tag: string, digest: string): Promise<childResultType>;
 
   abstract deleteImages(imageIDs: string[]): Promise<childResultType>;
 

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -60,7 +60,7 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
 
   async getImages(): Promise<imageProcessor.childResultType> {
     return await this.runImagesCommand(
-      ['images', '--format', '{{json .}}'],
+      ['images', '--digests', '--format', '{{json .}}'],
       false);
   }
 

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -100,7 +100,8 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
 
   parse(data: string): imageProcessor.imageType[] {
     const images: Array<imageProcessor.imageType> = [];
-    const records = data.split(/\r?\n/)
+    const records = data
+      .split(/\r?\n/)
       .filter(line => line.trim().length > 0)
       .map((line) => {
         try {
@@ -121,7 +122,8 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
         imageName: record.Repository,
         tag:       record.Tag,
         imageID:   record.ID,
-        size:      record.Size
+        size:      record.Size,
+        digest:    record.Digest
       });
     }
 

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -84,8 +84,10 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
     return await this.runImagesCommand(args);
   }
 
-  async deleteImage(imageID: string): Promise<imageProcessor.childResultType> {
-    return await this.runImagesCommand(['rmi', imageID]);
+  async deleteImage(imageID: string, name: string, tag: string, digest: string): Promise<imageProcessor.childResultType> {
+    const imageToDelete = tag !== '<none>' ? `${ name }:${ tag }` : `${ name }@${ digest }`;
+
+    return await this.runImagesCommand(['rmi', imageToDelete]);
   }
 
   async deleteImages(imageIDs: string[]): Promise<imageProcessor.childResultType> {

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -160,7 +160,8 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
         imageName: record.Repository,
         tag:       record.Tag,
         imageID:   record.ID,
-        size:      record.Size
+        size:      record.Size,
+        digest:    record.Digest
       });
     }
 

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -84,10 +84,8 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
     return await this.runImagesCommand(args);
   }
 
-  async deleteImage(imageID: string, name: string, tag: string, digest: string): Promise<imageProcessor.childResultType> {
-    const imageToDelete = tag !== '<none>' ? `${ name }:${ tag }` : `${ name }@${ digest }`;
-
-    return await this.runImagesCommand(['rmi', imageToDelete]);
+  async deleteImage(imageID: string): Promise<imageProcessor.childResultType> {
+    return await this.runImagesCommand(['rmi', imageID]);
   }
 
   async deleteImages(imageIDs: string[]): Promise<imageProcessor.childResultType> {

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -102,7 +102,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
 
   async getImages(): Promise<imageProcessor.childResultType> {
     return await this.runImagesCommand(
-      ['images', '--format', '{{json .}}'],
+      ['images', '--digests', '--format', '{{json .}}'],
       false);
   }
 

--- a/src/main/imageEvents.ts
+++ b/src/main/imageEvents.ts
@@ -55,9 +55,9 @@ export class ImageEventHandler {
       return this.imageProcessor.listImages();
     });
 
-    Electron.ipcMain.on('do-image-deletion', async(event, imageName, imageID) => {
+    Electron.ipcMain.on('do-image-deletion', async(event, imageName, imageID, imageTag, digest) => {
       try {
-        await this.imageProcessor.deleteImage(imageID);
+        await this.imageProcessor.deleteImage(imageID, imageName, imageTag, digest);
         await this.imageProcessor.refreshImages();
         event.reply('images-process-ended', 0);
       } catch (err) {

--- a/src/main/imageEvents.ts
+++ b/src/main/imageEvents.ts
@@ -55,9 +55,9 @@ export class ImageEventHandler {
       return this.imageProcessor.listImages();
     });
 
-    Electron.ipcMain.on('do-image-deletion', async(event, imageName, imageID, imageTag, digest) => {
+    Electron.ipcMain.on('do-image-deletion', async(event, imageName, imageID) => {
       try {
-        await this.imageProcessor.deleteImage(imageID, imageName, imageTag, digest);
+        await this.imageProcessor.deleteImage(imageID);
         await this.imageProcessor.refreshImages();
         event.reply('images-process-ended', 0);
       } catch (err) {


### PR DESCRIPTION
This attempts to make deleting images from the UI a little more predictable by making use of an image tag or digest instead of using the image id. This should still behave the same as before if there is an image with only a single tag. The docker documentation states:

> If an image has multiple tags, using this command with the tag as a parameter only removes the tag. If the tag is the only one for the image, both the image and the tag are removed.

I chose to also include the digest so that we can handle the case where we need to delete an image with no tag. I've been using `kubectl` to test this use case with

```
kubectl create deploy busybox --image=busybox --replicas=2 -- /bin/sh -c "sleep inf"
```

This should create an image without a tag when using `nerdctl`. 

More testing notes in #2347 

closes #2435
closes #2347