### PR TITLE
Make the `settings-write` main event take readonly settings.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -35,7 +35,7 @@ import Logging, { setLogLevel } from '@/utils/logging';
 import paths from '@/utils/paths';
 import { setupProtocolHandler, protocolRegistered } from '@/utils/protocols';
 import { jsonStringifyWithWhiteSpace } from '@/utils/stringify';
-import { RecursivePartial } from '@/utils/typeUtils';
+import { RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 import * as window from '@/window';
 import { closeDashboard, openDashboard } from '@/window/dashboard';
 import { preferencesSetDirtyFlag } from '@/window/preferences';
@@ -408,7 +408,7 @@ ipcMainProxy.on('preferences-set-dirty', (_event, dirtyFlag) => {
   preferencesSetDirtyFlag(dirtyFlag);
 });
 
-function writeSettings(arg: RecursivePartial<settings.Settings>) {
+function writeSettings(arg: RecursivePartial<RecursiveReadonly<settings.Settings>>) {
   _.merge(cfg, arg);
   settings.save(cfg);
   mainEvents.emit('settings-update', cfg);

--- a/src/main/mainEvents.ts
+++ b/src/main/mainEvents.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from 'events';
 import type { VMBackend } from '@/backend/backend';
 import type { Settings } from '@/config/settings';
 import type { TransientSettings } from '@/config/transientSettings';
-import { RecursivePartial } from '@/utils/typeUtils';
+import { RecursivePartial, RecursiveReadonly } from '@/utils/typeUtils';
 
 /**
  * MainEventNames describes the events available over the MainEvents event
@@ -42,7 +42,7 @@ interface MainEventNames {
    *
    * @param settings The settings to change.
    */
-  'settings-write'(settings: RecursivePartial<Settings>): void;
+  'settings-write'(settings: RecursivePartial<RecursiveReadonly<Settings>>): void;
 
   /**
    * Read the current transient settings.


### PR DESCRIPTION
#3246 saw issues when Jan added an array to `Settings['kubernetes']`:
```
…/src/backend/lima.ts
  277:16  error  'emit' is deprecated.   deprecation/deprecation

…/src/backend/wsl.ts
  173:16  error  'emit' is deprecated.   deprecation/deprecation
```
He later moved the code around so the array wasn't part of `Settings['kubernetes']`, and therefore no longer saw the error.  This fixes that issue:

Since we only ever copy things out of the passed-in (partial) settings, it's better to mark it as RecursiveReadonly.  This makes it possible to call `settings-write` by passing in readonly inputs.

So it's kind of actually catching issues, just that the error messages are terrible :(