### PR TITLE
GitHub: Issue template: rephrase to emphasize logs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,10 @@ body:
 - type: textarea
   attributes:
     label: Additional Information
-    description: "Add any other context about the problem here. Excerpt, attach logs or include screenshots if appropriate."
+    description: >-
+      Add any other context about the problem here.  Please make sure to excerpt
+      or attach logs.  Include screenshots if appropriate, but they are not a
+      replacement for logs.
 - type: input
   attributes:
     label: Rancher Desktop Version


### PR DESCRIPTION
The previous wording made it sound like not including logs was okay if they included a screenshot (with the error message); be explicit that this is not, in fact, helpful.