### PR TITLE
Refactoring: extract VM backend interface

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -100,16 +100,16 @@ export interface VMBackend {
   /** The name of the VM backend */
   readonly backend: 'wsl' | 'lima' | 'mock';
 
-  state: State;
+  readonly state: State;
 
   /** The number of CPUs in the running VM, or 0 if the VM is not running. */
-  cpus: Promise<number>;
+  readonly cpus: Promise<number>;
 
   /** The amount of memory in the VM, in MiB, or 0 if the VM is not running. */
-  memory: Promise<number>;
+  readonly memory: Promise<number>;
 
   /** Progress for the current action. */
-  progress: Readonly<BackendProgress>;
+  readonly progress: Readonly<BackendProgress>;
 
   /**
    * Whether debug mode is enabled. If this is set, the implementation should
@@ -171,7 +171,7 @@ export interface VMBackend {
    * A description of the last backend command, usually displayed by the progress tracker,
    * but available for the `FailureDetails` block.
    */
-  lastCommandComment: string;
+  readonly lastCommandComment: string;
 
   /**
    * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,0 +1,180 @@
+import { Settings } from '@/config/settings';
+import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
+
+export enum State {
+  STOPPED = 0, // The engine is not running.
+  STARTING, // The engine is attempting to start.
+  STARTED, // The engine is started; the dashboard is not yet ready.
+  STOPPING, // The engine is attempting to stop.
+  ERROR, // There is an error and we cannot recover automatically.
+  DISABLED, // The container backend is ready but the Kubernetes engine is disabled.
+}
+
+export class BackendError extends Error {
+  constructor(name: string, message: string, fatal = false) {
+    super(message);
+    this.name = name;
+    this.fatal = fatal;
+  }
+
+  readonly fatal: boolean;
+}
+
+export type BackendProgress = {
+  /** The current progress; valid values are 0 to max. */
+  current: number,
+  /** Maximum progress possible; if less than zero, the progress is indeterminate. */
+  max: number,
+  /** Details on the current action. */
+  description?: string,
+  /** When we entered this progress state. */
+  transitionTime?: Date,
+};
+
+export type Architecture = 'x86_64' | 'aarch64';
+
+export type FailureDetails = {
+  /** The last lima/wsl command run: */
+  lastCommand?: string,
+  lastCommandComment: string,
+  lastLogLines: Array<string>,
+};
+
+/**
+ * KubernetesBackendEvents describes the events that may be emitted by a
+ * Kubernetes backend (as an EventEmitter).  Each property name is the name of
+ * an event, and the property type is the type of the callback function expected
+ * for the given event.
+ */
+export interface BackendEvents {
+  /**
+   * Emitted when there has been a change in the progress in the current action.
+   * The progress can be read off the `progress` member on the backend.
+   */
+  'progress'(): void;
+
+  /**
+   * Emitted when the state of the backend has changed.
+   */
+  'state-changed'(state: State): void;
+
+  /**
+   * Show a notification to the user.
+   */
+  'show-notification'(options: Electron.NotificationConstructorOptions): void;
+}
+
+/**
+ * Settings that KubernetesBackend can access.
+ */
+export type BackendSettings = RecursiveReadonly<Settings['kubernetes']>;
+
+/**
+ * Reasons that the backend might need to restart, as returned from
+ * `requiresRestartReasons()`.
+ * @returns A mapping of the preference causing the restart to the changed
+ *          values.
+ */
+export type RestartReasons = Partial<Record<RecursiveKeys<Settings>, {
+  /**
+   * The currently active value.
+   */
+  current: any;
+  /**
+   * The desired value (which must be different from the current value to
+   * require a restart).
+   */
+  desired: any;
+  /**
+   * The severity of the restart; this may be set to `reset` for some values
+   * indicating that there will be data loss.
+   */
+  severity: 'restart' | 'reset';
+}>>;
+
+/**
+ * VMBackend describes a controller for managing a virtual machine upon which
+ * Rancher Desktop runs.
+ */
+export interface VMBackend {
+  /** The name of the VM backend */
+  readonly backend: 'wsl' | 'lima' | 'mock';
+
+  state: State;
+
+  /** The number of CPUs in the running VM, or 0 if the VM is not running. */
+  cpus: Promise<number>;
+
+  /** The amount of memory in the VM, in MiB, or 0 if the VM is not running. */
+  memory: Promise<number>;
+
+  /** Progress for the current action. */
+  progress: Readonly<BackendProgress>;
+
+  /**
+   * Whether debug mode is enabled. If this is set, the implementation should
+   * emit extra debug logging if possible.
+   */
+  debug: boolean;
+
+  /**
+   * Check if the current backend is valid.
+   * @returns Null if the backend is valid, otherwise an error describing why
+   * the backend is invalid that can be shown to the user.
+   */
+  getBackendInvalidReason(): Promise<BackendError | null>;
+
+  /**
+   * Start the Kubernetes cluster.  If it is already started, it will be
+   * restarted.
+   */
+  start(config: BackendSettings): Promise<void>;
+
+  /** Stop the Kubernetes cluster.  If applicable, shut down the VM. */
+  stop(): Promise<void>;
+
+  /** Delete the Kubernetes cluster, returning the exit code. */
+  del(): Promise<void>;
+
+  /** Reset the Kubernetes cluster, removing all workloads. */
+  reset(config: BackendSettings): Promise<void>;
+
+  /**
+   * Reset the cluster, completely deleting any user configuration.  This does
+   * not automatically restart the cluster.
+   */
+  factoryReset(keepSystemImages: boolean): Promise<void>;
+
+  /**
+   * Check if applying the given settings would require the backend to restart.
+   */
+  requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons>;
+
+  /**
+   * Get the external IP address where the services would be listening on, if
+   * available.  For VM-based systems, this would be the address of the VM's
+   * network interface.  This address may be undefined if the backend is
+   * currently not in a state that supports services; for example, if the VM is
+   * off.
+   */
+  readonly ipAddress: Promise<string | undefined>;
+
+  /**
+   * If called after a backend operation fails, this returns a block of data that attempts
+   * to give more information about what command was being run when the error happened.
+   *
+   * @param [exception] The associated exception.
+   */
+  getFailureDetails(exception: any): Promise<FailureDetails>;
+
+  /**
+   * A description of the last backend command, usually displayed by the progress tracker,
+   * but available for the `FailureDetails` block.
+   */
+  lastCommandComment: string;
+
+  /**
+   * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.
+   */
+  noModalDialogs: boolean;
+}

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 
-import { Architecture, KubernetesBackend } from './k8s';
+import { Architecture } from './backend';
+import { KubernetesBackend } from './k8s';
 import LimaBackend from './lima';
 import MockBackend from './mock';
 import WSLBackend from './wsl';

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -15,6 +15,8 @@ import { Response } from 'node-fetch';
 import semver from 'semver';
 import yaml from 'yaml';
 
