### PR TITLE
Refactor: progress tracker

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -171,12 +171,6 @@ export interface VMBackend {
   getFailureDetails(exception: any): Promise<FailureDetails>;
 
   /**
-   * A description of the last backend command, usually displayed by the progress tracker,
-   * but available for the `FailureDetails` block.
-   */
-  readonly lastCommandComment: string;
-
-  /**
    * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.
    */
   noModalDialogs: boolean;

--- a/src/backend/progressTracker.ts
+++ b/src/backend/progressTracker.ts
@@ -1,4 +1,4 @@
-import * as K8s from './k8s';
+import { BackendProgress } from './backend';
 
 /**
  * ProgressTracker is used to track the progress of multiple parallel actions.
@@ -15,7 +15,7 @@ export default class ProgressTracker {
   /**
    * @param notify The callback to invoke on progress change.
    */
-  constructor(notify: (progress: K8s.KubernetesProgress) => void) {
+  constructor(notify: (progress: BackendProgress) => void) {
     this.notify = notify;
   }
 
@@ -23,7 +23,7 @@ export default class ProgressTracker {
    * A function that will be called when there is any change in the
    * state of progress.
    */
-  protected notify: (progress: K8s.KubernetesProgress) => void;
+  protected notify: (progress: BackendProgress) => void;
 
   /**
    * A progress object that is preferred over progress objects that
@@ -31,13 +31,13 @@ export default class ProgressTracker {
    * of as an action without any associated Promise and with infinitely
    * high priority.
    */
-  protected numericProgress?: K8s.KubernetesProgress;
+  protected numericProgress?: BackendProgress;
 
   /**
    * A list of pending actions. The currently running action with
    * the highest priority will be passed to this.notify.
    */
-  protected actionProgress: {priority: number, id: number, progress: K8s.KubernetesProgress}[] = [];
+  protected actionProgress: {priority: number, id: number, progress: BackendProgress}[] = [];
 
   /**
    * Provides the ID of the next action.

--- a/src/backend/progressTracker.ts
+++ b/src/backend/progressTracker.ts
@@ -1,5 +1,11 @@
 import { BackendProgress } from './backend';
 
+const ErrorDescription = Symbol('progressTracker.description');
+
+export function getProgressErrorDescription(e: any) {
+  return e[ErrorDescription] as string | undefined;
+}
+
 /**
  * ProgressTracker is used to track the progress of multiple parallel actions.
  * It invokes a callback that takes a progress object as input when one of those
@@ -94,6 +100,15 @@ export default class ProgressTracker {
       }).catch((ex) => {
         this.actionProgress = this.actionProgress.filter(p => p.id !== id);
         this.update();
+        if (!(ErrorDescription in ex)) {
+          Object.defineProperty(
+            ex,
+            ErrorDescription,
+            {
+              enumerable: false,
+              value:      description,
+            });
+        }
         reject(ex);
       });
     });


### PR DESCRIPTION
This bundles two changes for the progress tracker:
- In ProgressTracker, import `BackendProgress` from `backend` instead of `k8s`.
- When an error occurs, attach the description of the current action directly to the error, and use that, instead of using an auxiliary variable on the backend.  This is needed because once we split things to VMBackend + KubernetesBackend, they would not be able to access each other's protected fields, so trying to set the state across the two will be very awkward.