### PR TITLE
Always set the allowSudo property.

### DIFF
--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -1559,6 +1559,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     this.setState(K8s.State.STARTING);
     this.currentAction = Action.STARTING;
     this.lastCommandComment = 'Starting Backend';
+    this.#allowSudo = !config_.suppressSudo;
     await this.progressTracker.action(this.lastCommandComment, 10, async() => {
       try {
         await this.ensureArchitectureMatch();


### PR DESCRIPTION
Fixes #2700 

To repro:
In RD turn off sudo access and choose moby CE (or set the prefs directly).
Shut down RD
Delete `/var/run/docker.sock` on macOS, or whatever the equivalent is on linux
Remove `"context": "rancher-desktop"` from `~/.docker/config.json`

Restart RD, don't allow sudo access

Without the fix, verify:
* no `"context" line in `~/.docker/config.json`
* `docker info` fails

With the fix, verify
* `"context" line in `~/.docker/config.json`
* `docker info` succeeds

We'll use the tests in `test-cross-platform-container` (PR #2691) as tests for this code.

Signed-off-by: Eric Promislow <epromislow@suse.com>