### PR TITLE
Postinstall: moby: Actually wait for the command to execute.

### DIFF
--- a/scripts/dependencies/moby-openapi.ts
+++ b/scripts/dependencies/moby-openapi.ts
@@ -4,8 +4,9 @@ import path from 'path';
 import { DownloadContext, Dependency, getOctokit } from 'scripts/lib/dependencies';
 import semver from 'semver';
 
-import buildUtils from '../lib/build-utils';
 import { download } from '../lib/download';
+
+import { spawnFile } from '@/utils/childProcess';
 
 // This downloads the moby openAPI specification (for WSL-helper) and generates
 // ./src/go/wsl-helper/pkg/dockerproxy/models/...
@@ -21,7 +22,7 @@ export class MobyOpenAPISpec implements Dependency {
 
     await download(url, outPath, { access: fs.constants.W_OK });
 
-    await buildUtils.spawn('go', 'generate', '-x', 'pkg/dockerproxy/generate.go', { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper') });
+    await spawnFile('go', ['generate', '-x', 'pkg/dockerproxy/generate.go'], { cwd: path.join(process.cwd(), 'src', 'go', 'wsl-helper'), stdio: 'inherit' });
     console.log('Moby API swagger models generated.');
   }
 


### PR DESCRIPTION
`buildUtils.spawn` returns a `ChildProcess`; it's used for running the Nuxt development server when running `npm run dev`.  It doesn't make sense to await on that.

Therefore we need to switch to `spawnFile`, which is actually meant to return after the process exits.