### PR TITLE
docker-credential-rancher-desktop should not display curl progress bar

### DIFF
--- a/src/assets/scripts/docker-credential-rancher-desktop
+++ b/src/assets/scripts/docker-credential-rancher-desktop
@@ -8,4 +8,4 @@ DATA="@-"
 # The "list" command doesn't have a payload on STDIN
 [ "$1" = "list" ] && DATA=""
 
-exec curl --user "$CREDFWD_AUTH" --data "$DATA" --noproxy '*' --fail-with-body "$CREDFWD_URL/$1"
+exec curl --silent --show-error --user "$CREDFWD_AUTH" --data "$DATA" --noproxy '*' --fail-with-body "$CREDFWD_URL/$1"


### PR DESCRIPTION
Otherwise it becomes visible when pulling images via nerdctl while
being logged into Docker Hub:

```console
$ nerdctl pull busybox
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   103    0    88  100    15   3361    572 --:--:-- --:--:-- --:--:--  3961
docker.io/library/busybox:latest:                                                 resolved       |++++++++++++++++++++++++++++++++++++++|
...
```
