### PR TITLE
Backend: Split out command executor interface.

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -186,17 +186,10 @@ export interface VMBackend {
  * execOptions is options for VMExecutor.
  */
 export type execOptions = childProcess.CommonOptions & {
-  /** Output encoding; defaults to utf16le. */
-  encoding?: BufferEncoding;
   /** Expect the command to fail; do not log on error.  Exceptions are still thrown. */
   expectFailure?: boolean;
   /** A custom log stream to write to; must have a file descriptor. */
   logStream?: stream.Writable;
-  /**
-   * The distribution to execute within.
-   * @note WSL only.
-   */
-  distro?: string;
   /**
    * If set, ensure that the command is run as the privileged user.
    * @note The command is always run as root on WSL.

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,4 +1,7 @@
+import stream from 'stream';
+
 import { Settings } from '@/config/settings';
+import * as childProcess from '@/utils/childProcess';
 import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 
 export enum State {
@@ -177,4 +180,41 @@ export interface VMBackend {
    * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.
    */
   noModalDialogs: boolean;
+}
+
+/**
+ * execOptions is options for VMExecutor.
+ */
+export type execOptions = childProcess.CommonOptions & {
+  /** Output encoding; defaults to utf16le. */
+  encoding?: BufferEncoding;
+  /** Expect the command to fail; do not log on error.  Exceptions are still thrown. */
+  expectFailure?: boolean;
+  /** A custom log stream to write to; must have a file descriptor. */
+  logStream?: stream.Writable;
+  /**
+   * The distribution to execute within.
+   * @note WSL only.
+   */
+  distro?: string;
+  /**
+   * If set, ensure that the command is run as the privileged user.
+   * @note The command is always run as root on WSL.
+   */
+  root?: boolean;
+};
+
+/**
+ * VMExecutor describes how to run commands in the virtual machine.
+ */
+export interface VMExecutor {
+  /**
+   * execCommand runs the given command in the virtual machine.
+   * @param options Execution options.  If capture is set, standard output is
+   *    returned.
+   * @param command The command to execute.
+   */
+  execCommand(...command: string[]): Promise<void>;
+  execCommand(options: execOptions, ...command: string[]): Promise<void>;
+  execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
 }

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -938,7 +938,7 @@ export default class K3sHelper extends events.EventEmitter {
   /**
    * Delete state related to Kubernetes.  This will ensure that images are not
    * deleted.
-   * @param execAsRoot A function to run commands on the VM as root.
+   * @param executor The interface to run commands in the VM.
    */
   async deleteKubeState(executor: VMExecutor) {
     const directories = [

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -14,7 +14,7 @@ import { Response } from 'node-fetch';
 import semver from 'semver';
 import yaml from 'yaml';
 
-import { Architecture } from './backend';
+import { Architecture, VMExecutor } from './backend';
 
 import { KubeClient } from '@/backend/client';
 import * as K8s from '@/backend/k8s';
@@ -940,7 +940,7 @@ export default class K3sHelper extends events.EventEmitter {
    * deleted.
    * @param execAsRoot A function to run commands on the VM as root.
    */
-  async deleteKubeState(execAsRoot: (...args: string[]) => Promise<void>) {
+  async deleteKubeState(executor: VMExecutor) {
     const directories = [
       '/var/lib/kubelet', // https://github.com/kubernetes/kubernetes/pull/86689
       // We need to keep /var/lib/rancher/k3s/agent/containerd for the images.
@@ -952,7 +952,7 @@ export default class K3sHelper extends events.EventEmitter {
     ];
 
     console.log(`Attempting to remove K3s state: ${ directories.sort().join(' ') }`);
-    await Promise.all(directories.map(d => execAsRoot('rm', '-rf', d)));
+    await Promise.all(directories.map(d => executor.execCommand({ root: true }, 'rm', '-rf', d)));
   }
 
   /**

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -18,7 +18,7 @@ import sudo from 'sudo-prompt';
 import tar from 'tar-stream';
 import yaml from 'yaml';
 
-import { Architecture, BackendError, execOptions, VMExecutor } from './backend';
+import { Architecture, execOptions, VMExecutor } from './backend';
 import K3sHelper, { NoCachedK3sVersionsError, ShortVersion } from './k3sHelper';
 import * as K8s from './k8s';
 import ProgressTracker from './progressTracker';
@@ -1584,7 +1584,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     let desiredVersion = await this.desiredVersion;
     const previousVersion = (await this.getLimaConfig())?.k3s?.version;
     const isDowngrade = previousVersion ? semver.gt(previousVersion, desiredVersion) : false;
-    let commandArgs: Array<string>;
 
     this.setState(K8s.State.STARTING);
     this.currentAction = Action.STARTING;

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -794,9 +794,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     } else {
       options = optionsOrArg;
     }
-    if (options.distro) {
-      throw new BackendError('Internal error', 'LimaBackend.execCommand does not support selecting distributions', true);
-    }
     if (options.root) {
       command = ['sudo'].concat(command);
     }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1527,7 +1527,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await this.progressTracker.action(
         this.lastCommandComment,
         100,
-        this.k3sHelper.deleteKubeState((...args: string[]) => this.execCommand({ root: true }, ...args)));
+        this.k3sHelper.deleteKubeState(this));
     }
   }
 
@@ -2046,8 +2046,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       await this.stop();
       // Start the VM, so that we can delete files.
       await this.startVM();
-      await this.k3sHelper.deleteKubeState(
-        (...args: string[]) => this.execCommand({ root: true }, ...args));
+      await this.k3sHelper.deleteKubeState(this);
       await this.start(config);
     });
   }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -18,7 +18,7 @@ import sudo from 'sudo-prompt';
 import tar from 'tar-stream';
 import yaml from 'yaml';
 
-import { Architecture } from './backend';
+import { Architecture, BackendError, execOptions, VMExecutor } from './backend';
 import K3sHelper, { NoCachedK3sVersionsError, ShortVersion } from './k3sHelper';
 import * as K8s from './k8s';
 import ProgressTracker from './progressTracker';
@@ -213,7 +213,7 @@ const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-l
 // (though this loses the type guarantees around it not modifying the instance).
 // [1]: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
 // [2]: https://github.com/microsoft/TypeScript/issues/46802
-export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend {
+export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend, VMExecutor {
   constructor(arch: Architecture, dockerDirManager: DockerDirManager) {
     super();
     this.arch = arch;
@@ -417,7 +417,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   get ipAddress(): Promise<string | undefined> {
     return (async() => {
       // Get the routing map structure
-      const state = await this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME, 'cat', '/proc/net/fib_trie');
+      const state = await this.execCommand({ capture: true }, 'cat', '/proc/net/fib_trie');
 
       // We look for the IP address by:
       // 1. Convert the structure (text) into lines.
@@ -783,8 +783,39 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return spawnWithSignal(LimaBackend.limactl, args, { env: LimaBackend.limaEnv });
   }
 
-  protected async ssh(...args: string[]): Promise<void> {
-    await this.lima('shell', '--workdir=.', MACHINE_NAME, ...args);
+  async execCommand(...command: string[]): Promise<void>;
+  async execCommand(options: execOptions, ...command: string[]): Promise<void>;
+  async execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
+  async execCommand(optionsOrArg: execOptions | string, ...command: string[]): Promise<void | string> {
+    let options: execOptions & { capture?: boolean } = {};
+
+    if (typeof optionsOrArg === 'string') {
+      command = [optionsOrArg].concat(command);
+    } else {
+      options = optionsOrArg;
+    }
+    if (options.distro) {
+      throw new BackendError('Internal error', 'LimaBackend.execCommand does not support selecting distributions', true);
+    }
+    if (options.root) {
+      command = ['sudo'].concat(command);
+    }
+
+    const expectFailure = options.expectFailure ?? false;
+
+    try {
+      // Print a slightly different message if execution fails.
+      const stdout = await this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME, ...command);
+
+      if (options.capture) {
+        return stdout;
+      }
+    } catch (ex) {
+      if (!expectFailure) {
+        console.log(`Lima: executing: ${ command.join(' ') }: ${ ex }`);
+      }
+      throw ex;
+    }
   }
 
   /**
@@ -1269,12 +1300,12 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       const k3s = this.arch === 'aarch64' ? 'k3s-arm64' : 'k3s';
 
       await fs.promises.writeFile(scriptPath, INSTALL_K3S_SCRIPT, { encoding: 'utf-8' });
-      await this.ssh('mkdir', '-p', 'bin');
+      await this.execCommand('mkdir', '-p', 'bin');
       await this.lima('copy', scriptPath, `${ MACHINE_NAME }:bin/install-k3s`);
-      await this.ssh('chmod', 'a+x', 'bin/install-k3s');
+      await this.execCommand('chmod', 'a+x', 'bin/install-k3s');
       if (this.cfg?.enabled) {
         await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
-        await this.ssh('sudo', 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
+        await this.execCommand({ root: true }, 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
       }
       const profilePath = path.join(paths.resources, 'scripts', 'profile');
 
@@ -1292,7 +1323,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
 
-      await this.ssh('sudo', 'mkdir', '-p', '/etc/cni/net.d');
+      await this.execCommand({ root: true }, 'mkdir', '-p', '/etc/cni/net.d');
 
       if (this.cfg?.options.flannel) {
         await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
@@ -1321,11 +1352,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       await fs.promises.writeFile(scriptPath, fileContents, 'utf-8');
       await this.lima('copy', scriptPath, `${ MACHINE_NAME }:${ tempPath }`);
-      await this.ssh('chmod', permissions.toString(8), tempPath);
-      await this.ssh('sudo', 'mv', tempPath, filePath);
+      await this.execCommand('chmod', permissions.toString(8), tempPath);
+      await this.execCommand({ root: true }, 'mv', tempPath, filePath);
     } finally {
       await fs.promises.rm(workdir, { recursive: true });
-      await this.ssh('sudo', 'rm', '-f', tempPath);
+      await this.execCommand({ root: true }, 'rm', '-f', tempPath);
     }
   }
 
@@ -1334,7 +1365,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    */
   protected async getInterfaceAddr(iface: string) {
     try {
-      const ipAddr = await this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME,
+      const ipAddr = await this.execCommand({ capture: true },
         'ip', '--family', 'inet', 'addr', 'show', iface);
       const match = ipAddr.match(' inet ([0-9.]+)');
 
@@ -1434,7 +1465,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const trivyPath = path.join(paths.resources, 'linux', 'internal', 'trivy');
 
     await this.lima('copy', trivyPath, `${ MACHINE_NAME }:./trivy`);
-    await this.ssh('sudo', 'mv', './trivy', '/usr/local/bin/trivy');
+    await this.execCommand({ root: true }, 'mv', './trivy', '/usr/local/bin/trivy');
   }
 
   protected async installGuestAgent(kubeVersion: semver.SemVer | null) {
@@ -1443,7 +1474,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     await Promise.all([
       (async() => {
         await this.lima('copy', guestAgentPath, `${ MACHINE_NAME }:./rancher-desktop-guestagent`);
-        await this.ssh('sudo', 'mv', './rancher-desktop-guestagent', '/usr/local/bin/rancher-desktop-guestagent');
+        await this.execCommand({ root: true }, 'mv', './rancher-desktop-guestagent', '/usr/local/bin/rancher-desktop-guestagent');
       })(),
       this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, 0o755),
       (async() => {
@@ -1456,7 +1487,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         });
       })(),
     ]);
-    await this.ssh('sudo', '/sbin/rc-service', 'rancher-desktop-guestagent', 'restart');
+    await this.execCommand({ root: true }, '/sbin/rc-service', 'rancher-desktop-guestagent', 'restart');
   }
 
   protected async followLogs() {
@@ -1496,7 +1527,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       await this.progressTracker.action(
         this.lastCommandComment,
         100,
-        this.k3sHelper.deleteKubeState((...args: string[]) => this.ssh('sudo', ...args)));
+        this.k3sHelper.deleteKubeState((...args: string[]) => this.execCommand({ root: true }, ...args)));
     }
   }
 
@@ -1643,7 +1674,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         if ((await this.status)?.status === 'Running') {
           this.lastCommandComment = 'Stopping existing instance';
           await this.progressTracker.action(this.lastCommandComment, 100, async() => {
-            await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
+            await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
             if (isDowngrade) {
               // If we're downgrading, stop the VM (and start it again immediately),
               // to ensure there are no containers running (so we can delete files).
@@ -1679,7 +1710,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
           this.progressTracker.action('Installing guest agent', 50, this.installGuestAgent(config.enabled ? desiredVersion : null)),
           this.progressTracker.action('Fixing binfmt_misc qemu', 50, async() => {
             await this.writeFile('/etc/conf.d/qemu-binfmt', 'binfmt_flags="POCF"');
-            await this.ssh('sudo', '/sbin/rc-service', 'qemu-binfmt', 'restart');
+            await this.execCommand({ root: true }, '/sbin/rc-service', 'qemu-binfmt', 'restart');
           }),
         ]);
 
@@ -1694,14 +1725,14 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         if (config.enabled) {
           // Remove flannel config if necessary, before starting k3s
           if (!this.cfg?.options.flannel) {
-            await this.ssh('sudo', 'rm', '-f', '/etc/cni/net.d/10-flannel.conflist');
+            await this.execCommand({ root: true }, 'rm', '-f', '/etc/cni/net.d/10-flannel.conflist');
           }
 
           this.lastCommandComment = 'Starting k3s';
           await this.progressTracker.action(this.lastCommandComment, 100, async() => {
             // Run rc-update as we have dynamic dependencies.
-            await this.ssh('sudo', '/sbin/rc-update', '--update');
-            await this.ssh('sudo', '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
+            await this.execCommand({ root: true }, '/sbin/rc-update', '--update');
+            await this.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
             await this.followLogs();
           });
 
@@ -1732,14 +1763,13 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
               console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
             },
           );
-          commandArgs = ['shell', '--workdir=.', MACHINE_NAME, 'sudo', 'cat', '/etc/rancher/k3s/k3s.yaml'];
           this.lastCommandComment = 'Updating kubeconfig';
           await this.progressTracker.action(
             this.lastCommandComment,
             50,
             this.k3sHelper.updateKubeconfig(
               async() => {
-                const k3sConfigString = await this.limaWithCapture(...commandArgs);
+                const k3sConfigString = await this.execCommand({ capture: true, root: true }, 'cat', '/etc/rancher/k3s/k3s.yaml');
                 const k3sConfig = yaml.parse(k3sConfigString);
 
                 k3sEndpoint = k3sConfig?.clusters?.[0]?.cluster?.server;
@@ -1830,7 +1860,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
             path.join(paths.altAppHome, 'docker.sock'),
             k3sEndpoint);
         } else if (config.containerEngine === ContainerEngine.CONTAINERD) {
-          await this.ssh('sudo', '/sbin/rc-service', '--ifnotstarted', 'buildkitd', 'start');
+          await this.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'buildkitd', 'start');
         }
 
         this.setState(config.enabled ? K8s.State.STARTED : K8s.State.DISABLED);
@@ -1847,7 +1877,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   protected async startService(serviceName: string) {
     this.lastCommandComment = `Starting ${ serviceName }`;
     await this.progressTracker.action(this.lastCommandComment, 50, async() => {
-      await this.ssh('sudo', '/sbin/rc-service', '--ifnotstarted', serviceName, 'start');
+      await this.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', serviceName, 'start');
     });
   }
 
@@ -1860,7 +1890,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-ca-'));
 
     try {
-      await this.ssh('sudo', '/bin/sh', '-c', 'rm -f /usr/local/share/ca-certificates/rd-*.crt');
+      await this.execCommand({ root: true }, '/bin/sh', '-c', 'rm -f /usr/local/share/ca-certificates/rd-*.crt');
 
       if (certs && certs.length > 0) {
         const writeStream = fs.createWriteStream(path.join(workdir, 'certs.tar'));
@@ -1881,12 +1911,12 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         await archiveFinished;
 
         await this.lima('copy', path.join(workdir, 'certs.tar'), `${ MACHINE_NAME }:/tmp/certs.tar`);
-        await this.ssh('sudo', 'tar', 'xf', '/tmp/certs.tar', '-C', '/usr/local/share/ca-certificates/');
+        await this.execCommand({ root: true }, 'tar', 'xf', '/tmp/certs.tar', '-C', '/usr/local/share/ca-certificates/');
       }
     } finally {
       await fs.promises.rm(workdir, { recursive: true, force: true });
     }
-    await this.ssh('sudo', 'update-ca-certificates');
+    await this.execCommand({ root: true }, 'update-ca-certificates');
   }
 
   protected async getHostIPAddr(): Promise<string> {
@@ -1895,7 +1925,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       let stdout = '';
 
       for (let attempt = 0; attempt < maxAttempt; ++attempt) {
-        stdout = await this.limaWithCapture('shell', '--workdir=.', MACHINE_NAME, 'ip', 'route', 'list', 'eth0');
+        stdout = await this.execCommand({ capture: true }, 'ip', 'route', 'list', 'eth0');
         const line = stdout.split(/\n/).find(line => /\bvia .* dev eth0\b/.test(line));
         const match = /\bvia (.*) dev eth0\b/.exec(line ?? '');
 
@@ -1934,13 +1964,13 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       const defaultConfig = { credsStore: 'rancher-desktop' };
       let existingConfig: Record<string, any>;
 
-      await this.ssh('sudo', 'mkdir', '-p', ETC_RANCHER_DESKTOP_DIR);
+      await this.execCommand({ root: true }, 'mkdir', '-p', ETC_RANCHER_DESKTOP_DIR);
       await this.writeFile(CREDENTIAL_FORWARDER_SETTINGS_PATH, fileContents, 0o644);
       await this.writeFile(DOCKER_CREDENTIAL_PATH, DOCKER_CREDENTIAL_SCRIPT, 0o755);
       try {
-        existingConfig = JSON.parse(await this.limaWithCapture('shell', '--workdir=.', '0', 'sudo', 'cat', ROOT_DOCKER_CONFIG_PATH));
+        existingConfig = JSON.parse(await this.execCommand({ capture: true, root: true }, 'cat', ROOT_DOCKER_CONFIG_PATH));
       } catch (err: any) {
-        await this.ssh('sudo', 'mkdir', '-p', ROOT_DOCKER_CONFIG_DIR);
+        await this.execCommand({ root: true }, 'mkdir', '-p', ROOT_DOCKER_CONFIG_DIR);
         existingConfig = {};
       }
       merge(existingConfig, defaultConfig);
@@ -1973,10 +2003,10 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         const status = await this.status;
 
         if (defined(status) && status.status === 'Running') {
-          await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
-          await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'buildkitd', 'stop');
-          await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'docker', 'stop');
-          await this.ssh('sudo', '/sbin/rc-service', '--ifstarted', 'containerd', 'stop');
+          await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
+          await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'buildkitd', 'stop');
+          await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'docker', 'stop');
+          await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'containerd', 'stop');
           await this.lima('stop', MACHINE_NAME);
         }
         this.setState(K8s.State.STOPPED);
@@ -2017,7 +2047,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       // Start the VM, so that we can delete files.
       await this.startVM();
       await this.k3sHelper.deleteKubeState(
-        (...args: string[]) => this.ssh('sudo', ...args));
+        (...args: string[]) => this.execCommand({ root: true }, ...args));
       await this.start(config);
     });
   }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -83,6 +83,13 @@ const DISTRO_DATA_DIRS = [
   '/var/lib',
 ];
 
