### PR TITLE
No need to pass `--tty --stdin` to `k exec` when not doing anything interactive.

### DIFF
--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -85,10 +85,10 @@ test.describe.serial('Helm Deployment Test', () => {
     // Get Node Port number.
     const nodePortNumber = (await kubectl('get', '--namespace', 'default', '--output=jsonpath={.spec.ports[0].nodePort}', 'services', 'nginx-sample')).trim();
 
-    const podName = (await kubectl('get', 'pods', '--output=name', '--namespace', 'default')).trim();
+    const podName = (await kubectl('get', 'pods', '--output=name', '--namespace', 'default')).split(/\s+/).filter(pod => pod.includes('pod/nginx-sample'))[0].trim();
 
     // Check is the app is running
-    const checkAppStatus = await kubectl('exec', '--namespace', 'default', '--stdin', '--tty',
+    const checkAppStatus = await kubectl('exec', '--namespace', 'default',
       podName, '--', 'curl', '--fail', `${ nodeIpAddress }:${ nodePortNumber }`);
 
     expect(checkAppStatus).toContain('Welcome to nginx!');

--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -85,9 +85,11 @@ test.describe.serial('Helm Deployment Test', () => {
     // Get Node Port number.
     const nodePortNumber = (await kubectl('get', '--namespace', 'default', '--output=jsonpath={.spec.ports[0].nodePort}', 'services', 'nginx-sample')).trim();
 
-    const podName = (await kubectl('get', 'pods', '--output=name', '--namespace', 'default')).split(/\s+/).filter(pod => pod.includes('pod/nginx-sample'))[0].trim();
+    const currentPodNames = (await kubectl('get', 'pods', '--output=name', '--namespace', 'default')).split(/\s+/);
+    const podName = currentPodNames.find(pod => pod.includes('pod/nginx-sample'))?.trim() ?? '';
 
-    // Check is the app is running
+    expect(podName).not.toBe('');
+    // Check if the app is running
     const checkAppStatus = await kubectl('exec', '--namespace', 'default',
       podName, '--', 'curl', '--fail', `${ nodeIpAddress }:${ nodePortNumber }`);
 


### PR DESCRIPTION
No existing issue.

Sometimes the CI fails the call to `kubectl exec NGINX-POD -- curl IP:PORT` with
the error message:

    stdout:
    stderr: Unable to use a TTY - input is not a terminal or the right kind of file
    Error from server: error dialing backend: EOF

There's no need to pass `--tty --stdin` to the call to `exec`.

Also filter out other pods for when this test is run locally on an existing
k8s backend, with other pods in the default namespace.

Signed-off-by: Eric Promislow <epromislow@suse.com>