### PR TITLE
Bump @rancher/components to v0.1.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.0",
-        "@rancher/components": "^0.1.0-alpha.1",
+        "@rancher/components": "0.1.0-alpha.2",
         "agent-base": "^6.0.2",
         "bufferutil": "^4.0.3",
         "cookie-universal-nuxt": "^2.0.17",
@@ -4631,9 +4631,9 @@
       "dev": true
     },
     "node_modules/@rancher/components": {
-      "version": "0.1.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.1.tgz",
-      "integrity": "sha512-iTfD390i/kRwA5ukUEhYpbqf4zamaeP0CS63dYODh1BwzI/CrrLZ/RXIQCPxhfLMIaTh0LiXADKSF5+/zTdjqw==",
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-uw8LcpT/jbDE1g7Beh6++kF9XEiYIB1FVkVuvnA6NyQG7YWQ228okUZGizgdhCZeo57mrmbA4wuNlHIe+AIQYA==",
       "dependencies": {
         "lodash.debounce": "^4.0.8"
       },
@@ -30920,9 +30920,9 @@
       "dev": true
     },
     "@rancher/components": {
-      "version": "0.1.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.1.tgz",
-      "integrity": "sha512-iTfD390i/kRwA5ukUEhYpbqf4zamaeP0CS63dYODh1BwzI/CrrLZ/RXIQCPxhfLMIaTh0LiXADKSF5+/zTdjqw==",
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-uw8LcpT/jbDE1g7Beh6++kF9XEiYIB1FVkVuvnA6NyQG7YWQ228okUZGizgdhCZeo57mrmbA4wuNlHIe+AIQYA==",
       "requires": {
         "lodash.debounce": "^4.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "main": "dist/app/background.js",
   "dependencies": {
     "@kubernetes/client-node": "^0.17.0",
-    "@rancher/components": "^0.1.0-alpha.1",
+    "@rancher/components": "0.1.0-alpha.2",
     "agent-base": "^6.0.2",
     "bufferutil": "^4.0.3",
     "cookie-universal-nuxt": "^2.0.17",

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,7 +1,4 @@
 <script lang="ts">
-// TODO: #2753 [diagnostics] Remove @ts-ignore for BadgeState import
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No exported member
 import { BadgeState } from '@rancher/components';
 import Vue from 'vue';
 


### PR DESCRIPTION
This bumps `@rancher/components` to `v0.1.0-alpha.2`. This latest alpha version includes:

* rancher/dashboard#6668
* rancher/dashboard#6656
* rancher/dashboard#6651

closes #2753

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>