### PR TITLE
GitHub Actions: add workflow for testing updates.

### DIFF
--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -66,7 +66,7 @@ jobs:
         if-no-files-found: error
     - name: Upload macOS archive
       uses: actions/upload-artifact@v3
-      #if: matrix.platform == 'mac'
+      if: matrix.platform == 'mac'
       with:
         name: Rancher Desktop-mac.${{ matrix.arch }}.zip
         path: dist/Rancher Desktop*.zip

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -1,0 +1,131 @@
+name: Generate Upgrade Test Data
+on:
+  workflow_dispatch: {}
+permissions:
+  contents: read
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+        - platform: mac
+          arch: x86_64
+          runs-on: macos-11
+        - platform: mac
+          arch: aarch64
+          runs-on: macos-11
+        - platform: win
+          runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+        # Needed to run `git describe` to get full version info
+        fetch-depth: 0
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '2.x'
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '^1.18'
+    - name: Install Windows dependencies
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
+    - name: Flag build for M1
+      if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
+      run: echo "M1=1" >> "${GITHUB_ENV}"
+    - run: npm ci
+    - run: npm run build -- --${{ matrix.platform }} --publish=never
+      env:
+        RD_FEAT_WIX: '1' # Will be optional soon
+    - name: Upload Windows exe installer
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Rancher Desktop Setup.exe
+        path: dist/Rancher Desktop*.exe
+        if-no-files-found: error
+    - name: Upload Windows installer
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Rancher Desktop Setup.msi
+        path: dist/Rancher Desktop*.msi
+        if-no-files-found: error
+    - name: Upload Windows build information
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-info.yml
+        path: dist/latest.yml
+        if-no-files-found: error
+    - name: Upload macOS archive
+      uses: actions/upload-artifact@v3
+      #if: matrix.platform == 'mac'
+      with:
+        name: Rancher Desktop-mac.${{ matrix.arch }}.zip
+        path: dist/Rancher Desktop*.zip
+        if-no-files-found: error
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+        path: pages
+        persist-credentials: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+    - run: npm ci
+    - name: Download installer (exe)
+      id: exe
+      uses: actions/download-artifact@v3
+      with:
+        name: Rancher Desktop Setup.exe
+        path: RD_SETUP_EXE
+    - name: Download installer (msi)
+      id: msi
+      uses: actions/download-artifact@v3
+      with:
+        name: Rancher Desktop Setup.msi
+        path: RD_SETUP_MSI
+    - name: Download mac x86_64 archive
+      id: mac_x86_64
+      uses: actions/download-artifact@v3
+      with:
+        name: Rancher Desktop-mac.x86_64.zip
+        path: MACX86_ZIP
+    - name: Download mac aarch64 archive
+      id: mac_aarch64
+      uses: actions/download-artifact@v3
+      with:
+        name: Rancher Desktop-mac.aarch64.zip
+        path: MACARM_ZIP
+    - name: Download build information
+      id: info
+      uses: actions/download-artifact@v3
+      with:
+        name: build-info.yml
+        path: RD_BUILD_INFO
+    - run: node scripts/ts-wrapper.js scripts/populate-update-server.ts
+      env:
+        RD_SETUP_EXE: ${{ steps.exe.outputs.download-path }}
+        RD_SETUP_MSI: ${{ steps.msi.outputs.download-path }}
+        RD_MACX86_ZIP: ${{ steps.mac_x86_64.outputs.download-path }}
+        RD_MACARM_ZIP: ${{ steps.mac_aarch64.outputs.download-path }}
+        RD_BUILD_INFO: ${{ steps.info.outputs.download-path }}
+        RD_OUTPUT_DIR: ${{ github.workspace }}/pages
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}

