### PR TITLE
ESLint: TypeScript: switch semicolon linting style.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -235,13 +235,17 @@ module.exports.overrides = [
     rules: {
       // For TypeScript, disable no-undef because the compiler checks it.
       // Also, it is unaware of TypeScript types.
-      'no-undef':              'off',
+      'no-undef':                'off',
       // For TypeScript, allow duplicate class members (function overloads).
-      'no-dupe-class-members': 'off',
+      'no-dupe-class-members':   'off',
       // For TypeScript, allow redeclarations (interface vs class).
-      'no-redeclare':          'off',
+      'no-redeclare':            'off',
       // For TypeScript, TS does use-before-define statically.
-      'no-use-before-define':  'off',
+      'no-use-before-define':    'off',
+      // For TypeScript, turn of the base "semi" rule as it conflicts with the
+      // TypeScript-specific one (and also TS/no-extra-semi).
+      semi:                      'off',
+      '@typescript-eslint/semi': 'warn',
     },
   },
 ];

--- a/src/integrations/legacy.ts
+++ b/src/integrations/legacy.ts
@@ -20,7 +20,7 @@ type EaccesError = {
   code: string;
   syscall: string;
   path: string;
-}
+};
 
 export class PermissionError {
   errors: EaccesError[] = [];

--- a/src/k8s-engine/client.ts
+++ b/src/k8s-engine/client.ts
@@ -175,7 +175,7 @@ export type ServiceEntry = {
   port?: number | string;
   /** The forwarded port on localhost (on the host), if any. */
   listenPort?: number;
-}
+};
 
 /**
  * KubeClient is a Kubernetes client that will _only_ manage the cluster we spin

--- a/src/k8s-engine/k3sHelper.ts
+++ b/src/k8s-engine/k3sHelper.ts
@@ -65,7 +65,7 @@ type cacheData = {
   versions: string[];
   /** Mapping of channel labels to current version (excluding build information). */
   channels: Record<string, string>;
-}
+};
 
 /**
  * RequiresRestartSeverityChecker is a function that will be used to determine

--- a/src/k8s-engine/k8s.ts
+++ b/src/k8s-engine/k8s.ts
@@ -38,7 +38,7 @@ export type KubernetesProgress = {
   description?: string,
   /** When we entered this progress state. */
   transitionTime?: Date,
-}
+};
 
 export type Architecture = 'x86_64' | 'aarch64';
 
@@ -47,7 +47,7 @@ export type FailureDetails = {
   lastCommand?: string,
   lastCommandComment: string,
   lastLogLines: Array<string>,
-}
+};
 
 /**
  * VersionEntry describes a version of K3s.

--- a/src/k8s-engine/lima.ts
+++ b/src/k8s-engine/lima.ts
@@ -109,7 +109,7 @@ type LimaConfiguration = {
   k3s?: {
     version: string;
   }
-}
+};
 
 /**
  * Lima networking configuration.

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -17,7 +17,7 @@ export type ServerState = {
   password: string;
   port: number;
   pid: number;
-}
+};
 
 type DispatchFunctionType = (request: http.IncomingMessage, response: http.ServerResponse, context: commandContext) => Promise<void>;
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -33,7 +33,7 @@ type SettingsValidationMapEntry<T> = {
   T[k] extends Record<string, infer V> ?
   SettingsValidationMapEntry<T[k]> | ValidatorFunc<T[k], Record<string, V>> :
   never;
-}
+};
 
 /**
  * SettingsValidationMap desscribes the full set of validators that will be used

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -18,7 +18,7 @@ export type ServerState = {
   password: string;
   port: number;
   pid: number;
-}
+};
 
 const SERVER_PORT = 6109;
 const console = Logging.server;

--- a/src/main/update/index.ts
+++ b/src/main/update/index.ts
@@ -56,7 +56,7 @@ export type UpdateState = {
   error?: Error;
   info?: UpdateInfo;
   progress?: ProgressInfo;
-}
+};
 const updateState: UpdateState = {
   configured: false, available: false, downloaded: false,
 };

--- a/src/store/applicationSettings.ts
+++ b/src/store/applicationSettings.ts
@@ -11,7 +11,7 @@ import type { PathManagementStrategy } from '@/integrations/pathManager';
 type State = {
   pathManagementStrategy: PathManagementStrategy;
   sudoAllowed: boolean;
-}
+};
 
 export const state: () => State = () => {
   // While we load the settings from disk here, we only otherwise interact with

--- a/src/store/ts-helpers.ts
+++ b/src/store/ts-helpers.ts
@@ -4,7 +4,7 @@ import type { CommitOptions, Dispatch } from 'vuex';
 
 type MutationsPayloadType<T> = {
   [key in keyof T as `SET_${ UpperSnakeCase<key> }`]: T[key];
-}
+};
 
 /**
  * MutationsType is used to describe the type that `mutations` should have.
@@ -13,7 +13,7 @@ type MutationsPayloadType<T> = {
  */
 export type MutationsType<T> = {
   [key in keyof T as `SET_${ UpperSnakeCase<key> }`]: (state: T, payload: T[key]) => any;
-}
+};
 
 /**
  * ActionContext is the first argument for an action.  We only declare the
@@ -28,4 +28,4 @@ export type ActionContext<T> = {
   dispatch: Dispatch;
   state: T;
   rootState: any;
-}
+};

--- a/src/utils/backgroundProcess.ts
+++ b/src/utils/backgroundProcess.ts
@@ -12,7 +12,7 @@ type BackgroundProcessConstructorOptions = {
   destroy?: (child: childProcess.ChildProcess) => Promise<void>;
   /** Additional checks to see if the process should be strarted. */
   shouldRun?: () => Promise<boolean>;
-}
+};
 
 /**
  * This manages a given persistent background process that must be kept running

--- a/src/utils/dockerDirManager.ts
+++ b/src/utils/dockerDirManager.ts
@@ -24,7 +24,7 @@ type AuthConfig = {
   serveraddress?: string,
   identitytoken?: string,
   registrytoken?: string,
-}
+};
 
 /**
  * The parts of a docker config.json file that concern Rancher Desktop.
@@ -34,7 +34,7 @@ type PartialDockerConfig = {
   credsStore?: string,
   credHelpers?: Record<string, string>,
   currentContext?: string,
-}
+};
 
 /**
  * Manages everything under the docker CLI config directory (except, at

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -8,7 +8,7 @@ export type RecursivePartial<T> = {
     // eslint-disable-next-line @typescript-eslint/ban-types
     T[P] extends object ? RecursivePartial<T[P]> :
       T[P];
-}
+};
 
 export type RecursiveReadonly<T> = {
   readonly [P in keyof T]:
@@ -16,7 +16,7 @@ export type RecursiveReadonly<T> = {
   // eslint-disable-next-line @typescript-eslint/ban-types
   T[P] extends object ? RecursiveReadonly<T[P]> :
   T[P];
-}
+};
 
 /** UpperAlpha is the set of upper-case alphabets. */
 type UpperAlpha =


### PR DESCRIPTION
The default ESlint rule ('semi') has conflicts with the recommended TypeScript lint rule (@TS/no-extra-semi); in TypeScript files, turn off the default `semi` rule and use the TypeScript-specific `@TS/semi` instead.

In particular, the conflict happens on exported interfaces; for details, please see https://github.com/typescript-eslint/typescript-eslint/issues/123.
