### PR TITLE
Download wix in postinstall.

### DIFF
--- a/scripts/dependencies/wix.ts
+++ b/scripts/dependencies/wix.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Dependency, DownloadContext, GithubVersionGetter } from '../lib/dependencies';
+import { download } from '../lib/download';
+
+import { spawnFile } from '@/utils/childProcess';
+
+/**
+ * Wix downloads the latest build of WiX3.
+ */
+export class Wix extends GithubVersionGetter implements Dependency {
+  readonly name = 'wix';
+
+  // Wix4 is packaged really oddly (involves NuGet), and while there's a sketchy
+  // build in github.com/electron-userland/electron-builder-binaries it's rather
+  // outdated (and has since-fixed bugs).
+  readonly githubOwner = 'wixtoolset';
+  readonly githubRepo = 'wix3';
+
+  async download(context: DownloadContext): Promise<void> {
+    // WiX doesn't appear to believe in checksum files...
+
+    const hostDir = path.join(context.resourcesDir, 'host');
+    const wixDir = path.join(hostDir, 'wix');
+    const archivePath = path.join(hostDir, `${ context.versions.wix }.zip`);
+    const url = `https://github.com/wixtoolset/wix3/releases/download/${ context.versions.wix }/wix311-binaries.zip`;
+
+    await fs.promises.mkdir(wixDir, { recursive: true });
+    await download(url, archivePath);
+    await spawnFile('unzip', ['-o', archivePath, '-d', wixDir], { cwd: wixDir, stdio: 'inherit' });
+  }
+}

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -46,6 +46,7 @@ export type DependencyVersions = {
   ECRCredentialHelper: string;
   hostResolver: string;
   mobyOpenAPISpec: string;
+  wix: string;
 };
 
 export async function readDependencyVersions(path: string): Promise<DependencyVersions> {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
+import { Wix } from 'scripts/dependencies/wix';
 import { WSLDistro, HostResolverHost, HostResolverPeer } from 'scripts/dependencies/wsl';
 import {
   DependencyPlatform, DependencyVersions, readDependencyVersions, DownloadContext, Dependency,
@@ -33,6 +34,7 @@ const unixDependencies = [
 const windowsDependencies = [
   new WSLDistro(),
   new HostResolverHost(),
+  new Wix(),
 ];
 
 // Dependencies that are specific to WSL.

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -7,6 +7,7 @@ import { Octokit } from 'octokit';
 import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
+import { Wix } from 'scripts/dependencies/wix';
 import { WSLDistro, HostResolverHost } from 'scripts/dependencies/wsl';
 import {
   DependencyVersions, readDependencyVersions, writeDependencyVersions, Dependency, AlpineLimaISOVersion, getOctokit,
@@ -38,6 +39,7 @@ const dependencies: Dependency[] = [
   new AlpineLimaISO(),
   new WSLDistro(),
   new HostResolverHost(), // we only need one of HostResolverHost and HostResolverPeer
+  new Wix(),
   new MobyOpenAPISpec(),
 ];
 

--- a/src/assets/dependencies.yaml
+++ b/src/assets/dependencies.yaml
@@ -16,3 +16,4 @@ dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0
 hostResolver: 0.1.2
 mobyOpenAPISpec: "1.42"
+wix: wix3112rtm


### PR DESCRIPTION
This will be used for the new Windows installer.

Note that this is downloaded into `resources/host/` instead of the usual `resources/win32/` because we never want to ship this as part of the build (to the user), whether in the zip build or the installer build.

I'm doing this instead of using the built-in msi building in electron-builder because that one has no options (so it wouldn't be able to do things like install the privileged service).

I'm opting for WiX3 instead of WiX4 because:
- WiX4 is still in development:
  - They only ship CI builds on GitHub packages, which means it requires NuGet to install, instead of just a zip file.
  - This also means it requires a GitHub token to install it (limitation of GitHub Packages).
- Electron-builder has a set of pre-built binaries, but:
  - That's an older build with known issues (I actually started with it, and rolled back to WiX3 because of bugs there).
  - It's unclear _how_ they got those binaries; it has unclear provenance.
 