### PR TITLE
Create template for Diagnostics

### DIFF
--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -90,10 +90,13 @@ export default Vue.extend({
       </template>
       <template #sub-row="{row}">
         <tr>
+          <!--We want an empty data cell so description will align with name-->
           <td></td>
           <td class="sub-row">
             {{ row.description }}
           </td>
+          <!--Empty data cells for remaining columns for row highlight-->
+          <td v-for="header in headers.length - 1" :key="header.name" />
         </tr>
       </template>
     </sortable-table>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -28,11 +28,20 @@ export default Vue.extend({
       ],
       rows: [
         {
+          id:            0,
           name:          'The ~/.rd/bin directory has not been added to the PATH, so commandline utilities are not configured in your back shell',
           documentation: 'https://docs.rancherdesktop.io/',
           category:      'Kubernetes',
           mute:          false,
           description:   'You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it.',
+        },
+        {
+          id:            1,
+          name:          'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+          documentation: 'https://docs.rancherdesktop.io/',
+          category:      'Kubernetes',
+          mute:          false,
+          description:   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet iaculis diam. Nullam ut dolor nec dolor vestibulum viverra id a arcu.',
         },
       ],
     };
@@ -51,6 +60,7 @@ export default Vue.extend({
       </div>
     </div>
     <sortable-table
+      key-field="id"
       :headers="headers"
       :rows="rows"
       :search="false"

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -89,10 +89,12 @@ export default Vue.extend({
         </td>
       </template>
       <template #sub-row="{row}">
-        <td></td>
-        <td class="sub-row">
-          {{ row.description }}
-        </td>
+        <tr>
+          <td></td>
+          <td class="sub-row">
+            {{ row.description }}
+          </td>
+        </tr>
       </template>
     </sortable-table>
   </div>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
   <div class="diagnostics">
     <div class="status">
       <div class="item-results">
-        6 failed (0 muted) Hide muted
+        <span class="icon icon-dot text-error" />6 failed (0 muted)
       </div>
       <div class="diagnostics-status-history">
         Last run: 52 minutes ago
@@ -98,7 +98,9 @@ export default Vue.extend({
       display: flex;
 
       .item-results {
+        display: flex;
         flex: 1;
+        gap: 0.5rem;
       }
     }
 

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
     return {
       headers: [
         {
-          name:  'name',
+          name:  'description',
           label: 'Name',
         },
         {
@@ -29,19 +29,19 @@ export default Vue.extend({
       rows: [
         {
           id:            0,
-          name:          'The ~/.rd/bin directory has not been added to the PATH, so commandline utilities are not configured in your back shell',
+          description:   'The ~/.rd/bin directory has not been added to the PATH, so commandline utilities are not configured in your back shell',
           documentation: 'https://docs.rancherdesktop.io/',
           category:      'Kubernetes',
           mute:          false,
-          description:   'You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it.',
+          fixes:         { description: 'You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it.' },
         },
         {
           id:            1,
-          name:          'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+          description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
           documentation: 'https://docs.rancherdesktop.io/',
           category:      'Kubernetes',
           mute:          false,
-          description:   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet iaculis diam. Nullam ut dolor nec dolor vestibulum viverra id a arcu.',
+          fixes:         { description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet iaculis diam. Nullam ut dolor nec dolor vestibulum viverra id a arcu.' },
         },
       ],
     };
@@ -70,9 +70,9 @@ export default Vue.extend({
       :sub-expandable="true"
       :sub-expand-column="true"
     >
-      <template #col:name="{row}">
+      <template #col:description="{row}">
         <td>
-          <span class="font-semibold">{{ row.name }}</span>
+          <span class="font-semibold">{{ row.description }}</span>
         </td>
       </template>
       <template #col:documentation="{row}">
@@ -93,7 +93,7 @@ export default Vue.extend({
           <!--We want an empty data cell so description will align with name-->
           <td></td>
           <td class="sub-row">
-            {{ row.description }}
+            {{ row.fixes.description }}
           </td>
           <!--Empty data cells for remaining columns for row highlight-->
           <td v-for="header in headers.length - 1" :key="header.name" />

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({ name: 'DiagnosticsBody' });
+</script>
+
+<template>
+  <div class="diagnostics-status">
+    <div class="item-results">
+      6 failed (0 muted) Hide muted
+    </div>
+    <div class="diagnostics-status-history">
+      Last run: 52 minutes ago
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .diagnostics-status {
+    display: flex;
+
+    .item-results {
+      flex: 1;
+    }
+  }
+</style>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -25,17 +25,14 @@ export default Vue.extend({
           name:  'category',
           label: 'Category',
         },
-        {
-          name:  'mute',
-          label: 'Mute',
-        },
       ],
       rows: [
         {
           name:          'The ~/.rd/bin directory has not been added to the PATH, so commandline utilities are not configured in your back shell',
-          documentation: 'Some link',
-          category:      'kubernetes',
+          documentation: 'https://docs.rancherdesktop.io/',
+          category:      'Kubernetes',
           mute:          false,
+          description:   'You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it.',
         },
       ],
     };
@@ -63,6 +60,11 @@ export default Vue.extend({
       :sub-expandable="true"
       :sub-expand-column="true"
     >
+      <template #col:name="{row}">
+        <td>
+          <span class="font-semibold">{{ row.name }}</span>
+        </td>
+      </template>
       <template #col:documentation="{row}">
         <td>
           <a :href="row.documentation"><span class="icon icon-external-link" /></a>
@@ -74,6 +76,12 @@ export default Vue.extend({
             :label="row.category"
             color="bg-warning"
           />
+        </td>
+      </template>
+      <template #sub-row="{row}">
+        <td></td>
+        <td class="sub-row">
+          {{ row.description }}
         </td>
       </template>
     </sortable-table>
@@ -92,6 +100,10 @@ export default Vue.extend({
       .item-results {
         flex: 1;
       }
+    }
+
+    .font-semibold {
+      font-weight: 600;
     }
   }
 </style>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,25 +1,97 @@
 <script lang="ts">
 import Vue from 'vue';
-export default Vue.extend({ name: 'DiagnosticsBody' });
+
+import BadgeState from '@/components/BadgeState.vue';
+import SortableTable from '@/components/SortableTable/index.vue';
+
+export default Vue.extend({
+  name:       'DiagnosticsBody',
+  components: {
+    SortableTable,
+    BadgeState,
+  },
+  data() {
+    return {
+      headers: [
+        {
+          name:  'name',
+          label: 'Name',
+        },
+        {
+          name:  'documentation',
+          label: 'Documentation',
+        },
+        {
+          name:  'category',
+          label: 'Category',
+        },
+        {
+          name:  'mute',
+          label: 'Mute',
+        },
+      ],
+      rows: [
+        {
+          name:          'The ~/.rd/bin directory has not been added to the PATH, so commandline utilities are not configured in your back shell',
+          documentation: 'Some link',
+          category:      'kubernetes',
+          mute:          false,
+        },
+      ],
+    };
+  },
+});
 </script>
 
 <template>
-  <div class="diagnostics-status">
-    <div class="item-results">
-      6 failed (0 muted) Hide muted
+  <div class="diagnostics">
+    <div class="status">
+      <div class="item-results">
+        6 failed (0 muted) Hide muted
+      </div>
+      <div class="diagnostics-status-history">
+        Last run: 52 minutes ago
+      </div>
     </div>
-    <div class="diagnostics-status-history">
-      Last run: 52 minutes ago
-    </div>
+    <sortable-table
+      :headers="headers"
+      :rows="rows"
+      :search="false"
+      :table-actions="false"
+      :row-actions="false"
+      :sub-rows="true"
+      :sub-expandable="true"
+      :sub-expand-column="true"
+    >
+      <template #col:documentation="{row}">
+        <td>
+          <a :href="row.documentation"><span class="icon icon-external-link" /></a>
+        </td>
+      </template>
+      <template #col:category="{row}">
+        <td>
+          <badge-state
+            :label="row.category"
+            color="bg-warning"
+          />
+        </td>
+      </template>
+    </sortable-table>
   </div>
 </template>
 
 <style lang="scss" scoped>
-  .diagnostics-status {
+  .diagnostics {
     display: flex;
+    flex-direction: column;
+    gap: 2rem;
 
-    .item-results {
-      flex: 1;
+    .status {
+      display: flex;
+
+      .item-results {
+        flex: 1;
+      }
     }
   }
 </style>

--- a/src/components/DiagnosticsButtonRun.vue
+++ b/src/components/DiagnosticsButtonRun.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({ name: 'diagnostics-button-run' });
+</script>
+
+<template>
+  <div class="diagnostics-actions">
+    <button class="btn btn-xs role-secondary">
+      <span class="icon icon-refresh icon-diagnostics"></span>
+      Rerun
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .diagnostics-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+
+  .btn-xs {
+    min-height: 2.25rem;
+    max-height: 2.25rem;
+    line-height: 0.25rem;
+  }
+
+  .icon-diagnostics {
+    padding-right: 0.25rem;
+  }
+</style>

--- a/src/components/DiagnosticsHeader.vue
+++ b/src/components/DiagnosticsHeader.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Diagnostics
+  </div>
+</template>

--- a/src/components/DiagnosticsHeader.vue
+++ b/src/components/DiagnosticsHeader.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    Diagnostics
-  </div>
-</template>

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -1,9 +1,14 @@
 <template>
   <nav>
     <ul>
-      <li v-for="item in items" :key="item" :item="item">
-        <NuxtLink :to="item">
-          {{ routes[item].name }}
+      <li v-for="item in items" :key="item.route" :item="item.route">
+        <NuxtLink :to="item.route">
+          {{ routes[item.route].name }}
+          <badge-state
+            v-if="item.error"
+            color="bg-error"
+            :label="item.error"
+          />
         </NuxtLink>
       </li>
     </ul>
@@ -13,19 +18,22 @@
 <script>
 import os from 'os';
 
+import BadgeState from '@/components/BadgeState.vue';
+
 export default {
-  props: {
+  components: { BadgeState },
+  props:      {
     items: {
       type:      Array,
       required:  true,
-      validator: (value) => {
+      validator: ({ route }) => {
         const routes = global.$nuxt.$router.getRoutes().reduce((paths, route) => {
           paths[route.path] = route;
 
           return paths;
         }, {});
 
-        return value && (value.length > 0) && value.every((path) => {
+        return route && (route.length > 0) && route.every((path) => {
           const result = path in routes;
 
           if (!result) {

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -7,7 +7,7 @@
           <badge-state
             v-if="item.error"
             color="bg-error"
-            :label="item.error"
+            :label="item.error.toString()"
           />
         </NuxtLink>
       </li>
@@ -26,18 +26,18 @@ export default {
     items: {
       type:      Array,
       required:  true,
-      validator: ({ route }) => {
+      validator: (value) => {
         const routes = global.$nuxt.$router.getRoutes().reduce((paths, route) => {
           paths[route.path] = route;
 
           return paths;
         }, {});
 
-        return route && (route.length > 0) && route.every((path) => {
-          const result = path in routes;
+        return value && (value.length > 0) && value.every(({ route }) => {
+          const result = route in routes;
 
           if (!result) {
-            console.error(`<Nav> error: path ${ JSON.stringify(path) } not found in routes ${ JSON.stringify(Object.keys(routes)) }`);
+            console.error(`<Nav> error: path ${ JSON.stringify(route) } not found in routes ${ JSON.stringify(Object.keys(routes)) }`);
           }
 
           return result;

--- a/src/components/TheTitle.vue
+++ b/src/components/TheTitle.vue
@@ -3,10 +3,11 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 
 import ImagesButtonAdd from '@/components/ImagesButtonAdd.vue';
+import DiagnosticsButtonRun from '@/components/DiagnosticsButtonRun.vue';
 
 export default Vue.extend({
   name:       'the-title',
-  components: { ImagesButtonAdd },
+  components: { ImagesButtonAdd, DiagnosticsButtonRun },
   data() {
     return {
       data() {

--- a/src/components/TheTitle.vue
+++ b/src/components/TheTitle.vue
@@ -2,8 +2,8 @@
 import Vue from 'vue';
 import { mapState } from 'vuex';
 
-import ImagesButtonAdd from '@/components/ImagesButtonAdd.vue';
 import DiagnosticsButtonRun from '@/components/DiagnosticsButtonRun.vue';
+import ImagesButtonAdd from '@/components/ImagesButtonAdd.vue';
 
 export default Vue.extend({
   name:       'the-title',

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -47,6 +47,7 @@ export default {
         '/PortForwarding',
         '/Images',
         '/Troubleshooting',
+        '/Diagnostics',
       ];
     },
   },

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -43,11 +43,11 @@ export default {
   computed: {
     routes() {
       return [
-        '/General',
-        '/PortForwarding',
-        '/Images',
-        '/Troubleshooting',
-        '/Diagnostics',
+        { route: '/General' },
+        { route: '/PortForwarding' },
+        { route: '/Images' },
+        { route: '/Troubleshooting' },
+        { route: '/Diagnostics', error: 3 },
       ];
     },
   },

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -42,13 +42,21 @@ export default {
 
   computed: {
     routes() {
-      return [
+      const routes = [
         { route: '/General' },
         { route: '/PortForwarding' },
         { route: '/Images' },
         { route: '/Troubleshooting' },
-        { route: '/Diagnostics', error: 3 },
       ];
+
+      if (this.featureDiagnostics) {
+        routes.push({ route: '/Diagnostics', error: 3 });
+      }
+
+      return routes;
+    },
+    featureDiagnostics() {
+      return !!this.$config.featureDiagnostics;
     },
   },
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -42,7 +42,7 @@ export default {
 
   computed: {
     routes() {
-      const routes = [
+      const routeTable = [
         { route: '/General' },
         { route: '/PortForwarding' },
         { route: '/Images' },
@@ -50,10 +50,10 @@ export default {
       ];
 
       if (this.featureDiagnostics) {
-        routes.push({ route: '/Diagnostics', error: 3 });
+        routeTable.push({ route: '/Diagnostics', error: 3 });
       }
 
-      return routes;
+      return routeTable;
     },
     featureDiagnostics() {
       return !!this.$config.featureDiagnostics;

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -79,6 +79,7 @@ export default {
       '~assets/styles/base/_mixins.scss',
     ],
   },
-  target:    'static',
-  telemetry: false,
+  target:              'static',
+  telemetry:           false,
+  publicRuntimeConfig: { featureDiagnostics: process.env.RD_ENV_DIAGNOSTICS === '1' },
 };

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import Vue from 'vue';
+
+import DiagnosticsBody from '@/components/DiagnosticsBody.vue';
+
+export default Vue.extend({
+  name:       'diagnostics',
+  components: { DiagnosticsBody },
+  mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      {
+        title:  'Diagnostics',
+        action: 'diagnostics-button-run',
+      },
+    );
+  },
+});
+</script>
+
+<template>
+  <div>
+    <diagnostics-body></diagnostics-body>
+  </div>
+</template>

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -19,7 +19,5 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
-    <diagnostics-body></diagnostics-body>
-  </div>
+  <diagnostics-body></diagnostics-body>
 </template>


### PR DESCRIPTION
This creates a simple template for Diagnostics with a few hard-coded examples for testing. 

We are missing a few elements that are represented in the design, most notably the mute toggle. I made the decision to leave this out for the time being. My preference is to get `ToggleSwitch.vue` published in `@rancher/components`. If this proves to be taking too long, we can simply copy the component over like we do with other Dashboard components.

Diagnostics is accessed by the `RD_ENV_DIAGNOSTICS` environment variable that functions as a feature flag. You can test the template with: 

```
$ RD_ENV_DIAGNOSTICS=1 npm run dev
```

### Examples

<img width="1052" alt="Screen Shot 2022-08-11 at 1 29 50 PM" src="https://user-images.githubusercontent.com/835961/184236655-447a9654-004e-409d-bcfb-c5d39a2c8d53.png">

<img width="1052" alt="Screen Shot 2022-08-11 at 1 29 42 PM" src="https://user-images.githubusercontent.com/835961/184236652-2216a0f2-062d-4e07-8cf5-e0d2f6818a7a.png">

contributes to #2656
