### PR TITLE
Diagnostics: UI update.

### DIFF
--- a/src/assets/styles/themes/_dark.scss
+++ b/src/assets/styles/themes/_dark.scss
@@ -114,6 +114,8 @@
   --progress-bg                : #{$medium};
   --progress-divider           : #{$lightest};
 
+  --sortable-table-bg          : #{lighten($darkest, 10%)};
+  --sortable-table-row-bg      : #{$darker};;
   --sortable-table-header-bg   : #{$darkest};
   --sortable-table-accent-bg   : #{$darker};
   --sortable-table-accent-alt  : #{$dark};

--- a/src/assets/styles/themes/_light.scss
+++ b/src/assets/styles/themes/_light.scss
@@ -11,7 +11,7 @@ $dark      : #B6B6C2;
 //light border and buttons
 $medium    : #DCDEE7;
 
-//light inputs 
+//light inputs
 $light     : #EEEFF4;
 
 //light sidebar and box
@@ -83,7 +83,7 @@ BODY, .theme-light {
   --link-banner-bg          : #{rgba($link, 0.15)};
   --link-light-bg           : #{rgba($link, 0.05)};
 
-  
+
   .text-link {
     color: var(--link) !important;
   }
@@ -296,7 +296,7 @@ BODY, .theme-light {
       background: var(--error-active-bg);
       }
   }
-  
+
 
   --body-bg                    : #{$lightest};
   --body-text                  : #{$darkest};
