### PR TITLE
This ensures that the user-or-everyone dialog selects the default radio button.

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -43,8 +43,8 @@
     <SetProperty Id="ALLUSERS" Sequence="both" After="ValidateProductID" Value="1">
       NOT WSLKERNELINSTALLED AND NOT Installed
     </SetProperty>
-    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="{}">
-      NOT WSLKERNELINSTALLED AND NOT Installed
+    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="0">
+      NOT Installed
     </SetProperty>
     <SetProperty Id="PowerShellExe" Sequence="execute" Before="SetInstallWSL"
       Value="&quot;[System64Folder]\WindowsPowerShell\v1.0\powershell.exe&quot;" />


### PR DESCRIPTION
Fixes #3490

... but I'm not sure if this breaks anything else. Also when I hit the `Back` button after confirming to install for all users, neither button was selected going back. So this change might be wrong and/or insufficient.

Signed-off-by: Eric Promislow <epromislow@suse.com>