### PR TITLE
Persist muted diagnostics & show muted in settings

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -618,7 +618,7 @@ test.describe('Command server', () => {
                   });
                   const settings = JSON.parse(stdout);
 
-                  expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy']).toMatchObject(Object.keys(settings));
+                  expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy', 'diagnostics']).toMatchObject(Object.keys(settings));
                 });
               }
             }

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -242,6 +242,14 @@ components:
         pathManagementStrategy:
           type: string
           enum: ['manual', 'rcfiles']
+        diagnostics:
+          type: object
+          properties:
+            showMuted:
+              type: boolean
+            mutedChecks:
+              type: object
+              additionalProperties: true
     diagnostics:
       type: object
       properties:

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
       this.$store.dispatch('diagnostics/updateDiagnostic', { isMuted, row });
     },
     toggleMute() {
-      this.$store.dispatch('preferences/toggleShowMuted');
+      this.$store.dispatch('preferences/toggleShowMuted', !this.showMuted as boolean);
     },
     toggleExpand(group: DiagnosticsCategory) {
       this.expanded[group] = !this.expanded[group];

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ToggleSwitch } from '@rancher/components';
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import DiagnosticsButtonRun from '@/components/DiagnosticsButtonRun.vue';
 import EmptyState from '@/components/EmptyState.vue';
@@ -38,11 +39,11 @@ export default Vue.extend({
           width: 76,
         },
       ],
