### PR TITLE
Wix: Use compress, reuse cabs.

### DIFF
--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -39,7 +39,7 @@ async function getAppVersion(appDir: string): Promise<string> {
 export default async function buildInstaller(workDir: string, development = false) {
   const appDir = path.join(workDir, 'appDir');
   const appVersion = await getAppVersion(appDir);
-  const compressionLevel = development ? 'none' : 'high';
+  const compressionLevel = development ? 'mszip' : 'high';
   const fileList = await generateFileList(appDir);
   const template = await fs.promises.readFile(path.join(process.cwd(), 'build', 'wix', 'main.wxs'), 'utf-8');
   const output = Mustache.render(template, {
@@ -86,6 +86,8 @@ export default async function buildInstaller(workDir: string, development = fals
     '-out', path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`),
     '-pedantic',
     '-wx',
+    '-cc', path.join(process.cwd(), 'dist', 'wix-cache'),
+    '-reusecab',
     ...inputs.map(n => path.join(workDir, `${ path.basename(n, '.wxs') }.wixobj`)),
   ], { stdio: 'inherit' });
 }


### PR DESCRIPTION
When our package size exceeds 2GB, Windows Installer starts failing with a confusing error message; in the logs it shows as code 1310:
> Error attempting to create the destination file: [3]. System error code: [2]

The system error code is 131:
> `ERROR_NEGATIVE_SEEK`: An attempt was made to move the file pointer before the beginning of the file.

The solution here is to turn on compression even for development, to keep the installer to less than 2GB.

To make development faster, this also adds support for reusing cached cabinet files; this reduces the building time from about 5½ minutes to about 2½ minutes, when no actual files have changed.