### PR TITLE
Bind the current Kubernetes version with v-model

### DIFF
--- a/src/components/Preferences/BodyKubernetes.vue
+++ b/src/components/Preferences/BodyKubernetes.vue
@@ -26,6 +26,7 @@ export default Vue.extend({
       settings:           { kubernetes: {} } as Settings,
       versions:           [] as VersionEntry[],
       cachedVersionsOnly: false,
+      kubernetesVersion:  this.preferences.kubernetes.version
     };
   },
   computed: {
@@ -100,9 +101,9 @@ export default Vue.extend({
       :legend-text="kubernetesVersionLabel"
     >
       <select
+        v-model="kubernetesVersion"
         class="select-k8s-version"
         :disabled="isKubernetesDisabled"
-        :value="preferences.kubernetes.version"
         @change="onChange('kubernetes.version', $event.target.value)"
       >
         <!--

--- a/src/components/Preferences/BodyKubernetes.vue
+++ b/src/components/Preferences/BodyKubernetes.vue
@@ -23,7 +23,6 @@ export default Vue.extend({
       enableKubernetes:   true,
       enableTraefik:      true,
       kubernetesPort:     6443,
-      settings:           { kubernetes: {} } as Settings,
       versions:           [] as VersionEntry[],
       cachedVersionsOnly: false,
       kubernetesVersion:  this.preferences.kubernetes.version
@@ -54,7 +53,6 @@ export default Vue.extend({
     ipcRenderer.on('k8s-versions', (event, versions, cachedVersionsOnly) => {
       this.versions = versions;
       this.cachedVersionsOnly = cachedVersionsOnly;
-      this.settings.kubernetes.version = this.defaultVersion.version.version;
     });
 
     ipcRenderer.send('k8s-versions');


### PR DESCRIPTION
This provides us with the correct default value for Kubernetes Version by using `v-model` instead of `:value` for the select. I'm not a fan of this approach because `v-model` is shorthand for using `:value` and `change`, but this is the change that's getting this to work right now. [I went back to the docs](https://v2.vuejs.org/v2/guide/forms.html#Basic-Usage) to double-check that the implementation was correct and it looks like it was

> select fields use `value` as a prop and `change` as an event.

This fixes the issue for now, but I'm still investigating to see if this is a new problem with the preferences ui or the result of something that has been recently merged. I'm open to other suggestions. 

closes #2599 