### PR TITLE
api: implement new transientSettings APIs

### DIFF
--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -184,6 +184,45 @@ paths:
               schema:
                 "$ref": "#/components/schemas/diagnostics"
 
+  /v0/transient_settings:
+    get:
+      operationId: listTransientSettings
+      summary:  List the current transient settings
+      responses:
+        '200':
+          description: >-
+            The current transient settings in JSON format
+          content:
+            application/json:
+              schema:
+                "$ref" : "#/components/schemas/transientSettings"
+    put:
+      operationId: updateTransientSettings
+      summary:  Updates application transient settings
+      requestBody:
+        description: >-
+          JSON block consisting of transient settings
+        content:
+          application/json:
+            schema:
+              "$ref" : "#/components/schemas/transientSettings"
+        required: true
+      responses:
+        '202':
+          description: >-
+            The settings were accepted.
+          content:
+            "text/plain":
+              schema:
+                type: string
+        '400':
+          description: >-
+            The proposed transient settings were not valid.
+          content:
+            "text/plain":
+              schema:
+                type: string
+
 components:
   schemas:
     preferences:
@@ -286,3 +325,13 @@ components:
                   properties:
                     description:
                       type: string
+    transientSettings:
+      type: object
+      properties:
+        noModalDialogs:
+          type: boolean
+        preferences:
+          type: object
+          properties:
+            currentNavItem:
+              type: string

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'path';
 
 import _ from 'lodash';
 
+import { TransientSettings } from '@/config/transientSettings';
 import { PathManagementStrategy } from '@/integrations/pathManager';
 import clone from '@/utils/clone';
 import Logging from '@/utils/logging';
@@ -78,8 +79,6 @@ export const defaultSettings = {
 };
 
 export type Settings = typeof defaultSettings;
-export const transientSettings = { noModalDialogs: false };
-export type TransientSettings = typeof transientSettings;
 
 let _isFirstRun = false;
 let settings: Settings | undefined;
@@ -170,7 +169,7 @@ export function getUpdatableNode(cfg: Settings, fqFieldAccessor: string): [Recor
 
   return (finalOptionPart in currentConfig) ? [currentConfig, finalOptionPart] : null;
 }
