### PR TITLE
Lima: disable #allowSudo if user declines prompt.

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -868,6 +868,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       this.showSudoReason(explanations));
 
     if (!allowed) {
+      this.#allowSudo = false;
+
       return false;
     }
 


### PR DESCRIPTION
Fixes #3078.

To reproduce:
- Do a factory reset
- Choose moby on the first run screen. (Can turn off Kubernetes too.)
- On sudo prompt, check the checkbox to never ask for sudo credentials.
- After start completes, check `docker context list` — `rancher-desktop` should be created and selected.
  - Before this PR, it's created but not selected.