### PR TITLE
Bump @rancher/components to v0.1.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.17.0",
-        "@rancher/components": "0.1.0-alpha.2",
+        "@rancher/components": "0.1.0-alpha.4",
         "agent-base": "^6.0.2",
         "bufferutil": "^4.0.3",
         "cookie-universal-nuxt": "^2.0.17",
@@ -4632,9 +4632,9 @@
       "dev": true
     },
     "node_modules/@rancher/components": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-uw8LcpT/jbDE1g7Beh6++kF9XEiYIB1FVkVuvnA6NyQG7YWQ228okUZGizgdhCZeo57mrmbA4wuNlHIe+AIQYA==",
+      "version": "0.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.4.tgz",
+      "integrity": "sha512-AmTl4DBoAf3v0rP5dZsVTaP6yFv8BJ5ZwbCfc28oPnZnhQ3sBjNgZ4Y9mAgOpQhypNh3P5HAFpwoVBfMqPSa8g==",
       "dependencies": {
         "lodash.debounce": "^4.0.8"
       },
@@ -30926,9 +30926,9 @@
       "dev": true
     },
     "@rancher/components": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.2.tgz",
-      "integrity": "sha512-uw8LcpT/jbDE1g7Beh6++kF9XEiYIB1FVkVuvnA6NyQG7YWQ228okUZGizgdhCZeo57mrmbA4wuNlHIe+AIQYA==",
+      "version": "0.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.0-alpha.4.tgz",
+      "integrity": "sha512-AmTl4DBoAf3v0rP5dZsVTaP6yFv8BJ5ZwbCfc28oPnZnhQ3sBjNgZ4Y9mAgOpQhypNh3P5HAFpwoVBfMqPSa8g==",
       "requires": {
         "lodash.debounce": "^4.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "main": "dist/app/background.js",
   "dependencies": {
     "@kubernetes/client-node": "^0.17.0",
-    "@rancher/components": "0.1.0-alpha.2",
+    "@rancher/components": "0.1.0-alpha.4",
     "agent-base": "^6.0.2",
     "bufferutil": "^4.0.3",
     "cookie-universal-nuxt": "^2.0.17",


### PR DESCRIPTION
This bumps `@rancher/components` to `0.1.0-alpha.4`. 

This release includes a fix for an issue in `ToggleSwitch` that was identified in #2767.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>