### PR TITLE
WiX: Uninstall existing RD before installing new one.

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -35,6 +35,38 @@
 
       <DirectoryRef Id="TARGETDIR" />
 
+      <!-- Check if the NSIS-based Rancher Desktop is installed, and uninstall if yes. -->
+      <Property Id="NSISUNINSTALLCOMMAND">
+        <RegistrySearch
+          Id="NSISInstalled"
+          Root="HKCU"
+          Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\358d85cc-bb94-539e-a3cd-9231b877c7a4"
+          Name="QuietUninstallString"
+          Type="raw" />
+      </Property>
+      <!--
+        - We use a CustomAction with a Directory= so we have full control of the
+        - execution (action type 34); a more obvious Property= (type 50) will
+        - interpret the whole string as the executable (argv[0]) and fail.
+        - Since this is run before anything is installed, we pick a random
+        - system directory as the working directory (i.e. Directory=).
+        - Note that this action *must* be run as the non-privileged user (so
+        - that it will clear out the uninstall registry key).
+        -->
+      <CustomAction
+        Id="UninstallNSIS"
+        ExeCommand="[NSISUNINSTALLCOMMAND]"
+        Execute="immediate"
+        Impersonate="yes"
+        Directory="ProgramFiles64Folder"
+        Return="check"
+      />
+      <InstallExecuteSequence>
+        <Custom Action="UninstallNSIS" After="InstallInitialize">
+          NSISUNINSTALLCOMMAND AND NOT Installed
+        </Custom>
+      </InstallExecuteSequence>
+
       <Feature Id="ProductFeature" Absent="disallow">
         <ComponentGroupRef Id="ProductComponents" />
       </Feature>


### PR DESCRIPTION
This removes the NSIS-based Rancher Desktop before installing the new one.

To test:
- Install Rancher Desktop 1.6.0
- Run the WiX-based installer.

Expected results:
- Only the new RD is installed (not the NSIS-based one).
- If the new version was installed "for everyone", then the application in `C:\Users\<>\AppData\Local\Programs\Rancher Desktop` should be deleted (and `C:\Program Files\Rancher Desktop` created in its place).