### PR TITLE
Background: Don't unnecessarily restart on settings change.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -877,6 +877,15 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       // Obviously if there are no settings to update, there's no need to restart.
       return ['no changes necessary', ''];
     }
+
+    // Check if the newly applied preferences demands a restart of the backend.
+    const restartReasons = await k8smanager.requiresRestartReasons(cfg.kubernetes);
+
+    if (Object.keys(restartReasons).length === 0) {
+      return ['settings updated; no restart required.', ''];
+    }
+
+    // Trigger a restart of the backend (possibly delayed).
     if (!backendIsBusy()) {
       pendingRestartContext = undefined;
       setImmediate(doFullRestart, context);

--- a/background.ts
+++ b/background.ts
@@ -882,7 +882,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     const restartReasons = await k8smanager.requiresRestartReasons(cfg.kubernetes);
 
     if (Object.keys(restartReasons).length === 0) {
-      return ['settings updated; no restart required.', ''];
+      return ['settings updated; no restart required', ''];
     }
 
     // Trigger a restart of the backend (possibly delayed).

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -304,6 +304,17 @@ test.describe('Command server', () => {
     expect(body).toContain('Unknown command: GET /v99bottlesofbeeronthewall');
   });
 
+  test('should not restart on unrelated changes', async() => {
+    let resp = await doRequest('/v0/settings');
+    let telemetry = false;
+
+    expect(resp.ok).toBeTruthy();
+    telemetry = (await resp.json() as Settings).telemetry;
+    resp = await doRequest('/v0/settings', JSON.stringify({ telemetry: !telemetry }), 'PUT');
+    expect(resp.ok).toBeTruthy();
+    await expect(resp.text()).resolves.toContain('no restart required');
+  });
+
   test.describe('rdctl', () => {
     test.describe('config-file and parameters', () => {
       test.describe("when the config-file doesn't exist", () => {


### PR DESCRIPTION
If the changed settings (via the API) doesn't require the backend to restart, don't restart it needlessly.
    

Fixes #2629.