### PR TITLE
Fix --flannel-iface option to include leading dashes

### DIFF
--- a/src/backend/kube/lima.ts
+++ b/src/backend/kube/lima.ts
@@ -412,10 +412,10 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
       if (cfg.options.flannel) {
         const iface = await this.vm.getListeningInterface();
 
-        config.ADDITIONAL_ARGS += `flannel-iface ${ iface }`;
+        config.ADDITIONAL_ARGS += ` --flannel-iface ${ iface }`;
       } else {
         console.log(`Disabling flannel and network policy`);
-        config.ADDITIONAL_ARGS += '--flannel-backend=none --disable-network-policy';
+        config.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';
       }
     }
     if (!cfg.options.traefik) {


### PR DESCRIPTION
Somehow they got lost during refactoring.

Also add a leading space because we are using `+=`.

Fixes #3201