### PR TITLE
Create a diagnostics store to sit between backend and UI.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -856,8 +856,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     return diagnostics.getIdsForCategory(category);
   }
 
-  getDiagnosticCheck(category: string, checkID: string): DiagnosticsCheck|undefined {
-    return diagnostics.getCheckByID(category, checkID);
+  getDiagnosticChecks(category: string|null, checkID: string|null): DiagnosticsCheck[] {
+    return diagnostics.getChecks(category, checkID);
   }
 
   factoryReset(keepSystemImages: boolean) {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -774,7 +774,7 @@ test.describe('Command server', () => {
             'GET /',
             'GET /v0',
             'GET /v0/diagnostic_categories',
-            'GET /v0/diagnostic_check',
+            'GET /v0/diagnostic_checks',
             'GET /v0/diagnostic_ids',
             'PUT /v0/factory_reset',
             'PUT /v0/propose_settings',
@@ -791,7 +791,7 @@ test.describe('Command server', () => {
           expect(JSON.parse(stdout)).toEqual([
             'GET /v0',
             'GET /v0/diagnostic_categories',
-            'GET /v0/diagnostic_check',
+            'GET /v0/diagnostic_checks',
             'GET /v0/diagnostic_ids',
             'PUT /v0/factory_reset',
             'PUT /v0/propose_settings',
@@ -835,28 +835,113 @@ test.describe('Command server', () => {
           expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'No diagnostic checks found in category cecinestpasuncategory' });
         });
         test('it finds a diagnostic check', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=Networking&id=CONNECTED_TO_INTERNET']);
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Networking&id=CONNECTED_TO_INTERNET']);
 
           expect(stderr).toEqual('');
-          expect(JSON.parse(stdout)).toMatchObject({
+          expect(JSON.parse(stdout)).toMatchObject([{
             id:            'CONNECTED_TO_INTERNET',
             documentation: 'path#connected_to_internet',
             description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
             mute:          false,
-          });
+          }]);
         });
-        test('it complains about insufficient parameters for a diagnostic check', async() => {
-          let { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check']);
+        test('it finds all diagnostic checks', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks']);
 
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no category or id specified' });
-          ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=Networking']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no id specified' });
-          ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?id=blip']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no category specified' });
-          ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=Networking&id=blip']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'No diagnostic checks found for category Networking, id blip' });
-          ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=xNetworking&id=CONNECTED_TO_INTERNET']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'No diagnostic checks found for category xNetworking, id CONNECTED_TO_INTERNET' });
+          expect(stderr).toEqual('');
+          expect(JSON.parse(stdout)).toMatchObject([
+            {
+              category:      'Utilities',
+              id:            'RD_BIN_IN_BASH_PATH',
+              documentation: 'path#rd_bin_bash',
+              description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
+              mute:          false,
+              fixes:         [
+                { description: 'You have selected manual PATH configuration. You can let Rancher Desktop automatically configure it.' },
+              ],
+            },
+            {
+              category:      'Utilities',
+              id:            'RD_BIN_SYMLINKS',
+              documentation: 'path#rd_bin_symlinks',
+              description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+              mute:          false,
+              fixes:         [
+                { description: 'Replace existing files in ~/.rd/bin with symlinks to the application\'s internal utility directory.' },
+              ],
+            },
+            {
+              category:      'Networking',
+              id:            'CONNECTED_TO_INTERNET',
+              documentation: 'path#connected_to_internet',
+              description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
+              mute:          false,
+            },
+          ]);
+        });
+        test('it finds all diagnostic checks for a category', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Utilities']);
+
+          expect(stderr).toEqual('');
+          expect(JSON.parse(stdout)).toEqual([
+            {
+              category:      'Utilities',
+              id:            'RD_BIN_IN_BASH_PATH',
+              documentation: 'path#rd_bin_bash',
+              description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
+              mute:          false,
+              fixes:         [
+                { description: 'You have selected manual PATH configuration. You can let Rancher Desktop automatically configure it.' },
+              ],
+            },
+            {
+              category:      'Utilities',
+              id:            'RD_BIN_SYMLINKS',
+              documentation: 'path#rd_bin_symlinks',
+              description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+              mute:          false,
+              fixes:         [
+                { description: 'Replace existing files in ~/.rd/bin with symlinks to the application\'s internal utility directory.' },
+              ],
+            },
+          ]);
+        });
+        test('it finds a diagnostic check by checkID', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?id=RD_BIN_SYMLINKS']);
+
+          expect(stderr).toEqual('');
+          expect(JSON.parse(stdout)).toEqual([
+            {
+              category:      'Utilities',
+              id:            'RD_BIN_SYMLINKS',
+              documentation: 'path#rd_bin_symlinks',
+              description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+              mute:          false,
+              fixes:         [
+                { description: 'Replace existing files in ~/.rd/bin with symlinks to the application\'s internal utility directory.' },
+              ],
+            },
+          ]);
+        });
+        test('it returns an empty array for a non-existent category', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=not*a*category']);
+
+          expect({ stdout: JSON.parse(stdout), stderr } ).toEqual({ stdout: [], stderr: '' });
+        });
+        test('it returns an empty array for a non-existent category with a valid ID', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=not*a*category&id=RD_BIN_SYMLINKS']);
+
+          expect({ stdout: JSON.parse(stdout), stderr } ).toEqual({ stdout: [], stderr: '' });
+        });
+        test('it returns an empty array for a non-existent checkID with a valid category', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Utilities&id=CONNECTED_TO_INTERNET']);
+
+          expect({ stdout: JSON.parse(stdout), stderr } ).toEqual({ stdout: [], stderr: '' });
+        });
+        test('it returns an empty array for a non-existent checkID when no category is specified', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?&id=blip']);
+
+          expect({ stdout: JSON.parse(stdout), stderr } ).toEqual({ stdout: [], stderr: '' });
         });
       });
     });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -848,11 +848,11 @@ test.describe('Command server', () => {
         test('it complains about insufficient parameters for a diagnostic check', async() => {
           let { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check']);
 
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_ids: no category or id specified' });
+          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no category or id specified' });
           ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=Networking']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_ids: no id specified' });
+          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no id specified' });
           ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?id=blip']));
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_ids: no category specified' });
+          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '400 Bad Request' }, stderr: 'diagnostic_check: no category specified' });
           ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=Networking&id=blip']));
           expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'No diagnostic checks found for category Networking, id blip' });
           ({ stdout, stderr } = await rdctl(['api', '/v0/diagnostic_check?category=xNetworking&id=CONNECTED_TO_INTERNET']));

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -156,9 +156,9 @@ paths:
 
   /v0/diagnostic_checks:
     get:
