### PR TITLE
Support .docker/config credHelpers.

### DIFF
--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -178,19 +178,19 @@ describeWithCreds('Credentials server', () => {
       if (!server.includes(matcher)) {
         continue;
       }
-      const body = stream.Readable.from(server ?? '');
+      const body = stream.Readable.from(server);
 
       try {
         const { stdout } = await spawnFile(dcName, ['erase'], { stdio: [body, 'pipe', 'pipe'] });
 
-        if (stdout !== '') {
-          const msg = `Problem ${ helper }-deleting ${ server }: got output stdout: ${ stdout }`;
+        if (stdout) {
+          const msg = `Problem deleting ${ server } using ${ dcName }: got output stdout: ${ stdout }`;
 
           console.log(msg);
           finalException ??= new Error(msg);
         }
       } catch (ex) {
-        console.log(`Error trying to ${ helper }-delete entry ${ server }: ${ ex }`);
+        console.log(`Problem deleting ${ server } using ${ dcName }: `, ex);
         finalException ??= ex;
       }
     }
@@ -246,10 +246,6 @@ describeWithCreds('Credentials server', () => {
   });
 
   test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-
     if (originalDockerConfigContents !== undefined && !process.env.CIRRUS_CI && !process.env.RD_E2E_DO_NOT_RESTORE_CONFIG) {
       try {
         await fs.promises.writeFile(dockerConfigPath, originalDockerConfigContents);
@@ -264,6 +260,12 @@ describeWithCreds('Credentials server', () => {
         console.error(`Failed to restore config file ${ plaintextConfigPath }: `, e);
       }
     }
+  });
+
+  test.afterAll(async() => {
+    await context.tracing.stop({ path: reportAsset(__filename) });
+    await packageLogs(__filename);
+    await electronApp.close();
   });
 
   test('should emit connection information', async() => {

--- a/src/main/credentialServer/httpCredentialHelperServer.ts
+++ b/src/main/credentialServer/httpCredentialHelperServer.ts
@@ -26,10 +26,19 @@ const SERVER_USERNAME = 'user';
 const SERVER_FILE_BASENAME = 'credential-server.json';
 const MAX_REQUEST_BODY_LENGTH = 4194304; // 4MiB
 
+type credHelperInfo = {
+  credsStore: string;
+  credHelpers: Record<string, string>
+};
+
 type checkerFnType = (stdout: string) => boolean;
 
 function requireNoOutput(stdout: string): boolean {
   return !stdout;
+}
+
+function requireNonEmptyOutput(stdout: string): boolean {
+  return !!stdout.length;
 }
 
 function requireJSONOutput(stdout: string): boolean {
@@ -45,6 +54,10 @@ function requireJSONOutput(stdout: string): boolean {
 
 export function getServerCredentialsPath(): string {
   return path.join(paths.appHome, SERVER_FILE_BASENAME);
+}
+
+function ensureEndsWithNewline(s: string) {
+  return !s || /\n$/.test(s) ? s : `${ s }\n`;
 }
 
 export class HttpCredentialHelperServer {
@@ -92,27 +105,37 @@ export class HttpCredentialHelperServer {
 
         return;
       }
-      const helperName = `docker-credential-${ await this.getCredentialHelperName() }`;
       const url = new URL(request.url ?? '', `http://${ request.headers.host }`);
       const path = url.pathname;
       const pathParts = path.split('/');
+
+      if (pathParts.shift()) {
+        console.debug(`FAILURE: Processing request ${ request.method } ${ path }`);
+        response.writeHead(400, { 'Content-Type': 'text/plain' });
+        response.write(`Unexpected data before first / in URL ${ path }`);
+
+        return;
+      }
+      const commandName = pathParts[0];
       const [data, error, errorCode] = await serverHelper.getRequestBody(request, MAX_REQUEST_BODY_LENGTH);
 
       if (error) {
+        console.debug(`FAILURE: Processing request ${ request.method } ${ path }`);
         console.debug(`${ path }: write back status ${ errorCode }, error: ${ error }`);
         response.writeHead(errorCode, { 'Content-Type': 'text/plain' });
         response.write(error);
 
         return;
       }
-      console.debug(`Processing request ${ request.method } ${ path }`);
-      if (pathParts.shift()) {
-        response.writeHead(400, { 'Content-Type': 'text/plain' });
-        response.write(`Unexpected data before first / in URL ${ path }`);
+      const helperInfo = await this.getCredentialHelperName(commandName, data);
+
+      if (commandName === 'list') {
+        await this.doListCommand(helperInfo, request, response);
       } else {
-        await this.doRequest(helperName, pathParts[0], data, request, response);
+        await this.doNonListCommand(`docker-credential-${ helperInfo.credsStore }`, commandName, data, request, response);
       }
     } catch (err) {
+      console.debug(`FAILURE: Processing request ${ request.method } ${ path }`);
       console.log(`Error handling ${ request.url }`, err);
       response.writeHead(500, { 'Content-Type': 'text/plain' });
       response.write('Error processing request.');
@@ -121,17 +144,36 @@ export class HttpCredentialHelperServer {
     }
   }
 
-  protected async doRequest(
+  protected async doNonListCommand(
     helperName: string,
     commandName: string,
     data: string,
     request: http.IncomingMessage,
     response: http.ServerResponse): Promise<void> {
-    let stderr: string;
+    try {
+      const stdout = await this.runCommand(helperName, commandName, data, request);
+
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.write(ensureEndsWithNewline(stdout));
+    } catch (err: any) {
+      const stderr = (err.stderr || err.stdout) ?? err.toString();
+
+      console.debug(`FAILURE: Processing request ${ commandName } with credential helper ${ helperName }`);
+      response.writeHead(400, { 'Content-Type': 'text/plain' });
+      response.write(ensureEndsWithNewline(stderr));
+    }
+  }
+
+  protected async runCommand(helperName: string,
+    commandName: string,
+    data: string,
+    request: http.IncomingMessage): Promise<string> {
     let requestCheckError: any = null;
     const checkers: Record<string, checkerFnType> = {
       list:  requireJSONOutput,
-      get:   requireJSONOutput,
+      // When pass starts throwing an exception for a failed 'get', this can change from
+      // requireNonEmptyOutput to requireJSONOutput, and requireNonEmptyOutput can be deleted.
+      get:   requireNonEmptyOutput,
       erase: requireNoOutput,
       store: requireNoOutput,
     };
@@ -143,43 +185,85 @@ export class HttpCredentialHelperServer {
       requestCheckError = `Unknown credential action '${ commandName }' for the credential-server, must be one of [${ Object.keys(checkers).sort().join('|') }]`;
     }
     if (requestCheckError) {
-      response.writeHead(400, { 'Content-Type': 'text/plain' });
-      response.write(requestCheckError);
+      throw new Error(requestCheckError);
+    }
+
+    const platform = os.platform();
+    let pathVar = process.env.PATH ?? '';
+
+    // The PATH needs to contain our resources directory (on macOS that would
+    // not be in the application's PATH), as well as /usr/local/bin.
+    // NOTE: This needs to match DockerDirManager.spawnFileWithExtraPath
+    pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
+    if (platform === 'darwin') {
+      pathVar += `${ path.delimiter }/usr/local/bin`;
+    }
+
+    const body = stream.Readable.from(data);
+    const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
+      env:   { ...process.env, PATH: pathVar },
+      stdio: [body, 'pipe', console],
+    });
+
+    if (!checkerFn(stdout)) {
+      throw new Error(`Invalid output for ${ commandName } command.`);
+    }
+
+    return stdout;
+  }
+
+  /**
+   * For the LIST command, there are multiple possible sources of information
+   * that need to be merged into a simple
+   *    { ServerURL: Username } hash.
+   * The first source is the credsStore.
+   * Then if any helper credsStores are identified in the `credHelpers` section,
+   * get the full { ServerURL: Username } from each of them,
+   * and keep only those ServerURLs that point to that credsStore.
+   *
+   * Modeled after https://github.com/docker/cli/blob/d0bd373986b6678bfe1a0eb6989ce13907247a85/cli/config/configfile/file.go#L285
+   *
+   * @param {String} credsStore: global credential-helper-name defined in ~/.docker/config.json
+   * @param {Record<string, string>} credHelpers: hash of URLs to credential-helper-name
+   * @param {http.IncomingMessage} request:
+   * @param {http.ServerResponse} response:
+   */
+  protected async doListCommand(
+    { credsStore, credHelpers }: credHelperInfo,
+    request: http.IncomingMessage,
+    response: http.ServerResponse): Promise<void> {
+    try {
+      const serverAndUsernameInfo: Record<string, string> =
+        JSON.parse(await this.runCommand(`docker-credential-${ credsStore }`,
+          'list', '', request));
+      const helperNames = new Set(Object.values(credHelpers ?? {}));
+
+      for (const helperName of helperNames) {
+        try {
+          const helperServerAndUserNames: Record<string, string> =
+            JSON.parse(await this.runCommand(`docker-credential-${ helperName }`,
+              'list', '', request));
+
+          for (const serverURL in helperServerAndUserNames) {
+            if (credHelpers[serverURL] === helperName) {
+              serverAndUsernameInfo[serverURL] = helperServerAndUserNames[serverURL];
+            }
+          }
+        } catch (err) {
+          console.debug(`Failed to get credential list for helper ${ helperName }`);
+        }
+      }
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.write(JSON.stringify(serverAndUsernameInfo));
 
       return;
-    }
-
-    try {
-      const platform = os.platform();
-      let pathVar = process.env.PATH ?? '';
-
-      // The PATH needs to contain our resources directory (on macOS that would
-      // not be in the application's PATH), as well as /usr/local/bin.
-      // NOTE: This needs to match DockerDirManager.
-      pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
-      if (platform === 'darwin') {
-        pathVar += `${ path.delimiter }/usr/local/bin`;
-      }
-
-      const body = stream.Readable.from(data);
-      const { stdout } = await childProcess.spawnFile(helperName, [commandName], {
-        env:   { ...process.env, PATH: pathVar },
-        stdio: [body, 'pipe', console],
-      });
-
-      if (checkerFn(stdout)) {
-        response.writeHead(200, { 'Content-Type': 'text/plain' });
-        response.write(stdout);
-
-        return;
-      }
-      stderr = stdout;
     } catch (err: any) {
-      stderr = (err.stderr || err.stdout) ?? err;
+      const stderr = err.stderr || err.stdout || err.toString();
+
+      console.debug(`credentialServer: list: writing back status 400, error: ${ stderr }`);
+      response.writeHead(400, { 'Content-Type': 'text/plain' });
+      response.write(stderr);
     }
-    console.debug(`credentialServer: ${ commandName }: writing back status 400, error: ${ stderr }`);
-    response.writeHead(400, { 'Content-Type': 'text/plain' });
-    response.write(stderr);
   }
 
   /**
@@ -188,17 +272,33 @@ export class HttpCredentialHelperServer {
    * Note that callers are responsible for catching exceptions, which usually happens if the
    * `$HOME/docker/config.json` doesn't exist, its JSON is corrupt, or it doesn't have a `credsStore` field.
    */
-  protected async getCredentialHelperName(): Promise<string> {
+  protected async getCredentialHelperName(command: string, payload: string): Promise<credHelperInfo> {
     const home = findHomeDir();
     const dockerConfig = path.join(home ?? '', '.docker', 'config.json');
     const contents = JSON.parse((await fs.promises.readFile(dockerConfig, { encoding: 'utf-8' })).toString());
-    const credsStore = contents['credsStore'];
+    const credHelpers = contents.credHelpers;
+    const credsStore = contents.credsStore;
 
-    if (!credsStore) {
-      throw new Error(`No credsStore field in ${ dockerConfig }`);
+    if (credHelpers) {
+      let credsStoreOverride = '';
+
+      switch (command) {
+      case 'erase':
+      case 'get':
+        credsStoreOverride = credHelpers[payload.trim()];
+        break;
+      case 'store': {
+        const obj = JSON.parse(payload);
+
+        credsStoreOverride = obj.ServerURL ? credHelpers[obj.ServerURL] : '';
+      }
+      }
+      if (credsStoreOverride) {
+        return { credsStore: credsStoreOverride, credHelpers: { } };
+      }
     }
 
-    return credsStore;
+    return { credsStore, credHelpers };
   }
 
   closeServer() {


### PR DESCRIPTION
Fixes #2321

- This lets users specify different credential helpers for different ServerURLs.

If a URL can be found by both the `config.credsStore` and an associated `config.credHelpers` entry, use only the `credHelpers` helper and pretend it doesn't exist using the default credential  helper.

Signed-off-by: Eric Promislow <epromislow@suse.com>