### PR TITLE
Introduce script and workflow to monitor external dependencies for unreleased changes

### DIFF
--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -1,0 +1,27 @@
+name: Check for unreleased changes
+on:
+  schedule:
+    - cron: '48 8 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  check-unreleased-changes:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - run: npm ci
+
+      - run: npm run ucmonitor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "generateReleases": "node ./scripts/generateReleaseList.js",
     "postinstall": "node scripts/ts-wrapper.js scripts/postinstall.ts",
     "postuninstall": "electron-builder install-app-deps",
-    "rddepman": "node scripts/ts-wrapper.js scripts/rddepman.ts"
+    "rddepman": "node scripts/ts-wrapper.js scripts/rddepman.ts",
+    "ucmonitor": "node scripts/ts-wrapper.js scripts/unreleased-change-monitor.ts"
   },
   "main": "dist/app/background.js",
   "dependencies": {

--- a/scripts/dependencies/lima.ts
+++ b/scripts/dependencies/lima.ts
@@ -6,12 +6,12 @@ import os from 'os';
 import path from 'path';
 
 import {
-  DownloadContext, Dependency, GithubVersionGetter, AlpineLimaISOVersion, getOctokit,
+  DownloadContext, Dependency, GithubVersionGetter, AlpineLimaISOVersion, getOctokit, UnreleasedChangeMonitor, hasUnreleasedChanges, HasUnreleasedChangesResult,
 } from 'scripts/lib/dependencies';
 
 import { download, getResource } from '../lib/download';
 
-export class LimaAndQemu extends GithubVersionGetter implements Dependency {
+export class LimaAndQemu extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'limaAndQemu';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'lima-and-qemu';
@@ -49,9 +49,13 @@ export class LimaAndQemu extends GithubVersionGetter implements Dependency {
       });
     });
   }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
+  }
 }
 
-export class AlpineLimaISO implements Dependency {
+export class AlpineLimaISO implements Dependency, UnreleasedChangeMonitor {
   name = 'alpineLimaISO';
   githubOwner = 'lima-vm';
   githubRepo = 'alpine-lima';
@@ -99,5 +103,9 @@ export class AlpineLimaISO implements Dependency {
       isoVersion,
       alpineVersion,
     };
+  }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
   }
 }

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -3,7 +3,9 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { DownloadContext, Dependency, GithubVersionGetter } from 'scripts/lib/dependencies';
+import {
+  DownloadContext, Dependency, GithubVersionGetter, UnreleasedChangeMonitor, hasUnreleasedChanges, HasUnreleasedChangesResult,
+} from 'scripts/lib/dependencies';
 
 import {
   download, downloadZip, downloadTarGZ, getResource, DownloadOptions, ArchiveDownloadOptions,
@@ -163,7 +165,7 @@ export class Helm extends GithubVersionGetter implements Dependency {
   }
 }
 
-export class DockerCLI extends GithubVersionGetter implements Dependency {
+export class DockerCLI extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'dockerCLI';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'rancher-desktop-docker-cli';
@@ -178,6 +180,10 @@ export class DockerCLI extends GithubVersionGetter implements Dependency {
     const expectedChecksum = await findChecksum(`${ baseURL }/sha256sum.txt`, executableName);
 
     await download(dockerURL, destPath, { expectedChecksum });
+  }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
   }
 }
 
@@ -248,7 +254,7 @@ export class Trivy extends GithubVersionGetter implements Dependency {
   }
 }
 
-export class Steve extends GithubVersionGetter implements Dependency {
+export class Steve extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'steve';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'rancher-desktop-steve';
@@ -269,9 +275,13 @@ export class Steve extends GithubVersionGetter implements Dependency {
         checksumAlgorithm: 'sha512',
       });
   }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
+  }
 }
 
-export class GuestAgent extends GithubVersionGetter implements Dependency {
+export class GuestAgent extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'guestAgent';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'rancher-desktop-agent';
@@ -284,9 +294,13 @@ export class GuestAgent extends GithubVersionGetter implements Dependency {
 
     await downloadTarGZ(url, destPath);
   }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
+  }
 }
 
-export class RancherDashboard extends GithubVersionGetter implements Dependency {
+export class RancherDashboard extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'rancherDashboard';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'dashboard';
@@ -339,6 +353,10 @@ export class RancherDashboard extends GithubVersionGetter implements Dependency 
       });
 
     fs.rmSync(destPath, { maxRetries: 10 });
+  }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
   }
 }
 

--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -2,7 +2,9 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import { DownloadContext, Dependency, GithubVersionGetter } from 'scripts/lib/dependencies';
+import {
+  DownloadContext, Dependency, UnreleasedChangeMonitor, GithubVersionGetter, hasUnreleasedChanges, HasUnreleasedChangesResult,
+} from 'scripts/lib/dependencies';
 
 import { download } from '../lib/download';
 
@@ -44,7 +46,7 @@ export class HostResolverPeer extends GithubVersionGetter implements Dependency 
   }
 }
 
-export class HostResolverHost extends GithubVersionGetter implements Dependency {
+export class HostResolverHost extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'hostResolver';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'rancher-desktop-host-resolver';
@@ -62,9 +64,13 @@ export class HostResolverHost extends GithubVersionGetter implements Dependency 
 
     extract(context.internalDir, resolverVsockHostPath, 'host-resolver.exe');
   }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
+  }
 }
 
