### PR TITLE
Fix checkKubernetesVersion logic

### DIFF
--- a/src/main/commandServer/settingsValidator.ts
+++ b/src/main/commandServer/settingsValidator.ts
@@ -259,14 +259,9 @@ export default class SettingsValidator {
 
   protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
     /**
-     * Kubernetes can be disabled but we still require a valid version or an
-     * empty string
+     * desiredVersion can be an empty string when Kubernetes is disabled, but otherwise it must be a valid version.
     */
-    if (!this.isKubernetesDesired && (desiredVersion === '' || this.k8sVersions.includes(desiredVersion))) {
-      return true;
-    }
-
-    if (!this.k8sVersions.includes(desiredVersion)) {
+    if ((this.isKubernetesDesired || desiredVersion !== '') && !this.k8sVersions.includes(desiredVersion)) {
       errors.push(`Kubernetes version "${ desiredVersion }" not found.`);
 
       return false;


### PR DESCRIPTION
The validator used to always return `true` (meaning the settings have changed) when Kubernetes was disabled. This seems wrong.

The new code continues to check if the `currentValue` matches the `desiredVersion` and only returns `true` when they are different.

The only thing that is different with Kubernetes being disabled is that the empty string is a valid desired version.

Before this change we would get this illogical result when Kubernetes was disabled:

```
$ rdctl api settings | rdctl api -X PUT --input - settings
settings updated; no restart required
```

After this change it produces the correct result, regardless whether Kubernetes is disabled or not:

```
$ rdctl api settings | rdctl api -X PUT --input - settings
no changes necessary
```