+import { Architecture } from './backend';
+
 import { KubeClient } from '@/backend/client';
 import * as K8s from '@/backend/k8s';
 import { loadFromString, exportConfig } from '@/backend/kubeconfig';
@@ -157,7 +159,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
   protected readonly minimumVersion = new semver.SemVer('1.15.0');
 
-  constructor(arch: K8s.Architecture) {
+  constructor(arch: Architecture) {
     super();
     this.arch = arch;
   }
@@ -173,7 +175,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected pendingInitialize: Promise<void> | undefined;
 
   /** The current architecture. */
-  protected readonly arch: K8s.Architecture;
+  protected readonly arch: Architecture;
 
   /**
    * Read the cached data and fill out this.versions.

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -31,7 +31,7 @@ import paths from '@/utils/paths';
 import resources from '@/utils/resources';
 import safeRename from '@/utils/safeRename';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
-import { defined, RecursiveKeys, RecursivePartial, RecursiveTypes } from '@/utils/typeUtils';
+import { defined, RecursivePartial, RecursiveTypes } from '@/utils/typeUtils';
 // TODO: Replace with the k8s version after kubernetes-client/javascript/pull/748 lands
 import { showMessageBox } from '@/window';
 

--- a/src/backend/k8s.ts
+++ b/src/backend/k8s.ts
@@ -1,53 +1,15 @@
-import events from 'events';
-import { EventEmitter } from 'stream';
-
 import semver from 'semver';
 
+import { VMBackend, BackendEvents } from './backend';
 import { ServiceEntry } from './client';
 
-import { Settings } from '@/config/settings';
-import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
+import EventEmitter from '@/utils/eventEmitter';
 
+export {
+  BackendSettings, FailureDetails, RestartReasons, State,
+  BackendError as KubernetesError, BackendProgress as KubernetesProgress,
+} from './backend';
 export { ServiceEntry } from './client';
-
-export enum State {
-  STOPPED = 0, // The engine is not running.
-  STARTING, // The engine is attempting to start.
-  STARTED, // The engine is started; the dashboard is not yet ready.
-  STOPPING, // The engine is attempting to stop.
-  ERROR, // There is an error and we cannot recover automatically.
-  DISABLED, // The container backend is ready but the Kubernetes engine is disabled.
-}
-
-export class KubernetesError extends Error {
-  constructor(name: string, message: string, fatal = false) {
-    super(message);
-    this.name = name;
-    this.fatal = fatal;
-  }
-
-  readonly fatal: boolean;
-}
-
-export type KubernetesProgress = {
-  /** The current progress; valid values are 0 to max. */
-  current: number,
-  /** Maximum progress possible; if less than zero, the progress is indeterminate. */
-  max: number,
-  /** Details on the current action. */
-  description?: string,
-  /** When we entered this progress state. */
-  transitionTime?: Date,
-};
-
-export type Architecture = 'x86_64' | 'aarch64';
-
-export type FailureDetails = {
-  /** The last lima/wsl command run: */
-  lastCommand?: string,
-  lastCommandComment: string,
-  lastLogLines: Array<string>,
-};
 
 /**
  * VersionEntry describes a version of K3s.
@@ -65,83 +27,34 @@ export interface VersionEntry {
  * an event, and the property type is the type of the callback function expected
  * for the given event.
  */
