### PR TITLE
WiX: Implement auto-update.

### DIFF
--- a/.github/workflows/wix.yaml
+++ b/.github/workflows/wix.yaml
@@ -32,7 +32,8 @@ jobs:
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
     - run: npm ci
     - run: npm run build -- --win --publish=never
-    - run: npm run wix
+      env:
+        RD_FEAT_WIX: '1'
     - name: Upload Windows installer
       uses: actions/upload-artifact@v3
       with:

--- a/background.ts
+++ b/background.ts
@@ -326,6 +326,8 @@ function isK8sError(object: any): object is K8sError {
 
 Electron.app.on('before-quit', async(event) => {
   if (gone) {
+    mainEvents.emit('quit');
+
     return;
   }
   event.preventDefault();

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -5,110 +5,127 @@
   - This file is a Mustache template that is rendered via installer-win32.ts.
   -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Product
-      Id="*"
-      Name="Rancher Desktop"
-      UpgradeCode="{1F717D5A-A55B-5FE2-9103-C0D74F7FBDE3}"
-      Version="{{appVersion}}"
-      Language="1033"
-      Codepage="65001"
-      Manufacturer="SUSE">
-      <Package Compressed="yes" InstallerVersion="500" />
-      <!-- As of Windows 10/11, msiexec.exe is manifested for Windows 8.1 -->
-      <Condition Message="Windows 10 and above is required">
-        <![CDATA[ Installed OR VersionNT >= 603 ]]>
-      </Condition>
-      <MajorUpgrade
-        AllowSameVersionUpgrades="yes"
-        DowngradeErrorMessage='A newer version of Rancher Desktop is already installed.' />
-      <MediaTemplate CompressionLevel="{{compressionLevel}}" EmbedCab="yes" />
-      <UIRef Id="WixUI_RD" />
+  <Product
+    Id="*"
+    Name="Rancher Desktop"
+    UpgradeCode="{1F717D5A-A55B-5FE2-9103-C0D74F7FBDE3}"
+    Version="{{appVersion}}"
+    Language="1033"
+    Codepage="65001"
+    Manufacturer="SUSE">
+    <Package Compressed="yes" InstallerVersion="500" />
+    <!-- As of Windows 10/11, msiexec.exe is manifested for Windows 8.1 -->
+    <Condition Message="Windows 10 and above is required">
+      <![CDATA[ Installed OR VersionNT >= 603 ]]>
+    </Condition>
+    <MajorUpgrade
+      AllowSameVersionUpgrades="yes"
+      DowngradeErrorMessage='A newer version of [ProductName] is already installed.' />
+    <MediaTemplate CompressionLevel="{{compressionLevel}}" EmbedCab="yes" />
+    <UIRef Id="WixUI_RD" />
 
-      <Property Id="ApplicationFolderName" Value="Rancher Desktop" />
-      <Property Id="WixAppFolder" Value="WixPerUserFolder" />
-      <Icon
-        Id="RancherDesktopIcon.exe"
-        SourceFile="$(var.appDir)\Rancher Desktop.exe" />
-      <Property Id="ARPPRODUCTICON" Value="RancherDesktopIcon.exe" />
-      <Property Id="ARPNOMODIFY" Value="1" />
-      <Property Id="ARPURLINFOABOUT" Value="https://rancherdesktop.io/" />
+    <Property Id="ApplicationFolderName" Value="Rancher Desktop" />
+    <Property Id="WixAppFolder" Value="WixPerUserFolder" />
+    <Icon
+      Id="RancherDesktopIcon.exe"
+      SourceFile="$(var.appDir)\Rancher Desktop.exe" />
+    <Property Id="ARPPRODUCTICON" Value="RancherDesktopIcon.exe" />
+    <Property Id="ARPNOMODIFY" Value="1" />
+    <Property Id="ARPURLINFOABOUT" Value="https://rancherdesktop.io/" />
 
-      <WixVariable Id="AppGUID" Value="358d85cc-bb94-539e-a3cd-9231b877c7a4" />
+    <WixVariable Id="AppGUID" Value="358d85cc-bb94-539e-a3cd-9231b877c7a4" />
 
-      <DirectoryRef Id="TARGETDIR" />
+    <DirectoryRef Id="TARGETDIR" />
 
-      <!-- Check if the NSIS-based Rancher Desktop is installed, and uninstall if yes. -->
-      <Property Id="NSISUNINSTALLCOMMAND">
-        <RegistrySearch
-          Id="NSISInstalled"
-          Root="HKCU"
-          Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\!(wix.AppGUID)"
-          Name="QuietUninstallString"
-          Type="raw" />
-      </Property>
-      <!--
-        - We use a CustomAction with a Directory= so we have full control of the
-        - execution (action type 34); a more obvious Property= (type 50) will
-        - interpret the whole string as the executable (argv[0]) and fail.
-        - Since this is run before anything is installed, we pick a random
-        - system directory as the working directory (i.e. Directory=).
-        - Note that this action *must* be run as the non-privileged user (so
-        - that it will clear out the uninstall registry key).
-        -->
-      <CustomAction
-        Id="UninstallNSIS"
-        ExeCommand="[NSISUNINSTALLCOMMAND]"
-        Execute="immediate"
-        Impersonate="yes"
-        Directory="ProgramFiles64Folder"
-        Return="check"
+    <!-- Check if the NSIS-based Rancher Desktop is installed, and uninstall if yes. -->
+    <Property Id="NSISUNINSTALLCOMMAND">
+      <RegistrySearch
+        Id="NSISInstalled"
+        Root="HKCU"
+        Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\!(wix.AppGUID)"
+        Name="QuietUninstallString"
+        Type="raw" />
+    </Property>
+    <!--
+      - We use a CustomAction with a Directory= so we have full control of the
+      - execution (action type 34); a more obvious Property= (type 50) will
+      - interpret the whole string as the executable (argv[0]) and fail.
+      - Since this is run before anything is installed, we pick a random
+      - system directory as the working directory (i.e. Directory=).
+      - Note that this action *must* be run as the non-privileged user (so
+      - that it will clear out the uninstall registry key).
+      -->
+    <CustomAction
+      Id="UninstallNSIS"
+      ExeCommand="[NSISUNINSTALLCOMMAND]"
+      Execute="immediate"
+      Impersonate="yes"
+      Directory="ProgramFiles64Folder"
+      Return="check"
+    />
+    <InstallExecuteSequence>
+      <Custom Action="UninstallNSIS" After="InstallInitialize">
+        NSISUNINSTALLCOMMAND AND NOT Installed
+      </Custom>
+    </InstallExecuteSequence>
+
+    <!-- Setting the PATH variable -->
+    <Component Id="PathUser" Directory="APPLICATIONFOLDER">
+      <Condition>MSIINSTALLPERUSER</Condition>
+      <RegistryValue
+        Root="HKCU"
+        Key="SOFTWARE\!(wix.AppGUID)"
+        Name="EnvironmentVariablesSet"
+        Value="yes"
+        Type="string"
+        KeyPath="yes"
       />
-      <InstallExecuteSequence>
-        <Custom Action="UninstallNSIS" After="InstallInitialize">
-          NSISUNINSTALLCOMMAND AND NOT Installed
-        </Custom>
-      </InstallExecuteSequence>
+      <Environment Id="PathWindowsUser" Name="PATH"
+        Action="set" Part="last" System="no" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
+      <Environment Id="PathLinuxUser" Name="PATH"
+        Action="set" Part="last" System="no" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
+    </Component>
+    <Component Id="PathSystem" Directory="APPLICATIONFOLDER">
+      <Condition>NOT MSIINSTALLPERUSER</Condition>
+      <RegistryValue
+        Root="HKLM"
+        Key="SOFTWARE\!(wix.AppGUID)"
+        Name="EnvironmentVariablesSet"
+        Value="yes"
+        Type="string"
+        KeyPath="yes"
+      />
+      <Environment Id="PathWindowsSystem" Name="PATH"
+        Action="set" Part="last" System="yes" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
+      <Environment Id="PathLinuxSystem" Name="PATH"
+        Action="set" Part="last" System="yes" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
+    </Component>
 
-      <!-- Setting the PATH variable -->
-      <Component Id="PathUser" Directory="APPLICATIONFOLDER">
-        <Condition>MSIINSTALLPERUSER</Condition>
-        <RegistryValue
-          Root="HKCU"
-          Key="SOFTWARE\!(wix.AppGUID)"
-          Name="EnvironmentVariablesSet"
-          Value="yes"
-          Type="string"
-          KeyPath="yes"
-        />
-        <Environment Id="PathWindowsUser" Name="PATH"
-          Action="set" Part="last" System="no" Permanent="no"
-          Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
-        <Environment Id="PathLinuxUser" Name="PATH"
-          Action="set" Part="last" System="no" Permanent="no"
-          Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
-      </Component>
-      <Component Id="PathSystem" Directory="APPLICATIONFOLDER">
-        <Condition>NOT MSIINSTALLPERUSER</Condition>
-        <RegistryValue
-          Root="HKLM"
-          Key="SOFTWARE\!(wix.AppGUID)"
-          Name="EnvironmentVariablesSet"
-          Value="yes"
-          Type="string"
-          KeyPath="yes"
-        />
-        <Environment Id="PathWindowsSystem" Name="PATH"
-          Action="set" Part="last" System="yes" Permanent="no"
-          Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
-        <Environment Id="PathLinuxSystem" Name="PATH"
-          Action="set" Part="last" System="yes" Permanent="no"
-          Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
-      </Component>
-      <Feature Id="ProductFeature" Absent="disallow">
-        <ComponentGroupRef Id="ProductComponents" />
-        <ComponentRef Id="PathUser" />
-        <ComponentRef Id="PathSystem" />
-      </Feature>
-    </Product>
-    {{ &fileList }}
+    <!-- If required, run the app after install (for updates) -->
+    <Property Id="RDRUNAFTERINSTALL" Secure="yes" />
+    <CustomAction
+      Id="RunApplication"
+      FileKey="mainExecutable"
+      ExeCommand=""
+      Execute="commit"
+      Impersonate="yes"
+      Return="asyncNoWait"
+    />
+    <InstallExecuteSequence>
+      <Custom Action="RunApplication" Before="InstallFinalize">
+        RDRUNAFTERINSTALL
+      </Custom>
+    </InstallExecuteSequence>
+
+    <Feature Id="ProductFeature" Absent="disallow">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentRef Id="PathUser" />
+      <ComponentRef Id="PathSystem" />
+    </Feature>
+  </Product>
+  {{ &fileList }}
 </Wix>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -27,6 +27,8 @@ win:
   target: [ nsis, zip ]
   signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2
   requestedExecutionLevel: asInvoker # The _app_ doesn't need privileges
+  extraFiles:
+  - electron-builder.yml
 linux:
   category: Utility
   executableName: rancher-desktop

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.18.9",
+        "@electron/asar": "^3.2.2",
         "@nuxt/types": "^2.15.2",
         "@nuxt/typescript-build": "^2.1.0",
         "@nuxtjs/eslint-config": "^10.0.0",
@@ -3248,6 +3249,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+      "integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+      "dev": true,
+      "dependencies": {
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      },
+      "optionalDependencies": {
+        "@types/glob": "^7.1.1"
       }
     },
     "node_modules/@electron/get": {
@@ -40800,6 +40822,19 @@
       "requires": {
         "ajv": "^6.12.0",
         "ajv-keywords": "^3.4.1"
+      }
+    },
+    "@electron/asar": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
+      "integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
       }
     },
     "@electron/get": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/rancher-sandbox/rancher-desktop.git"
   },
   "scripts": {
-    "wix": "node scripts/ts-wrapper.js scripts/lib/installer-win32.tsx",
     "dev": "node scripts/ts-wrapper.js scripts/dev.ts",
     "lint": "npm run lint:fix",
     "lint:fix": "npm run lint:typescript:fix && npm run lint:go:fix ",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.18.9",
+    "@electron/asar": "^3.2.2",
     "@nuxt/types": "^2.15.2",
     "@nuxt/typescript-build": "^2.1.0",
     "@nuxtjs/eslint-config": "^10.0.0",

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -103,6 +103,12 @@ interface MainEventNames {
    * checker).
    */
   'diagnostics-trigger'(id: string): void;
+
+  /**
+   * Emitted on application quit.  Note that at this point we're committed to
+   * quitting.
+   */
+  'quit'(): void;
 }
 
 /**

--- a/pkg/rancher-desktop/main/update/MSIUpdater.ts
+++ b/pkg/rancher-desktop/main/update/MSIUpdater.ts
@@ -1,0 +1,154 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { AllPublishOptions, newError } from 'builder-util-runtime';
+import { NsisUpdater } from 'electron-updater';
+import { InstallOptions } from 'electron-updater/out/BaseUpdater';
+import { ElectronHttpExecutor } from 'electron-updater/out/electronHttpExecutor';
+import { findFile } from 'electron-updater/out/providers/Provider';
+import { verifySignature } from 'electron-updater/out/windowsExecutableCodeSignatureVerifier';
+import { Lazy } from 'lazy-val';
+
+import mainEvents from '@/main/mainEvents';
+import paths from '@/utils/paths';
+
+import type { AppAdapter } from 'electron-updater/out/AppAdapter';
+import type { DownloadUpdateOptions } from 'electron-updater/out/AppUpdater';
+
+/**
+ * MsiUpdater implements updating for Rancher Desktop's MSI-based installer.
+ */
+// We extend from NsisUpdater because extending BaseUpdater appears to cause
+// issues with AppImageUpdater (where it thinks BaseUpdater is undefined)?
+export default class MsiUpdater extends NsisUpdater {
+  // eslint-disable-next-line no-useless-constructor -- This is used to change visibility
+  constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
+    super(options, app);
+  }
+
+  // This implements an abstract method in BaseUpdater.
+  protected doDownloadUpdate(downloadUpdateOptions: DownloadUpdateOptions): Promise<string[]> {
+    const { info, provider } = downloadUpdateOptions.updateInfoAndProvider;
+    const fileInfo = findFile(provider.resolveFiles(info), 'msi');
+
+    if (!fileInfo) {
+      throw newError(`Could not find update information for MSI installer version ${ info.version }`,
+        'ERR_UPDATER_INVALID_UPDATE_INFO');
+    }
+
+    return this.executeDownload({
+      fileExtension: 'msi',
+      fileInfo,
+      downloadUpdateOptions,
+      task:          async(destinationFile, downloadOptions, packageFile, removeTempDirIfAny) => {
+        const httpExecutor: ElectronHttpExecutor = (this as any).httpExecutor;
+        const mergedDownloadOptions = {
+          ...downloadOptions,
+          sha512: fileInfo.packageInfo?.sha512 ?? downloadOptions.sha512,
+        };
+
+        this._logger.debug?.(`Downloading update for ${ info.version } from ${ fileInfo.url } (sha512: ${ mergedDownloadOptions.sha512 })`);
+        await httpExecutor.download(fileInfo.url, destinationFile, mergedDownloadOptions);
+        const signatureError = await this.verifySignature_(destinationFile);
+
+        if (signatureError) {
+          await removeTempDirIfAny();
+          throw newError(
+            `New version ${ info.version } (${ fileInfo.url }) is not signed correctly: ${ signatureError }`,
+            'ERR_UPDATER_INVALID_SIGNATURE');
+        }
+      },
+    });
+  }
+
+  // Verify that the given file is signed by the expected entity (as configured
+  // in electron-builder.yml).
+  private async verifySignature_(destinationFile: string): Promise<string | null> {
+    let publisherName: string | Array<string> | null;
+
+    try {
+      const configOnDisk: Lazy<any> = (this as any).configOnDisk;
+
+      publisherName = (await configOnDisk.value).publisherName;
+      if (!publisherName) {
+        return null;
+      }
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') {
+        return null; // No updates configured
+      }
+      throw e;
+    }
+    const publisherNames = Array.isArray(publisherName) ? publisherName : [publisherName];
+
+    return await verifySignature(publisherNames, destinationFile, this._logger);
+  }
+
+  protected doInstall(options: InstallOptions): boolean {
+    const systemRoot = process.env.SystemRoot ?? 'C:\\Windows';
+    const msiexec = path.join(systemRoot, 'system32', 'msiexec.exe');
+    const args: string[] = [
+      '/norestart',
+      '/lv*', path.join(paths.logs, 'msiexec.log'),
+      '/i', options.installerPath,
+    ];
+
+    if (options.isSilent) {
+      args.push('/quiet');
+    } else {
+      args.push('/passive');
+    }
+
+    args.push(`MSIINSTALLPERUSER=${ options.isAdminRightsRequired || this.shouldElevate ? '0' : '1' }`);
+
+    if (options.isForceRunAfter) {
+      args.push('RDRUNAFTERINSTALL=1');
+    }
+
+    this._logger.debug?.(`Will invoke installer on restart with: msiexec ${ args.join(' ') }`);
+    mainEvents.on('quit', () => {
+      this._logger.debug?.(`Running msiexec ${ args.join(' ') }`);
+      const proc = spawn(msiexec, args, {
+        detached: true, stdio: 'ignore', windowsHide: true,
+      });
+
+      proc.on('error', (err: NodeJS.ErrnoException) => {
+        this._logger.error(`Cannot run installer: error code: ${ err.code }`);
+        this.dispatchError(err);
+      });
+      proc.on('exit', (code, signal) => {
+        this._logger.debug?.(`msiexec exited with ${ code }/${ signal }`);
+      });
+      proc.unref();
+    });
+
+    return true;
+  }
+
+  /**
+   * shouldElevate indicates whether we need elevation to install the update.
+   */
+  protected get shouldElevate(): boolean {
+    // Unfortunately, we seem to be able to write to the application directory
+    // even when installed elevated (possibly due to VirtualStore).  So we rely
+    // on the existence of the privileged service executable to determine
+    // whether we were installed elevated (since we drop the executed when
+    // non-elevated to avoid also installing the privileged service).
+    const checkPath = path.join(paths.resources, 'win32', 'internal', 'privileged-service.exe');
+
+    this._logger.debug?.(`Checking if elevation is needed via ${ checkPath }...`);
+    try {
+      // Unfortunately, doInstall is synchronous, so we need to use the sync
+      // version of access functions.
+      fs.accessSync(checkPath, fs.constants.F_OK);
+      this._logger.debug?.('Elevation is required.');
+
+      return true;
+    } catch (ex) {
+      this._logger.debug?.(`Elevation is not required: ${ ex }`);
+
+      return false;
+    }
+  }
+}

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -167,7 +167,10 @@ export default {
         ],
       },
       plugins: [
-        new webpack.EnvironmentPlugin({ NODE_ENV: process.env.NODE_ENV || 'production' }),
+        new webpack.EnvironmentPlugin({
+          NODE_ENV:    process.env.NODE_ENV || 'production',
+          RD_FEAT_WIX: process.env.RD_FEAT_WIX || '0',
+        }),
       ],
     };
   },

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -21,7 +21,7 @@ export class Element {
    * Create a new element; this is used by the TypeScript JSX support.
    */
   static new(tag: string, attribs: Record<string, string> | null, ...children: (Element | Element[] | string)[]) {
-    return new Element(tag, attribs ?? {}, ...children.flat());
+    return new Element(tag, attribs ?? {}, ...children.flat().filter(x => x));
   }
 
   tag: string;
@@ -157,7 +157,7 @@ export default async function generateFileList(rootPath: string): Promise<string
   const rootDir = await walk(rootPath);
   const descendantDirs = getDescendantDirs(rootDir).filter(d => d.files.length > 0);
 
-  const specialComponents: Record<string, (d: directory, f: { name: string, id: string }) => Element> = {
+  const specialComponents: Record<string, (d: directory, f: { name: string, id: string }) => Element | null> = {
     'Rancher Desktop.exe': (d, f) => {
       return <Component>
         <File
@@ -186,6 +186,11 @@ export default async function generateFileList(rootPath: string): Promise<string
           </Shortcut>
         </File>
       </Component>;
+    },
+
+    'electron-builder.yml': () => {
+      // This files does not need to be packaged.
+      return null;
     },
 
     'resources\\resources\\win32\\internal\\privileged-service.exe': (d, f) => {


### PR DESCRIPTION
This implements auto-update for Windows Installer:
- When examining releases, look for *.msi instead of *.exe
- Automatically determine if elevation is required
- Execute msiexec on application exit

In addition, we now build the Windows Installer package as part of `npm run build`.

Both of these only happen if a `RD_FEAT_WIX` environment variable is set (to `1`) during the build.

For testing, please override `upgradeServer`, `owner`, and `repo` in [`electron-builder.yml`](https://github.com/rancher-sandbox/rancher-desktop/blob/main/electron-builder.yml).

Due to some indenting issues in `main.wxs`, it may be better to use `diff -w` (etc.) when looking at changes.