### PR TITLE
WiX: Detect when WSL has been installed from the Windows store.

### DIFF
--- a/build/wix-install-wsl.ps1
+++ b/build/wix-install-wsl.ps1
@@ -1,9 +1,9 @@
 # .SYNOPSIS
 # Installs WSL as part of the WiX setup.
 # .NOTES
-# This only installs the Windows optional features, and schedules the WSL kernel
-# to be installed upon reboot.  It assumes that the kernel has not been
-# previously installed (since msiexec provides that check).
+# This installs the required Windows optional features, and (if necessary)
+# schedules the WSL kernel to be installed.  It assumes that the MSI version of
+# the WSL kernel has not been installed (since msiexec provides that check).
 # This script assumes that it's run elevated.
 
 function Install-Features {
@@ -27,6 +27,12 @@ function Install-Kernel {
     -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' `
     -Name '!Rancher Desktop WSL Kernel Install' `
     -Value "`"$Env:SystemRoot\system32\wsl.exe`" --update"
+}
+
+# Check if the Appx version of WSL has been installed.
+if (Get-AppxPackage -Name MicrosoftCorporationII.WindowsSubsystemForLinux) {
+  Write-Output "Found WSL installed from the Windows Store, skipping."
+  exit
 }
 
 Install-Features


### PR DESCRIPTION
If we've already been installed from the Window store, then we don't need to install again.  Note that this currently doesn't affect the installer flow (it still forces admin install, and requests a reboot at the end) even though it's not necessary.  It is currently not possible to detect from the MSI when this is the case; we'll probably need a custom action for that.

(While there's support for JScript-based custom actions, the advice from the main WiX developer seems to be to avoid using it. https://web.archive.org/web/20160217123733/http://blogs.msdn.com/b/robmen/archive/2004/05/20/136530.aspx )