### PR TITLE
Get application version via ipc

### DIFF
--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -1,3 +1,5 @@
+import { ipcRenderer } from 'electron';
+
 const baseUrl = 'https://docs.rancherdesktop.io';
 
 const paths: Record<string, string> = {
@@ -12,7 +14,19 @@ const paths: Record<string, string> = {
 };
 
 class HelpImpl {
-  readonly version = process.env.NODE_ENV === 'production' ? /\d+\.\d+/.exec(Electron.app.getVersion()) : 'next';
+  private version = 'next';
+
+  constructor() {
+    if (process.env.NODE_ENV !== 'production') {
+      return;
+    }
+
+    ipcRenderer.on('get-app-version', (_event, version) => {
+      this.version = /\d+\.\d+/.exec(version)?.toString() ?? 'next';
+    });
+
+    ipcRenderer.send('get-app-version');
+  }
 
   url(key: string | undefined): string {
     if (key) {

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -17,12 +17,10 @@ class HelpImpl {
   private version = 'next';
 
   constructor() {
-    if (process.env.NODE_ENV !== 'production') {
-      return;
-    }
-
     ipcRenderer.on('get-app-version', (_event, version) => {
-      this.version = /\d+\.\d+/.exec(version)?.toString() ?? 'next';
+      const releasePattern = /^(\d+\.\d+)\.\d+$/;
+
+      this.version = releasePattern.exec(version)?.[1] ?? 'next';
     });
 
     ipcRenderer.send('get-app-version');


### PR DESCRIPTION
This gets the Rancher Desktop version via ipc instead of attempting to invoke `Electron.app.getVersion`. 

I opted for the `get-app-version` ipc event because

- invoking `app.getVersion` throws an exception from a renderer process
- I did not find an existing API endpoint to get Rancher Desktop's version

I opted to default to `next` in the event that we don't match a version number because I thought it would be better to have a working documentation link that is inaccurate instead of one that is broken; using 'next' at least directs people to the general vicinity. 

closes #3500 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>