### PR TITLE
Allow preferences to update when Kubernetes is disabled and no version is selected

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2169,10 +2169,6 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
       desiredConfig,
       {
         version: (current: string, desired: string) => {
-          if (!desiredConfig.enabled) {
-            return 'restart';
-          }
-
           if (semver.gt(current || '0.0.0', desired)) {
             return 'reset';
           }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2169,6 +2169,10 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
       desiredConfig,
       {
         version: (current: string, desired: string) => {
+          if (!desiredConfig.enabled) {
+            return 'restart';
+          }
+
           if (semver.gt(current, desired)) {
             return 'reset';
           }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2173,7 +2173,7 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
             return 'restart';
           }
 
-          if (semver.gt(current, desired)) {
+          if (semver.gt(current || '0.0.0', desired)) {
             return 'reset';
           }
 

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1721,6 +1721,10 @@ class WSLKubernetesBackend extends events.EventEmitter implements K8s.Kubernetes
       newConfig,
       {
         version: (current: string, desired: string) => {
+          if (!newConfig.enabled) {
+            return 'restart';
+          }
+
           if (semver.gt(current, desired)) {
             return 'reset';
           }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1721,10 +1721,6 @@ class WSLKubernetesBackend extends events.EventEmitter implements K8s.Kubernetes
       newConfig,
       {
         version: (current: string, desired: string) => {
-          if (!newConfig.enabled) {
-            return 'restart';
-          }
-
           if (semver.gt(current || '0.0.0', desired)) {
             return 'reset';
           }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1725,7 +1725,7 @@ class WSLKubernetesBackend extends events.EventEmitter implements K8s.Kubernetes
             return 'restart';
           }
 
-          if (semver.gt(current, desired)) {
+          if (semver.gt(current || '0.0.0', desired)) {
             return 'reset';
           }
 

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -464,5 +464,37 @@ describe(SettingsValidator, () => {
         errors:       expect.objectContaining({ length: 1 }),
       });
     });
+
+    it('should allow empty Kubernetes version when Kubernetes is disabled', () => {
+      const [needToUpdate, errors] = subject.validateSettings(
+        cfg,
+        {
+          kubernetes: {
+            version: '',
+            enabled: false,
+          },
+        });
+
+      expect(needToUpdate).toBeTruthy();
+      expect(errors).toHaveLength(0);
+      expect(errors).toEqual([]);
+    });
+
+    it('should disallow empty Kubernetes version when Kubernetes is enabled', () => {
+      const [needToUpdate, errors] = subject.validateSettings(
+        cfg,
+        {
+          kubernetes: {
+            version: '',
+            enabled: true,
+          },
+        });
+
+      expect(needToUpdate).toBeFalsy();
+      expect(errors).toHaveLength(1);
+      expect(errors).toEqual([
+        'Kubernetes version "" not found.',
+      ]);
+    });
   });
 });

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -323,7 +323,7 @@ describe(SettingsValidator, () => {
       });
 
       it('should reject an unknown version', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { version: '3.2.1' } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { version: '3.2.1', enabled: true } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
@@ -345,7 +345,7 @@ describe(SettingsValidator, () => {
       it('should reject a non-version value', () => {
         const [needToUpdate, errors] = subject.validateSettings(
           cfg,
-          { kubernetes: { version: 'pikachu' } });
+          { kubernetes: { version: 'pikachu', enabled: true } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
@@ -427,6 +427,7 @@ describe(SettingsValidator, () => {
           containerEngine: { expected: 'a string' } as unknown as settings.ContainerEngine,
           version:         { expected: 'a string' } as unknown as string,
           options:         "ceci n'est pas un objet" as unknown as Record<string, boolean>,
+          enabled:         true,
         },
       });
       expect(needToUpdate).toBeFalsy();
@@ -449,6 +450,7 @@ describe(SettingsValidator, () => {
             'pitaya*paprika': false,
             traefik:          cfg.kubernetes.options.traefik,
           },
+          enabled: true,
         },
         portForwarding: {
           'kiwano // 8 1/2':          'cows',

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -45,8 +45,13 @@ export default class SettingsValidator {
   k8sVersions: Array<string> = [];
   allowedSettings: SettingsValidationMap | null = null;
   synonymsTable: settingsLike|null = null;
+  newSetting: RecursivePartial<Settings> = defaultSettings;
 
-  validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
+  validateSettings(
+    currentSettings: Settings,
+    newSettings: RecursivePartial<Settings>,
+  ): [boolean, string[]] {
+    this.newSetting = newSettings;
     this.allowedSettings ||= {
       version:    this.checkUnchanged,
       kubernetes: {
@@ -228,6 +233,10 @@ export default class SettingsValidator {
   }
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
+    if (!this.newSetting.kubernetes?.enabled) {
+      return true;
+    }
+
     if (!this.k8sVersions.includes(desiredVersion)) {
       errors.push(`Kubernetes version "${ desiredVersion }" not found.`);
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -45,10 +45,10 @@ export default class SettingsValidator {
   k8sVersions: Array<string> = [];
   allowedSettings: SettingsValidationMap | null = null;
   synonymsTable: settingsLike|null = null;
-  isKubernetesEnabled = false;
+  isKubernetesDesired = false;
 
   validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
-    this.isKubernetesEnabled = newSettings.kubernetes?.enabled || false;
+    this.isKubernetesDesired = typeof newSettings.kubernetes?.enabled !== 'undefined' ? newSettings.kubernetes.enabled : currentSettings.kubernetes.enabled;
     this.allowedSettings ||= {
       version:    this.checkUnchanged,
       kubernetes: {
@@ -230,7 +230,11 @@ export default class SettingsValidator {
   }
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
-    if (!this.isKubernetesEnabled) {
+    /**
+     * Kubernetes can be disabled but we still require a valid version or an
+     * empty string
+    */
+    if (!this.isKubernetesDesired && (desiredVersion === '' || this.k8sVersions.includes(desiredVersion))) {
       return true;
     }
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -45,13 +45,10 @@ export default class SettingsValidator {
   k8sVersions: Array<string> = [];
   allowedSettings: SettingsValidationMap | null = null;
   synonymsTable: settingsLike|null = null;
-  newSetting: RecursivePartial<Settings> = defaultSettings;
+  isKubernetesEnabled = false;
 
-  validateSettings(
-    currentSettings: Settings,
-    newSettings: RecursivePartial<Settings>,
-  ): [boolean, string[]] {
-    this.newSetting = newSettings;
+  validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
+    this.isKubernetesEnabled = newSettings.kubernetes?.enabled || false;
     this.allowedSettings ||= {
       version:    this.checkUnchanged,
       kubernetes: {
@@ -233,7 +230,7 @@ export default class SettingsValidator {
   }
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
-    if (!this.newSetting.kubernetes?.enabled) {
+    if (!this.isKubernetesEnabled) {
       return true;
     }
 


### PR DESCRIPTION
This allows for preferences to be applied when Kubernetes is disabled and no Kubernetes version is selected. 

closes #2816 