### PR TITLE
Move diagnostics run to before main window is opened in `Electron.app.whenReady` handler

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -171,6 +171,8 @@ Electron.app.whenReady().then(async() => {
       iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
     });
 
+    await diagnostics.runChecks().catch(console.error);
+
     setupTray();
     window.openMain();
 
@@ -196,8 +198,6 @@ Electron.app.whenReady().then(async() => {
         }
       }
     }
-
-    diagnostics.runChecks().catch(console.error);
 
     await startBackend(cfg);
   } catch (ex) {


### PR DESCRIPTION
Fixes #3044.

If this works for Jan, that is.