### PR TITLE
Try to get CI packaging working again with python 2.x

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -28,7 +28,7 @@ jobs:
         - platform: win
           runs-on: windows-2019
         - platform: linux
-          runs-on: ubuntu-latest
+          runs-on: ubuntu-20.04
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
On 2022-12-01 github actions switched ubuntu-latest to 22.04 which doesn't include python 2.x

Signed-off-by: Eric Promislow <epromislow@suse.com>