### PR TITLE
Bumps Rancher Desktop GuestAgent

### DIFF
--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerBuildx: 0.9.1
 dockerCompose: 2.11.1
 trivy: 0.32.0
 steve: 0.1.0-beta9
-guestAgent: 0.3.2
+guestAgent: 0.3.3
 rancherDashboard: desktop-v2.6.8.beta.3
 dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0


### PR DESCRIPTION
Bump RD agent to the latest [release](https://github.com/rancher-sandbox/rancher-desktop-agent/releases/tag/v0.3.3).

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3075

Signed-off-by: Nino Kodabande <nkodabande@suse.com>