### PR TITLE
Run fstrim /mnt/data during boot and before shutdown

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -38,6 +38,12 @@ provision:
     fi
     umount /bootfs
     rmdir /bootfs
+- # return unused space from the data volume back to the host
+  mode: system
+  script: |
+    #!/bin/sh
+    set -o errexit -o nounset -o xtrace
+    fstrim /mnt/data
 - # Persist /root directory on data volume
   mode: system
   script: |

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1784,6 +1784,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
           await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'buildkitd', 'stop');
           await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'docker', 'stop');
           await this.execCommand({ root: true }, '/sbin/rc-service', '--ifstarted', 'containerd', 'stop');
+          await this.execCommand({ root: true }, '/sbin/fstrim', '/mnt/data');
           await this.lima('stop', MACHINE_NAME);
           await this.dockerDirManager.clearDockerContext();
         }


### PR DESCRIPTION
Only when using Lima. Releases unused space in the data volume back to the host. The call during boot is redundant and only useful when the VM was not shut down via the Rancher Desktop app.

Verify change:

* Check disk size of data volume:

  ```console
  $ du -h ~/Library/Application\ Support/rancher-desktop/lima/0/diffdisk
  1.8G	/Users/jan/Library/Application Support/rancher-desktop/lima/0/diffdisk
  ```

* Create a big file inside the VM and delete it again:

  ```console
  $ rdctl shell sh -c 'time head -c 4294967296 </dev/urandom >$HOME/random'
  real	1m 41.68s
  $ rdctl shell sh -c 'rm $HOME/random'
  ```

* Check that the file size has increased:

  ```console
  $ du -h ~/Library/Application\ Support/rancher-desktop/lima/0/diffdisk
  6.0G	/Users/jan/Library/Application Support/rancher-desktop/lima/0/diffdisk
  ```

* Shutdown Rancher Desktop:

  ```console
  $ rdctl shutdown
  Shutting down.
  ```

* Verify that the disk space has been released:

  ```console
  $ du -h ~/Library/Application\ Support/rancher-desktop/lima/0/diffdisk
  1.7G	/Users/jan/Library/Application Support/rancher-desktop/lima/0/diffdisk
  ```

Fixes #3158