--- a/scripts/populate-update-server.ts
+++ b/scripts/populate-update-server.ts
@@ -1,0 +1,288 @@
+/**
+ * This script is run as part of the "Build Upgrade Testing" GitHub workflow
+ * (.github/workflows/upgrade-test.yaml) to generate upgrade data for testing
+ * Rancher Desktop upgrades.
+ *
+ * This will push changes to the "gh-pages" branch (for the upgrade manifest
+ * JSON file), as well as publish releases (or update existing ones) for the
+ * upgrade target.
+ *
+ * Note that this script intentionally blacklists the upstream repository (as
+ * defined in package.json) because it changes releases.
+ *
+ * Inputs are all in environment variables:
+ *   GITHUB_TOKEN:      GitHub access token.
+ *   GITHUB_REPOSITORY: The GitHub owner/repository (from GitHub Actions).
+ *   GITHUB_SHA:        Commit hash (if creating a new release).
+ *   GITHUB_ACTOR:      User that triggered this, github.actor
+ *   RD_SETUP_EXE:      The installer (exe file) to upload.
+ *   RD_SETUP_MSI:      The installer (msi file) to upload.
+ *   RD_MACX86_ZIP:     The macOS (x86_64) zip archive to upload.
+ *   RD_MACARM_ZIP:     The macOS (aarch64) zip archive to upload.
+ *   RD_BUILD_INFO:     Build information ("latest.yml" from electron-builder)
+ *   RD_OUTPUT_DIR:     Checkout of `gh-pages`, to be updated.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import { Octokit } from 'octokit';
+import yaml from 'yaml';
+
+import { spawnFile } from '@pkg/utils/childProcess';
+import { defined } from '@pkg/utils/typeUtils';
+
+/** Read input from the environment; throws an error if unset. */
+function getInput(name: string) {
+  const result = process.env[name];
+
+  if (!result) {
+    throw new Error(`Could not read input; \$${ name } is not set correctly.`);
+  }
+
+  return result;
+}
+
+/** Given a input variable that expects a single file, return it. */
+async function getInputFile(name: string) {
+  const inputPath = getInput(name);
+  const stat = await fs.promises.stat(inputPath);
+
+  if (!stat.isDirectory()) {
+    return inputPath;
+  }
+
+  for (const dirent of await fs.promises.readdir(inputPath, { withFileTypes: true })) {
+    if (dirent.isFile()) {
+      return path.join(inputPath, dirent.name);
+    }
+  }
+
+  throw new Error(`Could not find input file for ${ name }`);
+}
+
+/**
+ * assetInfo describes information we need about one asset.
+ */
+type assetInfo = {
+  /** file is the (full) path to the asset file. */
+  file: string;
+  /** filename is the base name of the asset. */
+  filename: string;
+  /** length of the file */
+  length: number;
+  /** checksum is the checksum file contents of the file. */
+  checksum: string;
+  /** checksumName is the base name of the checksum. */
+  checksumName: string;
+};
+
+/**
+ * Given environment name, write checksum contents for the file.
+ * @param name Name of the environment variable that holds the file path.
+ * @returns File name and checksum data.
+ */
+async function getChecksum(name: string, filenameOverride?: string): Promise<assetInfo> {
+  const filename = await getInputFile(name);
+  const outputName = filenameOverride || path.basename(filename);
+  const stat = await fs.promises.stat(filename);
+  const input = fs.createReadStream(filename);
+  const hasher = crypto.createHash('sha512');
+  const promise = new Promise((resolve) => {
+    input.on('end', resolve);
+  });
+
+  input.pipe(hasher).setEncoding('hex');
+  await promise;
+  await new Promise<void>((resolve) => {
+    hasher.end(() => {
+      resolve();
+    });
+  });
+
+  return {
+    file:         filename,
+    filename:     outputName,
+    length:       stat.size,
+    checksum:     `${ hasher.read() }  ${ outputName }`,
+    checksumName: `${ outputName }.sha512sum`,
+  };
+}
+
+async function getOctokit(): Promise<Octokit> {
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+  try {
+    await octokit.rest.meta.getZen();
+  } catch (ex) {
+    console.error(`Invalid credentials: please check GITHUB_TOKEN is set. ${ ex }`);
+    process.exit(1);
+  }
+
+  return octokit;
+}
+
+async function updateRelease(octokit: Octokit, owner: string, repo: string, tag: string) {
+  const files = {
+    exe:    await getChecksum('RD_SETUP_EXE', `Rancher.Desktop.Setup.${ tag }.exe`),
+    msi:    await getChecksum('RD_SETUP_MSI', `Rancher.Desktop.Setup.${ tag }.msi`),
+    macx86: await getChecksum('RD_MACX86_ZIP', `Rancher.Desktop-${ tag }-mac.x86_64.zip`),
+    macarm: await getChecksum('RD_MACARM_ZIP', `Rancher.Desktop-${ tag }-mac.aarch64.zip`),
+  };
+
+  console.log(`Updating release with files:\n${ yaml.stringify(files) }`);
+
+  let release: Awaited<ReturnType<Octokit['rest']['repos']['createRelease']>>['data'] | undefined;
+
+  try {
+    ({ data: release } = await octokit.rest.repos.getReleaseByTag({
+      owner, repo, tag,
+    }));
+  } catch (ex) {
+    console.log(`Creating new release for ${ tag }: ${ ex }`);
+    ({ data: release } = await octokit.rest.repos.createRelease({
+      owner,
+      repo,
+      name:             tag,
+      tag_name:         tag,
+      target_commitish: getInput('GITHUB_SHA'),
+      draft:            true,
+    }));
+  }
+  if (!release) {
+    throw new Error(`Could not get or create release for ${ tag }`);
+  }
+  console.log(`Got release info for ${ release.name }`);
+
+  await Promise.all(Object.values(files).map(async(info) => {
+    if (!release) {
+      throw new Error(`Could not get or create release for ${ tag }`);
+    }
+    const checksumAsset = release.assets.find(asset => asset.name === info.checksumName);
+
+    if (checksumAsset && release.assets.find(asset => asset.name === info.filename)) {
+      const existingChecksum = (await octokit.rest.repos.getReleaseAsset({
+        owner,
+        repo,
+        asset_id: checksumAsset.id,
+        headers:  { accept: 'application/octet-stream' },
+      })) as unknown as string;
+
+      if (existingChecksum.trim() === info.checksum.trim()) {
+        console.log(`Skipping ${ info.filename }, checksum matches`);
+
+        return;
+      }
+    }
+
+    await Promise.all([info.checksumName, info.filename]
+      .map(name => release?.assets.find(asset => asset.name === name))
+      .filter(defined)
+      .map((asset) => {
+        console.log(`Deleting obsolete asset ${ asset.name }`);
+
+        return octokit.rest.repos.deleteReleaseAsset({
+          owner, repo, asset_id: asset.id,
+        });
+      },
+      ));
+
+    await Promise.all([
+      octokit.rest.repos.uploadReleaseAsset({
+        owner,
+        repo,
+        release_id: release.id,
+        name:       info.checksumName,
+        data:       info.checksum,
+      }),
+      // We need a custom request for the  main file, as we need to stream it
+      // from a file strem.
+      octokit.request({
+        method:  'POST',
+        url:     release.upload_url,
+        headers: {
+          'Content-Length': info.length,
+          'Content-Type':   'application/octet-stream',
+        },
+        data: fs.createReadStream(info.file),
+        name: info.filename,
+      }),
+    ]);
+  }));
+  console.log(`Relase ${ release.name } updated.`);
+
+  return release.html_url;
+}
+
+async function updatePages(tag: string) {
+  const response = {
+    versions: [{
+      Name:        tag,
+      ReleaseDate: (new Date()).toISOString(),
+      Tags:        ['latest'],
+    }],
+    requestIntervalInMinutes: 1,
+  };
+
+  console.log('Updating gh-pages...');
+  await fs.promises.writeFile(path.join(getInput('RD_OUTPUT_DIR'), 'response.json'),
+    JSON.stringify(response),
+    'utf-8');
+  await spawnFile('git',
+    [
+      '-c', `user.name=${ getInput('GITHUB_ACTOR') }`,
+      '-c', `user.email=${ getInput('GITHUB_ACTOR') }@users.noreply.github.com`,
+      'commit', `--message=Automated update to ${ tag }`, 'response.json',
+    ], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      cwd:   getInput('RD_OUTPUT_DIR'),
+    });
+  await spawnFile('git',
+    ['push'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      cwd:   getInput('RD_OUTPUT_DIR'),
+    });
+  console.log('gh-pages updated.');
+}
+
+async function main() {
+  console.log('Reading configuration information...');
+  const buildInfoPath = await getInputFile('RD_BUILD_INFO');
+  const [owner, repo] = getInput('GITHUB_REPOSITORY').split('/');
+  const packageURL = new URL(JSON.parse(await fs.promises.readFile('package.json', 'utf-8')).repository.url);
+  const [packageOwner, packageRepo] = packageURL.pathname.replace(/\.git$/, '').split('/').filter(x => x);
+  const buildInfo = yaml.parse(await fs.promises.readFile(buildInfoPath, 'utf-8'));
+  const tag: string = buildInfo.version.replace(/^v?/, 'v');
+
+  console.log(`Publishing ${ tag } from ${ owner }/${ repo } (upstream is ${ packageOwner }/${ packageRepo })...`);
+  if (packageOwner === owner && packageRepo === repo) {
+    console.error(`Cowardly refusing to touch ${ packageURL }`);
+    process.exit(1);
+  }
+
+  const octokit = await getOctokit();
+  const releaseURL = await updateRelease(octokit, owner, repo, tag);
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+  await updatePages(tag);
+  if (summaryPath) {
+    await fs.promises.writeFile(
+      summaryPath,
+      `# Usage instructions
+      1. Publish the release at ${ releaseURL }
+      2. Configure \`resources\\app-update.yml\` to contain:
+      \`\`\`yaml
+      upgradeServer: https://${ owner }.github.io/${ repo }/response.json
+      owner: ${ owner }
+      repo: ${ repo }
+      \`\`\`
+      `.split(/\r?\n/).map(s => s.trim()).filter(s => s).join('\n'),
+      { encoding: 'utf-8' });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/populate-update-server.ts
+++ b/scripts/populate-update-server.ts
@@ -66,8 +66,8 @@ async function getInputFile(name: string) {
  * assetInfo describes information we need about one asset.
  */
 type assetInfo = {
-  /** file is the (full) path to the asset file. */
-  file: string;
+  /** filepath is the (full) path to the asset file. */
+  filepath: string;
   /** filename is the base name of the asset. */
   filename: string;
   /** length of the file */
@@ -84,10 +84,10 @@ type assetInfo = {
  * @returns File name and checksum data.
  */
 async function getChecksum(name: string, filenameOverride?: string): Promise<assetInfo> {
-  const filename = await getInputFile(name);
-  const outputName = filenameOverride || path.basename(filename);
-  const stat = await fs.promises.stat(filename);
-  const input = fs.createReadStream(filename);
+  const filepath = await getInputFile(name);
+  const outputName = filenameOverride || path.basename(filepath);
+  const stat = await fs.promises.stat(filepath);
+  const input = fs.createReadStream(filepath);
   const hasher = crypto.createHash('sha512');
   const promise = new Promise((resolve) => {
     input.on('end', resolve);
@@ -102,7 +102,7 @@ async function getChecksum(name: string, filenameOverride?: string): Promise<ass
   });
 
   return {
-    file:         filename,
+    filepath,
     filename:     outputName,
     length:       stat.size,
     checksum:     `${ hasher.read() }  ${ outputName }`,
@@ -205,12 +205,12 @@ async function updateRelease(octokit: Octokit, owner: string, repo: string, tag:
           'Content-Length': info.length,
           'Content-Type':   'application/octet-stream',
         },
-        data: fs.createReadStream(info.file),
+        data: fs.createReadStream(info.filepath),
         name: info.filename,
       }),
     ]);
   }));
-  console.log(`Relase ${ release.name } updated.`);
+  console.log(`Release ${ release.name } updated.`);
 
   return release.html_url;
 }


### PR DESCRIPTION
This adds a manually-triggered action that will build and upload to a release.  This should be triggered on a fork with a `gh-pages` branch.

Using this workflow:
1. Make a fork of https://github.com/rancher-sandbox/rancher-desktop
2. Push a `gh-pages` branch to that repo. (That branch can be empty, i.e. `git checkout --orphan gh-pages && git commit --allow-empty && git push origin gh-pages`.)
3. Find / make a branch that includes this script.
4. Tag it as `v99.0.0` or something else larger than the install you'll upgrade from.
5. Trigger a manual run of this action. (You may need to make that branch as the default branch in your fork to see it.)
6. Install a Rancher Desktop to be upgraded from. (Possibly in a VM.)
7. Scroll to the bottom of the Action run for run-specific instructions:
   1. Publish the created release.
   2. Modify `app-update.yml` according to instructions to point to the test upgrade server.