### PR TITLE
Implement imageAllowList settings and support them in the API

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -97,7 +97,7 @@ test.describe('Command server', () => {
   }
 
   function verifySettingsKeys(settings: Record<string, any>) {
-    expect(new Set(['version', 'kubernetes', 'portForwarding', 'images', 'telemetry',
+    expect(new Set(['version', 'containerEngine', 'kubernetes', 'portForwarding', 'images', 'telemetry',
       'updater', 'debug', 'pathManagementStrategy', 'diagnostics']))
       .toEqual(new Set(Object.keys(settings)));
   }

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -18,6 +18,11 @@ paths:
                 keepSystemImages:
                   type: boolean
         required: true
+      responses:
+        '202':
+          description: The application is performing a factory reset.
+        '400':
+          description: An error occurred
 
   /v0/propose_settings:
     put:
@@ -173,8 +178,8 @@ paths:
               schema:
                 "$ref" : "#/components/schemas/diagnostics"
     post:
-      operationId: dianosticRunChecks
-      summay: Run all diagnostic checks, and return any results.
+      operationId: diagnosticRunChecks
+      summary: Run all diagnostic checks, and return any results.
       responses:
         '200':
           description: >-

--- a/src/assets/specs/command-api.yaml
+++ b/src/assets/specs/command-api.yaml
@@ -233,6 +233,20 @@ components:
     preferences:
       type: object
       properties:
+        containerEngine:
+          type: object
+          properties:
+            imageAllowList:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                locked:
+                  type: boolean
+                patterns:
+                  type: array
+                  items:
+                    type: string
         kubernetes:
           type: object
           properties:

--- a/src/config/__tests__/settings.spec.ts
+++ b/src/config/__tests__/settings.spec.ts
@@ -13,7 +13,14 @@ describe('updateFromCommandLine', () => {
   beforeEach(() => {
     jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
     prefs = {
-      version:    4,
+      version:         4,
+      containerEngine: {
+        imageAllowList: {
+          enabled:  false,
+          locked:   false,
+          patterns: [],
+        },
+      },
       kubernetes: {
         version:                    '1.23.5',
         memoryInGB:                 4,
@@ -29,7 +36,7 @@ describe('updateFromCommandLine', () => {
         },
         suppressSudo:             false,
         hostResolver:             true,
-        experimental: { socketVMNet: true },
+        experimental:   { socketVMNet: true },
       },
       portForwarding: { includeKubernetesServices: false },
       images:         {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -36,7 +36,18 @@ export const ContainerEngineNames: Record<ContainerEngine, string> = {
 };
 
 export const defaultSettings = {
-  version:    CURRENT_SETTINGS_VERSION,
+  version:         CURRENT_SETTINGS_VERSION,
+  containerEngine: {
+    imageAllowList: {
+      enabled:  false,
+      /**
+       *  List will be locked when patterns have been loaded from an admin controlled location.
+       *  `enabled` will always be true when `locked` is true.
+       */
+      locked:   false,
+      patterns: [] as Array<string>,
+    },
+  },
   kubernetes: {
     /** The version of Kubernetes to launch, as a semver (without v prefix). */
     version:                    '',

--- a/src/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/src/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -63,6 +63,7 @@ describe(SettingsValidator, () => {
     describe('all standard fields', () => {
       // Special fields that cannot be checked here; this includes enums and maps.
       const specialFields = [
+        ['containerEngine', 'imageAllowList', 'locked'],
         ['kubernetes', 'checkForExistingKimBuilder'],
         ['kubernetes', 'containerEngine'],
         ['kubernetes', 'WSLIntegrations'],

--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -30,7 +30,7 @@ type ValidatorFunc<C, D> =
  */
 type SettingsValidationMapEntry<T> = {
   [k in keyof T]:
-  T[k] extends string | number | boolean ?
+  T[k] extends string | Array<string> | number | boolean ?
   ValidatorFunc<T[k], T[k]> :
   T[k] extends Record<string, infer V> ?
   SettingsValidationMapEntry<T[k]> | ValidatorFunc<T[k], Record<string, V>> :
@@ -55,7 +55,15 @@ export default class SettingsValidator {
   validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
     this.isKubernetesDesired = typeof newSettings.kubernetes?.enabled !== 'undefined' ? newSettings.kubernetes.enabled : currentSettings.kubernetes.enabled;
     this.allowedSettings ||= {
-      version:    this.checkUnchanged,
+      version:         this.checkUnchanged,
+      containerEngine: {
+        imageAllowList:             {
+          // TODO (maybe): `patterns` and `enabled` should be immutable if `locked` is true
+          enabled:  this.checkBoolean,
+          locked:   this.checkUnchanged,
+          patterns: this.checkStringArray,
+        },
+      },
       kubernetes: {
         version:                    this.checkKubernetesVersion,
         memoryInGB:                 this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
@@ -311,6 +319,16 @@ export default class SettingsValidator {
     }
 
     return errors.length === 0 && changed;
+  }
+
+  protected checkStringArray(currentValue: string[], desiredValue: string[], errors: string[], fqname: string): boolean {
+    if (!Array.isArray(desiredValue) || desiredValue.some(s => typeof (s) !== 'string')) {
+      errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+      return false;
+    }
+
+    return currentValue.length !== desiredValue.length || currentValue.some((v, i) => v !== desiredValue[i]);
   }
 
   protected checkPathManagementStrategy(currentValue: PathManagementStrategy,


### PR DESCRIPTION
This PR does not yet provide the full functionality for the `locked` setting; it will be added once admin-provided allow lists are supported.

This PR creates the top-level object `containerEngine` to stop putting container engine settings under `kubernetes`. Any settings that are still applicable when kubernetes is disabled do not belong in the `kubernetes` settings object.

Closes #3245 

```console
$ rdctl api settings | jq .containerEngine.imageAllowList
{
  "enabled": false,
  "locked": false,
  "patterns": []
}

$ rdctl api -X PUT --body '{"containerEngine":{"imageAllowList":{"enabled":true,"patterns":["a","b"]}}}' settings
settings updated; no restart required

$ rdctl api settings | jq .containerEngine.imageAllowList
{
  "enabled": true,
  "locked": false,
  "patterns": [
    "a",
    "b"
  ]
}

$ jq .containerEngine.imageAllowList < ~/Library/Preferences/rancher-desktop/settings.json
{
  "enabled": true,
  "locked": false,
  "patterns": [
    "a",
    "b"
  ]
}

$ rdctl api -X PUT --body '{"containerEngine":{"imageAllowList":{"locked":true}}}' settings
errors in attempt to update settings:
Changing field containerEngine.imageAllowList.locked via the API isn't supported.
{"message":"400 Bad Request"}
```