### PR TITLE
Wrap `checker.check()` in a try/catch

### DIFF
--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -128,7 +128,11 @@ export class DiagnosticsManager {
   async runChecks(): Promise<DiagnosticsResultCollection> {
     await Promise.all((await this.applicableCheckers(null, null)).map(async(checker) => {
       console.debug(`Running check ${ checker.id }`);
-      this.results[checker.id] = await checker.check();
+      try {
+        this.results[checker.id] = await checker.check();
+      } catch (e) {
+        console.error(`ERROR checking ${ checker.id }`, { e });
+      }
     }));
     this.lastUpdate = new Date();
 

--- a/src/main/diagnostics/diagnostics.ts
+++ b/src/main/diagnostics/diagnostics.ts
@@ -58,7 +58,11 @@ export class DiagnosticsManager {
       for (const checker of checkers) {
         checker.trigger = async(checker) => {
           console.debug(`Triggering diagnostics ${ checker.id }`);
-          this.results[checker.id] = await checker.check();
+          try {
+            this.results[checker.id] = await checker.check();
+          } catch (e) {
+            console.error(`ERROR triggering ${ checker.id }`, { e });
+          }
         };
         this.checkerIdByCategory[checker.category] ??= [];
         this.checkerIdByCategory[checker.category]?.push(checker.id);


### PR DESCRIPTION
This resolves an issue with the time last run not updating by wrapping `checker.check()` in a try/catch block. Catching errors here also properly adds unhandled exceptions to the `diagnostics.log` where they were previously showing up in `server.log`. 

closes #2954 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>