### PR TITLE
Lima: Fix seriazation of provisioning scripts.

### DIFF
--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -601,11 +601,11 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         100,
         this.updateBaseDisk(currentConfig),
       );
-      await fs.promises.writeFile(configPath, yaml.stringify(config), 'utf-8');
+      await fs.promises.writeFile(configPath, yaml.stringify(config, { lineWidth: 0 }), 'utf-8');
     } else {
       // new configuration
       await fs.promises.mkdir(path.dirname(this.CONFIG_PATH), { recursive: true });
-      await fs.promises.writeFile(this.CONFIG_PATH, yaml.stringify(config));
+      await fs.promises.writeFile(this.CONFIG_PATH, yaml.stringify(config, { lineWidth: 0 }));
       if (os.platform().startsWith('darwin')) {
         try {
           await childProcess.spawnFile('tmutil', ['addexclusion', paths.lima]);


### PR DESCRIPTION
The YAML serializer we're using (the npm package "yaml") appears to have issues serializing strings containing new lines with individual lines that hit the line folding threshold (default 80); it converts the string to folded style incorrectly and drops the newlines.  Disable line folding completely (we don't care about them) as a work around.

Signed-off-by: Mark Yen <mark.yen@suse.com>
(cherry picked from commit 0afe7c4535752468169cc447d8f52c2466b5013c)