### PR TITLE
We should enable IPTABLES for older k8s version

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -10,7 +10,7 @@ dockerBuildx: 0.9.1
 dockerCompose: 2.13.0
 trivy: 0.35.0
 steve: 0.1.0-beta9
-guestAgent: 0.3.6
+guestAgent: 0.3.7
 rancherDashboard: desktop-v2.7.0.beta.1
 dockerProvidedCredentialHelpers: 0.6.4
 ECRCredentialHelper: 0.6.0

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -733,7 +733,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       guestAgentConfig = {
         LOG_DIR:                       await this.wslify(paths.logs),
         GUESTAGENT_KUBERNETES:         enableKubernetes ? 'true' : 'false',
-        GUESTAGENT_IPTABLES:           'false',
+        GUESTAGENT_IPTABLES:           enableKubernetes ? 'false' : 'true', // only enable IPTABLES for older K8s
         GUESTAGENT_PRIVILEGED_SERVICE: 'true',
         GUESTAGENT_CONTAINERD:         cfg?.kubernetes?.containerEngine === ContainerEngine.CONTAINERD ? 'true' : 'false',
         GUESTAGENT_DOCKER:             cfg?.kubernetes?.containerEngine === ContainerEngine.MOBY ? 'true' : 'false',


### PR DESCRIPTION
Since we don't have kube watcher in guest agent enabled for older K8s versions <= 1.20.15 to pick up the nodeports via Kube API, an alternative is to pickup nodeports through IPTABLES.

Related issue: https://github.com/rancher-sandbox/rancher-desktop/issues/3407