### PR TITLE
WiX: register event log source for privileged service.

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -113,7 +113,7 @@
 
     <!-- Setting the PATH variable -->
     <Component Id="PathUser" Directory="APPLICATIONFOLDER">
-      <Condition>MSIINSTALLPERUSER</Condition>
+      <Condition>MSIINSTALLPERUSER = 1</Condition>
       <RegistryValue
         Root="HKCU"
         Key="SOFTWARE\!(wix.AppGUID)"
@@ -130,7 +130,9 @@
         Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
     </Component>
     <Component Id="PathSystem" Directory="APPLICATIONFOLDER">
-      <Condition>NOT MSIINSTALLPERUSER</Condition>
+      <Condition>
+        <![CDATA[MSIINSTALLPERUSER <> 1]]>
+      </Condition>
       <RegistryValue
         Root="HKLM"
         Key="SOFTWARE\!(wix.AppGUID)"

--- a/build/wix/scope.wxs
+++ b/build/wix/scope.wxs
@@ -45,7 +45,9 @@
           X="236" Y="243" Width="56" Height="17">
           <Publish Order="1" Property="MSIINSTALLPERUSER" Value="{}">MSIINSTALLPERUSER = 0</Publish>
           <Publish Order="2" Property="ALLUSERS" Value="{}">MSIINSTALLPERUSER</Publish>
-          <Publish Order="3" Property="ALLUSERS" Value="1">NOT MSIINSTALLPERUSER</Publish>
+          <Publish Order="3" Property="ALLUSERS" Value="1">
+            <![CDATA[MSIINSTALLPERUSER <> 1]]>
+          </Publish>
           <Publish Order="4" Event="NewDialog" Value="RDVerifyReadyDlg">1</Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -75,6 +75,8 @@ const Directory = 'Directory';
 const File = 'File';
 const Fragment = 'Fragment';
 const PermissionEx = 'PermissionEx';
+const RegistryKey = 'RegistryKey';
+const RegistryValue = 'RegistryValue';
 const ServiceControl = 'ServiceControl';
 const ServiceInstall = 'ServiceInstall';
 const Shortcut = 'Shortcut';
@@ -260,6 +262,13 @@ export default async function generateFileList(rootPath: string): Promise<string
           Remove="both"
           Wait="yes"
         />
+        <RegistryKey
+          Root="HKLM"
+          Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\RancherDesktopPrivilegedService"
+        >
+          <RegistryValue Name="EventMessageFile" Type="expandable" Value="%SYSTEMROOT%\System32\EventCreate.exe" />
+          <RegistryValue Name="TypesSupported" Type="integer" Value="7" />{/* Error, warning, info */}
+        </RegistryKey>
       </Component>;
     },
   };

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -213,7 +213,7 @@ export default async function generateFileList(rootPath: string): Promise<string
 
     'resources\\resources\\win32\\internal\\privileged-service.exe': (d, f) => {
       return <Component>
-        <Condition>NOT MSIINSTALLPERUSER</Condition>
+        <Condition>{'MSIINSTALLPERUSER <> 1'}</Condition>
         <File
           Name={f.name}
           Source={path.join('$(var.appDir)', d.name, f.name)}


### PR DESCRIPTION
This was missing from the new installer; this can lead to the service ending up in a half-installed state if:
1. User installs MSI installer. (Service is registered, not event source.)
2. User installs EXE installer. (Both service and event source installed.)
3. User uninstalls MSI installer. (Only event source installed.)

Additionally, this fixes a regression from #3494 because we changed `MSIINSTALLPERUSER` to possibly contain `0` (previously it was either `1` or unset), so conditions like `NOT MSIINSTALLPERUSER` was not matching correctly (`0` is still set, so it was truthy).

Fixes #3506.