### PR TITLE
Refactor: Export kube backend off VMBackend

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -310,7 +310,7 @@ async function startK8sManager() {
  */
 
 function setupImageProcessor() {
-  const imageProcessor = getImageProcessor(cfg.kubernetes.containerEngine, k8smanager);
+  const imageProcessor = getImageProcessor(cfg.kubernetes.containerEngine, k8smanager.executor);
 
   currentImageProcessor?.deactivate();
   if (!imageEventHandler) {

--- a/background.ts
+++ b/background.ts
@@ -447,7 +447,7 @@ ipcMainProxy.on('k8s-current-engine', () => {
 });
 
 ipcMainProxy.on('k8s-current-port', () => {
-  window.send('k8s-current-port', k8smanager.kube.desiredPort);
+  window.send('k8s-current-port', k8smanager.kubeBackend.desiredPort);
 });
 
 ipcMainProxy.on('k8s-reset', async(_, arg) => {
@@ -512,7 +512,7 @@ async function doK8sReset(arg: 'fast' | 'wipe' | 'fullRestart', context: Command
 }
 
 ipcMainProxy.on('k8s-restart', async() => {
-  if (cfg.kubernetes.port !== k8smanager.kube.desiredPort) {
+  if (cfg.kubernetes.port !== k8smanager.kubeBackend.desiredPort) {
     // On port change, we need to wipe the VM.
     return doK8sReset('wipe', { interactive: true });
   } else if (cfg.kubernetes.containerEngine !== currentContainerEngine || cfg.kubernetes.enabled !== enabledK8s) {
@@ -534,7 +534,7 @@ ipcMainProxy.on('k8s-restart', async() => {
 });
 
 ipcMainProxy.on('k8s-versions', async() => {
-  window.send('k8s-versions', await k8smanager.kube.availableVersions, await k8smanager.kube.cachedVersionsOnly());
+  window.send('k8s-versions', await k8smanager.kubeBackend.availableVersions, await k8smanager.kubeBackend.cachedVersionsOnly());
 });
 
 ipcMainProxy.on('k8s-progress', () => {
@@ -542,16 +542,16 @@ ipcMainProxy.on('k8s-progress', () => {
 });
 
 ipcMainProxy.handle('service-fetch', (_, namespace) => {
-  return k8smanager.kube.listServices(namespace);
+  return k8smanager.kubeBackend.listServices(namespace);
 });
 
 ipcMainProxy.handle('service-forward', async(_, service, state) => {
   if (state) {
     const hostPort = service.listenPort ?? 0;
 
-    await k8smanager.kube.forwardPort(service.namespace, service.name, service.port, hostPort);
+    await k8smanager.kubeBackend.forwardPort(service.namespace, service.name, service.port, hostPort);
   } else {
-    await k8smanager.kube.cancelForward(service.namespace, service.name, service.port);
+    await k8smanager.kubeBackend.cancelForward(service.namespace, service.name, service.port);
   }
 });
 
@@ -763,12 +763,12 @@ function newK8sManager() {
   const arch = (Electron.app.runningUnderARM64Translation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';
   const mgr = K8sFactory(arch, dockerDirManager);
 
-  mgr.kube.on('state-changed', (state: K8s.State) => {
+  mgr.kubeBackend.on('state-changed', (state: K8s.State) => {
     mainEvents.emit('k8s-check-state', mgr);
     window.send('k8s-check-state', state);
     if ([K8s.State.STARTED, K8s.State.DISABLED].includes(state)) {
       if (!cfg.kubernetes.version) {
-        writeSettings({ kubernetes: { version: mgr.kube.version } });
+        writeSettings({ kubernetes: { version: mgr.kubeBackend.version } });
       }
       currentImageProcessor?.relayNamespaces();
 
@@ -787,31 +787,31 @@ function newK8sManager() {
     }
   });
 
-  mgr.kube.on('current-port-changed', (port: number) => {
+  mgr.kubeBackend.on('current-port-changed', (port: number) => {
     window.send('k8s-current-port', port);
   });
 
-  mgr.kube.on('kim-builder-uninstalled', () => {
+  mgr.kubeBackend.on('kim-builder-uninstalled', () => {
     writeSettings({ kubernetes: { checkForExistingKimBuilder: false } });
   });
 
-  mgr.kube.on('service-changed', (services: K8s.ServiceEntry[]) => {
+  mgr.kubeBackend.on('service-changed', (services: K8s.ServiceEntry[]) => {
     window.send('service-changed', services);
   });
 
-  mgr.kube.on('service-error', (service: K8s.ServiceEntry, errorMessage: string) => {
+  mgr.kubeBackend.on('service-error', (service: K8s.ServiceEntry, errorMessage: string) => {
     window.send('service-error', service, errorMessage);
   });
 
-  mgr.kube.on('progress', () => {
+  mgr.kubeBackend.on('progress', () => {
     window.send('k8s-progress', mgr.progress);
   });
 
-  mgr.kube.on('versions-updated', async() => {
-    window.send('k8s-versions', await mgr.kube.availableVersions, await mgr.kube.cachedVersionsOnly());
+  mgr.kubeBackend.on('versions-updated', async() => {
+    window.send('k8s-versions', await mgr.kubeBackend.availableVersions, await mgr.kubeBackend.cachedVersionsOnly());
   });
 
-  mgr.kube.on('show-notification', (notificationOptions: Electron.NotificationConstructorOptions) => {
+  mgr.kubeBackend.on('show-notification', (notificationOptions: Electron.NotificationConstructorOptions) => {
     (new Electron.Notification(notificationOptions)).show();
   });
 
@@ -837,7 +837,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
    */
   protected async validateSettings(...args: Parameters<SettingsValidator['validateSettings']>) {
     if (this.k8sVersions.length === 0) {
-      this.k8sVersions = (await k8smanager.kube.availableVersions).map(entry => entry.version.version);
+      this.k8sVersions = (await k8smanager.kubeBackend.availableVersions).map(entry => entry.version.version);
       this.settingsValidator.k8sVersions = this.k8sVersions;
     }
 

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -4,6 +4,8 @@ import { Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
 import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 
+import type { KubernetesBackend } from './k8s';
+
 export enum State {
   STOPPED = 0, // The engine is not running.
   STARTING, // The engine is attempting to start.
@@ -174,6 +176,8 @@ export interface VMBackend {
    * If true, the backend cannot invoke any dialog boxes and needs to find an alternative.
    */
   noModalDialogs: boolean;
+
+  readonly kube: KubernetesBackend;
 }
 
 /**

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -178,7 +178,7 @@ export interface VMBackend {
   noModalDialogs: boolean;
 
   readonly executor: VMExecutor;
-  readonly kube: KubernetesBackend;
+  readonly kubeBackend: KubernetesBackend;
 }
 
 /**

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -177,6 +177,7 @@ export interface VMBackend {
    */
   noModalDialogs: boolean;
 
+  readonly executor: VMExecutor;
   readonly kube: KubernetesBackend;
 }
 
@@ -208,4 +209,11 @@ export interface VMExecutor {
   execCommand(...command: string[]): Promise<void>;
   execCommand(options: execOptions, ...command: string[]): Promise<void>;
   execCommand(options: execOptions & { capture: true }, ...command: string[]): Promise<string>;
+
+  /**
+   * spawn the given command in the virtual machine, returning the child
+   * process itself.
+   * @note No redirection or any other setup is done.
+   */
+  spawn(...command: string[]): childProcess.ChildProcess;
 }

--- a/src/backend/client.ts
+++ b/src/backend/client.ts
@@ -378,12 +378,6 @@ export class KubeClient extends events.EventEmitter {
     return null;
   }
 
-  async isServiceReady(namespace: string, service: string): Promise<boolean> {
-    const pod = await this.getActivePod(namespace, service);
-
-    return pod?.status?.phase === 'Running';
-  }
-
   /**
    * Formats the namespace, endpoint, and port as namespace/endpoint:port
    * @param namespace The namespace to forward to.

--- a/src/backend/images/imageFactory.ts
+++ b/src/backend/images/imageFactory.ts
@@ -1,7 +1,7 @@
+import { VMExecutor } from '@/backend/backend';
 import { ImageProcessor } from '@/backend/images/imageProcessor';
 import MobyImageProcessor from '@/backend/images/mobyImageProcessor';
 import NerdctlImageProcessor from '@/backend/images/nerdctlImageProcessor';
-import * as K8s from '@/backend/k8s';
 import { ContainerEngine } from '@/config/settings';
 
 const cachedImageProcessors: Partial<Record<ContainerEngine, ImageProcessor>> = { };
@@ -9,14 +9,14 @@ const cachedImageProcessors: Partial<Record<ContainerEngine, ImageProcessor>> = 
 /**
  * Return the appropriate ImageProcessor singleton for the specified ContainerEngine.
  */
-export function getImageProcessor(engineName: ContainerEngine, k8sManager: K8s.KubernetesBackend): ImageProcessor {
+export function getImageProcessor(engineName: ContainerEngine, executor: VMExecutor): ImageProcessor {
   if (!(engineName in cachedImageProcessors)) {
     switch (engineName) {
     case ContainerEngine.MOBY:
-      cachedImageProcessors[engineName] = new MobyImageProcessor(k8sManager);
+      cachedImageProcessors[engineName] = new MobyImageProcessor(executor);
       break;
     case ContainerEngine.CONTAINERD:
-      cachedImageProcessors[engineName] = new NerdctlImageProcessor(k8sManager);
+      cachedImageProcessors[engineName] = new NerdctlImageProcessor(executor);
       break;
     default:
       throw new Error(`No image processor called ${ engineName }`);

--- a/src/backend/images/mobyImageProcessor.ts
+++ b/src/backend/images/mobyImageProcessor.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import path from 'path';
 
+import { VMExecutor } from '@/backend/backend';
 import * as imageProcessor from '@/backend/images/imageProcessor';
 import * as K8s from '@/backend/k8s';
 import mainEvents from '@/main/mainEvents';
@@ -11,8 +12,8 @@ import * as window from '@/window';
 const console = Logging.images;
 
 export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
-  constructor(k8sManager: K8s.KubernetesBackend) {
-    super(k8sManager);
+  constructor(executor: VMExecutor) {
+    super(executor);
 
     mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
       if (!this.active) {

--- a/src/backend/images/nerdctlImageProcessor.ts
+++ b/src/backend/images/nerdctlImageProcessor.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import * as k8s from '@kubernetes/client-node';
 import { KubeConfig } from '@kubernetes/client-node/dist/config';
 
+import { VMExecutor } from '@/backend/backend';
 import * as imageProcessor from '@/backend/images/imageProcessor';
 import * as K8s from '@/backend/k8s';
 import mainEvents from '@/main/mainEvents';
@@ -14,8 +15,8 @@ import resources from '@/utils/resources';
 const console = Logging.images;
 
 export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor {
-  constructor(k8sManager: K8s.KubernetesBackend) {
-    super(k8sManager);
+  constructor(executor: VMExecutor) {
+    super(executor);
 
     mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
       if (!this.active) {

--- a/src/backend/k8s.ts
+++ b/src/backend/k8s.ts
@@ -82,13 +82,6 @@ export interface KubernetesBackend extends VMBackend, EventEmitter<KubernetesBac
    *                  return services across all namespaces.
    */
   listServices(namespace?: string): ServiceEntry[];
-
-  /**
-   * Check if a given service is ready.
-   * @param namespace The namespace in which to lookup the service.
-   * @param service The name of the service to lookup.
-   */
-  isServiceReady(namespace: string, service: string): Promise<boolean>;
 }
 
 export interface KubernetesBackendPortForwarder {

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -238,7 +238,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
-  readonly kube = this;
+  readonly kubeBackend = this;
   readonly executor = this;
 
   protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2075,10 +2075,6 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     return this.client?.listServices(namespace) || [];
   }
 
-  async isServiceReady(namespace: string, service: string): Promise<boolean> {
-    return (await this.client?.isServiceReady(namespace, service)) || false;
-  }
-
   async forwardPort(namespace: string, service: string, k8sPort: number | string, hostPort: number): Promise<number | undefined> {
     return await this.client?.forwardPort(namespace, service, k8sPort, hostPort);
   }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -238,6 +238,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
+  readonly kube = this;
+
   protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
   protected cfg: RecursiveReadonly<Settings['kubernetes']> | undefined;

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -239,6 +239,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   }
 
   readonly kube = this;
+  readonly executor = this;
 
   protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
@@ -803,6 +804,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       }
       throw ex;
     }
+  }
+
+  spawn(...command: string[]): ChildProcess {
+    return this.limaSpawn(command);
   }
 
   /**

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -15,6 +15,7 @@ import Logging from '@/utils/logging';
 const console = Logging.mock;
 
 export default class MockBackend extends events.EventEmitter implements KubernetesBackend {
+  readonly kube = this;
   readonly backend = 'mock';
   state: State = State.STOPPED;
   readonly availableVersions = Promise.resolve([{ version: new semver.SemVer('0.0.0'), channels: ['latest'] }]);

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -87,10 +87,6 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
     return [];
   }
 
-  isServiceReady(): Promise<boolean> {
-    return Promise.resolve(false);
-  }
-
   portForwarder = null;
 
   getFailureDetails() {

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -17,7 +17,7 @@ import Logging from '@/utils/logging';
 const console = Logging.mock;
 
 export default class MockBackend extends events.EventEmitter implements KubernetesBackend, VMExecutor {
-  readonly kube = this;
+  readonly kubeBackend = this;
   readonly executor = this;
   readonly backend = 'mock';
   state: State = State.STOPPED;

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -154,7 +154,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   /** The port the Kubernetes server is listening on (default 6443) */
   protected currentPort = 0;
 
-  readonly kube = this;
+  readonly kubeBackend = this;
   readonly executor = this;
 
   /** Not used in wsl.ts */

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1581,10 +1581,6 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     return this.client?.listServices(namespace) || [];
   }
 
-  async isServiceReady(namespace: string, service: string): Promise<boolean> {
-    return (await this.client?.isServiceReady(namespace, service)) || false;
-  }
-
   // The WSL implementation of requiresRestartReasons doesn't need to do
   // anything asynchronously; however, to match the API, we still need to return
   // a Promise.

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -155,6 +155,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   protected currentPort = 0;
 
   readonly kube = this;
+  readonly executor = this;
 
   /** Not used in wsl.ts */
   get noModalDialogs() {
@@ -879,6 +880,12 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
       throw ex;
     }
+  }
+
+  spawn(...command: string[]): childProcess.ChildProcess {
+    const args = ['--distribution', INSTANCE_NAME, '--exec', ...command];
+
+    return childProcess.spawn('wsl.exe', args);
   }
 
   /**

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -154,6 +154,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
   /** The port the Kubernetes server is listening on (default 6443) */
   protected currentPort = 0;
 
+  readonly kube = this;
+
   /** Not used in wsl.ts */
   get noModalDialogs() {
     throw new Error("internalError: noModalDialogs shouldn't be used in WSL");


### PR DESCRIPTION
This furthers the refactoring, consisting of three commits:
- Expose the `KubernetesBackend` off the `VMBackend`.
- Use the newly exports `KubernetesBackend` where appropriate.  Since currently `KubernetesBackend` just extends `VMBackend` this isn't very useful yet, but we'll move it into split objects soon.
- Use the `VMExecutor` interface where appropriate.