### PR TITLE
Have e2e tests use full paths for resource executables.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -86,13 +86,18 @@ export async function tearDownHelm() {
   await kubectl('delete', 'deploy', 'nginx-sample', '--namespace', 'default');
 }
 
+export function toolPath(tool: string): string {
+  const srcDir = path.dirname(__dirname);
+  const filename = os.platform().startsWith('win') ? `${ tool }.exe` : tool;
+
+  return path.join(srcDir, '..', 'resources', os.platform(), 'bin', filename);
+}
+
 /**
  * Run the given tool with the given arguments, returning its standard output.
  */
 export async function tool(tool: string, ...args: string[]): Promise<string> {
-  const srcDir = path.dirname(__dirname);
-  const filename = os.platform().startsWith('win') ? `${ tool }.exe` : tool;
-  const exe = path.join(srcDir, '..', 'resources', os.platform(), 'bin', filename);
+  const exe = toolPath(tool);
 
   try {
     const { stdout } = await childProcess.spawnFile(


### PR DESCRIPTION
Relying on the current path is unreliable.

In particular, on Windows the credential e2e tests are consistently failing because they can't find `docker-credentials-none`

Signed-off-by: Eric Promislow <epromislow@suse.com>