-interface KubernetesBackendEvents {
-  /**
-   * Emitted when there has been a change in the progress in the current action.
-   * The progress can be read off the `progress` member on the backend.
-   */
-  'progress': () => void;
-
+export interface KubernetesBackendEvents extends BackendEvents {
   /**
    * Emitted when the set of Kubernetes services has changed.
    */
-  'service-changed': (services: ServiceEntry[]) => void;
+  'service-changed'(services: ServiceEntry[]): void;
 
   /**
    * Emitted when an error related to the port forwarding server has occurred.
    */
-  'service-error': (service: ServiceEntry, errorMessage: string) => void;
-
-  /**
-   * Emitted when the state of the Kubernetes backend has changed.
-   */
-  'state-changed': (state: State) => void;
+  'service-error'(service: ServiceEntry, errorMessage: string): void;
 
   /**
    * Emitted when the versions of Kubernetes available has changed.
    */
-  'versions-updated': () => void;
+  'versions-updated'(): void;
 
   /**
    * Emitted when k8s is running on a new port
    */
-  'current-port-changed': (port: number) => void;
-
-  /**
-   * Show a notification to the user.
-   */
-  'show-notification': (options: Electron.NotificationConstructorOptions) => void;
+  'current-port-changed'(port: number): void;
 
   /**
    * Emitted when the checkForExistingKimBuilder setting pref changes
    */
-  'kim-builder-uninstalled': () => void;
+  'kim-builder-uninstalled'(): void;
 }
 
-/**
- * Settings that KubernetesBackend can access.
- */
-export type BackendSettings = RecursiveReadonly<Settings['kubernetes']>;
-
-/**
- * Reasons that the backend might need to restart, as returned from
- * `requiresRestartReasons()`.
- * @returns A mapping of the preference causing the restart to the changed
- *          values.
- */
-export type RestartReasons = Partial<Record<RecursiveKeys<Settings>, {
-  /**
-   * The currently active value.
-   */
-  current: any;
-  /**
-   * The desired value (which must be different from the current value to
-   * require a restart).
-   */
-  desired: any;
-  /**
-   * The severity of the restart; this may be set to `reset` for some values
-   * indicating that there will be data loss.
-   */
-  severity: 'restart' | 'reset';
-}>>;
-
-export interface KubernetesBackend extends events.EventEmitter, KubernetesBackendPortForwarder {
-  /** The name of the Kubernetes backend */
-  readonly backend: 'wsl' | 'lima' | 'mock';
-
-  state: State;
-
+export interface KubernetesBackend extends VMBackend, EventEmitter<KubernetesBackendEvents>, KubernetesBackendPortForwarder {
   /**
    * The versions that are available to install, sorted as would be displayed to
    * the user.
@@ -157,68 +70,11 @@ export interface KubernetesBackend extends events.EventEmitter, KubernetesBacken
   /** The version of Kubernetes that is currently installed. */
   version: string;
 
-  /** The number of CPUs in the running VM, or 0 if the VM is not running. */
-  cpus: Promise<number>;
-
-  /** The amount of memory in the VM, in MiB, or 0 if the VM is not running. */
-  memory: Promise<number>;
-
   /**
    * The port the Kubernetes server will listen on; this may not reflect the
    * port correctly if the server is not active.
    */
   readonly desiredPort: number;
-
-  /** Progress for the current action. */
-  progress: Readonly<KubernetesProgress>;
-
-  /**
-   * Whether debug mode is enabled. If this is set, the implementation should
-   * emit extra debug logging if possible.
-   */
-  debug: boolean;
-
-  /**
-   * Check if the current backend is valid.
-   * @returns Null if the backend is valid, otherwise an error describing why
-   * the backend is invalid that can be shown to the user.
-   */
-  getBackendInvalidReason(): Promise<KubernetesError | null>;
-
-  /**
-   * Start the Kubernetes cluster.  If it is already started, it will be
-   * restarted.
-   */
-  start(config: BackendSettings): Promise<void>;
-
-  /** Stop the Kubernetes cluster.  If applicable, shut down the VM. */
-  stop(): Promise<void>;
-
-  /** Delete the Kubernetes cluster, returning the exit code. */
-  del(): Promise<void>;
-
-  /** Reset the Kubernetes cluster, removing all workloads. */
-  reset(config: BackendSettings): Promise<void>;
-
-  /**
-   * Reset the cluster, completely deleting any user configuration.  This does
-   * not automatically restart the cluster.
-   */
-  factoryReset(keepSystemImages: boolean): Promise<void>;
-
-  /**
-   * Check if applying the given settings would require the backend to restart.
-   */
-  requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons>;
-
-  /**
-   * Get the external IP address where the services would be listening on, if
-   * available.  For VM-based systems, this would be the address of the VM's
-   * network interface.  This address may be undefined if the backend is
-   * currently not in a state that supports services; for example, if the VM is
-   * off.
-   */
-  readonly ipAddress: Promise<string | undefined>;
 
   /**
    * Fetch the list of services currently known to Kubernetes.
@@ -233,75 +89,6 @@ export interface KubernetesBackend extends events.EventEmitter, KubernetesBacken
    * @param service The name of the service to lookup.
    */
   isServiceReady(namespace: string, service: string): Promise<boolean>;
-
-  /**
-   * If called after a backend operation fails, this returns a block of data that attempts
-   * to give more information about what command was being run when the error happened.
-   *
-   * @param [exception] The associated exception.
-   */
-  getFailureDetails(exception: any): Promise<FailureDetails>;
-
-  /**
-   * A description of the last backend command, usually displayed by the progress tracker,
-   * but available for the `FailureDetails` block.
-   */
-  lastCommandComment: string;
-
-  /**
-   * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.
-   */
-  noModalDialogs: boolean;
-
-  // Override the EventEmitter methods to provide type information for
-  // TypeScript so that we can get type checking for event names.  This ensures
-  // that we do not accidentally listen for events that would never be emitted.
-  // Please refer to EventEmitter for documentation on the individual methods.
-  // #region Events
-  addListener<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  on<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  once<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  removeListener<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  off<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  removeAllListeners<eventName extends keyof KubernetesBackendEvents>(event: eventName): this;
-  listeners<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName
-  ): ReturnType<EventEmitter['listeners']>;
-  rawListeners<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName
-  ): ReturnType<EventEmitter['rawListeners']>;
-  emit<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    ...args: globalThis.Parameters<KubernetesBackendEvents[eventName]>
-  ): boolean;
-  listenerCount<eventName extends keyof KubernetesBackendEvents>(event: eventName): number;
-  prependListener<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  prependOnceListener<eventName extends keyof KubernetesBackendEvents>(
-    event: eventName,
-    listener: KubernetesBackendEvents[eventName]
-  ): this;
-  eventNames(): Array<string | symbol>;
-
-  // #endregion
-
 }
 
 export interface KubernetesBackendPortForwarder {

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -18,6 +18,7 @@ import sudo from 'sudo-prompt';
 import tar from 'tar-stream';
 import yaml from 'yaml';
 
+import { Architecture } from './backend';
 import K3sHelper, { NoCachedK3sVersionsError, ShortVersion } from './k3sHelper';
 import * as K8s from './k8s';
 import ProgressTracker from './progressTracker';
@@ -212,7 +213,7 @@ const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-l
 // [1]: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
 // [2]: https://github.com/microsoft/TypeScript/issues/46802
 export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
-  constructor(arch: K8s.Architecture, dockerDirManager: DockerDirManager) {
+  constructor(arch: Architecture, dockerDirManager: DockerDirManager) {
     super();
     this.arch = arch;
     this.dockerDirManager = dockerDirManager;
@@ -241,7 +242,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected cfg: RecursiveReadonly<Settings['kubernetes']> | undefined;
 
   /** The current architecture. */
-  protected readonly arch: K8s.Architecture;
+  protected readonly arch: Architecture;
 
   /** Used to manage the docker CLI config directory. */
   protected readonly dockerDirManager: DockerDirManager;
@@ -2104,4 +2105,22 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
 
     return details;
   }
+
+  // #region Events
+  eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
+    return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
+  }
+
+  listeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.listeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+
+  rawListeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.rawListeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+  // #endregion
 }

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -4,7 +4,9 @@ import util from 'util';
 
 import semver from 'semver';
 
