### PR TITLE
Lima: Fix switching vmnet interfaces.

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2098,9 +2098,11 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
   async stop() {
     if (this.cfg?.enabled) {
       try {
-        await this.vm.execCommand({ root: true, expectFailure: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
+        const script = 'if [ -e /etc/init.d/k3s ]; then /sbin/rc-service --ifstarted k3s stop; fi';
+
+        await this.vm.execCommand({ root: true, expectFailure: true }, '/bin/sh', '-c', script);
       } catch (ex) {
-        console.error('k3s stop failed: ', ex);
+        console.error('Failed to stop k3s while stopping kube backend: ', ex);
       }
     }
     this.client?.destroy();

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1047,10 +1047,11 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     if (haveFiles[LIMA_SUDOERS_LOCATION] && !haveFiles[PREVIOUS_LIMA_SUDOERS_LOCATION]) {
       // The name of the sudoer file is up-to-date. Return if `sudoers --check` is ok
       try {
-        await this.lima('sudoers', '--check');
+        await this.limaWithCapture(true, 'sudoers', '--check');
 
         return;
-      } catch {
+      } catch (ex: any) {
+        console.log(`lima sudoers --check returned failure, need to update sudoers file:\n${ ex?.stderr || '(no output)' }`);
       }
     }
     // Here we have to run `lima sudoers` as non-root and grab the output, and then

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -300,7 +300,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     case State.STOPPED:
     case State.ERROR:
     case State.DISABLED:
-      await this.kubeBackend.stop();
+      await this.kubeBackend.destroy();
     }
   }
 
@@ -2106,7 +2106,13 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
         console.error('Failed to stop k3s while stopping kube backend: ', ex);
       }
     }
+    await this.destroy();
+  }
+
+  destroy(): Promise<void> {
     this.client?.destroy();
+
+    return Promise.resolve();
   }
 
   async reset() {

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1711,7 +1711,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
             try {
               await this.execCommand({ root: true, expectFailure: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
             } catch (ex) {
-              console.error('k3s stop failed: ', ex);
+              console.error('Failed to stop k3s while stopping services: ', ex);
             }
           }
           await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'buildkitd', 'stop');

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -1189,13 +1189,13 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
         await fs.promises.rename(networkPath, backupName);
         console.log(`Lima network configuration has unexpected contents; existing file renamed as ${ backupName }.`);
-        config = NETWORKS_CONFIG;
+        config = clone(NETWORKS_CONFIG);
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
         console.log(`Existing networks.yaml file ${ networkPath } not yaml-parsable, got error ${ err }. It will be replaced.`);
       }
-      config = NETWORKS_CONFIG;
+      config = clone(NETWORKS_CONFIG);
     }
 
     if (vmnet === VMNet.VDE) {


### PR DESCRIPTION
This should fix #3067 and possibly what Eric saw in #3068 (but maybe not the original error).

The core of the issue is that when we didn't have network configuration (or it was invalid), we used the default value without copying; hence when we later mutated it, we mutated the default configuration in-place.

This PR also fixes some of the places where we run a command with special handling for the failure (to check if the sudoers file is up to date, for example); before this PR, we'd log the failure complete with stack trace.  This ended up being misleading when things failed for other reasons.