### PR TITLE
Create title component

### DIFF
--- a/src/components/TheTitle.vue
+++ b/src/components/TheTitle.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    ...mapState(
+    ...mapState<any, any>(
       'page',
       [
         'title',
@@ -117,7 +117,7 @@ export default Vue.extend({
     transition: opacity 0.25s ease-out;
   }
 
-  .fade-group-item-enter, .fade-group-item-leave-to
+  .fade-group-item-enter, .fade-group-leave-to
   {
     opacity: 0;
   }

--- a/src/components/TheTitle.vue
+++ b/src/components/TheTitle.vue
@@ -1,0 +1,144 @@
+<script lang="ts">
+import Vue from 'vue';
+import { mapState } from 'vuex';
+import ImagesButtonAdd from '@/components/ImagesButtonAdd.vue';
+
+export default Vue.extend({
+  name:       'the-title',
+  components: { ImagesButtonAdd },
+  data() {
+    return {
+      data() {
+        return { isChild: false };
+      },
+    };
+  },
+  computed: {
+    ...mapState(
+      'page',
+      [
+        'title',
+        'description',
+        'action'
+      ]),
+  },
+  watch: {
+    $route: {
+      immediate: true,
+      handler(current) {
+        this.isChild = current.path.lastIndexOf('/') > 0;
+      }
+    }
+  },
+  methods: {
+    routeBack() {
+      this.$router.back();
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="title">
+    <div class="title-top">
+      <transition-group
+        name="fade-group"
+        class="title-group"
+      >
+        <button
+          v-if="isChild"
+          key="back-btn"
+          data-test="back-btn"
+          class="btn role-link btn-sm btn-back fade-group-item"
+          type="button"
+          @click="routeBack"
+        >
+          <span
+            class="icon icon-chevron-left"
+          />
+        </button>
+        <h1
+          key="mainTitle"
+          data-test="mainTitle"
+          class="fade-group-item"
+        >
+          {{ title }}
+        </h1>
+      </transition-group>
+      <transition
+        name="fade"
+        appear
+      >
+        <div
+          v-if="action"
+          key="actions"
+          class="actions fade-actions"
+        >
+          <component :is="action" />
+        </div>
+      </transition>
+    </div>
+    <hr>
+    <div
+      v-show="description"
+      class="description"
+    >
+      {{ description }}
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .title {
+    padding: 20px 20px 0 20px;
+  }
+
+  .title-top{
+    display: flex;
+  }
+
+  .btn-back {
+    height: 27px;
+    font-weight: bolder;
+    font-size: 1.5em;
+  }
+
+  .btn-back:focus {
+    outline: none;
+    box-shadow: none;
+    background: var(--input-focus-bg);
+  }
+
+  .fade-group-item {
+    transition: all 0.25s ease-out;
+  }
+
+  .fade-actions{
+    transition: opacity 0.25s ease-out;
+  }
+
+  .fade-group-item-enter, .fade-group-item-leave-to
+  {
+    opacity: 0;
+  }
+
+  .fade-group-leave-active, .fade-group-item-enter-active {
+    position: absolute;
+  }
+
+  .fade-enter, .fade-leave-to {
+    opacity: 0;
+  }
+
+  .fade-active {
+    transition: all 0.25s ease-in;
+  }
+
+  .title-group {
+    display: inherit;
+  }
+
+  .actions {
+    margin-left: auto;
+  }
+</style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -2,54 +2,7 @@
   <div class="wrapper">
     <rd-header class="header" @open-preferences="openPreferences" />
     <rd-nav class="nav" :items="routes" />
-    <section class="title">
-      <section class="title-top">
-        <transition-group
-          name="fade-group"
-          class="title-group"
-          appear
-        >
-          <button
-            v-if="isChild"
-            key="back-btn"
-            data-test="back-btn"
-            class="btn role-link btn-sm btn-back fade-group-item"
-            type="button"
-            @click="routeBack"
-          >
-            <span
-              class="icon icon-chevron-left"
-            />
-          </button>
-          <h1
-            key="mainTitle"
-            data-test="mainTitle"
-            class="fade-group-item"
-          >
-            {{ title }}
-          </h1>
-        </transition-group>
-        <transition
-          name="fade"
-          appear
-        >
-          <section
-            v-if="action"
-            key="actions"
-            class="actions fade-actions"
-          >
-            <component :is="action" />
-          </section>
-        </transition>
-      </section>
-      <hr>
-      <section
-        v-show="description"
-        class="description"
-      >
-        {{ description }}
-      </section>
-    </section>
+    <the-title />
     <main class="body">
       <Nuxt />
     </main>
@@ -60,13 +13,11 @@
 </template>
 
 <script>
-import os from 'os';
 import { ipcRenderer } from 'electron';
-import { mapState } from 'vuex';
 import ActionMenu from '@/components/ActionMenu.vue';
 import Header from '@/components/Header.vue';
 import Nav from '@/components/Nav.vue';
-import ImagesButtonAdd from '@/components/ImagesButtonAdd.vue';
+import TheTitle from '@/components/TheTitle.vue';
 import BackendProgress from '@/components/BackendProgress.vue';
 
 export default {
@@ -74,13 +25,9 @@ export default {
   components: {
     ActionMenu,
     BackendProgress,
-    ImagesButtonAdd,
     rdNav:    Nav,
     rdHeader: Header,
-  },
-
-  data() {
-    return { isChild: false };
+    TheTitle
   },
 
   head() {
@@ -93,27 +40,14 @@ export default {
   },
 
   computed: {
-    ...mapState('page', {
-      title:       state => state.title,
-      description: state => state.description,
-      action:      state => state.action
-    }),
     routes() {
       return [
         '/General',
         '/PortForwarding',
         '/Images',
-        '/Troubleshooting'
+        '/Troubleshooting',
+        '/Diagnostics'
       ];
-    }
-  },
-
-  watch: {
-    $route: {
-      immediate: true,
-      handler(current, previous) {
-        this.isChild = current.path.lastIndexOf('/') > 0;
-      }
     }
   },
 
@@ -132,9 +66,6 @@ export default {
   },
 
   methods: {
-    routeBack() {
-      this.$router.back();
-    },
     openPreferences() {
       ipcRenderer.send('preferences-open');
     }
@@ -181,59 +112,5 @@ export default {
     padding: 0 20px 20px 20px;
     overflow: auto;
   }
-
-  .title {
-    padding: 20px 20px 0 20px;
-  }
-
-  .title-top{
-    display: flex;
-  }
-
-  .btn-back {
-    height: 27px;
-    font-weight: bolder;
-    font-size: 1.5em;
-  }
-
-  .btn-back:focus {
-    outline: none;
-    box-shadow: none;
-    background: var(--input-focus-bg);
-  }
-
-  .actions {
-    margin-left: auto;
-  }
-
-  .title-group {
-    display: inherit;
-  }
-
-  .fade-group-item {
-    transition: all 0.25s ease-out;
-  }
-
-  .fade-actions{
-    transition: opacity 0.25s ease-out;
-  }
-
-  .fade-group-enter, .fade-group-leave-to
-  {
-    opacity: 0;
-  }
-
-  .fade-group-leave-active, .fade-group-enter-active {
-    position: absolute;
-  }
-
-  .fade-enter, .fade-leave-to {
-    opacity: 0;
-  }
-
-  .fade-active {
-    transition: all 0.25s ease-in;
-  }
 }
-
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -45,8 +45,7 @@ export default {
         '/General',
         '/PortForwarding',
         '/Images',
-        '/Troubleshooting',
-        '/Diagnostics'
+        '/Troubleshooting'
       ];
     }
   },


### PR DESCRIPTION
This refactors the `default` layout by separating the title into its own component. 

I anticipate that we will need to make changes to the title in order to accommodate the proposed designs for #2656 so I'm breaking this out into a component now so that we can more easily isolate changes related to the page title. 

The name `TheTitle` is inspired by the [Vue style guide for single-instance component names.](https://v2.vuejs.org/v2/style-guide/?redirect=true#Single-instance-component-names-strongly-recommended). 