-import { KubernetesBackend, KubernetesError, State, RestartReasons } from './k8s';
+import {
+  KubernetesBackend, KubernetesError, State, RestartReasons, KubernetesBackendEvents,
+} from './k8s';
 import ProgressTracker from './progressTracker';
 
 import { Settings } from '@/config/settings';
@@ -124,4 +126,22 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
   cancelForward(namespace: string, service: string, k8sPort: number | string): Promise<void> {
     return Promise.resolve();
   }
+
+  // #region Events
+  eventNames(): Array<keyof KubernetesBackendEvents> {
+    return super.eventNames() as Array<keyof KubernetesBackendEvents>;
+  }
+
+  listeners<eventName extends keyof KubernetesBackendEvents>(
+    event: eventName,
+  ): KubernetesBackendEvents[eventName][] {
+    return super.listeners(event) as KubernetesBackendEvents[eventName][];
+  }
+
+  rawListeners<eventName extends keyof KubernetesBackendEvents>(
+    event: eventName,
+  ): KubernetesBackendEvents[eventName][] {
+    return super.rawListeners(event) as KubernetesBackendEvents[eventName][];
+  }
+  // #endregion
 }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1683,4 +1683,22 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
 
     return details;
   }
+
+  // #region Events
+  eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
+    return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
+  }
+
+  listeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.listeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+
+  rawListeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.rawListeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+  // #endregion
 }

