### PR TITLE
Enable Kube NodePort forwarding via RD-guest-agent

### DIFF
--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -208,6 +208,15 @@ export default async function main(rawPlatform) {
   // trivy.tgz files are top-level tarballs - not wrapped in a labelled directory :(
   await downloadTarGZ(trivyURL, trivyPath, { expectedChecksum: trivySHA });
 
+  // Download rancher-desktop-guestagent
+  const RDGuestAgentVersion = 'v0.2.0';
+  const RDGuestAgentBase = `https://github.com/rancher-sandbox/rancher-desktop-agent/releases/download/${ RDGuestAgentVersion }`;
+  const RDGuestAgentExecutable = 'rancher-desktop-guestagent';
+  const RDGuestAgentURL = `${ RDGuestAgentBase }/${ RDGuestAgentExecutable }-${ RDGuestAgentVersion }.tar.gz`;
+  const RDGuestAgentPath = path.join(linuxInternalDir, RDGuestAgentExecutable);
+
+  await downloadTarGZ(RDGuestAgentURL, RDGuestAgentPath);
+
   // Download Steve
   const steveVersion = 'v0.1.0-beta8';
   const steveURLBase = `https://github.com/rancher-sandbox/rancher-desktop-steve/releases/download/${ steveVersion }`;

--- a/src/assets/scripts/rancher-desktop-guestagent.initd
+++ b/src/assets/scripts/rancher-desktop-guestagent.initd
@@ -1,0 +1,35 @@
+#!/sbin/openrc-run
+# shellcheck shell=ksh
+
+depend() {
+  after network-online
+}
+
+GUESTAGENT_LOGFILE="${GUESTAGENT_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
+
+supervisor=supervise-daemon
+name="Rancher Desktop Guest Agent"
+command=/usr/local/bin/rancher-desktop-guestagent
+command_args="
+  ${GUESTAGENT_KUBERNETES:+-kubernetes=${GUESTAGENT_KUBERNETES}}
+  ${GUESTAGENT_IPTABLES:+-iptables=${GUESTAGENT_IPTABLES}}
+  ${GUESTAGENT_DEBUG:+-debug}
+  "
+command_args="${command_args//$'\n'/ }"
+output_log="${GUESTAGENT_LOGFILE}"
+error_log="${GUESTAGENT_LOGFILE}"
+
+respawn_delay=5
+respawn_max=0
+
+start_pre() {
+  cat > /etc/logrotate.d/guestagent <<EOF
+  ${GUESTAGENT_LOGFILE} {
+    missingok
+    notifempty
+  }
+EOF
+}
+
+set -o allexport
+if [ -f /etc/environment ]; then source /etc/environment; fi

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -1051,6 +1051,29 @@ export default class K3sHelper extends events.EventEmitter {
   }
 
   /**
+   * Check if the given Kubernetes version requires the port forwarding fix
+   * (where we listen on a local port).
+   *
+   * @param version Kubernetes version; null if no Kubernetes will run.
+   */
+  static requiresPortForwarding(version: semver.SemVer | null): boolean {
+    if (!version) {
+      // When Kubernetes is disabled, don't try to do NodePort forwarding.
+      return false;
+    }
+    switch (true) {
+    case version.major !== 1: return true;
+    case version.minor < 21: return false;
+    case version.minor === 21: return version.patch >= 12;
+    case version.minor === 22: return version.patch >= 10;
+    case version.minor === 23: return version.patch >= 7;
+    case version.minor >= 24: return true;
+    default:
+      throw new Error(`Unexpected Kubernetes version ${ version }`);
+    }
+  }
+
+  /**
    * Helper for implementing KubernetesBackend.requiresRestartReasons
    */
   requiresRestartReasons(

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -1056,7 +1056,7 @@ export default class K3sHelper extends events.EventEmitter {
    *
    * @param version Kubernetes version; null if no Kubernetes will run.
    */
-  static requiresPortForwarding(version: semver.SemVer | null): boolean {
+  static requiresPortForwardingFix(version: semver.SemVer | null): boolean {
     if (!version) {
       // When Kubernetes is disabled, don't try to do NodePort forwarding.
       return false;

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1434,7 +1434,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     await this.ssh('sudo', 'mv', './trivy', '/usr/local/bin/trivy');
   }
 
-  protected async installGuestAgent(kubeVersion: semver.SemVer | null, debug = false) {
+  protected async installGuestAgent(kubeVersion: semver.SemVer | null) {
     const guestAgentPath = path.join(paths.resources, 'linux', 'internal', 'rancher-desktop-guestagent');
 
     await Promise.all([
@@ -1444,12 +1444,12 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       })(),
       this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, 0o755),
       (async() => {
-        const kube = K3sHelper.requiresPortForwarding(kubeVersion);
+        const kube = K3sHelper.requiresPortForwardingFix(kubeVersion);
 
         await this.writeConf('rancher-desktop-guestagent', {
           GUESTAGENT_KUBERNETES: kube ? 'true' : 'false',
           GUESTAGENT_IPTABLES:   'false',
-          GUESTAGENT_DEBUG:      debug ? 'true' : 'false',
+          GUESTAGENT_DEBUG:      this.debug ? 'true' : 'false',
         });
       })(),
     ]);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -795,20 +795,20 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     await this.wslInstall(trivyExecPath, '/usr/local/bin');
   }
 
-  protected async installGuestAgent(kubeVersion: semver.SemVer | null, debug = false) {
+  protected async installGuestAgent(kubeVersion: semver.SemVer | null) {
     const guestAgentPath = path.join(paths.resources, 'linux', 'internal', 'rancher-desktop-guestagent');
 
     await Promise.all([
       this.wslInstall(guestAgentPath, '/usr/local/bin/'),
       this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, { permissions: 0o755 }),
       (async() => {
-        const kube = K3sHelper.requiresPortForwarding(kubeVersion);
+        const kube = K3sHelper.requiresPortForwardingFix(kubeVersion);
 
         await this.writeConf('rancher-desktop-guestagent', {
           LOG_DIR:               await this.wslify(paths.logs),
           GUESTAGENT_KUBERNETES: kube ? 'true' : 'false',
           GUESTAGENT_IPTABLES:   'true',
-          GUESTAGENT_DEBUG:      debug ? 'true' : 'false',
+          GUESTAGENT_DEBUG:      this.debug ? 'true' : 'false',
         });
       })(),
     ]);

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -26,6 +26,7 @@ import SERVICE_SCRIPT_DOCKERD from '@/assets/scripts/service-wsl-dockerd.initd';
 import LOGROTATE_K3S_SCRIPT from '@/assets/scripts/logrotate-k3s';
 import SERVICE_BUILDKITD_INIT from '@/assets/scripts/buildkit.initd';
 import SERVICE_BUILDKITD_CONF from '@/assets/scripts/buildkit.confd';
+import SERVICE_GUEST_AGENT_INIT from '@/assets/scripts/rancher-desktop-guestagent.initd';
 import SERVICE_SCRIPT_HOST_RESOLVER from '@/assets/scripts/service-host-resolver.initd';
 import SERVICE_SCRIPT_DNSMASQ_GENERATE from '@/assets/scripts/dnsmasq-generate.initd';
 import INSTALL_WSL_HELPERS_SCRIPT from '@/assets/scripts/install-wsl-helpers';
@@ -794,6 +795,25 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     await this.wslInstall(trivyExecPath, '/usr/local/bin');
   }
 
+  protected async installGuestAgent(kubeVersion: semver.SemVer | null, debug = false) {
+    const guestAgentPath = path.join(paths.resources, 'linux', 'internal', 'rancher-desktop-guestagent');
+
+    await Promise.all([
+      this.wslInstall(guestAgentPath, '/usr/local/bin/'),
+      this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, { permissions: 0o755 }),
+      (async() => {
+        const kube = K3sHelper.requiresPortForwarding(kubeVersion);
+
+        await this.writeConf('rancher-desktop-guestagent', {
+          LOG_DIR:               await this.wslify(paths.logs),
+          GUESTAGENT_KUBERNETES: kube ? 'true' : 'false',
+          GUESTAGENT_IPTABLES:   'true',
+          GUESTAGENT_DEBUG:      debug ? 'true' : 'false',
+        });
+      })(),
+    ]);
+  }
+
   /**
    * debugArg returns the given arguments in an array if the debug flag is
    * set, else an empty array.
@@ -1182,51 +1202,63 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
             const rotateConf = LOGROTATE_K3S_SCRIPT.replace(/\r/g, '')
               .replace('/var/log', logPath);
 
-            await this.writeFile('/etc/init.d/host-resolver', SERVICE_SCRIPT_HOST_RESOLVER, { permissions: 0o755 });
-            await this.writeFile('/etc/init.d/dnsmasq-generate', SERVICE_SCRIPT_DNSMASQ_GENERATE, { permissions: 0o755 });
-            // As `rc-update del …` fails if the service is already not in the run level, we add
-            // both `host-resolver` and `dnsmasq` to `default` and then delete the one we
-            // don't actually want to ensure that the appropriate one will be active.
-            await this.execCommand('/sbin/rc-update', 'add', 'host-resolver', 'default');
-            await this.execCommand('/sbin/rc-update', 'add', 'dnsmasq', 'default');
-            await this.execCommand('/sbin/rc-update', 'add', 'dnsmasq-generate', 'default');
-            await this.writeConf('host-resolver', {
-              RESOLVER_PEER_BINARY: await this.getHostResolverPeerPath(),
-              LOG_DIR:              logPath,
-            });
-            if (config.hostResolver) {
-              console.debug(`setting DNS to host-resolver`);
-              try {
-                this.resolverHostProcess.start();
-              } catch (error) {
-                console.error('Failed to run host-resolver vsock-host process:', error);
-              }
-              await this.execCommand('/sbin/rc-update', 'del', 'dnsmasq-generate', 'default');
-              await this.execCommand('/sbin/rc-update', 'del', 'dnsmasq', 'default');
-            } else {
-              await this.execCommand('/sbin/rc-update', 'del', 'host-resolver', 'default');
-            }
-            await this.writeFile('/etc/init.d/cri-dockerd', SERVICE_SCRIPT_CRI_DOCKERD, { permissions: 0o755 });
-            await this.writeConf('cri-dockerd', {
-              ENGINE:  config.containerEngine,
-              LOG_DIR: logPath,
-            });
-            await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, { permissions: 0o755 });
-            await this.writeFile('/etc/logrotate.d/k3s', rotateConf);
-            await this.execCommand('mkdir', '-p', '/etc/cni/net.d');
-            if (config.options.flannel) {
-              await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
-            }
-            await this.writeFile('/etc/containerd/config.toml', CONTAINERD_CONFIG);
-            await this.writeConf('containerd', { log_owner: 'root' });
-            await this.writeFile('/etc/init.d/docker', SERVICE_SCRIPT_DOCKERD, { permissions: 0o755 });
-            await this.writeConf('docker', {
-              WSL_HELPER_BINARY: await this.getWSLHelperPath(),
-              LOG_DIR:           logPath,
-            });
-            await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, { permissions: 0o755 });
-            await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF);
-            await this.execCommand('mkdir', '-p', '/var/lib/misc');
+            await Promise.all([
+              this.progressTracker.action('DNS configuration', 50, async() => {
+                await this.writeFile('/etc/init.d/host-resolver', SERVICE_SCRIPT_HOST_RESOLVER, { permissions: 0o755 });
+                await this.writeFile('/etc/init.d/dnsmasq-generate', SERVICE_SCRIPT_DNSMASQ_GENERATE, { permissions: 0o755 });
+                // As `rc-update del …` fails if the service is already not in the run level, we add
+                // both `host-resolver` and `dnsmasq` to `default` and then delete the one we
+                // don't actually want to ensure that the appropriate one will be active.
+                await this.execCommand('/sbin/rc-update', 'add', 'host-resolver', 'default');
+                await this.execCommand('/sbin/rc-update', 'add', 'dnsmasq', 'default');
+                await this.execCommand('/sbin/rc-update', 'add', 'dnsmasq-generate', 'default');
+                await this.writeConf('host-resolver', {
+                  RESOLVER_PEER_BINARY: await this.getHostResolverPeerPath(),
+                  LOG_DIR:              logPath,
+                });
+                // dnsmasq requires /var/lib/misc to exist
+                await this.execCommand('mkdir', '-p', '/var/lib/misc');
+                if (config.hostResolver) {
+                  console.debug(`setting DNS to host-resolver`);
+                  try {
+                    this.resolverHostProcess.start();
+                  } catch (error) {
+                    console.error('Failed to run host-resolver vsock-host process:', error);
+                  }
+                  await this.execCommand('/sbin/rc-update', 'del', 'dnsmasq-generate', 'default');
+                  await this.execCommand('/sbin/rc-update', 'del', 'dnsmasq', 'default');
+                } else {
+                  await this.execCommand('/sbin/rc-update', 'del', 'host-resolver', 'default');
+                }
+              }),
+              this.progressTracker.action('Kubernetes dockerd compatibility', 50, async() => {
+                await this.writeFile('/etc/init.d/cri-dockerd', SERVICE_SCRIPT_CRI_DOCKERD, { permissions: 0o755 });
+                await this.writeConf('cri-dockerd', {
+                  ENGINE:  config.containerEngine,
+                  LOG_DIR: logPath,
+                });
+              }),
+              this.progressTracker.action('Kubernetes components', 50, async() => {
+                await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, { permissions: 0o755 });
+                await this.writeFile('/etc/logrotate.d/k3s', rotateConf);
+                await this.execCommand('mkdir', '-p', '/etc/cni/net.d');
+                if (config.options.flannel) {
+                  await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
+                }
+              }),
+              this.progressTracker.action('container engine components', 50, async() => {
+                await this.writeFile('/etc/containerd/config.toml', CONTAINERD_CONFIG);
+                await this.writeConf('containerd', { log_owner: 'root' });
+                await this.writeFile('/etc/init.d/docker', SERVICE_SCRIPT_DOCKERD, { permissions: 0o755 });
+                await this.writeConf('docker', {
+                  WSL_HELPER_BINARY: await this.getWSLHelperPath(),
+                  LOG_DIR:           logPath,
+                });
+                await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, { permissions: 0o755 });
+                await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF);
+              }),
+              this.progressTracker.action('Rancher Desktop guest agent', 50, this.installGuestAgent(desiredVersion)),
+            ]);
 
             await this.runInit();
           }),


### PR DESCRIPTION
In newer versions of Kubernetes, the kubelet will no longer listen on the local port when setting up a NodePort service (which is actually handled via iptables).  However, our platforms (WSL & lima) actually rely on that
listening local port to determine when they need to do port forwarding from the host.  So we watch Kubernetes services and manually listen on the corresponding port to emulate the old behaviour (and repairing the port
forwarding).

This introduces the rancher-desktop-guestagent service for lima; it previously already existed on WSL for containerd-based port forwarding (which is handled on lima via lima-guest-agent).

Fixes #2593 