### PR TITLE
Ignore trailing slash(es) when checking for integration dir in PATH.

### DIFF
--- a/src/main/diagnostics/__tests__/rdBinInShell.spec.ts
+++ b/src/main/diagnostics/__tests__/rdBinInShell.spec.ts
@@ -1,0 +1,13 @@
+import { RDBinInShellPath } from '../rdBinInShell';
+
+describe(RDBinInShellPath, () => {
+  it('should remove trailing slashes', () => {
+    expect(RDBinInShellPath.removeTrailingSlash('/Users/mikey/.rd/bin/')).toBe('/Users/mikey/.rd/bin');
+    expect(RDBinInShellPath.removeTrailingSlash('/Users/mikey/.rd/bin////')).toBe('/Users/mikey/.rd/bin');
+    expect(RDBinInShellPath.removeTrailingSlash('/Users/mikey/.rd/bin')).toBe('/Users/mikey/.rd/bin');
+    expect(RDBinInShellPath.removeTrailingSlash('/')).toBe('/');
+    expect(RDBinInShellPath.removeTrailingSlash('//')).toBe('/');
+    expect(RDBinInShellPath.removeTrailingSlash('/////')).toBe('/');
+    expect(RDBinInShellPath.removeTrailingSlash('')).toBe('');
+  });
+});


### PR DESCRIPTION
Fixes #2977

Note that this relies on PR #2982 to avoid gnarly conflicts in the future.

This PR also assumes the temporary log statements from 2951 are no longer needed

- Paths coming from $PATH are user-supplied and need to be verified.
- paths.integration should never have a trailing slash, but we might as well check.

Signed-off-by: Eric Promislow <epromislow@suse.com>