### PR TITLE
Lima: force persist-argv for binfmt_misc/qemu.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1673,6 +1673,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           this.progressTracker.action('Installing CA certificates', 50, this.installCACerts()),
           this.progressTracker.action('Installing credential helper', 50, this.installCredentialHelper()),
           this.progressTracker.action('Installing guest agent', 50, this.installGuestAgent(config.enabled ? desiredVersion : null)),
+          this.progressTracker.action('Fixing binfmt_misc qemu', 50, async() => {
+            await this.writeFile('/etc/conf.d/qemu-binfmt', 'binfmt_flags="POCF"');
+            await this.ssh('sudo', '/sbin/rc-service', 'qemu-binfmt', 'restart');
+          }),
         ]);
 
         if (this.currentAction !== Action.STARTING) {


### PR DESCRIPTION
The version of qemu we are using now (inside the VM, for running foreign binaries) has a patch to assume persist-argv (the "P") flag is set for binfmt_misc (when it detects no flags at all).  Set that flag manually so that it will get executed correctly.

This is a cherry-pick of #2680 into the release-1.5 branch.