### PR TITLE
Windows Installer: Install WSL as needed

### DIFF
--- a/build/wix-install-wsl.ps1
+++ b/build/wix-install-wsl.ps1
@@ -1,0 +1,33 @@
+# .SYNOPSIS
+# Installs WSL as part of the WiX setup.
+# .NOTES
+# This only installs the Windows optional features, and schedules the WSL kernel
+# to be installed upon reboot.  It assumes that the kernel has not been
+# previously installed (since msiexec provides that check).
+# This script assumes that it's run elevated.
+
+function Install-Features {
+  # Install Windows features as needed.
+  $features = @('Microsoft-Windows-Subsystem-Linux', 'VirtualMachinePlatform')
+  foreach ($feature in $features) {
+    Write-Output "Checking Windows feature $feature..."
+    if ((Get-WindowsOptionalFeature -FeatureName $feature -Online).State -ne "Enabled") {
+      Write-Output "Enabling Windows feature $feature..."
+      Enable-WindowsOptionalFeature -All -FeatureName:$feature -Online -NoRestart
+    }
+  }
+  Write-Output "Windows features installed."
+}
+
+function Install-Kernel {
+  # Install WSL kernel on reboot.
+  Write-Output "Will install Linux kernel after reboot."
+
+  Set-ItemProperty `
+    -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' `
+    -Name '!Rancher Desktop WSL Kernel Install' `
+    -Value "`"$Env:SystemRoot\system32\wsl.exe`" --update"
+}
+
+Install-Features
+Install-Kernel

--- a/build/wix/dialogs.wxs
+++ b/build/wix/dialogs.wxs
@@ -41,7 +41,9 @@
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="3">NOT Installed</Publish>
 
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallScopeDlg" Order="2">NOT Installed</Publish>
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Order="1" Value="InstallScopeDlg">NOT Installed</Publish>
+      <!-- If the WSL kernel is not installed, force all-users install (so we can install WSL) -->
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Order="2" Value="VerifyReadyDlg">NOT WSLKERNELINSTALLED</Publish>
 
       <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="1" Property="MSIINSTALLPERUSER" Value="1">WixAppFolder = "WixPerUserFolder"</Publish>
@@ -50,6 +52,9 @@
       <!-- if installing for all users, add the VerifyReadyDlg so that the user sees the UAC shield -->
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="4" Event="NewDialog" Value="VerifyReadyDlg">NOT MSIINSTALLPERUSER</Publish>
 
+      <!-- Getting to VerifyReadyDlg means we need to install for all users -->
+      <Publish Dialog="VerifyReadyDlg" Control="Install" Order="4" Property="MSIINSTALLPERUSER" Value="{}">1</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Install" Order="5" Property="ALLUSERS" Value="1">1</Publish>
     </UI>
 
     <UIRef Id="WixUI_Common" />

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -37,6 +37,37 @@
 
     <DirectoryRef Id="TARGETDIR" />
 
+    <!-- Install WSL if the kernel is not already installed. -->
+    <Upgrade Id="{1C3DB5B6-65A5-4EBC-A5B9-2F2D6F665F48}">
+      <UpgradeVersion OnlyDetect="yes" Property="WSLKERNELINSTALLED" Minimum="5.4.0" />
+    </Upgrade>
+    <SetProperty Id="ALLUSERS" Sequence="both" After="ValidateProductID" Value="1">
+      NOT WSLKERNELINSTALLED
+    </SetProperty>
+    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="0">
+      NOT WSLKERNELINSTALLED
+    </SetProperty>
+    <SetProperty Id="PowerShellExe" Sequence="execute" Before="SetInstallWSL"
+      Value="&quot;[System64Folder]\WindowsPowerShell\v1.0\powershell.exe&quot;" />
+    <Property Id="PowerShellArgs"
+      Value="-NoProfile -NonInteractive -ExecutionPolicy RemoteSigned" />
+    <SetProperty Id="InstallWSL" Sequence="execute" Before="InstallWSL"
+      Value="[PowerShellExe] [PowerShellArgs] -File &quot;[#f_install_wsl]&quot;">
+      NOT WSLKERNELINSTALLED
+    </SetProperty>
+    <CustomAction
+      Id="InstallWSL" BinaryKey="WixCA" DllEntry="WixQuietExec64"
+      Execute="deferred" Return="check" Impersonate="no"
+    />
+    <InstallExecuteSequence>
+      <Custom Action="InstallWSL" After="InstallFiles">
+        NOT WSLKERNELINSTALLED AND NOT REMOVE
+      </Custom>
+      <ScheduleReboot After="InstallWSL">
+        NOT WSLKERNELINSTALLED AND NOT REMOVE
+      </ScheduleReboot>
+    </InstallExecuteSequence>
+
     <!-- Check if the NSIS-based Rancher Desktop is installed, and uninstall if yes. -->
     <Property Id="NSISUNINSTALLCOMMAND">
       <RegistrySearch

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -42,10 +42,10 @@
       <UpgradeVersion OnlyDetect="yes" Property="WSLKERNELINSTALLED" Minimum="5.4.0" />
     </Upgrade>
     <SetProperty Id="ALLUSERS" Sequence="both" After="ValidateProductID" Value="1">
-      NOT WSLKERNELINSTALLED
+      NOT WSLKERNELINSTALLED AND NOT REMOVE
     </SetProperty>
     <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="0">
