### PR TITLE
Refactoring: Create LimaKubernetesBackend

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -19,7 +19,7 @@ import tar from 'tar-stream';
 import yaml from 'yaml';
 
 import {
-  Architecture, BackendError, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMExecutor,
+  Architecture, BackendError, BackendEvents, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
 } from './backend';
 import BackendHelper from './backendHelper';
 import K3sHelper, { NoCachedK3sVersionsError, ShortVersion } from './k3sHelper';
@@ -205,6 +205,9 @@ const LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/zzzzz-rancher-desktop-lima
 // Filename used in versions 1.0.0 and earlier:
 const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-lima';
 
+// Version from LimaKubernetesBackend.download to indicate that download aborted.
+const INVALID_VERSION = Symbol('Invalid version');
+
 /**
  * LimaBackend implements all the Lima-specific functionality for Rancher
  * Desktop.  This is used on macOS and Linux.
@@ -217,17 +220,12 @@ const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-l
 // (though this loses the type guarantees around it not modifying the instance).
 // [1]: https://www.typescriptlang.org/docs/handbook/2/classes.html#this-parameters
 // [2]: https://github.com/microsoft/TypeScript/issues/46802
-export default class LimaBackend extends events.EventEmitter implements K8s.KubernetesBackend, VMExecutor {
+export default class LimaBackend extends events.EventEmitter implements VMBackend, VMExecutor {
   constructor(arch: Architecture, dockerDirManager: DockerDirManager) {
     super();
     this.arch = arch;
     this.dockerDirManager = dockerDirManager;
-    this.k3sHelper = new K3sHelper(arch);
-    this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
-    this.k3sHelper.initialize().catch((err) => {
-      console.log('k3sHelper.initialize failed: ', err);
-    });
-    mainEvents.on('network-ready', () => this.k3sHelper.networkReady());
+    this.kubeBackend = new LimaKubernetesBackend(arch, this);
 
     this.progressTracker = new ProgressTracker((progress) => {
       this.progress = progress;
@@ -242,7 +240,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     }
   }
 
-  readonly kubeBackend = this;
+  readonly kubeBackend: LimaKubernetesBackend;
   readonly executor = this;
 
   protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
@@ -258,9 +256,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /** The version of Kubernetes currently running. */
   protected activeVersion: semver.SemVer | null = null;
 
-  /** The port Kubernetes is actively listening on. */
-  protected currentPort = 0;
-
   /** Whether we can prompt the user for administrative access - this setting persists in the config. */
   #allowSudo = true;
 
@@ -275,26 +270,16 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     this.#noModalDialogs = value;
   }
 
-  /** Helper object to manage available K3s versions. */
-  protected readonly k3sHelper: K3sHelper;
-
-  protected client: KubeClient | null = null;
-
   /** Helper object to manage progress notifications. */
-  protected progressTracker;
-
-  /** Interval handle to update the progress. */
-  // The return type is odd because TypeScript is pulling in some of the DOM
-  // definitions here, which has an incompatible setInterval/clearInterval.
-  protected progressInterval: ReturnType<typeof timers.setInterval> | undefined;
+  progressTracker;
 
   /**
    * The current operation underway; used to avoid responding to state changes
    * when we're in the process of doing a different one.
    */
-  protected currentAction: Action = Action.NONE;
+  currentAction: Action = Action.NONE;
 
-  protected writeSetting(changed: RecursivePartial<typeof this.cfg>) {
+  writeSetting(changed: RecursivePartial<typeof this.cfg>) {
     mainEvents.emit('settings-write', { kubernetes: changed });
     this.cfg = merge({}, this.cfg, changed);
   }
@@ -312,14 +297,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     case State.STOPPED:
     case State.ERROR:
     case State.DISABLED:
-      this.client?.destroy();
+      this.kubeBackend.stop();
     }
   }
 
   progress: BackendProgress = { current: 0, max: 0 };
-
-  /** Process for tailing logs */
-  protected logProcess: childProcess.ChildProcess | null = null;
 
   debug = false;
 
@@ -327,18 +309,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
   get backend(): 'lima' {
     return 'lima';
-  }
-
-  get version(): ShortVersion {
-    return this.activeVersion?.version ?? '';
-  }
-
-  get availableVersions(): Promise<K8s.VersionEntry[]> {
-    return this.k3sHelper.availableVersions;
-  }
-
-  async cachedVersionsOnly(): Promise<boolean> {
-    return await K3sHelper.cachedVersionsOnly();
   }
 
   get cpus(): Promise<number> {
@@ -353,10 +323,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     })();
   }
 
