### PR TITLE
Don't add hard-coded /usr/local/bin to the PATH on macOS

### DIFF
--- a/pkg/rancher-desktop/main/credentialServer/httpCredentialHelperServer.ts
+++ b/pkg/rancher-desktop/main/credentialServer/httpCredentialHelperServer.ts
@@ -193,12 +193,9 @@ export class HttpCredentialHelperServer {
     let pathVar = process.env.PATH ?? '';
 
     // The PATH needs to contain our resources directory (on macOS that would
-    // not be in the application's PATH), as well as /usr/local/bin.
+    // not be in the application's PATH).
     // NOTE: This needs to match DockerDirManager.spawnFileWithExtraPath
     pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
-    if (platform === 'darwin') {
-      pathVar += `${ path.delimiter }/usr/local/bin`;
-    }
 
     const body = stream.Readable.from(data);
     const { stdout } = await childProcess.spawnFile(helperName, [commandName], {

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -184,16 +184,13 @@ export default class DockerDirManager {
 
   protected async spawnFileWithExtraPath(command: string, args: string[]) {
     // The PATH needs to contain our resources directory (on macOS that would
-    // not be in the application's PATH), as well as /usr/local/bin.
+    // not be in the application's PATH).
     // NOTE: This needs to match HttpCredentialHelperServer.
 
     const platform = os.platform();
     let pathVar = process.env.PATH ?? ''; // This should always be set.
 
     pathVar += path.delimiter + path.join(paths.resources, platform, 'bin');
-    if (platform === 'darwin') {
-      pathVar += `${ path.delimiter }/usr/local/bin`;
-    }
 
     return await spawnFile(command, args, {
       env:   { ...process.env, PATH: pathVar },


### PR DESCRIPTION
It should not be needed. If it was, then we should extract the actual PATH from the user's shell (the same way the diagnostics do it) instead of just guessing an additional directory name.
