### PR TITLE
Script collection of screenshots for UI

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -107,6 +107,7 @@ export function openMain() {
     {
       width:          940,
       height:         600,
+      resizable:      !process.env.MOCK_FOR_SCREENSHOTS, // remove window's shadows while taking screenshots
       icon:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
       webPreferences: {
         devTools:         !app.isPackaged,

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import path from 'path';
 
 import Electron, { BrowserWindow, app, shell } from 'electron';
 
@@ -8,6 +9,7 @@ import * as K8s from '@pkg/backend/k8s';
 import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import { isDevEnv } from '@pkg/utils/environment';
 import Logging from '@pkg/utils/logging';
+import paths from '@pkg/utils/paths';
 import { Shortcuts } from '@pkg/utils/shortcuts';
 
 const console = Logging.background;
@@ -105,6 +107,7 @@ export function openMain() {
     {
       width:          940,
       height:         600,
+      icon:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
       webPreferences: {
         devTools:         !app.isPackaged,
         nodeIntegration:  true,

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -1,9 +1,12 @@
+import path from 'path';
+
 import { app, dialog } from 'electron';
 
 import { webRoot, createWindow } from '.';
 
 import { Help } from '@pkg/config/help';
 import { NavItemName } from '@pkg/config/transientSettings';
+import paths from '@pkg/utils/paths';
 import { Shortcuts } from '@pkg/utils/shortcuts';
 import { getVersion } from '@pkg/utils/version';
 
@@ -39,6 +42,7 @@ export function openPreferences() {
     resizable:       false,
     minimizable:     false,
     show:            false,
+    icon:            path.join(paths.resources, 'icons', 'logo-square-512.png'),
     webPreferences:  {
       devTools:         !app.isPackaged,
       nodeIntegration:  true,

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
 
-import type { Page, PageScreenshotOptions } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 interface ScreenshotsOptions {
   directory?: string;

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -18,6 +18,7 @@ interface ScreenshotsOptions {
 
 export class Screenshots {
   private isOsCommand = true;
+  private sleepDuration = Number(process.env.RD_ENV_SCREENSHOT_SLEEP) || 1000;
 
   // used by Mac api
   private appBundleTitle = 'Rancher Desktop';
@@ -69,9 +70,9 @@ export class Screenshots {
         childProcess.execSync(command);
 
         if (os.platform() === 'win32') {
-          // sleep for 1 second to allow ShareX to write screenshot
+          // sleep to allow ShareX to write screenshot
           await (new Promise((resolve) => {
-            setTimeout(resolve, 1000);
+            setTimeout(resolve, this.sleepDuration);
           }));
 
           const screenshotsPath = path.resolve(process.cwd(), 'resources', 'ShareX', 'ShareX', 'Screenshots', `${ dayjs().format('YYYY-MM') }`);
@@ -83,7 +84,7 @@ export class Screenshots {
           );
         }
       } catch (e) {
-        console.error(`Error, command failed: ${ command }`);
+        console.error(`Error, command failed: ${ command }`, { error: e });
         process.exit(1);
       }
     }

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -21,7 +21,7 @@ export class Screenshots {
   private sleepDuration = Number(process.env.RD_ENV_SCREENSHOT_SLEEP) || 1000;
 
   // used by Mac api
-  private appBundleTitle = 'Rancher Desktop';
+  private appBundleTitle = 'Electron';
 
   protected windowTitle = '';
   private screenshotIndex = 0;

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -12,7 +12,7 @@ import { PreferencesPage } from '../e2e/pages/preferences';
 import type { Page } from '@playwright/test';
 
 interface ScreenshotsOptions {
-  directory?: string;
+  directory: string;
   isOsCommand?: boolean;
 }
 
@@ -26,37 +26,29 @@ export class Screenshots {
   protected windowTitle = '';
   private screenshotIndex = 0;
   readonly page: Page;
-  readonly directory: string | undefined;
-  readonly screenshotDirectory: string | undefined;
+  readonly directory: string;
 
-  constructor(page: Page, opt?: ScreenshotsOptions) {
+  constructor(page: Page, opt: ScreenshotsOptions) {
     this.page = page;
-    if (opt?.directory) {
-      const { directory } = opt;
+    const { directory } = opt;
 
-      this.directory = directory === undefined || directory === null ? '' : `${ directory }/`;
-      this.screenshotDirectory = path.resolve(__dirname, 'output', os.platform(), this.directory);
-    }
+    this.directory = path.resolve(__dirname, 'output', os.platform(), directory);
     if (opt?.isOsCommand) {
       this.isOsCommand = opt.isOsCommand;
     }
   }
 
   protected buildPath(title: string): string {
-    if (!this.screenshotDirectory) {
-      return '';
-    }
-
-    return path.resolve(this.screenshotDirectory, `${ this.screenshotIndex++ }_${ title }.png`);
+    return path.resolve(this.directory, `${ this.screenshotIndex++ }_${ title }.png`);
   }
 
   protected async createScreenshotsDirectory() {
-    if (!this.screenshotDirectory) {
+    if (!this.directory) {
       return;
     }
 
     await fs.promises.mkdir(
-      this.screenshotDirectory,
+      this.directory,
       { recursive: true },
     );
   }
@@ -111,7 +103,7 @@ export class Screenshots {
 }
 
 export class MainWindowScreenshots extends Screenshots {
-  constructor(page: Page, opt?: ScreenshotsOptions) {
+  constructor(page: Page, opt: ScreenshotsOptions) {
     super(page, opt);
     this.windowTitle = 'Rancher Desktop';
   }
@@ -130,7 +122,7 @@ export class MainWindowScreenshots extends Screenshots {
 export class PreferencesScreenshots extends Screenshots {
   readonly preferencePage: PreferencesPage;
 
-  constructor(page: Page, preferencePage: PreferencesPage, opt?: ScreenshotsOptions) {
+  constructor(page: Page, preferencePage: PreferencesPage, opt: ScreenshotsOptions) {
     super(page, opt);
     this.preferencePage = preferencePage;
     this.windowTitle = 'Rancher Desktop - Preferences';

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -61,32 +61,33 @@ export class Screenshots {
       path:     this.buildPath(title),
     };
 
-    await this.page.screenshot(options);
+    if (!this.isOsCommand) {
+      await this.page.screenshot(options);
+      return;
+    }
 
-    if (this.isOsCommand) {
-      const command = this.osCommand(options.path);
+    const command = this.osCommand(options.path);
 
-      try {
-        childProcess.execSync(command);
+    try {
+      childProcess.execSync(command);
 
-        if (os.platform() === 'win32') {
-          // sleep to allow ShareX to write screenshot
-          await (new Promise((resolve) => {
-            setTimeout(resolve, this.sleepDuration);
-          }));
+      if (os.platform() === 'win32') {
+        // sleep to allow ShareX to write screenshot
+        await (new Promise((resolve) => {
+          setTimeout(resolve, this.sleepDuration);
+        }));
 
-          const screenshotsPath = path.resolve(process.cwd(), 'resources', 'ShareX', 'ShareX', 'Screenshots', `${ dayjs().format('YYYY-MM') }`);
-          const screenshots = fs.readdirSync(screenshotsPath);
+        const screenshotsPath = path.resolve(process.cwd(), 'resources', 'ShareX', 'ShareX', 'Screenshots', `${ dayjs().format('YYYY-MM') }`);
+        const screenshots = fs.readdirSync(screenshotsPath);
 
-          fs.renameSync(
-            path.resolve(screenshotsPath, screenshots?.[0]),
-            this.buildPath(title),
-          );
-        }
-      } catch (e) {
-        console.error(`Error, command failed: ${ command }`, { error: e });
-        process.exit(1);
+        fs.renameSync(
+          path.resolve(screenshotsPath, screenshots?.[0]),
+          this.buildPath(title),
+        );
       }
+    } catch (e) {
+      console.error(`Error, command failed: ${ command }`, { error: e });
+      process.exit(1);
     }
   }
 }

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -6,8 +6,6 @@ import { expect } from '@playwright/test';
 import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
 
-import { isWin, isMac } from '@pkg/utils/platform';
-
 import type { Page, PageScreenshotOptions } from '@playwright/test';
 
 interface ScreenshotsOptions {
@@ -43,10 +41,10 @@ export class Screenshots {
   }
 
   protected osCommand(path: string): string {
-    if (isMac) {
-      return `screencapture -l $(GetWindowID  "${ this.appBundleTitle }" "${ this.windowTitle }") prefs.png`;
+    if (os.platform() === 'darwin') {
+      return `screencapture -l $(GetWindowID  "${ this.appBundleTitle }" "${ this.windowTitle }") ${ path }`;
     }
-    if (isWin) {
+    if (os.platform() === 'win32') {
       return `import -window root ${ path }`;
     }
 

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -33,7 +33,7 @@ export class Screenshots {
     const { directory } = opt;
 
     this.directory = path.resolve(__dirname, 'output', os.platform(), directory);
-    if (opt?.isOsCommand) {
+    if (typeof (opt?.isOsCommand) !== 'undefined' ) {
       this.isOsCommand = opt.isOsCommand;
     }
   }

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -27,6 +27,7 @@ export class Screenshots {
   private screenshotIndex = 0;
   readonly page: Page;
   readonly directory: string | undefined;
+  readonly screenshotDirectory: string | undefined;
 
   constructor(page: Page, opt?: ScreenshotsOptions) {
     this.page = page;
@@ -34,6 +35,7 @@ export class Screenshots {
       const { directory } = opt;
 
       this.directory = directory === undefined || directory === null ? '' : `${ directory }/`;
+      this.screenshotDirectory = path.resolve(__dirname, 'output', os.platform(), this.directory);
     }
     if (opt?.isOsCommand) {
       this.isOsCommand = opt.isOsCommand;
@@ -41,16 +43,20 @@ export class Screenshots {
   }
 
   protected buildPath(title: string): string {
-    return `screenshots/output/${ os.platform() }/${ this.directory }${ this.screenshotIndex++ }_${ title }.png`;
+    if (!this.screenshotDirectory) {
+      return '';
+    }
+
+    return path.resolve(this.screenshotDirectory, `${ this.screenshotIndex++ }_${ title }.png`);
   }
 
   protected async createScreenshotsDirectory() {
-    if (!this.directory) {
+    if (!this.screenshotDirectory) {
       return;
     }
 
     await fs.promises.mkdir(
-      path.resolve(__dirname, this.directory),
+      this.screenshotDirectory,
       { recursive: true },
     );
   }

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -44,6 +44,17 @@ export class Screenshots {
     return `screenshots/output/${ os.platform() }/${ this.directory }${ this.screenshotIndex++ }_${ title }.png`;
   }
 
+  protected async createScreenshotsDirectory() {
+    if (!this.directory) {
+      return;
+    }
+
+    await fs.promises.mkdir(
+      path.resolve(__dirname, this.directory),
+      { recursive: true },
+    );
+  }
+
   protected osCommand(file: string): string {
     if (os.platform() === 'darwin') {
       return `screencapture -l $(GetWindowID  "${ this.appBundleTitle }" "${ this.windowTitle }") ${ file }`;
@@ -63,6 +74,7 @@ export class Screenshots {
 
     if (!this.isOsCommand) {
       await this.page.screenshot(options);
+
       return;
     }
 
@@ -103,6 +115,8 @@ export class MainWindowScreenshots extends Screenshots {
       await navPage.navigateTo(tabName as any);
       await this.page.waitForTimeout(timeout);
     }
+
+    this.createScreenshotsDirectory();
     await this.screenshot(tabName);
   }
 }
@@ -123,6 +137,7 @@ export class PreferencesScreenshots extends Screenshots {
     await expect(tab.nav).toHaveClass('preferences-nav-item active');
     const path = subTabName ? `${ tabName }_${ subTabName }` : tabName;
 
+    this.createScreenshotsDirectory();
     await this.screenshot(path);
   }
 }

--- a/screenshots/playwright-config.ts
+++ b/screenshots/playwright-config.ts
@@ -1,3 +1,5 @@
+import childProcess from 'child_process';
+import os from 'os';
 import * as path from 'path';
 
 import type { Config, PlaywrightTestOptions } from '@playwright/test';
@@ -18,5 +20,13 @@ const config: Config<PlaywrightTestOptions> = {
   reporter:      'list',
   use:           { colorScheme },
 };
+
+if (os.platform() === 'win32' && process.env.THEME === 'dark') {
+  // Switch to Dark mode
+  childProcess.execSync('reg add HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme /t REG_DWORD /f /d 0');
+} else {
+  // Switch to Light mode
+  childProcess.execSync('reg add HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme /t REG_DWORD /f /d 1');
+}
 
 export default config;

--- a/screenshots/playwright-config.ts
+++ b/screenshots/playwright-config.ts
@@ -21,6 +21,10 @@ const config: Config<PlaywrightTestOptions> = {
   use:           { colorScheme },
 };
 
+if (os.platform() === 'darwin') {
+  childProcess.execSync(`osascript -e 'tell app "System Events" to tell appearance preferences to set dark mode to ${ colorScheme === 'dark' }'`);
+}
+
 if (os.platform() === 'win32') {
   const mode = process.env.THEME === 'dark' ? '0' : '1';
 

--- a/screenshots/playwright-config.ts
+++ b/screenshots/playwright-config.ts
@@ -21,12 +21,10 @@ const config: Config<PlaywrightTestOptions> = {
   use:           { colorScheme },
 };
 
-if (os.platform() === 'win32' && process.env.THEME === 'dark') {
-  // Switch to Dark mode
-  childProcess.execSync('reg add HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme /t REG_DWORD /f /d 0');
-} else {
-  // Switch to Light mode
-  childProcess.execSync('reg add HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme /t REG_DWORD /f /d 1');
+if (os.platform() === 'win32') {
+  const mode = process.env.THEME === 'dark' ? '0' : '1';
+
+  childProcess.execSync(`reg add HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme /t REG_DWORD /f /d ${ mode }`);
 }
 
 export default config;

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -91,18 +91,20 @@ test.describe.serial('Main App Test', () => {
     await e2ePreferences.application.automaticUpdatesCheckbox.click();
     await preferencesPage.waitForTimeout(200);
 
-    await screenshot.take('application', 'tabBehavior');
-
     if (!isWin) {
       await e2ePreferences.application.tabEnvironment.click();
       await expect(e2ePreferences.application.pathManagement).toBeVisible();
+      await screenshot.take('application', 'tabBehavior');
       await screenshot.take('application', 'tabEnvironment');
 
       await screenshot.take('virtualMachine');
+    } else {
+      await screenshot.take('application');
     }
 
     await screenshot.take('containerEngine', 'tabGeneral');
 
+    await e2ePreferences.containerEngine.nav.click();
     await e2ePreferences.containerEngine.tabAllowedImages.click();
     await expect(e2ePreferences.containerEngine.allowedImages).toBeVisible();
     await screenshot.take('containerEngine', 'tabAllowedImages');

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -92,9 +92,11 @@ test.describe.serial('Main App Test', () => {
     await preferencesPage.waitForTimeout(200);
 
     if (!isWin) {
+      await screenshot.take('application', 'tabBehavior');
+
+      await e2ePreferences.application.nav.click();
       await e2ePreferences.application.tabEnvironment.click();
       await expect(e2ePreferences.application.pathManagement).toBeVisible();
-      await screenshot.take('application', 'tabBehavior');
       await screenshot.take('application', 'tabEnvironment');
 
       await screenshot.take('virtualMachine');

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -69,7 +69,8 @@ test.describe.serial('Main App Test', () => {
     // show diagnostics badge
     await expect(diagnosticsPage.diagnostics).toBeVisible();
     await diagnosticsPage.checkerRows('MOCK_CHECKER').muteButton.click();
-    await page.waitForTimeout(200);
+    // wait for the red bullet to appear on the Diagnostics page label
+    await page.waitForTimeout(1000);
 
     await screenshot.take('Diagnostics');
   });


### PR DESCRIPTION
# Instructions

## Requirements

### Windows

1. Download ShareX portable https://github.com/ShareX/ShareX/releases/download/v14.1.0/ShareX-14.1.0-portable.zip
2. Extract contents into `resources`
3. Configure the sleep duration for ShareX to write screenshots `$Env:RD_ENV_SCREENSHOT_SLEEP = 5000; npm run screenshots`

### Linux

1. install `gnome-screenshot `

## Run Screenshots task

- `npm run screenshots` to take screenshots for each preferences tab.
- `npm run screenshots:dark` only dark mode 
- `npm run screenshots:light` only light mode 

Related to #3431