### PR TITLE
Update type for k8sState prop in PortForwarding

### DIFF
--- a/src/components/PortForwarding.vue
+++ b/src/components/PortForwarding.vue
@@ -114,7 +114,7 @@ export default Vue.extend({
       default: false,
     },
     k8sState: {
-      type:    Number,
+      type:    String as PropType<K8s.State>,
       default: K8s.State.STOPPED,
     },
     kubernetesIsDisabled: {


### PR DESCRIPTION
This fixes failing prop validation in `PortForwarding.vue`. We had previously updated the type for the `State` enum from `number` to `string` but it looks like we missed updating the prop in this instance.

closes #2995 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>