### PR TITLE
Diagnostics: Add docker CLI symlink checks.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -424,7 +424,7 @@ ipcMainProxy.on('api-get-credentials', () => {
   mainEvents.emit('api-get-credentials');
 });
 
-ipcMainProxy.on('update-network-status', async () => {
+ipcMainProxy.on('update-network-status', async() => {
   mainEvents.emit('update-network-status', await checkConnectivity('k3s.io'));
 });
 

--- a/background.ts
+++ b/background.ts
@@ -22,7 +22,7 @@ import { ImageEventHandler } from '@/main/imageEvents';
 import { getIpcMainProxy } from '@/main/ipcMain';
 import mainEvents from '@/main/mainEvents';
 import buildApplicationMenu from '@/main/mainmenu';
-import setupNetworking from '@/main/networking';
+import setupNetworking, { checkConnectivity } from '@/main/networking';
 import setupTray from '@/main/tray';
 import setupUpdate from '@/main/update';
 import * as childProcess from '@/utils/childProcess';
@@ -424,8 +424,8 @@ ipcMainProxy.on('api-get-credentials', () => {
   mainEvents.emit('api-get-credentials');
 });
 
-ipcMainProxy.on('update-network-status', (_, status) => {
-  mainEvents.emit('update-network-status', status);
+ipcMainProxy.on('update-network-status', async () => {
+  mainEvents.emit('update-network-status', await checkConnectivity('k3s.io'));
 });
 
 Electron.ipcMain.handle('api-get-credentials', () => {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -854,15 +854,17 @@ test.describe('Command server', () => {
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toMatchObject({
-            checks: [
+            checks: expect.arrayContaining([
               {
                 category:      'Networking',
                 id:            'CONNECTED_TO_INTERNET',
                 documentation: 'path#connected_to_internet',
                 description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
                 mute:          false,
+                fixes:         [],
+                passed:        expect.any(Boolean),
               },
-            ],
+            ]),
           });
         });
         test.skip('it finds all diagnostic checks for a category', async() => {

--- a/src/main/diagnostics/__tests__/diagnostics.spec.ts
+++ b/src/main/diagnostics/__tests__/diagnostics.spec.ts
@@ -5,6 +5,7 @@ describe(DiagnosticsManager, () => {
     {
       id:            'RD_BIN_IN_BASH_PATH',
       category:      DiagnosticsCategory.Utilities,
+      applicable: true,
       check:         () => Promise.resolve({
         documentation: 'path#rd_bin_bash',
         description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
@@ -15,6 +16,7 @@ describe(DiagnosticsManager, () => {
     {
       id:            'RD_BIN_SYMLINKS',
       category:      DiagnosticsCategory.Utilities,
+      applicable: true,
       check:         () => Promise.resolve({
         documentation: 'path#rd_bin_symlinks',
         description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
@@ -25,6 +27,7 @@ describe(DiagnosticsManager, () => {
     {
       id:            'CONNECTED_TO_INTERNET',
       category:      DiagnosticsCategory.Networking,
+      applicable: true,
       check:         () => Promise.resolve({
         documentation: 'path#connected_to_internet',
         description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -6,6 +6,7 @@ let online = false;
 
 mainEvents.on('update-network-status', (status) => {
   online = status;
+  CheckConnectedToInternet.trigger?.call(null, CheckConnectedToInternet);
 });
 
 /**

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -13,8 +13,9 @@ mainEvents.on('update-network-status', (status) => {
  * internet (which is required for most operations).
  */
 const CheckConnectedToInternet: DiagnosticsChecker = {
-  id:            'CONNECTED_TO_INTERNET',
-  category: 'Networking' as DiagnosticsCategory,
+  id:         'CONNECTED_TO_INTERNET',
+  category:   'Networking' as DiagnosticsCategory,
+  applicable: true,
   check() {
     return Promise.resolve({
       documentation: 'path#connected_to_internet',

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -28,6 +28,11 @@ export interface DiagnosticsChecker {
   /** Whether this checker should be used on this system. */
   applicable: boolean,
   /**
+   * A function that the checker can call to force this check to be updated.
+   * This does not change the global last-checked timestamp.
+   */
+  trigger?: (checker: DiagnosticsChecker) => void,
+  /**
    * Perform the check.
    */
   check(): Promise<DiagnosticsCheckerResult>;
@@ -84,6 +89,9 @@ export class DiagnosticsManager {
     })();
     this.checkers.then((checkers) => {
       for (const checker of checkers) {
+        checker.trigger = async (checker) => {
+          this.results[checker.id] = await checker.check();
+        }
         this.checkerIdByCategory[checker.category] ??= [];
         this.checkerIdByCategory[checker.category]?.push(checker.id);
       }

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -25,6 +25,8 @@ export interface DiagnosticsChecker {
   /** Unique identifier for this check. */
   id: string;
   category: DiagnosticsCategory,
+  /** Whether this checker should be used on this system. */
+  applicable: boolean,
   /**
    * Perform the check.
    */
@@ -77,7 +79,8 @@ export class DiagnosticsManager {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
       return (await Promise.all([
         import('./connectedToInternet'),
-      ])).map(obj => obj.default);
+        import('./dockerCliSymlinks'),
+      ])).map(obj => obj.default).filter(checker => checker.applicable);
     })();
     this.checkers.then((checkers) => {
       for (const checker of checkers) {

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -89,9 +89,9 @@ export class DiagnosticsManager {
     })();
     this.checkers.then((checkers) => {
       for (const checker of checkers) {
-        checker.trigger = async (checker) => {
+        checker.trigger = async(checker) => {
           this.results[checker.id] = await checker.check();
-        }
+        };
         this.checkerIdByCategory[checker.category] ??= [];
         this.checkerIdByCategory[checker.category]?.push(checker.id);
       }

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import paths from '@/utils/paths';
+
+import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+
+const CheckDockerCLISymlinks: DiagnosticsChecker = {
+  id:         'RD_BIN_SYMLINKS',
+  category:   'Utilities' as DiagnosticsCategory,
+  applicable: ['darwin', 'linux'].includes(os.platform()),
+  async check() {
+    const allNames = await fs.promises.readdir(paths.integration, 'utf-8');
+    const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
+    const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
+    const isInvalid = await Promise.all(names.map(async(name) => {
+      try {
+        const link = await fs.promises.readlink(path.join(dockerCliPluginDir, name));
+
+        return link !== path.join(paths.integration, name);
+      } catch (ex) {
+        // Is not a symlink, etc.
+        return true;
+      }
+    }));
+    const results = names.filter((_, i) => isInvalid[i]);
+    const passed = results.length === 0;
+    let description = 'All files under ~/.docker/cli-plugins are symlinks to ~/.rd/bin.';
+
+    if (!passed) {
+      description = `The following files in ~/.docker/cli-plugins are not symlinks to ~/.rd/bin: ${
+        results.sort().join(', ') }`;
+    }
+
+    return {
+      documentation: 'path#rd_bin_symlinks',
+      description,
+      passed,
+      fixes:         [],
+    };
+  },
+};
+
+export default CheckDockerCLISymlinks;

--- a/src/pages/General.vue
+++ b/src/pages/General.vue
@@ -93,9 +93,7 @@ export default {
     // This event is triggered when the Preferences page is revealed (among other times).
     // If the network status changed while the window was closed, this will update it.
     window.addEventListener('pageshow', () => {
-      if (window.navigator.onLine !== this.networkStatus) {
-        this.onNetworkUpdate(window.navigator.onLine);
-      }
+      this.onNetworkUpdate(window.navigator.onLine);
     });
   },
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -24,7 +24,7 @@ export const state: () => DiagnosticsState = () => (
 
 export const mutations: MutationsType<DiagnosticsState> = {
   SET_DIAGNOSTICS(state: DiagnosticsState, diagnostics: DiagnosticsResult[]) {
-    state.diagnostics = diagnostics;
+    state.diagnostics = diagnostics.filter(result => !result.passed);
     state.inError = false;
   },
   SET_TIME_LAST_RUN(state: DiagnosticsState, currentDate: Date) {


### PR DESCRIPTION
This adds the checks for the docker cli plugins (excluding credential helpers).

Notable changes:
- This diagnostic only applies on Linux & Darwin (Windows doesn't do symlinks)
- We no longer display _passed_ diagnostics in the diagnostics screen.
- The internet check ignores the `navigator.online` stuff (because it's unreliable) — we always do a connectivity check instead.
- We allow the diagnostics to trigger a check on itself (to update the online state).