### PR TITLE
Update BadgeState imports

### DIFF
--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,7 +1,10 @@
 <script lang="ts">
+// TODO: #2753 [diagnostics] Remove @ts-ignore for BadgeState import
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: No exported member
+import { BadgeState } from '@rancher/components';
 import Vue from 'vue';
 
-import BadgeState from '@/components/BadgeState.vue';
 import SortableTable from '@/components/SortableTable/index.vue';
 
 export default Vue.extend({

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -18,7 +18,7 @@
 <script>
 import os from 'os';
 
-import BadgeState from '@/components/BadgeState.vue';
+import { BadgeState } from '@rancher/components';
 
 export default {
   components: { BadgeState },


### PR DESCRIPTION
This updates the `BadgeState` imports for the diagnostics components so that they import from `@rancher/components`.

Please note that I opened #2753 so that we can circle back and remove the `@ts-ignore` comments after merging rancher/dashboard#6656. 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>