### PR TITLE
E2E: Use mock backend for prefs test.

### DIFF
--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -31,7 +31,8 @@ test.describe.serial('Main App Test', () => {
       ],
       env: {
         ...process.env,
-        RD_LOGS_DIR: reportAsset(__filename, 'log')
+        RD_LOGS_DIR:     reportAsset(__filename, 'log'),
+        RD_MOCK_BACKEND: '1',
       },
     });
     context = electronApp.context();

--- a/src/k8s-engine/mock.ts
+++ b/src/k8s-engine/mock.ts
@@ -13,7 +13,7 @@ const console = Logging.mock;
 export default class MockBackend extends events.EventEmitter implements KubernetesBackend {
   readonly backend = 'mock';
   state: State = State.STOPPED;
-  readonly availableVersions = Promise.resolve([{ version: new semver.SemVer('0.0.0') }]);
+  readonly availableVersions = Promise.resolve([{ version: new semver.SemVer('0.0.0'), channels: ['latest'] }]);
   version = '';
   readonly cpus = Promise.resolve(1);
   readonly memory = Promise.resolve(1);


### PR DESCRIPTION
This fixes the mock backend to pass the prefs E2E tests, and hooks it up.

This should lead to faster tests.