### PR TITLE
Make sure the user's selected k8s version is used.

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1431,6 +1431,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     let kubernetesVersion: semver.SemVer | undefined;
     let isDowngrade = false;
 
+    this.kubeBackend.cfg = config;
     this.setState(State.STARTING);
     this.currentAction = Action.STARTING;
     this.#allowSudo = !config_.suppressSudo;
@@ -2029,7 +2030,7 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
     await this.k3sHelper.deleteKubeState(this.vm);
   }
 
-  protected cfg: RecursiveReadonly<BackendSettings> | undefined;
+  cfg: RecursiveReadonly<BackendSettings> | undefined;
 
   protected readonly arch: Architecture;
   protected readonly vm: LimaBackend;

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -1006,6 +1006,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       { containerEngine: ContainerEngine.NONE }) as RecursiveReadonly<Settings['kubernetes']>;
     let kubernetesVersion: semver.SemVer | undefined;
 
+    this.kubeBackend.cfg = config;
     this.setState(State.STARTING);
     this.currentAction = Action.STARTING;
     await this.progressTracker.action('Initializing Rancher Desktop', 10, async() => {
@@ -1420,7 +1421,7 @@ class WSLKubernetesBackend extends events.EventEmitter implements K8s.Kubernetes
     mainEvents.on('network-ready', () => this.k3sHelper.networkReady());
   }
 
-  protected cfg: RecursiveReadonly<BackendSettings> | undefined;
+  cfg: RecursiveReadonly<BackendSettings> | undefined;
   protected vm: WSLBackend;
   /** Helper object to manage available K3s versions. */
   protected k3sHelper = new K3sHelper('x86_64');


### PR DESCRIPTION
Fixes #2927

The code was using a null object, instead of the actual config, so it was defaulting to the most recent stable version.

Signed-off-by: Eric Promislow <epromislow@suse.com>