### PR TITLE
WiX: Add license to initial screen.

### DIFF
--- a/build/license.rtf
+++ b/build/license.rtf
@@ -1,0 +1,202 @@
+{\rtf1
+{\fonttbl{\f0\fmodern\fcharset0}}
+\f0\fs18
+{\qc
+Apache License\line
+Version 2.0, January 2004\line
+http://www.apache.org/licenses/
+\par
+}
+\par\ql
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par\par
+
+1. Definitions.\par\par
+
+{\li200
+"License" shall mean the terms and conditions for use, reproduction, and
+ distribution as defined by Sections 1 through 9 of this document.\par\par
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+ owner that is granting the License.\par\par
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+ that control, are controlled by, or are under common control with that entity.
+ For the purposes of this definition, "control" means (i) the power, direct or
+ indirect, to cause the direction or management of such entity, whether by
+ contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+ outstanding shares, or (iii) beneficial ownership of such entity.\par\par
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+ permissions granted by this License.\par\par
+
+"Source" form shall mean the preferred form for making modifications, including
+ but not limited to software source code, documentation source, and
+ configuration files.\par\par
+
+"Object" form shall mean any form resulting from mechanical transformation or
+ translation of a Source form, including but not limited to compiled object
+ code, generated documentation, and conversions to other media types.\par\par
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+ available under the License, as indicated by a copyright notice that is
+ included in or attached to the work (an example is provided in the Appendix
+ below).\par\par
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+ is based on (or derived from) the Work and for which the editorial revisions,
+ annotations, elaborations, or other modifications represent, as a whole, an
+ original work of authorship. For the purposes of this License, Derivative Works
+ shall not include works that remain separable from, or merely link (or bind by
+ name) to the interfaces of, the Work and Derivative Works thereof.\par\par
+
+"Contribution" shall mean any work of authorship, including the original version
+ of the Work and any modifications or additions to that Work or Derivative Works
+ thereof, that is intentionally submitted to Licensor for inclusion in the Work
+ by the copyright owner or by an individual or Legal Entity authorized to submit
+ on behalf of the copyright owner. For the purposes of this definition,
+ "submitted" means any form of electronic, verbal, or written communication sent
+ to the Licensor or its representatives, including but not limited to
+ communication on electronic mailing lists, source code control systems, and
+ issue tracking systems that are managed by, or on behalf of, the Licensor for
+ the purpose of discussing and improving the Work, but excluding communication
+ that is conspicuously marked or otherwise designated in writing by the
+ copyright owner as "Not a Contribution."\par\par
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+ of whom a Contribution has been received by Licensor and subsequently
+ incorporated within the Work.\par\par
+}
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+ License, each Contributor hereby grants to You a perpetual, worldwide,
+ non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+ reproduce, prepare Derivative Works of, publicly display, publicly perform,
+ sublicense, and distribute the Work and such Derivative Works in Source or
+ Object form.\par\par
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+ License, each Contributor hereby grants to You a perpetual, worldwide,
+ non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+ section) patent license to make, have made, use, offer to sell, sell, import,
+ and otherwise transfer the Work, where such license applies only to those
+ patent claims licensable by such Contributor that are necessarily infringed by
+ their Contribution(s) alone or by combination of their Contribution(s) with the
+ Work to which such Contribution(s) was submitted. If You institute patent
+ litigation against any entity (including a cross-claim or counterclaim in a
+ lawsuit) alleging that the Work or a Contribution incorporated within the Work
+ constitutes direct or contributory patent infringement, then any patent
+ licenses granted to You under this License for that Work shall terminate as of
+ the date such litigation is filed.\par\par
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+ or Derivative Works thereof in any medium, with or without modifications, and
+ in Source or Object form, provided that You meet the following conditions:
+ \par\par
+
+{\fi-100\li200
+ a. You must give any other recipients of the Work or Derivative Works a
+ copy of this License; and\par\par
+
+ b. You must cause any modified files to carry prominent notices stating
+ that You changed the files; and\par\par
+
+ c. You must retain, in the Source form of any Derivative Works that You
+ distribute, all copyright, patent, trademark, and attribution notices from the
+ Source form of the Work, excluding those notices that do not pertain to any
+ part of the Derivative Works; and\par\par
+
+ d. If the Work includes a "NOTICE" text file as part of its
+ distribution, then any Derivative Works that You distribute must include a
+ readable copy of the attribution notices contained within such NOTICE file,
+ excluding those notices that do not pertain to any part of the Derivative
+ Works, in at least one of the following places: within a NOTICE text file
+ distributed as part of the Derivative Works; within the Source form or
+ documentation, if provided along with the Derivative Works; or, within a
+ display generated by the Derivative Works, if and wherever such third-party
+ notices normally appear. The contents of the NOTICE file are for informational
+ purposes only and do not modify the License. You may add Your own attribution
+ notices within Derivative Works that You distribute, alongside or as an
+ addendum to the NOTICE text from the Work, provided that such additional
+ attribution notices cannot be construed as modifying the License.\par\par
+
+ You may add Your own copyright statement to Your modifications and may provide
+ additional or different license terms and conditions for use, reproduction, or
+ distribution of Your modifications, or for any such Derivative Works as a
+ whole, provided Your use, reproduction, and distribution of the Work otherwise
+ complies with the conditions stated in this License.\par\par
+}
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+ any Contribution intentionally submitted for inclusion in the Work by You to
+ the Licensor shall be under the terms and conditions of this License, without
+ any additional terms or conditions. Notwithstanding the above, nothing herein
+ shall supersede or modify the terms of any separate license agreement you may
+ have executed with Licensor regarding such Contributions.\par\par
+
+6. Trademarks. This License does not grant permission to use the trade
+ names, trademarks, service marks, or product names of the Licensor, except as
+ required for reasonable and customary use in describing the origin of the Work
+ and reproducing the content of the NOTICE file.\par\par
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed
+ to in writing, Licensor provides the Work (and each Contributor provides its
+ Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied, including, without limitation, any warranties
+ or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+ PARTICULAR PURPOSE. You are solely responsible for determining the
+ appropriateness of using or redistributing the Work and assume any risks
+ associated with Your exercise of permissions under this License.\par\par
+
+8. Limitation of Liability. In no event and under no legal theory,
+ whether in tort (including negligence), contract, or otherwise, unless required
+ by applicable law (such as deliberate and grossly negligent acts) or agreed to
+ in writing, shall any Contributor be liable to You for damages, including any
+ direct, indirect, special, incidental, or consequential damages of any
+ character arising as a result of this License or out of the use or inability to
+ use the Work (including but not limited to damages for loss of goodwill, work
+ stoppage, computer failure or malfunction, or any and all other commercial
+ damages or losses), even if such Contributor has been advised of the
+ possibility of such damages.\par\par
+
+9. Accepting Warranty or Additional Liability. While redistributing the
+ Work or Derivative Works thereof, You may choose to offer, and charge a fee
+ for, acceptance of support, warranty, indemnity, or other liability obligations
+ and/or rights consistent with this License. However, in accepting such
+ obligations, You may act only on Your own behalf and on Your sole
+ responsibility, not on behalf of any other Contributor, and only if You agree
+ to indemnify, defend, and hold each Contributor harmless for any liability
+ incurred by, or claims asserted against, such Contributor by reason of your
+ accepting any such warranty or additional liability.\par\par
+
+\par END OF TERMS AND CONDITIONS\par
+
+\par
+How to apply the Apache License to your work\par\par
+
+Include a copy of the Apache License, typically in a file called LICENSE, in
+ your work, and consider also including a NOTICE file that references the
+ License.
+\par
+To apply the Apache License to specific files in your work, attach the following
+ boilerplate declaration, replacing the fields enclosed by brackets "[]" with
+ your own identifying information. (Don't include the brackets!) Enclose the
+ text in the appropriate comment syntax for the file format. We also recommend
+ that you include a file or class name and description of purpose on the same
+ "printed page" as the copyright notice for easier identification within
+ third-party archives.
+\par
+\pard
+\par Copyright [yyyy] [name of copyright owner]
+\par
+\par Licensed under the Apache License, Version 2.0 (the "License");
+\par you may not use this file except in compliance with the License.
+\par You may obtain a copy of the License at
+\par
+\par     http://www.apache.org/licenses/LICENSE-2.0
+\par
+\par Unless required by applicable law or agreed to in writing, software
+\par distributed under the License is distributed on an "AS IS" BASIS,
+\par WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\par See the License for the specific language governing permissions and
+\par limitations under the License.}

--- a/build/wix/dialogs.wxs
+++ b/build/wix/dialogs.wxs
@@ -10,6 +10,7 @@
       <TextStyle Id="WixUI_Font_Normal" FaceName="Segoe UI" Size="8" />
       <TextStyle Id="WixUI_Font_Bigger" FaceName="Segoe UI" Size="12" />
       <TextStyle Id="WixUI_Font_Title" FaceName="Segoe UI" Size="9" Bold="yes" />
+      <TextStyle Id="WixUI_Font_Emphasized" FaceName="Segoe UI" Size="8" Bold="yes" />
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
       <Property Id="WixUI_Mode" Value="RD" />
@@ -24,7 +25,7 @@
       <DialogRef Id="PrepareDlg" />
       <DialogRef Id="ResumeDlg" />
       <DialogRef Id="UserExit" />
-      <DialogRef Id="WelcomeDlg" />
+      <DialogRef Id="RDWelcomeDlg" />
       <UIRef Id="WixUI_ErrorProgressText" />
 
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
@@ -37,25 +38,30 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="1">Installed AND PATCH</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="3">NOT Installed</Publish>
+      <!-- Normal Install Flow -->
 
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Order="1" Value="InstallScopeDlg">NOT Installed</Publish>
+      <Publish Dialog="RDWelcomeDlg" Control="Next" Event="NewDialog" Order="1" Value="InstallScopeDlg">NOT Installed</Publish>
       <!-- If the WSL kernel is not installed, force all-users install (so we can install WSL) -->
-      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Order="2" Value="VerifyReadyDlg">NOT WSLKERNELINSTALLED</Publish>
+      <Publish Dialog="RDWelcomeDlg" Control="Next" Event="NewDialog" Order="2" Value="VerifyReadyDlg">NOT WSLKERNELINSTALLED</Publish>
 
-      <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="RDWelcomeDlg">1</Publish>
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="1" Property="MSIINSTALLPERUSER" Value="1">WixAppFolder = "WixPerUserFolder"</Publish>
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="2" Property="ALLUSERS" Value="{}">MSIINSTALLPERUSER</Publish>
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="3" Event="EndDialog" Value="Return">MSIINSTALLPERUSER</Publish>
       <!-- if installing for all users, add the VerifyReadyDlg so that the user sees the UAC shield -->
       <Publish Dialog="InstallScopeDlg" Control="Next" Order="4" Event="NewDialog" Value="VerifyReadyDlg">NOT MSIINSTALLPERUSER</Publish>
 
-      <!-- Getting to VerifyReadyDlg means we need to install for all users -->
-      <Publish Dialog="VerifyReadyDlg" Control="Install" Order="4" Property="MSIINSTALLPERUSER" Value="{}">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Install" Order="5" Property="ALLUSERS" Value="1">1</Publish>
+      <Publish Dialog="VerifyReadyDlg" Order="2" Control="Back" Event="NewDialog" Value="RDWelcomeDlg">NOT Installed</Publish>
+      <Publish Dialog="VerifyReadyDlg" Order="3" Control="Back" Event="NewDialog" Value="InstallScopeDlg">WSLKERNELINSTALLED</Publish>
+      <!-- Getting to VerifyReadyDlg means we need to install for all users (used when WSL is missing) -->
+      <Publish Dialog="VerifyReadyDlg" Order="4" Control="Install" Property="MSIINSTALLPERUSER" Value="{}">1</Publish>
+      <Publish Dialog="VerifyReadyDlg" Order="5" Control="Install" Property="ALLUSERS" Value="1">1</Publish>
+
     </UI>
+
+    <InstallUISequence>
+      <Show Dialog="MaintenanceWelcomeDlg" Before="RDWelcomeDlg">Installed AND NOT RESUME AND NOT Preselected AND NOT PATCH</Show>
+    </InstallUISequence>
 
     <UIRef Id="WixUI_Common" />
   </Fragment>

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -42,10 +42,10 @@
       <UpgradeVersion OnlyDetect="yes" Property="WSLKERNELINSTALLED" Minimum="5.4.0" />
     </Upgrade>
     <SetProperty Id="ALLUSERS" Sequence="both" After="ValidateProductID" Value="1">
-      NOT WSLKERNELINSTALLED AND NOT REMOVE
+      NOT WSLKERNELINSTALLED AND NOT Installed
     </SetProperty>
-    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="0">
-      NOT WSLKERNELINSTALLED AND NOT REMOVE
+    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="{}">
+      NOT WSLKERNELINSTALLED AND NOT Installed
     </SetProperty>
     <SetProperty Id="PowerShellExe" Sequence="execute" Before="SetInstallWSL"
       Value="&quot;[System64Folder]\WindowsPowerShell\v1.0\powershell.exe&quot;" />
@@ -61,10 +61,10 @@
     />
     <InstallExecuteSequence>
       <Custom Action="InstallWSL" After="InstallFiles">
-        NOT WSLKERNELINSTALLED AND NOT REMOVE
+        NOT WSLKERNELINSTALLED AND NOT Installed
       </Custom>
       <ScheduleReboot After="InstallWSL">
-        NOT WSLKERNELINSTALLED AND NOT REMOVE
+        NOT WSLKERNELINSTALLED AND NOT Installed
       </ScheduleReboot>
     </InstallExecuteSequence>
 

--- a/build/wix/welcome.wxs
+++ b/build/wix/welcome.wxs
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This describes the welcome dialog -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <UI>
+      <Dialog Id="RDWelcomeDlg" Width="370" Height="270" Title="!(loc.WelcomeEulaDlg_Title)">
+        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234"
+          TabSkip="no" Text="!(loc.WelcomeEulaDlgBitmap)" />
+        <Control Id="Title" Type="Text" X="130" Y="6" Width="225" Height="30"
+          Transparent="yes" NoPrefix="yes" Text="!(loc.WelcomeEulaDlgTitle)" />
+        <Control Id="BottomLine" Type="Line"
+          X="0" Y="234" Width="370" Height="0" />
+        <Control Id="LicenseAcceptedCheckBox" Type="CheckBox"
+          X="130" Y="207" Width="226" Height="18"
+          CheckBoxValue="1" Property="RDLicenseAccepted"
+          Text="!(loc.WelcomeEulaDlgLicenseAcceptedCheckBox)" />
+        <Control Id="Back" Type="PushButton" Disabled="yes"
+          X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+        <Control Id="Next" Type="PushButton" Default="yes"
+          X="236" Y="243" Width="56" Height="17" Text="!(loc.WixUINext)">
+          <Condition Action="disable">
+            <![CDATA[RDLicenseAccepted <> "1"]]>
+          </Condition>
+          <Condition Action="enable">RDLicenseAccepted = "1"</Condition>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" Cancel="yes"
+          X="304" Y="243" Width="56" Height="17" Text="!(loc.WixUICancel)">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+        <Control Id="LicenseText" Type="ScrollableText" Sunken="yes" TabSkip="no"
+          X="130" Y="36" Width="226" Height="162">
+          <Text SourceFile="$(var.licenseFile)" />
+        </Control>
+      </Dialog>
+    </UI>
+
+    <InstallUISequence>
+      <!-- Only show the welcome dialog if we're not repairing, upgrading, or removing. -->
+      <Show Dialog="RDWelcomeDlg" Before="ProgressDlg" Overridable="yes">NOT Installed AND NOT WIX_UPGRADE_DETECTED AND NOT REMOVE</Show>
+    </InstallUISequence>
+  </Fragment>
+</Wix>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,7 @@ win:
   signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2
   requestedExecutionLevel: asInvoker # The _app_ doesn't need privileges
   extraFiles:
+  - build/license.rtf
   - electron-builder.yml
 linux:
   category: Utility

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -188,6 +188,11 @@ export default async function generateFileList(rootPath: string): Promise<string
       </Component>;
     },
 
