### PR TITLE
Make the Nerdctl dockerresolver module happy.

### DIFF
--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -956,6 +956,18 @@ export default class K3sHelper extends events.EventEmitter {
   }
 
   /**
+   * Workaround for upstream error https://github.com/containerd/nerdctl/issues/1308
+   * Nerdctl client (version 0.22.0 +) wants a populated auths field when credsStore gives credentials.
+   * Note that we don't have to actually provide credentials in the value part of the `auths` field.
+   * The code currently wants to see a `ServerURL` that matches the well-known docker hub registry URL,
+   * even though it isn't needed, because at that point the code knows it's using the well-known registry.
+   * @param existingConfig
+   */
+  ensureDockerAuth(existingConfig: Record<string, any>): Record<string, any> {
+    return _.merge({ auths: { 'https://index.docker.io/v1/': {} } }, existingConfig);
+  }
+
+  /**
    * Manually uninstall the K3s-installed copy of Traefik, if it exists.
    * This exists to work around https://github.com/k3s-io/k3s/issues/5103
    */

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1944,6 +1944,12 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         existingConfig = {};
       }
       merge(existingConfig, defaultConfig);
+      if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
+        const fixedConfig = { auths: { 'https://index.docker.io/v1/': {} } };
+
+        merge(fixedConfig, existingConfig);
+        existingConfig = fixedConfig;
+      }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), 0o644);
     } catch (err: any) {
       console.log('Error trying to create/update docker credential files:', err);

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1945,10 +1945,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       }
       merge(existingConfig, defaultConfig);
       if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
-        const fixedConfig = { auths: { 'https://index.docker.io/v1/': {} } };
-
-        merge(fixedConfig, existingConfig);
-        existingConfig = fixedConfig;
+        existingConfig = this.k3sHelper.ensureDockerAuth(existingConfig);
       }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), 0o644);
     } catch (err: any) {

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -777,10 +777,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
       _.merge(existingConfig, defaultConfig);
       if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
-        const fixedConfig = { auths: { 'https://index.docker.io/v1/': {} } };
-
-        _.merge(fixedConfig, existingConfig);
-        existingConfig = fixedConfig;
+        existingConfig = this.k3sHelper.ensureDockerAuth(existingConfig);
       }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), { permissions: 0o644 });
     } catch (err: any) {

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -776,6 +776,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
         existingConfig = {};
       }
       _.merge(existingConfig, defaultConfig);
+      if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
+        const fixedConfig = { auths: { 'https://index.docker.io/v1/': {} } };
+
+        _.merge(fixedConfig, existingConfig);
+        existingConfig = fixedConfig;
+      }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), { permissions: 0o644 });
     } catch (err: any) {
       console.log('Error trying to create/update docker credential files:', err);


### PR DESCRIPTION
Fixes #2689

If a user is logged in, but there's no auths["https://index.docker.io/v1/"]
entry in the root's `.docker/config.json` file, the docker-resolver
code will get confused.

So here's how to get into the state that this change fixes:

* Factory-reset or create a clean state
* Start up RD in docker mode (with k8s off to speed things up)
* docker login
* Switch to containerd
* nerdctl pull busybox

Without this change, you'll see an error along the lines of

    FATA[0000] expected ac.ServerAddress ("") to be "https://index.docker.io/v1/"

With this change, nerdctl should proceed as usual.

Note that with no `auths` field in `/root/.docker/config.json`, running
`docker login` doesn't add it, but running `nerdctl login` does.

And if the user is logged out when the code is run, `nerdctl logout`
changes the field to `auths: {}`, but the behavior is the same for
logged out users, whether auths is empty or has an entry for
index.docker.io.

The real error here is that when a `configsStore` field is given in
`.docker/config.json`, the `auths` field should be ignored. Docker is
ignoring it, nerdctl isn't.

Upstream issue: github.com/containerd/nerdctl/pull/1315 with
PR 1315, but some integration tests are failing (looks like due to
flakes) and I don't see a straightforward way to provide unit tests.

Signed-off-by: Eric Promislow <epromislow@suse.com>