--- a/src/utils/eventEmitter.ts
+++ b/src/utils/eventEmitter.ts
@@ -1,5 +1,3 @@
-import events from 'events';
-
 /**
  * EventEmitter wrapper, where the events are defined by the given interface.
  * Each property on the given interface is an event name, and the value should
@@ -11,42 +9,56 @@ export default interface EventEmitter<T extends { [P in keyof T]: (...args: any)
     event: eventName,
     listener: T[eventName]
   ): this;
+
   emit<eventName extends keyof T>(
     event: eventName,
     ...args: globalThis.Parameters<T[eventName]>
   ): boolean;
+
   eventNames(): Array<keyof T>;
+
   getMaxListeners(): number;
+
   listenerCount<eventName extends keyof T>(event: eventName): number;
+
   listeners<eventName extends keyof T>(
     event: eventName
   ): T[eventName][];
+
   off<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   on<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   once<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   prependListener<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   prependOnceListener<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   removeAllListeners<eventName extends keyof T>(event: eventName): this;
+
   removeListener<eventName extends keyof T>(
     event: eventName,
     listener: T[eventName]
   ): this;
+
   setMaxListeners(n: number): void;
+
   rawListeners<eventName extends keyof T>(
     event: eventName
   ): T[eventName][];

--- a/src/utils/eventEmitter.ts
+++ b/src/utils/eventEmitter.ts
@@ -1,0 +1,53 @@
+import events from 'events';
+
+/**
+ * EventEmitter wrapper, where the events are defined by the given interface.
+ * Each property on the given interface is an event name, and the value should
+ * be a function where the arguments are the event parameters, and the return
+ * value is the return value of the event (most likely void).
+ */
+export default interface EventEmitter<T extends { [P in keyof T]: (...args: any) => void}> {
+  addListener<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  emit<eventName extends keyof T>(
+    event: eventName,
+    ...args: globalThis.Parameters<T[eventName]>
+  ): boolean;
+  eventNames(): Array<keyof T>;
+  getMaxListeners(): number;
+  listenerCount<eventName extends keyof T>(event: eventName): number;
+  listeners<eventName extends keyof T>(
+    event: eventName
+  ): T[eventName][];
+  off<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  on<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  once<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  prependListener<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  prependOnceListener<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  removeAllListeners<eventName extends keyof T>(event: eventName): this;
+  removeListener<eventName extends keyof T>(
+    event: eventName,
+    listener: T[eventName]
+  ): this;
+  setMaxListeners(n: number): void;
+  rawListeners<eventName extends keyof T>(
+    event: eventName
+  ): T[eventName][];
+}


### PR DESCRIPTION
In the quest for #1997, this PR extracts out the non-Kubernetes parts of `KubernetesBackend` into a new interface named `VMBackend`.  Currently, the existing backends simply implement both interfaces; in some future PR things will be changed so that there will be distinct objects.

Due to TypeScript restrictions, the events stuff is split out separately; eventually the two backend interfaces will internally declare the events (but that can't happen until they are completely separate).