### PR TITLE
Remove role-primary from dialog button static class

### DIFF
--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -85,7 +85,7 @@ export default Vue.extend({
           <button
             v-for="(buttonText, index) in buttons"
             :key="index"
-            class="btn role-primary"
+            class="btn"
             :class="index === 0 ? 'role-primary' : 'role-secondary'"
             @click="close(index)"
           >


### PR DESCRIPTION
This cleans up hover states on the dialog action buttons by removing the duplicate `role-primary` class. This class is only needed when the button is the primary action. 

### Before (hover)

![image](https://user-images.githubusercontent.com/835961/180845229-08969978-6f36-4bda-aed4-eb82c7869b59.png)

### After (hover)

![image](https://user-images.githubusercontent.com/835961/180845140-a26e96b1-ec29-46fc-a1ad-2dcf16865740.png)

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>