### PR TITLE
Bumps both host-resolver and lima-qemu

### DIFF
--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 ---
-limaAndQemu: "1.26"
+limaAndQemu: "1.27"
 alpineLimaISO:
   isoVersion: 0.2.21
   alpineVersion: 3.16.0
@@ -15,5 +15,5 @@ guestAgent: 0.3.2
 rancherDashboard: desktop-v2.6.8.beta.3
 dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0
-hostResolver: 0.1.0-beta.1
+hostResolver: 0.1.1
 mobyOpenAPISpec: "1.42"


### PR DESCRIPTION
Bumps Lima-qemu and host-resolver to include the following changes:

- Fixing TruncateReply option passing, fixes issues with oauth2.googleapis.com DNS resolution https://github.com/lima-vm/lima/commit/b158a138e90d200b4e2a28e28a6274e352109bef

- Return error when template expansion fails https://github.com/lima-vm/lima/commit/af905dfb4990f8ca1bd668a537b6e7dbcfb211cd

Signed-off-by: Nino Kodabande <nkodabande@suse.com>