### PR TITLE
wsl-helper: fix lint error.

### DIFF
--- a/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
+++ b/src/go/wsl-helper/pkg/reset/factory_reset_windows.go
@@ -79,7 +79,7 @@ func getDirectoriesToDelete(keepSystemImages bool) ([]string, error) {
 				cacheDir := path.Join(localRDAppData, baseName)
 				cacheFiles, err := ioutil.ReadDir(cacheDir)
 				if err != nil {
-					logrus.Infof("could not get files in folder %s: %w", cacheDir, err)
+					logrus.Infof("could not get files in folder %s: %s", cacheDir, err)
 				} else {
 					for _, cacheDirFile := range cacheFiles {
 						cacheDirFileName := cacheDirFile.Name()


### PR DESCRIPTION
`logrus.Infof` does not support `%w` formatting (because it's not returning an error).