@@ -384,8 +384,9 @@ BODY, .theme-light {
   --progress-bg                : #{$medium};
   --progress-divider           : #{$medium};
 
-  --sortable-table-bg          : transparent;
-  --sortable-table-header-bg   : transparent;
+  --sortable-table-bg          : #{darken($lightest, 5%)};
+  --sortable-table-row-bg      : #{$lightest};
+  --sortable-table-header-bg   : #{$lighter};
   --sortable-table-accent-bg   : #{$lighter};
   --sortable-table-accent-alt  : #{$lightest};
   --sortable-table-top-divider : var(--border);

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { BadgeState, ToggleSwitch } from '@rancher/components';
+import { ToggleSwitch } from '@rancher/components';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import Vue from 'vue';
@@ -18,7 +18,6 @@ export default Vue.extend({
   name:       'DiagnosticsBody',
   components: {
     SortableTable,
-    BadgeState,
     ToggleSwitch,
     EmptyState,
   },
@@ -35,16 +34,6 @@ export default Vue.extend({
         {
           name:  'description',
           label: 'Name',
-        },
-        {
-          name:  'documentation',
-          label: 'Documentation',
-          width: 106,
-        },
-        {
-          name:  'category',
-          label: 'Category',
-          width: 96,
         },
         {
           name:  'mute',
@@ -69,7 +58,7 @@ export default Vue.extend({
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();
     },
-    filteredRows(): any {
+    filteredRows(): DiagnosticsResult[] {
       if (!this.hideMuted) {
         return this.rows;
       }
@@ -135,9 +124,11 @@ export default Vue.extend({
       key-field="id"
       :headers="headers"
       :rows="filteredRows"
+      group-by="category"
       :search="false"
       :table-actions="false"
       :row-actions="false"
+      :show-headers="false"
       :sub-rows="featureFixes"
       :sub-expandable="featureFixes"
       :sub-expand-column="featureFixes"
@@ -162,20 +153,8 @@ export default Vue.extend({
       </template>
       <template #col:description="{row}">
         <td>
-          <span class="font-semibold">{{ row.description }}</span>
-        </td>
-      </template>
-      <template #col:documentation="{row}">
-        <td>
-          <a :href="row.documentation"><span class="icon icon-external-link" /></a>
-        </td>
-      </template>
-      <template #col:category="{row}">
-        <td>
-          <badge-state
-            :label="row.category"
-            color="bg-warning"
-          />
+          <span>{{ row.description }}</span>
+          <a :href="row.documentation" class="doclink"><span class="icon icon-external-link" /></a>
         </td>
       </template>
       <template #col:mute="{row}">
@@ -220,9 +199,8 @@ export default Vue.extend({
         align-items: center;
       }
     }
-
-    .font-semibold {
-      font-weight: 600;
+    .doclink {
+      margin-left: 1rem;
     }
   }
 </style>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -239,11 +239,16 @@ export default Vue.extend({
         }
       }
 
-      &:not([aria-expanded])::v-deep ~ .main-row {
-        visibility: collapse;
-        .toggle-container {
-          /* When using visibility:collapse, the toggle switch produces some
-          * artifacts; force it to display:none to avoid flickering. */
+      &:not([aria-expanded]) {
+        &::v-deep ~ .main-row {
+          visibility: collapse;
+          .toggle-container {
+            /* When using visibility:collapse, the toggle switch produces some
+            * artifacts; force it to display:none to avoid flickering. */
+            display: none;
+          }
+        }
+        .col-mute {
           display: none;
         }
       }

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -191,7 +191,7 @@ export default Vue.extend({
             </div>
           </td>
           <td class="col-mute" role="columnheader">
-            Mute
+            <span>Mute</span>
           </td>
         </tr>
       </template>
@@ -204,6 +204,7 @@ export default Vue.extend({
       <template #col:mute="{row}">
         <td>
           <toggle-switch
+            class="mute-toggle"
             :value="row.mute"
             @input="muteRow($event, row)"
           />
@@ -254,6 +255,14 @@ export default Vue.extend({
       .col-mute {
         text-align: center;
         width: 0; /* minimal width, to right-align it. */
+        /* Apply the same left/right padding so columns line up correctly. */
+        padding-left: 5px;
+        padding-right: 10px;
+        & > span {
+          /* Make the column label the same width as the toggle buttons */
+          display: inline-block;
+          width: 48px;
+        }
       }
     }
 
@@ -261,8 +270,19 @@ export default Vue.extend({
       visibility: collapse;
     }
 
+    .mute-toggle::v-deep .label {
+      /* We have no labels on the mute toggles; force them to not exist so that
+         the two sides of the table have equal padding. */
+      display: none;
+    }
+
     .doclink {
-      margin-left: 1rem;
+      margin-left: 0.1rem;
+      .icon {
+        /* These two rules work around the icon itself being too high. */
+        margin-bottom: 0.075rem;
+        vertical-align: bottom;
+      }
     }
   }
 </style>

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -73,11 +73,6 @@ export default Vue.extend({
       return !!this.$config.featureDiagnosticsFixes;
     },
   },
-  mounted() {
-    for (const group of Object.values(DiagnosticsCategory)) {
-      this.updateExpandVisibility(group);
-    }
-  },
   methods: {
     pluralize(count: number, unit: string): string {
       const units = count === 1 ? unit : `${ unit }s`;
@@ -90,23 +85,8 @@ export default Vue.extend({
     toggleMute() {
       this.hideMuted = !this.hideMuted;
     },
-    updateExpandVisibility(group: DiagnosticsCategory) {
-      const expanded = this.expanded[group];
-      const groupRow = this.$refs[`group-${ group }`];
-
-      if (groupRow instanceof HTMLElement) {
-        groupRow.setAttribute('aria-expaneded', expanded ? 'true' : 'false');
-        if (expanded) {
-          groupRow.parentElement?.setAttribute('data-expanded', '');
-        } else {
-          groupRow.parentElement?.removeAttribute('data-expanded');
-        }
-      }
-    },
     toggleExpand(group: DiagnosticsCategory) {
       this.expanded[group] = !this.expanded[group];
-
-      this.updateExpandVisibility(group);
     },
   },
 });
@@ -159,7 +139,7 @@ export default Vue.extend({
         </td>
       </template>
       <template #group-row="{group}">
-        <tr :ref="`group-${group.ref}`" class="group-row" aria-expanded="true">
+        <tr :ref="`group-${group.ref}`" class="group-row" :aria-expanded="expanded[group.ref]">
           <td class="col-description" role="columnheader">
             <div class="group-tab">
               <i
@@ -258,10 +238,15 @@ export default Vue.extend({
           width: 48px;
         }
       }
-    }
 
-    &::v-deep .group:not([data-expanded]) .main-row {
-      visibility: collapse;
+      &:not([aria-expanded])::v-deep ~ .main-row {
+        visibility: collapse;
+        .toggle-container {
+          /* When using visibility:collapse, the toggle switch produces some
+          * artifacts; force it to display:none to avoid flickering. */
+          display: none;
+        }
+      }
     }
 
     .mute-toggle::v-deep .label {

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -88,6 +88,10 @@ export default Vue.extend({
     emptyStateBody(): string {
       return this.areAllRowsMuted ? this.t('diagnostics.results.muted.body') : this.t('diagnostics.results.success.body');
     },
+
+    featureFixes(): boolean {
+      return !!this.$config.featureDiagnosticsFixes;
+    },
   },
   mounted() {
     lastRunInterval = setInterval(() => {
@@ -134,9 +138,9 @@ export default Vue.extend({
       :search="false"
       :table-actions="false"
       :row-actions="false"
-      :sub-rows="true"
-      :sub-expandable="true"
-      :sub-expand-column="true"
+      :sub-rows="featureFixes"
+      :sub-expandable="featureFixes"
+      :sub-expand-column="featureFixes"
     >
       <template #no-rows>
         <td :colspan="headers.length + 1">
@@ -182,7 +186,7 @@ export default Vue.extend({
           />
         </td>
       </template>
-      <template #sub-row="{row}">
+      <template v-if="featureFixes" #sub-row="{row}">
         <tr>
           <!--We want an empty data cell so description will align with name-->
           <td></td>

--- a/src/components/DiagnosticsButtonRun.vue
+++ b/src/components/DiagnosticsButtonRun.vue
@@ -1,7 +1,35 @@
 <script lang="ts">
-import Vue from 'vue';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import Vue, { PropType } from 'vue';
+
+dayjs.extend(relativeTime);
+
 export default Vue.extend({
-  name:    'diagnostics-button-run',
+  name:  'diagnostics-button-run',
+  props: { timeLastRun: Date as PropType<Date> },
+  data() {
+    return {
+      lastRunInterval: undefined as ReturnType<typeof setInterval> | undefined,
+      currentTime:     dayjs(),
+    };
+  },
+  computed: {
+    friendlyTimeLastRun(): string {
+      return this.currentTime.to(dayjs(this.timeLastRun));
+    },
+    timeLastRunTooltip(): string {
+      return this.timeLastRun.toLocaleString();
+    },
+  },
+  mounted() {
+    this.lastRunInterval = setInterval(() => {
+      this.currentTime = dayjs();
+    }, 1000);
+  },
+  beforeDestroy() {
+    clearInterval(this.lastRunInterval);
+  },
   methods: {
     async onClick() {
       const credentials = await this.$store.dispatch('credentials/fetchCredentials');
@@ -18,6 +46,9 @@ export default Vue.extend({
       <span class="icon icon-refresh icon-diagnostics"></span>
       Rerun
     </button>
+    <div class="diagnostics-status-history">
+      Last run: <span class="elapsed-timespan" :title="timeLastRunTooltip">{{ friendlyTimeLastRun }}</span>
+    </div>
   </div>
 </template>
 

--- a/src/main/diagnostics/__tests__/diagnostics.spec.ts
+++ b/src/main/diagnostics/__tests__/diagnostics.spec.ts
@@ -1,4 +1,5 @@
-import { DiagnosticsManager, DiagnosticsCategory, DiagnosticsChecker, DiagnosticsResult } from '../diagnostics';
+import { DiagnosticsManager, DiagnosticsResult } from '../diagnostics';
+import { DiagnosticsCategory, DiagnosticsChecker } from '../types';
 
 describe(DiagnosticsManager, () => {
   const mockDiagnostics: DiagnosticsChecker[] = [

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -1,6 +1,6 @@
-import mainEvents from '@/main/mainEvents';
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
-import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
+import mainEvents from '@/main/mainEvents';
 
 let online = false;
 
@@ -15,7 +15,7 @@ mainEvents.on('update-network-status', (status) => {
  */
 const CheckConnectedToInternet: DiagnosticsChecker = {
   id:         'CONNECTED_TO_INTERNET',
-  category:   'Networking' as DiagnosticsCategory,
+  category: DiagnosticsCategory.Networking,
   applicable() {
     return Promise.resolve(true);
   },

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -1,6 +1,6 @@
 import mainEvents from '@/main/mainEvents';
 
-import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 let online = false;
 

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -89,6 +89,7 @@ export class DiagnosticsManager {
   constructor(diagnostics?: DiagnosticsChecker[]) {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
       const imports = (await Promise.all([
+        import('./testCheckers'),
         import('./connectedToInternet'),
         import('./dockerCliSymlinks'),
         import('./rdBinInShell'),

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -1,52 +1,8 @@
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './types';
+
 import Logging from '@/utils/logging';
 
 const console = Logging.diagnostics;
-
-export enum DiagnosticsCategory {
-  Kubernetes = 'Kubernetes',
-  Networking = 'Networking',
-  Utilities = 'Utilities',
-}
-
-/**
- * DiagnosticsCheckerResult is the result for running a given diagnostics
- * checker.
- */
-export type DiagnosticsCheckerResult = {
-  /** Link to documentation about this check. */
-  documentation: string,
-  /** User-visible description about this check. */
-  description: string,
-  /** If true, the check succeeded (no fixes need to be applied). */
-  passed: boolean,
-  /** Potential fixes when this check fails. */
-  fixes: DiagnosticsFix[],
-};
-
-/**
- * DiagnosticsChecker describes an implementation of a single diagnostics check.
- */
-export interface DiagnosticsChecker {
-  /** Unique identifier for this check. */
-  id: string;
-  category: DiagnosticsCategory,
-  /** Whether this checker should be used on this system. */
-  applicable(): Promise<boolean>,
-  /**
-   * A function that the checker can call to force this check to be updated.
-   * This does not change the global last-checked timestamp.
-   */
-  trigger?: (checker: DiagnosticsChecker) => void,
-  /**
-   * Perform the check.
-   */
-  check(): Promise<DiagnosticsCheckerResult>;
-}
-
-type DiagnosticsFix = {
-  /** A textual description of the fix to be displayed to the user. */
-  description: string;
-};
 
 /**
  * DiagnosticsResult is the data structure that will be returned to clients (as
@@ -120,7 +76,7 @@ export class DiagnosticsManager {
   /**
    * Returns undefined if the categoryName isn't known, the list of IDs in that category otherwise.
    */
-  getIdsForCategory(categoryName: string): Array<string>|undefined {
+  getIdsForCategory(categoryName: string): Array<string> | undefined {
     return this.checkerIdByCategory[categoryName as DiagnosticsCategory];
   }
 
@@ -150,7 +106,7 @@ export class DiagnosticsManager {
   /**
    * Fetch the last known results, filtered by given category and id.
    */
-  async getChecks(categoryName: string|null, id: string|null): Promise<DiagnosticsResultCollection> {
+  async getChecks(categoryName: string | null, id: string | null): Promise<DiagnosticsResultCollection> {
     const checkers = (await this.applicableCheckers(categoryName, id))
       .filter(checker => checker.id in this.results);
 

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 
-import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 const console = Logging.diagnostics;
 

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
+
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
-
-import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 const console = Logging.diagnostics;
 
@@ -28,7 +28,7 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
     return `RD_BIN_DOCKER_CLI_SYMLINK_${ this.name.toUpperCase() }`;
   }
 
-  readonly category = 'Utilities' as DiagnosticsCategory;
+  readonly category = DiagnosticsCategory.Utilities;
   applicable() {
     return Promise.resolve(['darwin', 'linux'].includes(os.platform()));
   }

--- a/src/main/diagnostics/kubeContext.ts
+++ b/src/main/diagnostics/kubeContext.ts
@@ -2,7 +2,7 @@ import mainEvents from '@/main/mainEvents';
 import { spawnFile } from '@/utils/childProcess';
 import Logging from '@/utils/logging';
 
-import type { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './diagnostics';
+import type { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './types';
 
 const console = Logging.diagnostics;
 

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -2,12 +2,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
+
 import { PathManagementStrategy } from '@/integrations/pathManager';
 import mainEvents from '@/main/mainEvents';
 import { spawnFile } from '@/utils/childProcess';
 import paths from '@/utils/paths';
-
-import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 let pathStrategy = PathManagementStrategy.NotSet;
 
@@ -25,7 +25,7 @@ class RDBinInShellPath implements DiagnosticsChecker {
   id: string;
   executable: string;
   args: string[];
-  category = 'Utilities' as DiagnosticsCategory;
+  category = DiagnosticsCategory.Utilities;
   async applicable(): Promise<boolean> {
     if (!['darwin', 'linux'].includes(os.platform())) {
       return false;

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -7,7 +7,7 @@ import mainEvents from '@/main/mainEvents';
 import { spawnFile } from '@/utils/childProcess';
 import paths from '@/utils/paths';
 
-import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 let pathStrategy = PathManagementStrategy.NotSet;
 

--- a/src/main/diagnostics/testCheckers.ts
+++ b/src/main/diagnostics/testCheckers.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 /**
  * Sample tests for testing
@@ -13,7 +13,7 @@ class CheckTesting implements DiagnosticsChecker {
     return `STATIC_${ this.pass.toString().toUpperCase() }`;
   }
 
-  category = 'Testing' as DiagnosticsCategory;
+  category = DiagnosticsCategory.Testing;
   applicable(): Promise<boolean> {
     return Promise.resolve(/^dev|test/i.test(process.env.NODE_ENV ?? ''));
   }

--- a/src/main/diagnostics/testCheckers.ts
+++ b/src/main/diagnostics/testCheckers.ts
@@ -1,4 +1,4 @@
-import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+import type { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
 /**
  * Sample tests for testing

--- a/src/main/diagnostics/testCheckers.ts
+++ b/src/main/diagnostics/testCheckers.ts
@@ -1,0 +1,31 @@
+import type { DiagnosticsCategory, DiagnosticsChecker } from './diagnostics';
+
+/**
+ * Sample tests for testing
+ */
+class CheckTesting implements DiagnosticsChecker {
+  pass: boolean;
+  constructor(pass: boolean) {
+    this.pass = pass;
+  }
+
+  get id() {
+    return `STATIC_${ this.pass.toString().toUpperCase() }`;
+  }
+
+  category = 'Testing' as DiagnosticsCategory;
+  applicable(): Promise<boolean> {
+    return Promise.resolve(/^dev|test/i.test(process.env.NODE_ENV ?? ''));
+  }
+
+  check() {
+    return Promise.resolve({
+      passed:        this.pass,
+      documentation: '!!!',
+      description:   `This is a sample test that will ${ this.pass ? 'always' : 'never' } pass.`,
+      fixes:         [],
+    });
+  }
+}
+
+export default [new CheckTesting(true), new CheckTesting(false)];

--- a/src/main/diagnostics/types.ts
+++ b/src/main/diagnostics/types.ts
@@ -1,0 +1,45 @@
+export enum DiagnosticsCategory {
+  Kubernetes = 'Kubernetes',
+  Utilities = 'Utilities',
+  Networking = 'Networking',
+}
+
+type DiagnosticsFix = {
+  /** A textual description of the fix to be displayed to the user. */
+  description: string;
+};
+
+/**
+ * DiagnosticsCheckerResult is the result for running a given diagnostics
+ * checker.
+ */
+export type DiagnosticsCheckerResult = {
+  /* Link to documentation about this check. */
+  documentation: string,
+  /* User-visible description about this check. */
+  description: string,
+  /** If true, the check succeeded (no fixes need to be applied). */
+  passed: boolean,
+  /** Potential fixes when this check fails. */
+  fixes: DiagnosticsFix[],
+};
+
+/**
+ * DiagnosticsChecker describes an implementation of a single diagnostics check.
+ */
+export interface DiagnosticsChecker {
+  /** Unique identifier for this check. */
+  id: string;
+  category: DiagnosticsCategory,
+  /** Whether this checker should be used on this system. */
+  applicable(): Promise<boolean>,
+  /**
+   * A function that the checker can call to force this check to be updated.
+   * This does not change the global last-checked timestamp.
+   */
+  trigger?: (checker: DiagnosticsChecker) => void,
+  /**
+   * Perform the check.
+   */
+  check(): Promise<DiagnosticsCheckerResult>;
+}

--- a/src/main/diagnostics/types.ts
+++ b/src/main/diagnostics/types.ts
@@ -1,7 +1,8 @@
 export enum DiagnosticsCategory {
   Kubernetes = 'Kubernetes',
-  Utilities = 'Utilities',
   Networking = 'Networking',
+  Utilities = 'Utilities',
+  Testing = 'Testing',
 }
 
 type DiagnosticsFix = {

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -81,5 +81,8 @@ export default {
   },
   target:              'static',
   telemetry:           false,
-  publicRuntimeConfig: { featureDiagnostics: process.env.RD_ENV_DIAGNOSTICS === '1' },
+  publicRuntimeConfig: {
+    featureDiagnostics:      process.env.RD_ENV_DIAGNOSTICS === '1',
+    featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1',
+  },
 };

--- a/src/nuxt.config.js
+++ b/src/nuxt.config.js
@@ -82,7 +82,7 @@ export default {
   target:              'static',
   telemetry:           false,
   publicRuntimeConfig: {
-    featureDiagnostics:      process.env.RD_ENV_DIAGNOSTICS === '1',
+    featureDiagnostics:      true,
     featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1',
   },
 };

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -18,10 +18,7 @@ export default Vue.extend({
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      {
-        title:  'Diagnostics',
-        action: 'diagnostics-button-run',
-      },
+      { title: 'Diagnostics' },
     );
   },
 });


### PR DESCRIPTION
Fixes #2913.

I'm using the grouping code that already exists in `<SortableTable>` to ensure we have a consistent style across RD & dashboard (especially since we bundle dashboard…)

Note: This will conflict with #2908 — it might be a good idea to delay reviewing until that one is done.

![diagnostics, opened](https://user-images.githubusercontent.com/3977982/190527655-0d1e2fcf-84d2-4bda-99df-2e6fb8af98f1.png)
![diagnostics, one closed](https://user-images.githubusercontent.com/3977982/190527674-e1005384-8c2a-4859-91ef-02124b449076.png)

For reference, grouped sortable table in the dashboard:
![grouped pods in dashboard](https://user-images.githubusercontent.com/3977982/190527789-d8940ea3-3c5d-499f-b247-2f0200ef6fd7.png)


