### PR TITLE
Refactor: Split BackendEvents from KubernetesBackendEvents.

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -2,6 +2,7 @@ import stream from 'stream';
 
 import { Settings } from '@/config/settings';
 import * as childProcess from '@/utils/childProcess';
+import EventEmitter from '@/utils/eventEmitter';
 import { RecursiveKeys, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 
 import type { KubernetesBackend } from './k8s';
@@ -101,7 +102,7 @@ export type RestartReasons = Partial<Record<RecursiveKeys<Settings>, {
  * VMBackend describes a controller for managing a virtual machine upon which
  * Rancher Desktop runs.
  */
-export interface VMBackend {
+export interface VMBackend extends EventEmitter<BackendEvents> {
   /** The name of the VM backend */
   readonly backend: 'wsl' | 'lima' | 'mock';
 

--- a/src/backend/k8s.ts
+++ b/src/backend/k8s.ts
@@ -1,6 +1,6 @@
 import semver from 'semver';
 
-import { BackendEvents, BackendSettings, RestartReasons } from './backend';
+import { BackendSettings, RestartReasons } from './backend';
 import { ServiceEntry } from './client';
 import { ExtraRequiresReasons } from './k3sHelper';
 
@@ -29,7 +29,7 @@ export interface VersionEntry {
  * an event, and the property type is the type of the callback function expected
  * for the given event.
  */
-export interface KubernetesBackendEvents extends BackendEvents {
+export interface KubernetesBackendEvents {
   /**
    * Emitted when the set of Kubernetes services has changed.
    */

--- a/src/backend/kube/lima.ts
+++ b/src/backend/kube/lima.ts
@@ -8,9 +8,7 @@ import util from 'util';
 import semver from 'semver';
 import yaml from 'yaml';
 
-import {
-  Architecture, BackendEvents, BackendSettings, RestartReasons, State,
-} from '../backend';
+import { Architecture, BackendSettings, RestartReasons, State } from '../backend';
 import K3sHelper, { ExtraRequiresReasons, NoCachedK3sVersionsError, ShortVersion } from '../k3sHelper';
 import LimaBackend, { Action, MACHINE_NAME } from '../lima';
 
@@ -488,77 +486,6 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   }
 
   // #region Events
-  // #region Event forwarding
-
-  protected eventForwarders: {
-    [k in keyof BackendEvents]?: BackendEvents[k];
-  } = {};
-
-  addListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-      };
-
-      this.vm.addListener(event, baseListener);
-    }
-
-    return super.addListener(event, listener);
-  }
-
-  on<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-      };
-
-      this.vm.on(event, baseListener);
-    }
-
-    return super.on(event, listener);
-  }
-
-  once<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-        // This leaves a dangling listener
-      };
-
-      this.vm.on(event, baseListener);
-    }
-
-    return super.on(event, listener);
-  }
-
-  removeListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    super.removeListener(event, listener);
-    const eventName = event as keyof BackendEvents;
-    const baseListener = this.eventForwarders[eventName];
-
-    if (this.listenerCount(event) < 1 && baseListener) {
-      this.vm.removeListener(eventName, baseListener);
-      delete this.eventForwarders[eventName];
-    }
-
-    return this;
-  }
-
-  off<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    super.off(event, listener);
-    const eventName = event as keyof BackendEvents;
-    const baseListener = this.eventForwarders[eventName];
-
-    if (this.listenerCount(event) < 1 && baseListener) {
-      this.vm.off(eventName, baseListener);
-      delete this.eventForwarders[eventName];
-    }
-
-    return this;
-  }
-
-  // #endregion
-
   eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
     return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
   }

--- a/src/backend/kube/wsl.ts
+++ b/src/backend/kube/wsl.ts
@@ -11,7 +11,7 @@ import K3sHelper, { ExtraRequiresReasons, NoCachedK3sVersionsError, ShortVersion
 import WSLBackend, { Action } from '../wsl';
 
 import INSTALL_K3S_SCRIPT from '@/assets/scripts/install-k3s';
-import { BackendEvents, BackendSettings, RestartReasons } from '@/backend/backend';
+import { BackendSettings, RestartReasons } from '@/backend/backend';
 import * as K8s from '@/backend/k8s';
 import { ContainerEngine } from '@/config/settings';
 import mainEvents from '@/main/mainEvents';
@@ -352,77 +352,6 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
   }
 
   // #region Events
