### PR TITLE
WSL: Improve error handling

### DIFF
--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -332,7 +332,8 @@ export default class WSLBackend extends events.EventEmitter implements K8s.Kuber
     }
     await this.progressTracker.action('Registering WSL distribution', 100, async() => {
       await fs.promises.mkdir(paths.wslDistro, { recursive: true });
-      await this.execWSL('--import', INSTANCE_NAME, paths.wslDistro, this.distroFile, '--version', '2');
+      await this.execWSL({ logStream: await console.fdStream },
+        '--import', INSTANCE_NAME, paths.wslDistro, this.distroFile, '--version', '2');
     });
 
     if (!await this.isDistroRegistered()) {


### PR DESCRIPTION
This includes a few commits to handle & report errors better in the WSL backend:

- Windows now ships with `wsl.exe` (as a stub; `wsl.exe --install …` is required to get the real thing).  When we initially check if WSL is installed, _if_ the error is a usage message, assume that if `--exec` is not listed then we've encountered this stub (and adjust the errors to report that WSL isn't installed).
- When doing that initial check, log any errors to `wsl.log` rather than `wsl-exec.log` to make it easier to find — when we pop up the error dialog box, we only examine `wsl.log` and not `wsl-exec.log` (this means that if the user posts a screenshot of the dialog box, rather than attaching their log files, we can still help them identify the problem).
- When we attempt to import the WSL distribution, that is the place we first attempt to actually use the WSL VM.  If we end up with an error claiming that virtualization has an issue, display a more specific error so that the user has a better chance of resolving the problem. (In this case, the error message from `wsl.exe` is decent.)