### PR TITLE
Disable opening preferences window if Kubernetes is in Stopping/Stopped state

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,7 +18,7 @@ export default Vue.extend({
   },
   computed: {
     isDisabled(): boolean {
-      return isPreferencesEnabled(this.kubernetesState);
+      return !isPreferencesEnabled(this.kubernetesState);
     },
   },
   methods:    {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -17,7 +17,7 @@ export default Vue.extend({
   },
   computed: {
     isDisabled(): boolean {
-      return [State.STOPPED, State.STOPPING, State.ERROR].includes(this.kubernetesState);
+      return [State.STOPPED, State.STOPPING].includes(this.kubernetesState);
     },
   },
   methods:    {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,11 +1,25 @@
 <script lang="ts">
 import Vue from 'vue';
 
+import { State } from '@/backend/k8s';
 import PreferencesButton from '@/components/Preferences/ButtonOpen.vue';
+
+import type { PropType } from 'vue';
 
 export default Vue.extend({
   name:       'rd-header',
   components: { PreferencesButton },
+  props:      {
+    kubernetesState: {
+      type:    String as PropType<State>,
+      default: State.STARTING,
+    },
+  },
+  computed: {
+    isDisabled(): boolean {
+      return [State.STOPPED, State.STOPPING, State.ERROR].includes(this.kubernetesState);
+    },
+  },
   methods:    {
     openPreferences() {
       this.$emit('open-preferences');
@@ -20,7 +34,10 @@ export default Vue.extend({
       <img src="@/assets/images/logo.svg">
     </div>
     <div class="header-actions">
-      <preferences-button @open-preferences="openPreferences" />
+      <preferences-button
+        :disabled="isDisabled"
+        @open-preferences="openPreferences"
+      />
     </div>
   </header>
 </template>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -3,6 +3,7 @@ import Vue from 'vue';
 
 import { State } from '@/backend/k8s';
 import PreferencesButton from '@/components/Preferences/ButtonOpen.vue';
+import { isPreferencesEnabled } from '@/utils/preferences';
 
 import type { PropType } from 'vue';
 
@@ -17,7 +18,7 @@ export default Vue.extend({
   },
   computed: {
     isDisabled(): boolean {
-      return [State.STOPPED, State.STOPPING].includes(this.kubernetesState);
+      return isPreferencesEnabled(this.kubernetesState);
     },
   },
   methods:    {

--- a/src/components/Preferences/ButtonOpen.vue
+++ b/src/components/Preferences/ButtonOpen.vue
@@ -25,31 +25,37 @@ export default Vue.extend({
   // We make use of the term Floating Action Button (fab) here because the
   // design of this button is reminiscent of floating actions buttons from
   // Material Design
-  button.role-fab {
-    all: revert;
-    cursor: pointer;
-    font-size: 1.875rem;
-    line-height: 0;
-    border: 0;
-    padding: 0.5rem;
-    background: none;
-    color: var(--body-text);
-    transition: background 400ms;
-    border-radius: 50%;
-  }
+  button {
+    &.role-fab {
+      all: revert;
+      cursor: pointer;
+      font-size: 1.875rem;
+      line-height: 0;
+      border: 0;
+      padding: 0.5rem;
+      background: none;
+      color: var(--body-text);
+      transition: background 400ms;
+      border-radius: 50%;
+    }
 
-  button.ripple {
-    background-position: center;
-    transition: background 0.8s;
-  }
+    &:not([disabled]).ripple {
+      background-position: center;
+      transition: background 0.8s;
 
-  .ripple:hover {
-    background: var(--tooltip-bg) radial-gradient(circle, transparent 1%, var(--tooltip-bg) 1%) center/15000%;
-  }
+      &:hover {
+        background: var(--tooltip-bg) radial-gradient(circle, transparent 1%, var(--tooltip-bg) 1%) center/15000%;
+      }
 
-  .ripple:active {
-    background-color: var(--default);
-    background-size: 100%;
-    transition: background 0s;
+      &:active {
+        background-color: var(--default);
+        background-size: 100%;
+        transition: background 0s;
+      }
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 </style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="wrapper">
-    <rd-header class="header" @open-preferences="openPreferences" />
+    <rd-header
+      class="header"
+      :kubernetes-state="getK8sState"
+      @open-preferences="openPreferences"
+    />
     <rd-nav class="nav" :items="routes" />
     <the-title />
     <main class="body">
@@ -75,6 +79,7 @@ export default {
     },
     ...mapState('credentials', ['credentials']),
     ...mapGetters('diagnostics', ['diagnostics']),
+    ...mapGetters('k8sManager', ['getK8sState']),
   },
 
   beforeMount() {

--- a/src/main/mainmenu.ts
+++ b/src/main/mainmenu.ts
@@ -2,6 +2,7 @@ import Electron, { Menu, MenuItem, MenuItemConstructorOptions, shell } from 'ele
 
 import { State } from '@/backend/k8s';
 import mainEvents from '@/main/mainEvents';
+import { isPreferencesEnabled } from '@/utils/preferences';
 import { openMain } from '@/window';
 
 export default function buildApplicationMenu(): void {
@@ -189,7 +190,7 @@ function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
   return [
     {
       label:               'Preferences',
-      enabled:             (![State.STOPPING, State.STOPPED].includes(kubernetesState)),
+      enabled:             isPreferencesEnabled(kubernetesState),
       visible:             true,
       registerAccelerator: true,
       accelerator:         'CmdOrCtrl+,',

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -17,6 +17,7 @@ import mainEvents from '@/main/mainEvents';
 import { checkConnectivity } from '@/main/networking';
 import Logging from '@/utils/logging';
 import paths from '@/utils/paths';
+import { isPreferencesEnabled } from '@/utils/preferences';
 import { openMain, send } from '@/window';
 import { openDashboard } from '@/window/dashboard';
 
@@ -137,10 +138,6 @@ export class Tray {
       setTimeout(this.watchOnceAndRestart, 1000, kubeconfigPath);
     });
   };
-
-  private isPreferencesEnabled() {
-    return (![State.STOPPING, State.STOPPED].includes(this.kubernetesState));
-  }
 
   constructor() {
     this.trayMenu = new Electron.Tray(this.trayIconSet.starting);
@@ -311,7 +308,7 @@ export class Tray {
     const preferencesMenuItem = this.contextMenuItems.find(item => item.id === 'preferences');
 
     if (preferencesMenuItem) {
-      preferencesMenuItem.enabled = this.isPreferencesEnabled();
+      preferencesMenuItem.enabled = isPreferencesEnabled(this.kubernetesState);
     }
 
     const contextMenu = Electron.Menu.buildFromTemplate(this.contextMenuItems);

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -138,6 +138,10 @@ export class Tray {
     });
   };
 
+  private isPreferencesEnabled() {
+    return (![State.STOPPING, State.STOPPED].includes(this.kubernetesState));
+  }
+
   constructor() {
     this.trayMenu = new Electron.Tray(this.trayIconSet.starting);
     this.trayMenu.setToolTip('Rancher Desktop');
@@ -303,6 +307,13 @@ export class Tray {
     if (networkStatusItem) {
       networkStatusItem.label = `Network status: ${ this.currentNetworkStatus }`;
     }
+
+    const preferencesMenuItem = this.contextMenuItems.find(item => item.id === 'preferences');
+
+    if (preferencesMenuItem) {
+      preferencesMenuItem.enabled = this.isPreferencesEnabled();
+    }
+
     const contextMenu = Electron.Menu.buildFromTemplate(this.contextMenuItems);
 
     this.trayMenu.setContextMenu(contextMenu);

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -1,0 +1,11 @@
+import { State } from '@/backend/k8s';
+
+/**
+ * Determines if the preferences window can be opened based on the current
+ * Kubernetes state.
+ * @param kubernetesState The active Kubernetes state to test.
+ * @returns True if the preferences window can be opened.
+ */
+export const isPreferencesEnabled = (kubernetesState: State) => {
+  return (![State.STOPPING, State.STOPPED].includes(kubernetesState));
+};


### PR DESCRIPTION
This disables opening the Preferences window while Kubernetes is in a Stopping/Stopped state. This PR disables multiple modes of opening the preferences window, including

* Tray Menu
* Application Menu
* Application Shortcut (`Ctrl+,`/`Cmd+,`)
* Preferences Button

closes #2678 