### PR TITLE
Remove installation of flatpak dependency in `package` workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -49,12 +49,6 @@ jobs:
       if: runner.os == 'Windows'
       shell: powershell
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
-    - name: Install Flatpak dependencies
-      if: runner.os == 'Linux'
-      run: |
-          sudo apt-get update
-          sudo apt-get install flatpak flatpak-builder
-          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
     - name: Flag build for M1
       if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
       run: echo "M1=1" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Closes #3132.

I should note that this step is unnecessary for our current build process. I believe it remains from @davidcassany's explorations with packaging RD as a flatpak. But I don't think we are planning to try that again soon, and if we are, it's in the git history.