### PR TITLE
Enforce eslint comma dangle rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   env:  {
     browser: true,
     node:    true,
-    jest:    true
+    jest:    true,
   },
   parser:        'vue-eslint-parser',
   parserOptions: {
@@ -86,31 +86,31 @@ module.exports = {
         beforeColon: false,
         afterColon:  true,
         on:          'value',
-        mode:        'minimum'
+        mode:        'minimum',
       },
       multiLine: {
         beforeColon: false,
-        afterColon:  true
+        afterColon:  true,
       },
     }],
 
     'object-curly-newline':          ['warn', {
       ObjectExpression:  {
         multiline:     true,
-        minProperties: 3
+        minProperties: 3,
       },
       ObjectPattern:     {
         multiline:     true,
-        minProperties: 4
+        minProperties: 4,
       },
       ImportDeclaration: {
         multiline:     true,
-        minProperties: 5
+        minProperties: 5,
       },
       ExportDeclaration: {
         multiline:     true,
-        minProperties: 3
-      }
+        minProperties: 3,
+      },
     }],
 
     'padding-line-between-statements': [
@@ -129,13 +129,13 @@ module.exports = {
       {
         blankLine: 'always',
         prev:      ['const', 'let', 'var'],
-        next:      '*'
+        next:      '*',
       },
       {
         blankLine: 'any',
         prev:      ['const', 'let', 'var'],
-        next:      ['const', 'let', 'var']
-      }
+        next:      ['const', 'let', 'var'],
+      },
     ],
 
     quotes: [
@@ -143,7 +143,7 @@ module.exports = {
       'single',
       {
         avoidEscape:           true,
-        allowTemplateLiterals: true
+        allowTemplateLiterals: true,
       },
     ],
 
@@ -152,9 +152,9 @@ module.exports = {
       {
         words:    true,
         nonwords: false,
-      }
+      },
     ],
-  }
+  },
 };
 
 // Desktop additions
@@ -208,7 +208,7 @@ Object.assign(module.exports.rules, {
         pattern: '~/**',
         group:   'internal',
       },
-    ]
+    ],
   }],
 
   // Disable TypeScript rules that our code doesn't follow (yet).
@@ -242,6 +242,6 @@ module.exports.overrides = [
       'no-redeclare':          'off',
       // For TypeScript, TS does use-before-define statically.
       'no-use-before-define':  'off',
-    }
-  }
+    },
+  },
 ];

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     'arrow-spacing':                  ['warn', { before: true, after: true }],
     'block-spacing':                  ['warn', 'always'],
     'brace-style':                    ['warn', '1tbs'],
-    'comma-dangle':                   ['warn', 'only-multiline'],
+    'comma-dangle':                   ['warn', 'always-multiline'],
     'comma-spacing':                  'warn',
     curly:                           'warn',
     eqeqeq:                          'warn',

--- a/background.ts
+++ b/background.ts
@@ -637,7 +637,7 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
       parent: mainWindow || undefined,
       frame:  true,
       title:  options.title,
-      height: 225
+      height: 225,
     });
 
   let response: any;

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -120,8 +120,8 @@ test.describe.serial('KubernetesBackend', () => {
           options:                  {
             traefik: getAlt('options.traefik', true, false),
             flannel: getAlt('options.flannel', true, false),
-          }
-        }
+          },
+        },
       };
       const platformSettings: Record<string, RecursivePartial<Settings>> = {
         win32: { kubernetes: { hostResolver: getAlt('hostResolver', true, false) } },
@@ -177,15 +177,15 @@ test.describe.serial('KubernetesBackend', () => {
           WSLIntegrations: {
             [`true-${ random }`]:  true,
             [`false-${ random }`]: false,
-          }
-        }
+          },
+        },
       };
 
       await expect(put('/v0/propose_settings', newSettings)).resolves.toMatchObject({
         'kubernetes.WSLIntegrations': {
           current: {},
           desired: newSettings.kubernetes?.WSLIntegrations,
-        }
+        },
       });
     });
   });

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -135,7 +135,7 @@ describeWithCreds('Credentials server', () => {
       throw {
         stdout: err?.stdout ?? '',
         stderr: err?.stderr ?? '',
-        error:  err
+        error:  err,
       };
     }
   }
@@ -162,7 +162,7 @@ describeWithCreds('Credentials server', () => {
 
     await context.tracing.start({
       screenshots: true,
-      snapshots:   true
+      snapshots:   true,
     });
     page = await electronApp.firstWindow();
   });