-      NOT WSLKERNELINSTALLED
+      NOT WSLKERNELINSTALLED AND NOT REMOVE
     </SetProperty>
     <SetProperty Id="PowerShellExe" Sequence="execute" Before="SetInstallWSL"
       Value="&quot;[System64Folder]\WindowsPowerShell\v1.0\powershell.exe&quot;" />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "generate:nerdctl-stub": "powershell scripts/windows/generate-nerdctl-stub.ps1",
     "build": "node scripts/ts-wrapper.js scripts/build.ts",
     "sign": "node scripts/ts-wrapper.js scripts/sign.ts",
+    "wix": "node scripts/ts-wrapper.js scripts/wix.ts",
     "test": "npm run lint:nofix && npm run test:unit && npm run test:extra",
     "test:unit": "npm run test:unit:jest && npm run test:unit:nerdctl-stub && npm run test:unit:wsl-helper",
     "test:unit:jest": "jest",

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -193,6 +193,19 @@ export default async function generateFileList(rootPath: string): Promise<string
       return null;
     },
 
+    'wix-install-wsl.ps1': (d, f) => {
+      return <Component>
+        <Condition>NOT WSLKERNELINSTALLED</Condition>
+        <File
+          Name={f.name}
+          Source="build\\wix-install-wsl.ps1"
+          ReadOnly="yes"
+          KeyPath="yes"
+          Id={f.id}
+        />
+      </Component>;
+    },
+
     'resources\\resources\\win32\\internal\\privileged-service.exe': (d, f) => {
       return <Component>
         <Condition>NOT MSIINSTALLPERUSER</Condition>
@@ -245,6 +258,8 @@ export default async function generateFileList(rootPath: string): Promise<string
       </Component>;
     },
   };
+
+  rootDir.files.push({ name: 'wix-install-wsl.ps1', id: 'f_install_wsl' });
 
   return (<Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -93,6 +93,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     '-sice:ICE61',
     `-dappDir=${ appDir }`,
     '-ext', 'WixUIExtension',
+    '-ext', 'WixUtilExtension',
     '-nologo',
     '-out', path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`),
     '-pedantic',

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -50,6 +50,7 @@ function getAppVersion(appDir: string): string {
 export default async function buildInstaller(workDir: string, appDir: string, development = false) {
   const appVersion = getAppVersion(appDir);
   const compressionLevel = development ? 'mszip' : 'high';
+  const outFile = path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`);
 
   await writeUpdateConfig(appDir);
   const fileList = await generateFileList(appDir);
@@ -95,13 +96,14 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     '-ext', 'WixUIExtension',
     '-ext', 'WixUtilExtension',
     '-nologo',
-    '-out', path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`),
+    '-out', outFile,
     '-pedantic',
     '-wx',
     '-cc', path.join(process.cwd(), 'dist', 'wix-cache'),
     '-reusecab',
     ...inputs.map(n => path.join(workDir, `${ path.basename(n, '.wxs') }.wixobj`)),
   ], { stdio: 'inherit' });
+  console.log(`Built Windows installer: ${ outFile }`);
 }
 
 /**

--- a/scripts/wix.ts
+++ b/scripts/wix.ts
@@ -1,0 +1,19 @@
+// This script builds the wix installer, assuming the zip file has already been
+// built (and dist/win-unpacked is populated).
+// This is only used during development.
+
+import path from 'path';
+
+import buildInstaller from './lib/installer-win32';
+
+async function run() {
+  const distDir = path.join(process.cwd(), 'dist');
+  const appDir = path.join(distDir, 'win-unpacked');
+
+  await buildInstaller(distDir, appDir);
+}
+
+run().catch((ex) => {
+  console.error(ex);
+  process.exit(1);
+});

--- a/scripts/wix.ts
+++ b/scripts/wix.ts
@@ -2,6 +2,7 @@
 // built (and dist/win-unpacked is populated).
 // This is only used during development.
 
+import fs from 'fs';
 import path from 'path';
 
 import buildInstaller from './lib/installer-win32';
@@ -9,6 +10,16 @@ import buildInstaller from './lib/installer-win32';
 async function run() {
   const distDir = path.join(process.cwd(), 'dist');
   const appDir = path.join(distDir, 'win-unpacked');
+
+  try {
+    await fs.promises.access(path.join(appDir, 'resources', 'app.asar'), fs.constants.R_OK);
+  } catch (ex) {
+    if ((ex as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw ex;
+    }
+    console.error(`Could not find ${ appDir }, please run \`npm run build\` first.`);
+    process.exit(1);
+  }
 
   await buildInstaller(distDir, appDir);
 }


### PR DESCRIPTION
- We detect if the WSL kernel has been installed via its MSI product ID.
- If not, we run a powershell script to install it.
  - This script is only run when the kernel is missing, so it doesn't need to do much detection.
  - We can use `wsl --update` to install the kernel, so we do not need to handle restarts that much.
- If the kernel is not installed, we force system-wide install (since we require elevation to install WSL).
- The kernel still needs to be installed on reboot because we can't invoke a MSI installation from within a MSI installation.  We may wish to use an msi bundle in the future instead, at which point post-reboot actions would no longer be required (by setting `WSL_INSTALLING` property during the install to suppress the check).