-  // #region Event forwarding
-
-  protected eventForwarders: {
-    [k in keyof BackendEvents]?: BackendEvents[k];
-  } = {};
-
-  addListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-      };
-
-      this.vm.addListener(event, baseListener);
-    }
-
-    return super.addListener(event, listener);
-  }
-
-  on<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-      };
-
-      this.vm.on(event, baseListener);
-    }
-
-    return super.on(event, listener);
-  }
-
-  once<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    if (!(event in this.eventForwarders)) {
-      const baseListener = (...args: any[]) => {
-        this.emit(event, ...args);
-        // This leaves a dangling listener
-      };
-
-      this.vm.on(event, baseListener);
-    }
-
-    return super.on(event, listener);
-  }
-
-  removeListener<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    super.removeListener(event, listener);
-    const eventName = event as keyof BackendEvents;
-    const baseListener = this.eventForwarders[eventName];
-
-    if (this.listenerCount(event) < 1 && baseListener) {
-      this.vm.removeListener(eventName, baseListener);
-      delete this.eventForwarders[eventName];
-    }
-
-    return this;
-  }
-
-  off<eventName extends keyof K8s.KubernetesBackendEvents>(event: eventName, listener: K8s.KubernetesBackendEvents[eventName]): this {
-    super.off(event, listener);
-    const eventName = event as keyof BackendEvents;
-    const baseListener = this.eventForwarders[eventName];
-
-    if (this.listenerCount(event) < 1 && baseListener) {
-      this.vm.off(eventName, baseListener);
-      delete this.eventForwarders[eventName];
-    }
-
-    return this;
-  }
-
-  // #endregion
-
   eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
     return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
   }

--- a/src/backend/lima.ts
+++ b/src/backend/lima.ts
@@ -19,7 +19,7 @@ import tar from 'tar-stream';
 import yaml from 'yaml';
 
 import {
-  Architecture, BackendError, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
+  Architecture, BackendError, BackendEvents, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
 } from './backend';
 import BackendHelper from './backendHelper';
 import K3sHelper from './k3sHelper';
@@ -299,7 +299,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
   debug = false;
 
-  emit: K8s.KubernetesBackend['emit'] = this.emit;
+  emit: VMBackend['emit'] = this.emit;
 
   get backend(): 'lima' {
     return 'lima';
@@ -1887,20 +1887,20 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
   }
 
   // #region Events
-  eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
-    return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
+  eventNames(): Array<keyof BackendEvents> {
+    return super.eventNames() as Array<keyof BackendEvents>;
   }
 
-  listeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+  listeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): K8s.KubernetesBackendEvents[eventName][] {
-    return super.listeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.listeners(event) as BackendEvents[eventName][];
   }
 
-  rawListeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+  rawListeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): K8s.KubernetesBackendEvents[eventName][] {
-    return super.rawListeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.rawListeners(event) as BackendEvents[eventName][];
   }
   // #endregion
 }

--- a/src/backend/mock.ts
+++ b/src/backend/mock.ts
@@ -5,7 +5,7 @@ import util from 'util';
 import semver from 'semver';
 
 import {
-  BackendSettings, execOptions, State, RestartReasons, VMExecutor,
+  BackendSettings, execOptions, State, RestartReasons, VMExecutor, BackendEvents,
 } from './backend';
 import { KubernetesBackend, KubernetesError, KubernetesBackendEvents } from './k8s';
 import ProgressTracker from './progressTracker';
@@ -138,20 +138,20 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
   // #endregion
 
   // #region Events
