### PR TITLE
WiX: Clarify when elevation is needed for WSL.

### DIFF
--- a/build/wix/dialogs.wxs
+++ b/build/wix/dialogs.wxs
@@ -37,26 +37,6 @@
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
-
-      <!-- Normal Install Flow -->
-
-      <Publish Dialog="RDWelcomeDlg" Control="Next" Event="NewDialog" Order="1" Value="InstallScopeDlg">NOT Installed</Publish>
-      <!-- If the WSL kernel is not installed, force all-users install (so we can install WSL) -->
-      <Publish Dialog="RDWelcomeDlg" Control="Next" Event="NewDialog" Order="2" Value="VerifyReadyDlg">NOT WSLKERNELINSTALLED</Publish>
-
-      <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="RDWelcomeDlg">1</Publish>
-      <Publish Dialog="InstallScopeDlg" Control="Next" Order="1" Property="MSIINSTALLPERUSER" Value="1">WixAppFolder = "WixPerUserFolder"</Publish>
-      <Publish Dialog="InstallScopeDlg" Control="Next" Order="2" Property="ALLUSERS" Value="{}">MSIINSTALLPERUSER</Publish>
-      <Publish Dialog="InstallScopeDlg" Control="Next" Order="3" Event="EndDialog" Value="Return">MSIINSTALLPERUSER</Publish>
-      <!-- if installing for all users, add the VerifyReadyDlg so that the user sees the UAC shield -->
-      <Publish Dialog="InstallScopeDlg" Control="Next" Order="4" Event="NewDialog" Value="VerifyReadyDlg">NOT MSIINSTALLPERUSER</Publish>
-
-      <Publish Dialog="VerifyReadyDlg" Order="2" Control="Back" Event="NewDialog" Value="RDWelcomeDlg">NOT Installed</Publish>
-      <Publish Dialog="VerifyReadyDlg" Order="3" Control="Back" Event="NewDialog" Value="InstallScopeDlg">WSLKERNELINSTALLED</Publish>
-      <!-- Getting to VerifyReadyDlg means we need to install for all users (used when WSL is missing) -->
-      <Publish Dialog="VerifyReadyDlg" Order="4" Control="Install" Property="MSIINSTALLPERUSER" Value="{}">1</Publish>
-      <Publish Dialog="VerifyReadyDlg" Order="5" Control="Install" Property="ALLUSERS" Value="1">1</Publish>
-
     </UI>
 
     <InstallUISequence>

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -25,7 +25,6 @@
     <UIRef Id="WixUI_RD" />
 
     <Property Id="ApplicationFolderName" Value="Rancher Desktop" />
-    <Property Id="WixAppFolder" Value="WixPerUserFolder" />
     <Icon
       Id="RancherDesktopIcon.exe"
       SourceFile="$(var.appDir)\Rancher Desktop.exe" />

