### PR TITLE
Diagnostics: DockerCLISymlink: reword.

### DIFF
--- a/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -1,9 +1,6 @@
 import fs from 'fs';
-import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
-
-import { CheckerDockerCLISymlink } from '../dockerCliSymlinks';
 
 import paths from '@/utils/paths';
 
@@ -24,13 +21,15 @@ jest.mock('electron', () => {
 });
 
 // Mock fs.promises.readdir() for the default export.
-jest.mock('fs/promises');
-jest.mocked(fsPromises.readdir).mockImplementation((dir, encoding) => {
+jest.spyOn(fs.promises, 'readdir').mockImplementation((dir, encoding) => {
   expect(dir).toEqual(paths.integration);
   expect(encoding).toEqual('utf-8');
 
   return Promise.resolve([]);
 });
+
+// eslint-disable-next-line import/first, import/order -- Need to mock first.
+import { CheckerDockerCLISymlink } from '../dockerCliSymlinks';
 
 const { mkdtemp, rm } = jest.requireActual('fs/promises');
 

--- a/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -1,0 +1,216 @@
+import fs from 'fs';
+import fsPromises from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { CheckerDockerCLISymlink } from '../dockerCliSymlinks';
+
+import paths from '@/utils/paths';
+
+// The (mock) application directory.
+let appDir = '';
+
+// Mock Electron.app.getAppPath() to return appDir.
+jest.mock('electron', () => {
+  return {
+    __esModule: true,
+    default:    {
+      app: {
+        isPackaged: false,
+        getAppPath: () => appDir,
+      },
+    },
+  };
+});
+
+// Mock fs.promises.readdir() for the default export.
+jest.mock('fs/promises');
+jest.mocked(fsPromises.readdir).mockImplementation((dir, encoding) => {
+  expect(dir).toEqual(paths.integration);
+  expect(encoding).toEqual('utf-8');
+
+  return Promise.resolve([]);
+});
+
+const { mkdtemp, rm } = jest.requireActual('fs/promises');
+
+describe(CheckerDockerCLISymlink, () => {
+  const executable = 'test-executable';
+  const cliPluginsDir = path.join(os.homedir(), '.docker', 'cli-plugins');
+  const rdBinDir = path.join(os.homedir(), '.rd', 'bin');
+  const rdBinExecutable = path.join(rdBinDir, executable);
+  let appDirExecutable = '';
+
+  beforeAll(async() => {
+    appDir = await mkdtemp(path.join(os.tmpdir(), 'rd-diag-'));
+    appDirExecutable = path.join(appDir, executable);
+  });
+  afterAll(async() => {
+    await rm(appDir, { recursive: true, force: true });
+  });
+
+  it('should pass', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink').mockImplementationOnce((filepath, options) => {
+      expect(filepath).toEqual(path.join(cliPluginsDir, executable));
+      expect(options).toBeUndefined();
+
+      return Promise.resolve(rdBinExecutable);
+    }).mockImplementationOnce((filepath, options) => {
+      expect(filepath).toEqual(rdBinExecutable);
+      expect(options).toBeUndefined();
+
+      return Promise.resolve(appDirExecutable);
+    }).mockImplementation((filepath, options) => {
+      expect(filepath).toEqual(appDirExecutable);
+      expect(options).toBeUndefined();
+
+      return Promise.reject({ code: 'EINVAL' });
+    });
+    jest.spyOn(subject, 'access').mockImplementation((filepath, mode) => {
+      expect(filepath).toEqual(appDirExecutable);
+      expect(mode).toEqual(fs.constants.X_OK);
+
+      return Promise.resolve();
+    });
+
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(new RegExp(`${ executable } is a symlink to ~/\\.rd/${ executable }\\.$`)),
+      passed:      true,
+    }));
+  });
+
+  function matchError(desc: string) {
+    return new RegExp(`${ executable } ${ desc }\\.\\s+It should be a symlink to ~/\\.rd/bin/${ executable }\\.$`);
+  }
+
+  it('should catch missing link', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink').mockRejectedValue({ code: 'ENOENT' });
+    jest.spyOn(subject, 'access');
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError('does not exist')),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
+  });
+
+  it('should catch not a symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink').mockRejectedValue({ code: 'EINVAL' });
+    jest.spyOn(subject, 'access');
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError('is not a symlink')),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
+  });
+
+  it('should catch generic errors', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink').mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access');
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError('cannot be read')),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
+  });
+
+  it('should catch incorrect link', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce('/usr/bin/true')
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access');
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError('is a symlink to /usr/bin/true')),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
+  });
+
+  it('should catch incorrect second symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce(rdBinExecutable)
+      .mockResolvedValueOnce('/usr/bin/true')
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access');
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError('is a symlink to /usr/bin/true, which is not from Rancher Desktop')),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
+  });
+
+  it('should catch dangling second symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce(rdBinExecutable)
+      .mockResolvedValueOnce(appDirExecutable)
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access')
+      .mockRejectedValue({ code: 'ENOENT' });
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError(`is a symlink to ${ appDirExecutable }, which does not exist`)),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).toHaveBeenCalledTimes(1);
+  });
+
+  it('should catch looping second symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce(rdBinExecutable)
+      .mockResolvedValueOnce(appDirExecutable)
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access')
+      .mockRejectedValue({ code: 'ELOOP' });
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError(`is a symlink with a loop`)),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).toHaveBeenCalledTimes(1);
+  });
+
+  it('should catch inaccessible second symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce(rdBinExecutable)
+      .mockResolvedValueOnce(appDirExecutable)
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access')
+      .mockRejectedValue({ code: 'EACCES' });
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError(`is a symlink to ${ appDirExecutable }, which is not executable`)),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).toHaveBeenCalledTimes(1);
+  });
+
+  it('should catch error reading second symlink', async() => {
+    const subject = new CheckerDockerCLISymlink(executable);
+
+    jest.spyOn(subject, 'readlink')
+      .mockResolvedValueOnce(rdBinExecutable)
+      .mockResolvedValueOnce(appDirExecutable)
+      .mockRejectedValue({ code: 'EPONY' });
+    jest.spyOn(subject, 'access')
+      .mockRejectedValue({ code: 'EPONY' });
+    await expect(subject.check()).resolves.toEqual(expect.objectContaining({
+      description: expect.stringMatching(matchError(`is a symlink to ${ appDirExecutable }, but we could not read it \\(EPONY\\)`)),
+      passed:      false,
+    }));
+    expect(jest.spyOn(subject, 'access')).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -82,10 +82,12 @@ export class DiagnosticsManager {
 
   constructor(diagnostics?: DiagnosticsChecker[]) {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
-      return (await Promise.all([
+      const imports = (await Promise.all([
         import('./connectedToInternet'),
         import('./dockerCliSymlinks'),
-      ])).map(obj => obj.default).filter(checker => checker.applicable);
+      ])).flatMap(obj => obj.default);
+
+      return (await Promise.all(imports)).flat().filter(checker => checker.applicable);
     })();
     this.checkers.then((checkers) => {
       for (const checker of checkers) {

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -2,35 +2,100 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import Electron from 'electron';
+
+import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 
 import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
 
-const CheckDockerCLISymlinks: DiagnosticsChecker = {
-  id:         'RD_BIN_SYMLINKS',
-  category:   'Utilities' as DiagnosticsCategory,
-  applicable: ['darwin', 'linux'].includes(os.platform()),
-  async check() {
-    const allNames = await fs.promises.readdir(paths.integration, 'utf-8');
-    const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
-    const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
-    const isInvalid = await Promise.all(names.map(async(name) => {
-      try {
-        const link = await fs.promises.readlink(path.join(dockerCliPluginDir, name));
+const console = Logging.diagnostics;
 
-        return link !== path.join(paths.integration, name);
-      } catch (ex) {
-        // Is not a symlink, etc.
-        return true;
+export class CheckerDockerCLISymlink implements DiagnosticsChecker {
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  readonly name: string;
+  get id() {
+    return `RD_BIN_DOCKER_CLI_SYMLINK_${ this.name.toUpperCase() }`;
+  }
+
+  readonly category = 'Utilities' as DiagnosticsCategory;
+  readonly applicable = ['darwin', 'linux'].includes(os.platform());
+  trigger?: ((checker: DiagnosticsChecker) => void) | undefined;
+
+  // For testing use
+  readonly readlink = fs.promises.readlink;
+  readonly access = fs.promises.access;
+
+  async check() {
+    const rdBin = path.join(paths.integration, this.name);
+    const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
+    let passed = false;
+    let state;
+
+    function replaceHome(input: string) {
+      if (input.startsWith(os.homedir() + path.sep)) {
+        return input.replace(os.homedir(), '~');
       }
-    }));
-    const results = names.filter((_, i) => isInvalid[i]);
-    const passed = results.length === 0;
-    let description = 'All files under ~/.docker/cli-plugins are symlinks to files in ~/.rd/bin.';
+
+      return input;
+    }
+
+    try {
+      let link = await this.readlink(path.join(dockerCliPluginDir, this.name));
+
+      console.debug(`docker-cli symlink: ${ this.name }: first-level symlink: ${ link } (expect ${ rdBin })`);
+      if (link === rdBin) {
+        while (true) {
+          try {
+            link = await this.readlink(link);
+          } catch (ex) {
+            break;
+          }
+        }
+        console.debug(`docker-cli symlink: ${ this.name }: final symlink: ${ link } (app dir ${ Electron.app.getAppPath() })`);
+        if (path.relative(Electron.app.getAppPath(), link).startsWith('.')) {
+          state = `is a symlink to ${ replaceHome(link) }, which is not from Rancher Desktop`;
+        } else {
+          try {
+            await this.access(link, fs.constants.X_OK);
+            state = `is a symlink to ~/.rd/${ this.name }`;
+            passed = true;
+          } catch (ex) {
+            const code = (ex as any).code ?? '';
+
+            if (code === 'ENOENT') {
+              state = `is a symlink to ${ replaceHome(link) }, which does not exist`;
+            } else if (code === 'ELOOP') {
+              state = `is a symlink with a loop`;
+            } else if (code === 'EACCES') {
+              state = `is a symlink to ${ replaceHome(link) }, which is not executable`;
+            } else {
+              state = `is a symlink to ${ replaceHome(link) }, but we could not read it (${ code })`;
+            }
+          }
+        }
+      } else {
+        state = `is a symlink to ${ replaceHome(link) }`;
+      }
+    } catch (ex) {
+      const code = (ex as any).code ?? '';
+
+      console.debug(`docker-cli symlink: ${ this.name } got exception ${ code }: ${ ex }`);
+      if (code === 'ENOENT') {
+        state = `does not exist`;
+      } else if (code === 'EINVAL') {
+        state = `is not a symlink`;
+      } else {
+        state = `cannot be read`;
+      }
+    }
+    let description = `The file ~/.docker/cli-plugins/${ this.name } ${ state }.`;
 
     if (!passed) {
-      description = `The following files in ~/.docker/cli-plugins are not symlinks to files in ~/.rd/bin: ${
-        results.sort().join(', ') }`;
+      description += `  It should be a symlink to ~/.rd/bin/${ this.name }.`;
     }
 
     return {
@@ -39,7 +104,16 @@ const CheckDockerCLISymlinks: DiagnosticsChecker = {
       passed,
       fixes:         [],
     };
-  },
-};
+  }
+}
 
-export default CheckDockerCLISymlinks;
+const checkers: Promise<DiagnosticsChecker[]> = (async() => {
+  const allNames = await fs.promises.readdir(paths.integration, 'utf-8');
+  const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
+
+  return names.map((name) => {
+    return new CheckerDockerCLISymlink(name);
+  });
+})();
+
+export default checkers;

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -11,6 +11,15 @@ import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
 
 const console = Logging.diagnostics;
 
+/** Given a path, replace the user's home directory with "~". */
+function replaceHome(input: string) {
+  if (input.startsWith(os.homedir() + path.sep)) {
+    return input.replace(os.homedir(), '~');
+  }
+
+  return input;
+}
+
 export class CheckerDockerCLISymlink implements DiagnosticsChecker {
   constructor(name: string) {
     this.name = name;
@@ -30,24 +39,16 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
   readonly access = fs.promises.access;
 
   async check() {
-    const rdBin = path.join(paths.integration, this.name);
+    const rdBinPath = path.join(paths.integration, this.name);
     const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
     let passed = false;
     let state;
 
-    function replaceHome(input: string) {
-      if (input.startsWith(os.homedir() + path.sep)) {
-        return input.replace(os.homedir(), '~');
-      }
-
-      return input;
-    }
-
     try {
       let link = await this.readlink(path.join(dockerCliPluginDir, this.name));
 
-      console.debug(`docker-cli symlink: ${ this.name }: first-level symlink: ${ link } (expect ${ rdBin })`);
-      if (link === rdBin) {
+      console.debug(`docker-cli symlink: ${ this.name }: first-level symlink: ${ link } (expect ${ rdBinPath })`);
+      if (link === rdBinPath) {
         while (true) {
           try {
             link = await this.readlink(link);

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -26,10 +26,10 @@ const CheckDockerCLISymlinks: DiagnosticsChecker = {
     }));
     const results = names.filter((_, i) => isInvalid[i]);
     const passed = results.length === 0;
-    let description = 'All files under ~/.docker/cli-plugins are symlinks to ~/.rd/bin.';
+    let description = 'All files under ~/.docker/cli-plugins are symlinks to files in ~/.rd/bin.';
 
     if (!passed) {
-      description = `The following files in ~/.docker/cli-plugins are not symlinks to ~/.rd/bin: ${
+      description = `The following files in ~/.docker/cli-plugins are not symlinks to files in ~/.rd/bin: ${
         results.sort().join(', ') }`;
     }
 


### PR DESCRIPTION
Rewording some text in response to a previous review comment.

Addresses: https://github.com/rancher-sandbox/rancher-desktop/pull/2868#discussion_r965345256

The wording discussion wasn't quite as detailed as I thought it might have been.

(Reminder: Set `RD_ENV_DIAGNOSTICS=1` before running `npm run dev`.)