### PR TITLE
Bump Steve to version v0.1.0-beta9

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,7 +10,7 @@ dockerCLI: v20.10.17
 dockerBuildx: v0.8.2
 dockerCompose: v2.6.1
 trivy: 0.30.0
-steve: v0.1.0-beta8
+steve: v0.1.0-beta9
 guestAgent: v0.2.0
 rancherDashboard: desktop-v2.6.3.beta.12
 dockerProvidedCredentialHelpers: 0.6.4


### PR DESCRIPTION
This bumps the Rancher Desktop build of Steve to v0.1.0-beta9

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>