-export function updateFromCommandLine(cfg: Settings, commandLineArgs: string[]): [TransientSettings, Settings] {
+export function updateFromCommandLine(cfg: Settings, commandLineArgs: string[]): Settings {
   const lim = commandLineArgs.length;
   let processingExternalArguments = true;
 
@@ -193,10 +192,10 @@ export function updateFromCommandLine(cfg: Settings, commandLineArgs: string[]):
       switch (value) {
       case '':
       case 'true':
-        transientSettings.noModalDialogs = true;
+        TransientSettings.update({ noModalDialogs: true });
         break;
       case 'false':
-        transientSettings.noModalDialogs = false;
+        TransientSettings.update({ noModalDialogs: false });
         break;
       default:
         throw new Error(`Invalid associated value for ${ arg }: must be unspecified (set to true), true or false`);
@@ -257,7 +256,7 @@ export function updateFromCommandLine(cfg: Settings, commandLineArgs: string[]):
     _isFirstRun = false;
   }
 
-  return [transientSettings, cfg];
+  return cfg;
 }
 /**
  * Load the settings file or create it if not present.  If the settings have

--- a/src/config/transientSettings.ts
+++ b/src/config/transientSettings.ts
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+
+import { RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
+
+export const defaultTransientSettings = {
+  noModalDialogs: false,
+  preferences:    { currentNavItem: 'Application' },
+};
+export type TransientSettings = typeof defaultTransientSettings;
+
+class TransientSettingsImpl {
+  private _value = _.cloneDeep(defaultTransientSettings);
+
+  get value(): RecursiveReadonly<TransientSettings> {
+    return this._value;
+  }
+
+  update(transientSettings: RecursivePartial<TransientSettings>) {
+    _.merge(this._value, transientSettings);
+  }
+}
+
+export const TransientSettings = new TransientSettingsImpl();

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 
 import type { VMBackend } from '@/backend/backend';
 import type { Settings } from '@/config/settings';
+import type { TransientSettings } from '@/config/transientSettings';
 import { RecursivePartial } from '@/utils/typeUtils';
 
 /**
@@ -42,6 +43,18 @@ interface MainEventNames {
    * @param settings The settings to change.
    */
   'settings-write'(settings: RecursivePartial<Settings>): void;
+
+  /**
+   * Read the current transient settings.
+   */
+  'transient-settings-fetch'(): TransientSettings;
+
+   /**
+    * Emitted to update current transient settings.
+    *
+    * @param transientSettings The new transient settings.
+    */
+  'transient-settings-update'(transientSettings: RecursivePartial<TransientSettings>): void;
 
   /**
    * Emitted as a request to get the CA certificates.

--- a/src/store/transientSettings.ts
+++ b/src/store/transientSettings.ts
@@ -1,0 +1,81 @@
+import _ from 'lodash';
+
+import { ActionContext, MutationsType } from './ts-helpers';
+
+import { defaultTransientSettings, TransientSettings } from '@/config/transientSettings';
+import type { ServerState } from '@/main/commandServer/httpCommandServer';
+import { RecursivePartial } from '@/utils/typeUtils';
+
+import type { GetterTree } from 'vuex';
+
+type Preferences = typeof defaultTransientSettings.preferences;
+
+interface CommitArgs extends ServerState {
+  payload?: RecursivePartial<TransientSettings>;
+}
+
+const uri = (port: number) => `http://localhost:${ port }/v0/transient_settings`;
+
+export const state: () => TransientSettings = () => _.cloneDeep(defaultTransientSettings);
+
+export const mutations: MutationsType<TransientSettings> = {
+  SET_PREFERENCES(state, preferences) {
+    state.preferences = preferences;
+  },
+  SET_NO_MODAL_DIALOGS(state, noModalDialogs) {
+    state.noModalDialogs = noModalDialogs;
+  },
+};
+
+type TransientSettingsContext = ActionContext<TransientSettings>;
+
+export const actions = {
+  setPreferences({ commit }: TransientSettingsContext, preferences: Preferences) {
+    commit('SET_PREFERENCES', _.cloneDeep(preferences));
+  },
+  async fetchTransientSettings({ commit }: TransientSettingsContext, args: ServerState) {
+    const { port, user, password } = args;
+
+    const response = await fetch(
+      uri(port),
+      {
+        headers: new Headers({
+          Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
+      });
+    const transientSettings: TransientSettings = await response.json();
+
+    commit('SET_PREFERENCES', _.cloneDeep(transientSettings.preferences));
+  },
+  async commitPreferences({ state, dispatch }: TransientSettingsContext, args: CommitArgs) {
+    const {
+      port, user, password, payload,
+    } = args;
+
+    await fetch(
+      uri(port),
+      {
+        method:  'PUT',
+        headers: new Headers({
+          Authorization:  `Basic ${ window.btoa(`${ user }:${ password }`) }`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        }),
+        body: JSON.stringify(payload ?? state.preferences),
+      });
+
+    await dispatch(
+      'transientSettings/fetchTransientSettings',
+      args,
+      { root: true });
+  },
+};
+
+export const getters: GetterTree<TransientSettings, TransientSettings> = {
+  getPreferences(state: TransientSettings) {
+    return state.preferences;
+  },
+  getNoModalDialogs(state: TransientSettings) {
+    return state.noModalDialogs;
+  },
+};

--- a/src/typings/electron-ipc.d.ts
+++ b/src/typings/electron-ipc.d.ts
@@ -72,6 +72,8 @@ interface IpcMainEvents {
  */
 interface IpcMainInvokeEvents {
   'settings-write': (arg: RecursivePartial<import('@/config/settings').Settings>) => void;
+  'transient-settings-fetch': () => import('@/config/transientSettings').TransientSettings;
+  'transient-settings-update': (arg: RecursivePartial<import('@/config/transientSettings').TransientSettings>) => void;
   'service-fetch': (namespace?: string) => import('@/backend/k8s').ServiceEntry[];
   'service-forward': (service: {namespace: string, name: string, port: string | number}, state: boolean) => void;
   'get-app-version': () => string;

--- a/src/typings/store.d.ts
+++ b/src/typings/store.d.ts
@@ -3,6 +3,7 @@ import type { actions as CredentialsActions } from '@/store/credentials';
 import type { actions as DiagnosticsActions } from '@/store/diagnostics';
 import type { actions as PageActions } from '@/store/page';
 import type { actions as PreferencesActions } from '@/store/preferences';
+import type { actions as TransientSettingsActions } from '@/store/transientSettings';
 
 type Actions<
   store extends string,
@@ -17,7 +18,8 @@ type storeActions = Record<string, never>
   & Actions<'page', typeof PageActions>
   & Actions<'preferences', typeof PreferencesActions>
   & Actions<'diagnostics', typeof DiagnosticsActions>
-  & Actions<'credentials', typeof CredentialsActions>;
+  & Actions<'credentials', typeof CredentialsActions>
+  & Actions<'transientSettings', typeof TransientSettingsActions>;
 
 declare module 'vuex/types' {
   export interface Dispatch {

--- a/src/window/preferences.ts
+++ b/src/window/preferences.ts
@@ -2,6 +2,13 @@ import { app, dialog } from 'electron';
 
 import { webRoot, createWindow } from '.';
 
+export const preferencesTabs = [
+  'Application',
+  process.platform === 'win32' ? 'WSL' : 'Virtual Machine',
+  'Container Engine',
+  'Kubernetes',
+];
+
 let isDirty = false;
 
 /**


### PR DESCRIPTION
- add new transientSettings store.
- update command-api.yaml.
- add new Rest APIs to manage Transient Settings.
- add electron IPC callbacks to manage Transient Settings.
- add new rdctl tests.

Required by #3010

Fixes #2634 
Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>