### PR TITLE
Add markdown support for diagnostic descriptions

### DIFF
--- a/pkg/rancher-desktop/components/DiagnosticsBody.vue
+++ b/pkg/rancher-desktop/components/DiagnosticsBody.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { ToggleSwitch } from '@rancher/components';
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
@@ -75,6 +77,9 @@ export default Vue.extend({
     },
   },
   methods: {
+    markdown(raw: string): string {
+      return DOMPurify.sanitize(marked.parseInline(raw), { USE_PROFILES: { html: true } });
+    },
     pluralize(count: number, unit: string): string {
       const units = count === 1 ? unit : `${ unit }s`;
 
@@ -163,7 +168,7 @@ export default Vue.extend({
       </template>
       <template #col:description="{row}">
         <td>
-          <span>{{ row.description }}</span>
+          <span v-html="markdown(row.description)"></span>
           <a v-if="row.documentation" :href="row.documentation" class="doclink"><span class="icon icon-external-link" /></a>
         </td>
       </template>
@@ -265,9 +270,7 @@ export default Vue.extend({
     .doclink {
       margin-left: 0.1rem;
       .icon {
-        /* These two rules work around the icon itself being too high. */
-        margin-bottom: 0.075rem;
-        vertical-align: bottom;
+        vertical-align: baseline;
       }
     }
   }

--- a/pkg/rancher-desktop/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/pkg/rancher-desktop/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -77,30 +77,30 @@ describeUnix(CheckerDockerCLISymlink, () => {
     });
 
     await expect(subject.check()).resolves.toEqual(expect.objectContaining({
-      description: expect.stringMatching(new RegExp(`${ path.join('~/\\.docker/cli-plugins', executable) } is a symlink to ${ appDirExecutable } through .*\.rd/bin/.*\.`)),
+      description: expect.stringMatching(new RegExp(`\`${ path.join('~/\\.docker/cli-plugins', executable) }\` is a symlink to \`${ appDirExecutable }\` through .*\.rd/bin/.*\.`)),
       passed:      true,
     }));
   });
 
   function wrongFirstLinkError(desc: string) {
-    return new RegExp(`${ executable } should be a symlink to ~/\\.rd/bin/${ executable }, ${ desc }\\.`);
+    return new RegExp(`${ executable }\` should be a symlink to \`~/\\.rd/bin/${ executable }\`, ${ desc }\\.`);
   }
 
   function badFirstLinkError(desc: string) {
-    return new RegExp(`${ executable } ${ desc }\\.\\s+It should be a symlink to ~/\\.rd/bin/${ executable }\\.$`);
+    return new RegExp(`${ executable }\` ${ desc }\\.\\s+It should be a symlink to \`~/\\.rd/bin/${ executable }\`\\.$`);
   }
 
   function badSecondLinkError(desc: string) {
-    return new RegExp(`${ executable } should be a symlink to ${ appDirExecutable }, ${ desc }\\.$`);
+    return new RegExp(`${ executable }\` should be a symlink to \`${ appDirExecutable }\`, ${ desc }\\.$`);
   }
 
   function problematicSecondLinkError(desc: string) {
-    return new RegExp(`${ executable } is a symlink to ${ appDirExecutable }, ${ desc }\\.`);
+    return new RegExp(`${ executable }\` is a symlink to \`${ appDirExecutable }\`, ${ desc }\\.`);
   }
 
   function intermediateFileNotSymlinkError(desc: string) {
     return new RegExp(
-      `${ executable } ${ desc }\\. It should be a symlink to ${ appDirExecutable }\\.`);
+      `${ executable }\` ${ desc }\\. It should be a symlink to \`${ appDirExecutable }\`\\.`);
   }
 
   it('should catch missing link', async() => {
@@ -147,7 +147,7 @@ describeUnix(CheckerDockerCLISymlink, () => {
       .mockRejectedValue({ code: 'EPONY' });
     jest.spyOn(subject, 'access');
     await expect(subject.check()).resolves.toEqual(expect.objectContaining({
-      description: expect.stringMatching(wrongFirstLinkError('but points to /usr/bin/true')),
+      description: expect.stringMatching(wrongFirstLinkError('but points to `/usr/bin/true`')),
       passed:      false,
     }));
     expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();
@@ -161,7 +161,7 @@ describeUnix(CheckerDockerCLISymlink, () => {
       .mockResolvedValueOnce('/usr/bin/true');
     jest.spyOn(subject, 'access');
     await expect(subject.check()).resolves.toEqual(expect.objectContaining({
-      description: expect.stringMatching(badSecondLinkError('but points to /usr/bin/true')),
+      description: expect.stringMatching(badSecondLinkError('but points to `/usr/bin/true`')),
       passed:      false,
     }));
     expect(jest.spyOn(subject, 'access')).not.toHaveBeenCalled();

--- a/pkg/rancher-desktop/main/diagnostics/dockerCliSymlinks.ts
+++ b/pkg/rancher-desktop/main/diagnostics/dockerCliSymlinks.ts
@@ -48,7 +48,7 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
     const finalTarget = path.join(paths.resources, os.platform(), 'bin', this.name);
     const displayableFinalTarget = replaceHome(finalTarget);
     let state;
-    let description = `The file ${ displayableStartingPath }`;
+    let description = `The file \`${ displayableStartingPath }\``;
     let finalDescription = '';
 
     try {
@@ -58,7 +58,7 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
 
       if (link !== rdBinPath) {
         return {
-          description: `${ description } should be a symlink to ${ displayableRDBinPath }, but points to ${ replaceHome(link) }.`,
+          description: `${ description } should be a symlink to \`${ displayableRDBinPath }\`, but points to \`${ replaceHome(link) }\`.`,
           passed:      false,
           fixes:       [], // TODO: [{ description: `ln -sf ${ displayableRDBinPath } ${ displayableStartingPath }` }],
         };
@@ -75,19 +75,19 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
       }
 
       return {
-        description: `${ description } ${ state }. It should be a symlink to ${ displayableRDBinPath }.`,
+        description: `${ description } ${ state }. It should be a symlink to \`${ displayableRDBinPath }\`.`,
         passed:      false,
         fixes:       [],
       };
     }
 
-    description = `The file ${ displayableRDBinPath }`;
+    description = `The file \`${ displayableRDBinPath }\``;
     try {
       const link = await this.readlink(rdBinPath);
 
       if (link !== finalTarget) {
         return {
-          description: `${ description } should be a symlink to ${ displayableFinalTarget }, but points to ${ replaceHome(link) }.`,
+          description: `${ description } should be a symlink to \`${ displayableFinalTarget }\`, but points to \`${ replaceHome(link) }\`.`,
           passed:      false,
           fixes:       [],
         };
@@ -95,7 +95,7 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
       await this.access(link, fs.constants.X_OK);
 
       return {
-        description: `${ displayableStartingPath } is a symlink to ${ displayableFinalTarget } through ${ displayableRDBinPath }.`,
+        description: `\`${ displayableStartingPath }\` is a symlink to \`${ displayableFinalTarget }\` through \`${ displayableRDBinPath }\`.`,
         passed:      true,
         fixes:       [],
       };
@@ -103,19 +103,19 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
       const code = ex.code ?? '';
 
       if (code === 'ENOENT') {
-        finalDescription = `${ description } is a symlink to ${ displayableFinalTarget }, which does not exist.`;
+        finalDescription = `${ description } is a symlink to \`${ displayableFinalTarget }\`, which does not exist.`;
       } else if (code === 'EINVAL') {
         state = `is not a symlink`;
       } else if (code === 'ELOOP') {
         state = `is a symlink with a loop`;
       } else if (code === 'EACCES') {
-        finalDescription = `${ description } is a symlink to ${ displayableFinalTarget }, which is not executable.`;
+        finalDescription = `${ description } is a symlink to \`${ displayableFinalTarget }\`, which is not executable.`;
       } else {
-        finalDescription = `${ description } is a symlink to ${ displayableFinalTarget }, but cannot be read (${ code || 'unknown error' }).`;
+        finalDescription = `${ description } is a symlink to \`${ displayableFinalTarget }\`, but cannot be read (${ code || 'unknown error' }).`;
       }
 
       return {
-        description: finalDescription || `${ description } ${ state }. It should be a symlink to ${ displayableFinalTarget }.`,
+        description: finalDescription || `${ description } ${ state }. It should be a symlink to \`${ displayableFinalTarget }\`.`,
         passed:      false,
         fixes:       [],
       };

--- a/pkg/rancher-desktop/main/diagnostics/kubeContext.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeContext.ts
@@ -33,15 +33,15 @@ const KubeContextDefaultChecker: DiagnosticsChecker = {
     console.debug(`${ this.id }: using ${ kubectl }`);
     console.debug(`${ this.id }: defaults to RD context? ${ passed }`);
     if (passed) {
-      description = 'Kubernetes is using the rancher-desktop context.';
+      description = 'Kubernetes is using the \`rancher-desktop\` context.';
     } else {
       const context = contexts.map(context => context.name).filter(c => c).shift();
 
       console.debug(`${ this.id }: current default context: ${ context }`);
       if (context) {
-        description = `Kubernetes is using context ${ context } instead of rancher-desktop.`;
+        description = `Kubernetes is using context \`${ context }\` instead of \`rancher-desktop\`.`;
       } else {
-        description = 'No active Kubernetes context found; should be rancher-desktop.';
+        description = 'No active Kubernetes context found; should be \`rancher-desktop\`.';
       }
     }
 

--- a/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
+++ b/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
@@ -52,11 +52,11 @@ export class RDBinInShellPath implements DiagnosticsChecker {
       const exe = path.basename(this.executable);
 
       passed = desiredDirs.length > 0;
-      description = `The ~/.rd/bin directory has not been added to the PATH, so command-line utilities are not configured in your ${ exe } shell.`;
+      description = `The \`~/.rd/bin\` directory has not been added to the \`PATH\`, so command-line utilities are not configured in your **${ exe }** shell.`;
       if (passed) {
-        description = `The ~/.rd/bin directory is found in your PATH as seen from ${ exe }.`;
+        description = `The \`~/.rd/bin\` directory is found in your \`PATH\` as seen from **${ exe }**.`;
       } else if (pathStrategy !== PathManagementStrategy.RcFiles) {
-        const description = `You have selected manual PATH configuration;
+        const description = `You have selected manual \`PATH\` configuration;
             consider letting Rancher Desktop automatically configure it.`;
 
         fixes.push({ description: description.replace(/\s+/gm, ' ') });

--- a/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
+++ b/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
@@ -22,7 +22,7 @@ class CheckTesting implements DiagnosticsChecker {
     return Promise.resolve({
       passed:        this.pass,
       documentation: 'https://www.example.com/not-a-valid-link',
-      description:   `This is a sample test that will ${ this.pass ? 'always' : 'never' } pass.`,
+      description:   `This is a \`sample\` test that will **${ this.pass ? 'always' : 'never' }** pass.`,
       fixes:         [],
     });
   }

--- a/pkg/rancher-desktop/main/diagnostics/types.ts
+++ b/pkg/rancher-desktop/main/diagnostics/types.ts
@@ -17,7 +17,7 @@ type DiagnosticsFix = {
 export type DiagnosticsCheckerResult = {
   /* Link to documentation about this check. */
   documentation?: string,
-  /* User-visible description about this check. */
+  /* User-visible markdown description about this check. */
   description: string,
   /** If true, the check succeeded (no fixes need to be applied). */
   passed: boolean,


### PR DESCRIPTION
Should only be used for simple formatting, like making substrings bold, italic, or code blocks.

Fixes #3238

There are several display issues that should be fixed before this is merged. Sample screenshots with both light and dark backgrounds:

<img width="1052" alt="Screen Shot 2022-10-22 at 9 50 45 PM" src="https://user-images.githubusercontent.com/78947/197374561-91713738-da01-4fb9-909b-b144dffb3a82.png">
<img width="1052" alt="Screen Shot 2022-10-22 at 9 50 32 PM" src="https://user-images.githubusercontent.com/78947/197374560-6dbcdfa3-1948-4d05-b782-a92351ceab21.png">

Issues (@manuelecarlini, @rak-phillip, please take a look):

* [ ] The code block box is too tall. The boxes on successive lines are almost touching; they need visible separation.
* [ ] The code block box is also a tiny bit too wide IMO[^1].
* [ ] The documentation link is aligned with the bottom of the line, and not with the baseline of the text.
* [ ] The background of the code box is black on a dark background. Instead it should be a lighter grey instead.
* [ ] The background of the code box is very light grey on a light background. It should be a darker grey.

Take a look at the Github colour scheme (and box sizing); it is much more readable!

[^1]: Take a look at the space when the code block is followed by punctuation! In the `PATH,` example, the space between the `H` and the `,` should not be larger than the space between the `,` and the next word. Maybe it is not possible to make it look good; seems like Github has the same issue.