### PR TITLE
ESLint: enable some checks for no-unsed-vars.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,10 +211,14 @@ Object.assign(module.exports.rules, {
     ],
   }],
 
+  // Existing code only follows a subset of settings for no-unused-vars.
+  '@typescript-eslint/no-unused-vars':                 ['warn', {
+    args: 'none', ignoreRestSiblings: true, varsIgnorePattern: '^_.',
+  }],
+
   // Disable TypeScript rules that our code doesn't follow (yet).
   '@typescript-eslint/explicit-module-boundary-types': 'off',
   '@typescript-eslint/no-var-requires':                'off',
-  '@typescript-eslint/no-unused-vars':                 'off',
   '@typescript-eslint/no-this-alias':                  'off',
   '@typescript-eslint/no-empty-function':              'off',
   // Allow using `any` in TypeScript, until the whole project is converted.

--- a/background.ts
+++ b/background.ts
@@ -889,7 +889,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   }
 
   async proposeSettings(context: CommandWorkerInterface.CommandContext, newSettings: RecursivePartial<settings.Settings>): Promise<[string, string]> {
-    const [_, errors] = await this.validateSettings(cfg, newSettings);
+    const [, errors] = await this.validateSettings(cfg, newSettings);
 
     if (errors.length > 0) {
       return ['', `errors in proposed settings:\n${ errors.join('\n') }`];

--- a/e2e/kubectl.e2e.spec.ts
+++ b/e2e/kubectl.e2e.spec.ts
@@ -1,9 +1,7 @@
 import path from 'path';
 
 import { test, expect } from '@playwright/test';
-import {
-  ElectronApplication, BrowserContext, _electron, Page, Locator,
-} from 'playwright';
+import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
 import { createDefaultSettings, kubectl, packageLogs, reportAsset } from './utils/TestUtils';

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import path from 'path';
 
 import { test, expect } from '@playwright/test';

--- a/scripts/check-api-schema.ts
+++ b/scripts/check-api-schema.ts
@@ -23,7 +23,6 @@ limitations under the License.
 
 import fs from 'fs';
 
-import _ from 'lodash';
 import yaml from 'yaml';
 
 import { defaultSettings } from '@/config/settings';

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -7,7 +7,6 @@
 import events from 'events';
 import util from 'util';
 
-import Electron from 'electron';
 import fetch from 'node-fetch';
 
 import buildUtils from './lib/build-utils.mjs';

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -146,7 +146,7 @@ export class VersionEntry implements K8s.VersionEntry {
  * @returns The K3s build version
  */
 export function buildVersion(version: semver.SemVer) {
-  const [_, numString] = /k3s(\d+)/.exec(version.build[0]) || [undefined, -1];
+  const [, numString] = /k3s(\d+)/.exec(version.build[0]) || [undefined, -1];
 
   return parseInt(`${ numString || '-1' }`);
 }

--- a/src/typings/vue-i18n.ts
+++ b/src/typings/vue-i18n.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported for side effect.
 import Vue from 'vue';
 
 // This is required to keep typescript from complaining. It is required for

--- a/src/window/dashboard.ts
+++ b/src/window/dashboard.ts
@@ -1,4 +1,4 @@
-import { BrowserView, BrowserWindow } from 'electron';
+import { BrowserWindow } from 'electron';
 
 import { windowMapping, restoreWindow } from '.';
 


### PR DESCRIPTION
We need to disable part of the check, but we can still enable some:
 - args are used (in callbacks) as documentation
 - rest siblings is used from code imported from dashboard
 - varsIgnorePattern matches things used as documentation.

This will catch unused imports.