### PR TITLE
docker-credential-rancher-desktop should not show curl errors

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -127,7 +127,7 @@ describeWithCreds('Credentials server', () => {
   async function rdctlCredWithStdin(command: string, input?: string): Promise<{ stdout: string, stderr: string }> {
     try {
       const body = stream.Readable.from(input ?? '');
-      const args = ['shell', '/usr/local/bin/docker-credential-rancher-desktop'].concat([command]);
+      const args = ['shell', 'sh', '-c', `CREDFWD_CURL_OPTS=--show-error /usr/local/bin/docker-credential-rancher-desktop ${ command }`];
 
       return await spawnFile(rdctlPath(), args, { stdio: [body, 'pipe', 'pipe'] });
     } catch (err: any) {
@@ -317,7 +317,8 @@ describeWithCreds('Credentials server', () => {
       'shell',
       'sh',
       '-c',
-      `SECRET=$(tr -dc 'A-Za-z0-9,._=' < /dev/urandom |  head -c5242880); \
+      `export CREDFWD_CURL_OPTS="--show-error"; \
+       SECRET=$(tr -dc 'A-Za-z0-9,._=' < /dev/urandom |  head -c5242880); \
        echo '{"ServerURL":"https://example.com/v1","Username":"alice","Secret":"'$SECRET'"}' |
          /usr/local/bin/docker-credential-rancher-desktop store`
     ];

--- a/src/assets/scripts/docker-credential-rancher-desktop
+++ b/src/assets/scripts/docker-credential-rancher-desktop
@@ -8,4 +8,5 @@ DATA="@-"
 # The "list" command doesn't have a payload on STDIN
 [ "$1" = "list" ] && DATA=""
 
-exec curl --silent --show-error --user "$CREDFWD_AUTH" --data "$DATA" --noproxy '*' --fail-with-body "$CREDFWD_URL/$1"
+# $CREDFWD_CURL_OPTS is intentionally *not* quoted
+exec curl --silent --user "$CREDFWD_AUTH" --data "$DATA" --noproxy '*' --fail-with-body ${CREDFWD_CURL_OPTS:-} "$CREDFWD_URL/$1"


### PR DESCRIPTION
But add an option to allow adding --show-error option for e2e tests.

Fixes #2613