### PR TITLE
Wrap sudo reasons paths in scrollable code block

### DIFF
--- a/src/pages/SudoPrompt.vue
+++ b/src/pages/SudoPrompt.vue
@@ -13,9 +13,11 @@
           <summary>{{ SUDO_REASON_DESCRIPTION[reason].title }}</summary>
           <p>{{ SUDO_REASON_DESCRIPTION[reason].description.replace(/\s+/g, ' ') }}</p>
           <p>{{ t('sudoPrompt.explanation') }}</p>
-          <ul>
-            <li v-for="path in paths" :key="path" class="monospace" v-text="path" />
-          </ul>
+          <code>
+            <ul>
+              <li v-for="path in paths" :key="path" class="monospace" v-text="path" />
+            </ul>
+          </code>
         </details>
       </li>
     </ul>
@@ -95,6 +97,7 @@ export default Vue.extend({
   .contents {
     padding: 0.75rem;
     min-width: 32rem;
+    max-width: 32rem;
   }
 
   summary {
@@ -117,6 +120,15 @@ export default Vue.extend({
   li.monospace {
     /* font-family is set in _typography.scss */
     white-space: pre;
+  }
+
+  .reasons code {
+    display: block;
+    overflow: auto;
+  }
+
+  code::-webkit-scrollbar-corner {
+    background: rgba(0,0,0,0.5);
   }
 
   #suppress {


### PR DESCRIPTION
This adds a maximum width to the sudo reasons dialog to resolve an issue on macOS that would cause multiple resize events to trigger due to a horizontal scrollbar that show/hides in rapid succession. 

This scrollbar would trigger on paths that were too long to fit cleanly inside of their parent, causing their container to grow. Adding a maximum width easily resolves the issue.

The inclusion of the code block is a purely aesthetic choice. I think that the code block provides some contrast that makes it obvious that the area can be scrollable. 

closes #2848 

## Examples

<img width="1052" alt="Screen Shot 2022-09-20 at 1 11 43 PM" src="https://user-images.githubusercontent.com/835961/191355413-5f12c7b6-a4d9-4bde-8368-05b946f9eb3f.png">

<img width="1052" alt="Screen Shot 2022-09-20 at 1 10 53 PM" src="https://user-images.githubusercontent.com/835961/191355419-3ce6d2fd-1df3-4d29-a4e2-f8e80a9f4da4.png">

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>