### PR TITLE
Switch from vdeVMNet to socketVMNet

### DIFF
--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 ---
-limaAndQemu: "1.24"
+limaAndQemu: "1.25"
 alpineLimaISO:
   isoVersion: 0.2.21
   alpineVersion: 3.16.0

--- a/src/assets/networks-config.yaml
+++ b/src/assets/networks-config.yaml
@@ -1,17 +1,16 @@
-# Paths to vde executables. Because vde_vmnet is invoked via sudo it should be
+# Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
 # installed where only root can modify/replace it. This means also none of the
 # parent directories should be writable by the user.
 #
 # The varRun directory also must not be writable by the user because it will
-# include the vde_vmnet pid files. Those will be terminated via sudo, so replacing
-# the pid files would allow killing of arbitrary privileged processes. varRun
+# include the socket_vmnet pid file. Those will be terminated via sudo, so replacing
+# the pid file would allow killing of arbitrary privileged processes. varRun
 # however MUST be writable by the daemon user.
 #
 # None of the paths segments may be symlinks, which is why it has to be /private/var
 # instead of /var etc.
 paths:
-  vdeSwitch: /opt/rancher-desktop/bin/vde_switch
-  vdeVMNet: /opt/rancher-desktop/bin/vde_vmnet
+  socketVMNet: /opt/rancher-desktop/bin/socket_vmnet
   varRun: /private/var/run
   sudoers: /private/etc/sudoers.d/zzzzz-rancher-desktop-lima
 group: everyone


### PR DESCRIPTION
Bumps to lima 0.12.0

Should not be merged until #2882 has been fixed, as the deprecation warnings break stuff in `rdctl`, and are excessively annoying even in logs or when you `rdctl shell`.

May want to refresh `lima-and-qemu` release to include https://github.com/lima-vm/lima/pull/1049 which I ran into while testing this upgrade.

Fixes #2882
Closes #2900