### PR TITLE
Refactoring: Split KubernetesBackend more

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -7,12 +7,12 @@ import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/type
 import type { KubernetesBackend } from './k8s';
 
 export enum State {
-  STOPPED = 0, // The engine is not running.
-  STARTING, // The engine is attempting to start.
-  STARTED, // The engine is started; the dashboard is not yet ready.
-  STOPPING, // The engine is attempting to stop.
-  ERROR, // There is an error and we cannot recover automatically.
-  DISABLED, // The container backend is ready but the Kubernetes engine is disabled.
+  STOPPED = 'STOPPED', // The engine is not running.
+  STARTING = 'STARTING', // The engine is attempting to start.
+  STARTED = 'STARTED', // The engine is started; the dashboard is not yet ready.
+  STOPPING = 'STOPPING', // The engine is attempting to stop.
+  ERROR = 'ERROR', // There is an error and we cannot recover automatically.
+  DISABLED = 'DISABLED', // The container backend is ready but the Kubernetes engine is disabled.
 }
 
 export class BackendError extends Error {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -213,7 +213,9 @@ export interface VMExecutor {
   /**
    * spawn the given command in the virtual machine, returning the child
    * process itself.
-   * @note No redirection or any other setup is done.
+   * @param options Execution options.
+   * @param command The command to execute.
    */
   spawn(...command: string[]): childProcess.ChildProcess;
+  spawn(options: execOptions, ...command: string[]): childProcess.ChildProcess;
 }

--- a/src/backend/backendHelper.ts
+++ b/src/backend/backendHelper.ts
@@ -1,0 +1,14 @@
+import merge from 'lodash/merge';
+
+export default class BackendHelper {
+  /**
+   * Workaround for upstream error https://github.com/containerd/nerdctl/issues/1308
+   * Nerdctl client (version 0.22.0 +) wants a populated auths field when credsStore gives credentials.
+   * Note that we don't have to actually provide credentials in the value part of the `auths` field.
+   * The code currently wants to see a `ServerURL` that matches the well-known docker hub registry URL,
+   * even though it isn't needed, because at that point the code knows it's using the well-known registry.
+   */
+  static ensureDockerAuth(existingConfig: Record<string, any>): Record<string, any> {
+    return merge({ auths: { 'https://index.docker.io/v1/': {} } }, existingConfig);
+  }
+}

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -1,14 +1,13 @@
 import os from 'os';
 
-import { Architecture } from './backend';
-import { KubernetesBackend } from './k8s';
+import { Architecture, VMBackend } from './backend';
 import LimaBackend from './lima';
 import MockBackend from './mock';
 import WSLBackend from './wsl';
 
 import DockerDirManager from '@/utils/dockerDirManager';
 
-export default function factory(arch: Architecture, dockerDirManager: DockerDirManager): KubernetesBackend {
+export default function factory(arch: Architecture, dockerDirManager: DockerDirManager): VMBackend {
   const platform = os.platform();
 
   if (process.env.RD_MOCK_BACKEND === '1') {

--- a/src/backend/images/mobyImageProcessor.ts
+++ b/src/backend/images/mobyImageProcessor.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import path from 'path';
 
-import { VMExecutor } from '@/backend/backend';
+import { VMBackend, VMExecutor } from '@/backend/backend';
 import * as imageProcessor from '@/backend/images/imageProcessor';
 import * as K8s from '@/backend/k8s';
 import mainEvents from '@/main/mainEvents';
@@ -15,7 +15,7 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
   constructor(executor: VMExecutor) {
     super(executor);
 
-    mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
+    mainEvents.on('k8s-check-state', (mgr: VMBackend) => {
       if (!this.active) {
         return;
       }

--- a/src/backend/images/nerdctlImageProcessor.ts
+++ b/src/backend/images/nerdctlImageProcessor.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import * as k8s from '@kubernetes/client-node';
 import { KubeConfig } from '@kubernetes/client-node/dist/config';
 
-import { VMExecutor } from '@/backend/backend';
+import { VMBackend, VMExecutor } from '@/backend/backend';
 import * as imageProcessor from '@/backend/images/imageProcessor';
 import * as K8s from '@/backend/k8s';
 import mainEvents from '@/main/mainEvents';
@@ -18,7 +18,7 @@ export default class NerdctlImageProcessor extends imageProcessor.ImageProcessor
   constructor(executor: VMExecutor) {
     super(executor);
 
-    mainEvents.on('k8s-check-state', (mgr: K8s.KubernetesBackend) => {
+    mainEvents.on('k8s-check-state', (mgr: VMBackend) => {
       if (!this.active) {
         return;
       }

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -956,18 +956,6 @@ export default class K3sHelper extends events.EventEmitter {
   }
 
   /**
-   * Workaround for upstream error https://github.com/containerd/nerdctl/issues/1308
-   * Nerdctl client (version 0.22.0 +) wants a populated auths field when credsStore gives credentials.
-   * Note that we don't have to actually provide credentials in the value part of the `auths` field.
-   * The code currently wants to see a `ServerURL` that matches the well-known docker hub registry URL,
-   * even though it isn't needed, because at that point the code knows it's using the well-known registry.
-   * @param existingConfig
-   */
-  ensureDockerAuth(existingConfig: Record<string, any>): Record<string, any> {
-    return _.merge({ auths: { 'https://index.docker.io/v1/': {} } }, existingConfig);
-  }
-
-  /**
    * Manually uninstall the K3s-installed copy of Traefik, if it exists.
    * This exists to work around https://github.com/k3s-io/k3s/issues/5103
    */

--- a/src/backend/k8s.ts
+++ b/src/backend/k8s.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-import { VMBackend, BackendEvents } from './backend';
+import { BackendEvents } from './backend';
 import { ServiceEntry } from './client';
 
 import EventEmitter from '@/utils/eventEmitter';

--- a/src/backend/k8s.ts
+++ b/src/backend/k8s.ts
@@ -54,7 +54,7 @@ export interface KubernetesBackendEvents extends BackendEvents {
   'kim-builder-uninstalled'(): void;
 }
 
-export interface KubernetesBackend extends VMBackend, EventEmitter<KubernetesBackendEvents>, KubernetesBackendPortForwarder {
+export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>, KubernetesBackendPortForwarder {
   /**
    * The versions that are available to install, sorted as would be displayed to
    * the user.

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -19,6 +19,7 @@ import tar from 'tar-stream';
 import yaml from 'yaml';
 
 import { Architecture, execOptions, VMExecutor } from './backend';
+import BackendHelper from './backendHelper';
 import K3sHelper, { NoCachedK3sVersionsError, ShortVersion } from './k3sHelper';
 import * as K8s from './k8s';
 import ProgressTracker, { getProgressErrorDescription } from './progressTracker';
@@ -1943,7 +1944,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       }
       merge(existingConfig, defaultConfig);
       if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
-        existingConfig = this.k3sHelper.ensureDockerAuth(existingConfig);
+        existingConfig = BackendHelper.ensureDockerAuth(existingConfig);
       }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), 0o644);
     } catch (err: any) {

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -142,7 +142,9 @@ export default class MockBackend extends events.EventEmitter implements Kubernet
     return Promise.resolve();
   }
 
-  spawn(...command: string[]): ChildProcess {
+  spawn(...command: string[]): ChildProcess;
+  spawn(options: execOptions, ...command: string[]): ChildProcess;
+  spawn(optionsOrCommand: string | execOptions, ...command: string[]): ChildProcess {
     return null as unknown as ChildProcess;
   }
 

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -883,8 +883,17 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     }
   }
 
-  spawn(...command: string[]): childProcess.ChildProcess {
-    const args = ['--distribution', INSTANCE_NAME, '--exec', ...command];
+  spawn(...command: string[]): childProcess.ChildProcess;
+  spawn(options: execOptions, ...command: string[]): childProcess.ChildProcess;
+  spawn(optionsOrCommand: execOptions | string, ...command: string[]): childProcess.ChildProcess {
+    const args = ['--distribution', INSTANCE_NAME, '--exec'];
+
+    if (typeof optionsOrCommand === 'string') {
+      args.push(optionsOrCommand);
+    } else {
+      throw new TypeError('Not supported yet');
+    }
+    args.push(...command);
 
     return childProcess.spawn('wsl.exe', args);
   }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -14,6 +14,7 @@ import semver from 'semver';
 import tar from 'tar-stream';
 
 import { execOptions, VMExecutor } from './backend';
+import BackendHelper from './backendHelper';
 import K3sHelper, { ShortVersion } from './k3sHelper';
 import * as K8s from './k8s';
 import ProgressTracker, { getProgressErrorDescription } from './progressTracker';
@@ -762,7 +763,7 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
       }
       _.merge(existingConfig, defaultConfig);
       if (this.cfg?.containerEngine === ContainerEngine.CONTAINERD) {
-        existingConfig = this.k3sHelper.ensureDockerAuth(existingConfig);
+        existingConfig = BackendHelper.ensureDockerAuth(existingConfig);
       }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), { permissions: 0o644 });
     } catch (err: any) {

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from 'events';
 
-import * as K8s from '@/backend/k8s';
+import { VMBackend } from '@/backend/backend';
 import { Settings } from '@/config/settings';
 import { RecursivePartial } from '@/utils/typeUtils';
 
@@ -13,7 +13,7 @@ interface MainEventNames {
   /**
    * Emitted when the Kubernetes backend state has changed.
    */
-   'k8s-check-state'(mgr: K8s.KubernetesBackend): void;
+   'k8s-check-state'(mgr: VMBackend): void;
    /**
     * Emitted when the settings have been changed.
     *


### PR DESCRIPTION
More progress towards #1997:

- Make the factory return `VMBackend` instead of `KubernetesBackend`.
- Make `KubernetesBackend` not extend `VMBackend`.
- Move `ensureDockerAuth` outside of `K3sHelper` (since it will still be required without Kubernetes)
- Use a string enum for states, so that if we print it out for debugging it's easier to understand.
- Add options for `spawn` on `VMExecutor`; this will be needed for future changes.  This is currently only implemented for Lima — WSL will be in a follow-up.

> 11 files changed, 69 insertions(+), 39 deletions(-)