-export class WSLDistro extends GithubVersionGetter implements Dependency {
+export class WSLDistro extends GithubVersionGetter implements Dependency, UnreleasedChangeMonitor {
   name = 'WSLDistro';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'rancher-desktop-wsl-distro';
@@ -76,5 +82,9 @@ export class WSLDistro extends GithubVersionGetter implements Dependency {
     const destPath = path.join(context.resourcesDir, context.platform, tarName);
 
     await download(url, destPath, { access: fs.constants.W_OK });
+  }
+
+  async hasUnreleasedChanges(): Promise<HasUnreleasedChangesResult> {
+    return await hasUnreleasedChanges(this.githubOwner, this.githubRepo);
   }
 }

--- a/scripts/unreleased-change-monitor.ts
+++ b/scripts/unreleased-change-monitor.ts
@@ -1,0 +1,116 @@
+import { Octokit } from 'octokit';
+import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import * as tools from 'scripts/dependencies/tools';
+import { WSLDistro, HostResolverHost } from 'scripts/dependencies/wsl';
+import { Dependency, UnreleasedChangeMonitor, HasUnreleasedChangesResult, getOctokit } from 'scripts/lib/dependencies';
+
+const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
+const GITHUB_REPO = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'rancher-desktop';
+// a (hopefully) unique and communicative key that is used to find issues created by
+// this script by filtering them down to the ones that have it in their title
+const UCMONITOR = 'ucmonitor';
+
+type UnreleasedChangeMonitoringDependency = Dependency & UnreleasedChangeMonitor;
+
+type DependencyState = { dependency: UnreleasedChangeMonitoringDependency } & HasUnreleasedChangesResult;
+
+const dependencies: UnreleasedChangeMonitoringDependency[] = [
+  new LimaAndQemu(),
+  new WSLDistro(),
+  new tools.DockerCLI(),
+  new tools.Steve(),
+  new tools.GuestAgent(),
+  new tools.RancherDashboard(),
+  new AlpineLimaISO(),
+  new HostResolverHost(), // we only need one of HostResolverHost and HostResolverPeer
+];
+
+type Issue = Awaited<ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>>['data']['items'][0];
+
+async function getExistingIssuesFor(dependencyName: string): Promise<Issue[]> {
+  const queryString = `type:issue in:title repo:${ GITHUB_OWNER }/${ GITHUB_REPO } ${ UCMONITOR } ${ dependencyName } sort:updated`;
+  const response = await getOctokit().rest.search.issuesAndPullRequests({ q: queryString });
+
+  return response.data.items;
+}
+
+async function reopenIssue(issue: Issue): Promise<void> {
+  await getOctokit().rest.issues.update({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'open',
+  });
+  console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
+}
+
+async function closeIssue(issue: Issue): Promise<void> {
+  await getOctokit().rest.issues.update({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'closed',
+  });
+  console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
+}
+
+async function createIssue(latestReleaseTag: string, dependency: UnreleasedChangeMonitoringDependency): Promise<void> {
+  const title = `${ UCMONITOR }: ${ dependency.name } has changes since ${ latestReleaseTag }`;
+  const body = `Unreleased Change Monitor has detected changes to ${ dependency.name } since its last release, ${ latestReleaseTag }.` +
+    `\n\nThis is a reminder to release these changes so they make it into the next Rancher Desktop release.`;
+  const response = await getOctokit().rest.issues.create({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, title, body,
+  });
+  const issue = response.data;
+
+  console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
+}
+
+// Creates issues in the main Rancher Desktop repo for external
+// depndencies that have changes that have not been released.
+// Also closes issues that were previously created by this script,
+// but that are no longer relevant.
+async function checkForUnreleasedChanges(): Promise<void> {
+  const dependencyStates: DependencyState[] = await Promise.all(dependencies.map(async(dependency) => {
+    const result = await dependency.hasUnreleasedChanges();
+
+    return { ...result, dependency };
+  }));
+
+  // reconcile issues with dependency states
+  await Promise.all(dependencyStates.map(async(dependencyState) => {
+    const dependency = dependencyState.dependency;
+
+    // get issues that are relevant to this specific dependency
+    const existingIssues = await getExistingIssuesFor(dependency.name);
+
+    if (dependencyState.hasUnreleasedChanges) {
+      let issueExists = false;
+
+      await Promise.all(existingIssues.map(async(existingIssue) => {
+        const issueTitleMatchesLatestReleaseTag = existingIssue.title.endsWith(` ${ dependencyState.latestReleaseTag }`);
+
+        if (existingIssue.state === 'closed' && issueTitleMatchesLatestReleaseTag) {
+          // issue is closed, but it is the same as the one we would create; open it
+          issueExists = true;
+          await reopenIssue(existingIssue);
+        } else if (existingIssue.state === 'open' && issueTitleMatchesLatestReleaseTag) {
+          // we have an issue that is open that we want to be open
+          issueExists = true;
+        } else if (existingIssue.state === 'open' && !issueTitleMatchesLatestReleaseTag) {
+          // this is an open issue that does not match this release; close it
+          await closeIssue(existingIssue);
+        }
+      }));
+      if (!issueExists) {
+        await createIssue(dependencyState.latestReleaseTag, dependency);
+      }
+    } else {
+      await Promise.all(existingIssues.map(async(existingIssue) => {
+        if (existingIssue.state === 'open') {
+          // there should be no open issues; close this one
+          await closeIssue(existingIssue);
+        }
+      }));
+    }
+  }));
+}
+
+checkForUnreleasedChanges().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #3118.

Things that this PR does:
- introduces scripts/unreleased-change-monitor.ts
- introduces ucmonitor.yaml github actions workflow
- introduces the `UnreleasedChangeMonitor` interface and implements it on the relevant dependencies