### PR TITLE
Do not return an err if service is already running

### DIFF
--- a/src/go/privileged-service/pkg/manage/manage.go
+++ b/src/go/privileged-service/pkg/manage/manage.go
@@ -18,6 +18,7 @@ package manage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 	"time"
@@ -46,7 +47,9 @@ func StartService(name string) error {
 	}
 	defer s.Close()
 	if err = s.Start(); err != nil {
-		return fmt.Errorf("could not start service: %w", err)
+		if !errors.Is(err, windows.ERROR_SERVICE_ALREADY_RUNNING) {
+			return fmt.Errorf("could not start service: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
We should not return an error `Error: could not start service: An instance of the service is already running.` from Privileged Service if the service is already running. This is due to the fact that we rely on the [returns error](https://github.com/rancher-sandbox/rancher-desktop/blob/8d0206d7b28af3b1ac8f6bca2df70ba8856dab5c/src/backend/wsl.ts#L701) from the `start` command to determine if the service is available or not. 

Signed-off-by: Nino Kodabande <nkodabande@suse.com>