-  eventNames(): Array<keyof KubernetesBackendEvents> {
-    return super.eventNames() as Array<keyof KubernetesBackendEvents>;
+  eventNames(): Array<keyof BackendEvents> {
+    return super.eventNames() as Array<keyof BackendEvents>;
   }
 
-  listeners<eventName extends keyof KubernetesBackendEvents>(
+  listeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): KubernetesBackendEvents[eventName][] {
-    return super.listeners(event) as KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.listeners(event) as BackendEvents[eventName][];
   }
 
-  rawListeners<eventName extends keyof KubernetesBackendEvents>(
+  rawListeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): KubernetesBackendEvents[eventName][] {
-    return super.rawListeners(event) as KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.rawListeners(event) as BackendEvents[eventName][];
   }
   // #endregion
 }

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -16,7 +16,6 @@ import {
 } from './backend';
 import BackendHelper from './backendHelper';
 import K3sHelper from './k3sHelper';
-import * as K8s from './k8s';
 import ProgressTracker, { getProgressErrorDescription } from './progressTracker';
 
 import DEPENDENCY_VERSIONS from '@/assets/dependencies.yaml';
@@ -48,6 +47,8 @@ import { wslHostIPv4Address } from '@/utils/networks';
 import paths from '@/utils/paths';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
 import { defined, RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
+
+import type { KubernetesBackend } from './k8s';
 
 const console = Logging.wsl;
 const INSTANCE_NAME = 'rancher-desktop';
@@ -88,7 +89,7 @@ type wslExecOptions = execOptions & {
 };
 
 export default class WSLBackend extends events.EventEmitter implements VMBackend, VMExecutor {
-  constructor(kubeFactory: (backend: WSLBackend) => K8s.KubernetesBackend) {
+  constructor(kubeFactory: (backend: WSLBackend) => KubernetesBackend) {
     super();
     this.progressTracker = new ProgressTracker((progress) => {
       this.progress = progress;
@@ -141,7 +142,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
    */
   protected resolverHostProcess: BackgroundProcess;
 
-  readonly kubeBackend: K8s.KubernetesBackend;
+  readonly kubeBackend: KubernetesBackend;
   readonly executor = this;
 
   /** Not used in wsl.ts */
@@ -164,8 +165,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
   /** Whether debug mode is enabled */
   debug = false;
-
-  emit: VMBackend['emit'] = this.emit;
 
   get backend(): 'wsl' {
     return 'wsl';

--- a/src/backend/wsl.ts
+++ b/src/backend/wsl.ts
@@ -12,7 +12,7 @@ import semver from 'semver';
 import tar from 'tar-stream';
 
 import {
-  BackendError, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
+  BackendError, BackendEvents, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
 } from './backend';
 import BackendHelper from './backendHelper';
 import K3sHelper from './k3sHelper';
@@ -164,6 +164,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
   /** Whether debug mode is enabled */
   debug = false;
+
+  emit: VMBackend['emit'] = this.emit;
 
   get backend(): 'wsl' {
     return 'wsl';
@@ -1423,20 +1425,20 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   }
 
   // #region Events
-  eventNames(): Array<keyof K8s.KubernetesBackendEvents> {
-    return super.eventNames() as Array<keyof K8s.KubernetesBackendEvents>;
+  eventNames(): Array<keyof BackendEvents> {
+    return super.eventNames() as Array<keyof BackendEvents>;
   }
 
-  listeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+  listeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): K8s.KubernetesBackendEvents[eventName][] {
-    return super.listeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.listeners(event) as BackendEvents[eventName][];
   }
 
-  rawListeners<eventName extends keyof K8s.KubernetesBackendEvents>(
+  rawListeners<eventName extends keyof BackendEvents>(
     event: eventName,
-  ): K8s.KubernetesBackendEvents[eventName][] {
-    return super.rawListeners(event) as K8s.KubernetesBackendEvents[eventName][];
+  ): BackendEvents[eventName][] {
+    return super.rawListeners(event) as BackendEvents[eventName][];
   }
   // #endregion
 }


### PR DESCRIPTION
The things on BackendEvents are now properly emitted from VMBackend, rather than KubernetesBackend.  (This required that the two interfaces are implemented by different objects due to TypeScript reasons.)

This also has an additional commit to reduce the import surface of WSL.

This should be the last of #1997; we'll have to look at that later.