### PR TITLE
Revert cred helper bump to 0.7.0

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -365,7 +365,8 @@ export class DockerProvidedCredHelpers extends GithubVersionGetter implements De
     for (const baseName of credHelperNames) {
       const versionedBaseName = `${ baseName }-v${ version }.${ platformReleaseName }-${ arch }${ extension }`;
       const sourceUrl = `${ baseUrl }/v${ version }/${ versionedBaseName }`;
-      const destPath = path.join(context.binDir, `${ baseName }${ extension }`);
+      const binName = context.platform.startsWith('win') ? `${ baseName }.exe` : baseName;
+      const destPath = path.join(context.binDir, binName);
       const desiredChecksums = allChecksums.filter(line => line.includes(versionedBaseName));
 
       if (desiredChecksums.length < 1) {

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -359,22 +359,13 @@ export class DockerProvidedCredHelpers extends GithubVersionGetter implements De
     const platformReleaseName = context.platform === 'win32' ? 'windows' : context.platform;
     const promises = [];
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
-    const checksumUrl = `${ baseUrl }/v${ version }/checksums.txt`;
-    const allChecksums = (await getResource(checksumUrl)).split(/\r?\n/);
 
     for (const baseName of credHelperNames) {
-      const versionedBaseName = `${ baseName }-v${ version }.${ platformReleaseName }-${ arch }${ extension }`;
-      const sourceUrl = `${ baseUrl }/v${ version }/${ versionedBaseName }`;
+      const sourceUrl = `${ baseUrl }/v${ version }/${ baseName }-v${ version }.${ platformReleaseName }-${ arch }${ extension }`;
       const binName = context.platform.startsWith('win') ? `${ baseName }.exe` : baseName;
       const destPath = path.join(context.binDir, binName);
-      const desiredChecksums = allChecksums.filter(line => line.includes(versionedBaseName));
 
-      if (desiredChecksums.length < 1) {
-        throw new Error(`Couldn't find a matching SHA for [${ versionedBaseName }] in [${ allChecksums }]`);
-      }
-      const checksum = desiredChecksums[0].split(/\s+/, 1)[0];
-
-      promises.push(download(sourceUrl, destPath, { expectedChecksum: checksum }));
+      promises.push(download(sourceUrl, destPath));
     }
 
     await Promise.all(promises);

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -350,22 +350,22 @@ export class DockerProvidedCredHelpers extends GithubVersionGetter implements De
   async download(context: DownloadContext): Promise<void> {
     const arch = context.isM1 ? 'arm64' : 'amd64';
     const version = context.versions.dockerProvidedCredentialHelpers;
-    const extension = context.platform.startsWith('win') ? '.exe' : '';
+    const extension = context.platform.startsWith('win') ? 'zip' : 'tar.gz';
+    const downloadFunc = context.platform.startsWith('win') ? downloadZip : downloadTarGZ;
     const credHelperNames = {
       linux:  ['docker-credential-secretservice', 'docker-credential-pass'],
       darwin: ['docker-credential-osxkeychain'],
       win32:  ['docker-credential-wincred'],
     }[context.platform];
-    const platformReleaseName = context.platform === 'win32' ? 'windows' : context.platform;
     const promises = [];
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
 
     for (const baseName of credHelperNames) {
-      const sourceUrl = `${ baseUrl }/v${ version }/${ baseName }-v${ version }.${ platformReleaseName }-${ arch }${ extension }`;
+      const sourceUrl = `${ baseUrl }/v${ version }/${ baseName }-v${ version }-${ arch }.${ extension }`;
       const binName = context.platform.startsWith('win') ? `${ baseName }.exe` : baseName;
       const destPath = path.join(context.binDir, binName);
 
-      promises.push(download(sourceUrl, destPath));
+      promises.push(downloadFunc(sourceUrl, destPath));
     }
 
     await Promise.all(promises);

--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -12,7 +12,7 @@ trivy: 0.32.1
 steve: 0.1.0-beta9
 guestAgent: 0.3.4
 rancherDashboard: desktop-v2.6.8.beta.3
-dockerProvidedCredentialHelpers: 0.7.0
+dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0
 hostResolver: 0.1.1
 mobyOpenAPISpec: "1.42"

--- a/src/go/docker-credential-none/dcnone/dcnone.go
+++ b/src/go/docker-credential-none/dcnone/dcnone.go
@@ -18,7 +18,7 @@ import (
 
 const configFileName = "plaintext-credentials.config.json"
 
-const VERSION = "1.0.1"
+const VERSION = "0.6.4"
 
 // DCNone handles secrets using HOME/.docker/plaintext-credentials.config.json as a store.
 type DCNone struct{}


### PR DESCRIPTION
`docker-credential-osxkeychain` 0.7.0 is broken (get doesn't work) and Jan would prefer to ship only one version of the credential helpers for all the platforms.