### PR TITLE
Dependabot: Add various golang code bases.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,35 @@ updates:
 
   # Maintain dependencies for Golang
   - package-ecosystem: "gomod"
+    directory: "/src/go/docker-credential-none"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels: ["component/dependencies"]
+
+  - package-ecosystem: "gomod"
+    directory: "/src/go/mock-wsl"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels: ["component/dependencies"]
+
+  - package-ecosystem: "gomod"
     directory: "/src/go/nerdctl-stub"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels: ["component/dependencies"]
+
+  - package-ecosystem: "gomod"
+    directory: "/src/go/rdctl"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels: ["component/dependencies"]
+
+  - package-ecosystem: "gomod"
+    directory: "/src/go/vtunnel"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,40 +22,40 @@ updates:
     directory: "/src/go/docker-credential-none"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/src/go/mock-wsl"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/src/go/nerdctl-stub"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/src/go/rdctl"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/src/go/vtunnel"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]
 
   - package-ecosystem: "gomod"
     directory: "/src/go/wsl-helper"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels: ["component/dependencies"]


### PR DESCRIPTION
We had forgotten to add dependabot to new golang codebases as we added them.

I just copied the existing settings; however, I'm not sure that's the best idea, as the limits seem to be independent:
<img width="706" alt="image showing 11 dependabot pull requests" src="https://user-images.githubusercontent.com/3977982/183725510-98054cd8-a688-4cb1-a2f4-a5781201fd2d.png">
