### PR TITLE
Allow linux users to close windows without quitting rancher.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -344,7 +344,7 @@ Electron.app.on('window-all-closed', () => {
   Electron.app.dock?.hide();
   // On windows and macOS platforms, we only quit via the notification tray / menu bar.
   // On Linux we close the application since not all distros support tray menu/icons
-  if (os.platform() === 'linux' && !settings.firstRunDialogNeeded()) {
+  if (os.platform() === 'linux' && !cfg.minimizeOnClose && !settings.firstRunDialogNeeded()) {
     Electron.app.quit();
   }
 });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -618,7 +618,7 @@ test.describe('Command server', () => {
                   });
                   const settings = JSON.parse(stdout);
 
-                  expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy', 'diagnostics']).toMatchObject(Object.keys(settings));
+                  expect(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry', 'updater', 'debug', 'pathManagementStrategy', 'minimizeOnClose', 'diagnostics']).toMatchObject(Object.keys(settings));
                 });
               }
             }

--- a/src/components/Preferences/ApplicationBehavior.vue
+++ b/src/components/Preferences/ApplicationBehavior.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import os from 'os';
+
 import { Checkbox } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
@@ -47,6 +49,9 @@ export default Vue.extend({
     onSudoAllowedChange(val: boolean) {
       this.$store.dispatch('applicationSettings/commitSudoAllowed', val);
     },
+    isLinux() {
+      return os.platform().startsWith('linux');
+    },
   },
 });
 </script>
@@ -84,6 +89,10 @@ export default Vue.extend({
         :value="preferences.telemetry"
         @input="onChange('telemetry', $event)"
       />
+    </rd-fieldset>
+    <rd-fieldset data-test="tray-minimize" legend-text="Minimize to tray" v-if="isLinux()">
+      <checkbox label="Minimize app to tray instead of closing it."
+        :value="preferences.minimizeOnClose" @input="onChange('minimizeOnClose', $event)" />
     </rd-fieldset>
   </div>
 </template>

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -39,6 +39,7 @@ describe('updateFromCommandLine', () => {
       updater:                true,
       debug:                  true,
       pathManagementStrategy: PathManagementStrategy.NotSet,
+      minimizeOnClose: false,
       diagnostics:            {
         showMuted:   false,
         mutedChecks: { },

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -71,6 +71,7 @@ export const defaultSettings = {
   updater:                true,
   debug:                  false,
   pathManagementStrategy: PathManagementStrategy.NotSet,
+  minimizeOnClose: false,
   diagnostics:            {
     showMuted:   false,
     mutedChecks: {} as Record<string, boolean>,

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -74,6 +74,7 @@ export default class SettingsValidator {
       updater:                this.checkBoolean,
       debug:                  this.checkBoolean,
       pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
+      minimizeOnClose: this.checkBoolean,
       diagnostics:            {
         mutedChecks: this.checkBooleanMapping,
         showMuted:   this.checkBoolean,

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -84,6 +84,13 @@ export class Tray {
     },
     { type: 'separator' },
     {
+      label: 'Show Rancher Desktop',
+      type:  'normal',
+      click(){
+        openMain(false);
+      },
+    },
+    {
       label: 'Quit Rancher Desktop',
       role:  'quit',
       type:  'normal',


### PR DESCRIPTION
Added option to enable "minimize on close" on Linux, instead of always closing Rancher desktop instance.