### PR TITLE
Show warning when kubernetes will restart

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -454,13 +454,11 @@ Electron.ipcMain.on('api-get-credentials', () => {
   mainEvents.emit('api-get-credentials');
 });
 
-Electron.ipcMain.handle('api-get-credentials', async() => {
-  const credentials = await (new Promise<void>((resolve) => {
-    mainEvents.on('api-credentials', resolve);
+Electron.ipcMain.handle('api-get-credentials', () => {
+  return new Promise<void>((resolve) => {
+    mainEvents.once('api-credentials', resolve);
     mainEvents.emit('api-get-credentials');
-  }));
-
-  return credentials;
+  });
 });
 
 mainEvents.on('api-credentials', (credentials) => {

--- a/background.ts
+++ b/background.ts
@@ -454,6 +454,14 @@ Electron.ipcMain.on('api-get-credentials', () => {
   mainEvents.emit('api-get-credentials');
 });
 
+Electron.ipcMain.handle('api-get-credentials', async() => {
+  const credentials = await (new Promise<void>((resolve) => {
+    mainEvents.on('api-credentials', resolve);
+  }));
+
+  return credentials;
+});
+
 mainEvents.on('api-credentials', (credentials) => {
   window.send('api-credentials', credentials);
 });

--- a/background.ts
+++ b/background.ts
@@ -457,6 +457,7 @@ Electron.ipcMain.on('api-get-credentials', () => {
 Electron.ipcMain.handle('api-get-credentials', async() => {
   const credentials = await (new Promise<void>((resolve) => {
     mainEvents.on('api-credentials', resolve);
+    mainEvents.emit('api-get-credentials');
   }));
 
   return credentials;

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4606,6 +4606,15 @@ troubleshooting:
   needHelp: 'Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.'
 
 ##############################
+### Preferences Page
+##############################
+preferences:
+  actions:
+    banner:
+      reset: Kubernetes reset required.
+      restart: Kubernetes restart required.
+
+##############################
 ### Integrations Page
 ##############################
 integrations: 

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4611,8 +4611,8 @@ troubleshooting:
 preferences:
   actions:
     banner:
-      reset: Kubernetes reset required.
-      restart: Kubernetes restart required.
+      reset: Kubernetes will reset after applying changes.
+      restart: Kubernetes will restart after applying changes.
 
 ##############################
 ### Integrations Page

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -55,6 +55,7 @@ export default Vue.extend({
     >
       <banner
         v-if="severity"
+        class="banner-notify"
         :color="severityLevel"
       >
         <span
@@ -90,7 +91,7 @@ export default Vue.extend({
     border-top: 1px solid var(--header-border);
   }
 
-  .banner {
+  .banner-notify {
     margin: 0;
   }
 

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
 import Vue from 'vue';
+import Banner from '@/components/Banner.vue';
 
 export default Vue.extend({
-  name:    'preferences-actions',
-  props: {
+  name:       'preferences-actions',
+  components: { Banner },
+  props:      {
     isDirty: {
       type:     Boolean,
       required: true
@@ -22,6 +24,10 @@ export default Vue.extend({
 
 <template>
   <div class="preferences-actions">
+    <banner color="warning">
+      <span class="icon icon-warning"></span>
+      Kubernetes reset required.
+    </banner>
     <button
       data-test="preferences-cancel"
       class="btn role-secondary"
@@ -46,5 +52,9 @@ export default Vue.extend({
     gap: 1rem;
     padding: var(--preferences-content-padding);
     border-top: 1px solid var(--header-border);
+  }
+
+  .banner {
+    margin: 0;
   }
 </style>

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
+import { mapState } from 'vuex';
+
 import Banner from '@/components/Banner.vue';
 
 export default Vue.extend({
@@ -11,7 +13,27 @@ export default Vue.extend({
       required: true
     }
   },
-  methods: {
+  computed: {
+    ...mapState('preferences', ['severities']),
+    severity() {
+      if (this.severities.reset) {
+        return 'reset';
+      }
+
+      if (this.severities.restart) {
+        return 'restart';
+      }
+
+      return '';
+    },
+    severityLevel() {
+      return this.severity === 'reset' ? 'warning' : 'info';
+    },
+    iconClass() {
+      return `icon-${ this.severityLevel }`;
+    }
+  },
+  methods:  {
     cancel() {
       this.$emit('cancel');
     },
@@ -24,9 +46,15 @@ export default Vue.extend({
 
 <template>
   <div class="preferences-actions">
-    <banner color="warning">
-      <span class="icon icon-warning"></span>
-      Kubernetes reset required.
+    <banner
+      v-if="severity"
+      :color="severityLevel"
+    >
+      <span
+        class="icon"
+        :class="[iconClass]"
+      ></span>
+      Kubernetes {{ severity }} required.
     </banner>
     <button
       data-test="preferences-cancel"

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -31,6 +31,9 @@ export default Vue.extend({
     },
     iconClass() {
       return `icon-${ this.severityLevel }`;
+    },
+    bannerText() {
+      return this.t(`preferences.actions.banner.${ this.severity }`);
     }
   },
   methods:  {
@@ -57,8 +60,8 @@ export default Vue.extend({
         <span
           class="icon"
           :class="[iconClass]"
-        ></span>
-        Kubernetes {{ severity }} required.
+        />
+        {{ bannerText }}
       </banner>
     </transition>
     <button

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -46,16 +46,21 @@ export default Vue.extend({
 
 <template>
   <div class="preferences-actions">
-    <banner
-      v-if="severity"
-      :color="severityLevel"
+    <transition
+      name="fade"
+      appear
     >
-      <span
-        class="icon"
-        :class="[iconClass]"
-      ></span>
-      Kubernetes {{ severity }} required.
-    </banner>
+      <banner
+        v-if="severity"
+        :color="severityLevel"
+      >
+        <span
+          class="icon"
+          :class="[iconClass]"
+        ></span>
+        Kubernetes {{ severity }} required.
+      </banner>
+    </transition>
     <button
       data-test="preferences-cancel"
       class="btn role-secondary"
@@ -84,5 +89,13 @@ export default Vue.extend({
 
   .banner {
     margin: 0;
+  }
+
+  .fade-enter, .fade-leave-to {
+    opacity: 0;
+  }
+
+  .fade-active {
+    transition: all 0.25s ease-in;
   }
 </style>

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -56,7 +56,7 @@ export default Vue.extend({
   },
   methods:  {
     async fetchCredentials() {
-      const result = await this.$store.dispatch('credentials/fetchCredentials', undefined);
+      const result = await this.$store.dispatch('credentials/fetchCredentials');
 
       return result;
     },

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
   },
   methods:  {
     async fetchCredentials() {
-      const result = await this.$store.dispatch('credentials/fetchCredentials');
+      const result = await this.$store.dispatch('credentials/fetchCredentials', undefined);
 
       return result;
     },

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -9,7 +9,7 @@ import PreferencesNav from '@/components/Preferences/ModalNav.vue';
 import PreferencesBody from '@/components/Preferences/ModalBody.vue';
 import PreferencesActions from '@/components/Preferences/ModalActions.vue';
 import EmptyState from '@/components/EmptyState.vue';
-import { Credentials } from '@/typings/credentials.interface';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 export default Vue.extend({
   name:       'preferences-modal',
@@ -25,7 +25,7 @@ export default Vue.extend({
   },
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
-    await this.$store.dispatch('preferences/fetchPreferences', this.credentials as Credentials);
+    await this.$store.dispatch('preferences/fetchPreferences', this.credentials as ServerState);
     this.preferencesLoaded = true;
 
     ipcRenderer.on('k8s-integrations', (_, integrations: Record<string, string | boolean>) => {
@@ -70,14 +70,14 @@ export default Vue.extend({
 
       await this.$store.dispatch(
         'preferences/commitPreferences',
-        this.credentials as Credentials
+        this.credentials as ServerState
       );
       this.closePreferences();
     },
     async proposePreferences() {
       const { reset } = await this.$store.dispatch(
         'preferences/proposePreferences',
-        this.credentials as Credentials
+        this.credentials as ServerState
       );
 
       if (!reset) {

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -9,6 +9,7 @@ import PreferencesNav from '@/components/Preferences/ModalNav.vue';
 import PreferencesBody from '@/components/Preferences/ModalBody.vue';
 import PreferencesActions from '@/components/Preferences/ModalActions.vue';
 import EmptyState from '@/components/EmptyState.vue';
+import { Credentials } from '@/typings/credentials.interface';
 
 export default Vue.extend({
   name:       'preferences-modal',
@@ -74,20 +75,20 @@ export default Vue.extend({
 
       await this.$store.dispatch(
         'preferences/commitPreferences',
-        this.credentials as { port: number, user: string, password: string}
+        this.credentials as Credentials
       );
       this.closePreferences();
     },
     async fetchPreferences() {
       await this.$store.dispatch(
         'preferences/fetchPreferences',
-        this.credentials as { port: number, user: string, password: string}
+        this.credentials as Credentials
       );
     },
     async proposePreferences() {
       const { reset } = await this.$store.dispatch(
         'preferences/proposePreferences',
-        this.credentials as { port: number, user: string, password: string}
+        this.credentials as Credentials
       );
 
       if (!reset) {

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -24,8 +24,8 @@ export default Vue.extend({
     };
   },
   async fetch() {
-    await this.fetchCredentials();
-    await this.fetchPreferences();
+    await this.$store.dispatch('credentials/fetchCredentials');
+    await this.$store.dispatch('preferences/fetchPreferences', this.credentials as Credentials);
     this.preferencesLoaded = true;
 
     ipcRenderer.on('k8s-integrations', (_, integrations: Record<string, string | boolean>) => {
@@ -55,11 +55,6 @@ export default Vue.extend({
     window.removeEventListener('keydown', this.handleKeypress, true);
   },
   methods:  {
-    async fetchCredentials() {
-      const result = await this.$store.dispatch('credentials/fetchCredentials');
-
-      return result;
-    },
     navChanged(tabName: string) {
       this.currentNavItem = tabName;
     },
@@ -78,12 +73,6 @@ export default Vue.extend({
         this.credentials as Credentials
       );
       this.closePreferences();
-    },
-    async fetchPreferences() {
-      await this.$store.dispatch(
-        'preferences/fetchPreferences',
-        this.credentials as Credentials
-      );
     },
     async proposePreferences() {
       const { reset } = await this.$store.dispatch(

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -2,7 +2,7 @@
 import os from 'os';
 import { ipcRenderer } from 'electron';
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import PreferencesHeader from '@/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@/components/Preferences/ModalNav.vue';
@@ -37,9 +37,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapGetters('preferences', ['getPreferences', 'isPreferencesDirty', 'hasError', 'isPlatformWindows']),
-    credentials(): {port: number, user: string, password: string} {
-      return this.$store.state.credentials.credentials;
-    },
+    ...mapState('credentials', ['credentials']),
     navItems(): string[] {
       return [
         'Application',
@@ -76,18 +74,21 @@ export default Vue.extend({
 
       await this.$store.dispatch(
         'preferences/commitPreferences',
-        this.credentials
+        this.credentials as { port: number, user: string, password: string}
       );
       this.closePreferences();
     },
     async fetchPreferences() {
       await this.$store.dispatch(
         'preferences/fetchPreferences',
-        this.credentials
+        this.credentials as { port: number, user: string, password: string}
       );
     },
     async proposePreferences() {
-      const { reset } = await this.$store.dispatch('preferences/proposePreferences', this.credentials);
+      const { reset } = await this.$store.dispatch(
+        'preferences/proposePreferences',
+        this.credentials as { port: number, user: string, password: string}
+      );
 
       if (!reset) {
         return true;

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -2,7 +2,7 @@
 import os from 'os';
 import { ipcRenderer } from 'electron';
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 
 import PreferencesHeader from '@/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@/components/Preferences/ModalNav.vue';
@@ -56,13 +56,22 @@ export default Vue.extend({
       ];
     }
   },
-  beforeMount() {
+  async beforeMount() {
+    const credentials = await this.fetchCredentials();
+
+    console.debug('CREDENTIALS', { credentials });
+
     window.addEventListener('keydown', this.handleKeypress, true);
   },
   beforeDestroy() {
     window.removeEventListener('keydown', this.handleKeypress, true);
   },
   methods:  {
+    async fetchCredentials() {
+      const result = await this.$store.dispatch('credentials/fetchCredentials');
+
+      return result;
+    },
     navChanged(tabName: string) {
       this.currentNavItem = tabName;
     },

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -1,0 +1,42 @@
+import { ipcRenderer } from 'electron';
+import { ActionContext, MutationsType } from './ts-helpers';
+
+interface CredentialsState {
+  credentials: {
+    password: string,
+    pid: number,
+    port: number,
+    user: string
+  }
+}
+
+export const state: () => CredentialsState = () => (
+  {
+    credentials: {
+      password: '',
+      pid:      0,
+      port:     0,
+      user:     ''
+    }
+  }
+);
+
+export const mutations: MutationsType<CredentialsState> = {
+  SET_CREDENTIALS(state, credentials) {
+    state.credentials = credentials;
+  }
+};
+
+type CredActionContext = ActionContext<CredentialsState>;
+
+export const actions = {
+  async fetchCredentials({ commit }: CredActionContext) {
+    const result = await ipcRenderer.invoke('api-get-credentials');
+
+    console.debug('CREDENTIALS', { result });
+
+    commit('SET_CREDENTIALS', result);
+
+    return result;
+  }
+};

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -1,9 +1,9 @@
 import { ipcRenderer } from 'electron';
 import { ActionContext, MutationsType } from './ts-helpers';
-import { Credentials } from '@/typings/credentials.interface';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 interface CredentialsState {
-  credentials: Credentials;
+  credentials: ServerState;
 }
 
 export const state: () => CredentialsState = () => (

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -33,8 +33,6 @@ export const actions = {
   async fetchCredentials({ commit }: CredActionContext) {
     const result = await ipcRenderer.invoke('api-get-credentials');
 
-    console.debug('CREDENTIALS', { result });
-
     commit('SET_CREDENTIALS', result);
 
     return result;

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -1,13 +1,9 @@
 import { ipcRenderer } from 'electron';
 import { ActionContext, MutationsType } from './ts-helpers';
+import { Credentials } from '@/typings/credentials.interface';
 
 interface CredentialsState {
-  credentials: {
-    password: string,
-    pid: number,
-    port: number,
-    user: string
-  }
+  credentials: Credentials;
 }
 
 export const state: () => CredentialsState = () => (

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -66,8 +66,11 @@ export const actions = {
     commit('SET_PREFERENCES', _.cloneDeep(preferences));
     commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
   },
-  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: { port: number, user: string, password: string}) {
+  async fetchPreferences({ dispatch, commit, rootState }: PrefActionContext, args: { port: number, user: string, password: string}) {
     const { port, user, password } = args;
+
+    console.debug('ROOT STATE', { rootState });
+    // const { port, user, password } = dispatch('credentials/fetchCredentials', {}, { root: true });
     const response = await fetch(
       uri(port),
       {
@@ -109,10 +112,11 @@ export const actions = {
       { root: true });
   },
 
-  updatePreferencesData<P extends RecursiveKeys<Settings>>({ commit, state }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {
+  updatePreferencesData<P extends RecursiveKeys<Settings>>({ commit, dispatch, state }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {
     const { property, value } = args;
 
     commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));
+    // dispatch('preferences/proposePreferences', {}, { root: true });
   },
   setWslIntegrations({ commit }: PrefActionContext, integrations: { [distribution: string]: string | boolean}) {
     commit('SET_WSL_INTEGRATIONS', integrations);

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -66,11 +66,9 @@ export const actions = {
     commit('SET_PREFERENCES', _.cloneDeep(preferences));
     commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
   },
-  async fetchPreferences({ dispatch, commit, rootState }: PrefActionContext, args: { port: number, user: string, password: string}) {
+  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: { port: number, user: string, password: string}) {
     const { port, user, password } = args;
 
-    console.debug('ROOT STATE', { rootState });
-    // const { port, user, password } = dispatch('credentials/fetchCredentials', {}, { root: true });
     const response = await fetch(
       uri(port),
       {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -109,6 +109,13 @@ export const actions = {
       { root: true });
   },
 
+  /**
+   * Update a given property for preferences. Propose the new preferences after
+   * each update to check if kubernetes requires a reset or restart.
+   * @param context The vuex context object
+   * @param payload Key, value pair that corresponds to a property and its value
+   * in the preferences object
+   */
   updatePreferencesData<P extends RecursiveKeys<Settings>>({
     commit, dispatch, state, rootState
   }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { ActionContext, MutationsType } from './ts-helpers';
 import { defaultSettings, Settings } from '@/config/settings';
 import { RecursiveKeys, RecursiveTypes } from '@/utils/typeUtils';
+import { Credentials } from '@/typings/credentials.interface';
 
 interface Severities {
   reset: boolean;
@@ -66,7 +67,7 @@ export const actions = {
     commit('SET_PREFERENCES', _.cloneDeep(preferences));
     commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
   },
-  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: { port: number, user: string, password: string}) {
+  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: Credentials) {
     const { port, user, password } = args;
 
     const response = await fetch(
@@ -88,7 +89,7 @@ export const actions = {
 
     dispatch('preferences/initializePreferences', settings, { root: true });
   },
-  async commitPreferences({ state, dispatch }: PrefActionContext, args: {port: number, user: string, password: string}) {
+  async commitPreferences({ state, dispatch }: PrefActionContext, args: Credentials) {
     const { port, user, password } = args;
 
     await fetch(
@@ -104,9 +105,7 @@ export const actions = {
 
     await dispatch(
       'preferences/fetchPreferences',
-      {
-        port, user, password
-      },
+      args,
       { root: true });
   },
 
@@ -118,7 +117,7 @@ export const actions = {
     commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));
     dispatch(
       'preferences/proposePreferences',
-      rootState.credentials.credentials as {port: number, user: string, password: string},
+      rootState.credentials.credentials as Credentials,
       { root: true }
     );
   },
@@ -133,7 +132,7 @@ export const actions = {
   setPlatformWindows({ commit }: PrefActionContext, isPlatformWindows: boolean) {
     commit('SET_IS_PLATFORM_WINDOWS', isPlatformWindows);
   },
-  async proposePreferences({ commit, state }: PrefActionContext, { port, user, password }: {port: number, user: string, password: string}) {
+  async proposePreferences({ commit, state }: PrefActionContext, { port, user, password }: Credentials) {
     const result = await fetch(
       proposedSettings(port),
       {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { ActionContext, MutationsType } from './ts-helpers';
 import { defaultSettings, Settings } from '@/config/settings';
 import { RecursiveKeys, RecursiveTypes } from '@/utils/typeUtils';
-import { Credentials } from '@/typings/credentials.interface';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 interface Severities {
   reset: boolean;
@@ -67,7 +67,7 @@ export const actions = {
     commit('SET_PREFERENCES', _.cloneDeep(preferences));
     commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
   },
-  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: Credentials) {
+  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: ServerState) {
     const { port, user, password } = args;
 
     const response = await fetch(
@@ -89,7 +89,7 @@ export const actions = {
 
     dispatch('preferences/initializePreferences', settings, { root: true });
   },
-  async commitPreferences({ state, dispatch }: PrefActionContext, args: Credentials) {
+  async commitPreferences({ state, dispatch }: PrefActionContext, args: ServerState) {
     const { port, user, password } = args;
 
     await fetch(
@@ -117,7 +117,7 @@ export const actions = {
     commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));
     dispatch(
       'preferences/proposePreferences',
-      rootState.credentials.credentials as Credentials,
+      rootState.credentials.credentials as ServerState,
       { root: true }
     );
   },
@@ -132,7 +132,7 @@ export const actions = {
   setPlatformWindows({ commit }: PrefActionContext, isPlatformWindows: boolean) {
     commit('SET_IS_PLATFORM_WINDOWS', isPlatformWindows);
   },
-  async proposePreferences({ commit, state }: PrefActionContext, { port, user, password }: Credentials) {
+  async proposePreferences({ commit, state }: PrefActionContext, { port, user, password }: ServerState) {
     const result = await fetch(
       proposedSettings(port),
       {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -113,12 +113,12 @@ export const actions = {
    * Update a given property for preferences. Propose the new preferences after
    * each update to check if kubernetes requires a reset or restart.
    * @param context The vuex context object
-   * @param payload Key, value pair that corresponds to a property and its value
+   * @param args Key, value pair that corresponds to a property and its value
    * in the preferences object
    */
   updatePreferencesData<P extends RecursiveKeys<Settings>>({
     commit, dispatch, state, rootState
-  }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {
+  }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}): void {
     const { property, value } = args;
 
     commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -112,11 +112,17 @@ export const actions = {
       { root: true });
   },
 
-  updatePreferencesData<P extends RecursiveKeys<Settings>>({ commit, dispatch, state }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {
+  updatePreferencesData<P extends RecursiveKeys<Settings>>({
+    commit, dispatch, state, rootState
+  }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}) {
     const { property, value } = args;
 
     commit('SET_PREFERENCES', _.set(_.cloneDeep(state.preferences), property, value));
-    // dispatch('preferences/proposePreferences', {}, { root: true });
+    dispatch(
+      'preferences/proposePreferences',
+      rootState.credentials.credentials as {port: number, user: string, password: string},
+      { root: true }
+    );
   },
   setWslIntegrations({ commit }: PrefActionContext, integrations: { [distribution: string]: string | boolean}) {
     commit('SET_WSL_INTEGRATIONS', integrations);

--- a/src/store/ts-helpers.ts
+++ b/src/store/ts-helpers.ts
@@ -26,4 +26,5 @@ export type ActionContext<T> = {
     commitOptions?: CommitOptions): void;
   dispatch: Dispatch;
   state: T;
+  rootState: any;
 }

--- a/src/store/ts-helpers.ts
+++ b/src/store/ts-helpers.ts
@@ -22,7 +22,7 @@ export type MutationsType<T> = {
 export type ActionContext<T> = {
   commit<mutationType extends keyof MutationsPayloadType<T>>(
     type: mutationType,
-    payload?: MutationsPayloadType<T>[mutationType],
+    payload: MutationsPayloadType<T>[mutationType],
     commitOptions?: CommitOptions): void;
   dispatch: Dispatch;
   state: T;

--- a/src/store/ts-helpers.ts
+++ b/src/store/ts-helpers.ts
@@ -22,7 +22,7 @@ export type MutationsType<T> = {
 export type ActionContext<T> = {
   commit<mutationType extends keyof MutationsPayloadType<T>>(
     type: mutationType,
-    payload: MutationsPayloadType<T>[mutationType],
+    payload?: MutationsPayloadType<T>[mutationType],
     commitOptions?: CommitOptions): void;
   dispatch: Dispatch;
   state: T;

--- a/src/typings/credentials.interface.ts
+++ b/src/typings/credentials.interface.ts
@@ -1,0 +1,6 @@
+export interface Credentials {
+  password: string;
+  pid: number;
+  port: number;
+  user: string;
+}

--- a/src/typings/credentials.interface.ts
+++ b/src/typings/credentials.interface.ts
@@ -1,6 +1,0 @@
-export interface Credentials {
-  password: string;
-  pid: number;
-  port: number;
-  user: string;
-}

--- a/src/typings/store.d.ts
+++ b/src/typings/store.d.ts
@@ -1,6 +1,8 @@
 import type { actions as ApplicationSettingsActions } from '@/store/applicationSettings';
 import type { actions as PageActions } from '@/store/page';
 import type { actions as PreferencesActions } from '@/store/preferences';
+import type { actions as CredentialsActions } from '@/store/credentials';
+
 type Actions<
   store extends string,
   actions extends Record<string, (context: any, args: any) => any>
@@ -12,7 +14,8 @@ type Actions<
 type storeActions = Record<string, never>
   & Actions<'applicationSettings', typeof ApplicationSettingsActions>
   & Actions<'page', typeof PageActions>
-  & Actions<'preferences', typeof PreferencesActions>;
+  & Actions<'preferences', typeof PreferencesActions>
+  & Actions<'credentials', typeof CredentialsActions>;
 
 declare module 'vuex/types' {
   export interface Dispatch {

--- a/src/typings/store.d.ts
+++ b/src/typings/store.d.ts
@@ -22,7 +22,7 @@ declare module 'vuex/types' {
     <action extends keyof storeActions>
       (
         type: action,
-        payload: Parameters<storeActions[action]>[0],
+        payload?: Parameters<storeActions[action]>[0],
         options?: DispatchOptions
       ): Promise<ReturnType<storeActions[action]>>;
 

--- a/src/typings/store.d.ts
+++ b/src/typings/store.d.ts
@@ -22,8 +22,13 @@ declare module 'vuex/types' {
     <action extends keyof storeActions>
       (
         type: action,
-        payload?: Parameters<storeActions[action]>[0],
+        payload: Parameters<storeActions[action]>[0],
         options?: DispatchOptions
+      ): Promise<ReturnType<storeActions[action]>>;
+
+    <action extends keyof storeActions>
+      (
+        type: action,
       ): Promise<ReturnType<storeActions[action]>>;
 
     /** @deprecated */


### PR DESCRIPTION
This adds a banner that notifies when a change to preferences will reset or restart kubernetes. This is achieved by invoking the `/v0/propose_settings` for each change made in the preferences window.

This also creates a credentials store that allows us to dispatch the `updatePreferencesData` action without the need of any given component needing to know about the existence of credentials.

### Examples 

<img width="880" alt="Screen Shot 2022-07-28 at 10 41 12 AM" src="https://user-images.githubusercontent.com/835961/181604627-34c13376-f8d3-42ea-9edb-c0abf89df0ee.png">

<img width="880" alt="Screen Shot 2022-07-28 at 10 41 20 AM" src="https://user-images.githubusercontent.com/835961/181604649-fce663d2-5fdc-4e3a-b4d0-32497c1bf1b7.png">

### Bonus Video

https://user-images.githubusercontent.com/835961/181604755-85810f75-c7f0-4358-ad16-f0273623f067.mp4


