### PR TITLE
Fix installer failing to elevate

### DIFF
--- a/build/elevated-install.ps1
+++ b/build/elevated-install.ps1
@@ -117,10 +117,9 @@ function Install-Kernel {
 function Install-PrivilegedService {
   Param([String] $InstallDir)
   Write-Output "Installing Rancher Desktop Privileged Service"
-  $ExecPath = (Join-Path $InstallDir 'resources\win32\internal\privileged-service.exe')
-  $InstallCommand = "`"${InstallDir}`" install"
-  $Exec = Invoke-Expression -Command $InstallCommand
-  if ($Exec.ExitCode -ne '0') {
+  $ExecPath = (Join-Path $InstallDir 'resources\resources\win32\internal\privileged-service.exe')
+  (& "$ExecPath" "install")
+  if ($LASTEXITCODE -ne '0') {
     exit 102
   }
 }

--- a/build/elevated-install.ps1
+++ b/build/elevated-install.ps1
@@ -34,7 +34,7 @@ function Restart-ScriptForElevation {
     Write-Output "Script is already elevated, no need to restart; continuing with installation..."
     return
   }
-  $CommandLine = "-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File `"${PSCommandPath}`" $($args)"
+  $CommandLine = "-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -File `"${PSCommandPath}`" -InstallDir:`"${InstallDir}`" -Stage:$Stage"
   Write-Output "Restarting script with arguments ${CommandLine}"
   $Process = (Start-Process -FilePath "${PSHOME}\PowerShell.exe" -Verb RunAs -Wait -PassThru -ArgumentList $CommandLine)
   Exit $Process.ExitCode
@@ -117,7 +117,7 @@ function Install-Kernel {
 function Install-PrivilegedService {
   Param([String] $InstallDir)
   Write-Output "Installing Rancher Desktop Privileged Service"
-  $ExecPath = (Join-Path $InstallDir 'resources\resources\win32\internal\privileged-service.exe')
+  $ExecPath = (Join-Path "${InstallDir}" 'resources\resources\win32\internal\privileged-service.exe')
   (& "$ExecPath" "install")
   if ($LASTEXITCODE -ne '0') {
     exit 102
@@ -125,7 +125,8 @@ function Install-PrivilegedService {
 }
 
 Restart-ScriptForElevation $args
-Install-PrivilegedService $args
+Install-PrivilegedService ${InstallDir}
+
 
 switch ($Stage) {
   "Initial" {

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -27,7 +27,7 @@
   # elevate here.
   nsExec::ExecToLog 'powershell.exe \
     -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
-    -File "$PLUGINSDIR\elevated-install.ps1" "-InstallDir:$INSTDIR"'
+    -File "$PLUGINSDIR\elevated-install.ps1" -InstallDir:"$INSTDIR"'
   Pop $R0
   ${If} $R0 == "error"
     Abort "Error occured during elevated install."
@@ -56,17 +56,17 @@
 !macroend
 
 !macro customUnInstall
+  # Uninstall Priviliged Service
+  File "/oname=$PLUGINSDIR\uninstall-privileged-service.ps1" "${BUILD_RESOURCES_DIR}\uninstall-privileged-service.ps1"
+  nsExec::ExecToLog 'powershell.exe \
+    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
+    -File "$PLUGINSDIR\uninstall-privileged-service.ps1" -InstallPath:"$INSTDIR"'
+  Pop $R0
+
   # Remove the bin directory from the PATH
   File "/oname=$PLUGINSDIR\remove-from-path.ps1" "${BUILD_RESOURCES_DIR}\remove-from-path.ps1"
   nsExec::ExecToLog 'powershell.exe \
     -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
     -File "$PLUGINSDIR\remove-from-path.ps1" "$INSTDIR"'
-  Pop $R0
-
-  # Uninstall Priviliged Service
-  File "/oname=$PLUGINSDIR\uninstall-privileged-service.ps1" "${BUILD_RESOURCES_DIR}\uninstall-privileged-service.ps1"
-  nsExec::ExecToLog 'powershell.exe \
-    -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned \
-    -File "$PLUGINSDIR\uninstall-privileged-service.ps1" "$INSTDIR"'
   Pop $R0
 !macroend

--- a/build/uninstall-privileged-service.ps1
+++ b/build/uninstall-privileged-service.ps1
@@ -1,15 +1,16 @@
 # .SYNOPSIS
 # PowerShell script to uninstall Rancher Desktop Privileged Service
 
-param($ServiceExecutable)
+param($InstallDir)
 
 # .SYNOPSIS
 # Uninstalls Rancher Desktop Privileged Service
 function Uninstall-PrivilegedService {
-  Param([String] $ServiceExecutable)
-  Write-Output "Uninstalling Rancher Desktop Privileged Service"
-  $Process = (Start-Process -FilePath "${ServiceExecutable}" -Verb RunAs -Wait -PassThru -ArgumentList "uninstall")
-  exit $Process.ExitCode
+  Param([String] $LiteralPath)
+  $ExecPath = (Join-Path "${LiteralPath}" 'resources\resources\win32\internal\privileged-service.exe')
+  Start-Process -FilePath ${ExecPath} -Verb RunAs -Wait -PassThru -ArgumentList "uninstall"
+  exit $LASTEXITCODE
 }
 
-Uninstall-PrivilegedService (Join-Path $ServiceExecutable 'resources\win32\internal\privileged-service.exe')
+
+Uninstall-PrivilegedService ${InstallDir}


### PR DESCRIPTION
Invoke Expression when encountered space in the paths it would through an exception nor is it the right tool for this scenario. This change removes Invoke-Expression altogether.

Signed-off-by: Nino Kodabande <nkodabande@suse.com>