-  get desiredPort() {
-    return this.cfg?.port ?? 6443;
-  }
-
   protected async ensureArchitectureMatch() {
     if (os.platform().startsWith('darwin')) {
       // Normally, `file` command returns "... executable arm64" or "... executable x86_64"
@@ -364,7 +330,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       // error message to stdout, and returns exit code 0 (overridable with a `-E` flag on newer
       // versions of macos). Best to do our own check before invoking `file':
       try {
-        await fs.promises.access(LimaBackend.limactl, fs.constants.R_OK);
+        await fs.promises.access(LimaBackend.limactl, fs.constants.X_OK);
       } catch (err: any) {
         switch (err.code) {
         case 'ENOENT':
@@ -435,34 +401,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
       // Assume any of the addresses works to connect to the apiserver, so pick the first one.
       return addresses[0];
-    })();
-  }
-
-  get desiredVersion(): Promise<semver.SemVer> {
-    return (async() => {
-      const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
-      const storedVersion = semver.parse(this.cfg?.version);
-      const version = storedVersion ?? availableVersions[0];
-
-      if (!version) {
-        throw new Error('No version available');
-      }
-
-      const matchedVersion = availableVersions.find(v => v.compare(version) === 0);
-
-      if (matchedVersion) {
-        if (!storedVersion) {
-          // No (valid) stored version; save the selected one.
-          this.writeSetting({ version: matchedVersion.version });
-        }
-
-        return matchedVersion;
-      }
-
-      console.error(`Could not use saved version ${ version.raw }, not in ${ availableVersions }`);
-      this.writeSetting({ version: availableVersions[0].version });
-
-      return availableVersions[0];
     })();
   }
 
@@ -735,7 +673,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /**
    * Run `limactl` with the given arguments.
    */
-  protected async lima(this: Readonly<this>, ...args: string[]): Promise<void> {
+  async lima(this: Readonly<this>, ...args: string[]): Promise<void> {
     args = this.debug ? ['--debug'].concat(args) : args;
     try {
       const { stdout, stderr } = await childProcess.spawnFile(LimaBackend.limactl, args,
@@ -1294,33 +1232,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return JSON.parse(stdout).SPNetworkDataType;
   }
 
-  /**
-   * Install K3s into the VM for execution.
-   * @param version The version to install.
-   */
-  protected async installK3s(version: semver.SemVer) {
-    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-k3s-install-'));
-
-    try {
-      const scriptPath = path.join(workdir, 'install-k3s');
-      const k3s = this.arch === 'aarch64' ? 'k3s-arm64' : 'k3s';
-
-      await fs.promises.writeFile(scriptPath, INSTALL_K3S_SCRIPT, { encoding: 'utf-8' });
-      await this.execCommand('mkdir', '-p', 'bin');
-      await this.lima('copy', scriptPath, `${ MACHINE_NAME }:bin/install-k3s`);
-      await this.execCommand('chmod', 'a+x', 'bin/install-k3s');
-      if (this.cfg?.enabled) {
-        await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
-        await this.execCommand({ root: true }, 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
-      }
-      const profilePath = path.join(paths.resources, 'scripts', 'profile');
-
-      await this.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
-    } finally {
-      await fs.promises.rm(workdir, { recursive: true });
-    }
-  }
-
   protected async configureContainerd(): Promise<void> {
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-containerd-install-'));
 
@@ -1349,7 +1260,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    * @param fileContents The contents of the file.
    * @param permissions The file permissions.
    */
-  protected async writeFile(filePath: string, fileContents: string, permissions: fs.Mode = 0o644) {
+  async writeFile(filePath: string, fileContents: string, permissions: fs.Mode = 0o644) {
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `rd-${ path.basename(filePath) }-`));
     const tempPath = `/tmp/${ path.basename(workdir) }.${ path.basename(filePath) }`;
 
@@ -1369,7 +1280,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
   /**
    * Get IPv4 address for specified interface.
    */
-  protected async getInterfaceAddr(iface: string) {
+  async getInterfaceAddr(iface: string) {
     try {
       const ipAddr = await this.execCommand({ capture: true },
         'ip', '--family', 'inet', 'addr', 'show', iface);
@@ -1380,6 +1291,35 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       console.error(`Could not get address for ${ iface }: ${ ex?.stderr || ex }`);
 
       return '';
+    }
+  }
+
+  /**
+   * Get the network interface to listen on for services; used for flannel
+   * configuration.
+   */
+  async getListeningInterface() {
+    const bridgedIP = await this.getInterfaceAddr('rd0');
+
+    if (bridgedIP) {
+      console.log(`Using ${ bridgedIP } on bridged network rd0`);
+
+      return 'rd0';
+    } else {
+      const sharedIP = await this.getInterfaceAddr('rd1');
+
+      if (!this.cfg?.suppressSudo) {
+        await this.noBridgedNetworkDialog(sharedIP);
+      }
+      if (sharedIP) {
+        console.log(`Using ${ sharedIP } on shared network rd1`);
+
+        return 'rd1';
+      } else {
+        console.log(`Neither bridged network rd0 nor shared network rd1 have an IPv4 address`);
+
+        return 'eth0';
+      }
     }
   }
 
@@ -1402,55 +1342,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
     return Promise.resolve();
   }
 
-  /**
-   * Write the openrc script for k3s.
-   */
-  protected async writeServiceScript() {
-    const config: Record<string, string> = {
-      PORT:            this.desiredPort.toString(),
-      ENGINE:          this.cfg?.containerEngine ?? ContainerEngine.NONE,
-      ADDITIONAL_ARGS: '',
-    };
-
-    if (this.#allowSudo && os.platform() === 'darwin') {
-      if (this.cfg?.options.flannel) {
-        const bridgedIP = await this.getInterfaceAddr('rd0');
-
-        if (bridgedIP) {
-          config.ADDITIONAL_ARGS += '--flannel-iface rd0';
-          console.log(`Using ${ bridgedIP } on bridged network rd0`);
-        } else {
-          const sharedIP = await this.getInterfaceAddr('rd1');
-
-          if (!this.cfg?.suppressSudo) {
-            await this.noBridgedNetworkDialog(sharedIP);
-          }
-          if (sharedIP) {
-            config.ADDITIONAL_ARGS += '--flannel-iface rd1';
-            console.log(`Using ${ sharedIP } on shared network rd1`);
-          } else {
-            config.ADDITIONAL_ARGS += '--flannel-iface eth0';
-            console.log(`Neither bridged network rd0 nor shared network rd1 have an IPv4 address`);
-          }
-        }
-      } else {
-        console.log(`Disabling flannel and network policy`);
-        config.ADDITIONAL_ARGS += '--flannel-backend=none --disable-network-policy';
-      }
-    }
-    if (!this.cfg?.options.traefik) {
-      config.ADDITIONAL_ARGS += ' --disable traefik';
-    }
-    await this.writeFile('/etc/init.d/cri-dockerd', SERVICE_CRI_DOCKERD_SCRIPT, 0o755);
-    await this.writeConf('cri-dockerd', {
-      LOG_DIR:         paths.logs,
-      ENGINE:  this.cfg?.containerEngine ?? ContainerEngine.NONE,
-    });
-    await this.writeFile('/etc/init.d/k3s', SERVICE_K3S_SCRIPT, 0o755);
-    await this.writeConf('k3s', config);
-    await this.writeFile('/etc/logrotate.d/k3s', LOGROTATE_K3S_SCRIPT);
-  }
-
   protected async writeBuildkitScripts() {
     await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, 0o755);
     await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF, 0o644);
@@ -1461,7 +1352,7 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
    * @param service The name of the OpenRC service to configure.
    * @param settings A mapping of configuration values.  This should be shell escaped.
    */
-  protected async writeConf(service: string, settings: Record<string, string>) {
+  async writeConf(service: string, settings: Record<string, string>) {
     const contents = Object.entries(settings).map(([key, value]) => `${ key }="${ value }"\n`).join('');
 
     await this.writeFile(`/etc/conf.d/${ service }`, contents);
@@ -1494,46 +1385,6 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       })(),
     ]);
     await this.execCommand({ root: true }, '/sbin/rc-service', 'rancher-desktop-guestagent', 'restart');
-  }
-
-  protected async followLogs() {
-    try {
-      this.logProcess?.kill('SIGTERM');
-    } catch (ex) { }
-    let args = ['shell', '--workdir=.', MACHINE_NAME,
-      '/usr/bin/tail', '-n+1', '-F', '/var/log/k3s.log'];
-
-    args = this.debug ? ['--debug'].concat(args) : args;
-    this.logProcess = childProcess.spawn(
-      LimaBackend.limactl,
-      args,
-      {
-        env:   LimaBackend.limaEnv,
-        stdio: ['ignore', await Logging.k3s.fdStream, await Logging.k3s.fdStream],
-      },
-    );
-    this.logProcess.on('exit', (status, signal) => {
-      this.logProcess = null;
-      if (![Action.STARTING, Action.NONE].includes(this.currentAction)) {
-        // Allow the log process to exit if we're stopping
-        return;
-      }
-      if (![State.STARTING, State.STARTED].includes(this.state)) {
-        // Allow the log process to exit if we're not active.
-        return;
-      }
-      console.log(`Log process exited with ${ status }/${ signal }, restarting...`);
-      setTimeout(this.followLogs.bind(this), 1_000);
-    });
-  }
-
-  protected async deleteIncompatibleData(isDowngrade: boolean) {
-    if (isDowngrade) {
-      await this.progressTracker.action(
-        'Deleting incompatible Kubernetes state',
-        100,
-        this.k3sHelper.deleteKubeState(this));
-    }
   }
 
   /**
@@ -1585,9 +1436,8 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
 
   async start(config_: RecursiveReadonly<BackendSettings>): Promise<void> {
     const config = this.cfg = clone(config_);
-    let desiredVersion = await this.desiredVersion;
-    const previousVersion = (await this.getLimaConfig())?.k3s?.version;
-    const isDowngrade = previousVersion ? semver.gt(previousVersion, desiredVersion) : false;
+    let kubernetesVersion: semver.SemVer | undefined;
+    let isDowngrade = false;
 
     this.setState(State.STARTING);
     this.currentAction = Action.STARTING;
@@ -1596,81 +1446,30 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       try {
         await this.ensureArchitectureMatch();
         if (config.enabled) {
-          if (this.progressInterval) {
-            timers.clearInterval(this.progressInterval);
-          }
-          this.progressInterval = timers.setInterval(() => {
-            const statuses = [
-              this.k3sHelper.progress.checksum,
-              this.k3sHelper.progress.exe,
-              this.k3sHelper.progress.images,
-            ];
-            const sum = (key: 'current' | 'max') => {
-              return statuses.reduce((v, c) => v + c[key], 0);
-            };
+          const [version, downgrade] = await this.kubeBackend.download();
 
-            this.progressTracker.numeric('Downloading Kubernetes components', sum('current'), sum('max'));
-          }, 250);
+          if (version === INVALID_VERSION) {
+            // The desired version was unavailable, and the user declined a downgrade.
+            this.setState(State.ERROR);
+
+            return;
+          }
+          [kubernetesVersion, isDowngrade] = [version, downgrade];
         }
 
         await Promise.all([
           this.progressTracker.action('Ensuring virtualization is supported', 50, this.ensureVirtualizationSupported()),
-          this.progressTracker.action('Updating cluster configuration', 50, this.updateConfig(desiredVersion)),
+          this.progressTracker.action('Updating cluster configuration', 50, this.updateConfig(kubernetesVersion)),
         ]);
-        if (config.enabled) {
-          try {
-            await this.progressTracker.action('Checking k3s images', 100, this.k3sHelper.ensureK3sImages(desiredVersion));
-          } catch (ex:any) {
-            console.log(`Failed to find version ${ desiredVersion.raw }: ${ ex }`, ex);
-            if (!(await checkConnectivity('github.com'))) {
-              try {
-                const newVersion: semver.SemVer = await K3sHelper.selectClosestImage(desiredVersion);
-
-                if (semver.lt(newVersion, desiredVersion)) {
-                  const options: Electron.MessageBoxOptions = {
-                    message:   `Downgrading from ${ desiredVersion.raw } to ${ newVersion.raw } will lose existing Kubernetes workloads. Delete the data?`,
-                    type:      'question',
-                    buttons:   ['Delete Workloads', 'Cancel'],
-                    defaultId: 1,
-                    title:     'Confirming migration',
-                    cancelId:  1,
-                  };
-                  const result = await showMessageBox(options, true);
-
-                  if (result.response !== 0) {
-                    this.setState(State.ERROR);
-
-                    return;
-                  }
-                }
-                console.log(`Going with version ${ newVersion.raw }`);
-                this.writeSetting({ version: newVersion.version });
-                desiredVersion = newVersion;
-              } catch (ex: any) {
-                if (ex instanceof NoCachedK3sVersionsError) {
-                  throw new BackendError('No version available', 'The k3s cache is empty and there is no network connection.');
-                } else {
-                  throw ex;
-                }
-              }
-            } else {
-              throw ex;
-            }
-          }
-        }
 
         if (this.currentAction !== Action.STARTING) {
           // User aborted before we finished
           return;
         }
 
-        // We have no good estimate for the rest of the steps, go indeterminate.
-        timers.clearInterval(this.progressInterval as ReturnType<typeof timers.setInterval>);
-        this.progressInterval = undefined;
-
         if ((await this.status)?.status === 'Running') {
           await this.progressTracker.action('Stopping existing instance', 100, async() => {
-            await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
+            await this.kubeBackend.stop();
             if (isDowngrade) {
               // If we're downgrading, stop the VM (and start it again immediately),
               // to ensure there are no containers running (so we can delete files).
@@ -1682,25 +1481,22 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         // Start the VM; if it's already running, this does nothing.
         await this.startVM();
 
-        await this.deleteIncompatibleData(isDowngrade);
         await this.progressTracker.action('Configuring containerd', 50, this.configureContainerd());
         if (config.containerEngine === ContainerEngine.CONTAINERD) {
           await this.startService('containerd');
         } else if (config.containerEngine === ContainerEngine.MOBY) {
           await this.startService('docker');
         }
-        // Always install the k3s config files
-        await this.progressTracker.action('Installing k3s', 50, async() => {
-          await this.installK3s(desiredVersion);
-          await this.writeServiceScript();
-        });
+        if (kubernetesVersion) {
+          await this.kubeBackend.install(config, kubernetesVersion, isDowngrade, this.#allowSudo);
+        }
 
         await this.progressTracker.action('Installing Buildkit', 50, this.writeBuildkitScripts());
         await Promise.all([
           this.progressTracker.action('Installing image scanner', 50, this.installTrivy()),
           this.progressTracker.action('Installing CA certificates', 50, this.installCACerts()),
           this.progressTracker.action('Installing credential helper', 50, this.installCredentialHelper()),
-          this.progressTracker.action('Installing guest agent', 50, this.installGuestAgent(config.enabled ? desiredVersion : undefined)),
+          this.progressTracker.action('Installing guest agent', 50, this.installGuestAgent(kubernetesVersion)),
           this.progressTracker.action('Fixing binfmt_misc qemu', 50, async() => {
             await this.writeFile('/etc/conf.d/qemu-binfmt', 'binfmt_flags="POCF"');
             await this.execCommand({ root: true }, '/sbin/rc-service', 'qemu-binfmt', 'restart');
@@ -1715,132 +1511,10 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
         /** k3sEndpoint is the Kubernetes endpoint we want to use for the docker config. */
         let k3sEndpoint: string | undefined;
 
-        if (config.enabled) {
-          // Remove flannel config if necessary, before starting k3s
-          if (!this.cfg?.options.flannel) {
-            await this.execCommand({ root: true }, 'rm', '-f', '/etc/cni/net.d/10-flannel.conflist');
-          }
-
-          await this.progressTracker.action('Starting k3s', 100, async() => {
-            // Run rc-update as we have dynamic dependencies.
-            await this.execCommand({ root: true }, '/sbin/rc-update', '--update');
-            await this.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
-            await this.followLogs();
-          });
-
-          await this.progressTracker.action(
-            'Waiting for Kubernetes API',
-            100,
-            async() => {
-              await this.k3sHelper.waitForServerReady(() => Promise.resolve('127.0.0.1'), config.port);
-              while (true) {
-                if (this.currentAction !== Action.STARTING) {
-                  // User aborted
-                  return;
-                }
-                try {
-                  let args = ['shell', '--workdir=.', MACHINE_NAME,
-                    'ls', '/etc/rancher/k3s/k3s.yaml'];
-
-                  args = this.debug ? ['--debug'].concat(args) : args;
-                  await childProcess.spawnFile(LimaBackend.limactl, args,
-                    { env: LimaBackend.limaEnv, stdio: 'ignore' });
-                  break;
-                } catch (ex) {
-                  console.log('Configuration /etc/rancher/k3s/k3s.yaml not present in lima vm; will check again...');
-                  await util.promisify(setTimeout)(1_000);
-                }
-              }
-              console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
-            },
-          );
-          await this.progressTracker.action(
-            'Updating kubeconfig',
-            50,
-            this.k3sHelper.updateKubeconfig(
-              async() => {
-                const k3sConfigString = await this.execCommand({ capture: true, root: true }, 'cat', '/etc/rancher/k3s/k3s.yaml');
-                const k3sConfig = yaml.parse(k3sConfigString);
-
-                k3sEndpoint = k3sConfig?.clusters?.[0]?.cluster?.server;
-
-                return k3sConfigString;
-              }));
-
-          this.client = new KubeClient();
-
-          await this.progressTracker.action(
-            'Waiting for services',
-            50,
-            async() => {
-              const client = this.client as KubeClient;
-
-              await client.waitForServiceWatcher();
-              client.on('service-changed', (services) => {
-                this.emit('service-changed', services);
-              });
-              client.on('service-error', (service, errorMessage) => {
-                this.emit('service-error', service, errorMessage);
-              });
-            },
-          );
-
-          this.activeVersion = desiredVersion;
-          this.currentPort = config.port;
-          this.emit('current-port-changed', this.currentPort);
-
-          // Remove traefik if necessary.
-          if (!this.cfg?.options.traefik) {
-            await this.progressTracker.action(
-              'Removing Traefik',
-              50,
-              this.k3sHelper.uninstallTraefik(this.client));
-          }
-
-          await this.k3sHelper.getCompatibleKubectlVersion(this.activeVersion);
-          if (this.cfg?.options.flannel) {
-            await this.progressTracker.action(
-              'Waiting for nodes',
-              100,
-              async() => {
-                if (!await this.client?.waitForReadyNodes()) {
-                  throw new Error('No client');
-                }
-              });
-          } else {
-            await this.progressTracker.action(
-              'Skipping node checks, flannel is disabled',
-              100,
-              async() => {
-                await new Promise(resolve => setTimeout(resolve, 5000));
-              });
-          }
+        if (kubernetesVersion) {
+          k3sEndpoint = await this.kubeBackend.start(config, kubernetesVersion);
         }
 
-        // We can't install buildkitd earlier because if we were running an older version of rancher-desktop,
-        // we have to remove the kim buildkitd k8s artifacts. And we can't remove them until k8s is running.
-        // Note that if the user's workflow is:
-        // A. Only containerd
-        // settings version 3: containerd (which installs buildkitd)
-        // upgrade to settings version 4, still on containerd:
-        //   - remove the old kim/buildkitd artifacts
-        //   - set config.kubernetes.checkForExistingKimBuilder to false (forever)
-
-        // B. Mix of containerd and moby
-        // settings version 3: containerd (which installs buildkitd)
-        // settings version 3: switch to moby (which will uninstall buildkitd)
-        // upgrade to settings version 4, still on moby: do nothing here
-        // settings version 4, switch to containerd
-        //   - config.kubernetes.checkForExistingKimBuilder should be true, but there are no kim/buildkitd artifacts
-        //   - do nothing, and set config.kubernetes.checkForExistingKimBuilder to false (forever)
-
-        if (config.checkForExistingKimBuilder && config.enabled) {
-          this.client ??= new KubeClient();
-          await getImageProcessor(config.containerEngine, this).removeKimBuilder(this.client.k8sClient);
-          // No need to remove kim builder components ever again.
-          this.writeSetting({ checkForExistingKimBuilder: false });
-          this.emit('kim-builder-uninstalled');
-        }
         if (config.containerEngine === ContainerEngine.MOBY) {
           await this.dockerDirManager.ensureDockerContextConfigured(
             this.#allowSudo,
@@ -1854,6 +1528,11 @@ export default class LimaBackend extends events.EventEmitter implements K8s.Kube
       } catch (err) {
         console.error('Error starting lima:', err);
         this.setState(State.ERROR);
+        if (err instanceof BackendError) {
+          if (!err.fatal) {
+            return;
+          }
+        }
         throw err;
       } finally {
         this.currentAction = Action.NONE;
@@ -2029,7 +1708,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       await this.stop();
       // Start the VM, so that we can delete files.
       await this.startVM();
-      await this.k3sHelper.deleteKubeState(this);
+      await this.kubeBackend.reset();
       await this.start(config);
     });
   }
@@ -2067,11 +1746,435 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       return {}; // No need to restart if nothing exists
     }
 
+    return this.kubeBackend.requiresRestartReasons(this.cfg, cfg, limaConfig);
+  }
+
+  async getFailureDetails(exception: any): Promise<FailureDetails> {
+    const logfile = console.path;
+    const logLines = (await fs.promises.readFile(logfile, 'utf-8')).split('\n').slice(-10);
+
+    return {
+      lastCommand:        exception[childProcess.ErrorCommand],
+      lastCommandComment: getProgressErrorDescription(exception) ?? 'Unknown',
+      lastLogLines:       logLines,
+    };
+  }
+
+  // #region Events
+  eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
+    return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
+  }
+
+  listeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.listeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+
+  rawListeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+    event: eventName,
+  ): K8s.KubernetesBackendEvents[eventName][] {
+    return super.rawListeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  }
+  // #endregion
+}
+
+class LimaKubernetesBackend extends events.EventEmitter implements K8s.KubernetesBackend {
+  constructor(arch: Architecture, vm: LimaBackend) {
+    super();
+    this.arch = arch;
+    this.vm = vm;
+
+    this.k3sHelper = new K3sHelper(arch);
+    this.k3sHelper.on('versions-updated', () => this.emit('versions-updated'));
+    this.k3sHelper.initialize().catch((err) => {
+      console.log('k3sHelper.initialize failed: ', err);
+    });
+    mainEvents.on('network-ready', () => this.k3sHelper.networkReady());
+  }
+
+  /**
+   * Download K3s images.  This will also calculate the version to download.
+   * @returns The version of K3s images downloaded, and whether this is a
+   * downgrade.
+   */
+  async download(): Promise<[semver.SemVer | typeof INVALID_VERSION, boolean]> {
+    const interval = timers.setInterval(() => {
+      const statuses = [
+        this.k3sHelper.progress.checksum,
+        this.k3sHelper.progress.exe,
+        this.k3sHelper.progress.images,
+      ];
+      const sum = (key: 'current' | 'max') => {
+        return statuses.reduce((v, c) => v + c[key], 0);
+      };
+
+      const current = sum('current');
+      const max = sum('max');
+
+      this.progressTracker.numeric('Downloading Kubernetes components', current, max);
+    });
+
+    try {
+      const desiredVersion = await this.desiredVersion;
+
+      try {
+        await this.progressTracker.action('Checking k3s images', 100, this.k3sHelper.ensureK3sImages(desiredVersion));
+
+        return [desiredVersion, false];
+      } catch (ex) {
+        if (!await checkConnectivity('github.com')) {
+          throw ex;
+        }
+
+        try {
+          const newVersion = await K3sHelper.selectClosestImage(desiredVersion);
+          const isDowngrade = semver.lt(newVersion, desiredVersion);
+
+          if (isDowngrade) {
+            const options: Electron.MessageBoxOptions = {
+              message:   `Downgrading from ${ desiredVersion.raw } to ${ newVersion.raw } will lose existing Kubernetes workloads. Delete the data?`,
+              type:      'question',
+              buttons:   ['Delete Workloads', 'Cancel'],
+              defaultId: 1,
+              title:     'Confirming migration',
+              cancelId:  1,
+            };
+            const result = await showMessageBox(options, true);
+
+            if (result.response !== 0) {
+              return [INVALID_VERSION, false];
+            }
+          }
+          console.log(`Going with alternative version ${ newVersion.raw }`);
+
+          return [newVersion, isDowngrade];
+        } catch (ex: any) {
+          if (ex instanceof NoCachedK3sVersionsError) {
+            throw new K8s.KubernetesError('No version available', 'The k3s cache is empty and there is no network connection.');
+          }
+          throw ex;
+        }
+      }
+    } finally {
+      timers.clearInterval(interval);
+    }
+  }
+
+  /**
+   * Install the Kubernetes files.
+   */
+  async install(config: RecursiveReadonly<BackendSettings>, desiredVersion: semver.SemVer, isDowngrade: boolean, allowSudo: boolean) {
+    await this.deleteIncompatibleData(isDowngrade);
+
+    await this.progressTracker.action('Installing k3s', 50, async() => {
+      await this.installK3s(desiredVersion);
+      await this.writeServiceScript(config, allowSudo);
+    });
+
+    this.activeVersion = desiredVersion;
+  }
+
+  /**
+   * Start Kubernetes.
+   * @returns The Kubernetes endpoint
+   */
+  async start(config_: RecursiveReadonly<BackendSettings>, kubernetesVersion: semver.SemVer): Promise<string> {
+    const config = this.cfg = clone(config_);
+    let k3sEndpoint = '';
+
+    // Remove flannel config if necessary, before starting k3s
+    if (!config.options.flannel) {
+      await this.vm.execCommand({ root: true }, 'rm', '-f', '/etc/cni/net.d/10-flannel.conflist');
+    }
+
+    await this.progressTracker.action('Starting k3s', 100, async() => {
+      // Run rc-update as we have dynamic dependencies.
+      await this.vm.execCommand({ root: true }, '/sbin/rc-update', '--update');
+      await this.vm.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
+      await this.followLogs();
+    });
+
+    await this.progressTracker.action(
+      'Waiting for Kubernetes API',
+      100,
+      async() => {
+        await this.k3sHelper.waitForServerReady(() => Promise.resolve('127.0.0.1'), config.port);
+        while (true) {
+          if (this.vm.currentAction !== Action.STARTING) {
+            // User aborted
+            return;
+          }
+          try {
+            await this.vm.execCommand({ expectFailure: true }, 'ls', '/etc/rancher/k3s/k3s.yaml');
+            break;
+          } catch (ex) {
+            console.log('Configuration /etc/rancher/k3s/k3s.yaml not present in lima vm; will check again...');
+            await util.promisify(setTimeout)(1_000);
+          }
+        }
+        console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
+      },
+    );
+    await this.progressTracker.action(
+      'Updating kubeconfig',
+      50,
+      this.k3sHelper.updateKubeconfig(
+        async() => {
+          const k3sConfigString = await this.vm.execCommand({ capture: true, root: true }, 'cat', '/etc/rancher/k3s/k3s.yaml');
+          const k3sConfig = yaml.parse(k3sConfigString);
+
+          k3sEndpoint = k3sConfig?.clusters?.[0]?.cluster?.server;
+
+          return k3sConfigString;
+        }));
+
+    this.client = new KubeClient();
+
+    await this.progressTracker.action(
+      'Waiting for services',
+      50,
+      async() => {
+        const client = this.client as KubeClient;
+
+        await client.waitForServiceWatcher();
+        client.on('service-changed', (services) => {
+          this.emit('service-changed', services);
+        });
+        client.on('service-error', (service, errorMessage) => {
+          this.emit('service-error', service, errorMessage);
+        });
+      },
+    );
+
+    this.activeVersion = kubernetesVersion;
+    this.currentPort = config.port;
+    this.emit('current-port-changed', this.currentPort);
+
+    // Remove traefik if necessary.
+    if (!this.cfg?.options.traefik) {
+      await this.progressTracker.action(
+        'Removing Traefik',
+        50,
+        this.k3sHelper.uninstallTraefik(this.client));
+    }
+
+    await this.k3sHelper.getCompatibleKubectlVersion(this.activeVersion);
+    if (this.cfg?.options.flannel) {
+      await this.progressTracker.action(
+        'Waiting for nodes',
+        100,
+        async() => {
+          if (!await this.client?.waitForReadyNodes()) {
+            throw new Error('No client');
+          }
+        });
+    } else {
+      await this.progressTracker.action(
+        'Skipping node checks, flannel is disabled',
+        100,
+        async() => {
+          await new Promise(resolve => setTimeout(resolve, 5000));
+        });
+    }
+
+    // We can't install buildkitd earlier because if we were running an older version of rancher-desktop,
+    // we have to remove the kim buildkitd k8s artifacts. And we can't remove them until k8s is running.
+    // Note that if the user's workflow is:
+    // A. Only containerd
+    // settings version 3: containerd (which installs buildkitd)
+    // upgrade to settings version 4, still on containerd:
+    //   - remove the old kim/buildkitd artifacts
+    //   - set config.kubernetes.checkForExistingKimBuilder to false (forever)
+
+    // B. Mix of containerd and moby
+    // settings version 3: containerd (which installs buildkitd)
+    // settings version 3: switch to moby (which will uninstall buildkitd)
+    // upgrade to settings version 4, still on moby: do nothing here
+    // settings version 4, switch to containerd
+    //   - config.kubernetes.checkForExistingKimBuilder should be true, but there are no kim/buildkitd artifacts
+    //   - do nothing, and set config.kubernetes.checkForExistingKimBuilder to false (forever)
+
+    if (config.checkForExistingKimBuilder) {
+      this.client ??= new KubeClient();
+      await getImageProcessor(config.containerEngine, this.vm).removeKimBuilder(this.client.k8sClient);
+      // No need to remove kim builder components ever again.
+      this.vm.writeSetting({ checkForExistingKimBuilder: false });
+      this.emit('kim-builder-uninstalled');
+    }
+
+    return k3sEndpoint;
+  }
+
+  protected async followLogs() {
+    try {
+      this.logProcess?.kill('SIGTERM');
+    } catch (ex) { }
+    this.logProcess = this.vm.spawn(
+      { logStream: await Logging.k3s.fdStream },
+      '/usr/bin/tail', '-n+1', '-F', '/var/log/k3s.log');
+    this.logProcess.on('exit', (status, signal) => {
+      this.logProcess = null;
+      if (![Action.STARTING, Action.NONE].includes(this.vm.currentAction)) {
+        // Allow the log process to exit if we're stopping
+        return;
+      }
+      if (![State.STARTING, State.STARTED].includes(this.vm.state)) {
+        // Allow the log process to exit if we're not active.
+        return;
+      }
+      console.log(`Log process exited with ${ status }/${ signal }, restarting...`);
+      setTimeout(this.followLogs.bind(this), 1_000);
+    });
+  }
+
+  async stop() {
+    await this.vm.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
+    this.client?.destroy();
+  }
+
+  async reset() {
+    await this.k3sHelper.deleteKubeState(this.vm);
+  }
+
+  protected cfg: RecursiveReadonly<BackendSettings> | undefined;
+
+  protected readonly arch: Architecture;
+  protected readonly vm: LimaBackend;
+  protected activeVersion?: semver.SemVer;
+
+  /** The port Kubernetes is actively listening on. */
+  protected currentPort = 0;
+
+  /** Helper object to manage available K3s versions. */
+  protected readonly k3sHelper: K3sHelper;
+
+  protected client: KubeClient | null = null;
+
+  /** Process for tailing logs */
+  protected logProcess: childProcess.ChildProcess | null = null;
+
+  protected get progressTracker() {
+    return this.vm.progressTracker;
+  }
+
+  get version(): ShortVersion {
+    return this.activeVersion?.version ?? '';
+  }
+
+  get availableVersions(): Promise<K8s.VersionEntry[]> {
+    return this.k3sHelper.availableVersions;
+  }
+
+  async cachedVersionsOnly(): Promise<boolean> {
+    return await K3sHelper.cachedVersionsOnly();
+  }
+
+  get desiredPort() {
+    return this.cfg?.port ?? 6443;
+  }
+
+  protected get desiredVersion(): Promise<semver.SemVer> {
+    return (async() => {
+      const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
+      const storedVersion = semver.parse(this.cfg?.version);
+      const version = storedVersion ?? availableVersions[0];
+
+      if (!version) {
+        throw new Error('No version available');
+      }
+
+      const matchedVersion = availableVersions.find(v => v.compare(version) === 0);
+
+      if (matchedVersion) {
+        if (!storedVersion) {
+          // No (valid) stored version; save the selected one.
+          this.vm.writeSetting({ version: matchedVersion.version });
+        }
+
+        return matchedVersion;
+      }
+
+      console.error(`Could not use saved version ${ version.raw }, not in ${ availableVersions }`);
+      this.vm.writeSetting({ version: availableVersions[0].version });
+
+      return availableVersions[0];
+    })();
+  }
+
+  /**
+   * Install K3s into the VM for execution.
+   * @param version The version to install.
+   */
+  protected async installK3s(version: semver.SemVer) {
+    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-k3s-install-'));
+
+    try {
+      const k3s = this.arch === 'aarch64' ? 'k3s-arm64' : 'k3s';
+
+      await this.vm.execCommand('mkdir', '-p', 'bin');
+      await this.vm.writeFile('bin/install-k3s', INSTALL_K3S_SCRIPT, 'a+x');
+      await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
+      await this.vm.execCommand({ root: true }, 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
+      const profilePath = path.join(paths.resources, 'scripts', 'profile');
+
+      await this.vm.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
+    } finally {
+      await fs.promises.rm(workdir, { recursive: true });
+    }
+  }
+
+  /**
+   * Write the openrc script for k3s.
+   */
+  protected async writeServiceScript(cfg: RecursiveReadonly<BackendSettings>, allowSudo: boolean) {
+    const config: Record<string, string> = {
+      PORT:            this.desiredPort.toString(),
+      ENGINE:          cfg.containerEngine ?? ContainerEngine.NONE,
+      ADDITIONAL_ARGS: '',
+    };
+
+    if (allowSudo && os.platform() === 'darwin') {
+      if (cfg.options.flannel) {
+        const iface = await this.vm.getListeningInterface();
+
+        config.ADDITIONAL_ARGS += `flannel-iface ${ iface }`;
+      } else {
+        console.log(`Disabling flannel and network policy`);
+        config.ADDITIONAL_ARGS += '--flannel-backend=none --disable-network-policy';
+      }
+    }
+    if (!cfg.options.traefik) {
+      config.ADDITIONAL_ARGS += ' --disable traefik';
+    }
+    await this.vm.writeFile('/etc/init.d/cri-dockerd', SERVICE_CRI_DOCKERD_SCRIPT, 0o755);
+    await this.vm.writeConf('cri-dockerd', {
+      LOG_DIR:         paths.logs,
+      ENGINE:  cfg.containerEngine ?? ContainerEngine.NONE,
+    });
+    await this.vm.writeFile('/etc/init.d/k3s', SERVICE_K3S_SCRIPT, 0o755);
+    await this.vm.writeConf('k3s', config);
+    await this.vm.writeFile('/etc/logrotate.d/k3s', LOGROTATE_K3S_SCRIPT);
+  }
+
+  protected async deleteIncompatibleData(isDowngrade: boolean) {
+    if (isDowngrade) {
+      await this.progressTracker.action(
+        'Deleting incompatible Kubernetes state',
+        100,
+        this.k3sHelper.deleteKubeState(this.vm));
+    }
+  }
+
+  async requiresRestartReasons(currentConfig: BackendSettings, desiredConfig: RecursivePartial<BackendSettings>, limaConfig: LimaConfiguration): Promise<RestartReasons> {
     const GiB = 1024 * 1024 * 1024;
 
+    // This is a placeholder to force this method to be async
+    await Promise.all([]);
+
     return this.k3sHelper.requiresRestartReasons(
-      this.cfg,
-      cfg,
+      currentConfig,
+      desiredConfig,
       {
         version: (current: string, desired: string) => {
           if (semver.gt(current, desired)) {
@@ -2106,18 +2209,78 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     await this.client?.cancelForwardPort(namespace, service, k8sPort);
   }
 
-  async getFailureDetails(exception: any): Promise<FailureDetails> {
-    const logfile = console.path;
-    const logLines = (await fs.promises.readFile(logfile, 'utf-8')).split('\n').slice(-10);
+  // #region Events
+  // #region Event forwarding
 
-    return {
-      lastCommand:        exception[childProcess.ErrorCommand],
-      lastCommandComment: getProgressErrorDescription(exception) ?? 'Unknown',
-      lastLogLines:       logLines,
-    };
+  protected eventForwarders: {
+    [k in keyof BackendEvents]?: BackendEvents[k];
+  } = {};
+
+  addListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
+    if (!(event in this.eventForwarders)) {
+      const baseListener = (...args: any[]) => {
+        this.emit(event, ...args);
+      };
+
+      this.vm.addListener(event, baseListener);
+    }
+
+    return super.addListener(event, listener);
   }
 
-  // #region Events
+  on<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
+    if (!(event in this.eventForwarders)) {
+      const baseListener = (...args: any[]) => {
+        this.emit(event, ...args);
+      };
+
+      this.vm.on(event, baseListener);
+    }
+
+    return super.on(event, listener);
+  }
+
+  once<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
+    if (!(event in this.eventForwarders)) {
+      const baseListener = (...args: any[]) => {
+        this.emit(event, ...args);
+        // This leaves a dangling listener
+      };
+
+      this.vm.on(event, baseListener);
+    }
+
+    return super.on(event, listener);
+  }
+
+  removeListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
+    super.removeListener(event, listener);
+    const eventName = event as keyof BackendEvents;
+    const baseListener = this.eventForwarders[eventName];
+
+    if (this.listenerCount(event) < 1 && baseListener) {
+      this.vm.removeListener(eventName, baseListener);
+      delete this.eventForwarders[eventName];
+    }
+
+    return this;
+  }
+
+  off<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
+    super.off(event, listener);
+    const eventName = event as keyof BackendEvents;
+    const baseListener = this.eventForwarders[eventName];
+
+    if (this.listenerCount(event) < 1 && baseListener) {
+      this.vm.off(eventName, baseListener);
+      delete this.eventForwarders[eventName];
+    }
+
+    return this;
+  }
+
+  // #endregion
+
   eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
     return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
   }


### PR DESCRIPTION
This splits out the Kubernetes backend from Lima.

Some notes:
- The new class is still in the same file for now — there will be a separate PR to move it out later.
- For now, a few methods on `LimaBackend` are made public for ease of refactoring.  The plan is to tighten things again once we have done the WSL backend too (to see any commonalities).
- Similarly, `LimaBackend` currently has a direct reference to `LimaKubernetesBackend`.  That will be made more abstract around the time it's split into a separate file.
- The event handling is icky at the moment because of the forwarding; once all backends are split we can limit the events and drop the forwarding.

As before, https://github.com/mook-as/rd/commits/refactor is the actual work-in-progress branch (where some of the points above has been resolved).