### PR TITLE
Fix checking for ~/.rd/bin in shell rc files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "vue-select": "^3.20.0",
         "vue-shortkey": "^3.1.7",
         "vue-slider-component": "^3.2.20",
+        "which": "^2.0.2",
         "xdg-app-paths": "^5.4.1",
         "yaml": "^2.1.1"
       },
@@ -74,6 +75,7 @@
         "@types/ref-struct-di": "^1.1.6",
         "@types/semver": "^7.3.10",
         "@types/tar-stream": "^2.2.1",
+        "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.33.0",
         "@vue/test-utils": "^1.1.2",
@@ -5872,6 +5874,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "6.0.4",
@@ -33176,6 +33184,12 @@
           "dev": true
         }
       }
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
     },
     "@types/ws": {
       "version": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vue-select": "^3.20.0",
     "vue-shortkey": "^3.1.7",
     "vue-slider-component": "^3.2.20",
+    "which": "^2.0.2",
     "xdg-app-paths": "^5.4.1",
     "yaml": "^2.1.1"
   },
@@ -105,6 +106,7 @@
     "@types/ref-struct-di": "^1.1.6",
     "@types/semver": "^7.3.10",
     "@types/tar-stream": "^2.2.1",
+    "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.33.0",
     "@vue/test-utils": "^1.1.2",

--- a/src/main/diagnostics/rdBinInShell.ts
+++ b/src/main/diagnostics/rdBinInShell.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import which from 'which';
 
-import { DiagnosticsCategory, DiagnosticsChecker } from './types';
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './types';
 
 import { PathManagementStrategy } from '@/integrations/pathManager';
 import mainEvents from '@/main/mainEvents';
@@ -33,10 +33,10 @@ class RDBinInShellPath implements DiagnosticsChecker {
     return Promise.resolve(!!this.executable);
   }
 
-  async check() {
+  async check(): Promise<DiagnosticsCheckerResult> {
     const fixes: {description: string}[] = [];
     let passed = false;
-    let description = '';
+    let description: string;
 
     try {
       const { stdout } = await spawnFile(this.executable, this.args, { stdio: 'pipe' });
@@ -57,7 +57,6 @@ class RDBinInShellPath implements DiagnosticsChecker {
     } catch (ex: any) {
       description = ex.message ?? ex.toString();
       passed = false;
-      fixes.push({ description: 'fix the exception' });
     }
 
     return {


### PR DESCRIPTION
Fixes #2951

* Use -ic 'echo $PATH' for both bash and zsh
* Don't assume the full paths for bash and zsh
* Allow for shell login processes to output to stdout -- separate it from the path

Signed-off-by: Eric Promislow <epromislow@suse.com>