### PR TITLE
Diagnostics: Add PATH management.

### DIFF
--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -187,7 +187,7 @@ export default Vue.extend({
           <!--We want an empty data cell so description will align with name-->
           <td></td>
           <td v-if="row.fixes.length > 0" class="sub-row">
-            {{ row.fixes.description }}
+            {{ row.fixes.map(fix => fix.description).join('\n') }}
           </td>
           <td v-else>
             (No fixes available)

--- a/src/main/diagnostics/__tests__/diagnostics.spec.ts
+++ b/src/main/diagnostics/__tests__/diagnostics.spec.ts
@@ -5,7 +5,9 @@ describe(DiagnosticsManager, () => {
     {
       id:            'RD_BIN_IN_BASH_PATH',
       category:      DiagnosticsCategory.Utilities,
-      applicable: true,
+      applicable() {
+        return Promise.resolve(true);
+      },
       check:         () => Promise.resolve({
         documentation: 'path#rd_bin_bash',
         description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
@@ -16,7 +18,9 @@ describe(DiagnosticsManager, () => {
     {
       id:            'RD_BIN_SYMLINKS',
       category:      DiagnosticsCategory.Utilities,
-      applicable: true,
+      applicable() {
+        return Promise.resolve(true);
+      },
       check:         () => Promise.resolve({
         documentation: 'path#rd_bin_symlinks',
         description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
@@ -27,7 +31,9 @@ describe(DiagnosticsManager, () => {
     {
       id:            'CONNECTED_TO_INTERNET',
       category:      DiagnosticsCategory.Networking,
-      applicable: true,
+      applicable() {
+        return Promise.resolve(true);
+      },
       check:         () => Promise.resolve({
         documentation: 'path#connected_to_internet',
         description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -16,7 +16,9 @@ mainEvents.on('update-network-status', (status) => {
 const CheckConnectedToInternet: DiagnosticsChecker = {
   id:         'CONNECTED_TO_INTERNET',
   category:   'Networking' as DiagnosticsCategory,
-  applicable: true,
+  applicable() {
+    return Promise.resolve(true);
+  },
   check() {
     return Promise.resolve({
       documentation: 'path#connected_to_internet',

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -31,7 +31,10 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
   }
 
   readonly category = 'Utilities' as DiagnosticsCategory;
-  readonly applicable = ['darwin', 'linux'].includes(os.platform());
+  applicable() {
+    return Promise.resolve(['darwin', 'linux'].includes(os.platform()));
+  }
+
   trigger?: ((checker: DiagnosticsChecker) => void) | undefined;
 
   // For testing use

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -15,7 +15,7 @@ mainEvents.on('settings-update', (cfg) => {
   pathStrategy = cfg.pathManagementStrategy;
 });
 
-class RDBinInShell implements DiagnosticsChecker {
+class RDBinInShellPath implements DiagnosticsChecker {
   constructor(id: string, executable: string, ...args: string[]) {
     this.id = id;
     this.executable = executable;
@@ -66,7 +66,7 @@ class RDBinInShell implements DiagnosticsChecker {
   }
 }
 
-const RDBinInBash = new RDBinInShell('RD_BIN_IN_BASH_PATH', '/bin/bash', '-l', '-c', 'echo $PATH');
-const RDBinInZsh = new RDBinInShell('RD_BIN_IN_ZSH_PATH', '/bin/zsh', '--rcs', '-c', 'echo $PATH');
+const RDBinInBash = new RDBinInShellPath('RD_BIN_IN_BASH_PATH', '/bin/bash', '-l', '-c', 'echo $PATH');
+const RDBinInZsh = new RDBinInShellPath('RD_BIN_IN_ZSH_PATH', '/bin/zsh', '--rcs', '-c', 'echo $PATH');
 
 export default [RDBinInBash, RDBinInZsh] as DiagnosticsChecker[];

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { PathManagementStrategy } from '@/integrations/pathManager';
+import mainEvents from '@/main/mainEvents';
+import { spawnFile } from '@/utils/childProcess';
+import paths from '@/utils/paths';
+
+import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+
+let pathStrategy = PathManagementStrategy.NotSet;
+
+mainEvents.on('settings-update', (cfg) => {
+  pathStrategy = cfg.pathManagementStrategy;
+});
+
+class RDBinInShell implements DiagnosticsChecker {
+  constructor(id: string, executable: string, ...args: string[]) {
+    this.id = id;
+    this.executable = executable;
+    this.args = args;
+  }
+
+  id: string;
+  executable: string;
+  args: string[];
+  category = 'Utilities' as DiagnosticsCategory;
+  async applicable(): Promise<boolean> {
+    if (!['darwin', 'linux'].includes(os.platform())) {
+      return false;
+    }
+    try {
+      await fs.promises.access(this.executable, fs.constants.X_OK);
+
+      return true;
+    } catch (ex) {
+      return false;
+    }
+  }
+
+  async check() {
+    const { stdout } = await spawnFile(this.executable, this.args, { stdio: 'pipe' });
+    const dirs = stdout.trim().split(':');
+    const desiredDirs = dirs.filter(p => p === paths.integration);
+    const passed = desiredDirs.length > 0;
+    const fixes: {description: string}[] = [];
+    const exe = path.basename(this.executable);
+    let description = `The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your ${ exe } shell.`;
+
+    if (passed) {
+      description = `The ~/.rd/bin directory is found in your PATH as seen from ${ exe }.`;
+    } else if (pathStrategy !== PathManagementStrategy.RcFiles) {
+      const description = `You have selected manual PATH configuration;
+          consider letting Rancher Desktop automatically configure it.`;
+
+      fixes.push({ description: description.replace(/\s+/gm, ' ') });
+    }
+
+    return {
+      documentation: `path#${ this.id.toLowerCase() }`,
+      description,
+      passed,
+      fixes,
+    };
+  }
+}
+
+const RDBinInBash = new RDBinInShell('RD_BIN_IN_BASH_PATH', '/bin/bash', '-l', '-c', 'echo $PATH');
+const RDBinInZsh = new RDBinInShell('RD_BIN_IN_ZSH_PATH', '/bin/zsh', '--rcs', '-c', 'echo $PATH');
+
+export default [RDBinInBash, RDBinInZsh] as DiagnosticsChecker[];


### PR DESCRIPTION
This adds diagnostics for bash & zsh; these are only applicable for macOS & Linux.

As before, set `RD_ENV_DIAGNOSTICS=1` before `npm run dev` to see the UI.

Part of #2319.