### PR TITLE
`pass` handles bogus ServerURLs different from other helpers.

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -38,6 +38,7 @@ import { findHomeDir } from '@/config/findHomeDir';
 import { ServerState } from '@/main/commandServer/httpCommandServer';
 import { spawnFile } from '@/utils/childProcess';
 import paths from '@/utils/paths';
+let credStore = '';
 
 // If credsStore is `none` there's no need to test that the helper is available in advance: we want
 // the tests to fail if it isn't available.
@@ -49,7 +50,7 @@ function haveCredentialServerHelper(): boolean {
 
   try {
     const contents = JSON.parse(fs.readFileSync(dockerConfigPath).toString());
-    const credStore = contents.credsStore;
+    credStore = contents.credsStore;
 
     if (!credStore) {
       if (process.env.CIRRUS_CI) {
@@ -238,8 +239,10 @@ describeWithCreds('Credentials server', () => {
 
     await doRequestExpectStatus('erase', bobsURL, 200);
 
-    stdout = await doRequest('get', bobsURL);
-    expect(stdout).toContain('credentials not found in native keychain');
+    if (credStore !== 'pass') {
+      stdout = await doRequest('get', bobsURL);
+      expect(stdout).toContain('credentials not found in native keychain');
+    }
 
     // Don't bother trying to test erasing a non-existent credential, because the
     // behavior is all over the place. Fails with osxkeychain, succeeds with wincred.
@@ -305,12 +308,13 @@ describeWithCreds('Credentials server', () => {
     ({ stdout } = await rdctlCredWithStdin('get', bobsURL));
     expect(JSON.parse(stdout)).toMatchObject(body);
 
-    await expect(rdctlCredWithStdin('erase', bobsURL)).resolves.toMatchObject({ stdout: '' });
-
-    await expect(rdctlCredWithStdin('get', bobsURL)).rejects.toMatchObject({
-      stdout: expect.stringContaining('credentials not found in native keychain'),
-      stderr: expect.stringContaining('Error: exit status 22'),
-    });
+    if (credStore !== 'pass') {
+      await expect(rdctlCredWithStdin('erase', bobsURL)).resolves.toMatchObject({ stdout: '' });
+      await expect(rdctlCredWithStdin('get', bobsURL)).rejects.toMatchObject({
+        stdout: expect.stringContaining('credentials not found in native keychain'),
+        stderr: expect.stringContaining('Error: exit status 22'),
+      });
+    }
   });
 
   test('complains when the limit is exceeded (on the server - do an inexact check)', async() => {


### PR DESCRIPTION
Instead of returning an error message, it returns an
object that echoes back the ServerURl with empty Username and
Secret fields.

Signed-off-by: Eric Promislow <epromislow@suse.com>