### PR TITLE
GitHub Workflow: simplify packaging a bit.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,15 +18,16 @@ jobs:
   package:
     strategy:
       matrix:
-        os: [macos-intel, macos-arm, windows, linux]
         include:
-        - os: macos-intel
+        - platform: mac
+          arch: x86_64
           runs-on: macos-11
-        - os: macos-arm
+        - platform: mac
+          arch: aarch64
           runs-on: macos-11
-        - os: windows
+        - platform: win
           runs-on: windows-2019
-        - os: linux
+        - platform: linux
           runs-on: ubuntu-latest
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -54,103 +55,72 @@ jobs:
           sudo apt-get update
           sudo apt-get install flatpak flatpak-builder
           flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-    - name: npm ci
-      if: matrix.os != 'macos-arm'
-      run: npm ci
-    - name: npm ci (for M1)
-      if: matrix.os == 'macos-arm'
-      run: M1=1 npm ci
-    - name: npm run build
-      run: |
-        case "${{ matrix.os }}" in
-          macos-intel)
-            # Build Intel version with Intel assets
-            npm run build -- --mac --publish=never
-            ;;
-          macos-arm)
-            # Build Intel version with M1 assets
-            M1=1 npm run build -- --mac --publish=never
-            ;;
-          windows)
-            npm run build -- --win --publish=never
-            ;;
-          linux)
-            npm run build -- --linux --publish=never
-            ;;
-        esac
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'macos-intel'
+    - name: Flag build for M1
+      if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
+      run: echo "M1=1" >> "${GITHUB_ENV}"
+    - run: npm ci
+    - run: npm run build -- --${{ matrix.platform }} --publish=never
+    - name: Upload mac disk image
+      uses: actions/upload-artifact@v3
+      if: matrix.platform == 'mac'
       with:
-        name: Rancher Desktop.x86_64.dmg
+        name: Rancher Desktop.${{ matrix.arch }}.dmg
         path: dist/Rancher Desktop*.dmg
         if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'macos-intel'
+    - name: Upload mac zip
+      uses: actions/upload-artifact@v3
+      if: matrix.platform == 'mac'
       with:
-        name: Rancher Desktop-mac.x86_64.zip
+        name: Rancher Desktop-mac.${{ matrix.arch }}.zip
         path: dist/Rancher Desktop*.zip
         if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'macos-arm'
-      with:
-        name: Rancher Desktop.aarch64.dmg
-        path: dist/Rancher Desktop*.dmg
-        if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'macos-arm'
-      with:
-        name: Rancher Desktop-mac.aarch64.zip
-        path: dist/Rancher Desktop*.zip
-        if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'windows'
+    - name: Upload Windows installer
+      uses: actions/upload-artifact@v3
+      if: matrix.platform == 'win'
       with:
         name: Rancher Desktop Setup.exe
         path: dist/Rancher Desktop*.exe
         if-no-files-found: error
-    - uses: actions/upload-artifact@v3
-      if: matrix.os == 'windows'
+    - name: Upload Windows zip
+      uses: actions/upload-artifact@v3
+      if: matrix.platform == 'win'
       with:
         name: Rancher Desktop-win.zip
         path: dist/Rancher Desktop-*-win.zip
         if-no-files-found: error
-    - name: set zip_name env var
-      run: |
-        # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge";
-        # remove slashes since they aren't valid in filenames
-        no_slash_ref_name=$(echo $GITHUB_REF_NAME | sed -E 's/\//-/g')
-        zip_name="rancher-desktop-linux-${no_slash_ref_name}.zip"
-        echo "zip_name=$zip_name" >> $GITHUB_ENV
-    - name: Ensure linux zip file has a known name
-      uses: canastro/copy-file-action@0.0.2
-      if: matrix.os == 'linux'
-      with:
-        source: "dist/rancher-desktop*.zip"
-        target: ${{ format('dist/{0}', env.zip_name) }}
-    - name: Upload zip as workflow artifact
+    - name: Upload Linux zip
       uses: actions/upload-artifact@v3
-      if: matrix.os == 'linux'
+      if: matrix.platform == 'linux'
       with:
         name: Rancher Desktop-linux.zip
-        path: ${{ format('dist/{0}', env.zip_name) }}
+        path: dist/rancher-desktop-*-linux.zip
         if-no-files-found: error
     - id: has_s3
       name: Check if S3 secrets are available
       continue-on-error: true
-      if: matrix.os == 'linux' && github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
+      if: github.ref_type == 'branch' && ( startsWith(github.ref_name, 'main') || startsWith(github.ref_name, 'release-') )
       run: '[[ -n "${key}" ]]'
       env:
         key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    - name: set zip_name env var
+      id: zip_name
+      if: matrix.platform == 'linux' && steps.has_s3.outcome == 'success'
+      run: |
+        # in pull requests GITHUB_REF_NAME is in the form "<pr_number>/merge";
+        # remove slashes since they aren't valid in filenames
+        no_slash_ref_name="${GITHUB_REF_NAME//\//-/}"
+        zip_name="rancher-desktop-linux-${no_slash_ref_name}.zip"
+        echo "::set-output name=zip_name::${zip_name}"
     - name: Copy zip file to S3
-      uses: prewk/s3-cp-action@v2
-      if: steps.has_s3.outcome == 'success'
+      uses: prewk/s3-cp-action@74701625561055a306f92fa5c18e948f9d14a54a
+      if: matrix.platform == 'linux' && steps.has_s3.outcome == 'success'
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: ${{ format('./dist/{0}', env.zip_name) }}
-        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.zip_name) }}
+        source: dist/rancher-desktop-*-linux.zip
+        dest: s3://rancher-desktop-assets-for-obs/${{ steps.zip_name.outputs.zip_name }}
     - name: Trigger OBS services for relevant package in dev channel
-      if: steps.has_s3.outcome == 'success'
+      if: matrix.platform == 'linux' && steps.has_s3.outcome == 'success'
       run: |
         curl -X POST \
           -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
@@ -161,11 +131,7 @@ jobs:
   sign:
     name: Test Signing
     needs: package
-    strategy:
-      matrix:
-        os:
-        - windows-2019
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-2022
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
- Make packaging matrix explicit (listing all the options)
- Actually mark the platform, rather than doing substring comparisons.  List the platform + arch first, because they show up in the Actions view in order.
- Set M1 flag centrally (if required)
- Reuse artifact upload steps (for mac)
- Simplify S3 uploading — no need to rename the zip file, just use a glob when uploading.
- Pin the S3 action to commit hash (to avoid issues if they change the action to steal secrets)