### PR TITLE
Lima/kube: don't use tail to copy logs.

### DIFF
--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -94,6 +94,12 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
   download(config: BackendSettings): Promise<readonly [semver.SemVer | undefined, boolean]>;
 
   /**
+   * Delete Kubernetes data that may cause issues if we were to move to the
+   * given version.
+   */
+  deleteIncompatibleData(desiredVersion: semver.SemVer): Promise<void>;
+
+  /**
    * Install a pre-downloaded version of Kubernetes.
    */
   install(config: BackendSettings, kubernetesVersion: semver.SemVer, isDowngrade: boolean, allowSudo: boolean): Promise<void>;

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -126,7 +126,6 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
    */
   async install(config: BackendSettings, desiredVersion: semver.SemVer, allowSudo: boolean) {
     await this.progressTracker.action('Installing k3s', 50, async() => {
-      await this.deleteIncompatibleData(desiredVersion);
       await this.installK3s(desiredVersion);
       await this.writeServiceScript(config, allowSudo);
     });
@@ -399,11 +398,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     await this.vm.writeFile('/etc/logrotate.d/k3s', LOGROTATE_K3S_SCRIPT);
   }
 
-  /**
-   * Delete k3s data that may cause issues if we were to move to the given
-   * version.
-   */
-  protected async deleteIncompatibleData(desiredVersion: semver.SemVer) {
+  async deleteIncompatibleData(desiredVersion: semver.SemVer) {
     const existingVersion = await K3sHelper.getInstalledK3sVersion(this.vm);
 
     if (!existingVersion) {

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -354,21 +354,15 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
    * @param version The version to install.
    */
   protected async installK3s(version: semver.SemVer) {
-    const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-k3s-install-'));
+    const k3s = this.arch === 'aarch64' ? 'k3s-arm64' : 'k3s';
 
-    try {
-      const k3s = this.arch === 'aarch64' ? 'k3s-arm64' : 'k3s';
+    await this.vm.execCommand('mkdir', '-p', 'bin');
+    await this.vm.writeFile('bin/install-k3s', INSTALL_K3S_SCRIPT, 'a+x');
+    await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
+    await this.vm.execCommand({ root: true }, 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
+    const profilePath = path.join(paths.resources, 'scripts', 'profile');
 
-      await this.vm.execCommand('mkdir', '-p', 'bin');
-      await this.vm.writeFile('bin/install-k3s', INSTALL_K3S_SCRIPT, 'a+x');
-      await fs.promises.chmod(path.join(paths.cache, 'k3s', version.raw, k3s), 0o755);
-      await this.vm.execCommand({ root: true }, 'bin/install-k3s', version.raw, path.join(paths.cache, 'k3s'));
-      const profilePath = path.join(paths.resources, 'scripts', 'profile');
-
-      await this.vm.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
-    } finally {
-      await fs.promises.rm(workdir, { recursive: true });
-    }
+    await this.vm.lima('copy', profilePath, `${ MACHINE_NAME }:~/.profile`);
   }
 
   /**

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -96,11 +96,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     })();
   }
 
-  /**
-   * Delete k3s data that may cause issues if we were to move to the given
-   * version.
-   */
-  protected async deleteIncompatibleData(desiredVersion: semver.SemVer) {
+  async deleteIncompatibleData(desiredVersion: semver.SemVer) {
     const existingVersion = await K3sHelper.getInstalledK3sVersion(this.vm);
 
     if (!existingVersion) {
@@ -188,18 +184,9 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     }
   }
 
-  /**
-   * Install K3s into the VM for execution.
-   * @param version The version to install.
-   */
-  protected async installK3s(version: semver.SemVer) {
+  async install(config: BackendSettings, version: semver.SemVer) {
     await this.vm.runInstallScript(INSTALL_K3S_SCRIPT,
       'install-k3s', version.raw, await this.vm.wslify(path.join(paths.cache, 'k3s')));
-  }
-
-  async install(config: BackendSettings, desiredVersion: semver.SemVer, isDowngrade: boolean, allowSudo: boolean) {
-    await this.deleteIncompatibleData(desiredVersion);
-    await this.installK3s(desiredVersion);
   }
 
   async start(config: BackendSettings, activeVersion: semver.SemVer): Promise<string> {

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -536,6 +536,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       memory: (this.cfg?.memoryInGB || 4) * 1024 * 1024 * 1024,
       mounts: [
         { location: path.join(paths.cache, 'k3s'), writable: false },
+        { location: paths.logs, writable: true },
         { location: '~', writable: true },
         { location: '/tmp/rancher-desktop', writable: true },
       ],

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1582,6 +1582,10 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           return;
         }
 
+        if (kubernetesVersion) {
+          await this.kubeBackend.deleteIncompatibleData(kubernetesVersion);
+        }
+
         await this.progressTracker.action('Configuring containerd', 50, this.configureContainerd());
         if (config.containerEngine === ContainerEngine.CONTAINERD) {
           await this.startService('containerd');

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -181,6 +181,10 @@ class MockKubernetesBackend extends events.EventEmitter implements KubernetesBac
     return Promise.resolve([undefined, false] as const);
   }
 
+  deleteIncompatibleData() {
+    return Promise.resolve();
+  }
+
   install() {
     return Promise.resolve();
   }

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1173,9 +1173,13 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         ];
 
         if (kubernetesVersion) {
+          const version = kubernetesVersion;
+
           installerActions.push(
-            this.progressTracker.action('Installing k3s', 100,
-              this.kubeBackend.install(config, kubernetesVersion, isDowngrade, false)));
+            this.progressTracker.action('Installing k3s', 100, async() => {
+              await this.kubeBackend.deleteIncompatibleData(version);
+              await this.kubeBackend.install(config, version, isDowngrade, false);
+            }));
         }
         try {
           await this.progressTracker.action('Running installer actions', 0, Promise.all(installerActions));


### PR DESCRIPTION
On macOS Ventura (13), we are seeing hangs once Kubernetes starts up.  It appears to have to do with the process tailing the k3s logs to copy it to the host.

Rather than using an explicit process for that, just mount the logs directory inside the VM (via sshfs built in to lima) and write the logs there directly.  This appears to fix the issue.

Also includes a couple commits for fixes from the refactoring:
- Simplify `backend/kube/lima` `installK3s`: we no longer use the temporary directory.
- Fix `backend/kube/lima`: delete incompatible Kubernetes data before starting container runtime.

Fixes #3288.