+    'build\\license.rtf': () => {
+      // This is used for the installer, and does not need to shipped.
+      return null;
+    },
+
     'electron-builder.yml': () => {
       // This files does not need to be packaged.
       return null;

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -66,6 +66,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
   const inputs = [
     path.join(workDir, 'project.wxs'),
     path.join(process.cwd(), 'build', 'wix', 'dialogs.wxs'),
+    path.join(process.cwd(), 'build', 'wix', 'welcome.wxs'),
   ];
 
   await Promise.all(inputs.map(input => spawnFile(
@@ -73,6 +74,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     [
       '-arch', 'x64',
       `-dappDir=${ appDir }`,
+      `-dlicenseFile=${ path.join(appDir, 'build', 'license.rtf') }`,
       '-nologo',
       '-out', path.join(workDir, `${ path.basename(input, '.wxs') }.wixobj`),
       '-pedantic',
@@ -93,6 +95,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     // https://learn.microsoft.com/en-us/windows/win32/msi/ice61
     '-sice:ICE61',
     `-dappDir=${ appDir }`,
+    `-dlicenseFile=${ path.join(appDir, 'build', 'license.rtf') }`,
     '-ext', 'WixUIExtension',
     '-ext', 'WixUtilExtension',
     '-nologo',


### PR DESCRIPTION
The `ScrollableText` control only takes a _very_ limited set of RTF, so it's easiest to just make everything monospaced.

This required a custom dialog as the built-in ones assumed we'd immediately start the install on the next step (i.e. had the elevation shield).

Also includes a fix for the WSL install stuff when doing maintenance (running the installer after having already installed it).