### PR TITLE
Move preferences alert into body

### DIFF
--- a/src/components/Preferences/Alert.vue
+++ b/src/components/Preferences/Alert.vue
@@ -1,0 +1,131 @@
+<script lang="ts">
+import { Banner } from '@rancher/components';
+import Vue from 'vue';
+import { mapState } from 'vuex';
+
+interface Alert {
+  icon: string;
+  bannerText: string;
+  color: string;
+}
+
+type AlertMap = Record<'reset'|'restart'|'error', Alert>;
+
+const alertMap: AlertMap = {
+  reset: {
+    icon:       'icon-alert',
+    bannerText: 'preferences.actions.banner.reset',
+    color:      'warning',
+  },
+  restart: {
+    icon:       'icon-info',
+    bannerText: `preferences.actions.banner.restart`,
+    color:      'info',
+  },
+  error: {
+    icon:       'icon-warning',
+    bannerText: `preferences.actions.banner.error`,
+    color:      'error',
+  },
+};
+
+export default Vue.extend({
+  name:       'preferences-alert',
+  components: { Banner },
+  computed:   {
+    ...mapState('preferences', ['severities', 'preferencesError']),
+    severity(): keyof AlertMap | undefined {
+      if (this.severities.error) {
+        return 'error';
+      }
+
+      if (this.severities.reset) {
+        return 'reset';
+      }
+
+      if (this.severities.restart) {
+        return 'restart';
+      }
+
+      return undefined;
+    },
+    alert(): Alert | undefined {
+      if (!this.severity) {
+        return undefined;
+      }
+
+      return alertMap[this.severity];
+    },
+    errorSplit(): string[] {
+      return this.preferencesError.split(/\r?\n/);
+    },
+    errorTitle(): string {
+      return this.errorSplit[0];
+    },
+    errorRest(): string[] {
+      return this.errorSplit.slice(1, this.errorSplit.length);
+    },
+  },
+});
+</script>
+
+<template>
+  <transition
+    name="fade"
+    appear
+  >
+    <banner
+      v-if="alert"
+      class="banner-notify"
+      :color="alert.color"
+    >
+      <span
+        class="icon"
+        :class="alert.icon"
+      />
+      {{ t(alert.bannerText, { }, true) }}
+      <v-popover v-if="preferencesError">
+        <a class="text-error">Click here to learn more.</a>
+        <template #popover>
+          {{ errorTitle }}
+          <ul>
+            <li v-for="(error, index) in errorRest" :key="index">
+              {{ error }}
+            </li>
+          </ul>
+        </template>
+      </v-popover>
+    </banner>
+  </transition>
+</template>
+
+<style lang="scss" scoped>
+  .banner-notify {
+    margin: 0;
+  }
+
+  .fade-enter, .fade-leave-to {
+    opacity: 0;
+  }
+
+  .fade-active {
+    transition: all 0.25s ease-in;
+  }
+
+  .text-error {
+    cursor: pointer;
+    font-weight: 600;
+  }
+</style>
+
+<style lang="scss">
+  // Adding unscoped style to control the background of the popover so that it
+  // will match the background color of v-tooltip. This approach isn't ideal,
+  // but it's been proving quite difficult to make use of v-deep because:
+  //
+  // 1. Classes for v-popover aren't attached to root element in the template
+  // 2. The popover is inserted into the DOM at the body
+  .popover .popover-inner {
+    background: var(--tooltip-bg);
+  }
+</style>

