### PR TITLE
Lima: Restore support for vde_vmnet.

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -99,8 +99,13 @@ test.describe.serial('KubernetesBackend', () => {
         headers: { Authorization: `basic ${ auth }` },
         method:  'PUT',
       });
+      const text = await result.text();
 
-      return await result.json();
+      try {
+        return JSON.parse(text);
+      } catch (ex) {
+        throw new Error(`Response text is not JSON: \n${ text }`);
+      }
     }
 
     test('should detect changes', async() => {

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -128,24 +128,32 @@ test.describe.serial('KubernetesBackend', () => {
           },
         },
       };
-      const platformSettings: Partial<Record<NodeJS.Platform | 'lima', RecursivePartial<Settings>>> = {
+      /** Platform-specific changes to `newSettings`. */
+      const platformSettings: Partial<Record<NodeJS.Platform, RecursivePartial<Settings>>> = {
         win32: { kubernetes: { hostResolver: getAlt('hostResolver', true, false) } },
-        lima:  {
-          kubernetes: {
-            numberCPUs:   getAlt('numberCPUs', 1, 2),
-            memoryInGB:   getAlt('memoryInGB', 3, 4),
-            suppressSudo: getAlt('suppressSudo', true, false),
-          },
-        },
         darwin: { kubernetes: { experimental: { socketVMNet: getAlt('experimental.socketVMNet', true, false) } } },
       };
 
       _.merge(newSettings, platformSettings[process.platform] ?? {});
       if (['darwin', 'linux'].includes(process.platform)) {
-        _.merge(newSettings, platformSettings.lima);
+        // Lima-specific changes to `newSettings`.
+        _.merge(newSettings, {
+          kubernetes: {
+            numberCPUs: getAlt('numberCPUs', 1, 2),
+            memoryInGB: getAlt('memoryInGB', 3, 4),
+            suppressSudo: getAlt('suppressSudo', true, false),
+          },
+        });
       }
 
-      const expectedDefinition: Partial<Record<RecursiveKeys<Settings['kubernetes']>, boolean>> = {
+      /**
+       * Helper type; an (incomplete) mapping where the key is the preference
+       * name (the `kubernetes.` prefix is implied), and the value is a boolean
+       * value indicating whether reset is needed.
+       */
+      type ExpectedDefinition = Partial<Record<RecursiveKeys<KubeSettings>, boolean>>;
+
+      const expectedDefinition: ExpectedDefinition = {
         version:           semver.lt(newSettings.kubernetes?.version ?? '0.0.0', currentSettings.kubernetes.version),
         port:              false,
         containerEngine:   false,
@@ -154,7 +162,8 @@ test.describe.serial('KubernetesBackend', () => {
         'options.flannel': false,
       };
 
-      const platformExpectedDefinitions: Partial<Record<NodeJS.Platform, Partial<Record<keyof RecursiveTypes<KubeSettings>, boolean>>>> = {
+      /** Platform-specific additions to `expectedDefinition`. */
+      const platformExpectedDefinitions: Partial<Record<NodeJS.Platform, ExpectedDefinition>> = {
         win32:  { hostResolver: false },
         darwin: { 'experimental.socketVMNet': false },
       };
@@ -162,6 +171,7 @@ test.describe.serial('KubernetesBackend', () => {
       _.merge(expectedDefinition, platformExpectedDefinitions[process.platform] ?? {});
 
       if (['darwin', 'linux'].includes(process.platform)) {
+        // Lima additions to expectedDefinition
         expectedDefinition.suppressSudo = false;
         expectedDefinition.numberCPUs = false;
         expectedDefinition.memoryInGB = false;

--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 ---
-limaAndQemu: "1.25"
+limaAndQemu: "1.26"
 alpineLimaISO:
   isoVersion: 0.2.21
   alpineVersion: 3.16.0

--- a/src/assets/networks-config.yaml
+++ b/src/assets/networks-config.yaml
@@ -1,16 +1,19 @@
-# Path to socket_vmnet executable. Because socket_vmnet is invoked via sudo it should be
-# installed where only root can modify/replace it. This means also none of the
-# parent directories should be writable by the user.
+# Path to vde_vmnet / socket_vmnet executables. Because both vde_vmnet and
+# socket_vmnet are invoked via sudo, they should be installed where only root
+# can modify/replace them. This means also none of the parent directories should
+# be writable by the user.
 #
 # The varRun directory also must not be writable by the user because it will
-# include the socket_vmnet pid file. Those will be terminated via sudo, so replacing
-# the pid file would allow killing of arbitrary privileged processes. varRun
-# however MUST be writable by the daemon user.
+# include the vde_vmnet / socket_vmnet pid files. Those will be terminated via
+# sudo, so replacing the pid file would allow killing of arbitrary privileged
+# processes. varRun however MUST be writable by the daemon user.
 #
 # None of the paths segments may be symlinks, which is why it has to be /private/var
 # instead of /var etc.
 paths:
   socketVMNet: /opt/rancher-desktop/bin/socket_vmnet
+  vdeSwitch: /opt/rancher-desktop/bin/vde_switch
+  vdeVMNet: /opt/rancher-desktop/bin/vde_vmnet
   varRun: /private/var/run
   sudoers: /private/etc/sudoers.d/zzzzz-rancher-desktop-lima
 group: everyone

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -221,6 +221,11 @@ components:
               type: boolean
             hostResolver:
               type: boolean
+            experimental:
+              type: object
+              properties:
+                socketVMNet:
+                  type: boolean
         portForwarding:
           type: object
           properties:

--- a/src/backend/__tests__/k3sHelper.spec.ts
+++ b/src/backend/__tests__/k3sHelper.spec.ts
@@ -90,6 +90,10 @@ describe(K3sHelper, () => {
       expect(process('1.2.3-beta1')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
+    it('should skip valid but erroneous verions', async() => {
+      expect(process('1.2.3+rk3s1')).toEqual(true);
+      expect(await subject.availableVersions).toHaveLength(0);
+    });
     it('should ignore old versions', async() => {
       expect(process('0.2.0')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);

--- a/src/backend/__tests__/k3sHelper.spec.ts
+++ b/src/backend/__tests__/k3sHelper.spec.ts
@@ -90,7 +90,7 @@ describe(K3sHelper, () => {
       expect(process('1.2.3-beta1')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
-    it('should skip valid but erroneous verions', async() => {
+    it('should skip valid but erroneous versions', async () => {
       expect(process('1.2.3+rk3s1')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -292,7 +292,7 @@ export default class K3sHelper extends events.EventEmitter {
       return true;
     }
     if (!/^v?[0-9.]+(?:-rc\d+)?\+k3s\d+$/.test(version.raw)) {
-      console.log(`Version ${ version.raw } looks like an errorneous version, skipping.`);
+      console.log(`Version ${ version.raw } looks like an erroneous version, skipping.`);
 
       return true;
     }

--- a/src/backend/k3sHelper.ts
+++ b/src/backend/k3sHelper.ts
@@ -291,6 +291,11 @@ export default class K3sHelper extends events.EventEmitter {
       // We may have new patch versions for really old releases; fetch more.
       return true;
     }
+    if (!/^v?[0-9.]+(?:-rc\d+)?\+k3s\d+$/.test(version.raw)) {
+      console.log(`Version ${ version.raw } looks like an errorneous version, skipping.`);
+
+      return true;
+    }
     const build = buildVersion(version);
     const oldVersion = this.versions[version.version];
 

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -64,6 +64,14 @@ enum Action {
 }
 
 /**
+ * Enumeration for determining whether to use vde_vmnet or socket_vmnet.
+ */
+enum VMNet {
+  VDE,
+  SOCKET,
+}
+
+/**
  * Lima configuration
  */
 type LimaConfiguration = {
@@ -117,7 +125,9 @@ type LimaConfiguration = {
  */
 interface LimaNetworkConfiguration {
   paths: {
-    socketVMNet: string;
+    socketVMNet?: string;
+    vdeSwitch?: string;
+    vdeVMNet?: string;
     varRun: string;
     sudoers?: string;
   }
@@ -189,7 +199,7 @@ const ROOT_DOCKER_CONFIG_PATH = path.join(ROOT_DOCKER_CONFIG_DIR, 'config.json')
 /** The following files, and their parents up to /, must only be writable by root,
  *  and none of them are allowed to be symlinks (lima-vm requirements).
  */
-const SOCKET_VMNET_DIR = '/opt/rancher-desktop';
+const VMNET_DIR = '/opt/rancher-desktop';
 
 // Make this file the last one to be loaded by `sudoers` so others don't override needed settings.
 // Details at https://github.com/rancher-sandbox/rancher-desktop/issues/1444
@@ -575,7 +585,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           console.log('Could not find any acceptable host networks for bridging.');
         }
       } else {
-        console.log('Administrator access disallowed, not using socket_vmnet.');
+        console.log('Administrator access disallowed, not using vde/socket_vmnet.');
         delete config.networks;
       }
     }
@@ -648,9 +658,9 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
   protected static get limaEnv() {
     const binDir = path.join(paths.resources, os.platform(), 'lima', 'bin');
-    const socketVMNETDir = path.join(SOCKET_VMNET_DIR, 'bin');
+    const VMNETDir = path.join(VMNET_DIR, 'bin');
     const pathList = (process.env.PATH || '').split(path.delimiter);
-    const newPath = [binDir, socketVMNETDir].concat(...pathList).filter(x => x);
+    const newPath = [binDir, VMNETDir].concat(...pathList).filter(x => x);
 
     return {
       ...process.env, LIMA_HOME: paths.lima, PATH: newPath.join(path.delimiter),
@@ -811,7 +821,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    *          if no privileged access was required.
    * @note This may request the root password.
    */
-  protected async installToolsWithSudo(): Promise<boolean> {
+  protected async installToolsWithSudo(vmnet: VMNet): Promise<boolean> {
     const randomTag = LimaBackend.calcRandomTag(8);
     const commands: Array<string> = [];
     const explanations: Partial<Record<SudoReason, string[]>> = {};
@@ -825,7 +835,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
     if (os.platform() === 'darwin') {
       await this.progressTracker.action('Setting up virtual ethernet', 10, async() => {
-        processCommand(await this.installSocketVMNETTools());
+        processCommand(await this.installVMNETTools(vmnet));
       });
       await this.progressTracker.action('Setting Lima permissions', 10, async() => {
         processCommand(await this.ensureRunLimaLocation());
@@ -870,11 +880,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   /**
-   * Determine the commands required to install socket_vmnet-related tools.
+   * Determine the commands required to install vmnet-related tools.
    */
-  protected async installSocketVMNETTools(this: unknown): Promise<SudoCommand | undefined> {
-    const sourcePath = path.join(paths.resources, os.platform(), 'lima', 'socket_vmnet');
-    const installedPath = SOCKET_VMNET_DIR;
+  protected async installVMNETTools(this: unknown, vmnet: VMNet): Promise<SudoCommand | undefined> {
+    const toolsDir = vmnet === VMNet.SOCKET ? 'socket_vmnet' : 'vde';
+    const sourcePath = path.join(paths.resources, os.platform(), 'lima', toolsDir);
+    const installedPath = VMNET_DIR;
     const walk = async(dir: string): Promise<[string[], string[]]> => {
       const fullPath = path.resolve(sourcePath, dir);
       const entries = await fs.promises.readdir(fullPath, { withFileTypes: true });
@@ -929,8 +940,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       return;
     }
 
-    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-socket-vmnet-install'));
-    const tarPath = path.join(workdir, 'socket_vmnet.tar');
+    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-vmnet-install'));
+    const tarPath = path.join(workdir, 'vmnet.tar');
     const commands: string[] = [];
 
     try {
@@ -993,7 +1004,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       await archiveFinished;
       const command = `tar -xf "${ tarPath }" -C "${ path.dirname(installedPath) }"`;
 
-      console.log(`Socket VMNET tools install required: ${ command }`);
+      console.log(`VMNET tools install required: ${ command }`);
       commands.push(command);
     } finally {
       commands.push(`rm -fr ${ workdir }`);
@@ -1002,7 +1013,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     return {
       reason: 'networking',
       commands,
-      paths:  [SOCKET_VMNET_DIR],
+      paths:  [VMNET_DIR],
     };
   }
 
@@ -1153,7 +1164,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    * If there's an existing file, replace it if it doesn't contain a
    * paths.varRun setting for rancher-desktop
    */
-  protected async installCustomLimaNetworkConfig(allowRoot = true) {
+  protected async installCustomLimaNetworkConfig(vmnet: VMNet, allowRoot = true) {
     const networkPath = path.join(paths.lima, '_config', 'networks.yaml');
 
     let config: LimaNetworkConfiguration;
@@ -1174,8 +1185,18 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       config = NETWORKS_CONFIG;
     }
 
-    // lima 0.12 deprecates vdeVMNet and adds support for socketVMNet
-    config.paths.socketVMNet ??= NETWORKS_CONFIG.paths.socketVMNet;
+    if (vmnet === VMNet.VDE) {
+      config.paths.vdeSwitch ??= NETWORKS_CONFIG.paths.vdeSwitch;
+      config.paths.vdeVMNet ??= NETWORKS_CONFIG.paths.vdeVMNet;
+      delete config.paths.socketVMNet;
+    } else if (vmnet === VMNet.SOCKET) {
+      // lima 0.12 deprecates vdeVMNet and adds support for socketVMNet
+      config.paths.socketVMNet ??= NETWORKS_CONFIG.paths.socketVMNet;
+      delete config.paths.vdeSwitch;
+      delete config.paths.vdeVMNet;
+    } else {
+      throw new BackendError('Invalid Configuration', `Unexpected VMNet value ${ vmnet }`, true);
+    }
 
     if (config.group === 'staff') {
       config.group = 'everyone';
@@ -1383,21 +1404,23 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    * @precondition The VM configuration is correct.
    */
   protected async startVM() {
+    const vmnet = this.cfg?.experimental.socketVMNet ? VMNet.SOCKET : VMNet.VDE;
+
     if (os.platform() === 'darwin') {
       await this.progressTracker.action('Installing networking requirements', 100, async() => {
-        await this.installCustomLimaNetworkConfig(this.#allowSudo);
+        await this.installCustomLimaNetworkConfig(vmnet, this.#allowSudo);
       });
     }
 
     // We need both the lima config + the lima network config to correctly check if we need sudo
     // access; but if it's denied, we need to regenerate both again to account for the change.
-    const allowRoot = this.#allowSudo && await this.progressTracker.action('Asking for permission to run tasks as administrator', 100, this.installToolsWithSudo());
+    const allowRoot = this.#allowSudo && await this.progressTracker.action('Asking for permission to run tasks as administrator', 100, this.installToolsWithSudo(vmnet));
 
     if (!allowRoot) {
       // sudo access was denied; re-generate the config.
       await this.progressTracker.action('Regenerating configuration to account for lack of permissions', 100, Promise.all([
         this.updateConfig(false),
-        this.installCustomLimaNetworkConfig(false),
+        this.installCustomLimaNetworkConfig(vmnet, false),
       ]));
     }
 

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -28,6 +28,7 @@ describe('updateFromCommandLine', () => {
         },
         suppressSudo:             false,
         hostResolver:             true,
+        experimental: { socketVMNet: true },
       },
       portForwarding: { includeKubernetesServices: false },
       images:         {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -53,6 +53,10 @@ export const defaultSettings = {
     * is handled by host-resolver on Windows platform only.
     */
     hostResolver:               true,
+    experimental:               {
+      /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
+      socketVMNet: false,
+    },
   },
   portForwarding:  { includeKubernetesServices: false },
   images:          {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -49,10 +49,13 @@ export const defaultSettings = {
     options:                    { traefik: true, flannel: true },
     suppressSudo:               false,
     /**
-    * when set to true Dnsmasq is disabled and all DNS resolution
-    * is handled by host-resolver on Windows platform only.
-    */
+     * when set to true Dnsmasq is disabled and all DNS resolution
+     * is handled by host-resolver on Windows platform only.
+     */
     hostResolver:               true,
+    /**
+     * Experimental settings - there should not be any UI for these.
+     */
     experimental:               {
       /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
       socketVMNet: false,

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -77,6 +77,7 @@ describe(SettingsValidator, () => {
         'kubernetes.memoryInGB':               'darwin',
         'kubernetes.numberCPUs':               'linux',
         'kubernetes.suppressSudo':             'linux',
+        'kubernetes.experimental.socketVMNet': 'darwin',
       };
 
       const spyValidateSettings = jest.spyOn(subject, 'validateSettings');


### PR DESCRIPTION
We seem to be having issues with `socket_vmnet`; default back to using `vde_vmnet` with a possibility to use `socket_vmnet` for testing.

- Add a new `kubernetes.experimental.socketVMNet` preference for this; there will be no UI for this setting, and it's only applicable on macOS (because vmnet is darwin-specific).
- Bump lima-and-qemu to pick up vde binaries (that were removed).
- Copy the VDE files as needed, sort of reverting 8a631e4a131f5b218e1f84dd185d832e73a0e922
- If the user changes the preference via API, restart the backend to apply it.
- Includes a fix to k3shelper due to k3s having a badly named release.
