### PR TITLE
Update last run timestamp on an interval

### DIFF
--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -52,8 +52,8 @@ export default Vue.extend({
           width: 76,
         },
       ],
-      hideMuted: false,
-      timeStamp: dayjs(),
+      hideMuted:   false,
+      currentTime: dayjs(),
     };
   },
   computed: {
@@ -64,7 +64,7 @@ export default Vue.extend({
       return this.rows.filter(row => row.mute).length;
     },
     friendlyTimeLastRun(): string {
-      return this.timeStamp.to(dayjs(this.timeLastRun));
+      return this.currentTime.to(dayjs(this.timeLastRun));
     },
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();
@@ -91,7 +91,7 @@ export default Vue.extend({
   },
   mounted() {
     lastRunInterval = setInterval(() => {
-      this.timeStamp = dayjs();
+      this.currentTime = dayjs();
     }, 1000);
   },
   beforeDestroy() {

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -12,6 +12,8 @@ import type { PropType } from 'vue';
 
 dayjs.extend(relativeTime);
 
+let lastRunInterval: ReturnType<typeof setInterval>;
+
 export default Vue.extend({
   name:       'DiagnosticsBody',
   components: {
@@ -51,6 +53,7 @@ export default Vue.extend({
         },
       ],
       hideMuted: false,
+      timeStamp: dayjs(),
     };
   },
   computed: {
@@ -61,7 +64,7 @@ export default Vue.extend({
       return this.rows.filter(row => row.mute).length;
     },
     friendlyTimeLastRun(): string {
-      return dayjs().to(dayjs(this.timeLastRun));
+      return this.timeStamp.to(dayjs(this.timeLastRun));
     },
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();
@@ -85,6 +88,14 @@ export default Vue.extend({
     emptyStateBody(): string {
       return this.areAllRowsMuted ? this.t('diagnostics.results.muted.body') : this.t('diagnostics.results.success.body');
     },
+  },
+  mounted() {
+    lastRunInterval = setInterval(() => {
+      this.timeStamp = dayjs();
+    }, 1000);
+  },
+  beforeDestroy() {
+    clearInterval(lastRunInterval);
   },
   methods: {
     pluralize(count: number, unit: string): string {


### PR DESCRIPTION
This adds an interval to the diagnostics body so that we can update the last run timestamp to reflect the duration while a user is spending time on the page.

We make sure to clean up the `lastRunInterval` in the `beforeDestroy` hook to stop to interval when navigating away from diagnostics and to prevent multiple instances of the interval from being created.

I arbitrarily chose `1000ms` for the delay and we could probably dial this back quite a bit for the given use case. 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>