### PR TITLE
Bump Rancher Dashboard version

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerCompose: 2.12.2
 trivy: 0.34.0
 steve: 0.1.0-beta9
 guestAgent: 0.3.6
-rancherDashboard: desktop-v2.6.8.beta.3
+rancherDashboard: desktop-v2.7.0.beta.1
 dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0
 hostResolver: 0.1.2


### PR DESCRIPTION
This bumps the Rancher Dashboard version to v2.7.0.

closes #3162 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>