--- a/src/components/Preferences/Alert.vue
+++ b/src/components/Preferences/Alert.vue
@@ -56,6 +56,17 @@ export default Vue.extend({
 
       return alertMap[this.severity];
     },
+    bannerText(): string | null {
+      if (this.preferencesError) {
+        return this.preferencesError;
+      }
+
+      if (this.alert) {
+        return this.t(this.alert.bannerText, { }, true);
+      }
+
+      return null;
+    },
     errorSplit(): string[] {
       return this.preferencesError.split(/\r?\n/);
     },
@@ -83,7 +94,7 @@ export default Vue.extend({
         class="icon"
         :class="alert.icon"
       />
-      {{ preferencesError }}
+      {{ bannerText }}
     </banner>
   </transition>
 </template>

--- a/src/components/Preferences/Alert.vue
+++ b/src/components/Preferences/Alert.vue
@@ -83,18 +83,7 @@ export default Vue.extend({
         class="icon"
         :class="alert.icon"
       />
-      {{ t(alert.bannerText, { }, true) }}
-      <v-popover v-if="preferencesError">
-        <a class="text-error">Click here to learn more.</a>
-        <template #popover>
-          {{ errorTitle }}
-          <ul>
-            <li v-for="(error, index) in errorRest" :key="index">
-              {{ error }}
-            </li>
-          </ul>
-        </template>
-      </v-popover>
+      {{ preferencesError }}
     </banner>
   </transition>
 </template>
@@ -110,22 +99,5 @@ export default Vue.extend({
 
   .fade-active {
     transition: all 0.25s ease-in;
-  }
-
-  .text-error {
-    cursor: pointer;
-    font-weight: 600;
-  }
-</style>
-
-<style lang="scss">
-  // Adding unscoped style to control the background of the popover so that it
-  // will match the background color of v-tooltip. This approach isn't ideal,
-  // but it's been proving quite difficult to make use of v-deep because:
-  //
-  // 1. Classes for v-popover aren't attached to root element in the template
-  // 2. The popover is inserted into the DOM at the body
-  .popover .popover-inner {
-    background: var(--tooltip-bg);
   }
 </style>

--- a/src/components/Preferences/ModalActions.vue
+++ b/src/components/Preferences/ModalActions.vue
@@ -1,71 +1,11 @@
 <script lang="ts">
-import { Banner } from '@rancher/components';
 import Vue from 'vue';
-import { mapState, mapGetters } from 'vuex';
-
-interface Alert {
-  icon: string;
-  bannerText: string;
-  color: string;
-}
-
-type AlertMap = Record<'reset'|'restart'|'error', Alert>;
-
-const alertMap: AlertMap = {
-  reset: {
-    icon:       'icon-alert',
-    bannerText: 'preferences.actions.banner.reset',
-    color:      'warning',
-  },
-  restart: {
-    icon:       'icon-info',
-    bannerText: `preferences.actions.banner.restart`,
-    color:      'info',
-  },
-  error: {
-    icon:       'icon-warning',
-    bannerText: `preferences.actions.banner.error`,
-    color:      'error',
-  },
-};
+import { mapGetters } from 'vuex';
 
 export default Vue.extend({
   name:       'preferences-actions',
-  components: { Banner },
   computed:   {
-    ...mapState('preferences', ['severities', 'preferencesError']),
     ...mapGetters('preferences', ['canApply']),
-    severity(): keyof AlertMap | undefined {
-      if (this.severities.error) {
-        return 'error';
-      }
-
-      if (this.severities.reset) {
-        return 'reset';
-      }
-
-      if (this.severities.restart) {
-        return 'restart';
-      }
-
-      return undefined;
-    },
-    alert(): Alert | undefined {
-      if (!this.severity) {
-        return undefined;
-      }
-
-      return alertMap[this.severity];
-    },
-    errorSplit(): string[] {
-      return this.preferencesError.split(/\r?\n/);
-    },
-    errorTitle(): string {
-      return this.errorSplit[0];
-    },
-    errorRest(): string[] {
-      return this.errorSplit.slice(1, this.errorSplit.length);
-    },
     isDisabled(): boolean {
       return !this.canApply;
     },
@@ -83,33 +23,6 @@ export default Vue.extend({
 
 <template>
   <div class="preferences-actions">
-    <transition
-      name="fade"
-      appear
-    >
-      <banner
-        v-if="alert"
-        class="banner-notify"
-        :color="alert.color"
-      >
-        <span
-          class="icon"
-          :class="alert.icon"
-        />
-        {{ t(alert.bannerText, { }, true) }}
-        <v-popover v-if="preferencesError">
-          <a class="text-error">Click here to learn more.</a>
-          <template #popover>
-            {{ errorTitle }}
-            <ul>
-              <li v-for="(error, index) in errorRest" :key="index">
-                {{ error }}
-              </li>
-            </ul>
-          </template>
-        </v-popover>
-      </banner>
-    </transition>
     <button
       data-test="preferences-cancel"
       class="btn role-secondary"
@@ -134,34 +47,5 @@ export default Vue.extend({
     gap: 1rem;
     padding: var(--preferences-content-padding);
     border-top: 1px solid var(--header-border);
-  }
-
-  .banner-notify {
-    margin: 0;
-  }
-
-  .fade-enter, .fade-leave-to {
-    opacity: 0;
-  }
-
-  .fade-active {
-    transition: all 0.25s ease-in;
-  }
-
-  .text-error {
-    cursor: pointer;
-    font-weight: 600;
-  }
-</style>
-
-<style lang="scss">
-  // Adding unscoped style to control the background of the popover so that it
-  // will match the background color of v-tooltip. This approach isn't ideal,
-  // but it's been proving quite difficult to make use of v-deep because:
-  //
-  // 1. Classes for v-popover aren't attached to root element in the template
-  // 2. The popover is inserted into the DOM at the body
-  .popover .popover-inner {
-    background: var(--tooltip-bg);
   }
 </style>

--- a/src/components/Preferences/ModalBody.vue
+++ b/src/components/Preferences/ModalBody.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
+import PreferencesAlert from '@/components/Preferences/Alert.vue';
 import PreferencesBodyApplication from '@/components/Preferences/BodyApplication.vue';
 import PreferencesBodyContainerEngine from '@/components/Preferences/BodyContainerEngine.vue';
 import PreferencesBodyKubernetes from '@/components/Preferences/BodyKubernetes.vue';
@@ -18,6 +19,7 @@ export default Vue.extend({
     PreferencesBodyWsl,
     PreferencesBodyContainerEngine,
     PreferencesBodyKubernetes,
+    PreferencesAlert,
   },
   props:      {
     currentNavItem: {
@@ -41,7 +43,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
+  <div class="preferences-body">
     <slot>
       <component
         :is="componentFromNavItem"
@@ -49,5 +51,20 @@ export default Vue.extend({
         v-on="$listeners"
       />
     </slot>
+    <div class="preferences-alert">
+      <preferences-alert />
+    </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  .preferences-body {
+    display: flex;
+    flex-direction: column;
+
+    .preferences-alert {
+      margin-top: auto;
+      padding: var(--preferences-content-padding);
+    }
+  }
+</style>


### PR DESCRIPTION
This moves the preferences alerts into the body of the preferences window. We came to the conclusion that this would be a better location for the alert during UX review of this feature. 

This PR also renders contents of error messages in the alert in favor of placing them in a popover.

### Before

<img width="880" alt="Screen Shot 2022-08-19 at 11 23 24 AM" src="https://user-images.githubusercontent.com/835961/185683180-7c9f33c5-1129-484a-b8e0-f4c06eb4358a.png">

<img width="880" alt="Screen Shot 2022-08-19 at 11 23 31 AM" src="https://user-images.githubusercontent.com/835961/185683187-8d3f1994-968d-4fb6-9853-59611536c9d5.png">

<img width="880" alt="Screen Shot 2022-08-19 at 11 23 37 AM" src="https://user-images.githubusercontent.com/835961/185683194-0f300544-eaa2-4715-a065-a53db6e67100.png">

### After

<img width="880" alt="Screen Shot 2022-08-19 at 11 20 10 AM" src="https://user-images.githubusercontent.com/835961/185682982-01f98d3b-3c60-4532-b4c0-84f6dc14c044.png">

<img width="880" alt="Screen Shot 2022-08-19 at 11 20 17 AM" src="https://user-images.githubusercontent.com/835961/185682988-c0311c40-7c5c-4f29-810b-a0777d60d1a3.png">

<img width="880" alt="Screen Shot 2022-08-19 at 11 20 01 AM" src="https://user-images.githubusercontent.com/835961/185682978-fea1c2c2-60a3-44d4-b11e-ed39b2998f6c.png">