--- a/build/wix/scope.wxs
+++ b/build/wix/scope.wxs
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - This describes the install scope dialog; we are customizing this one to
+  - emphasize per-machine installation, as that is required for privileged
+  - service. (If WSL needs to be installed, this dialog is skipped and we
+  - always install per-machine.)
+  -->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <UI>
+      <Dialog Id="RDInstallScopeDlg" Width="370" Height="270" Title="!(loc.InstallScopeDlg_Title)" KeepModeless="yes">
+        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallScopeDlgTitle)" />
+        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="20" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallScopeDlgDescription)" />
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" Text="!(loc.InstallScopeDlgBannerBitmap)" />
+        <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+
+        <Control Id="BothScopes" Type="RadioButtonGroup" Property="MSIINSTALLPERUSER"
+          X="20" Y="55" Width="330" Height="120" Hidden="yes">
+          <RadioButtonGroup Property="MSIINSTALLPERUSER">
+            <RadioButton Value="0"
+              Text="!(loc.InstallScopeDlgPerMachine)"
+              X="0" Y="0" Width="295" Height="16" />
+            <RadioButton Value="1"
+              Text="!(loc.InstallScopeDlgPerUser)"
+              X="0" Y="72" Width="295" Height="16" />
+          </RadioButtonGroup>
+          <Condition Action="show">Privileged AND WSLKERNELINSTALLED</Condition>
+        </Control>
+
+        <Control Id="PerMachineDescription" Type="Text" Hidden="yes"
+          NoPrefix="yes" Text="!(loc.InstallScopeDlgPerMachineDescription)"
+          X="33" Y="70" Width="300" Height="48">
+          <Condition Action="show">Privileged</Condition>
+        </Control>
+        <Control Id="PerUserDescription" Type="Text"
+          NoPrefix="yes" Text="!(loc.InstallScopeDlgPerUserDescription)"
+          X="33" Y="143" Width="300" Height="48" />
+
+        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+        <Control Id="Back" Type="PushButton" Text="!(loc.WixUIBack)"
+          X="180" Y="243" Width="56" Height="17">
+          <Publish Event="NewDialog" Value="RDWelcomeDlg">1</Publish>
+        </Control>
+        <Control Id="Next" Type="PushButton" Default="yes" Text="!(loc.WixUINext)"
+          X="236" Y="243" Width="56" Height="17">
+          <Publish Order="1" Property="MSIINSTALLPERUSER" Value="{}">MSIINSTALLPERUSER = 0</Publish>
+          <Publish Order="2" Property="ALLUSERS" Value="{}">MSIINSTALLPERUSER</Publish>
+          <Publish Order="3" Property="ALLUSERS" Value="1">NOT MSIINSTALLPERUSER</Publish>
+          <Publish Order="4" Event="NewDialog" Value="RDVerifyReadyDlg">1</Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+      </Dialog>
+    </UI>
+  </Fragment>
+</Wix>

--- a/build/wix/string-overrides.wxl
+++ b/build/wix/string-overrides.wxl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="en-US" Codepage="1252" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+  <!-- White space is preserved, so we must not line wrap. -->
+  <String Id="InstallScopeDlgPerMachineDescription" Overridable="yes">[ProductName] will be installed in a per-machine folder and be available for all users. This enables listening on non-loopback ports and other features that require additional privileges. You must have local Administrator privileges.</String>
+  <String Id="InstallScopeDlgPerUserDescription">[ProductName] will be installed in a per-user folder and be available just for your user account. You do not need local Administrator privileges. This will disable support for listening on non-loopback ports, and requires WSL2 to already be installed on your machine.</String>
+  <String Id="InstallScopeDlgNoPerUserDescription" Overridable="yes">[ProductName] cannot be installed per-user, as Windows Subsystem for Linux 2 was not found. Continuing to install [ProductName] will also install WSL2.</String>
+  <String Id="VerifyReadyDlgKernelInstallText" Overridable="yes">[ProductName] will be installed in a per-machine folder and be available for all users. This enables listening on non-loopback ports and other features that require additional privileges.  Windows Subsystem for Linux 2 will also be installed as a prerequisite.</String>
+</WixLocalization>