-      operationId: diagnosticForCategoryAndID
+      operationId: diagnosticChecks
       summary: >-
-        Return all the checks, optionally filtered by specified category and/or checkID, or 404.
+        Return all the checks, optionally filtered by specified category and/or checkID.
       parameters:
         - in: query
           name: category

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -154,11 +154,11 @@ paths:
           description: The category is not recognized.
 
 
-  /v0/diagnostic_check:
+  /v0/diagnostic_checks:
     get:
       operationId: diagnosticForCategoryAndID
       summary: >-
-        Return the check for the given category and checkID, or 404.
+        Return all the checks, optionally filtered by specified category and/or checkID, or 404.
       parameters:
         - in: query
           name: category
@@ -167,13 +167,11 @@ paths:
       responses:
         '200':
           description: >-
-            The specified check.
+            A list of check objects. An invalid or unrecognized query parameter returns (200, empty array)
           content:
             application/json:
               schema:
                 "$ref" : "#/components/schemas/diagnostics"
-        '404':
-          description: The category and/or checkID are not recognized.
 
 components:
   schemas:
@@ -237,28 +235,25 @@ components:
       type: object
       properties:
         last_update: string
-        categories:
+        diagnostics:
           type: array
           items:
             type: object
             properties:
-              title:
+              id:
                 type: string
-              checks:
+              category:
+                type: string
+              documentation:
+                type: string
+              description:
+                type: string
+              mute:
+                type: boolean
+              fixes:
                 type: array
                 items:
                   type: object
                   properties:
-                    id:
-                      type: string
-                    documentation:
-                      type: string
                     description:
                       type: string
-                    mute:
-                      type: boolean
-                    fixes:
-                      type: object
-                      properties:
-                        description:
-                          type: string

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -232,28 +232,24 @@ components:
           type: string
           enum: ['manual', 'rcfiles']
     diagnostics:
