### PR TITLE
Start RD guest agent after communication tunnel is up and running

### DIFF
--- a/src/assets/scripts/rancher-desktop-guestagent.initd
+++ b/src/assets/scripts/rancher-desktop-guestagent.initd
@@ -2,6 +2,7 @@
 # shellcheck shell=ksh
 
 depend() {
+  need vtunnel-peer
   after network-online
 }
 

--- a/src/assets/scripts/service-vtunnel-peer.initd
+++ b/src/assets/scripts/service-vtunnel-peer.initd
@@ -1,11 +1,11 @@
 #!/sbin/openrc-run
 
-# This script is used to manage vtunnel's peer process for credhelper via OpenRC.
+# This script is used to manage vtunnel's peer process via OpenRC.
 
 # shellcheck shell=ksh
 
-name="credhelper-vtunnel-peer"
-description="Rancher Desktop peer process for credhelper's vtunnel"
+name="vtunnel-peer"
+description="Rancher Desktop peer process for vtunnel"
 
 supervisor=supervise-daemon
 command="'${VTUNNEL_PEER_BINARY:-/usr/local/bin/vtunnel}'"

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -32,10 +32,10 @@ import INSTALL_WSL_HELPERS_SCRIPT from '@/assets/scripts/install-wsl-helpers';
 import CONTAINERD_CONFIG from '@/assets/scripts/k3s-containerd-config.toml';
 import LOGROTATE_K3S_SCRIPT from '@/assets/scripts/logrotate-k3s';
 import SERVICE_GUEST_AGENT_INIT from '@/assets/scripts/rancher-desktop-guestagent.initd';
-import SERVICE_CREDHELPER_VTUNNEL_PEER from '@/assets/scripts/service-credhelper-vtunnel-peer.initd';
 import SERVICE_SCRIPT_CRI_DOCKERD from '@/assets/scripts/service-cri-dockerd.initd';
 import SERVICE_SCRIPT_HOST_RESOLVER from '@/assets/scripts/service-host-resolver.initd';
 import SERVICE_SCRIPT_K3S from '@/assets/scripts/service-k3s.initd';
+import SERVICE_VTUNNEL_PEER from '@/assets/scripts/service-vtunnel-peer.initd';
 import SERVICE_SCRIPT_DOCKERD from '@/assets/scripts/service-wsl-dockerd.initd';
 import SCRIPT_DATA_WSL_CONF from '@/assets/scripts/wsl-data.conf';
 import WSL_INIT_SCRIPT from '@/assets/scripts/wsl-init';
@@ -648,13 +648,13 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       const defaultConfig = { credsStore: 'rancher-desktop' };
       let existingConfig: Record<string, any>;
 
-      await this.writeFile('/etc/init.d/credhelper-vtunnel-peer', SERVICE_CREDHELPER_VTUNNEL_PEER, { permissions: 0o755 });
-      await this.writeConf('credhelper-vtunnel-peer', {
+      await this.writeFile('/etc/init.d/vtunnel-peer', SERVICE_VTUNNEL_PEER, { permissions: 0o755 });
+      await this.writeConf('vtunnel-peer', {
         VTUNNEL_PEER_BINARY: await this.getVtunnelPeerPath(),
         LOG_DIR:             await this.wslify(paths.logs),
         CONFIG_PATH:         await this.wslify(getVtunnelConfigPath()),
       });
-      await this.execCommand('/sbin/rc-update', 'add', 'credhelper-vtunnel-peer', 'default');
+      await this.execCommand('/sbin/rc-update', 'add', 'vtunnel-peer', 'default');
 
       await this.execCommand('mkdir', '-p', ETC_RANCHER_DESKTOP_DIR);
       await this.writeFile(CREDENTIAL_FORWARDER_SETTINGS_PATH, fileContents, { permissions: 0o644 });


### PR DESCRIPTION
Fixes: [Start RD Agent after Vtunnel #3075](https://github.com/rancher-sandbox/rancher-desktop/issues/3075)

This change renames `Vtunnel` peer process service, and allows the RD agent to startup after vtunnel peer is up.

Signed-off-by: Nino Kodabande <nkodabande@suse.com>