### PR TITLE
Subtract # muted diagnostics from # failed ones.

### DIFF
--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
   },
   computed: {
     numFailed(): number {
-      return this.rows.length;
+      return this.rows.length - this.numMuted;
     },
     numMuted(): number {
       return this.rows.filter(row => row.mute).length;
@@ -97,7 +97,7 @@ export default Vue.extend({
     <div class="status">
       <div class="result-info">
         <div class="item-results">
-          <span class="icon icon-dot text-error" />{{ numFailed }} failed ({{ numMuted }} muted)
+          <span class="icon icon-dot text-error" />{{ numFailed }} failed, {{ numMuted }} muted
         </div>
         <toggle-switch
           v-model="showMuted"

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
     <div class="status">
       <div class="result-info">
         <div class="item-results">
-          <span class="icon icon-dot text-error" />{{ numFailed }} failed, {{ numMuted }} muted
+          <span class="icon icon-dot text-error" />{{ numFailed }} failed plus {{ numMuted }} muted
         </div>
         <toggle-switch
           v-model="showMuted"

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -71,7 +71,7 @@ export default {
       return !!this.$config.featureDiagnostics;
     },
     errorCount() {
-      return this.diagnostics.length;
+      return this.diagnostics.filter(diagnostic => !diagnostic.mute).length;
     },
     ...mapState('credentials', ['credentials']),
     ...mapGetters('diagnostics', ['diagnostics']),


### PR DESCRIPTION
Fixes #2955

Note that when the number of non-failed diagnostics goes to 0 the badge automatically disappears from the routing tab. Nice default (I assume) in vue/vuex's routing table?

Signed-off-by: Eric Promislow <epromislow@suse.com>