### PR TITLE
Ensure that `rancher-desktop` distro is created after unregistering it when upgrading

### DIFF
--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -267,9 +267,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
    */
   protected async ensureDistroRegistered(): Promise<void> {
     if (await this.isDistroRegistered()) {
-      // rancher-desktop distribution is already registered.
-      await this.progressTracker.action('Checking distribution version', 50, this.upgradeDistroAsNeeded());
-
       return;
     }
     await this.progressTracker.action('Registering WSL distribution', 100, async() => {
@@ -889,6 +886,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       await this.progressTracker.action('Upgrading WSL distribution', 100, async() => {
         await this.initDataDistribution();
         await this.execWSL('--unregister', INSTANCE_NAME);
+        await this.ensureDistroRegistered();
       });
     }
   }
@@ -1014,6 +1012,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         const prepActions = [(async() => {
           await this.ensureDistroRegistered();
           await this.initDataDistribution();
+          await this.upgradeDistroAsNeeded();
           await this.writeHostsFile();
           await this.writeResolvConf();
         })(),

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -285,6 +285,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     if (!await this.isDistroRegistered()) {
       throw new Error(`Error registering WSL2 distribution`);
     }
+
+    await this.initDataDistribution();
   }
 
   /**
@@ -1011,7 +1013,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       try {
         const prepActions = [(async() => {
           await this.ensureDistroRegistered();
-          await this.initDataDistribution();
           await this.upgradeDistroAsNeeded();
           await this.writeHostsFile();
           await this.writeResolvConf();


### PR DESCRIPTION
`upgradeDistroAsNeeded` unregisters the `rancher-desktop` distro when it is out of date, but does not create it again. This was the case in 1.5.1 as well, but it wasn't a problem there because `ensureDistroRegistered` was called immediately after `upgradeDistroAsNeeded`.

Closes #2934.