@@ -213,7 +213,7 @@ describeWithCreds('Credentials server', () => {
     const bobsSecondSecret = 'shoppers with spaces and % and \' and &s';
 
     const body = {
-      ServerURL: bobsURL, Username: 'bob', Secret: bobsFirstSecret
+      ServerURL: bobsURL, Username: 'bob', Secret: bobsFirstSecret,
     };
     let stdout: string = await doRequest('list');
 
@@ -280,7 +280,7 @@ describeWithCreds('Credentials server', () => {
     const body = {
       ServerURL: bobsURL,
       Username:  'bob',
-      Secret:    bobsFirstSecret
+      Secret:    bobsFirstSecret,
     };
 
     let { stdout } = await rdctlCredWithStdin('list');
@@ -321,7 +321,7 @@ describeWithCreds('Credentials server', () => {
       `export CREDFWD_CURL_OPTS="--show-error"; \
        SECRET=$(tr -dc 'A-Za-z0-9,._=' < /dev/urandom |  head -c5242880); \
        echo '{"ServerURL":"https://example.com/v1","Username":"alice","Secret":"'$SECRET'"}' |
-         /usr/local/bin/docker-credential-rancher-desktop store`
+         /usr/local/bin/docker-credential-rancher-desktop store`,
     ];
 
     try {
@@ -332,7 +332,7 @@ describeWithCreds('Credentials server', () => {
     } catch (err: any) {
       expect(err).toMatchObject({
         stdout: expect.stringContaining('request body is too long, request body size exceeds 4194304'),
-        stderr: expect.stringContaining('The requested URL returned error: 413\nError: exit status 22')
+        stderr: expect.stringContaining('The requested URL returned error: 413\nError: exit status 22'),
       });
     }
   });
@@ -346,7 +346,7 @@ describeWithCreds('Credentials server', () => {
       'sh',
       '-c',
       `echo '{"ServerURL":"${ calsURL }","Username":"cal","Secret":"${ secret }"}' |
-         /usr/local/bin/docker-credential-rancher-desktop store`
+         /usr/local/bin/docker-credential-rancher-desktop store`,
     ];
 
     await expect(spawnFile(rdctlPath(), args, { stdio: ['ignore', 'pipe', 'pipe'] })).resolves.toBeDefined();
@@ -378,7 +378,7 @@ describeWithCreds('Credentials server', () => {
 
     test('it should not complain about extra fields', async() => {
       const body: Record<string, string> = {
-        ServerURL: bobsURL, Username: 'bob', Soup: 'gazpacho'
+        ServerURL: bobsURL, Username: 'bob', Soup: 'gazpacho',
       };
 
       await expect(rdctlCredWithStdin('store', JSON.stringify(body))).resolves.toMatchObject({ stdout: '' });
@@ -388,7 +388,7 @@ describeWithCreds('Credentials server', () => {
       expect({ stdout: JSON.parse(stdout), stderr }).toMatchObject({
         // Playwright type definitions for `expect.not` is missing; see
         // playwright issue #15087.
-        stdout: (expect as any).not.objectContaining({ Soup: 'gazpacho' })
+        stdout: (expect as any).not.objectContaining({ Soup: 'gazpacho' }),
       });
     });
   });

--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -5,7 +5,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, packageLogs
+  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, packageLogs,
 } from './utils/TestUtils';
 
 let page: Page;

--- a/e2e/kubectl.e2e.spec.ts
+++ b/e2e/kubectl.e2e.spec.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { test, expect } from '@playwright/test';
 import {
-  ElectronApplication, BrowserContext, _electron, Page, Locator
+  ElectronApplication, BrowserContext, _electron, Page, Locator,
 } from 'playwright';
 
 import { NavPage } from './pages/nav-page';

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -29,7 +29,7 @@ import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, packageLogs, reportAsset, tool
+  createDefaultSettings, kubectl, packageLogs, reportAsset, tool,
 } from './utils/TestUtils';
 
 import { Settings } from '@/config/settings';
@@ -52,7 +52,7 @@ test.describe('Command server', () => {
       method,
       headers: {
         Authorization: `Basic ${ Buffer.from(auth)
-          .toString('base64') }`
+          .toString('base64') }`,
       },
     };
 
@@ -72,7 +72,7 @@ test.describe('Command server', () => {
       return await spawnFile(rdctlPath(), commandArgs, { stdio: 'pipe' });
     } catch (err: any) {
       return {
-        stdout: err?.stdout ?? '', stderr: err?.stderr ?? '', error: err
+        stdout: err?.stdout ?? '', stderr: err?.stderr ?? '', error: err,
       };
     }
   }
@@ -88,7 +88,7 @@ test.describe('Command server', () => {
       return await spawnFile(rdctlPath(), commandArgs, { stdio: [stream, 'pipe', 'pipe'] });
     } catch (err: any) {
       return {
-        stdout: err?.stdout ?? '', stderr: err?.stderr ?? '', error: err
+        stdout: err?.stdout ?? '', stderr: err?.stderr ?? '', error: err,
       };
     } finally {
       stream?.close();
@@ -117,7 +117,7 @@ test.describe('Command server', () => {
 
     await context.tracing.start({
       screenshots: true,
-      snapshots:   true
+      snapshots:   true,
     });
     page = await electronApp.firstWindow();
   });
@@ -224,7 +224,7 @@ test.describe('Command server', () => {
           containerEngine:            desiredEngine,
           version:                    desiredVersion,
           checkForExistingKimBuilder: !settings.kubernetes.checkForExistingKimBuilder, // not supported
-        }
+        },
     });
     const resp2 = await doRequest('/v0/settings', JSON.stringify(requestedSettings), 'PUT');
 
@@ -247,7 +247,7 @@ test.describe('Command server', () => {
         containerEngine: { status: 'should be a scalar' },
       },
       portForwarding: 'bob',
-      telemetry:      { oops: 15 }
+      telemetry:      { oops: 15 },
     };
     const resp2 = await doRequest('/v0/settings', JSON.stringify(newSettings), 'PUT');
 
@@ -328,11 +328,11 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctl(['list-settings']);
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  expect.any(Error),
             stderr: expect.stringContaining(`Error: open ${ configFilePath }: ${ ENOENTMessage }`),
-            stdout: ''
+            stdout: '',
           });
           expect(stderr).not.toContain('Usage:');
         });
@@ -341,7 +341,7 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctl(parameters.concat(['list-settings']));
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  undefined,
             stderr: '',
@@ -357,7 +357,7 @@ test.describe('Command server', () => {
             telemetry:              expect.anything(),
             updater:                expect.anything(),
             debug:                  expect.anything(),
-            pathManagementStrategy: expect.anything()
+            pathManagementStrategy: expect.anything(),
           });
         });
         test("it complains when some parameters aren't specified", async() => {
@@ -366,11 +366,11 @@ test.describe('Command server', () => {
             const { stdout, stderr, error } = await rdctl(partialParameters.concat(['list-settings']));
 
             expect({
-              stdout, stderr, error
+              stdout, stderr, error,
             }).toEqual({
               error:  expect.any(Error),
               stderr: expect.stringContaining(`Error: open ${ configFilePath }: ${ ENOENTMessage }`),
-              stdout: ''
+              stdout: '',
             });
             expect(stderr).not.toContain('Usage:');
           }
@@ -385,11 +385,11 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(parameters.concat(['list-settings', '--config-path', configFile]));
 
               expect({
-                stdout, stderr, error
+                stdout, stderr, error,
               }).toEqual({
                 error:  expect.any(Error),
                 stderr: expect.stringContaining(`Error: open ${ configFile }: ${ ENOENTMessage }`),
-                stdout: ''
+                stdout: '',
               });
               expect(stderr).not.toContain('Usage:');
             } finally {
@@ -403,7 +403,7 @@ test.describe('Command server', () => {
       const { stdout, stderr, error } = await rdctl(['list-settings']);
 
       expect({
-        stdout, stderr, error
+        stdout, stderr, error,
       }).toEqual({
         error:  undefined,
         stderr: '',
@@ -419,7 +419,7 @@ test.describe('Command server', () => {
         telemetry:              expect.anything(),
         updater:                expect.anything(),
         debug:                  expect.anything(),
-        pathManagementStrategy: expect.anything()
+        pathManagementStrategy: expect.anything(),
       });
 
       const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
@@ -429,7 +429,7 @@ test.describe('Command server', () => {
 
       expect(result).toMatchObject({
         stderr: '',
-        stdout: expect.stringContaining('Status: no changes necessary.')
+        stdout: expect.stringContaining('Status: no changes necessary.'),
       });
     });
 
@@ -438,11 +438,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['set']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringContaining('Error: set command: no settings to change were given'),
-          stdout: ''
+          stdout: '',
         });
         expect(stderr).toContain('Usage:');
       });
@@ -451,11 +451,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['set', '--container-engine']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringContaining('Error: flag needs an argument: --container-engine'),
-          stdout: ''
+          stdout: '',
         });
         expect(stderr).toContain('Usage:');
       });
@@ -464,11 +464,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['set', '--kubernetes-enabled=gorb']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringContaining('Error: invalid argument "gorb" for "--kubernetes-enabled" flag: strconv.ParseBool: parsing "gorb": invalid syntax'),
-          stdout: ''
+          stdout: '',
         });
         expect(stderr).toContain('Usage:');
       });
@@ -478,11 +478,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['set', `--container-engine=${ myEngine }`]);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringContaining(`Invalid value for kubernetes.containerEngine: <"${ myEngine }">; must be 'containerd', 'docker', or 'moby'`),
-          stdout: ''
+          stdout: '',
         });
         expect(stderr).toContain('Error: errors in attempt to update settings:');
         expect(stderr).not.toContain('Usage:');
@@ -492,11 +492,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['set', '--kubernetes-version=karl']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringMatching(/Error: errors in attempt to update settings:\s+Kubernetes version "karl" not found./),
-          stdout: ''
+          stdout: '',
         });
         expect(stderr).not.toContain('Usage:');
       });
@@ -513,11 +513,11 @@ test.describe('Command server', () => {
             const { stdout, stderr, error } = await rdctl(args);
 
             expect({
-              stdout, stderr, error
+              stdout, stderr, error,
             }).toEqual({
               error:  expect.any(Error),
               stderr: expect.stringContaining(`Error: unknown command "string" for "rdctl ${ cmd }"`),
-              stdout: ''
+              stdout: '',
             });
             expect(stderr).toContain('Usage:');
           });
@@ -532,11 +532,11 @@ test.describe('Command server', () => {
             const { stdout, stderr, error } = await rdctl(args);
 
             expect({
-              stdout, stderr, error
+              stdout, stderr, error,
             }).toEqual({
               error:  expect.any(Error),
               stderr: expect.stringContaining(`Error: unknown flag: ${ args[1] }`),
-              stdout: ''
+              stdout: '',
             });
             expect(stderr).toContain('Usage:');
           });
@@ -550,11 +550,11 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctl(['api']);
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  expect.any(Error),
             stderr: expect.stringContaining('Error: api command: no endpoint specified'),
-            stdout: ''
+            stdout: '',
           });
           expect(stderr).toContain('Usage:');
         });
@@ -563,11 +563,11 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctl(['api', '']);
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  expect.any(Error),
             stderr: expect.stringContaining('Error: api command: no endpoint specified'),
-            stdout: ''
+            stdout: '',
           });
           expect(stderr).toContain('Usage:');
         });
@@ -577,11 +577,11 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctl(['api', ...endpoints]);
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  expect.any(Error),
             stderr: expect.stringContaining(`Error: api command: too many endpoints specified ([${ endpoints.join(' ') }]); exactly one must be specified`),
-            stdout: ''
+            stdout: '',
           });
           expect(stderr).toContain('Usage:');
         });
@@ -598,11 +598,11 @@ test.describe('Command server', () => {
                   const { stdout, stderr, error } = await rdctl(args);
 
                   expect({
-                    stdout, stderr, error
+                    stdout, stderr, error,
                   }).toEqual({
                     error:  undefined,
                     stderr: '',
-                    stdout: expect.stringMatching(/{.+}/s)
+                    stdout: expect.stringMatching(/{.+}/s),
                   });
                   const settings = JSON.parse(stdout);
 
@@ -625,11 +625,11 @@ test.describe('Command server', () => {
                       const { stdout, stderr, error } = await rdctlWithStdin(settingsFile, args);
 
                       expect({
-                        stdout, stderr, error
+                        stdout, stderr, error,
                       }).toEqual({
                         error:  undefined,
                         stderr: '',
-                        stdout: expect.stringContaining('no changes necessary')
+                        stdout: expect.stringContaining('no changes necessary'),
                       });
                     });
                   }
@@ -648,11 +648,11 @@ test.describe('Command server', () => {
                       const { stdout, stderr, error } = await rdctl(args);
 
                       expect({
-                        stdout, stderr, error
+                        stdout, stderr, error,
                       }).toEqual({
                         error:  undefined,
                         stderr: '',
-                        stdout: expect.stringContaining('no changes necessary')
+                        stdout: expect.stringContaining('no changes necessary'),
                       });
                     });
                   }
@@ -664,11 +664,11 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(['api', '/settings', '-X', 'PUT', '--input-']);
 
               expect({
-                stdout, stderr, error
+                stdout, stderr, error,
               }).toEqual({
                 error:  expect.any(Error),
                 stderr: expect.stringContaining('Error: unknown flag: --input-'),
-                stdout: ''
+                stdout: '',
               });
               expect(stderr).toContain('Usage:');
             });
@@ -686,11 +686,11 @@ test.describe('Command server', () => {
                       const { stdout, stderr, error } = await rdctl(args.concat(settingsBody));
 
                       expect({
-                        stdout, stderr, error
+                        stdout, stderr, error,
                       }).toEqual({
                         error:  undefined,
                         stderr: '',
-                        stdout: expect.stringContaining('no changes necessary')
+                        stdout: expect.stringContaining('no changes necessary'),
                       });
                     });
                   }
@@ -706,11 +706,11 @@ test.describe('Command server', () => {
                   const { stdout, stderr, error } = await rdctl(args);
 
                   expect({
-                    stdout, stderr, error
+                    stdout, stderr, error,
                   }).toEqual({
                     error:  expect.any(Error),
                     stderr: expect.stringContaining('Error: api command: --body and --input options cannot both be specified'),
-                    stdout: ''
+                    stdout: '',
                   });
                   expect(stderr).toContain('Usage:');
                 });
@@ -721,11 +721,11 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-X', 'PUT']);
 
               expect({
-                stdout, stderr, error
+                stdout, stderr, error,
               }).toEqual({
                 error:  expect.any(Error),
                 stderr: expect.stringContaining('no settings specified in the request'),
-                stdout: expect.stringMatching(/{.*}/s)
+                stdout: expect.stringMatching(/{.*}/s),
               });
               expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
               expect(stderr).not.toContain('Usage:');
@@ -736,11 +736,11 @@ test.describe('Command server', () => {
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
               expect({
-                stdout, stderr, error
+                stdout, stderr, error,
               }).toEqual({
                 error:  expect.any(Error),
                 stderr: expect.stringMatching(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <"beefalo">; must be 'containerd', 'docker', or 'moby'/),
-                stdout: expect.stringMatching(/{.*}/s)
+                stdout: expect.stringMatching(/{.*}/s),
               });
               expect(stderr).not.toContain('Usage:');
               expect(JSON.parse(stdout)).toEqual({ message: '400 Bad Request' } );
@@ -754,11 +754,11 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['api', endpoint]);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
           stderr: expect.stringContaining(`Unknown command: GET ${ endpoint }`),
-          stdout: expect.stringMatching(/{.*}/s)
+          stdout: expect.stringMatching(/{.*}/s),
         });
         expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found' });
         expect(stderr).not.toContain('Usage:');
@@ -800,22 +800,22 @@ test.describe('Command server', () => {
         const { stdout, stderr, error } = await rdctl(['shell', 'echo', 'abc', 'def']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  undefined,
           stderr: '',
-          stdout: expect.stringContaining('abc def')
+          stdout: expect.stringContaining('abc def'),
         });
       });
       test('can run a command with a dash-option', async() => {
         const { stdout, stderr, error } = await rdctl(['shell', 'uname', '-a']);
 
         expect({
-          stdout, stderr, error
+          stdout, stderr, error,
         }).toEqual({
           error:  undefined,
           stderr: '',
-          stdout: expect.stringMatching(/\S/)
+          stdout: expect.stringMatching(/\S/),
         });
       });
       test('can run a shell', async() => {
@@ -827,11 +827,11 @@ test.describe('Command server', () => {
           const { stdout, stderr, error } = await rdctlWithStdin(inputPath, ['shell']);
 
           expect({
-            stdout, stderr, error
+            stdout, stderr, error,
           }).toEqual({
             error:  undefined,
             stderr: '',
-            stdout: expect.stringContaining('orate linds chump')
+            stdout: expect.stringContaining('orate linds chump'),
           });
         } finally {
           await fs.promises.rm(tmpDir, { recursive: true, force: true });

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -57,7 +57,7 @@ export function createDefaultSettings(overrides: RecursivePartial<Settings> = {}
 export function reportAsset(testPath: string, type: 'trace' | 'log' = 'trace') {
   const name = {
     trace: 'pw-trace.zip',
-    log:   'logs'
+    log:   'logs',
   }[type];
 
   // Note that CirrusCI doesn't upload folders...
@@ -108,7 +108,7 @@ export async function tool(tool: string, ...args: string[]): Promise<string> {
     // Normally, it would just print out `ex.toString()`, which mostly just says
     // "<command> exited with code 1" and doesn't explain _why_ that happened.
     expect({
-      stdout: ex.stdout, stderr: ex.stderr, message: ex.toString()
+      stdout: ex.stdout, stderr: ex.stderr, message: ex.toString(),
     }).toBeUndefined();
     throw ex;
   }

--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -69,7 +69,7 @@ test.describe('WSL Integrations', () => {
             '  alpha  Stopped  2',
             '  beta   Stopped  2',
             '  gamma  Stopped  2',
-            ''
+            '',
           ].join('\n'),
           utf16le: true,
         },
@@ -124,7 +124,7 @@ test.describe('WSL Integrations', () => {
           mode:   'repeated',
           stdout: (opts?.gamma ?? 'some error').toString(),
         },
-      ]
+      ],
     };
 
     await fs.promises.writeFile(path.join(workdir, 'config.json'), JSON.stringify(config, undefined, 2));
@@ -154,7 +154,7 @@ test.describe('WSL Integrations', () => {
         '--whitelisted-ips=',
         // See src/utils/commandLine.ts before changing the next item as the final option.
         '--disable-dev-shm-usage',
-        '--no-modal-dialogs'
+        '--no-modal-dialogs',
       ],
       env: {
         ...(process.env as Record<string, string>),

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -19,7 +19,7 @@ class Builder {
       path.resolve(buildUtils.distDir),
     ];
     const options = {
-      force: true, maxRetries: 3, recursive: true
+      force: true, maxRetries: 3, recursive: true,
     };
 
     await Promise.all(dirs.map(dir => fs.rm(dir, options)));

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -67,7 +67,7 @@ class DevRunner extends events.EventEmitter {
         'node_modules/electron/cli.js',
         buildUtils.srcDir,
         this.rendererPort,
-        ...process.argv
+        ...process.argv,
       );
       this.#mainProcess.on('exit', (code, signal) => {
         if (code === 201) {

--- a/scripts/download/lima.mjs
+++ b/scripts/download/lima.mjs
@@ -23,7 +23,7 @@ async function getLima(platform) {
   const tarPath = path.join(resourcesDir, `lima-${ limaTag }.tgz`);
 
   await download(url, tarPath, {
-    expectedChecksum, checksumAlgorithm: 'sha512', access: fs.constants.W_OK
+    expectedChecksum, checksumAlgorithm: 'sha512', access: fs.constants.W_OK,
   });
   await fs.promises.mkdir(limaDir, { recursive: true });
 
@@ -47,7 +47,7 @@ async function getAlpineLima(arch) {
   const expectedChecksum = (await getResource(`${ url }.sha512sum`)).split(/\s+/)[0];
 
   await download(url, destPath, {
-    expectedChecksum, checksumAlgorithm: 'sha512', access: fs.constants.W_OK
+    expectedChecksum, checksumAlgorithm: 'sha512', access: fs.constants.W_OK,
   });
 }
 

--- a/scripts/download/tools.mjs
+++ b/scripts/download/tools.mjs
@@ -231,7 +231,7 @@ export default async function main(rawPlatform) {
     stevePath,
     {
       expectedChecksum:  steveSHA,
-      checksumAlgorithm: 'sha512'
+      checksumAlgorithm: 'sha512',
     });
 
   downloadRancherDashboard();
@@ -298,7 +298,7 @@ async function downloadRancherDashboard() {
     {
       expectedChecksum:  rancherDashboardSHA,
       checksumAlgorithm: 'sha512',
-      access:            fs.constants.W_OK
+      access:            fs.constants.W_OK,
     });
 
   await fs.promises.mkdir(rancherDashboardDir, { recursive: true });
@@ -317,7 +317,7 @@ async function downloadRancherDashboard() {
     args.slice(1),
     {
       cwd:   rancherDashboardDir,
-      stdio: 'inherit'
+      stdio: 'inherit',
     });
 
   fs.rmSync(rancherDashboardPath, { maxRetries: 10 });

--- a/scripts/download/wsl.mjs
+++ b/scripts/download/wsl.mjs
@@ -29,7 +29,7 @@ function extract(resourcesPath, file, expectedFile) {
     ['-xzf', file, expectedFile],
     {
       cwd:   resourcesPath,
-      stdio: 'inherit'
+      stdio: 'inherit',
     });
   fs.rmSync(file, { maxRetries: 10 });
 }

--- a/scripts/lib/build-utils.mjs
+++ b/scripts/lib/build-utils.mjs
@@ -156,7 +156,7 @@ export default {
         rules: [
           {
             test: /\.ts$/,
-            use:  { loader: 'ts-loader' }
+            use:  { loader: 'ts-loader' },
           },
           {
             test: /\.js$/,
@@ -230,7 +230,7 @@ export default {
           ...process.env,
           GOOS:        this.goOSMapping[platform],
           CGO_ENABLED: '0',
-        }
+        },
       });
     };
 
@@ -268,7 +268,7 @@ export default {
       env: {
         ...process.env,
         GOOS: os,
-      }
+      },
     });
   },
 
@@ -285,7 +285,7 @@ export default {
       env: {
         ...process.env,
         GOOS: this.goOSMapping[platform],
-      }
+      },
     });
   },
 
@@ -302,7 +302,7 @@ export default {
       env: {
         ...process.env,
         GOOS: this.goOSMapping[platform],
-      }
+      },
     });
   },
 

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -19,6 +19,6 @@ exports.default = async function notarizing(context) {
     appBundleId:     'io.rancherdesktop.app',
     appPath:         `${ appOutDir }/${ appName }.app`,
     appleId,
-    appleIdPassword: process.env.AC_PASSWORD
+    appleIdPassword: process.env.AC_PASSWORD,
   });
 };

--- a/src/components/ActionDropdown.vue
+++ b/src/components/ActionDropdown.vue
@@ -5,18 +5,18 @@ export default {
   props: {
     size: {
       type:    String,
-      default: '' // possible values are xs, sm, lg. empty is default .btn
+      default: '', // possible values are xs, sm, lg. empty is default .btn
     },
     // whether this is a button and dropdown (default) or dropdown that looks like a button/dropdown
     dualAction: {
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     disableButton: {
       type:    Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {
@@ -41,7 +41,7 @@ export default {
       }
 
       return out;
-    }
+    },
   },
 
   methods: {
@@ -53,7 +53,7 @@ export default {
     togglePopover() {
       // this.$refs.popoverButton.click();
     },
-  }
+  },
 };
 </script>
 <template>

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -13,7 +13,7 @@ export default {
   data() {
     return {
       phase: HIDDEN,
-      style: {}
+      style: {},
     };
   },
 
@@ -22,7 +22,7 @@ export default {
       targetElem:  'action-menu/elem',
       targetEvent: 'action-menu/event',
       shouldShow:  'action-menu/showing',
-      options:     'action-menu/options'
+      options:     'action-menu/options',
     }),
 
     showing() {
@@ -51,7 +51,7 @@ export default {
 
     '$route.path'(val, old) {
       this.hide();
-    }
+    },
   },
 
   methods: {
@@ -83,14 +83,14 @@ export default {
       const opts = { alt: isAlternate(event) };
 
       this.$store.dispatch('action-menu/execute', {
-        action, args, opts
+        action, args, opts,
       });
       this.hide();
     },
 
     hasOptions(options) {
       return options.length !== undefined ? options.length : Object.keys(options).length > 0;
-    }
+    },
   },
 };
 </script>

--- a/src/components/BadgeState.vue
+++ b/src/components/BadgeState.vue
@@ -16,7 +16,7 @@ export default {
 
     icon: {
       type:    String,
-      default: null
+      default: null,
     },
 
     label: {
@@ -32,8 +32,8 @@ export default {
 
     msg() {
       return this.value?.stateDisplay || this.label;
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/Banner.vue
+++ b/src/components/Banner.vue
@@ -4,7 +4,7 @@ export default Vue.extend({
   props: {
     color: {
       type:    String,
-      default: 'secondary'
+      default: 'secondary',
     },
     label: {
       type:    [String, Error, Object],
@@ -17,8 +17,8 @@ export default Vue.extend({
     closable: {
       type:    Boolean,
       default: false,
-    }
-  }
+    },
+  },
 });
 </script>
 <template>

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -3,29 +3,29 @@ export default {
   props:      {
     title: {
       type:     String,
-      default: ''
+      default: '',
     },
     content: {
       type:    String,
-      default: ''
+      default: '',
     },
     buttonAction: {
       type:    Function,
-      default: () => {}
+      default: () => {},
     },
     buttonText: {
       type:    String,
-      default: 'go'
+      default: 'go',
     },
     showHighlightBorder: {
       type:    Boolean,
-      default: true
+      default: true,
     },
     showActions: {
       type:    Boolean,
-      default: true
-    }
-  }
+      default: true,
+    },
+  },
 };
 </script>
 

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -5,21 +5,21 @@ export default Vue.extend({
   props: {
     icon: {
       type:    String,
-      default: 'icon-alert'
+      default: 'icon-alert',
     },
     heading: {
       type:    String,
-      default: 'Empty state'
+      default: 'Empty state',
     },
     body: {
       type:    String,
-      default: 'This is an example of an empty state.'
-    }
+      default: 'This is an example of an empty state.',
+    },
   },
   computed: {
     hasPrimaryActionSlot(): boolean {
       return !!this.$slots['primary-action'];
-    }
+    },
   },
 });
 </script>

--- a/src/components/EngineSelector.vue
+++ b/src/components/EngineSelector.vue
@@ -11,8 +11,8 @@ export default {
     },
     row: {
       type:    Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   computed: {
     options() {
@@ -22,16 +22,16 @@ export default {
           return {
             label:       this.t(`containerEngine.options.${ x }.label`),
             value:       x,
-            description: this.t(`containerEngine.options.${ x }.description`)
+            description: this.t(`containerEngine.options.${ x }.description`),
           };
         });
-    }
+    },
   },
   methods: {
     updateEngine(value) {
       this.$emit('change', value);
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -9,8 +9,8 @@ export default Vue.extend({
   methods:    {
     openPreferences() {
       this.$emit('open-preferences');
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/ImageAddTabs.vue
+++ b/src/components/ImageAddTabs.vue
@@ -31,7 +31,7 @@ export default Vue.extend({
 
   components: {
     RdTabbed,
-    Tab
+    Tab,
   },
 
   data() {
@@ -42,7 +42,7 @@ export default Vue.extend({
     tabSelected({ tab }: { tab: any }) {
       this.activeTab = tab.name;
       this.$emit('click', this.activeTab);
-    }
-  }
+    },
+  },
 });
 </script>

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -93,7 +93,7 @@ export default {
     Card,
     Checkbox,
     SortableTable,
-    ImagesOutputWindow
+    ImagesOutputWindow,
   },
   props:      {
     images: {
@@ -152,7 +152,7 @@ export default {
       keepImageManagerOutputWindowOpen: false,
       imageOutputCuller:                null,
       mainWindowScroll:                 -1,
-      selected:                         []
+      selected:                         [],
     };
   },
   computed: {
@@ -162,7 +162,7 @@ export default {
           return {
             ...image,
             si:   parseSi(image.size),
-            _key: `${ index }-${ image.imageID }-${ this.imageTag(image.tag) }`
+            _key: `${ index }-${ image.imageID }-${ this.imageTag(image.tag) }`,
           };
         });
     },
@@ -283,7 +283,7 @@ export default {
         buttons:   ['Yes', 'No'],
         defaultId: 1,
         title:     'Confirming image deletion',
-        cancelId:  1
+        cancelId:  1,
       };
 
       const result = await ipcRenderer.invoke('show-message-box', options);
@@ -305,7 +305,7 @@ export default {
         buttons:   ['Yes', 'No'],
         defaultId: 1,
         title:     'Confirming image deletion',
-        cancelId:  1
+        cancelId:  1,
       };
       const result = await ipcRenderer.invoke('show-message-box', options);
 
@@ -363,7 +363,7 @@ export default {
     },
     getTaggedImage(image) {
       return image.tag !== '<none>' ? `${ image.imageName }:${ image.tag }` : `${ image.imageName }@${ image.digest }`;
-    }
+    },
   },
 };
 </script>

--- a/src/components/ImagesButtonAdd.vue
+++ b/src/components/ImagesButtonAdd.vue
@@ -26,8 +26,8 @@ export default Vue.extend({
   methods: {
     route() {
       this.$router.push({ name: 'images-add' });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/ImagesFormAdd.vue
+++ b/src/components/ImagesFormAdd.vue
@@ -33,19 +33,19 @@ export default Vue.extend({
   props: {
     currentCommand: {
       type:    String,
-      default: ''
+      default: '',
     },
     keepOutputWindowOpen: {
       type:    Boolean,
-      default: false
+      default: false,
     },
     action: {
       type:     String,
       required: true,
       validator(value) {
         return ['pull', 'build'].includes(value);
-      }
-    }
+      },
+    },
   },
 
   data() {
@@ -70,14 +70,14 @@ export default Vue.extend({
     },
     inputPlaceholder(): string {
       return this.t(`images.manager.input.${ this.action }.placeholder`);
-    }
+    },
   },
 
   methods: {
     submit() {
       this.$emit('click', { action: this.action, image: this.image });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/ImagesOutputWindow.vue
+++ b/src/components/ImagesOutputWindow.vue
@@ -9,26 +9,26 @@ export default {
 
   components: {
     Banner,
-    LoadingIndicator
+    LoadingIndicator,
   },
 
   props: {
     currentCommand: {
       type:    String,
-      default: null
+      default: null,
     },
     action: {
       type:    String,
-      default: ''
+      default: '',
     },
     imageOutputCuller: {
       type:    Object,
-      default: null
+      default: null,
     },
     showStatus: {
       type:    Boolean,
-      default: true
-    }
+      default: true,
+    },
   },
 
   data() {
@@ -65,7 +65,7 @@ export default {
     },
     errorText() {
       return this.t('images.add.errorText', { action: this.action, image: this.imageToPull }, true);
-    }
+    },
   },
 
   mounted() {

--- a/src/components/ImagesScanResults.vue
+++ b/src/components/ImagesScanResults.vue
@@ -18,13 +18,13 @@ const SEVERITY_MAP = {
   CRITICAL: {
     color: 'bg-error',
     id:    3,
-  }
+  },
 };
 
 export default {
   components: {
     SortableTable,
-    BadgeState
+    BadgeState,
   },
 
   props: {
@@ -34,8 +34,8 @@ export default {
     },
     tableData: {
       type:    Array,
-      default: () => []
-    }
+      default: () => [],
+    },
   },
 
   data() {
@@ -63,7 +63,7 @@ export default {
         {
           name:  'FixedVersion',
           label: this.t('images.scan.results.headers.fixed'),
-        }
+        },
       ],
     };
   },
@@ -75,7 +75,7 @@ export default {
           return {
             SeverityId: this.id(Severity),
             Severity,
-            ...rest
+            ...rest,
           };
         });
     },
@@ -108,7 +108,7 @@ export default {
     },
     issueLabel() {
       return `${ this.t('images.scan.labels.issuesFound') }: ${ this.issueSum }`;
-    }
+    },
   },
 
   methods: {
@@ -120,8 +120,8 @@ export default {
     },
     issueCount(severity) {
       return this.rows.filter(row => row.SeverityId === severity).length;
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/LoadingIndicator.vue
+++ b/src/components/LoadingIndicator.vue
@@ -36,9 +36,9 @@ export default Vue.extend({
   props: {
     loadingText: {
       type:    String,
-      default: ''
-    }
-  }
+      default: '',
+    },
+  },
 });
 </script>
 

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -35,7 +35,7 @@ export default {
       validator(values) {
         return values.every(value => value.key && value.color && value.message);
       },
-    }
+    },
   },
   data() {
     return { closed: {} };
@@ -51,13 +51,13 @@ export default {
       }
 
       return this.notifications.filter(v => !this.closed[v.key]);
-    }
+    },
   },
   methods: {
     close(key) {
       this.$set(this.closed, key, true);
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/PathManagementSelector.vue
+++ b/src/components/PathManagementSelector.vue
@@ -19,16 +19,16 @@ export default Vue.extend({
   props:      {
     value: {
       type:    String,
-      default: PathManagementStrategy.RcFiles
+      default: PathManagementStrategy.RcFiles,
     },
     row: {
       type:    Boolean,
-      default: false
+      default: false,
     },
     showLabel: {
       type:    Boolean,
-      default: true
-    }
+      default: true,
+    },
   },
   computed: {
     options(): pathManagementOptions[] {
@@ -53,13 +53,13 @@ export default Vue.extend({
     },
     tooltip(): string {
       return this.showLabel ? this.t('pathManagement.tooltip', { }, true) : '';
-    }
+    },
   },
   methods: {
     updateVal(value: PathManagementStrategy) {
       this.$emit('input', value);
     },
-  }
+  },
 });
 </script>
 

--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -96,14 +96,14 @@ type ServiceEntryWithKey = K8s.ServiceEntry & { key: string }
 
 export default Vue.extend({
   components: {
-    SortableTable, Checkbox, Banner
+    SortableTable, Checkbox, Banner,
   },
   directives: {
     focus: {
       inserted: function(element) {
         element.focus();
-      }
-    }
+      },
+    },
   },
   props:      {
     services: {
@@ -219,7 +219,7 @@ export default Vue.extend({
     },
     emitCloseError(): void {
       this.$emit('closeError');
-    }
+    },
   },
 });
 </script>

--- a/src/components/Preferences/ApplicationBehavior.vue
+++ b/src/components/Preferences/ApplicationBehavior.vue
@@ -15,8 +15,8 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return {
@@ -38,7 +38,7 @@ export default Vue.extend({
     },
     canAutoUpdate(): boolean {
       return this.preferences?.updater || false;
-    }
+    },
   },
   methods:  {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
@@ -47,7 +47,7 @@ export default Vue.extend({
     onSudoAllowedChange(val: boolean) {
       this.$store.dispatch('applicationSettings/commitSudoAllowed', val);
     },
-  }
+  },
 });
 </script>
 

--- a/src/components/Preferences/ApplicationEnvironment.vue
+++ b/src/components/Preferences/ApplicationEnvironment.vue
@@ -15,15 +15,15 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   computed:   { ...mapGetters('applicationSettings', ['pathManagementStrategy']) },
   methods:    {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/BodyApplication.vue
+++ b/src/components/Preferences/BodyApplication.vue
@@ -21,8 +21,8 @@ export default Vue.extend({
   props: {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return { activeTab: 'behavior' };
@@ -31,8 +31,8 @@ export default Vue.extend({
   methods:    {
     tabSelected({ tab }: { tab: Vue.Component }) {
       this.activeTab = tab.name || '';
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/BodyContainerEngine.vue
+++ b/src/components/Preferences/BodyContainerEngine.vue
@@ -14,8 +14,8 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return { containerEngine: ContainerEngine.CONTAINERD };
@@ -27,8 +27,8 @@ export default Vue.extend({
     },
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/BodyKubernetes.vue
+++ b/src/components/Preferences/BodyKubernetes.vue
@@ -16,8 +16,8 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return {
@@ -26,7 +26,7 @@ export default Vue.extend({
       kubernetesPort:     6443,
       versions:           [] as VersionEntry[],
       cachedVersionsOnly: false,
-      kubernetesVersion:  this.preferences.kubernetes.version
+      kubernetesVersion:  this.preferences.kubernetes.version,
     };
   },
   computed: {
@@ -78,7 +78,7 @@ export default Vue.extend({
     castToNumber(val: string): number | null {
       return val ? Number(val) : null;
     },
-  }
+  },
 });
 </script>
 

--- a/src/components/Preferences/BodyVirtualMachine.vue
+++ b/src/components/Preferences/BodyVirtualMachine.vue
@@ -15,8 +15,8 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   data() {
     return { settings: defaultSettings };
@@ -35,8 +35,8 @@ export default Vue.extend({
   methods: {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/BodyWsl.vue
+++ b/src/components/Preferences/BodyWsl.vue
@@ -15,8 +15,8 @@ export default Vue.extend({
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: { ...mapGetters('preferences', ['getWslIntegrations']) },
   methods:  {
@@ -25,8 +25,8 @@ export default Vue.extend({
 
       this.$store.dispatch('preferences/updateWslIntegrations', { distribution: `["${ distro }"]`, value });
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -5,8 +5,8 @@ export default Vue.extend({
   methods: {
     openPreferences() {
       this.$emit('open-preferences');
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -10,8 +10,8 @@ export default Vue.extend({
   props:      {
     isDirty: {
       type:     Boolean,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
     ...mapState('preferences', ['severities']),
@@ -34,7 +34,7 @@ export default Vue.extend({
     },
     bannerText() {
       return this.t(`preferences.actions.banner.${ this.severity }`);
-    }
+    },
   },
   methods:  {
     cancel() {
@@ -42,8 +42,8 @@ export default Vue.extend({
     },
     apply() {
       this.$emit('apply');
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/ModalBody.vue
+++ b/src/components/Preferences/ModalBody.vue
@@ -17,17 +17,17 @@ export default Vue.extend({
     PreferencesBodyVirtualMachine,
     PreferencesBodyWsl,
     PreferencesBodyContainerEngine,
-    PreferencesBodyKubernetes
+    PreferencesBodyKubernetes,
   },
   props:      {
     currentNavItem: {
       type:     String,
-      required: true
+      required: true,
     },
     preferences: {
       type:     Object as PropType<Settings>,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
     normalizeNavItem(): string {
@@ -35,8 +35,8 @@ export default Vue.extend({
     },
     componentFromNavItem(): string {
       return `preferences-body-${ this.normalizeNavItem }`;
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/ModalNav.vue
+++ b/src/components/Preferences/ModalNav.vue
@@ -9,12 +9,12 @@ export default Vue.extend({
   props:      {
     currentNavItem: {
       type:     String,
-      required: true
+      required: true,
     },
     navItems: {
       type:     Array,
-      required: true
-    }
+      required: true,
+    },
   },
   methods: {
     navClicked(tabName: string) {
@@ -22,8 +22,8 @@ export default Vue.extend({
     },
     navToKebab(navItem: string): string {
       return `nav-${ navItem.toLowerCase().replaceAll(' ', '-') }`;
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Preferences/ModalNavItem.vue
+++ b/src/components/Preferences/ModalNavItem.vue
@@ -8,21 +8,21 @@ export default Vue.extend({
      */
     active: {
       type:    Boolean,
-      default: false
+      default: false,
     },
     /**
      * The Nav Item name
      */
     name: {
       type:     String,
-      required: true
-    }
+      required: true,
+    },
   },
   methods: {
     navClicked() {
       this.$emit('click', this.name);
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/Progress.vue
+++ b/src/components/Progress.vue
@@ -22,7 +22,7 @@ export default Vue.extend({
     secondaryColor: {
       type:    String,
       default: '--border',
-    }
+    },
   },
   computed: {
     indicatorStyle(): Record<string, string> {
@@ -46,7 +46,7 @@ export default Vue.extend({
     barStyle(): Record<string, string> {
       return { backgroundColor: `var(${ this.secondaryColor })` };
     },
-  }
+  },
 });
 </script>
 

--- a/src/components/SortableTable/THead.vue
+++ b/src/components/SortableTable/THead.vue
@@ -8,19 +8,19 @@ export default {
   props:      {
     columns: {
       type:     Array,
-      required: true
+      required: true,
     },
     sortBy: {
       type:     String,
-      required: true
+      required: true,
     },
     defaultSortBy: {
       type:    String,
-      default: ''
+      default: '',
     },
     descending: {
       type:     Boolean,
-      required: true
+      required: true,
     },
     tableActions: {
       type:     Boolean,
@@ -40,7 +40,7 @@ export default {
     },
     rowActionsWidth: {
       type:     Number,
-      required: true
+      required: true,
     },
     subExpandColumn: {
       type:    Boolean,
@@ -76,12 +76,12 @@ export default {
 
       set(value) {
         this.$emit('on-toggle-all', value);
-      }
+      },
     },
 
     isIndeterminate() {
       return this.howMuchSelected === SOME;
-    }
+    },
   },
 
   methods: {
@@ -102,7 +102,7 @@ export default {
     isCurrent(col) {
       return col.name === this.sortBy;
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/SortableTable/actions.js
+++ b/src/components/SortableTable/actions.js
@@ -146,6 +146,6 @@ export default {
       if (!showActionsDropdown) {
         actionsDropdown.style.display = 'none';
       }
-    }, 10)
-  }
+    }, 10),
+  },
 };

--- a/src/components/SortableTable/filtering.js
+++ b/src/components/SortableTable/filtering.js
@@ -121,7 +121,7 @@ export default {
     arrangedRows(q) {
       // The rows changed so the old filter result is no longer useful
       this.previousResult = null;
-    }
+    },
   },
 };
 

--- a/src/components/SortableTable/grouping.js
+++ b/src/components/SortableTable/grouping.js
@@ -28,7 +28,7 @@ export default {
           entry = {
             key,
             ref,
-            rows: [obj]
+            rows: [obj],
           };
           map[key] = entry;
           out.push(entry);
@@ -36,6 +36,6 @@ export default {
       }
 
       return out;
-    }
-  }
+    },
+  },
 };

--- a/src/components/SortableTable/index.vue
+++ b/src/components/SortableTable/index.vue
@@ -30,7 +30,7 @@ export const COLUMN_BREAKPOINTS = {
   /**
    * Only show column if at desktop width or wider
    */
-  DESKTOP: 'desktop'
+  DESKTOP: 'desktop',
 };
 
 // @TODO:
@@ -46,7 +46,7 @@ export const COLUMN_BREAKPOINTS = {
 export default {
   name:       'SortableTable',
   components: {
-    THead, Checkbox, ActionDropdown
+    THead, Checkbox, ActionDropdown,
   },
   mixins: [filtering, sorting, paging, grouping, selection, actions],
 
@@ -61,12 +61,12 @@ export default {
       //    width:  number
       // }
       type:     Array,
-      required: true
+      required: true,
     },
     rows: {
       // The array of objects to show
       type:     Array,
-      required: true
+      required: true,
     },
     keyField: {
       // Field that is unique for each row.
@@ -76,13 +76,13 @@ export default {
 
     loading: {
       type:     Boolean,
-      required: false
+      required: false,
     },
 
     groupBy: {
       // Field to group rows by, row[groupBy] must be something that can be a map key
       type:    String,
-      default: null
+      default: null,
     },
     groupRef: {
       // Object to provide as the reference for rendering the grouping row
@@ -92,26 +92,26 @@ export default {
     groupSort: {
       // Field to order groups by, defaults to groupBy
       type:    Array,
-      default: null
+      default: null,
     },
 
     defaultSortBy: {
       // Default field to sort by if none is specified
       // uses name on headers
       type:    String,
-      default: null
+      default: null,
     },
 
     tableActions: {
       // Show bulk table actions
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     rowActions: {
       // Show action dropdown on the end of each row
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     mangleActionResources: {
@@ -122,19 +122,19 @@ export default {
     rowActionsWidth: {
       // How wide the action dropdown column should be
       type:    Number,
-      default: 40
+      default: 40,
     },
 
     search: {
       // Show search input to filter rows
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     extraSearchFields: {
       // Additional fields that aren't defined in the headers to search in on each row
       type:    Array,
-      default: null
+      default: null,
     },
 
     subRows: {
@@ -170,7 +170,7 @@ export default {
      */
     topDivider: {
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     /**
@@ -178,16 +178,16 @@ export default {
      */
     bodyDividers: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     overflowX: {
       type:    Boolean,
-      default: false
+      default: false,
     },
     overflowY: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     /**
@@ -203,7 +203,7 @@ export default {
      */
     pagingLabel: {
       type:    String,
-      default: 'sortableTable.paging.generic'
+      default: 'sortableTable.paging.generic',
     },
 
     /**
@@ -229,7 +229,7 @@ export default {
      */
     noRowsKey: {
       type:    String,
-      default: 'sortableTable.noRows'
+      default: 'sortableTable.noRows',
     },
 
     /**
@@ -237,7 +237,7 @@ export default {
      */
     showNoRows: {
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     /**
@@ -245,7 +245,7 @@ export default {
      */
     noDataKey: {
       type:    String,
-      default: 'sortableTable.noData'
+      default: 'sortableTable.noData',
     },
 
     /**
@@ -253,7 +253,7 @@ export default {
      */
     showHeaders: {
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     sortGenerationFn: {
@@ -268,8 +268,8 @@ export default {
      */
     getCustomDetailLink: {
       type:    Function,
-      default: null
-    }
+      default: null,
+    },
   },
 
   data() {
@@ -410,7 +410,7 @@ export default {
             key:                        this.get(row, this.keyField),
             showSubRow:                 this.showSubRow(row, this.keyField),
             canRunBulkActionOfInterest: this.canRunBulkActionOfInterest(row),
-            columns:                    []
+            columns:                    [],
           };
 
           group.rows.push(rowData);
@@ -441,7 +441,7 @@ export default {
       });
 
       return rows;
-    }
+    },
   },
 
   watch: {
@@ -704,8 +704,8 @@ export default {
         event,
         targetElement: this.$refs[`actionButton${ i }`][0],
       });
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/SortableTable/paging.js
+++ b/src/components/SortableTable/paging.js
@@ -37,7 +37,7 @@ export default {
       } else {
         return this.filteredRows;
       }
-    }
+    },
   },
 
   data() {
@@ -113,6 +113,6 @@ export default {
       }
 
       this.setPage(page);
-    }
-  }
+    },
+  },
 };

--- a/src/components/SortableTable/selection.js
+++ b/src/components/SortableTable/selection.js
@@ -107,7 +107,7 @@ export default {
       });
 
       return out.sort((a, b) => (b.weight || 0) - (a.weight || 0));
-    }
+    },
   },
 
   data() {
@@ -134,7 +134,7 @@ export default {
       }
 
       this.update([], toRemove);
-    }
+    },
   },
 
   methods: {
@@ -411,7 +411,7 @@ export default {
           if ( rows[j] === node ) {
             return {
               group: i,
-              item:  j
+              item:  j,
             };
           }
         }
@@ -519,7 +519,7 @@ export default {
       this.update([], this.selectedRows);
     },
 
-  }
+  },
 };
 
 // ---------------------------------------------------------------------

--- a/src/components/SystemPreferences.vue
+++ b/src/components/SystemPreferences.vue
@@ -160,7 +160,7 @@ export default {
 
       return marks
         .filter((_val, i, arr) => i === 0 || i === arr.length - 1 || !(i % step));
-    }
+    },
   },
 };
 </script>

--- a/src/components/Tabbed/RdTabbed.vue
+++ b/src/components/Tabbed/RdTabbed.vue
@@ -5,7 +5,7 @@ import Tabbed from '@/components/Tabbed/index.vue';
 
 export default Vue.extend({
   name:       'rd-tabbed',
-  components: { Tabbed }
+  components: { Tabbed },
 });
 </script>
 

--- a/src/components/Tabbed/Tab.vue
+++ b/src/components/Tabbed/Tab.vue
@@ -5,30 +5,30 @@ export default {
   props: {
     label: {
       default: null,
-      type:    String
+      type:    String,
     },
     labelKey: {
       default: null,
-      type:    String
+      type:    String,
     },
     name: {
       required: true,
-      type:     String
+      type:     String,
     },
     tooltip: {
       default: null,
-      type:    [String, Object]
+      type:    [String, Object],
     },
     weight: {
       default:  0,
       required: false,
-      type:     Number
+      type:     Number,
     },
 
     showHeader: {
       type:    Boolean,
       default: null, // Default true for side-tabs, false for top.
-    }
+    },
   },
 
   data() {
@@ -54,7 +54,7 @@ export default {
       }
 
       return this.sideTabs || false;
-    }
+    },
   },
 
   watch: {
@@ -62,7 +62,7 @@ export default {
       if (neu) {
         this.$emit('active');
       }
-    }
+    },
   },
 
   mounted() {
@@ -71,7 +71,7 @@ export default {
 
   beforeDestroy() {
     this.removeTab(this);
-  }
+  },
 };
 </script>
 

--- a/src/components/Tabbed/index.vue
+++ b/src/components/Tabbed/index.vue
@@ -27,7 +27,7 @@ export default {
 
       removeTab(tab) {
         removeObject(tabs, tab);
-      }
+      },
     };
   },
 
@@ -39,18 +39,18 @@ export default {
 
     sideTabs: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     showTabsAddRemove: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     // whether or not to scroll to the top of the new tab on tab change. This is particularly ugly with side tabs
     scrollOnChange: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     useHash: {
@@ -61,7 +61,7 @@ export default {
     noContent: {
       type:    Boolean,
       default: false,
-    }
+    },
   },
 
   data() {
@@ -83,7 +83,7 @@ export default {
       const {
         defaultTab,
         useHash,
-        $route: { hash }
+        $route: { hash },
       } = this;
       const activeTab = tabs.find(t => t.active);
 

--- a/src/components/TheTitle.vue
+++ b/src/components/TheTitle.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
       [
         'title',
         'description',
-        'action'
+        'action',
       ]),
   },
   watch: {
@@ -28,8 +28,8 @@ export default Vue.extend({
       immediate: true,
       handler(current) {
         this.isChild = current.path.lastIndexOf('/') > 0;
-      }
-    }
+      },
+    },
   },
   methods: {
     routeBack() {

--- a/src/components/UpdateStatus.vue
+++ b/src/components/UpdateStatus.vue
@@ -70,7 +70,7 @@ const UpdateStatusProps = Vue.extend({
       type:    String,
       default: '(checking...)',
     },
-  }
+  },
 });
 
 @Component({ components: { Card, Checkbox } })

--- a/src/components/WSLIntegration.vue
+++ b/src/components/WSLIntegration.vue
@@ -46,8 +46,8 @@ const WSLIntegrationProps = Vue.extend({
 
 @Component({
   components: {
-    Banner, Card, Checkbox
-  }
+    Banner, Card, Checkbox,
+  },
 })
 class WSLIntegration extends WSLIntegrationProps {
   name = 'wsl-integration';
@@ -66,11 +66,11 @@ class WSLIntegration extends WSLIntegrationProps {
           this.$delete(this.busy, name);
         }
         results.push({
-          name, value, disabled: name in this.busy, description: ''
+          name, value, disabled: name in this.busy, description: '',
         });
       } else {
         results.push({
-          name, value: false, disabled: true, description: value
+          name, value: false, disabled: true, description: value,
         });
         this.$delete(this.busy, name);
       }

--- a/src/components/__tests__/UpdateStatus.spec.ts
+++ b/src/components/__tests__/UpdateStatus.spec.ts
@@ -43,7 +43,7 @@ describe('UpdateStatus.vue', () => {
       const wrapper = wrap({
         enabled:     true,
         updateState: {
-          available: true, error: new Error('hello'), downloaded: true
+          available: true, error: new Error('hello'), downloaded: true,
         } as UpdateState,
       });
 
@@ -67,7 +67,7 @@ describe('UpdateStatus.vue', () => {
       const wrapper = wrap({
         enabled:     true,
         updateState: {
-          available: true, downloaded: true, info: { version: 'v1.2.3' }
+          available: true, downloaded: true, info: { version: 'v1.2.3' },
         } as UpdateState,
       });
 
@@ -82,7 +82,7 @@ describe('UpdateStatus.vue', () => {
       const wrapper = wrap({
         enabled:     true,
         updateState: {
-          available: true, downloaded: true, info: { version: 'v1.2.3' }
+          available: true, downloaded: true, info: { version: 'v1.2.3' },
         } as UpdateState,
       });
 
@@ -98,14 +98,14 @@ describe('UpdateStatus.vue', () => {
           available:  true,
           downloaded: false,
           info:       {
-            version: 'v1.2.3', files: [], path: '', sha512: '', releaseDate: ''
+            version: 'v1.2.3', files: [], path: '', sha512: '', releaseDate: '',
           },
           progress: {
             percent:        12.34,
             bytesPerSecond: 1234567,
             total:          0,
             delta:          0,
-            transferred:    0
+            transferred:    0,
           },
         } as UpdateState,
         locale: 'en',

--- a/src/components/form/Checkbox.vue
+++ b/src/components/form/Checkbox.vue
@@ -10,27 +10,27 @@ export default {
   props: {
     value: {
       type:    [Boolean, Array],
-      default: false
+      default: false,
     },
 
     label: {
       type:    String,
-      default: null
+      default: null,
     },
 
     labelKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     disabled: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     indeterminate: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     mode: {
@@ -40,27 +40,27 @@ export default {
 
     tooltip: {
       type:    [String, Object],
-      default: null
+      default: null,
     },
 
     tooltipKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     valueWhenTrue: {
       type:    null,
-      default: true
+      default: true,
     },
 
     descriptionKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     description: {
       type:    String,
-      default: null
+      default: null,
     },
   },
 
@@ -70,7 +70,7 @@ export default {
     },
     isChecked() {
       return this.isMulti() ? this.value.find(v => v === this.valueWhenTrue) : this.value === this.valueWhenTrue;
-    }
+    },
   },
 
   methods: {
@@ -99,8 +99,8 @@ export default {
     },
     isMulti() {
       return Array.isArray(this.value);
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/form/LabeledInput.vue
+++ b/src/components/form/LabeledInput.vue
@@ -19,12 +19,12 @@ export default {
 
     status: {
       type:      String,
-      default:   null
+      default:   null,
     },
 
     tooltip: {
       default: null,
-      type:    [String, Object]
+      type:    [String, Object],
     },
 
     hoverTooltip: {
@@ -35,7 +35,7 @@ export default {
     ignorePasswordManagers: {
       default: false,
       type:    Boolean,
-    }
+    },
   },
 
   computed: {
@@ -72,7 +72,7 @@ export default {
       }
 
       return '';
-    }
+    },
   },
 
   methods: {
@@ -101,8 +101,8 @@ export default {
       this.onBlurLabeled();
     },
 
-    escapeHtml
-  }
+    escapeHtml,
+  },
 };
 </script>
 

--- a/src/components/form/LabeledTooltip.vue
+++ b/src/components/form/LabeledTooltip.vue
@@ -3,18 +3,18 @@ export default {
   props: {
     value: {
       type:    [String, Object],
-      default: null
+      default: null,
     },
 
     status: {
       type:    String,
-      default: 'error'
+      default: 'error',
     },
 
     hover: {
       type:    Boolean,
-      default: true
-    }
+      default: true,
+    },
   },
 };
 </script>

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -5,7 +5,7 @@ export default {
     // The name of the input, for grouping
     name: {
       type:    String,
-      default: ''
+      default: '',
     },
 
     // The value for this option
@@ -23,12 +23,12 @@ export default {
     // The label shown next to the radio
     label: {
       type:    String,
-      default: ''
+      default: '',
     },
 
     disabled: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     mode: {
@@ -38,12 +38,12 @@ export default {
 
     descriptionKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     description: {
       type:    String,
-      default: null
+      default: null,
     },
   },
 
@@ -63,7 +63,7 @@ export default {
 
     hasDescriptionSlot() {
       return !!this.$slots.description;
-    }
+    },
   },
 
   watch: {
@@ -72,7 +72,7 @@ export default {
       if ( this.isChecked ) {
         this.$refs.custom.focus();
       }
-    }
+    },
   },
 
   methods: {
@@ -87,7 +87,7 @@ export default {
 
       this.$emit('input', this.val);
     },
-  }
+  },
 };
 </script>
 

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -14,7 +14,7 @@ export default {
     // Options can be an array of {label, value}, or just values
     options: {
       type:     Array,
-      required: true
+      required: true,
     },
 
     // If options are just values, then labels can be a corresponding display value
@@ -26,44 +26,44 @@ export default {
     // The selected value
     value: {
       type:    [Boolean, String, Object],
-      default: null
+      default: null,
     },
 
     disabled: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     mode: {
       type:    String,
-      default: 'edit'
+      default: 'edit',
     },
 
     // Label for above the radios
     label: {
       type:    String,
-      default: null
+      default: null,
     },
     labelKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     // Label for above the radios
     tooltip: {
       type:    [String, Object],
-      default: null
+      default: null,
     },
     tooltipKey: {
       type:    String,
-      default: null
+      default: null,
     },
 
     // show radio buttons in column or row
     row: {
       type:    Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
 
   computed: {
@@ -83,7 +83,7 @@ export default {
         } else {
           out.push({
             label: opt,
-            value: opt
+            value: opt,
           });
         }
       }
@@ -101,7 +101,7 @@ export default {
 
     hasLabelSlot() {
       return this.$slots.label;
-    }
+    },
   },
 
   methods: {
@@ -118,8 +118,8 @@ export default {
       }
 
       this.$emit('input', opts[newIndex].value);
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/components/form/RdFieldset.vue
+++ b/src/components/form/RdFieldset.vue
@@ -8,13 +8,13 @@ export default Vue.extend({
   props: {
     legendText: {
       type:    String,
-      default: ''
+      default: '',
     },
     legendTooltip: {
       type:    String,
-      default: ''
-    }
-  }
+      default: '',
+    },
+  },
 });
 </script>
 

--- a/src/components/form/RdSlider.vue
+++ b/src/components/form/RdSlider.vue
@@ -11,42 +11,42 @@ export default Vue.extend({
   props:      {
     label: {
       type:    String,
-      default: ''
+      default: '',
     },
     value: {
       type:     Number,
-      required: true
+      required: true,
     },
     min: {
       type:     Number,
-      required: true
+      required: true,
     },
     max: {
       type:     Number,
-      required: true
+      required: true,
     },
     interval: {
       type:    Number,
-      default: 1
+      default: 1,
     },
     marks: {
       type:     Array,
-      required: true
+      required: true,
     },
     disabled: {
       type:    Boolean,
-      default: false
+      default: false,
     },
     process: {
       type:     Function,
-      required: true
+      required: true,
     },
   },
   methods: {
     updatedVal(value: string) {
       this.$emit('change', value);
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/form/TextAreaAutoGrow.vue
+++ b/src/components/form/TextAreaAutoGrow.vue
@@ -10,7 +10,7 @@ export default {
   props: {
     mode: {
       type:    String,
-      default: _EDIT
+      default: _EDIT,
     },
 
     minHeight: {
@@ -27,13 +27,13 @@ export default {
     },
     spellcheck: {
       type:    Boolean,
-      default: true
+      default: true,
     },
 
     disabled: {
       type:    Boolean,
       default: false,
-    }
+    },
   },
 
   data() {
@@ -60,7 +60,7 @@ export default {
       deep: true,
       handler() {
         this.queueResize();
-      }
+      },
     },
   },
 
@@ -103,8 +103,8 @@ export default {
       $el.css('height', `${ neu }px`);
 
       this.curHeight = neu;
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -32,7 +32,7 @@ describe('updateFromCommandLine', () => {
       portForwarding: { includeKubernetesServices: false },
       images:         {
         showAll:   true,
-        namespace: 'k8s.io'
+        namespace: 'k8s.io',
       },
       telemetry:              true,
       updater:                true,
@@ -144,7 +144,7 @@ describe('updateFromCommandLine', () => {
       '--kubernetes-suppressSudo',
       '--portForwarding-includeKubernetesServices=true',
       '--kubernetes-containerEngine=containerd',
-      '--kubernetes-port', '6444'
+      '--kubernetes-port', '6444',
     ])[1];
 
     expect(newPrefs.kubernetes.options.traefik).toBeFalsy();

--- a/src/config/types.js
+++ b/src/config/types.js
@@ -69,7 +69,7 @@ export const WORKLOAD_TYPES = {
   JOB:                    'batch.job',
   STATEFUL_SET:           'apps.statefulset',
   REPLICA_SET:            'apps.replicaset',
-  REPLICATION_CONTROLLER: 'replicationcontroller'
+  REPLICATION_CONTROLLER: 'replicationcontroller',
 };
 
 const {
@@ -109,7 +109,7 @@ export const MONITORING = {
     RESPONDER:            'monitoring.coreos.com.receiver.responder',
     ROUTE:                'monitoring.coreos.com.route',
     ROUTE_SPEC:           'monitoring.coreos.com.route.spec',
-  }
+  },
 };
 
 export const LONGHORN = {
@@ -175,13 +175,13 @@ export const FLEET = {
 
 export const GATEKEEPER = {
   CONSTRAINT_TEMPLATE: 'templates.gatekeeper.sh.constrainttemplate',
-  SPOOFED:             { CONSTRAINT: 'constraints.gatekeeper.sh.constraint' }
+  SPOOFED:             { CONSTRAINT: 'constraints.gatekeeper.sh.constraint' },
 };
 
 export const ISTIO = {
   VIRTUAL_SERVICE:  'networking.istio.io.virtualservice',
   DESTINATION_RULE:  'networking.istio.io.destinationrule',
-  GATEWAY:          'networking.istio.io.gateway'
+  GATEWAY:          'networking.istio.io.gateway',
 };
 
 export const RIO = {
@@ -229,8 +229,8 @@ export const LOGGING = {
     PARSESECTION:       'logging.banzaicloud.io.output.filters.parsesection',
     METRICSECTION:      'logging.banzaicloud.io.output.filters.metricsection',
     REPLACE:            'logging.banzaicloud.io.output.filters.replace',
-    SINGLEPARSESECTION: 'logging.banzaicloud.io.output.filters.replace.singleparsesection'
-  }
+    SINGLEPARSESECTION: 'logging.banzaicloud.io.output.filters.replace.singleparsesection',
+  },
 };
 
 export const BACKUP_RESTORE = {
@@ -243,7 +243,7 @@ export const CIS = {
   CLUSTER_SCAN:         'cis.cattle.io.clusterscan',
   CLUSTER_SCAN_PROFILE: 'cis.cattle.io.clusterscanprofile',
   BENCHMARK:            'cis.cattle.io.clusterscanbenchmark',
-  REPORT:               'cis.cattle.io.clusterscanreport'
+  REPORT:               'cis.cattle.io.clusterscanreport',
 };
 
 export const UI = { NAV_LINK: 'ui.cattle.io.navlink' };

--- a/src/integrations/__tests__/windowsIntegrationManager.spec.ts
+++ b/src/integrations/__tests__/windowsIntegrationManager.spec.ts
@@ -55,7 +55,7 @@ describe('WindowsIntegrationManager', () => {
       const state = await integrationManager['getStateForIntegration'](distro);
 
       expect(state).toEqual(
-        expect.stringMatching(`Rancher Desktop can only integrate with v2 WSL distributions.*`)
+        expect.stringMatching(`Rancher Desktop can only integrate with v2 WSL distributions.*`),
       );
     });
   });

--- a/src/integrations/windowsIntegrationManager.ts
+++ b/src/integrations/windowsIntegrationManager.ts
@@ -94,7 +94,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
               stdio:       ['ignore', stream, stream],
               windowsHide: true,
             });
-        }
+        },
       });
 
     // Trigger a settings-update.
@@ -175,7 +175,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
         encoding:    opts.encoding ?? 'utf-8',
         stdio:       ['ignore', logStream, logStream],
         windowsHide: true,
-      }
+      },
     );
   }
 
@@ -202,7 +202,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
         encoding:    opts.encoding ?? 'utf-8',
         stdio:       ['ignore', 'pipe', logStream],
         windowsHide: true,
-      }
+      },
     );
 
     return stdout;
@@ -220,7 +220,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       await this.wslExe,
       ['--distribution', distro, '--exec', '/bin/wslpath', '-a', '-u',
         path.join(paths.resources, 'linux', ...tool)],
-      { stdio: ['ignore', 'pipe', logStream] }
+      { stdio: ['ignore', 'pipe', logStream] },
     );
 
     return stdout.trim();
@@ -242,7 +242,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
     await Promise.all(
       (await this.supportedDistros).map((distro) => {
         return this.syncDistroSocketProxy(distro.name, shouldRun);
-      })
+      }),
     );
   }
 
@@ -267,8 +267,8 @@ export default class WindowsIntegrationManager implements IntegrationManager {
                 'docker-proxy', 'serve', ...this.wslHelperDebugArgs],
               {
                 stdio:       ['ignore', await logStream.fdStream, await logStream.fdStream],
-                windowsHide: true
-              }
+                windowsHide: true,
+              },
             );
           },
           destroy: async(child) => {
@@ -277,7 +277,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
             // of sync.
             await this.execCommand({ distro, root: true },
               executable, 'docker-proxy', 'kill', ...this.wslHelperDebugArgs);
-          }
+          },
         });
       this.distroSocketProxyProcesses[distro].start();
     } else {
@@ -351,7 +351,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
     await Promise.all(
       (await this.supportedDistros).map((distro) => {
         return this.syncDistroKubeconfig(distro.name, kubeconfigPath);
-      })
+      }),
     );
   }
 
@@ -368,7 +368,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
               ...process.env,
               KUBECONFIG: kubeconfigPath,
               WSLENV:     `${ process.env.WSLENV }:KUBECONFIG/up`,
-            }
+            },
           },
           await this.getLinuxToolPath(distro, 'wsl-helper'),
           'kubeconfig',

--- a/src/k8s-engine/__tests__/k3sHelper.spec.ts
+++ b/src/k8s-engine/__tests__/k3sHelper.spec.ts
@@ -7,7 +7,7 @@ import fetch from 'node-fetch';
 import semver from 'semver';
 
 import K3sHelper, {
-  buildVersion, ChannelMapping, NoCachedK3sVersionsError, ReleaseAPIEntry, VersionEntry
+  buildVersion, ChannelMapping, NoCachedK3sVersionsError, ReleaseAPIEntry, VersionEntry,
 } from '../k3sHelper';
 
 import paths from '@/utils/paths';
@@ -185,8 +185,8 @@ describe(K3sHelper, () => {
             data: [{
               name:   'stable',
               latest: 'v1.2.3+k3s3',
-            }]
-          })
+            }],
+          }),
         ));
       })
       .mockImplementationOnce((url) => {
@@ -201,7 +201,7 @@ describe(K3sHelper, () => {
             { tag_name: 'v1.2.4+k3s1', assets: [] },
             { tag_name: 'v1.2.1+k3s2', assets: validAssets },
           ]),
-          { headers: { link: '<url>; rel="next"' } }
+          { headers: { link: '<url>; rel="next"' } },
         ));
       })
       .mockImplementationOnce((url) => {
@@ -209,7 +209,7 @@ describe(K3sHelper, () => {
 
         return Promise.resolve(new FetchResponse(
           null,
-          { status: 403, headers: { 'X-RateLimit-Remaining': '0' } }
+          { status: 403, headers: { 'X-RateLimit-Remaining': '0' } },
         ));
       })
       .mockImplementationOnce((url) => {
@@ -220,7 +220,7 @@ describe(K3sHelper, () => {
             { tag_name: 'Invalid tag name', assets: validAssets },
             { tag_name: 'v1.2.0+k3s5', assets: validAssets },
           ]),
-          { headers: { link: '<url>; rel="first"' } }
+          { headers: { link: '<url>; rel="first"' } },
         ));
       })
       .mockImplementationOnce((url) => {

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -152,7 +152,7 @@ class WrappedWatch extends k8s.Watch {
     path: string,
     queryParams: any,
     callback: (phase: string, apiObj: any, watchObj?: any) => void,
-    done: (err: any) => void
+    done: (err: any) => void,
   ): Promise<any> {
     const wrappedCallback = (phase: string, apiObj: any, watchObj?: any) => {
       callback(phase, apiObj, watchObj);

--- a/src/k8s-engine/images/imageProcessor.ts
+++ b/src/k8s-engine/images/imageProcessor.ts
@@ -167,7 +167,7 @@ export abstract class ImageProcessor extends EventEmitter {
       'image',
       '--format',
       'json',
-      taggedImageName
+      taggedImageName,
     ]);
   }
 
@@ -256,7 +256,7 @@ export abstract class ImageProcessor extends EventEmitter {
         const [imageName, tag, digest, imageID, _created, _platform, size, _blobSize] = line.split(/\s+/);
 
         return {
-          imageName, tag, imageID, size, digest
+          imageName, tag, imageID, size, digest,
         };
       });
 
@@ -338,7 +338,7 @@ export abstract class ImageProcessor extends EventEmitter {
             [ErrorCommand]: {
               enumerable: false,
               value:      child.spawnargs,
-            }
+            },
           }));
         } else {
           reject(Object.create(result, {
@@ -346,7 +346,7 @@ export abstract class ImageProcessor extends EventEmitter {
             [ErrorCommand]: {
               enumerable: false,
               value:      child.spawnargs,
-            }
+            },
           }));
         }
       });

--- a/src/k8s-engine/images/mobyImageProcessor.ts
+++ b/src/k8s-engine/images/mobyImageProcessor.ts
@@ -71,7 +71,7 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
         'image',
         '--format',
         'json',
-        taggedImageName
+        taggedImageName,
       ]);
   }
 
@@ -123,7 +123,7 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
         tag:       record.Tag,
         imageID:   record.ID,
         size:      record.Size,
-        digest:    record.Digest
+        digest:    record.Digest,
       });
     }
 

--- a/src/k8s-engine/images/nerdctlImageProcessor.ts
+++ b/src/k8s-engine/images/nerdctlImageProcessor.ts
@@ -114,7 +114,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
         'image',
         '--format',
         'json',
-        taggedImageName
+        taggedImageName,
       ]);
   }
 
@@ -162,7 +162,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
         tag:       record.Tag,
         imageID:   record.ID,
         size:      record.Size,
-        digest:    record.Digest
+        digest:    record.Digest,
       });
     }
 

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -708,7 +708,7 @@ export default class K3sHelper extends events.EventEmitter {
       await safeRename(workDir, path.join(cacheDir, version.raw));
     } finally {
       await fs.promises.rm(workDir, {
-        recursive: true, maxRetries: 3, force: true
+        recursive: true, maxRetries: 3, force: true,
       });
     }
   }
@@ -742,7 +742,7 @@ export default class K3sHelper extends events.EventEmitter {
         await new Promise<void>((resolve, reject) => {
           const socket = tls.connect(
             {
-              host, port, rejectUnauthorized: false
+              host, port, rejectUnauthorized: false,
             },
             () => {
               const cert = socket.getPeerCertificate();
@@ -866,7 +866,7 @@ export default class K3sHelper extends events.EventEmitter {
           workConfig.clusters[clusterIndex] = { ...workConfig.clusters[clusterIndex], name: contextName };
         }
         workConfig.contexts[contextIndex] = {
-          ...context, name: contextName, user: contextName, cluster: contextName
+          ...context, name: contextName, user: contextName, cluster: contextName,
         };
 
         workConfig.currentContext = contextName;
@@ -914,7 +914,7 @@ export default class K3sHelper extends events.EventEmitter {
       await safeRename(workPath, userPath);
     } finally {
       await fs.promises.rm(workDir, {
-        recursive: true, force: true, maxRetries: 10
+        recursive: true, force: true, maxRetries: 10,
       });
     }
   }
@@ -1106,7 +1106,7 @@ export default class K3sHelper extends events.EventEmitter {
       }
       if (!_.isEqual(current, desired)) {
         results[fullKey] = {
-          current, desired, severity: checker ? checker(current, desired) : 'restart'
+          current, desired, severity: checker ? checker(current, desired) : 'restart',
         };
       }
     }
@@ -1130,7 +1130,7 @@ export default class K3sHelper extends events.EventEmitter {
         const fullKey = `kubernetes.${ key }` as keyof K8s.RestartReasons;
 
         results[fullKey] = {
-          current, desired, severity: severity ? (severity as any)(current, desired) : 'restart'
+          current, desired, severity: severity ? (severity as any)(current, desired) : 'restart',
         };
       }
     }

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -617,8 +617,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           'lima-rancher-desktop':          'lima-0',
           'host.rancher-desktop.internal': 'host.lima.internal',
           'host.docker.internal':          'host.lima.internal',
-        }
-      }
+        },
+      },
     });
 
     if (desiredVersion) {
@@ -666,7 +666,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await this.progressTracker.action(
         this.lastCommandComment,
         100,
-        this.updateBaseDisk(currentConfig)
+        this.updateBaseDisk(currentConfig),
       );
       await fs.promises.writeFile(configPath, yaml.stringify(config), 'utf-8');
     } else {
@@ -731,7 +731,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const newPath = [binDir, vdeDir].concat(...pathList).filter(x => x);
 
     return {
-      ...process.env, LIMA_HOME: paths.lima, PATH: newPath.join(path.delimiter)
+      ...process.env, LIMA_HOME: paths.lima, PATH: newPath.join(path.delimiter),
     };
   }
 
@@ -955,7 +955,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       const sourceFile = path.normalize(path.join(sourcePath, relPath));
       const installedFile = path.normalize(path.join(installedPath, relPath));
       const [sourceHash, installedHash] = await Promise.all([
-        hashFile(sourceFile), hashFile(installedFile)
+        hashFile(sourceFile), hashFile(installedFile),
       ]);
 
       return sourceHash === installedHash;
@@ -988,7 +988,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       await newEntry({
         ...baseHeader,
-        name: path.basename(installedPath)
+        name: path.basename(installedPath),
       });
       for (const relPath of directories) {
         const info = await fs.promises.lstat(path.join(sourcePath, relPath));
@@ -1602,7 +1602,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
                     buttons:   ['Delete Workloads', 'Cancel'],
                     defaultId: 1,
                     title:     'Confirming migration',
-                    cancelId:  1
+                    cancelId:  1,
                   };
                   const result = await showMessageBox(options, true);
 
@@ -1727,7 +1727,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
                 }
               }
               console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
-            }
+            },
           );
           commandArgs = ['shell', '--workdir=.', MACHINE_NAME, 'sudo', 'cat', '/etc/rancher/k3s/k3s.yaml'];
           this.lastCommandComment = 'Updating kubeconfig';
@@ -1760,7 +1760,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
               client.on('service-error', (service, errorMessage) => {
                 this.emit('service-error', service, errorMessage);
               });
-            }
+            },
           );
 
           this.activeVersion = desiredVersion;

--- a/src/k8s-engine/progressTracker.ts
+++ b/src/k8s-engine/progressTracker.ts
@@ -55,7 +55,7 @@ export default class ProgressTracker {
   numeric(description: string, current: number, max: number) {
     if (current < max) {
       this.numericProgress = {
-        current, max, description, transitionTime: new Date()
+        current, max, description, transitionTime: new Date(),
       };
     } else {
       this.numericProgress = undefined;
@@ -80,7 +80,7 @@ export default class ProgressTracker {
       id,
       progress: {
         current: 0, max: -1, description, transitionTime: new Date(),
-      }
+      },
     });
     this.update();
 

--- a/src/k8s-engine/steve.ts
+++ b/src/k8s-engine/steve.ts
@@ -56,8 +56,8 @@ export class Steve {
         '--ui-path',
         path.join(paths.resources, 'rancher-dashboard'),
         '--offline',
-        'true'
-      ]
+        'true',
+      ],
     );
 
     const { stdout, stderr } = this.process;

--- a/src/k8s-engine/wsl.ts
+++ b/src/k8s-engine/wsl.ts
@@ -673,7 +673,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
     // Run wslpath here, to ensure that WSL generates any files we need.
     const windowsPath = (await this.execCommand({
-      distro, encoding, capture: true
+      distro, encoding, capture: true,
     }, '/bin/wslpath', '-w', filePath)).trim();
 
     return await fs.promises.readFile(windowsPath, options?.encoding ?? 'utf-8');
@@ -888,7 +888,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     try {
       // Print a slightly different message if execution fails.
       return await this.execWSL({
-        encoding: 'utf-8', ...options, expectFailure: true
+        encoding: 'utf-8', ...options, expectFailure: true,
       }, '--distribution', options.distro ?? INSTANCE_NAME, '--exec', ...command);
     } catch (ex) {
       if (!expectFailure) {
@@ -1157,7 +1157,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
                   buttons:   ['Delete Workloads', 'Cancel'],
                   defaultId: 1,
                   title:     'Confirming migration',
-                  cancelId:  1
+                  cancelId:  1,
                 };
                 const result = await showMessageBox(options, true);
 
@@ -1292,7 +1292,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
               await this.deleteIncompatibleData(actualDesiredVersion);
               await this.installK3s(actualDesiredVersion);
               await this.persistVersion(actualDesiredVersion);
-            })
+            }),
           );
         }
         try {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -28,7 +28,7 @@ export default {
     BackendProgress,
     rdNav:    Nav,
     rdHeader: Header,
-    TheTitle
+    TheTitle,
   },
 
   head() {
@@ -46,9 +46,9 @@ export default {
         '/General',
         '/PortForwarding',
         '/Images',
-        '/Troubleshooting'
+        '/Troubleshooting',
       ];
-    }
+    },
   },
 
   beforeMount() {
@@ -68,8 +68,8 @@ export default {
   methods: {
     openPreferences() {
       ipcRenderer.send('preferences-open');
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/layouts/dialog.vue
+++ b/src/layouts/dialog.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
       ipcRenderer.send('dialog/ready');
     });
     ipcRenderer.send('dialog/load');
-  }
+  },
 });
 </script>
 

--- a/src/layouts/preferences.vue
+++ b/src/layouts/preferences.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
   },
   mounted() {
     ipcRenderer.send('preferences/load');
-  }
+  },
 });
 </script>
 

--- a/src/main/commandServer/__tests__/httpCommandServer.spec.ts
+++ b/src/main/commandServer/__tests__/httpCommandServer.spec.ts
@@ -51,7 +51,7 @@ describe(HttpCommandServer, () => {
     const listSettingsRejects = expect(() => spawnFile(rdctlPath,
       [
         // Provide bogus connection arguments so the test can run without a `rd-engine.json` file present.
-        'list-settings', '--user=not-a-user', '--password=not-a-password', '--port=1234'
+        'list-settings', '--user=not-a-user', '--password=not-a-password', '--port=1234',
       ], { stdio: 'pipe' })).rejects;
 
     await listSettingsRejects.toHaveProperty('stdout', '');

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -34,7 +34,7 @@ describe(SettingsValidator, () => {
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: false,
-        errors:       []
+        errors:       [],
       });
     });
 
@@ -50,13 +50,13 @@ describe(SettingsValidator, () => {
             version:         newVersion,
             containerEngine: newEngine,
             options:         { flannel: newFlannelEnabled },
-          }
+          },
       });
       const [needToUpdate, errors] = subject.validateSettings(cfg, newConfig);
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: true,
-        errors:       []
+        errors:       [],
       });
     });
 
@@ -397,7 +397,7 @@ describe(SettingsValidator, () => {
     it('should complain about unchangeable fields', () => {
       const unchangeableFieldsAndValues = {
         'kubernetes.checkForExistingKimBuilder': !cfg.kubernetes.checkForExistingKimBuilder,
-        version:                                 -1
+        version:                                 -1,
       };
 
       // Check that we _don't_ ask for update when we  have errors.
@@ -427,7 +427,7 @@ describe(SettingsValidator, () => {
           containerEngine: { expected: 'a string' } as unknown as settings.ContainerEngine,
           version:         { expected: 'a string' } as unknown as string,
           options:         "ceci n'est pas un objet" as unknown as Record<string, boolean>,
-        }
+        },
       });
       expect(needToUpdate).toBeFalsy();
       expect(errors).toHaveLength(3);
@@ -448,18 +448,18 @@ describe(SettingsValidator, () => {
           options:             {
             'pitaya*paprika': false,
             traefik:          cfg.kubernetes.options.traefik,
-          }
+          },
         },
         portForwarding: {
           'kiwano // 8 1/2':          'cows',
           includeKubernetesServices: cfg.portForwarding.includeKubernetesServices,
         },
-        'feijoa - Alps': []
+        'feijoa - Alps': [],
       } as unknown as settings.Settings);
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: false,
-        errors:       expect.objectContaining({ length: 1 })
+        errors:       expect.objectContaining({ length: 1 }),
       });
     });
   });

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -54,7 +54,7 @@ export class HttpCommandServer {
         settings:         this.updateSettings,
         propose_settings: this.proposeSettings,
       },
-    }
+    },
   };
 
   constructor(commandWorker: CommandWorkerInterface) {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -187,7 +187,7 @@ export class HttpCredentialHelperServer {
       const body = stream.Readable.from(data);
       const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
         env:   { ...process.env, PATH: pathVar },
-        stdio: [body, 'pipe', console]
+        stdio: [body, 'pipe', console],
       });
 
       if (outputChecker(stdout)) {

--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -35,7 +35,7 @@ function getEditMenu(isMac: boolean): MenuItem {
       { role: 'delete', label: 'De&lete' },
       ...(!isMac ? [{ type: 'separator' } as MenuItemConstructorOptions] : []),
       { role: 'selectAll', label: 'Select &All' },
-    ]
+    ],
   });
 }
 
@@ -47,9 +47,9 @@ function getHelpMenu(isMac: boolean): MenuItem {
         label: `&About ${ Electron.app.name }`,
         click() {
           Electron.app.showAboutPanel();
-        }
+        },
       } as MenuItemConstructorOptions,
-      { type: 'separator' } as MenuItemConstructorOptions
+      { type: 'separator' } as MenuItemConstructorOptions,
     ] : []),
     {
       label: 'Get &Help',
@@ -80,7 +80,7 @@ function getHelpMenu(isMac: boolean): MenuItem {
   return new MenuItem({
     role:    'help',
     label:   '&Help',
-    submenu: helpMenuItems
+    submenu: helpMenuItems,
   });
 }
 
@@ -98,8 +98,8 @@ function getMacApplicationMenu(): Array<MenuItem> {
         { role: 'hideOthers' },
         { role: 'unhide' },
         { type: 'separator' },
-        { role: 'quit' }
-      ]
+        { role: 'quit' },
+      ],
     }),
     new MenuItem({
       label: 'File',
@@ -114,7 +114,7 @@ function getMacApplicationMenu(): Array<MenuItem> {
         { role: 'zoomOut' },
         { type: 'separator' },
         { role: 'togglefullscreen' },
-      ]
+      ],
     }) : new MenuItem({
       label: 'View',
       role:  'viewMenu',
@@ -136,9 +136,9 @@ function getWindowsApplicationMenu(): Array<MenuItem> {
         ...getPreferencesMenuItem(),
         {
           role:  'quit',
-          label: 'E&xit'
-        }
-      ]
+          label: 'E&xit',
+        },
+      ],
     }),
     getEditMenu(false),
     new MenuItem({
@@ -156,7 +156,7 @@ function getWindowsApplicationMenu(): Array<MenuItem> {
         { role: 'zoomOut', label: 'Zoom &Out' },
         { type: 'separator' },
         { role: 'togglefullscreen', label: 'Toggle Full &Screen' },
-      ]
+      ],
     }),
     getHelpMenu(false),
   ];
@@ -175,8 +175,8 @@ function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
       accelerator:         'CmdOrCtrl+,',
       click() {
         openMain(true);
-      }
+      },
     },
-    { type: 'separator' }
+    { type: 'separator' },
   ];
 }

--- a/src/main/networking/__tests__/mac-ca.spec.ts
+++ b/src/main/networking/__tests__/mac-ca.spec.ts
@@ -60,7 +60,7 @@ testDarwin('getMacCertificates', async() => {
         subject:    'some subject',
         acceptable: true,
       },
-    }
+    },
   };
   const expected: string[] = [];
   const actual: string[] = [];

--- a/src/main/networking/cert-parse.ts
+++ b/src/main/networking/cert-parse.ts
@@ -156,8 +156,8 @@ function parseIssuer(encoded: any): Record<string, string> {
       enumerable: false,
       value() {
         return this.CN || this.OU || JSON.stringify(this);
-      }
-    }
+      },
+    },
   });
 
   for (const item of decoded) {
@@ -246,7 +246,7 @@ export default function checkCertValidity(pem: string): boolean {
       convertDate(capture.validityGeneralized1, 'generalizedTimeToDate'),
       convertDate(capture.validityUTC2, 'utcTimeToDate'),
       convertDate(capture.validityGeneralized2, 'generalizedTimeToDate'),
-    ].filter(defined)
+    ].filter(defined),
   };
 
   console.debug('Inspecting certificate', certInfo);

--- a/src/main/networking/mac-ca.ts
+++ b/src/main/networking/mac-ca.ts
@@ -26,7 +26,7 @@ export default async function* getMacCertificates(): AsyncIterable<string> {
     }
   } finally {
     await fs.promises.rm(workdir, {
-      recursive: true, force: true, maxRetries: 3
+      recursive: true, force: true, maxRetries: 3,
     });
   }
 }

--- a/src/main/networking/proxy.ts
+++ b/src/main/networking/proxy.ts
@@ -80,7 +80,7 @@ class CustomHttpsProxyAgent extends HttpsProxyAgent {
     // Use object destructing here to ensure we only get wanted properties.
     const { hostname, port, protocol } = new URL(proxyURL);
     const mergedOpts = Object.assign({}, opts, {
-      hostname, port, protocol
+      hostname, port, protocol,
     });
 
     super(mergedOpts);
@@ -99,7 +99,7 @@ class CustomSocksProxyAgent extends SocksProxyAgent {
     // Use object destructing here to ensure we only get wanted properties.
     const { hostname, port, protocol } = new URL(proxyURL);
     const mergedOpts = Object.assign({}, opts, {
-      hostname, port, protocol
+      hostname, port, protocol,
     });
 
     super(mergedOpts);

--- a/src/main/networking/vtunnel.ts
+++ b/src/main/networking/vtunnel.ts
@@ -54,7 +54,7 @@ class VTunnel {
         'peer-address':            c.peerAddress,
         'peer-port':               c.peerPort,
         'upstream-server-address': c.upstreamServerAddress,
-      }))
+      })),
     };
 
     const configYaml = yaml.stringify(conf);

--- a/src/main/networking/win-ca.ts
+++ b/src/main/networking/win-ca.ts
@@ -203,7 +203,7 @@ export default async function* getWinCertificates(options: Options = {}): AsyncI
           const serial = serialParts.reverse().join('').toUpperCase();
 
           yield {
-            ...decodedInfo, pem, serial
+            ...decodedInfo, pem, serial,
           };
         }
       } finally {

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -233,7 +233,7 @@ export class Tray {
       this.updateContexts();
       this.contextMenuItems = this.updateDashboardState(
         this.kubernetesState === State.STARTED &&
-        this.settings.kubernetes.enabled
+        this.settings.kubernetes.enabled,
       );
     } else if (this.kubernetesState === State.ERROR) {
       // For licensing reasons, we cannot just tint the Kubernetes logo.

--- a/src/main/update/LonghornProvider.ts
+++ b/src/main/update/LonghornProvider.ts
@@ -199,7 +199,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
   constructor(
     private readonly configuration: CustomPublishOptions,
     private readonly updater: AppUpdater,
-    runtimeOptions: ProviderRuntimeOptions
+    runtimeOptions: ProviderRuntimeOptions,
   ) {
     super(runtimeOptions);
     this.platform = runtimeOptions.platform;
@@ -290,7 +290,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
       console.log(`Rejecting release ${ releaseInfo.name } - could not find usable asset.`);
       throw newError(
         `Could not find suitable assets in release ${ releaseInfo.name }`,
-        'ERR_UPDATER_ASSET_NOT_FOUND'
+        'ERR_UPDATER_ASSET_NOT_FOUND',
       );
     }
 
@@ -300,7 +300,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
       console.log(`Rejecting release ${ releaseInfo.name } - could not find checksum for ${ wantedAsset.name }`);
       throw newError(
         `Could not find checksum for asset ${ wantedAsset.name }`,
-        'ERR_UPDATER_ASSET_NOT_FOUND'
+        'ERR_UPDATER_ASSET_NOT_FOUND',
       );
     }
 
@@ -317,7 +317,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
         url:      wantedAsset.browser_download_url,
         size:     wantedAsset.size,
         checksum: await this.getSha512Sum(checksumAsset.browser_download_url),
-      }
+      },
     };
 
     await fs.promises.writeFile(gCachePath, JSON.stringify(cache),

--- a/src/main/update/index.ts
+++ b/src/main/update/index.ts
@@ -10,7 +10,7 @@ import { CustomPublishOptions } from 'builder-util-runtime';
 import Electron from 'electron';
 import {
   AppImageUpdater, MacUpdater, NsisUpdater,
-  AppUpdater, ProgressInfo, UpdateInfo
+  AppUpdater, ProgressInfo, UpdateInfo,
 } from 'electron-updater';
 import { ElectronAppAdapter } from 'electron-updater/out/ElectronAppAdapter';
 import yaml from 'yaml';
@@ -58,7 +58,7 @@ export type UpdateState = {
   progress?: ProgressInfo;
 }
 const updateState: UpdateState = {
-  configured: false, available: false, downloaded: false
+  configured: false, available: false, downloaded: false,
 };
 
 Electron.ipcMain.on('update-state', () => {

--- a/src/middleware/i18n.js
+++ b/src/middleware/i18n.js
@@ -1,5 +1,5 @@
 export default async function({
-  isHMR, app, store, route, params, error, redirect
+  isHMR, app, store, route, params, error, redirect,
 }) {
   // If middleware is called from hot module replacement, ignore it
   if (isHMR) {

--- a/src/mixins/labeled-form-element.js
+++ b/src/mixins/labeled-form-element.js
@@ -13,22 +13,22 @@ export default {
 
     label: {
       type:     String,
-      default: null
+      default: null,
     },
 
     labelKey: {
       type:     String,
-      default: null
+      default: null,
     },
 
     placeholderKey: {
       type:     String,
-      default: null
+      default: null,
     },
 
     tooltip: {
       type:    [String, Object],
-      default: null
+      default: null,
     },
 
     hoverTooltip: {
@@ -38,7 +38,7 @@ export default {
 
     tooltipKey: {
       type:     String,
-      default: null
+      default: null,
     },
 
     required: {
@@ -53,12 +53,12 @@ export default {
 
     placeholder: {
       type:    String,
-      default: ''
+      default: '',
     },
 
     value: {
       type:    [String, Number, Object],
-      default: ''
+      default: '',
     },
   },
 
@@ -130,6 +130,6 @@ export default {
       if ( !this.value ) {
         this.raised = false;
       }
-    }
-  }
+    },
+  },
 };

--- a/src/mixins/vue-select-overrides.js
+++ b/src/mixins/vue-select-overrides.js
@@ -94,5 +94,5 @@ export default {
 
       return out;
     },
-  }
+  },
 };

--- a/src/pages/Dialog.vue
+++ b/src/pages/Dialog.vue
@@ -18,7 +18,7 @@ export default Vue.extend({
       buttons:         [],
       response:        0,
       checkboxChecked: false,
-      cancelId:        0
+      cancelId:        0,
     };
   },
   beforeMount() {
@@ -50,8 +50,8 @@ export default Vue.extend({
       if (event.key === 'Escape') {
         this.close(this.cancelId);
       }
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/pages/FirstRun.vue
+++ b/src/pages/FirstRun.vue
@@ -74,7 +74,7 @@ import { PathManagementStrategy } from '~/integrations/pathManager';
 
 export default Vue.extend({
   components: {
-    Checkbox, EngineSelector, PathManagementSelector
+    Checkbox, EngineSelector, PathManagementSelector,
   },
   layout: 'dialog',
   data() {
@@ -111,7 +111,7 @@ export default Vue.extend({
     },
     pathManagementRelevant(): boolean {
       return os.platform() === 'linux' || os.platform() === 'darwin';
-    }
+    },
   },
   mounted() {
     ipcRenderer.on('settings-read', (event, settings) => {
@@ -141,7 +141,7 @@ export default Vue.extend({
         'settings-write',
         {
           kubernetes:             { version: this.settings.kubernetes.version },
-          pathManagementStrategy: this.pathManagementStrategy
+          pathManagementStrategy: this.pathManagementStrategy,
         });
     },
     close() {
@@ -152,7 +152,7 @@ export default Vue.extend({
       try {
         ipcRenderer.invoke(
           'settings-write',
-          { kubernetes: { containerEngine: desiredEngine } }
+          { kubernetes: { containerEngine: desiredEngine } },
         );
       } catch (err) {
         console.log('invoke settings-write failed: ', err);
@@ -162,7 +162,7 @@ export default Vue.extend({
       try {
         ipcRenderer.invoke(
           'settings-write',
-          { kubernetes: { enabled: value } }
+          { kubernetes: { enabled: value } },
         );
       } catch (err) {
         console.log('invoke settings-write failed: ', err);
@@ -186,8 +186,8 @@ export default Vue.extend({
     },
     offlineCheck() {
       return this.cachedVersionsOnly ? ' (cached versions only)' : '';
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/pages/General.vue
+++ b/src/pages/General.vue
@@ -56,7 +56,7 @@ export default {
       {
         title:       this.t('general.title'),
         description: this.t('general.description'),
-      }
+      },
     );
     ipcRenderer.on('settings-update', this.onSettingsUpdate);
     ipcRenderer.on('update-state', this.onUpdateState);
@@ -92,7 +92,7 @@ export default {
     updateTelemetry(value) {
       ipcRenderer.invoke('settings-write', { telemetry: value });
     },
-  }
+  },
 };
 </script>
 

--- a/src/pages/Images.vue
+++ b/src/pages/Images.vue
@@ -45,7 +45,7 @@ export default {
       return this.imageManagerState ? 'READY' : 'IMAGE_MANAGER_UNREADY';
     },
     ...mapGetters('k8sManager', { k8sState: 'getK8sState' }),
-    ...mapGetters('imageManager', { imageManagerState: 'getImageManagerState' })
+    ...mapGetters('imageManager', { imageManagerState: 'getImageManagerState' }),
   },
 
   watch: {
@@ -53,7 +53,7 @@ export default {
       handler(state) {
         this.$store.dispatch(
           'page/setHeader',
-          { title: this.t('images.title') }
+          { title: this.t('images.title') },
         );
 
         if (!state) {
@@ -62,11 +62,11 @@ export default {
 
         this.$store.dispatch(
           'page/setAction',
-          { action: 'images-button-add' }
+          { action: 'images-button-add' },
         );
       },
-      immediate: true
-    }
+      immediate: true,
+    },
   },
 
   mounted() {
@@ -146,7 +146,7 @@ export default {
         ipcRenderer.invoke('settings-write',
           { images: { namespace: value } } );
       }
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/pages/KubernetesError.vue
+++ b/src/pages/KubernetesError.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
     },
     versionString(): string {
       return `Rancher Desktop ${ this.appVersion } - ${ this.platform } (${ this.arch })`;
-    }
+    },
   },
   beforeMount() {
     ipcRenderer.on('get-app-version', (_event, version) => {
@@ -90,7 +90,7 @@ export default Vue.extend({
     close() {
       window.close();
     },
-  }
+  },
 });
 </script>
 

--- a/src/pages/LegacyIntegrationNotification.vue
+++ b/src/pages/LegacyIntegrationNotification.vue
@@ -17,7 +17,7 @@ export default Vue.extend({
   methods: {
     close() {
       window.close();
-    }
+    },
   },
 });
 </script>

--- a/src/pages/PortForwarding.vue
+++ b/src/pages/PortForwarding.vue
@@ -49,13 +49,13 @@ export default Vue.extend({
           this.serviceBeingEdited = Object.assign(this.serviceBeingEdited, { listenPort: newService.listenPort });
         }
       }
-    }
+    },
   },
 
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: this.t('portForwarding.title') }
+      { title: this.t('portForwarding.title') },
     );
     ipcRenderer.on('k8s-check-state', (event, state) => {
       this.$data.state = state;
@@ -144,8 +144,8 @@ export default Vue.extend({
 
     handleCloseError(): void {
       this.errorMessage = null;
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -15,13 +15,13 @@ import type { ServerState } from '@/main/commandServer/httpCommandServer';
 export default Vue.extend({
   name:       'preferences-modal',
   components: {
-    PreferencesHeader, PreferencesNav, PreferencesBody, PreferencesActions, EmptyState
+    PreferencesHeader, PreferencesNav, PreferencesBody, PreferencesActions, EmptyState,
   },
   layout: 'preferences',
   data() {
     return {
       currentNavItem:    'Application',
-      preferencesLoaded: false
+      preferencesLoaded: false,
     };
   },
   async fetch() {
@@ -45,9 +45,9 @@ export default Vue.extend({
         'Application',
         this.isPlatformWindows ? 'WSL' : 'Virtual Machine',
         'Container Engine',
-        'Kubernetes'
+        'Kubernetes',
       ];
-    }
+    },
   },
   beforeMount() {
     window.addEventListener('keydown', this.handleKeypress, true);
@@ -71,14 +71,14 @@ export default Vue.extend({
 
       await this.$store.dispatch(
         'preferences/commitPreferences',
-        this.credentials as ServerState
+        this.credentials as ServerState,
       );
       this.closePreferences();
     },
     async proposePreferences() {
       const { reset } = await this.$store.dispatch(
         'preferences/proposePreferences',
-        this.credentials as ServerState
+        this.credentials as ServerState,
       );
 
       if (!reset) {
@@ -95,8 +95,8 @@ export default Vue.extend({
         cancelId: cancelPosition,
         buttons:  [
           'Apply and reset',
-          'Cancel'
-        ]
+          'Cancel',
+        ],
       });
 
       if (result.response === cancelPosition) {
@@ -112,8 +112,8 @@ export default Vue.extend({
       if (event.key === 'Escape') {
         this.closePreferences();
       }
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -52,8 +52,8 @@ const SUDO_REASON_DESCRIPTION: Record<SudoReason, {title: string, description: s
   },
   'docker-socket': {
     title:       'Set up default docker socket',
-    description: 'Provides compatibility with tools that use the docker socket without the ability to use docker contexts.'
-  }
+    description: 'Provides compatibility with tools that use the docker socket without the ability to use docker contexts.',
+  },
 };
 
 export default Vue.extend({
@@ -82,7 +82,7 @@ export default Vue.extend({
       ipcRenderer.send('sudo-prompt/closed', this.suppress);
       window.close();
     },
-  }
+  },
 });
 </script>
 

--- a/src/pages/Troubleshooting.vue
+++ b/src/pages/Troubleshooting.vue
@@ -91,7 +91,7 @@ export default {
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: this.t('troubleshooting.title') }
+      { title: this.t('troubleshooting.title') },
     );
     ipcRenderer.on('k8s-check-state', (_, newState) => {
       this.$data.state = newState;
@@ -121,11 +121,11 @@ export default {
           checkboxChecked: false,
           buttons:         [
             this.t('troubleshooting.general.factoryReset.messageBox.ok'),
-            this.t('troubleshooting.general.factoryReset.messageBox.cancel')
+            this.t('troubleshooting.general.factoryReset.messageBox.cancel'),
           ],
-          cancelId: cancelPosition
+          cancelId: cancelPosition,
         },
-        true
+        true,
       );
 
       const { response, checkboxChecked: keepImages } = confirm;
@@ -158,11 +158,11 @@ export default {
           checkboxChecked: false,
           buttons:         [
             this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.ok'),
-            this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.cancel')
+            this.t('troubleshooting.kubernetes.resetKubernetes.messageBox.cancel'),
           ],
-          cancelId: cancelPosition
+          cancelId: cancelPosition,
         },
-        true
+        true,
       );
 
       const { response, checkboxChecked } = confirm;
@@ -172,7 +172,7 @@ export default {
       }
 
       ipcRenderer.send('k8s-reset', checkboxChecked ? 'wipe' : 'fast');
-    }
+    },
   },
 };
 </script>

--- a/src/pages/images/add.vue
+++ b/src/pages/images/add.vue
@@ -36,7 +36,7 @@ export default {
   components: {
     ImageAddTabs,
     ImagesFormAdd,
-    ImagesOutputWindow
+    ImagesOutputWindow,
   },
   data() {
     return {
@@ -44,7 +44,7 @@ export default {
       currentCommand:                   null,
       imageToPull:                      '',
       imageOutputCuller:                null,
-      showOutput:                       false
+      showOutput:                       false,
     };
   },
   computed: {
@@ -58,7 +58,7 @@ export default {
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: this.t('images.add.title') }
+      { title: this.t('images.add.title') },
     );
   },
   methods: {
@@ -100,8 +100,8 @@ export default {
     },
     toggleOutput(val) {
       this.showOutput = val;
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/pages/images/scans/_image-name.vue
+++ b/src/pages/images/scans/_image-name.vue
@@ -50,7 +50,7 @@ export default {
     ImagesScanResults,
     ImagesOutputWindow,
     Banner,
-    LoadingIndicator
+    LoadingIndicator,
   },
 
   data() {
@@ -97,7 +97,7 @@ export default {
             id: `${ PkgName }-${ VulnerabilityID }`,
             PkgName,
             VulnerabilityID,
-            ...rest
+            ...rest,
           };
         });
     },
@@ -106,13 +106,13 @@ export default {
     },
     errorText() {
       return this.t('images.scan.errorText', { image: this.image }, true);
-    }
+    },
   },
 
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: this.t('images.scan.title', { image: this.$route.params.image }, true) }
+      { title: this.t('images.scan.title', { image: this.$route.params.image }, true) },
     );
 
     ipcRenderer.on('ok:images-process-output', (_event, data) => {
@@ -135,7 +135,7 @@ export default {
       this.completionStatus = val;
       this.currentCommand = null;
     },
-  }
+  },
 };
 </script>
 

--- a/src/plugins/directives.js
+++ b/src/plugins/directives.js
@@ -7,7 +7,7 @@ Vue.directive('focus', {
     if (element) {
       element.focus();
     }
-  }
+  },
 });
 
 const getElement = (vnode) => {

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -80,7 +80,7 @@ Vue.component('t', {
     },
     tag: {
       type:    [String, Object],
-      default: 'span'
+      default: 'span',
     },
   },
 
@@ -90,12 +90,12 @@ Vue.component('t', {
     if ( this.raw ) {
       return h(
         this.tag,
-        { domProps: { innerHTML: msg } }
+        { domProps: { innerHTML: msg } },
       );
     } else {
       return h(
         this.tag,
-        [msg]
+        [msg],
       );
     }
   },

--- a/src/plugins/trim-whitespace.js
+++ b/src/plugins/trim-whitespace.js
@@ -33,5 +33,5 @@ export function trimWhitespaceSsr(el, dir) {
 
 Vue.directive('trim-whitespace', {
   inserted:         trimWhitespace,
-  componentUpdated: trimWhitespace
+  componentUpdated: trimWhitespace,
 });

--- a/src/store/action-menu.js
+++ b/src/store/action-menu.js
@@ -57,7 +57,7 @@ export const getters = {
 
   isSelected: state => (resource) => {
     return state.tableSelected.includes(resource);
-  }
+  },
 };
 
 export const mutations = {
@@ -148,7 +148,7 @@ export const mutations = {
     }
 
     state.modalData = data;
-  }
+  },
 };
 
 export const actions = {

--- a/src/store/applicationSettings.ts
+++ b/src/store/applicationSettings.ts
@@ -53,7 +53,7 @@ export const actions = {
       commit('SET_SUDO_ALLOWED', allowed);
       await ipcRenderer.invoke('settings-write', { kubernetes: { suppressSudo: !allowed } });
     }
-  }
+  },
 };
 
 export const getters = {

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -14,15 +14,15 @@ export const state: () => CredentialsState = () => (
       password: '',
       pid:      0,
       port:     0,
-      user:     ''
-    }
+      user:     '',
+    },
   }
 );
 
 export const mutations: MutationsType<CredentialsState> = {
   SET_CREDENTIALS(state, credentials) {
     state.credentials = credentials;
-  }
+  },
 };
 
 type CredActionContext = ActionContext<CredentialsState>;
@@ -34,5 +34,5 @@ export const actions = {
     commit('SET_CREDENTIALS', result);
 
     return result;
-  }
+  },
 };

--- a/src/store/i18n.js
+++ b/src/store/i18n.js
@@ -95,7 +95,7 @@ export const getters = {
       const moreArgs = {
         vendor:  getVendor(),
         appName: getProduct(),
-        ...args
+        ...args,
       };
 
       return formatter.format(moreArgs);
@@ -146,7 +146,7 @@ export const getters = {
     } else {
       return fallback;
     }
-  }
+  },
 };
 
 export const mutations = {
@@ -215,5 +215,5 @@ export const actions = {
     } else {
       return dispatch('switchTo', NONE);
     }
-  }
+  },
 };

--- a/src/store/imageManager.js
+++ b/src/store/imageManager.js
@@ -9,11 +9,11 @@ export const mutations = {
 export const actions = {
   setImageManagerState({ commit }, imageManagerState) {
     commit('SET_IMAGE_MANAGER_STATE', imageManagerState);
-  }
+  },
 };
 
 export const getters = {
   getImageManagerState({ imageManagerState }) {
     return imageManagerState;
-  }
+  },
 };

--- a/src/store/k8sManager.js
+++ b/src/store/k8sManager.js
@@ -11,11 +11,11 @@ export const mutations = {
 export const actions = {
   setK8sState({ commit }, k8sState) {
     commit('SET_K8S_STATE', k8sState);
-  }
+  },
 };
 
 export const getters = {
   getK8sState({ k8sState }) {
     return k8sState;
-  }
+  },
 };

--- a/src/store/page.ts
+++ b/src/store/page.ts
@@ -9,7 +9,7 @@ interface PageState {
 export const state: () => PageState = () => ({
   title:       '',
   description: '',
-  action:      ''
+  action:      '',
 });
 
 export const mutations: MutationsType<PageState> = {
@@ -21,7 +21,7 @@ export const mutations: MutationsType<PageState> = {
   },
   SET_ACTION(state, action) {
     state.action = action;
-  }
+  },
 };
 
 type PageActionContext = ActionContext<PageState>;
@@ -38,5 +38,5 @@ export const actions = {
     const { action } = args;
 
     commit('SET_ACTION', action);
-  }
+  },
 };

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -34,7 +34,7 @@ export const state: () => PreferencesState = () => (
     wslIntegrations:    { },
     isPlatformWindows:  false,
     hasError:           false,
-    severities:         { reset: false, restart: false }
+    severities:         { reset: false, restart: false },
   }
 );
 
@@ -56,7 +56,7 @@ export const mutations: MutationsType<PreferencesState> = {
   },
   SET_SEVERITIES(state, severities) {
     state.severities = severities;
-  }
+  },
 };
 
 type PrefActionContext = ActionContext<PreferencesState>;
@@ -77,8 +77,8 @@ export const actions = {
       {
         headers: new Headers({
           Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
-          'Content-Type': 'application/x-www-form-urlencoded'
-        })
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
       });
 
     if (!response.ok) {
@@ -100,9 +100,9 @@ export const actions = {
         method:  'PUT',
         headers: new Headers({
           Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
         }),
-        body: JSON.stringify(state.preferences)
+        body: JSON.stringify(state.preferences),
       });
 
     await dispatch(
@@ -119,7 +119,7 @@ export const actions = {
    * in the preferences object
    */
   updatePreferencesData<P extends RecursiveKeys<Settings>>({
-    commit, dispatch, state, rootState
+    commit, dispatch, state, rootState,
   }: PrefActionContext, args: {property: P, value: RecursiveTypes<Settings>[P]}): void {
     const { property, value } = args;
 
@@ -127,7 +127,7 @@ export const actions = {
     dispatch(
       'preferences/proposePreferences',
       rootState.credentials.credentials as ServerState,
-      { root: true }
+      { root: true },
     );
   },
   setWslIntegrations({ commit }: PrefActionContext, integrations: { [distribution: string]: string | boolean}) {
@@ -148,9 +148,9 @@ export const actions = {
         method:  'PUT',
         headers: new Headers({
           Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/x-www-form-urlencoded',
         }),
-        body: JSON.stringify(state.preferences)
+        body: JSON.stringify(state.preferences),
       });
 
     const changes: Record<string, {severity: 'reset' | 'restart'}> = await result.json();
@@ -163,7 +163,7 @@ export const actions = {
     commit('SET_SEVERITIES', severities);
 
     return severities;
-  }
+  },
 };
 
 export const getters: GetterTree<PreferencesState, PreferencesState> = {
@@ -185,5 +185,5 @@ export const getters: GetterTree<PreferencesState, PreferencesState> = {
   },
   hasError(state: PreferencesState) {
     return state.hasError;
-  }
+  },
 };

--- a/src/store/prefs.js
+++ b/src/store/prefs.js
@@ -33,7 +33,7 @@ export const mapPref = function(name) {
 
     set(value) {
       this.$store.dispatch('prefs/set', { key: name, value });
-    }
+    },
   };
 };
 
@@ -75,15 +75,15 @@ export const DATE_FORMAT = create('date-format', 'ddd, MMM D YYYY', {
     'ddd, D MMM YYYY',
     'D/M/YYYY',
     'M/D/YYYY',
-    'YYYY-MM-DD'
-  ]
+    'YYYY-MM-DD',
+  ],
 });
 
 export const TIME_FORMAT = create('time-format', 'h:mm:ss a', {
   options: [
     'h:mm:ss a',
-    'HH:mm:ss'
-  ]
+    'HH:mm:ss',
+  ],
 });
 
 export const TIME_ZONE = create('time-zone', 'local');
@@ -215,7 +215,7 @@ export const getters = {
     default:
       return { name: afterLoginRoutePref };
     }
-  }
+  },
 };
 
 export const mutations = {
@@ -243,7 +243,7 @@ export const actions = {
     if ( definition.asCookie ) {
       const opt = {
         ...cookieOptions,
-        parseJSON: definition.parseJSON === true
+        parseJSON: definition.parseJSON === true,
       };
 
       this.$cookies.set(`${ cookiePrefix }${ key }`.toUpperCase(), value, opt);
@@ -369,7 +369,7 @@ export const actions = {
           force:                true,
           watch:                false,
           redirectUnauthorized: false,
-        }
+        },
       }, { root: true });
 
       server = all?.[0];
@@ -443,7 +443,7 @@ export const actions = {
         }
       } catch {}
     }
-  }
+  },
 };
 
 function getLoginRoute(route) {
@@ -467,6 +467,6 @@ function getLoginRoute(route) {
 
   return {
     name: parts.join('-'),
-    params
+    params,
   };
 }

--- a/src/utils/__tests__/dockerDirManager.spec.ts
+++ b/src/utils/__tests__/dockerDirManager.spec.ts
@@ -104,7 +104,7 @@ describe('DockerDirManager', () => {
           docker: {
             Host:          `unix://${ sockPath }`,
             SkipTLSVerify: false,
-          }
+          },
         },
         Metadata: { Description: 'Rancher Desktop moby context' },
         Name:     'rancher-desktop',

--- a/src/utils/__tests__/paths.spec.ts
+++ b/src/utils/__tests__/paths.spec.ts
@@ -16,8 +16,8 @@ jest.mock('electron', () => {
       app: {
         isPackaged: false,
         getAppPath: () => CURRENT_DIR,
-      }
-    }
+      },
+    },
   };
 });
 