-      type: object
-      properties:
-        last_update: string
-        diagnostics:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: string
-              category:
-                type: string
-              documentation:
-                type: string
-              description:
-                type: string
-              mute:
-                type: boolean
-              fixes:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    description:
-                      type: string
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          category:
+            type: string
+          documentation:
+            type: string
+          description:
+            type: string
+          mute:
+            type: boolean
+          fixes:
+            type: array
+            items:
+              type: object
+              properties:
+                description:
+                  type: string

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,9 +1,13 @@
 <script lang="ts">
 import { BadgeState } from '@rancher/components';
 import Vue from 'vue';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 
 import SortableTable from '@/components/SortableTable/index.vue';
 import type { DiagnosticsCheck } from '@/main/diagnostics/diagnostics';
+
+dayjs.extend(relativeTime);
 
 export default Vue.extend({
   name:       'DiagnosticsBody',
@@ -43,34 +47,12 @@ export default Vue.extend({
     numMuted(): number {
       return this.rows.filter(row => (row as DiagnosticsCheck).mute).length;
     },
-    // npm module timeago-simple is substandard - see https://github.com/mikepenzin/timeago-simple/issues/1
-    // npm module timediff requires as much work as this function uses, so let's stick with it
     friendlyTimeLastRun(): string {
-      const timeAsNumber: number = this.timeLastRun.valueOf() as unknown as number;
-      const deltaMSec = Date.now() - timeAsNumber;
-      const deltaSec = deltaMSec / 1000;
-
-      if (deltaSec < 60) {
-        return this.pluralize(Math.round(deltaSec), 'second');
-      }
-      if (deltaSec < 60 * 60) {
-        return this.pluralize(Math.round(deltaSec / 60), 'minute');
-      }
-      if (deltaSec < 60 * 60 * 24) {
-        return this.pluralize(Math.round(deltaSec / (60 * 60)), 'hour');
-      }
-      if (deltaSec < 60 * 60 * 24 * 30) {
-        return this.pluralize(Math.round(deltaSec / (60 * 60 * 24)), 'day');
-      }
-      if (deltaSec < 60 * 60 * 24 * (30 * 12 + 5)) {
-        return this.pluralize(Math.round(deltaSec / (60 * 60 * 24 * 30)), 'month');
-      }
-
-      return this.pluralize(Math.round(deltaSec / (60 * 60 * 24 * 365)), 'year');
+      return dayjs().to(dayjs(this.timeLastRun));
     },
     timeLastRunTooltip(): string {
       return (this.timeLastRun as unknown as Date).toLocaleString();
-    }
+    },
   },
   methods: {
     pluralize(count: number, unit: string): string {

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -7,6 +7,8 @@ import Vue from 'vue';
 import SortableTable from '@/components/SortableTable/index.vue';
 import type { DiagnosticsCheck } from '@/main/diagnostics/diagnostics';
 
+import type { PropType } from 'vue';
+
 dayjs.extend(relativeTime);
 
 export default Vue.extend({
@@ -17,10 +19,10 @@ export default Vue.extend({
   },
   props: {
     rows: {
-      type:     Array,
+      type:     Array as PropType<DiagnosticsCheck[]>,
       required: true,
     },
-    timeLastRun: Date,
+    timeLastRun: Date as PropType<Date>,
   },
   data() {
     return {
@@ -45,13 +47,13 @@ export default Vue.extend({
       return this.rows.length;
     },
     numMuted(): number {
-      return this.rows.filter(row => (row as DiagnosticsCheck).mute).length;
+      return this.rows.filter(row => row.mute).length;
     },
     friendlyTimeLastRun(): string {
       return dayjs().to(dayjs(this.timeLastRun));
     },
     timeLastRunTooltip(): string {
-      return (this.timeLastRun as unknown as Date).toLocaleString();
+      return this.timeLastRun.toLocaleString();
     },
   },
   methods: {

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { BadgeState } from '@rancher/components';
-import Vue from 'vue';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import Vue from 'vue';
 
 import SortableTable from '@/components/SortableTable/index.vue';
 import type { DiagnosticsCheck } from '@/main/diagnostics/diagnostics';

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -14,6 +14,9 @@
 
 <script>
 import { ipcRenderer } from 'electron';
+import { mapGetters, mapState } from 'vuex';
+
+// import { ServerState } from '../main/commandServer/httpCommandServer';
 
 import ActionMenu from '@/components/ActionMenu.vue';
 import BackendProgress from '@/components/BackendProgress.vue';
@@ -29,6 +32,12 @@ export default {
     rdNav:    Nav,
     rdHeader: Header,
     TheTitle,
+  },
+  async fetch() {
+    if (this.$config.featureDiagnostics) {
+      await this.$store.dispatch('credentials/fetchCredentials');
+      await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
+    }
   },
 
   head() {
@@ -50,7 +59,12 @@ export default {
       ];
 
       if (this.featureDiagnostics) {
-        routeTable.push({ route: '/Diagnostics', error: 3 });
+        const route = { route: '/Diagnostics' };
+
+        if (this.errorCount !== undefined) {
+          route.error = this.errorCount;
+        }
+        routeTable.push(route);
       }
 
       return routeTable;
@@ -58,6 +72,11 @@ export default {
     featureDiagnostics() {
       return !!this.$config.featureDiagnostics;
     },
+    errorCount() {
+      return this.diagnostics.length;
+    },
+    ...mapState('credentials', ['credentials']),
+    ...mapGetters('diagnostics', ['diagnostics']),
   },
 
   beforeMount() {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -16,8 +16,6 @@
 import { ipcRenderer } from 'electron';
 import { mapGetters, mapState } from 'vuex';
 
-// import { ServerState } from '../main/commandServer/httpCommandServer';
-
 import ActionMenu from '@/components/ActionMenu.vue';
 import BackendProgress from '@/components/BackendProgress.vue';
 import Header from '@/components/Header.vue';

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -34,6 +34,11 @@ export default {
   async fetch() {
     if (this.$config.featureDiagnostics) {
       await this.$store.dispatch('credentials/fetchCredentials');
+      if (!this.credentials.port || !this.credentials.user || !this.credentials.password) {
+        console.log(`Credentials aren't ready for getting diagnostics -- will try later`);
+
+        return;
+      }
       await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
     }
   },
@@ -57,12 +62,7 @@ export default {
       ];
 
       if (this.featureDiagnostics) {
-        const route = { route: '/Diagnostics' };
-
-        if (this.errorCount !== undefined) {
-          route.error = this.errorCount;
-        }
-        routeTable.push(route);
+        routeTable.push({ route: '/Diagnostics', error: this.errorCount });
       }
 
       return routeTable;

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -232,7 +232,7 @@ export class HttpCommandServer {
     const id = searchParams.get('id');
 
     if (!category || !id) {
-      let msg = 'diagnostic_ids: ';
+      let msg = 'diagnostic_check: ';
 
       if (!category) {
         if (!id) {
@@ -243,7 +243,7 @@ export class HttpCommandServer {
       } else {
         msg += 'no id specified';
       }
-      console.debug('diagnostic_ids: failed 400');
+      console.debug('diagnostic_check: failed 400');
       response.writeHead(400, { 'Content-Type': 'text/plain' });
       response.write(msg);
 

--- a/src/main/commandServer/httpCommandServer.ts
+++ b/src/main/commandServer/httpCommandServer.ts
@@ -52,7 +52,7 @@ export class HttpCommandServer {
         settings:              this.listSettings,
         diagnostic_categories: this.diagnosticCategories,
         diagnostic_ids:        this.diagnosticIDsForCategory,
-        diagnostic_check:      this.diagnosticForCategoryAndID,
+        diagnostic_checks:      this.diagnosticChecks,
       },
       PUT: {
         factory_reset:    this.factoryReset,
@@ -225,41 +225,16 @@ export class HttpCommandServer {
     return Promise.resolve();
   }
 
-  protected diagnosticForCategoryAndID(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
+  protected diagnosticChecks(request: http.IncomingMessage, response: http.ServerResponse, context: commandContext): Promise<void> {
     const url = new URL(`http://localhost/${ request.url }`);
     const searchParams = url.searchParams;
     const category = searchParams.get('category');
     const id = searchParams.get('id');
+    const checks = this.commandWorker.getDiagnosticChecks(category, id, context);
 
-    if (!category || !id) {
-      let msg = 'diagnostic_check: ';
-
-      if (!category) {
-        if (!id) {
-          msg += 'no category or id specified';
-        } else {
-          msg += 'no category specified';
-        }
-      } else {
-        msg += 'no id specified';
-      }
-      console.debug('diagnostic_check: failed 400');
-      response.writeHead(400, { 'Content-Type': 'text/plain' });
-      response.write(msg);
-
-      return Promise.resolve();
-    }
-    const check = this.commandWorker.getDiagnosticCheck(category, id, context);
-
-    if (check) {
-      console.debug('diagnostic_check: succeeded 200');
-      response.writeHead(200, { 'Content-Type': 'application/json' });
-      response.write(jsonStringifyWithWhiteSpace(check));
-    } else {
-      console.debug('diagnostic_check: failed 404');
-      response.writeHead(404, { 'Content-Type': 'text/plain' });
-      response.write(`No diagnostic checks found for category ${ category }, id ${ id }`);
-    }
+    console.debug('diagnostic_checks: succeeded 200');
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.write(jsonStringifyWithWhiteSpace(checks));
 
     return Promise.resolve();
   }
@@ -493,7 +468,7 @@ export interface CommandWorkerInterface {
   requestShutdown: (context: commandContext) => void;
   getDiagnosticCategories: (context: commandContext) => string[]|undefined;
   getDiagnosticIdsByCategory: (category: string, context: commandContext) => string[]|undefined;
-  getDiagnosticCheck: (category: string, checkID: string, context: commandContext) => DiagnosticsCheck|undefined;
+  getDiagnosticChecks: (category: string|null, checkID: string|null, context: commandContext) => DiagnosticsCheck[];
 }
 
 // Extend CommandWorkerInterface to have extra types, as these types are used by

--- a/src/main/diagnostics/__tests__/diagnostics.spec.ts
+++ b/src/main/diagnostics/__tests__/diagnostics.spec.ts
@@ -17,13 +17,13 @@ diagnostics:
           description: "The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell."
           mute: false
           fixes:
-            description: "You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it."
+          - description: "You have selected manual PATH configuration. You can let Rancher Desktop automatically configure it."
         - id: RD_BIN_SYMLINKS
           documentation: path#rd_bin_symlinks
           description: "Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?"
           mute: false
           fixes:
-            description: "Replace existing files in ~/.rd/bin with symlinks to the application's internal utility directory"
+          - description: "Replace existing files in ~/.rd/bin with symlinks to the application's internal utility directory"
     - title: Networking
       checks:
         - id: CONNECTED_TO_INTERNET
@@ -44,27 +44,57 @@ diagnostics:
   });
 
   test('it finds the checks', () => {
-    expect(diagnostics.getCheckByID('Chummily', 'CONNECTED_TO_INTERNET')).toBeUndefined();
-    expect(diagnostics.getCheckByID('Utilities', 'gallop the friendly purple')).toBeUndefined();
-    expect(diagnostics.getCheckByID('Utilities', 'RD_BIN_IN_BASH_PATH')).toMatchObject({
+    expect(diagnostics.getChecks(null, null)).toEqual(expect.arrayContaining([
+      {
+        category:      'Utilities',
+        id:            'RD_BIN_IN_BASH_PATH',
+        documentation: 'path#rd_bin_bash',
+        description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
+        mute:          false,
+        fixes:         [
+          { description: 'You have selected manual PATH configuration. You can let Rancher Desktop automatically configure it.' },
+        ],
+      },
+      {
+        category:      'Utilities',
+        id:            'RD_BIN_SYMLINKS',
+        documentation: 'path#rd_bin_symlinks',
+        description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
+        mute:          false,
+        fixes:         [
+          { description: 'Replace existing files in ~/.rd/bin with symlinks to the application\'s internal utility directory' },
+        ],
+      },
+      {
+        category:      'Networking',
+        id:            'CONNECTED_TO_INTERNET',
+        documentation: 'path#connected_to_internet',
+        description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
+        mute:          false,
+        fixes:         [],
+      },
+    ]));
+    expect(diagnostics.getChecks('Chummily', 'CONNECTED_TO_INTERNET')).toEqual([]);
+    expect(diagnostics.getChecks('Utilities', 'gallop the friendly purple')).toEqual([]);
+    expect(diagnostics.getChecks('Utilities', 'RD_BIN_IN_BASH_PATH')).toMatchObject([{
       documentation: 'path#rd_bin_bash',
       description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
       mute:          false,
-      fixes:         { description: 'You have selected manual PATH configuration, you can let Rancher Desktop automatically configure it.' },
-    });
-    expect(diagnostics.getCheckByID('Utilities', 'RD_BIN_SYMLINKS')).toMatchObject({
+      fixes:         [{ description: 'You have selected manual PATH configuration. You can let Rancher Desktop automatically configure it.' }],
+    }]);
+    expect(diagnostics.getChecks('Utilities', 'RD_BIN_SYMLINKS')).toMatchObject([{
       documentation: 'path#rd_bin_symlinks',
       description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
       mute:          false,
-      fixes:         { description: "Replace existing files in ~/.rd/bin with symlinks to the application's internal utility directory" },
-    });
-    const internetCheck = diagnostics.getCheckByID('Networking', 'CONNECTED_TO_INTERNET');
+      fixes:         [{ description: "Replace existing files in ~/.rd/bin with symlinks to the application's internal utility directory" }],
+    }]);
+    const internetCheck = diagnostics.getChecks('Networking', 'CONNECTED_TO_INTERNET');
 
-    expect(internetCheck).toMatchObject({
+    expect(internetCheck[0]).toMatchObject({
       documentation: 'path#connected_to_internet',
       description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
       mute:          false,
     });
-    expect(internetCheck).not.toMatchObject({ fixes: { description: expect.any(String) } });
+    expect(internetCheck[0]).not.toMatchObject({ fixes: { description: expect.any(String) } });
   });
 });

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -8,6 +8,7 @@ export type DiagnosticsCheck = {
   id: string,
   documentation: string,
   description: string,
+  category: string,
   mute: boolean,
   fixes: DiagnosticsFix[],
 };

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -55,9 +55,40 @@ export class Diagnostics {
   /**
    * @param categoryName {string}
    * @param id {string}
-   * Returns {unknown} if the categoryName isn't known or id not in that category, the check object otherwise.
+   * Returns an array of all matching checkObjects, depending on which of categoryName and id are specified.
    */
-  getCheckByID(categoryName: string, id: string): DiagnosticsCheck {
-    return this.checksByCategory[categoryName]?.filter(check => check.id === id)[0];
+  getChecks(categoryName: string|null, id: string|null): DiagnosticsCheck[] {
+    if (categoryName) {
+      const checksByCategory = this.checksByCategory[categoryName];
+
+      if (!checksByCategory) {
+        return [];
+      } else if (!id) {
+        return augmentChecks(categoryName, checksByCategory);
+      } else {
+        return augmentChecks(categoryName, checksByCategory.filter(check => check.id === id));
+      }
+    }
+    let finalChecks: DiagnosticsCheck[] = [];
+
+    for (const category in this.checksByCategory) {
+      let checks = this.checksByCategory[category];
+
+      if (id) {
+        checks = checks.filter(check => check.id === id);
+      }
+      finalChecks = finalChecks.concat(augmentChecks(category, checks));
+    }
+
+    return finalChecks;
   }
+}
+
+function augmentChecks(category: string, checks: DiagnosticsCheck[]): DiagnosticsCheck[] {
+  return checks.map((check) => {
+    check.category = category;
+    check.fixes ??= [];
+
+    return check;
+  });
 }

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -26,12 +26,15 @@ type DiagnosticsType = {
 export class Diagnostics {
   diagnostics: DiagnosticsType;
   checksByCategory: Record<string, Array<DiagnosticsCheck>> = {};
+  checks: Array<DiagnosticsCheck> = [];
   constructor(diagnosticsTable: DiagnosticsType|undefined = undefined) {
     this.diagnostics = diagnosticsTable || DIAGNOSTICS_TABLE.diagnostics;
     for (const category of this.diagnostics.categories) {
       for (const check of category.checks) {
         check.mute ??= false;
         check.fixes ??= [];
+        check.category = category.title;
+        this.checks.push(check);
       }
       this.checksByCategory[category.title] = category.checks;
     }
@@ -58,37 +61,8 @@ export class Diagnostics {
    * Returns an array of all matching checkObjects, depending on which of categoryName and id are specified.
    */
   getChecks(categoryName: string|null, id: string|null): DiagnosticsCheck[] {
-    if (categoryName) {
-      const checksByCategory = this.checksByCategory[categoryName];
-
-      if (!checksByCategory) {
-        return [];
-      } else if (!id) {
-        return augmentChecks(categoryName, checksByCategory);
-      } else {
-        return augmentChecks(categoryName, checksByCategory.filter(check => check.id === id));
-      }
-    }
-    let finalChecks: DiagnosticsCheck[] = [];
-
-    for (const category in this.checksByCategory) {
-      let checks = this.checksByCategory[category];
-
-      if (id) {
-        checks = checks.filter(check => check.id === id);
-      }
-      finalChecks = finalChecks.concat(augmentChecks(category, checks));
-    }
-
-    return finalChecks;
+    return this.checks
+      .filter(check => categoryName ? check.category === categoryName : true)
+      .filter(check => id ? check.id === id : true);
   }
-}
-
-function augmentChecks(category: string, checks: DiagnosticsCheck[]): DiagnosticsCheck[] {
-  return checks.map((check) => {
-    check.category = category;
-    check.fixes ??= [];
-
-    return check;
-  });
 }

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -4,6 +4,7 @@ import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
 import DiagnosticsBody from '@/components/DiagnosticsBody.vue';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 export default Vue.extend({
   name:       'diagnostics',
@@ -11,7 +12,7 @@ export default Vue.extend({
 
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
-    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials as ServerState);
   },
   computed: {
     ...mapState('credentials', ['credentials']),

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -4,19 +4,14 @@ import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
 import DiagnosticsBody from '@/components/DiagnosticsBody.vue';
-import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 export default Vue.extend({
   name:       'diagnostics',
   components: { DiagnosticsBody },
 
-  data() {
-    return { rows: [] };
-  },
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
-    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials as ServerState);
-    this.$data.rows = this.diagnostics;
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
   },
   computed: {
     ...mapState('credentials', ['credentials']),
@@ -35,5 +30,5 @@ export default Vue.extend({
 </script>
 
 <template>
-  <diagnostics-body :rows="rows" :time-last-run="timeLastRun"></diagnostics-body>
+  <diagnostics-body :rows="diagnostics" :time-last-run="timeLastRun"></diagnostics-body>
 </template>

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -1,23 +1,20 @@
 <script lang="ts">
 
 import Vue from 'vue';
-import { mapGetters, mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 
 import DiagnosticsBody from '@/components/DiagnosticsBody.vue';
-import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 export default Vue.extend({
   name:       'diagnostics',
   components: { DiagnosticsBody },
 
   async fetch() {
-    await this.$store.dispatch('credentials/fetchCredentials');
-    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials as ServerState);
+    const credentials = await this.$store.dispatch('credentials/fetchCredentials');
+
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', credentials);
   },
-  computed: {
-    ...mapState('credentials', ['credentials']),
-    ...mapGetters('diagnostics', ['diagnostics', 'timeLastRun']),
-  },
+  computed: mapGetters('diagnostics', ['diagnostics', 'timeLastRun']),
   mounted() {
     this.$store.dispatch(
       'page/setHeader',

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -1,11 +1,27 @@
 <script lang="ts">
+
 import Vue from 'vue';
+import { mapGetters, mapState } from 'vuex';
 
 import DiagnosticsBody from '@/components/DiagnosticsBody.vue';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
 
 export default Vue.extend({
   name:       'diagnostics',
   components: { DiagnosticsBody },
+
+  data() {
+    return { rows: [] };
+  },
+  async fetch() {
+    await this.$store.dispatch('credentials/fetchCredentials');
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials as ServerState);
+    this.$data.rows = this.diagnostics;
+  },
+  computed: {
+    ...mapState('credentials', ['credentials']),
+    ...mapGetters('diagnostics', ['diagnostics', 'timeLastRun']),
+  },
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
@@ -19,5 +35,5 @@ export default Vue.extend({
 </script>
 
 <template>
-  <diagnostics-body></diagnostics-body>
+  <diagnostics-body :rows="rows" :time-last-run="timeLastRun"></diagnostics-body>
 </template>

--- a/src/store/credentials.ts
+++ b/src/store/credentials.ts
@@ -28,7 +28,7 @@ export const mutations: MutationsType<CredentialsState> = {
 type CredActionContext = ActionContext<CredentialsState>;
 
 export const actions = {
-  async fetchCredentials({ commit }: CredActionContext) {
+  async fetchCredentials({ commit }: CredActionContext): Promise<ServerState> {
     const result = await ipcRenderer.invoke('api-get-credentials');
 
     commit('SET_CREDENTIALS', result);

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -78,7 +78,7 @@ export const actions = {
 
       for (const checkID of checkIDs) {
         const response = await fetch(
-          uri(port, `diagnostic_check?category=${ category }&id=${ checkID }`),
+          uri(port, `diagnostic_checks?category=${ category }&id=${ checkID }`),
           {
             headers: new Headers({
               Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -1,0 +1,112 @@
+import { ActionContext } from './ts-helpers';
+
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
+import { DiagnosticsCheck } from '@/main/diagnostics/diagnostics';
+
+interface DiagnosticsState {
+  diagnostics: Array<DiagnosticsCheck>,
+  timeLastRun: Date;
+  inError: boolean;
+}
+
+const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v0/${ pathRemainder }`;
+
+export const state: () => DiagnosticsState = () => (
+  {
+    diagnostics: [],
+    timeLastRun: new Date(),
+    inError:     false,
+  }
+);
+
+export const mutations = {
+  SET_DIAGNOSTICS(state: DiagnosticsState, diagnostics: DiagnosticsCheck[]) {
+    state.diagnostics = diagnostics;
+    state.inError = false;
+  },
+  SET_TIME_LAST_RUN(state: DiagnosticsState, currentDate: Date) {
+    state.timeLastRun = currentDate;
+  },
+  SET_IN_ERROR(state: DiagnosticsState, status: boolean) {
+    state.inError = status;
+  },
+};
+
+type DiagActionContext = ActionContext<DiagnosticsState>;
+
+export const actions = {
+  async fetchDiagnostics({ state, commit }: DiagActionContext, args: ServerState) {
+    const rows: Array<DiagnosticsCheck> = [];
+    const {
+      port,
+      user,
+      password,
+    } = args;
+    const response = await fetch(
+      uri(port, 'diagnostic_categories'),
+      {
+        headers: new Headers({
+          Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
+      });
+
+    if (!response.ok) {
+      commit('SET_IN_ERROR', true);
+
+      return;
+    }
+
+    const categories: string[] = await response.json();
+
+    for (const category of categories) {
+      const response = await fetch(
+        uri(port, `diagnostic_ids?category=${ category }`),
+        {
+          headers: new Headers({
+            Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        });
+
+      if (!response.ok) {
+        commit('SET_IN_ERROR', true);
+
+        return;
+      }
+      const checkIDs: string[] = await response.json();
+
+      for (const checkID of checkIDs) {
+        const response = await fetch(
+          uri(port, `diagnostic_check?category=${ category }&id=${ checkID }`),
+          {
+            headers: new Headers({
+              Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
+              'Content-Type': 'application/x-www-form-urlencoded',
+            }),
+          });
+
+        if (!response.ok) {
+          commit('SET_IN_ERROR', true);
+
+          return;
+        }
+        const res = await response.json();
+
+        res.category = category;
+        rows.push(res);
+      }
+    }
+    commit('SET_DIAGNOSTICS', rows);
+    commit('SET_TIME_LAST_RUN', new Date());
+  },
+};
+
+export const getters = {
+  diagnostics(state: DiagnosticsState) {
+    return state.diagnostics;
+  },
+  timeLastRun(state: DiagnosticsState) {
+    return state.timeLastRun;
+  },
+};

--- a/src/typings/store.d.ts
+++ b/src/typings/store.d.ts
@@ -1,5 +1,6 @@
 import type { actions as ApplicationSettingsActions } from '@/store/applicationSettings';
 import type { actions as CredentialsActions } from '@/store/credentials';
+import type { actions as DiagnosticsActions } from '@/store/diagnostics';
 import type { actions as PageActions } from '@/store/page';
 import type { actions as PreferencesActions } from '@/store/preferences';
 
@@ -15,6 +16,7 @@ type storeActions = Record<string, never>
   & Actions<'applicationSettings', typeof ApplicationSettingsActions>
   & Actions<'page', typeof PageActions>
   & Actions<'preferences', typeof PreferencesActions>
+  & Actions<'diagnostics', typeof DiagnosticsActions>
   & Actions<'credentials', typeof CredentialsActions>;
 
 declare module 'vuex/types' {


### PR DESCRIPTION
Fixes #2783

- Remove hardwired diagnostics from the front-end
  (they're temporarily in the YAML file now).

Signed-off-by: Eric Promislow <epromislow@suse.com>