### PR TITLE
Fix --flannel-iface option to include leading dashes

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -2295,10 +2295,10 @@ class LimaKubernetesBackend extends events.EventEmitter implements K8s.Kubernete
       if (cfg.options.flannel) {
         const iface = await this.vm.getListeningInterface();
 
-        config.ADDITIONAL_ARGS += `flannel-iface ${ iface }`;
+        config.ADDITIONAL_ARGS += ` --flannel-iface ${ iface }`;
       } else {
         console.log(`Disabling flannel and network policy`);
-        config.ADDITIONAL_ARGS += '--flannel-backend=none --disable-network-policy';
+        config.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';
       }
     }
     if (!cfg.options.traefik) {


### PR DESCRIPTION
Somehow they got lost during refactoring.

Also add a leading space because we are using `+=`.

Signed-off-by: Jan Dubois <jan.dubois@suse.com>

(cherry picked from commit 5054dee78de979c16cca8a147f7e3fb88b532d44)
(manually re-applied to renamed file)