### PR TITLE
Diagnostics: force trigger shell tests on applying.

### DIFF
--- a/src/integrations/pathManager.ts
+++ b/src/integrations/pathManager.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import manageLinesInFile from '@/integrations/manageLinesInFile';
+import mainEvents from '@/main/mainEvents';
 import paths from '@/utils/paths';
 
 /**
@@ -122,6 +123,9 @@ export class RcFilePathManager implements PathManager {
 
       return manageLinesInFile(rcPath, [pathLine], desiredPresent);
     }));
+
+    mainEvents.emit('diagnostics-trigger', 'RD_BIN_IN_BASH_PATH');
+    mainEvents.emit('diagnostics-trigger', 'RD_BIN_IN_ZSH_PATH');
   }
 
   protected async manageCsh(desiredPresent: boolean): Promise<void> {

--- a/src/main/diagnostics/types.ts
+++ b/src/main/diagnostics/types.ts
@@ -35,11 +35,6 @@ export interface DiagnosticsChecker {
   /** Whether this checker should be used on this system. */
   applicable(): Promise<boolean>,
   /**
-   * A function that the checker can call to force this check to be updated.
-   * This does not change the global last-checked timestamp.
-   */
-  trigger?: (checker: DiagnosticsChecker) => void,
-  /**
    * Perform the check.
    */
   check(): Promise<DiagnosticsCheckerResult>;

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -5,8 +5,8 @@
 
 import { EventEmitter } from 'events';
 
-import { VMBackend } from '@/backend/backend';
-import { Settings } from '@/config/settings';
+import type { VMBackend } from '@/backend/backend';
+import type { Settings } from '@/config/settings';
 import { RecursivePartial } from '@/utils/typeUtils';
 
 /**

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -81,6 +81,15 @@ interface MainEventNames {
    * interaction.
    */
   'api-credentials'(credentials: { user: string, password: string, port: number }): void;
+
+  /**
+   * Force trigger diagnostics with the given id.
+   * This is used when something has changed that might affect whether the given
+   * diagnostic needs to be re-run.
+   * @note This does not update the last run time (since it only runs a single
+   * checker).
+   */
+  'diagnostics-trigger'(id: string): void;
 }
 
 /**


### PR DESCRIPTION
This helps (but does not completely solve) issues with seeing incorrect diagnostics on startup due to things being half-applied.
