### PR TITLE
Allows rd guestagent to start by default

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -753,9 +753,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     await Promise.all([
       this.wslInstall(guestAgentPath, '/usr/local/bin/'),
       this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, { permissions: 0o755 }),
-      (async() => {
-        await this.writeConf('rancher-desktop-guestagent', guestAgentConfig);
-      })(),
+      this.writeConf('rancher-desktop-guestagent', guestAgentConfig),
+      this.execCommand('/sbin/rc-update', 'add', 'rancher-desktop-guestagent', 'default'),
     ]);
   }
 


### PR DESCRIPTION
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3405

The PR https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/pull/53 removed the ability to start RD guestagent by default. This change allows rd to start the agent by default.

Signed-off-by: Nino Kodabande <nkodabande@suse.com>