### PR TITLE
Move keep cached images option to message box

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -626,7 +626,11 @@ Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBo
 });
 
 Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.MessageBoxOptions, modal = false) => {
-  const dialog = window.openDialog('Dialog', { frame: true });
+  const mainWindow = modal ? window.getWindow('main') : null;
+
+  const dialog = window.openDialog('Dialog', {
+    modal, parent: mainWindow || undefined, frame: true
+  });
 
   let response = {};
 

--- a/background.ts
+++ b/background.ts
@@ -634,7 +634,8 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
       modal,
       parent: mainWindow || undefined,
       frame:  true,
-      title:  options.title
+      title:  options.title,
+      height: 225
     });
 
   let response: any;

--- a/background.ts
+++ b/background.ts
@@ -628,9 +628,13 @@ Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBo
 Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.MessageBoxOptions, modal = false) => {
   const mainWindow = modal ? window.getWindow('main') : null;
 
-  const dialog = window.openDialog('Dialog', {
-    modal, parent: mainWindow || undefined, frame: true
-  });
+  const dialog = window.openDialog(
+    'Dialog', {
+      modal,
+      parent: mainWindow || undefined,
+      frame:  true,
+      title:  options.title
+    });
 
   let response = {};
 

--- a/background.ts
+++ b/background.ts
@@ -640,7 +640,7 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
   let response: any;
 
   dialog.webContents.on('ipc-message', (_event, channel, args) => {
-    if (channel === 'dialog/ready') {
+    if (channel === 'dialog/mounted') {
       dialog.webContents.send('dialog/options', options);
     }
 

--- a/background.ts
+++ b/background.ts
@@ -625,6 +625,10 @@ Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBo
   return window.showMessageBox(options, modal);
 });
 
+Electron.ipcMain.handle('show-message-box-rd', (_event, options: Electron.MessageBoxOptions, modal = false) => {
+  window.openDialog('Dialog', { frame: true });
+});
+
 function getProductionVersion() {
   try {
     return Electron.app.getVersion();

--- a/background.ts
+++ b/background.ts
@@ -626,7 +626,17 @@ Electron.ipcMain.handle('show-message-box', (_event, options: Electron.MessageBo
 });
 
 Electron.ipcMain.handle('show-message-box-rd', (_event, options: Electron.MessageBoxOptions, modal = false) => {
-  window.openDialog('Dialog', { frame: true });
+  const dialog = window.openDialog('Dialog', { frame: true });
+
+  dialog.webContents.on('ipc-message', (_event, channel) => {
+    if (channel === 'dialog/ready') {
+      dialog.webContents.send('dialog/options', options);
+    }
+
+    if (channel === 'dialog/close') {
+      console.debug('NOT FAIL');
+    }
+  });
 });
 
 function getProductionVersion() {

--- a/background.ts
+++ b/background.ts
@@ -629,14 +629,15 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
   const mainWindow = modal ? window.getWindow('main') : null;
 
   const dialog = window.openDialog(
-    'Dialog', {
+    'Dialog',
+    {
       modal,
       parent: mainWindow || undefined,
       frame:  true,
       title:  options.title
     });
 
-  let response = {};
+  let response: any;
 
   dialog.webContents.on('ipc-message', (_event, channel, args) => {
     if (channel === 'dialog/ready') {
@@ -644,9 +645,17 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
     }
 
     if (channel === 'dialog/close') {
-      response = args;
+      response = args || { response: options.cancelId };
       dialog.close();
     }
+  });
+
+  dialog.on('close', () => {
+    if (response) {
+      return;
+    }
+
+    response = { response: options.cancelId };
   });
 
   await (new Promise<void>((resolve) => {

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4596,6 +4596,13 @@ troubleshooting:
       title: Factory Reset
       description: Factory Reset will remove all Rancher Desktop Configurations.
       buttonText: Factory Reset
+      messageBox:
+        title: Rancher Desktop - Factory Reset
+        message: Perform a factory reset?
+        detail: Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again. Are you sure you want to factory reset?
+        checkboxLabel: Keep cached Kubernetes images
+        ok: Factory Reset
+        cancel: Cancel
   needHelp: 'Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.'
 
 ##############################

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4599,7 +4599,7 @@ troubleshooting:
       messageBox:
         title: Rancher Desktop - Factory Reset
         message: Perform a factory reset?
-        detail: Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again. Are you sure you want to factory reset?
+        detail: <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to factory reset?</p>
         checkboxLabel: Keep cached Kubernetes images
         ok: Factory Reset
         cancel: Cancel

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4599,7 +4599,7 @@ troubleshooting:
       messageBox:
         title: Rancher Desktop - Factory Reset
         message: Perform a factory reset?
-        detail: <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to factory reset?</p>
+        detail: <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
         checkboxLabel: Keep cached Kubernetes images
         ok: Factory Reset
         cancel: Cancel

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -1,0 +1,55 @@
+<script lang="ts">
+import Vue from 'vue';
+import Checkbox from '@/components/form/Checkbox.vue';
+
+export default Vue.extend({
+  name:       'rd-dialog',
+  components: { Checkbox },
+  layout:     'dialog'
+});
+</script>
+
+<template>
+  <div class="dialog-container">
+    <div class="title">
+      <slot name="title">
+        This is an example title
+      </slot>
+    </div>
+    <div class="detail">
+      <slot name="detail">
+        This is some great detail.
+      </slot>
+    </div>
+    <div class="checkbox">
+      <slot name="checkbox">
+        <checkbox label="I think this is great?" />
+      </slot>
+    </div>
+    <div class="actions">
+      <slot name="actions">
+        <button class="btn role-primary">
+          OK
+        </button>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .dialog-container {
+    display: flex;
+  }
+
+  .title {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    padding-top: 1rem;
+  }
+</style>

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
     </div>
     <div v-if="detail" class="detail">
       <slot name="detail">
-        {{ detail }}
+        <span class="detail-span" v-html="detail" />
       </slot>
     </div>
     <div v-if="checkboxLabel" class="checkbox">
@@ -108,6 +108,17 @@ export default Vue.extend({
     font-size: 1.5rem;
     line-height: 2rem;
     font-weight: 600;
+  }
+
+  .detail {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  .detail-span {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
   }
 
   .checkbox {

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
+import { ipcRenderer } from 'electron';
+
 import Checkbox from '@/components/form/Checkbox.vue';
 
 export default Vue.extend({
@@ -8,32 +10,43 @@ export default Vue.extend({
   layout:     'dialog',
   data() {
     return {
-      message:           '',
+      message:         '',
       detail:          '',
       checkboxLabel:   '',
       buttons:         [],
       response:        0,
       checkboxChecked: false
     };
+  },
+  mounted() {
+    ipcRenderer.on('dialog/options', (_event, options: any) => {
+      console.debug('DIALOG OPTIONS', { options });
+      this.message = options.message;
+      this.detail = options.detail;
+      this.checkboxLabel = options.checkboxLabel;
+      this.buttons = options.buttons;
+    });
+
+    ipcRenderer.send('dialog/ready');
   }
 });
 </script>
 
 <template>
   <div class="dialog-container">
-    <div class="message">
+    <div v-if="message" class="message">
       <slot name="message">
-        This is an example message
+        {{ message }}
       </slot>
     </div>
-    <div class="detail">
+    <div v-if="detail" class="detail">
       <slot name="detail">
-        This is some great detail.
+        {{ detail }}
       </slot>
     </div>
-    <div class="checkbox">
+    <div v-if="checkboxLabel" class="checkbox">
       <slot name="checkbox">
-        <checkbox v-model="checkboxChecked" label="I think this is great?" />
+        <checkbox v-model="checkboxChecked" :label="checkboxLabel" />
       </slot>
     </div>
     <div class="actions">
@@ -61,11 +74,18 @@ export default Vue.extend({
 <style lang="scss" scoped>
   .dialog-container {
     display: flex;
+    width: 32rem;
+    max-width: 40rem;
   }
 
   .message {
     font-size: 1.5rem;
     line-height: 2rem;
+    font-weight: 600;
+  }
+
+  .checkbox {
+    padding-left: 0.25rem;
   }
 
   .actions {

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -22,7 +22,6 @@ export default Vue.extend({
   },
   mounted() {
     ipcRenderer.on('dialog/options', (_event, options: any) => {
-      console.debug('DIALOG OPTIONS', { options });
       this.message = options.message;
       this.detail = options.detail;
       this.checkboxLabel = options.checkboxLabel;
@@ -34,12 +33,9 @@ export default Vue.extend({
   },
   methods: {
     close(index: number) {
-      console.debug('close', { index, isChecked: this.checkboxChecked });
       ipcRenderer.send('dialog/close', { response: index, checkboxChecked: this.checkboxChecked });
     },
     isDarwin() {
-      console.debug(os.platform().startsWith('darwin'));
-
       return os.platform().startsWith('darwin');
     }
   }

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import os from 'os';
 import Vue from 'vue';
 import { ipcRenderer } from 'electron';
 
@@ -35,6 +36,11 @@ export default Vue.extend({
     close(index: number) {
       console.debug('close', { index, isChecked: this.checkboxChecked });
       ipcRenderer.send('dialog/close', { response: index, checkboxChecked: this.checkboxChecked });
+    },
+    isDarwin() {
+      console.debug(os.platform().startsWith('darwin'));
+
+      return os.platform().startsWith('darwin');
     }
   }
 });
@@ -57,7 +63,10 @@ export default Vue.extend({
         <checkbox v-model="checkboxChecked" :label="checkboxLabel" />
       </slot>
     </div>
-    <div class="actions">
+    <div
+      class="actions"
+      :class="{ 'actions-reverse': isDarwin() }"
+    >
       <slot name="actions">
         <template v-if="!buttons.length">
           <button class="btn role-primary">
@@ -103,5 +112,10 @@ export default Vue.extend({
     justify-content: flex-end;
     gap: 0.25rem;
     padding-top: 1rem;
+  }
+
+  .actions-reverse {
+    justify-content: flex-start;
+    flex-direction: row-reverse;
   }
 </style>

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -5,15 +5,25 @@ import Checkbox from '@/components/form/Checkbox.vue';
 export default Vue.extend({
   name:       'rd-dialog',
   components: { Checkbox },
-  layout:     'dialog'
+  layout:     'dialog',
+  data() {
+    return {
+      message:           '',
+      detail:          '',
+      checkboxLabel:   '',
+      buttons:         [],
+      response:        0,
+      checkboxChecked: false
+    };
+  }
 });
 </script>
 
 <template>
   <div class="dialog-container">
-    <div class="title">
-      <slot name="title">
-        This is an example title
+    <div class="message">
+      <slot name="message">
+        This is an example message
       </slot>
     </div>
     <div class="detail">
@@ -23,14 +33,26 @@ export default Vue.extend({
     </div>
     <div class="checkbox">
       <slot name="checkbox">
-        <checkbox label="I think this is great?" />
+        <checkbox v-model="checkboxChecked" label="I think this is great?" />
       </slot>
     </div>
     <div class="actions">
       <slot name="actions">
-        <button class="btn role-primary">
-          OK
-        </button>
+        <template v-if="!buttons.length">
+          <button class="btn role-primary">
+            OK
+          </button>
+        </template>
+        <template v-else>
+          <button
+            v-for="(buttonText, index) in buttons"
+            :key="index"
+            class="btn role-primary"
+            :class="index === 0 ? 'role-primary' : 'role-secondary'"
+          >
+            {{ buttonText }}
+          </button>
+        </template>
       </slot>
     </div>
   </div>
@@ -41,7 +63,7 @@ export default Vue.extend({
     display: flex;
   }
 
-  .title {
+  .message {
     font-size: 1.5rem;
     line-height: 2rem;
   }
@@ -50,6 +72,7 @@ export default Vue.extend({
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+    gap: 0.25rem;
     padding-top: 1rem;
   }
 </style>

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -30,9 +30,10 @@ export default Vue.extend({
       this.checkboxLabel = options.checkboxLabel;
       this.buttons = options.buttons;
       this.cancelId = options.cancelId;
+      ipcRenderer.send('dialog/ready');
     });
 
-    ipcRenderer.send('dialog/ready');
+    ipcRenderer.send('dialog/mounted');
   },
   beforeDestroy() {
     window.removeEventListener('keydown', this.handleKeypress, true);

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -20,6 +20,9 @@ export default Vue.extend({
       cancelId:        0
     };
   },
+  beforeMount() {
+    window.addEventListener('keydown', this.handleKeypress, true);
+  },
   mounted() {
     ipcRenderer.on('dialog/options', (_event, options: any) => {
       this.message = options.message;
@@ -31,12 +34,20 @@ export default Vue.extend({
 
     ipcRenderer.send('dialog/ready');
   },
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.handleKeypress, true);
+  },
   methods: {
     close(index: number) {
       ipcRenderer.send('dialog/close', { response: index, checkboxChecked: this.checkboxChecked });
     },
     isDarwin() {
       return os.platform().startsWith('darwin');
+    },
+    handleKeypress(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        this.close(this.cancelId);
+      }
     }
   }
 });

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -15,7 +15,8 @@ export default Vue.extend({
       checkboxLabel:   '',
       buttons:         [],
       response:        0,
-      checkboxChecked: false
+      checkboxChecked: false,
+      cancelId:        0
     };
   },
   mounted() {
@@ -25,9 +26,16 @@ export default Vue.extend({
       this.detail = options.detail;
       this.checkboxLabel = options.checkboxLabel;
       this.buttons = options.buttons;
+      this.cancelId = options.cancelId;
     });
 
     ipcRenderer.send('dialog/ready');
+  },
+  methods: {
+    close(index: number) {
+      console.debug('close', { index, isChecked: this.checkboxChecked });
+      ipcRenderer.send('dialog/close', { response: index, checkboxChecked: this.checkboxChecked });
+    }
   }
 });
 </script>
@@ -62,6 +70,7 @@ export default Vue.extend({
             :key="index"
             class="btn role-primary"
             :class="index === 0 ? 'role-primary' : 'role-secondary'"
+            @click="close(index)"
           >
             {{ buttonText }}
           </button>

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -123,7 +123,8 @@ export default {
             this.t('troubleshooting.general.factoryReset.messageBox.cancel')
           ],
           cancelId: cancelPosition
-        }
+        },
+        true
       );
 
       const { response, checkboxChecked: keepImages } = confirm;
@@ -146,7 +147,7 @@ export default {
       const detail = this.t('troubleshooting.kubernetes.resetKubernetes.description');
 
       const confirm = await ipcRenderer.invoke(
-        'show-message-box',
+        'show-message-box-rd',
         {
           message,
           detail,

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -107,7 +107,7 @@ export default {
     async factoryReset() {
       const cancelPosition = 1;
       const message = this.t('troubleshooting.general.factoryReset.messageBox.message');
-      const detail = this.t('troubleshooting.general.factoryReset.messageBox.detail');
+      const detail = this.t('troubleshooting.general.factoryReset.messageBox.detail', { }, true);
 
       const confirm = await ipcRenderer.invoke(
         'show-message-box-rd',

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -110,7 +110,7 @@ export default {
       const detail = this.t('troubleshooting.general.factoryReset.messageBox.detail');
 
       const confirm = await ipcRenderer.invoke(
-        'show-message-box',
+        'show-message-box-rd',
         {
           message,
           detail,
@@ -123,8 +123,7 @@ export default {
             this.t('troubleshooting.general.factoryReset.messageBox.cancel')
           ],
           cancelId: cancelPosition
-        },
-        true
+        }
       );
 
       const { response, checkboxChecked: keepImages } = confirm;

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -117,6 +117,7 @@ export interface IpcRendererEvents {
   // #region dialog
   'dalog/populate': (...args: any) => void;
   'dialog/size': (size: {width: number, height: number}) => void;
+  'dialog/options': (...args: any) => void;
   // #endregion
 
   // #region api

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -118,6 +118,7 @@ export interface IpcRendererEvents {
   'dalog/populate': (...args: any) => void;
   'dialog/size': (size: {width: number, height: number}) => void;
   'dialog/options': (...args: any) => void;
+  'dialog/close': (...args: any) => void;
   // #endregion
 
   // #region api

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -154,7 +154,7 @@ function resizeWindow(window: Electron.BrowserWindow, width: number, height: num
  * @param id The URL for the dialog, corresponds to a Nuxt page; e.g. FirstRun.
  * @returns The opened window
  */
-function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions) {
+export function openDialog(id: string, opts?: Electron.BrowserWindowConstructorOptions) {
   const webRoot = getWebRoot();
   const window = createWindow(
     id,


### PR DESCRIPTION
This moves the "Keep cached images" option to the Factory Reset dialog. This pattern is consistent with the Reset Kubernetes dialog and keeps the actions on the page right-aligned. 

### Example

<img width="1052" alt="Screen Shot 2022-07-21 at 4 21 19 PM" src="https://user-images.githubusercontent.com/835961/180330989-4dc94002-02d6-4376-b7ae-9201fb83bccf.png">

closes #2494 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>