### PR TITLE
Don't use `paths.integration` when running on Windows

### DIFF
--- a/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -22,7 +22,7 @@ jest.mock('electron', () => {
 
 // Mock fs.promises.readdir() for the default export.
 jest.spyOn(fs.promises, 'readdir').mockImplementation((dir, encoding) => {
-  expect(dir).toEqual(paths.integration);
+  expect(dir).toEqual(path.join(paths.resources, os.platform(), 'bin'));
   expect(encoding).toEqual('utf-8');
 
   return Promise.resolve([]);

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -112,10 +112,8 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
 }
 
 const checkers: Promise<DiagnosticsChecker[]> = (async() => {
-  if (!['darwin', 'linux'].includes(os.platform())) {
-    return Promise.resolve([]);
-  }
-  const allNames = await fs.promises.readdir(paths.integration, 'utf-8');
+  const resourcesDir = path.join(paths.resources, os.platform(), 'bin');
+  const allNames = await fs.promises.readdir(resourcesDir, 'utf-8');
   const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
 
   return names.map((name) => {

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -112,6 +112,9 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
 }
 
 const checkers: Promise<DiagnosticsChecker[]> = (async() => {
+  if (!['darwin', 'linux'].includes(os.platform())) {
+    return Promise.resolve([]);
+  }
   const allNames = await fs.promises.readdir(paths.integration, 'utf-8');
   const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
 


### PR DESCRIPTION
I ran into this while working on #2186. By default, dockerCliSymlinks.ts uses `paths.integration`, which works fine on Unix OS's, but on Windows it throws an error. This fixes that.