### PR TITLE
Diagnostics: make documentation link optional.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -843,7 +843,6 @@ test.describe('Command server', () => {
           expect(JSON.parse(stdout)).toMatchObject({
             checks: [{
               id:            'CONNECTED_TO_INTERNET',
-              documentation: 'path#connected_to_internet',
               description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
               mute:          false,
             }],
@@ -858,7 +857,6 @@ test.describe('Command server', () => {
               {
                 category:      'Networking',
                 id:            'CONNECTED_TO_INTERNET',
-                documentation: 'path#connected_to_internet',
                 description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
                 mute:          false,
                 fixes:         [],
@@ -876,7 +874,6 @@ test.describe('Command server', () => {
               {
                 category:      'Utilities',
                 id:            'RD_BIN_IN_BASH_PATH',
-                documentation: 'path#rd_bin_bash',
                 description:   'The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your bash shell.',
                 mute:          false,
                 fixes:         [
@@ -886,7 +883,6 @@ test.describe('Command server', () => {
               {
                 category:      'Utilities',
                 id:            'RD_BIN_SYMLINKS',
-                documentation: 'path#rd_bin_symlinks',
                 description:   'Are the files under ~/.docker/cli-plugins symlinks to ~/.rd/bin?',
                 mute:          false,
                 fixes:         [
@@ -905,7 +901,6 @@ test.describe('Command server', () => {
               {
                 category:      'Networking',
                 id:            'CONNECTED_TO_INTERNET',
-                documentation: 'path#connected_to_internet',
                 description:   'The application cannot reach the general internet for updated kubernetes versions and other components, but can still operate.',
                 mute:          false,
               },

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -162,7 +162,7 @@ export default Vue.extend({
       <template #col:description="{row}">
         <td>
           <span>{{ row.description }}</span>
-          <a :href="row.documentation" class="doclink"><span class="icon icon-external-link" /></a>
+          <a v-if="row.documentation" :href="row.documentation" class="doclink"><span class="icon icon-external-link" /></a>
         </td>
       </template>
       <template #col:mute="{row}">

--- a/src/main/diagnostics/connectedToInternet.ts
+++ b/src/main/diagnostics/connectedToInternet.ts
@@ -21,7 +21,6 @@ const CheckConnectedToInternet: DiagnosticsChecker = {
   },
   check() {
     return Promise.resolve({
-      documentation: 'path#connected_to_internet',
       description:   'The application cannot reach the general internet for ' +
       'updated kubernetes versions and other components, but can still operate.',
       passed: online,

--- a/src/main/diagnostics/dockerCliSymlinks.ts
+++ b/src/main/diagnostics/dockerCliSymlinks.ts
@@ -101,10 +101,9 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
     }
 
     return {
-      documentation: 'path#rd_bin_symlinks',
       description,
       passed,
-      fixes:         [],
+      fixes: [],
     };
   }
 }

--- a/src/main/diagnostics/kubeContext.ts
+++ b/src/main/diagnostics/kubeContext.ts
@@ -42,8 +42,7 @@ const KubeContextDefaultChecker: DiagnosticsChecker = {
 
     return {
       description,
-      documentation: 'path#kube_default_context',
-      fixes:         [],
+      fixes: [],
       passed,
     };
   },

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -58,7 +58,6 @@ class RDBinInShellPath implements DiagnosticsChecker {
     }
 
     return {
-      documentation: `path#${ this.id.toLowerCase() }`,
       description,
       passed,
       fixes,

--- a/src/main/diagnostics/testCheckers.ts
+++ b/src/main/diagnostics/testCheckers.ts
@@ -21,7 +21,7 @@ class CheckTesting implements DiagnosticsChecker {
   check() {
     return Promise.resolve({
       passed:        this.pass,
-      documentation: '!!!',
+      documentation: 'https://www.example.com/not-a-valid-link',
       description:   `This is a sample test that will ${ this.pass ? 'always' : 'never' } pass.`,
       fixes:         [],
     });

--- a/src/main/diagnostics/types.ts
+++ b/src/main/diagnostics/types.ts
@@ -16,7 +16,7 @@ type DiagnosticsFix = {
  */
 export type DiagnosticsCheckerResult = {
   /* Link to documentation about this check. */
-  documentation: string,
+  documentation?: string,
   /* User-visible description about this check. */
   description: string,
   /** If true, the check succeeded (no fixes need to be applied). */


### PR DESCRIPTION
We won't have the correct documentation in place by the time we ship; hide the documentation links if we don't have them.

Fixes #2952