### PR TITLE
Rerun diagnostics when entering the diagnostics tab.

### DIFF
--- a/src/components/DiagnosticsButtonRun.vue
+++ b/src/components/DiagnosticsButtonRun.vue
@@ -26,6 +26,7 @@ export default Vue.extend({
     this.lastRunInterval = setInterval(() => {
       this.currentTime = dayjs();
     }, 1000);
+    this.onClick();
   },
   beforeDestroy() {
     clearInterval(this.lastRunInterval);


### PR DESCRIPTION
Fixes #2972 

I did see the connectivity status getting updated on tab switch, but didn't see updates for either
docker-plugin symlink or the kubectl context check. This change updates everything, when it's needed.
Note that if there has been a change in the # of diagnostics since the diagnostics panel was last shown,
the badge # in the Diagnostics tab doesn't get updated until the list in the panel is updated.

Signed-off-by: Eric Promislow <epromislow@suse.com>