@@ -41,7 +41,7 @@ describe('paths', () => {
     logs: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/logs/',
       linux:  '%HOME%/.local/share/rancher-desktop/logs/',
-      darwin: '%HOME%/Library/Logs/rancher-desktop/'
+      darwin: '%HOME%/Library/Logs/rancher-desktop/',
     },
     cache: {
       win32:  '%LOCALAPPDATA%/rancher-desktop/cache/',
@@ -77,7 +77,7 @@ describe('paths', () => {
       win32:  RESOURCES_PATH,
       linux:  RESOURCES_PATH,
       darwin: RESOURCES_PATH,
-    }
+    },
   };
 
   const table = Object.entries(cases).flatMap(

--- a/src/utils/childProcess.ts
+++ b/src/utils/childProcess.ts
@@ -1,12 +1,12 @@
 import {
-  spawn, CommonOptions, IOType, MessagingOptions, StdioOptions, StdioNull, StdioPipe
+  spawn, CommonOptions, IOType, MessagingOptions, StdioOptions, StdioNull, StdioPipe,
 } from 'child_process';
 import stream from 'stream';
 
 import { Log } from '@/utils/logging';
 
 export {
-  ChildProcess, CommonOptions, SpawnOptions, exec, spawn
+  ChildProcess, CommonOptions, SpawnOptions, exec, spawn,
 } from 'child_process';
 
 /**
@@ -148,7 +148,7 @@ export async function spawnFile(
 export async function spawnFile(
   command: string,
   args?: string[] | SpawnOptionsLog & SpawnOptionsEncoding,
-  options: SpawnOptionsLog & SpawnOptionsEncoding = {}
+  options: SpawnOptionsLog & SpawnOptionsEncoding = {},
 ): Promise<{ stdout?: string, stderr?: string }> {
   let finalArgs: string[] = [];
 
@@ -250,7 +250,7 @@ export async function spawnFile(
         [ErrorCommand]: {
           enumerable: false,
           value:      `${ command } ${ finalArgs.join(' ') }`,
-        }
+        },
       });
       if (typeof result.stdout !== 'undefined') {
         error.stdout = result.stdout;

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -81,9 +81,9 @@ function wrapCreateConnection(agent: https.Agent) {
           }
 
           return socket;
-        }
-      }
-    })
+        },
+      },
+    }),
   };
 
   return result;
@@ -130,7 +130,7 @@ export default async function fetch(url: string, options?: RequestInit) {
         result = wrapCreateConnection(secureAgent);
 
         return result.agent;
-      }
+      },
     });
   } catch (ex) {
     // result.lastError may be set by createConnection from wrapCreateConnection.

--- a/src/utils/imageOutputCuller.js
+++ b/src/utils/imageOutputCuller.js
@@ -4,7 +4,7 @@ import TrivyScanImageOutputCuller from '@/utils/processOutputInterpreters/trivy-
 
 const cullersByName = {
   build:         ImageBuildOutputCuller,
-  'trivy-image': TrivyScanImageOutputCuller
+  'trivy-image': TrivyScanImageOutputCuller,
 };
 
 export default function getImageOutputCuller(command) {

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -147,7 +147,7 @@ export default new Proxy<Module>({}, {
     }
 
     return logs.get(prop);
-  }
+  },
 });
 
 /**

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -123,7 +123,7 @@ export class LinuxPaths extends ProvidesResources implements Paths {
 const UnsupportedPaths: Paths = new Proxy({} as Paths, {
   get(target, prop) {
     throw new Error(`Paths ${ String(prop) } not available for ${ os.platform() }`);
-  }
+  },
 });
 
 function getPaths(): Paths {

--- a/src/utils/safeRename.ts
+++ b/src/utils/safeRename.ts
@@ -30,7 +30,7 @@ export default async function safeRename(srcPath: string, destPath: string): Pro
 
       await fsExtra.copy(srcPath, destPath);
       await fsPromises.rm(srcPath, {
-        recursive: true, force: true, maxRetries: 2
+        recursive: true, force: true, maxRetries: 2,
       });
     } else {
       await fsPromises.copyFile(srcPath, destPath);

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -51,7 +51,7 @@ const entityMap = {
   '>': '&gt;',
   '"': '&quot;',
   "'": '&#39;',
-  '/': '&#x2F;'
+  '/': '&#x2F;',
 };
 
 export function escapeHtml(html) {

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -9,7 +9,7 @@ export function formatSi(inValue, {
   startingExponent = 0,
   minExponent = 0,
   maxExponent = 99,
-  maxPrecision = 2
+  maxPrecision = 2,
 } = {}) {
   let val = inValue;
   let exp = startingExponent;
@@ -121,8 +121,8 @@ export const MEMORY_PARSE_RULES = {
       minExponent:      0,
       startingExponent: 0,
       suffix:           'iB',
-    }
-  }
+    },
+  },
 };
 
 export function createMemoryFormat(n) {
@@ -151,7 +151,7 @@ export function createMemoryValues(total, useful) {
   return {
     total:  Number.parseFloat(formattedTotal),
     useful: Number.parseFloat(formattedUseful),
-    units:  createMemoryUnits(parsedTotal)
+    units:  createMemoryUnits(parsedTotal),
   };
 }
 

--- a/src/window/dashboard.ts
+++ b/src/window/dashboard.ts
@@ -17,7 +17,7 @@ export function openDashboard() {
     title:  'Rancher Dashboard',
     width:  800,
     height: 600,
-    show:   false
+    show:   false,
   });
 
   window.loadURL(dashboardURL);

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -147,8 +147,8 @@ function resizeWindow(window: Electron.BrowserWindow, width: number, height: num
 
   window.setContentBounds(
     {
-      x: centered, y: prefY, width, height
-    }
+      x: centered, y: prefY, width, height,
+    },
   );
 }
 
@@ -182,8 +182,8 @@ export function openDialog(id: string, opts?: Electron.BrowserWindowConstructorO
         contextIsolation:        false,
         enablePreferredSizeMode: true,
         ...opts?.webPreferences ?? {},
-      }
-    }
+      },
+    },
   );
 
   window.menuBarVisible = false;
@@ -290,7 +290,7 @@ export async function openLegacyIntegrations(): Promise<void> {
     {
       title:          'Rancher Desktop - Legacy Integrations',
       parent:         getWindow('main') ?? undefined,
-    }
+    },
   );
 
   await (new Promise<void>((resolve) => {

--- a/src/window/preferences.ts
+++ b/src/window/preferences.ts
@@ -48,8 +48,8 @@ export function openPreferences() {
         cancelId: cancelPosition,
         buttons:  [
           'Discard changes',
-          'Cancel'
-        ]
+          'Cancel',
+        ],
       });
 
     if (result === cancelPosition) {


### PR DESCRIPTION
This enforces the eslint comma dangle rule with `always-multiline` so that there is a consistent style applied throughout the project. This is raised as a result of discussion from PR #2688

> Prefer trailing commas to make future change slightly cleaner (but if you don't feel like it then that's fine too)

_Originally posted by @mook-as in https://github.com/rancher-sandbox/rancher-desktop/pull/2688#discussion_r940484154_