### PR TITLE
Offline signing: Add support for WiX

### DIFF
--- a/.github/workflows/wix.yaml
+++ b/.github/workflows/wix.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+permissions:
+  contents: read
 
 jobs:
   package:
@@ -34,6 +36,59 @@ jobs:
     - run: npm run build -- --win --publish=never
       env:
         RD_FEAT_WIX: '1'
+    - name: Upload Windows installer
+      uses: actions/upload-artifact@v3
+      with:
+        name: Rancher Desktop Setup unsigned.msi
+        path: dist/Rancher Desktop*.msi
+        if-no-files-found: error
+    - name: Upload Windows zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: Rancher Desktop-win.zip
+        path: dist/Rancher Desktop-*-win.zip
+        if-no-files-found: error
+  sign:
+    name: Test Signing
+    needs: package
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - name: Install Windows dependencies
+      shell: powershell
+      run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+    - run: npm ci
+    - uses: actions/download-artifact@v3
+      with:
+        name: Rancher Desktop-win.zip
+    - shell: powershell
+      env:
+        RD_FEAT_WIX: '1'
+      run: |
+        # Generate a test signing certificate
+        $cert = New-SelfSignedCertificate `
+          -Type Custom `
+          -Subject "CN=Rancher-Sandbox, C=CA" `
+          -KeyUsage DigitalSignature `
+          -CertStoreLocation Cert:\CurrentUser\My `
+          -FriendlyName "Rancher-Sandbox Code Signing" `
+          -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+        Write-Output $cert
+        $env:CSC_FINGERPRINT = $cert.Thumbprint
+        # Run the signing script
+        npm run sign -- (Get-Item "Rancher Desktop*-win.zip")
+        # Check that the file was signed by the expected cert
+        $usedCert = (Get-AuthenticodeSignature -FilePath 'dist\Rancher Desktop Setup*.msi').SignerCertificate
+        Write-Output $usedCert
+        if ($cert -ne $usedCert) {
+          Write-Output "Expected Certificate" $cert "Actual Certificate" $usedCert
+          Throw "Installer signed with wrong certicate"
+        }
     - name: Upload Windows installer
       uses: actions/upload-artifact@v3
       with:

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -46,8 +46,9 @@ function getAppVersion(appDir: string): string {
  * Given an unpacked build, produce a MSI installer.
  * @param workDir Directory in which we can write temporary work files.
  * @param appDir Directory containing extracted application zip file.
+ * @returns The path of the built installer.
  */
-export default async function buildInstaller(workDir: string, appDir: string, development = false) {
+export default async function buildInstaller(workDir: string, appDir: string, development = false): Promise<string> {
   const appVersion = getAppVersion(appDir);
   const compressionLevel = development ? 'mszip' : 'high';
   const outFile = path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`);
@@ -104,6 +105,8 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     ...inputs.map(n => path.join(workDir, `${ path.basename(n, '.wxs') }.wixobj`)),
   ], { stdio: 'inherit' });
   console.log(`Built Windows installer: ${ outFile }`);
+
+  return outFile;
 }
 
 /**


### PR DESCRIPTION
This adds Windows Installer signing support for the offline signing script. As with others, this is enabled by the `RD_FEA_WIX` environment variable.

As before, use `npm run sign -- dist/Rancher*.zip` to test.  The resulting `dist/Rancher Desktop Setup *.msi` file should be signed, as well as the executables (e.g. `privileged-service.exe`).  See [documentation](https://github.com/rancher-sandbox/rancher-desktop/blob/main/docs/development/signing.md) for more details.

Screenshot of signed installer (seen when we request elevation):
![UAC prompt, expanded](https://user-images.githubusercontent.com/3977982/202827460-ff1dc9f7-a425-484d-872c-2f59620eb0a1.png)
Note that here I used a certificate with a subject of _Rancher Sandbox_, whereas the installer has an author of _SUSE_ from https://github.com/rancher-sandbox/rancher-desktop/blob/046e6bb6c5bcf8dcb832ce85d3d838ac083585e0/build/wix/main.wxs#L15
