### PR TITLE
Add a toggle switch for muting diagnostics

### DIFF
--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4608,6 +4608,20 @@ troubleshooting:
 ##############################
 ### Preferences Page
 ##############################
+diagnostics:
+  results:
+    muted:
+      icon: icon-search
+      heading: No results found
+      body: Try showing muted diagnostics.
+    success:
+      icon: icon-checkmark
+      heading: No problems detected
+      body: Rancher Desktop appears to be functioning correctly.
+
+##############################
+### Preferences Page
+##############################
 preferences:
   actions:
     banner:

--- a/src/assets/translations/en-us.yaml
+++ b/src/assets/translations/en-us.yaml
@@ -4606,7 +4606,7 @@ troubleshooting:
   needHelp: 'Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.'
 
 ##############################
-### Preferences Page
+### Diagnostics Page
 ##############################
 diagnostics:
   results:

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -37,14 +37,17 @@ export default Vue.extend({
         {
           name:  'documentation',
           label: 'Documentation',
+          width: 106,
         },
         {
           name:  'category',
           label: 'Category',
+          width: 96,
         },
         {
           name:  'mute',
           label: 'Mute',
+          width: 76,
         },
       ],
       hideMuted: false,

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { BadgeState } from '@rancher/components';
+import { BadgeState, ToggleSwitch } from '@rancher/components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import Vue from 'vue';
@@ -16,6 +16,7 @@ export default Vue.extend({
   components: {
     SortableTable,
     BadgeState,
+    ToggleSwitch,
   },
   props: {
     rows: {
@@ -71,6 +72,7 @@ export default Vue.extend({
     <div class="status">
       <div class="item-results">
         <span class="icon icon-dot text-error" />{{ numFailed }} failed ({{ numMuted }} muted)
+        <toggle-switch off-label="Hide Muted" />
       </div>
       <div class="diagnostics-status-history">
         Last run: <span class="elapsed-timespan" :title="timeLastRunTooltip">{{ friendlyTimeLastRun }}</span>
@@ -133,6 +135,7 @@ export default Vue.extend({
         display: flex;
         flex: 1;
         gap: 0.5rem;
+        align-items: center;
       }
     }
 

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -40,6 +40,10 @@ export default Vue.extend({
           name:  'category',
           label: 'Category',
         },
+        {
+          name:  'mute',
+          label: 'Mute',
+        },
       ],
     };
   },
@@ -62,6 +66,15 @@ export default Vue.extend({
       const units = count === 1 ? unit : `${ unit }s`;
 
       return `${ count } ${ units } ago`;
+    },
+    muteRow(event: boolean, row: any) {
+      const rowToUpdate = this.rows.find(x => x.id === row.id);
+
+      if (rowToUpdate === undefined) {
+        return;
+      }
+
+      rowToUpdate.mute = event;
     },
   },
 });
@@ -104,6 +117,14 @@ export default Vue.extend({
           <badge-state
             :label="row.category"
             color="bg-warning"
+          />
+        </td>
+      </template>
+      <template #col:mute="{row}">
+        <td>
+          <toggle-switch
+            :value="row.mute"
+            @input="muteRow($event, row)"
           />
         </td>
       </template>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
         return this.rows;
       }
 
-      return this.rows.filter(x => x.mute === false);
+      return this.rows.filter(x => !x.mute);
     },
     hasMutedResults(): boolean {
       return !!this.rows.length && this.hideMuted;

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import Vue from 'vue';
 
+import EmptyState from '@/components/EmptyState.vue';
 import SortableTable from '@/components/SortableTable/index.vue';
 import type { DiagnosticsCheck } from '@/main/diagnostics/diagnostics';
 
@@ -17,6 +18,7 @@ export default Vue.extend({
     SortableTable,
     BadgeState,
     ToggleSwitch,
+    EmptyState,
   },
   props: {
     rows: {
@@ -84,6 +86,9 @@ export default Vue.extend({
 
       rowToUpdate.mute = event;
     },
+    toggleMute() {
+      this.hideMuted = !this.hideMuted;
+    },
   },
 });
 </script>
@@ -113,6 +118,24 @@ export default Vue.extend({
       :sub-expandable="true"
       :sub-expand-column="true"
     >
+      <template #no-rows>
+        <td :colspan="headers.length + 1">
+          <empty-state
+            icon="icon-search"
+            heading="No results found"
+            body="Try showing muted diagnostics to see some results."
+          >
+            <template #primary-action>
+              <button
+                class="btn role-primary"
+                @click="toggleMute"
+              >
+                Show Muted
+              </button>
+            </template>
+          </empty-state>
+        </td>
+      </template>
       <template #col:description="{row}">
         <td>
           <span class="font-semibold">{{ row.description }}</span>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -45,6 +45,7 @@ export default Vue.extend({
           label: 'Mute',
         },
       ],
+      hideMuted: false,
     };
   },
   computed: {
@@ -59,6 +60,13 @@ export default Vue.extend({
     },
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();
+    },
+    filteredRows(): any {
+      if (!this.hideMuted) {
+        return this.rows;
+      }
+
+      return this.rows.filter(x => x.mute === false);
     },
   },
   methods: {
@@ -85,7 +93,10 @@ export default Vue.extend({
     <div class="status">
       <div class="item-results">
         <span class="icon icon-dot text-error" />{{ numFailed }} failed ({{ numMuted }} muted)
-        <toggle-switch off-label="Hide Muted" />
+        <toggle-switch
+          v-model="hideMuted"
+          off-label="Hide Muted"
+        />
       </div>
       <div class="diagnostics-status-history">
         Last run: <span class="elapsed-timespan" :title="timeLastRunTooltip">{{ friendlyTimeLastRun }}</span>
@@ -94,7 +105,7 @@ export default Vue.extend({
     <sortable-table
       key-field="id"
       :headers="headers"
-      :rows="rows"
+      :rows="filteredRows"
       :search="false"
       :table-actions="false"
       :row-actions="false"

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -77,14 +77,8 @@ export default Vue.extend({
 
       return `${ count } ${ units } ago`;
     },
-    muteRow(event: boolean, row: any) {
-      const rowToUpdate = this.rows.find(x => x.id === row.id);
-
-      if (rowToUpdate === undefined) {
-        return;
-      }
-
-      rowToUpdate.mute = event;
+    muteRow(isMuted: boolean, row: DiagnosticsCheck) {
+      this.$store.dispatch('diagnostics/updateDiagnostic', { isMuted, row });
     },
     toggleMute() {
       this.hideMuted = !this.hideMuted;

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -70,17 +70,17 @@ export default Vue.extend({
 
       return this.rows.filter(x => !x.mute);
     },
-    hasMutedResults(): boolean {
-      return !!this.rows.length && this.hideMuted;
+    areAllRowsMuted(): boolean {
+      return !!this.rows.length && this.rows.every(x => x.mute);
     },
     emptyStateIcon(): string {
-      return this.hasMutedResults ? this.t('diagnostics.results.muted.icon') : this.t('diagnostics.results.success.icon');
+      return this.areAllRowsMuted ? this.t('diagnostics.results.muted.icon') : this.t('diagnostics.results.success.icon');
     },
     emptyStateHeading(): string {
-      return this.hasMutedResults ? this.t('diagnostics.results.muted.heading') : this.t('diagnostics.results.success.heading');
+      return this.areAllRowsMuted ? this.t('diagnostics.results.muted.heading') : this.t('diagnostics.results.success.heading');
     },
     emptyStateBody(): string {
-      return this.hasMutedResults ? this.t('diagnostics.results.muted.body') : this.t('diagnostics.results.success.body');
+      return this.areAllRowsMuted ? this.t('diagnostics.results.muted.body') : this.t('diagnostics.results.success.body');
     },
   },
   methods: {
@@ -131,7 +131,7 @@ export default Vue.extend({
             :heading="emptyStateHeading"
             :body="emptyStateBody"
           >
-            <template v-if="hasMutedResults" #primary-action>
+            <template v-if="areAllRowsMuted" #primary-action>
               <button
                 class="btn role-primary"
                 @click="toggleMute"

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -70,6 +70,18 @@ export default Vue.extend({
 
       return this.rows.filter(x => x.mute === false);
     },
+    hasMutedResults(): boolean {
+      return !!this.rows.length && this.hideMuted;
+    },
+    emptyStateIcon(): string {
+      return this.hasMutedResults ? this.t('diagnostics.results.muted.icon') : this.t('diagnostics.results.success.icon');
+    },
+    emptyStateHeading(): string {
+      return this.hasMutedResults ? this.t('diagnostics.results.muted.heading') : this.t('diagnostics.results.success.heading');
+    },
+    emptyStateBody(): string {
+      return this.hasMutedResults ? this.t('diagnostics.results.muted.body') : this.t('diagnostics.results.success.body');
+    },
   },
   methods: {
     pluralize(count: number, unit: string): string {
@@ -115,11 +127,11 @@ export default Vue.extend({
       <template #no-rows>
         <td :colspan="headers.length + 1">
           <empty-state
-            icon="icon-search"
-            heading="No results found"
-            body="Try showing muted diagnostics to see some results."
+            :icon="emptyStateIcon"
+            :heading="emptyStateHeading"
+            :body="emptyStateBody"
           >
-            <template #primary-action>
+            <template v-if="hasMutedResults" #primary-action>
               <button
                 class="btn role-primary"
                 @click="toggleMute"

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -7,6 +7,7 @@
           <badge-state
             v-if="item.error"
             color="bg-error"
+            class="nav-badge"
             :label="item.error.toString()"
           />
         </NuxtLink>
@@ -94,6 +95,12 @@ ul {
             background-color: var(--nav-active);
         }
     }
+}
+
+.nav-badge {
+  line-height: initial;
+  letter-spacing: initial;
+  font-size: 0.75rem;
 }
 
 </style>

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { GetterTree } from 'vuex';
 
 import { ActionContext, MutationsType } from './ts-helpers';
@@ -60,6 +61,18 @@ export const actions = {
     }
     commit('SET_DIAGNOSTICS', (await response.json()) as Array<DiagnosticsCheck>);
     commit('SET_TIME_LAST_RUN', new Date());
+  },
+  updateDiagnostic({ commit, state }: DiagActionContext, { isMuted, row }: { isMuted: boolean, row: DiagnosticsCheck }) {
+    const diagnostics = _.cloneDeep(state.diagnostics);
+    const rowToUpdate = diagnostics.find(x => x.id === row.id);
+
+    if (rowToUpdate === undefined) {
+      return;
+    }
+
+    rowToUpdate.mute = isMuted;
+
+    commit('SET_DIAGNOSTICS', diagnostics);
   },
 };
 


### PR DESCRIPTION
This adds a toggle switch for toggling the display of muted diagnostics.

### Examples

<img width="1052" alt="Screen Shot 2022-08-22 at 12 38 12 PM" src="https://user-images.githubusercontent.com/835961/186004576-12ee4df3-cc43-4cbc-ba6a-f32e1b378138.png">
<img width="1052" alt="Screen Shot 2022-08-22 at 12 38 06 PM" src="https://user-images.githubusercontent.com/835961/186004583-1b445647-64c2-4c3a-b68b-2db2249f7d90.png">
<img width="1052" alt="Screen Shot 2022-08-22 at 12 38 00 PM" src="https://user-images.githubusercontent.com/835961/186004590-deecb50c-43ef-4f06-bd8e-6cb817950405.png">


closes #2656