### PR TITLE
Reduce e2e test flakiness.

### DIFF
--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -34,12 +34,14 @@ export class NavPage {
    * https://github.com/rancher-sandbox/rancher-desktop/issues/1217
    */
   async progressBecomesReady() {
+    const timeout = 400_000;
+
     // Wait until progress bar show up. It takes roughly ~60s to start in CI
-    await this.progressBar.waitFor({ state: 'visible', timeout: 200_000 });
+    await this.progressBar.waitFor({ state: 'visible', timeout });
     // Wait until progress bar be detached. With that we can make sure the services were started
     // This seems to sometimes return too early; actually check the result.
     while (await this.progressBar.count() > 0) {
-      await this.progressBar.waitFor({ state: 'detached', timeout: 120_000 });
+      await this.progressBar.waitFor({ state: 'detached', timeout: Math.round(timeout * 0.6) });
     }
   }
 

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -57,10 +57,12 @@ class E2ETestRunner extends events.EventEmitter {
   #testProcess: null | childProcess.ChildProcess = null;
   startTestProcess(): Promise<void> {
     const args = process.argv.slice(2).filter(x => x !== '--serial');
+    const spawnArgs = ['node_modules/playwright/cli.js', 'test', '--config=e2e/config/playwright-config.ts'];
 
-    this.#testProcess = this.spawn('Test process',
-      'node', 'node_modules/playwright/cli.js',
-      'test', '--config=e2e/config/playwright-config.ts', ...args);
+    if (process.env.CIRRUS_CI) {
+      spawnArgs.push('--retries=2');
+    }
+    this.#testProcess = this.spawn('Test process', 'node', ...spawnArgs, ...args);
 
     return new Promise((resolve, reject) => {
       this.#testProcess?.on('exit', (code: number, signal: string) => {


### PR DESCRIPTION
Fixes #2820

First try: double the waiting time for the app to be ready.

Signed-off-by: Eric Promislow <epromislow@suse.com>