--- a/build/wix/verify.wxs
+++ b/build/wix/verify.wxs
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <UI>
+      <Dialog Id="RDVerifyReadyDlg" Title="!(loc.VerifyReadyDlg_Title)"
+        Width="370" Height="270" TrackDiskSpace="yes">
+        <Control Id="InstallTitle" Type="Text" NoPrefix="yes"
+          X="15" Y="15" Width="300" Height="15" Transparent="yes"
+          Text="!(loc.VerifyReadyDlgInstallTitle)" />
+        <Control Id="BannerBitmap" Type="Bitmap"
+          X="0" Y="0" Width="370" Height="44"
+          Text="!(loc.VerifyReadyDlgBannerBitmap)" />
+        <Control Id="BannerLine" Type="Line"
+          X="0" Y="44" Width="370" Height="0" />
+
+        <Control Id="InstallText" Type="Text"
+          X="25" Y="70" Width="320" Height="80" Hidden="yes" NoPrefix="yes"
+          Text="!(loc.VerifyReadyDlgInstallText)">
+          <Condition Action="show">WSLKERNELINSTALLED</Condition>
+        </Control>
+        <Control Id="InstallKernelText" Type="Text"
+          X="25" Y="70" Width="320" Height="80" Hidden="yes" NoPrefix="yes"
+          Text="!(loc.VerifyReadyDlgKernelInstallText)">
+          <Condition Action="show">NOT WSLKERNELINSTALLED</Condition>
+        </Control>
+
+        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+        <Control Id="Back" Type="PushButton" X="156" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">
+          <Publish Order="1" Event="NewDialog" Value="RDInstallScopeDlg">1</Publish>
+          <Publish Order="2" Event="NewDialog" Value="RDWelcomeDlg">NOT WSLKERNELINSTALLED</Publish>
+        </Control>
+
+        <Control Id="Install" Type="PushButton" ElevationShield="yes"
+          X="212" Y="243" Width="80" Height="17"
+          Default="yes" Hidden="yes"
+          Text="!(loc.VerifyReadyDlgInstall)">
+          <Condition Action="show">ALLUSERS</Condition>
+          <Publish Event="EndDialog" Value="Return">
+            <![CDATA[OutOfDiskSpace <> 1]]>
+          </Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
+          <Publish Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
+        </Control>
+        <Control Id="InstallNoShield" Type="PushButton" ElevationShield="no"
+          X="212" Y="243" Width="80" Height="17"
+          Default="yes" Hidden="yes"
+          Text="!(loc.VerifyReadyDlgInstall)">
+          <Condition Action="show">NOT ALLUSERS</Condition>
+          <Publish Event="EndDialog" Value="Return">
+            <![CDATA[OutOfDiskSpace <> 1]]>
+          </Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
+          <Publish Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
+        </Control>
+
+        <Control Id="Cancel" Type="PushButton" Cancel="yes"
+          X="304" Y="243" Width="56" Height="17" Text="!(loc.WixUICancel)">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+      </Dialog>
+    </UI>
+  </Fragment>
+</Wix>

--- a/build/wix/welcome.wxs
+++ b/build/wix/welcome.wxs
@@ -22,6 +22,11 @@
             <![CDATA[RDLicenseAccepted <> "1"]]>
           </Condition>
           <Condition Action="enable">RDLicenseAccepted = "1"</Condition>
+          <!-- If the kernel is not installed, the user doesn't have a choice
+            - and we can skip to the verify install dialog directly.
+            -->
+          <Publish Event="NewDialog" Order="1" Value="RDInstallScopeDlg">1</Publish>
+          <Publish Event="NewDialog" Order="2" Value="RDVerifyReadyDlg">NOT WSLKERNELINSTALLED</Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" Cancel="yes"
           X="304" Y="243" Width="56" Height="17" Text="!(loc.WixUICancel)">

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -67,6 +67,8 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     path.join(workDir, 'project.wxs'),
     path.join(process.cwd(), 'build', 'wix', 'dialogs.wxs'),
     path.join(process.cwd(), 'build', 'wix', 'welcome.wxs'),
+    path.join(process.cwd(), 'build', 'wix', 'scope.wxs'),
+    path.join(process.cwd(), 'build', 'wix', 'verify.wxs'),
   ];
 
   await Promise.all(inputs.map(input => spawnFile(
@@ -104,6 +106,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     '-wx',
     '-cc', path.join(process.cwd(), 'dist', 'wix-cache'),
     '-reusecab',
+    '-loc', path.join(path.join(process.cwd(), 'build', 'wix', 'string-overrides.wxl')),
     ...inputs.map(n => path.join(workDir, `${ path.basename(n, '.wxs') }.wixobj`)),
   ], { stdio: 'inherit' });
   console.log(`Built Windows installer: ${ outFile }`);


### PR DESCRIPTION
- Use our own install scope dialog, so that we can move the per-machine install option to the top, with custom text describing the additional features we get in that case.
- Use our own verify ready dialog, with custom text when we need to force an admin install in order to install WSL.
- Given the custom dialogs, we no longer need to override the default dialog flow (avoiding potential issues when doing repair/etc. flows).