-      showMuted:   false,
-      expanded:    Object.fromEntries(Object.values(DiagnosticsCategory).map(c => [c, true])) as Record<DiagnosticsCategory, boolean>,
+      expanded: Object.fromEntries(Object.values(DiagnosticsCategory).map(c => [c, true])) as Record<DiagnosticsCategory, boolean>,
     };
   },
   computed: {
+    ...mapGetters('preferences', ['showMuted']),
     numFailed(): number {
       return this.rows.length;
     },
@@ -83,7 +84,7 @@ export default Vue.extend({
       this.$store.dispatch('diagnostics/updateDiagnostic', { isMuted, row });
     },
     toggleMute() {
-      this.showMuted = !this.showMuted;
+      this.$store.dispatch('preferences/toggleShowMuted');
     },
     toggleExpand(group: DiagnosticsCategory) {
       this.expanded[group] = !this.expanded[group];
@@ -100,8 +101,9 @@ export default Vue.extend({
           <span class="icon icon-dot text-error" />{{ numFailed }} failed ({{ numMuted }} muted)
         </div>
         <toggle-switch
-          v-model="showMuted"
           off-label="Show Muted"
+          :value="showMuted"
+          @input="toggleMute"
         />
       </div>
       <div class="spacer" />

--- a/src/components/DiagnosticsBody.vue
+++ b/src/components/DiagnosticsBody.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
       this.$store.dispatch('diagnostics/updateDiagnostic', { isMuted, row });
     },
     toggleMute() {
-      this.$store.dispatch('preferences/toggleShowMuted', !this.showMuted as boolean);
+      this.$store.dispatch('preferences/setShowMuted', !this.showMuted as boolean);
     },
     toggleExpand(group: DiagnosticsCategory) {
       this.expanded[group] = !this.expanded[group];

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -38,6 +38,10 @@ describe('updateFromCommandLine', () => {
       updater:                true,
       debug:                  true,
       pathManagementStrategy: PathManagementStrategy.NotSet,
+      diagnostics:            {
+        showMuted:   false,
+        mutedChecks: [],
+      },
     };
     origPrefs = clone(prefs);
   });

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -40,7 +40,7 @@ describe('updateFromCommandLine', () => {
       pathManagementStrategy: PathManagementStrategy.NotSet,
       diagnostics:            {
         showMuted:   false,
-        mutedChecks: [],
+        mutedChecks: { },
       },
     };
     origPrefs = clone(prefs);

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -66,7 +66,7 @@ export const defaultSettings = {
   pathManagementStrategy: PathManagementStrategy.NotSet,
   diagnostics:            {
     showMuted:   false,
-    mutedChecks: [] as string[],
+    mutedChecks: {} as Record<string, boolean>,
   },
 };
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -64,6 +64,10 @@ export const defaultSettings = {
   updater:                true,
   debug:                  false,
   pathManagementStrategy: PathManagementStrategy.NotSet,
+  diagnostics:            {
+    showMuted:   false,
+    mutedChecks: [] as string[],
+  },
 };
 
 export type Settings = typeof defaultSettings;

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -39,6 +39,7 @@ export default {
 
         return;
       }
+      await this.$store.dispatch('preferences/fetchPreferences', this.credentials);
       await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
     }
   },

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -59,7 +59,7 @@ export default class SettingsValidator {
         containerEngine:            this.checkContainerEngine,
         checkForExistingKimBuilder: this.checkUnchanged, // Should only be set internally
         enabled:                    this.checkBoolean,
-        WSLIntegrations:            this.checkWindows(this.checkWSLIntegrations),
+        WSLIntegrations:            this.checkWindows(this.validateBooleanMapping),
         options:                    { traefik: this.checkBoolean, flannel: this.checkBoolean },
         suppressSudo:               this.checkLima(this.checkBoolean),
         hostResolver:               this.checkWindows(this.checkBoolean),
@@ -74,7 +74,7 @@ export default class SettingsValidator {
       debug:                  this.checkBoolean,
       pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
       diagnostics:            {
-        mutedChecks: this.checkMutedDiagnostics,
+        mutedChecks: this.validateBooleanMapping,
         showMuted:   this.checkBoolean,
       },
     };
@@ -233,8 +233,6 @@ export default class SettingsValidator {
     return currentValue !== desiredEngine;
   }
 
-  protected checkMutedDiagnostics = this.checkWSLIntegrations;
-
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
     /**
      * Kubernetes can be disabled but we still require a valid version or an
@@ -265,7 +263,7 @@ export default class SettingsValidator {
     return false;
   }
 
-  protected checkWSLIntegrations(currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
+  protected validateBooleanMapping(currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
     if (typeof (desiredValue) !== 'object') {
       errors.push(`Proposed field ${ fqname } should be an object, got <${ desiredValue }>.`);
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -59,7 +59,7 @@ export default class SettingsValidator {
         containerEngine:            this.checkContainerEngine,
         checkForExistingKimBuilder: this.checkUnchanged, // Should only be set internally
         enabled:                    this.checkBoolean,
-        WSLIntegrations:            this.checkWindows(this.validateBooleanMapping),
+        WSLIntegrations:            this.checkWindows(this.checkBooleanMapping),
         options:                    { traefik: this.checkBoolean, flannel: this.checkBoolean },
         suppressSudo:               this.checkLima(this.checkBoolean),
         hostResolver:               this.checkWindows(this.checkBoolean),
@@ -74,7 +74,7 @@ export default class SettingsValidator {
       debug:                  this.checkBoolean,
       pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
       diagnostics:            {
-        mutedChecks: this.validateBooleanMapping,
+        mutedChecks: this.checkBooleanMapping,
         showMuted:   this.checkBoolean,
       },
     };
@@ -263,7 +263,13 @@ export default class SettingsValidator {
     return false;
   }
 
-  protected validateBooleanMapping(currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
+  /**
+   * Ensures that settings that are object that adhere to their type of
+   * Record<string, boolean>. This is useful for checking that values other than
+   * booleans are not unintentionally added to settings like WSLIntegrations
+   * and mutedChecks.
+   */
+  protected checkBooleanMapping(currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
     if (typeof (desiredValue) !== 'object') {
       errors.push(`Proposed field ${ fqname } should be an object, got <${ desiredValue }>.`);
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -76,7 +76,7 @@ export default class SettingsValidator {
       debug:                  this.checkBoolean,
       pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
       diagnostics:            {
-        mutedChecks: () => true,
+        mutedChecks: this.checkMutedDiagnostics,
         showMuted:   this.checkBoolean,
       },
     };
@@ -181,19 +181,6 @@ export default class SettingsValidator {
   }
 
   /**
-   * checkArray is a generic checker for simple boolean values.
-   */
-  protected checkArray(currentValue: string[], desiredValue: string[], errors: string[], fqname: string): boolean {
-    if (Array.isArray(desiredValue)) {
-      return currentValue !== desiredValue;
-    }
-
-    errors.push(this.invalidSettingMessage(fqname, desiredValue));
-
-    return false;
-  }
-
-  /**
    * checkBoolean is a generic checker for simple boolean values.
    */
   protected checkBoolean(currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
@@ -247,6 +234,8 @@ export default class SettingsValidator {
 
     return currentValue !== desiredEngine;
   }
+
+  protected checkMutedDiagnostics = this.checkWSLIntegrations;
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
     /**

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -264,7 +264,7 @@ export default class SettingsValidator {
   }
 
   /**
-   * Ensures that settings that are object that adhere to their type of
+   * Ensures settings that are objects adhere to their type of
    * Record<string, boolean>. This is useful for checking that values other than
    * booleans are not unintentionally added to settings like WSLIntegrations
    * and mutedChecks.

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -32,8 +32,6 @@ type SettingsValidationMapEntry<T> = {
   ValidatorFunc<T[k], T[k]> :
   T[k] extends Record<string, infer V> ?
   SettingsValidationMapEntry<T[k]> | ValidatorFunc<T[k], Record<string, V>> :
-  T[k] extends Array<infer V> ?
-  ValidatorFunc<T[k], Array<V>> :
   never;
 };
 

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -76,7 +76,7 @@ export default class SettingsValidator {
       debug:                  this.checkBoolean,
       pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
       diagnostics:            {
-        mutedChecks: this.checkArray,
+        mutedChecks: () => true,
         showMuted:   this.checkBoolean,
       },
     };

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -12,8 +12,8 @@ export default Vue.extend({
   async fetch() {
     const credentials = await this.$store.dispatch('credentials/fetchCredentials');
 
-    await this.$store.dispatch('diagnostics/fetchDiagnostics', credentials);
     await this.$store.dispatch('preferences/fetchPreferences', credentials);
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', credentials);
   },
   computed: mapGetters('diagnostics', ['diagnostics', 'timeLastRun']),
   mounted() {

--- a/src/pages/Diagnostics.vue
+++ b/src/pages/Diagnostics.vue
@@ -13,6 +13,7 @@ export default Vue.extend({
     const credentials = await this.$store.dispatch('credentials/fetchCredentials');
 
     await this.$store.dispatch('diagnostics/fetchDiagnostics', credentials);
+    await this.$store.dispatch('preferences/fetchPreferences', credentials);
   },
   computed: mapGetters('diagnostics', ['diagnostics', 'timeLastRun']),
   mounted() {

--- a/src/pages/Preferences.vue
+++ b/src/pages/Preferences.vue
@@ -71,7 +71,7 @@ export default Vue.extend({
 
       await this.$store.dispatch(
         'preferences/commitPreferences',
-        this.credentials as ServerState,
+        { ...this.credentials as ServerState },
       );
       this.closePreferences();
     },

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -23,11 +23,7 @@ const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }
  */
 const mapMutedDiagnostics = (checks: DiagnosticsResult[], mutedChecks: Record<string, boolean>) => {
   return checks.map((check) => {
-    if (Object.keys(mutedChecks).includes(check.id)) {
-      check.mute = mutedChecks[check.id];
-    }
-
-    return check;
+    return check.id in mutedChecks ? { ...check, mute: mutedChecks[check.id] } : check;
   });
 };
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -3,7 +3,7 @@ import { GetterTree } from 'vuex';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
-import { Settings } from '@/config/settings';
+import type { Settings } from '@/config/settings';
 import type { ServerState } from '@/main/commandServer/httpCommandServer';
 import type { DiagnosticsResult, DiagnosticsResultCollection } from '@/main/diagnostics/diagnostics';
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -3,7 +3,6 @@ import { GetterTree } from 'vuex';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
-import type { Settings } from '@/config/settings';
 import type { ServerState } from '@/main/commandServer/httpCommandServer';
 import type { DiagnosticsResult, DiagnosticsResultCollection } from '@/main/diagnostics/diagnostics';
 
@@ -123,7 +122,7 @@ export const actions = {
       'preferences/commitPreferences',
       {
         ...rootState.credentials.credentials as ServerState,
-        payload: { diagnostics: { mutedChecks } } as Partial<Settings>,
+        payload: { diagnostics: { mutedChecks } },
       },
       { root: true },
     );

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -137,7 +137,7 @@ export const actions = {
 };
 
 export const getters: GetterTree<DiagnosticsState, DiagnosticsState> = {
-  diagnostics(state: DiagnosticsState, _getters) {
+  diagnostics(state: DiagnosticsState, getters) {
     return state.diagnostics;
   },
   timeLastRun(state: DiagnosticsState) {

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -3,6 +3,7 @@ import { GetterTree } from 'vuex';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
+import { Settings } from '@/config/settings';
 import type { ServerState } from '@/main/commandServer/httpCommandServer';
 import type { DiagnosticsResult, DiagnosticsResultCollection } from '@/main/diagnostics/diagnostics';
 
@@ -116,17 +117,14 @@ export const actions = {
 
     rowToUpdate.mute = isMuted;
 
-    await dispatch(
-      'preferences/updatePreferencesData',
-      {
-        property: `diagnostics.mutedChecks.${ rowToUpdate.id }`,
-        value:    isMuted,
-      },
-      { root: true });
+    const mutedChecks = { ...rootState.preferences.preferences.diagnostics.mutedChecks, [rowToUpdate.id]: isMuted };
 
     await dispatch(
       'preferences/commitPreferences',
-      rootState.credentials.credentials as ServerState,
+      {
+        ...rootState.credentials.credentials as ServerState,
+        payload: { diagnostics: { mutedChecks } } as Partial<Settings>,
+      },
       { root: true },
     );
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -22,9 +22,7 @@ const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }
  * @returns A collection of diagnostic results with an updated muted property.
  */
 const mapMutedDiagnostics = (checks: DiagnosticsResult[], mutedChecks: Record<string, boolean>) => {
-  return checks.map((check) => {
-    return check.id in mutedChecks ? { ...check, mute: mutedChecks[check.id] } : check;
-  });
+  return checks.map(check => ({ ...check, mute: !!mutedChecks[check.id] }));
 };
 
 export const state: () => DiagnosticsState = () => (

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -3,8 +3,10 @@ import { GetterTree } from 'vuex';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
+import { Settings } from '@/config/settings';
 import type { ServerState } from '@/main/commandServer/httpCommandServer';
 import type { DiagnosticsResult, DiagnosticsResultCollection } from '@/main/diagnostics/diagnostics';
+import { RecursivePartial } from '~/utils/typeUtils';
 
 interface DiagnosticsState {
   diagnostics: Array<DiagnosticsResult>,
@@ -122,7 +124,7 @@ export const actions = {
       'preferences/commitPreferences',
       {
         ...rootState.credentials.credentials as ServerState,
-        payload: { diagnostics: { mutedChecks } },
+        payload: { diagnostics: { mutedChecks } } as RecursivePartial<Settings>,
       },
       { root: true },
     );

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -14,6 +14,23 @@ interface DiagnosticsState {
 
 const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v0/${ pathRemainder }`;
 
+/**
+ * Updates the muted property for diagnostic results.
+ * @param checks A collection of diagnostic results that require muting.
+ * @param mutedChecks A collection of key, value pairs that contains a key of
+ * the ID for the diagnostic and a boolean value for muting the result.
+ * @returns A collection of diagnostic results with an updated muted property.
+ */
+const mapMutedDiagnostics = (checks: DiagnosticsResult[], mutedChecks: any) => {
+  return checks.map((check) => {
+    if (Object.keys(mutedChecks).includes(check.id)) {
+      check.mute = mutedChecks[check.id];
+    }
+
+    return check;
+  });
+};
+
 export const state: () => DiagnosticsState = () => (
   {
     diagnostics: [],
@@ -61,18 +78,8 @@ export const actions = {
     }
     const result: DiagnosticsResultCollection = await response.json();
 
-    console.debug('NOT FAIL', { rootState });
-
     const mutedChecks = rootState.preferences.preferences.diagnostics.mutedChecks;
-    const checks = result.checks.map((x) => {
-      if (Object.keys(mutedChecks).includes(x.id)) {
-        x.mute = mutedChecks[x.id];
-
-        return x;
-      }
-
-      return x;
-    });
+    const checks = mapMutedDiagnostics(result.checks, mutedChecks);
 
     commit('SET_DIAGNOSTICS', checks);
     commit('SET_TIME_LAST_RUN', new Date(result.last_update));
@@ -97,18 +104,8 @@ export const actions = {
     }
     const result: DiagnosticsResultCollection = await response.json();
 
-    console.debug('NOT FAIL', { rootState });
-
     const mutedChecks = rootState.preferences.preferences.diagnostics.mutedChecks;
-    const checks = result.checks.map((x) => {
-      if (Object.keys(mutedChecks).includes(x.id)) {
-        x.mute = mutedChecks[x.id];
-
-        return x;
-      }
-
-      return x;
-    });
+    const checks = mapMutedDiagnostics(result.checks, mutedChecks);
 
     commit('SET_DIAGNOSTICS', checks);
     commit('SET_TIME_LAST_RUN', new Date(result.last_update));

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -21,7 +21,7 @@ const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }
  * the ID for the diagnostic and a boolean value for muting the result.
  * @returns A collection of diagnostic results with an updated muted property.
  */
-const mapMutedDiagnostics = (checks: DiagnosticsResult[], mutedChecks: any) => {
+const mapMutedDiagnostics = (checks: DiagnosticsResult[], mutedChecks: Record<string, boolean>) => {
   return checks.map((check) => {
     if (Object.keys(mutedChecks).includes(check.id)) {
       check.mute = mutedChecks[check.id];
@@ -129,7 +129,7 @@ export const actions = {
         value:    {
           ...rootState.preferences.preferences.diagnostics.mutedChecks,
           [rowToUpdate.id]: isMuted,
-        },
+        } as Record<string, boolean>,
       },
       { root: true });
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -121,11 +121,8 @@ export const actions = {
     await dispatch(
       'preferences/updatePreferencesData',
       {
-        property: 'diagnostics.mutedChecks',
-        value:    {
-          ...rootState.preferences.preferences.diagnostics.mutedChecks,
-          [rowToUpdate.id]: isMuted,
-        } as Record<string, boolean>,
+        property: `diagnostics.mutedChecks.${ rowToUpdate.id }`,
+        value:    isMuted,
       },
       { root: true });
 

--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -122,10 +122,6 @@ export const actions = {
 
     rowToUpdate.mute = isMuted;
 
-    console.debug('DIAGNOSTICS', {
-      rowToUpdate, diagnostics, rootState,
-    });
-
     await dispatch(
       'preferences/updatePreferencesData',
       {
@@ -136,6 +132,7 @@ export const actions = {
         },
       },
       { root: true });
+
     await dispatch(
       'preferences/commitPreferences',
       rootState.credentials.credentials as ServerState,

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -206,7 +206,7 @@ export const actions = {
 
     return severities;
   },
-  async toggleShowMuted({ dispatch, rootState }: PrefActionContext, isMuted: boolean) {
+  async setShowMuted({ dispatch, rootState }: PrefActionContext, isMuted: boolean) {
     await dispatch(
       'preferences/updatePreferencesData',
       {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -5,7 +5,7 @@ import { ActionContext, MutationsType } from './ts-helpers';
 
 import { defaultSettings, Settings } from '@/config/settings';
 import type { ServerState } from '@/main/commandServer/httpCommandServer';
-import { RecursiveKeys, RecursiveTypes } from '@/utils/typeUtils';
+import { RecursiveKeys, RecursivePartial, RecursiveTypes } from '@/utils/typeUtils';
 
 import type { GetterTree } from 'vuex';
 

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -26,7 +26,7 @@ interface PreferencesState {
 }
 
 interface CommitArgs extends ServerState {
-  payload?: Partial<Settings>;
+  payload?: RecursivePartial<Settings>;
 }
 
 const uri = (port: number) => `http://localhost:${ port }/v0/settings`;

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -206,6 +206,22 @@ export const actions = {
 
     return severities;
   },
+  async toggleShowMuted({ dispatch, rootState }: PrefActionContext) {
+    await dispatch(
+      'preferences/updatePreferencesData',
+      {
+        property: 'diagnostics.showMuted',
+        value:    !rootState.preferences.preferences.diagnostics.showMuted,
+      },
+      { root: true },
+    );
+
+    await dispatch(
+      'preferences/commitPreferences',
+      rootState.credentials.credentials as ServerState,
+      { root: true },
+    );
+  },
 };
 
 export const getters: GetterTree<PreferencesState, PreferencesState> = {
@@ -230,5 +246,8 @@ export const getters: GetterTree<PreferencesState, PreferencesState> = {
   },
   canApply(state: PreferencesState, getters) {
     return getters.isPreferencesDirty && state.preferencesError.length === 0;
+  },
+  showMuted(state: PreferencesState) {
+    return state.preferences.diagnostics.showMuted;
   },
 };

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -109,8 +109,6 @@ export const actions = {
       port, user, password, payload,
     } = args;
 
-    console.debug({ payload });
-
     await fetch(
       uri(port),
       {
@@ -219,7 +217,7 @@ export const actions = {
       'preferences/commitPreferences',
       {
         ...rootState.credentials.credentials as ServerState,
-        payload: { diagnostics: { showMuted: isMuted } } as Partial<Settings>,
+        payload: { diagnostics: { showMuted: isMuted } },
       },
       { root: true },
     );

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -206,12 +206,12 @@ export const actions = {
 
     return severities;
   },
-  async toggleShowMuted({ dispatch, rootState }: PrefActionContext) {
+  async toggleShowMuted({ dispatch, rootState }: PrefActionContext, isMuted: boolean) {
     await dispatch(
       'preferences/updatePreferencesData',
       {
         property: 'diagnostics.showMuted',
-        value:    !rootState.preferences.preferences.diagnostics.showMuted,
+        value:    isMuted,
       },
       { root: true },
     );


### PR DESCRIPTION
This persists choices made for muting individual diagnostics and showing muted diagnostics in the settings object. In order to achieve this, we added a new `diagnostics` property to the settings object as well as updating the `diagnostics` and `preferences` stores so that they save these choices while muting.

closes #2968