### PR TITLE
Dependabot: block webpack 5 and newer.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       - # Blocked by nuxt; this also blocks vue-template-compiler.
         dependency-name: "vue"
         versions: [ ">2.6" ]
+      - # Webpack 5 requires Nuxt 3. https://github.com/nuxt/nuxt.js/issues/8252
+        dependency-name: "webpack"
+        versions: [ ">4" ]
       - # node-fetch 3+ requires ECMAScript modules, but Electron doesn't
         # support that. See https://github.com/electron/electron/issues/21457
         dependency-name: "node-fetch"


### PR DESCRIPTION
Nuxt 2 only supports webpack 4; nuxt 3 is required for webpack 5.

Closes #2758.

[Documentation](https://v3.nuxtjs.org/getting-started/migration/).