### PR TITLE
Handle cases when the diag runtime appears to happen in the future.

### DIFF
--- a/src/components/DiagnosticsButtonRun.vue
+++ b/src/components/DiagnosticsButtonRun.vue
@@ -16,7 +16,11 @@ export default Vue.extend({
   },
   computed: {
     friendlyTimeLastRun(): string {
-      return this.currentTime.to(dayjs(this.timeLastRun));
+      // Because the currentTime is updated only every second it's possible for the last-time-run to have
+      // happened after the current-time.
+      // We can't update this.currentTime because computed methods can't have side-effects, so treat an
+      // older currentTime the same as timeLastRun.
+      return this.timeLastRun.valueOf() >= this.currentTime.valueOf() ? this.currentTime.to(this.currentTime) : this.currentTime.to(dayjs(this.timeLastRun));
     },
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();

--- a/src/components/DiagnosticsButtonRun.vue
+++ b/src/components/DiagnosticsButtonRun.vue
@@ -20,7 +20,12 @@ export default Vue.extend({
       // happened after the current-time.
       // We can't update this.currentTime because computed methods can't have side-effects, so treat an
       // older currentTime the same as timeLastRun.
-      return this.timeLastRun.valueOf() >= this.currentTime.valueOf() ? this.currentTime.to(this.currentTime) : this.currentTime.to(dayjs(this.timeLastRun));
+
+      if (this.currentTime.valueOf() >= this.timeLastRun.valueOf()) {
+        return this.currentTime.to(dayjs(this.timeLastRun));
+      } else {
+        return this.currentTime.to(this.currentTime);
+      }
     },
     timeLastRunTooltip(): string {
       return this.timeLastRun.toLocaleString();

--- a/src/main/diagnostics/__tests__/diagnostics.spec.ts
+++ b/src/main/diagnostics/__tests__/diagnostics.spec.ts
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
 import { DiagnosticsManager, DiagnosticsResult } from '../diagnostics';
 import { DiagnosticsCategory, DiagnosticsChecker } from '../types';
 
@@ -122,5 +125,23 @@ describe(DiagnosticsManager, () => {
       },
     });
     await internetCheck.not.toMatchObject({ checks: { 0: { fixes: { description: expect.any(String) } } } });
+  });
+});
+
+dayjs.extend(relativeTime);
+
+describe('dayjs', () => {
+  it('rounds sub-seconds up', () => {
+    const time1 = dayjs(new Date());
+    const time2 = dayjs(time1.valueOf() + 100);
+
+    expect(time1.to(time2)).toEqual('in a few seconds');
+    expect(time2.to(time1)).toEqual('a few seconds ago');
+  });
+  it('treats equality as a few seconds ago', () => {
+    const time1 = dayjs(new Date());
+
+    expect(time1.to(time1))
+      .toEqual('a few seconds ago');
   });
 });


### PR DESCRIPTION
Fixes #3041

The problem is that we only update the `this.currentTime` once a second, so always ensure that `this.currentTime` > `this.timeLastRun`

Includes unit tests to show how `dayjs` handles sub-second differences.

Signed-off-by: Eric Promislow <epromislow@suse.com>