### PR TITLE
Diagnostics: docker cli symlink: fix app directory.

### DIFF
--- a/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/src/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -2,8 +2,6 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import paths from '@/utils/paths';
-
 // The (mock) application directory.
 let appDir = '';
 
@@ -22,7 +20,7 @@ jest.mock('electron', () => {
 
 // Mock fs.promises.readdir() for the default export.
 jest.spyOn(fs.promises, 'readdir').mockImplementation((dir, encoding) => {
-  expect(dir).toEqual(path.join(paths.resources, os.platform(), 'bin'));
+  expect(dir).toEqual(path.join(appDir, 'resources', os.platform(), 'bin'));
   expect(encoding).toEqual('utf-8');
 
   return Promise.resolve([]);
@@ -42,7 +40,8 @@ describe(CheckerDockerCLISymlink, () => {
 
   beforeAll(async() => {
     appDir = await mkdtemp(path.join(os.tmpdir(), 'rd-diag-'));
-    appDirExecutable = path.join(appDir, executable);
+    await fs.promises.mkdir(path.join(appDir, 'resources'));
+    appDirExecutable = path.join(appDir, 'resources', executable);
   });
   afterAll(async() => {
     await rm(appDir, { recursive: true, force: true });

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -2,8 +2,6 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import Electron from 'electron';
-
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
 
@@ -59,8 +57,8 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
             break;
           }
         }
-        console.debug(`docker-cli symlink: ${ this.name }: final symlink: ${ link } (app dir ${ Electron.app.getAppPath() })`);
-        if (path.relative(Electron.app.getAppPath(), link).startsWith('.')) {
+        console.debug(`docker-cli symlink: ${ this.name }: final symlink: ${ link } (app dir ${ paths.resources })`);
+        if (path.relative(paths.resources, link).startsWith('.')) {
           state = `is a symlink to ${ replaceHome(link) }, which is not from Rancher Desktop`;
         } else {
           try {


### PR DESCRIPTION
The directory we used for expected resources location was incorrect for packaged builds.  Use the actual path we use to install things instead, so that it always matches up.

Fixes #2928