+type wslExecOptions = execOptions & {
+  /** Output encoding; defaults to utf16le. */
+  encoding?: BufferEncoding;
+  /** The distribution to execute within. */
+  distro?: string;
+};
+
 export default class WSLBackend extends events.EventEmitter implements K8s.KubernetesBackend, VMExecutor {
   constructor() {
     super();
@@ -818,10 +825,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * the log files.
    */
   protected async execWSL(...args: string[]): Promise<void>;
-  protected async execWSL(options: execOptions, ...args: string[]): Promise<void>;
-  protected async execWSL(options: execOptions & { capture: true }, ...args: string[]): Promise<string>;
-  protected async execWSL(optionsOrArg: execOptions | string, ...args: string[]): Promise<void | string> {
-    let options: execOptions & { capture?: boolean } = {};
+  protected async execWSL(options: wslExecOptions, ...args: string[]): Promise<void>;
+  protected async execWSL(options: wslExecOptions & { capture: true }, ...args: string[]): Promise<string>;
+  protected async execWSL(optionsOrArg: wslExecOptions | string, ...args: string[]): Promise<void | string> {
+    let options: wslExecOptions & { capture?: boolean } = {};
 
     if (typeof optionsOrArg === 'string') {
       args = [optionsOrArg].concat(...args);
@@ -857,10 +864,10 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   }
 
   async execCommand(...command: string[]): Promise<void>;
-  async execCommand(options: execOptions, ...command: string[]): Promise<void>;
-  async execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
-  async execCommand(optionsOrArg: execOptions | string, ...command: string[]): Promise<void | string> {
-    let options: execOptions = {};
+  async execCommand(options: wslExecOptions, ...command: string[]): Promise<void>;
+  async execCommand(options: wslExecOptions & { capture: true }, ...command: string[]): Promise<string>;
+  async execCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<void | string> {
+    let options: wslExecOptions = {};
 
     if (typeof optionsOrArg === 'string') {
       command = [optionsOrArg].concat(command);
@@ -890,8 +897,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
    * @returns The output of the command.
    */
   protected async captureCommand(...command: string[]): Promise<string>;
-  protected async captureCommand(options: execOptions, ...command: string[]): Promise<string>;
-  protected async captureCommand(optionsOrArg: execOptions | string, ...command: string[]): Promise<string> {
+  protected async captureCommand(options: wslExecOptions, ...command: string[]): Promise<string>;
+  protected async captureCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<string> {
     if (typeof optionsOrArg === 'string') {
       return await this.execCommand({ capture: true }, optionsOrArg, ...command);
     }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -634,7 +634,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       await this.progressTracker.action(
         'Deleting incompatible Kubernetes state',
         100,
-        this.k3sHelper.deleteKubeState((...args) => this.execCommand(...args)));
+        this.k3sHelper.deleteKubeState(this));
     }
   }
 
@@ -856,11 +856,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     }
   }
 
-  /**
-   * execCommand runs the given command in the K3s WSL environment.
-   * @param options Execution options; encoding defaults to utf-8.
-   * @param command The command to execute.
-   */
   async execCommand(...command: string[]): Promise<void>;
   async execCommand(options: execOptions, ...command: string[]): Promise<void>;
   async execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
@@ -1581,7 +1576,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       const distroLock = await this.mountData();
 
       try {
-        await this.k3sHelper.deleteKubeState((...args) => this.execCommand(...args));
+        await this.k3sHelper.deleteKubeState(this);
       } finally {
         distroLock.kill('SIGTERM');
       }


### PR DESCRIPTION
This adds an interface for executing commands within the VM.  This PR also includes switching K3sHelper to use the new interface as a sample.

This is part of #1997.