### PR TITLE
Force nuxt to use localhost as hostname

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -89,6 +89,7 @@ class DevRunner extends events.EventEmitter {
   startRendererProcess() {
     this.#rendererProcess = this.spawn('Renderer process',
       'node', 'node_modules/nuxt/bin/nuxt.js',
+      '--hostname', 'localhost',
       '--port', this.rendererPort, buildUtils.rendererSrcDir);
 
     return Promise.resolve();

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -83,6 +83,7 @@ class E2ETestRunner extends events.EventEmitter {
   startRendererProcess() {
     this.#rendererProcess = this.spawn('Renderer process',
       'node', 'node_modules/nuxt/bin/nuxt.js',
+      '--hostname', 'localhost',
       '--port', this.rendererPort, buildUtils.rendererSrcDir);
 
     return Promise.resolve();


### PR DESCRIPTION
This allows e2e tests and `npm run dev` to run correctly in contexts where the environment variable `$HOST` is set to anything other than `localhost` (this happens by default on openSUSE).

Context: https://github.com/rancher-sandbox/rancher-desktop/pull/2177#issuecomment-1161529636