### PR TITLE
Introduce script to create an issue when it is time to create another rancher-desktop-docker-cli release

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -1,0 +1,27 @@
+name: Check for new releases of docker/cli
+on:
+  schedule:
+    - cron: '55 8 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  check-docker-cli:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - run: npm ci
+
+      - run: npm run dcmonitor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "postinstall": "node scripts/ts-wrapper.js scripts/postinstall.ts",
     "postuninstall": "electron-builder install-app-deps",
     "rddepman": "node scripts/ts-wrapper.js scripts/rddepman.ts",
-    "ucmonitor": "node scripts/ts-wrapper.js scripts/unreleased-change-monitor.ts"
+    "ucmonitor": "node scripts/ts-wrapper.js scripts/unreleased-change-monitor.ts",
+    "dcmonitor": "node scripts/ts-wrapper.js scripts/docker-cli-monitor.ts"
   },
   "main": "dist/app/background.js",
   "dependencies": {

--- a/scripts/docker-cli-monitor.ts
+++ b/scripts/docker-cli-monitor.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
-import { Octokit } from 'octokit';
-import { readDependencyVersions, getOctokit } from 'scripts/lib/dependencies';
+import { readDependencyVersions, getOctokit, RancherDesktopRepository, IssueOrPullRequest } from 'scripts/lib/dependencies';
 import semver from 'semver';
 
 const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
@@ -10,8 +9,7 @@ const DOCKER_CLI_OWNER = process.env.DOCKER_CLI_OWNER || 'docker';
 const DOCKER_CLI_REPO = process.env.DOCKER_CLI_REPO || 'cli';
 const TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
 const SCRIPT_NAME = 'docker-cli-monitor';
-
-type Issue = Awaited<ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>>['data']['items'][0];
+const mainRepo = new RancherDesktopRepository(GITHUB_OWNER, GITHUB_REPO);
 
 async function getLatestDockerCliVersion(): Promise<string> {
   const result = await getOctokit().rest.repos.listTags({
@@ -34,33 +32,7 @@ async function getLatestDockerCliVersion(): Promise<string> {
   return latestTag.name;
 }
 
-async function reopenIssue(issue: Issue): Promise<void> {
-  await getOctokit().rest.issues.update({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'open',
-  });
-  console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
-}
-
-async function closeIssue(issue: Issue): Promise<void> {
-  await getOctokit().rest.issues.update({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'closed',
-  });
-  console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
-}
-
-async function createIssue(latestTagName: string): Promise<void> {
-  const title = `${ SCRIPT_NAME }: make rancher-desktop-docker-cli release for version ${ latestTagName }`;
-  const body = `The Docker CLI monitor has detected a new release of docker/cli.
-Please make a corresponding release in rancher-desktop-docker-cli to keep it up to date in Rancher Desktop.`;
-  const result = await getOctokit().rest.issues.create({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, title, body,
-  });
-  const issue = result.data;
-
-  console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
-}
-
-async function getDockerCliIssues(): Promise<Issue[]> {
+async function getDockerCliIssues(): Promise<IssueOrPullRequest[]> {
   const query = `type:issue repo:${ GITHUB_OWNER }/${ GITHUB_REPO } sort:updated in:title ${ SCRIPT_NAME }`;
   const result = await getOctokit().rest.search.issuesAndPullRequests({ q: query });
 
@@ -89,14 +61,18 @@ async function checkDockerCli(): Promise<void> {
     if (issue.title.endsWith(` ${ latestTagName }`)) {
       issueFound = true;
       if (issue.state === 'closed') {
-        await reopenIssue(issue);
+        await mainRepo.reopenIssue(issue);
       }
     } else if (issue.state === 'open') {
-      await closeIssue(issue);
+      await mainRepo.closeIssue(issue);
     }
   }));
   if (!issueFound) {
-    await createIssue(latestTagName);
+    const title = `${ SCRIPT_NAME }: make rancher-desktop-docker-cli release for version ${ latestTagName }`;
+    const body = `The Docker CLI monitor has detected a new release of docker/cli. ` +
+      `Please make a corresponding release in rancher-desktop-docker-cli to keep it up to date in Rancher Desktop.`;
+
+    await mainRepo.createIssue(title, body);
   }
 }
 

--- a/scripts/docker-cli-monitor.ts
+++ b/scripts/docker-cli-monitor.ts
@@ -1,0 +1,106 @@
+import path from 'path';
+
+import { Octokit } from 'octokit';
+import { readDependencyVersions, getOctokit } from 'scripts/lib/dependencies';
+import semver from 'semver';
+
+const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
+const GITHUB_REPO = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'rancher-desktop';
+const DOCKER_CLI_OWNER = process.env.DOCKER_CLI_OWNER || 'docker';
+const DOCKER_CLI_REPO = process.env.DOCKER_CLI_REPO || 'cli';
+const TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
+const SCRIPT_NAME = 'docker-cli-monitor';
+
+type Issue = Awaited<ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>>['data']['items'][0];
+
+async function getLatestDockerCliVersion(): Promise<string> {
+  const result = await getOctokit().rest.repos.listTags({
+    owner: DOCKER_CLI_OWNER, repo: DOCKER_CLI_REPO, per_page: 100,
+  });
+  const tags = result.data;
+  const fullReleaseTags = tags.filter(tag => TAG_REGEX.test(tag.name));
+
+  if (fullReleaseTags.length === 0) {
+    throw new Error('Failed to find any valid tags');
+  }
+  fullReleaseTags.sort((previous, current) => {
+    const previousWithoutV = previous.name.replace('v', '');
+    const currentWithoutV = current.name.replace('v', '');
+
+    return semver.rcompare(previousWithoutV, currentWithoutV, { loose: true });
+  });
+  const latestTag = fullReleaseTags[0];
+
+  return latestTag.name;
+}
+
+async function reopenIssue(issue: Issue): Promise<void> {
+  await getOctokit().rest.issues.update({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'open',
+  });
+  console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
+}
+
+async function closeIssue(issue: Issue): Promise<void> {
+  await getOctokit().rest.issues.update({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'closed',
+  });
+  console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
+}
+
+async function createIssue(latestTagName: string): Promise<void> {
+  const title = `${ SCRIPT_NAME }: make rancher-desktop-docker-cli release for version ${ latestTagName }`;
+  const body = `The Docker CLI monitor has detected a new release of docker/cli.
+Please make a corresponding release in rancher-desktop-docker-cli to keep it up to date in Rancher Desktop.`;
+  const result = await getOctokit().rest.issues.create({
+    owner: GITHUB_OWNER, repo: GITHUB_REPO, title, body,
+  });
+  const issue = result.data;
+
+  console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
+}
+
+async function getDockerCliIssues(): Promise<Issue[]> {
+  const query = `type:issue repo:${ GITHUB_OWNER }/${ GITHUB_REPO } sort:updated in:title ${ SCRIPT_NAME }`;
+  const result = await getOctokit().rest.search.issuesAndPullRequests({ q: query });
+
+  return result.data.items;
+}
+
+async function checkDockerCli(): Promise<void> {
+  const latestTagName = await getLatestDockerCliVersion();
+  const latestVersion = latestTagName.replace('v', '');
+
+  console.log(`Latest version: ${ latestVersion }`);
+
+  const depVersionsPath = path.join('pkg', 'rancher-desktop', 'assets', 'dependencies.yaml');
+  const dependencyVersions = await readDependencyVersions(depVersionsPath);
+
+  console.log(`Current version: ${ dependencyVersions.dockerCLI }`);
+
+  if (latestVersion === dependencyVersions.dockerCLI) {
+    return;
+  }
+
+  const issues = await getDockerCliIssues();
+  let issueFound = false;
+
+  await Promise.all(issues.map(async(issue) => {
+    if (issue.title.endsWith(` ${ latestTagName }`)) {
+      issueFound = true;
+      if (issue.state === 'closed') {
+        await reopenIssue(issue);
+      }
+    } else if (issue.state === 'open') {
+      await closeIssue(issue);
+    }
+  }));
+  if (!issueFound) {
+    await createIssue(latestTagName);
+  }
+}
+
+checkDockerCli().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -157,3 +157,42 @@ export function getOctokit() {
 
   return new Octokit({ auth: personalAccessToken });
 }
+
+export type IssueOrPullRequest = Awaited<ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>>['data']['items'][0];
+
+/**
+ * Represents the main Rancher Desktop repo (rancher-sandbox/rancher-desktop
+ * as of the time of writing) or one of its forks.
+ */
+export class RancherDesktopRepository {
+  owner: string;
+  repo: string;
+
+  constructor(owner: string, repo: string) {
+    this.owner = owner;
+    this.repo = repo;
+  }
+
+  async createIssue(title: string, body: string): Promise<void> {
+    const result = await getOctokit().rest.issues.create({
+      owner: this.owner, repo: this.repo, title, body,
+    });
+    const issue = result.data;
+
+    console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
+  }
+
+  async reopenIssue(issue: IssueOrPullRequest): Promise<void> {
+    await getOctokit().rest.issues.update({
+      owner: this.owner, repo: this.repo, issue_number: issue.number, state: 'open',
+    });
+    console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
+  }
+
+  async closeIssue(issue: IssueOrPullRequest): Promise<void> {
+    await getOctokit().rest.issues.update({
+      owner: this.owner, repo: this.repo, issue_number: issue.number, state: 'closed',
+    });
+    console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
+  }
+}

--- a/scripts/unreleased-change-monitor.ts
+++ b/scripts/unreleased-change-monitor.ts
@@ -2,13 +2,16 @@ import { Octokit } from 'octokit';
 import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import * as tools from 'scripts/dependencies/tools';
 import { WSLDistro, HostResolverHost } from 'scripts/dependencies/wsl';
-import { Dependency, UnreleasedChangeMonitor, HasUnreleasedChangesResult, getOctokit } from 'scripts/lib/dependencies';
+import {
+  Dependency, UnreleasedChangeMonitor, HasUnreleasedChangesResult, getOctokit, RancherDesktopRepository,
+} from 'scripts/lib/dependencies';
 
 const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
 const GITHUB_REPO = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'rancher-desktop';
 // a (hopefully) unique and communicative key that is used to find issues created by
 // this script by filtering them down to the ones that have it in their title
 const UCMONITOR = 'ucmonitor';
+const mainRepo = new RancherDesktopRepository(GITHUB_OWNER, GITHUB_REPO);
 
 type UnreleasedChangeMonitoringDependency = Dependency & UnreleasedChangeMonitor;
 
@@ -32,32 +35,6 @@ async function getExistingIssuesFor(dependencyName: string): Promise<Issue[]> {
   const response = await getOctokit().rest.search.issuesAndPullRequests({ q: queryString });
 
   return response.data.items;
-}
-
-async function reopenIssue(issue: Issue): Promise<void> {
-  await getOctokit().rest.issues.update({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'open',
-  });
-  console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
-}
-
-async function closeIssue(issue: Issue): Promise<void> {
-  await getOctokit().rest.issues.update({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, issue_number: issue.number, state: 'closed',
-  });
-  console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
-}
-
-async function createIssue(latestReleaseTag: string, dependency: UnreleasedChangeMonitoringDependency): Promise<void> {
-  const title = `${ UCMONITOR }: ${ dependency.name } has changes since ${ latestReleaseTag }`;
-  const body = `Unreleased Change Monitor has detected changes to ${ dependency.name } since its last release, ${ latestReleaseTag }.` +
-    `\n\nThis is a reminder to release these changes so they make it into the next Rancher Desktop release.`;
-  const response = await getOctokit().rest.issues.create({
-    owner: GITHUB_OWNER, repo: GITHUB_REPO, title, body,
-  });
-  const issue = response.data;
-
-  console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
 }
 
 // Creates issues in the main Rancher Desktop repo for external
@@ -87,23 +64,27 @@ async function checkForUnreleasedChanges(): Promise<void> {
         if (existingIssue.state === 'closed' && issueTitleMatchesLatestReleaseTag) {
           // issue is closed, but it is the same as the one we would create; open it
           issueExists = true;
-          await reopenIssue(existingIssue);
+          await mainRepo.reopenIssue(existingIssue);
         } else if (existingIssue.state === 'open' && issueTitleMatchesLatestReleaseTag) {
           // we have an issue that is open that we want to be open
           issueExists = true;
         } else if (existingIssue.state === 'open' && !issueTitleMatchesLatestReleaseTag) {
           // this is an open issue that does not match this release; close it
-          await closeIssue(existingIssue);
+          await mainRepo.closeIssue(existingIssue);
         }
       }));
       if (!issueExists) {
-        await createIssue(dependencyState.latestReleaseTag, dependency);
+        const title = `${ UCMONITOR }: ${ dependency.name } has changes since ${ dependencyState.latestReleaseTag }`;
+        const body = `Unreleased Change Monitor has detected changes to ${ dependency.name } since its last release, ${ dependencyState.latestReleaseTag }.` +
+          `\n\nThis is a reminder to release these changes so they make it into the next Rancher Desktop release.`;
+
+        await mainRepo.createIssue(title, body);
       }
     } else {
       await Promise.all(existingIssues.map(async(existingIssue) => {
         if (existingIssue.state === 'open') {
           // there should be no open issues; close this one
-          await closeIssue(existingIssue);
+          await mainRepo.closeIssue(existingIssue);
         }
       }));
     }


### PR DESCRIPTION
Closes #3119.

This PR is similar to #3377. I introduced `RancherDesktopRepository` to eliminate duplication where it was feasible, and modified `unreleased-change-monitor.ts` and `docker-cli-monitor.ts` to use it.

Edit: the original issue implies that we want to automate releases of rancher-desktop-docker-cli when new tags on docker/cli are detected. This doesn't do that: I had a conversation with @jandubois and it was decided that we would create issues to remind us to release rancher-desktop-docker-cli, rather than automating the releases themselves.