### PR TITLE
Remove expansion of muted checks

### DIFF
--- a/src/store/diagnostics.ts
+++ b/src/store/diagnostics.ts
@@ -118,13 +118,11 @@ export const actions = {
 
     rowToUpdate.mute = isMuted;
 
-    const mutedChecks = { ...rootState.preferences.preferences.diagnostics.mutedChecks, [rowToUpdate.id]: isMuted };
-
     await dispatch(
       'preferences/commitPreferences',
       {
         ...rootState.credentials.credentials as ServerState,
-        payload: { diagnostics: { mutedChecks } } as RecursivePartial<Settings>,
+        payload: { diagnostics: { mutedChecks: { [rowToUpdate.id]: isMuted } } } as RecursivePartial<Settings>,
       },
       { root: true },
     );


### PR DESCRIPTION
There's no need to send all `mutedChecks` in the payload when we could just send the `mutedCheck` for the property that we're interested in updating. 

closes #2993 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>