### PR TITLE
Prevent second instances from being started and improve window closing behaviour

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -34,7 +34,7 @@ import * as childProcess from '@pkg/utils/childProcess';
 import getCommandLineArgs from '@pkg/utils/commandLine';
 import DockerDirManager from '@pkg/utils/dockerDirManager';
 import { arrayCustomizer } from '@pkg/utils/filters';
-import Logging, { setLogLevel } from '@pkg/utils/logging';
+import Logging, { setLogLevel, clearLoggingDirectory } from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { setupProtocolHandler, protocolRegistered } from '@pkg/utils/protocols';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
@@ -43,11 +43,17 @@ import * as window from '@pkg/window';
 import { closeDashboard, openDashboard } from '@pkg/window/dashboard';
 import { preferencesSetDirtyFlag } from '@pkg/window/preferences';
 
-Electron.app.setName('Rancher Desktop');
 Electron.app.setPath('cache', paths.cache);
 Electron.app.setAppLogsPath(paths.logs);
 
 const console = Logging.background;
+
+if (!Electron.app.requestSingleInstanceLock()) {
+  process.exit(201);
+}
+
+clearLoggingDirectory();
+
 const ipcMainProxy = getIpcMainProxy(console);
 const dockerDirManager = new DockerDirManager(path.join(os.homedir(), '.docker'));
 const k8smanager = newK8sManager();
@@ -78,11 +84,6 @@ let pendingRestartContext: CommandWorkerInterface.CommandContext | undefined;
 let httpCommandServer: HttpCommandServer|null = null;
 const httpCredentialHelperServer = new HttpCredentialHelperServer();
 
-if (!Electron.app.requestSingleInstanceLock()) {
-  gone = true;
-  process.exit(201);
-}
-
 // Scheme must be registered before the app is ready
 Electron.protocol.registerSchemesAsPrivileged([
   { scheme: 'app', privileges: { secure: true, standard: true } },
@@ -94,6 +95,11 @@ process.on('unhandledRejection', (reason: any, promise: any) => {
   } else {
     console.error('UnhandledRejectionWarning:', reason);
   }
+});
+
+Electron.app.on('second-instance', async() => {
+  await protocolRegistered;
+  window.openMain();
 });
 
 // takes care of any propagation of settings we want to do
@@ -313,13 +319,6 @@ function setupImageProcessor() {
   window.send('k8s-current-engine', cfg.kubernetes.containerEngine);
 }
 
-Electron.app.on('second-instance', async() => {
-  // Someone tried to run another instance of Rancher Desktop,
-  // reveal and focus this window instead.
-  await protocolRegistered;
-  window.openMain();
-});
-
 interface K8sError {
   errCode: number | string
 }
@@ -359,11 +358,6 @@ Electron.app.on('before-quit', async(event) => {
 Electron.app.on('window-all-closed', () => {
   // On macOS, hide the dock icon.
   Electron.app.dock?.hide();
-  // On windows and macOS platforms, we only quit via the notification tray / menu bar.
-  // On Linux we close the application since not all distros support tray menu/icons
-  if (os.platform() === 'linux' && !settings.firstRunDialogNeeded()) {
-    Electron.app.quit();
-  }
 });
 
 Electron.app.on('activate', async() => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rancher-desktop",
+  "productName": "Rancher Desktop",
   "license": "Apache-2.0",
   "version": "1.6.0",
   "author": {

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -91,6 +91,7 @@ export class HttpCommandServer {
     }
     const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
 
+    await fs.promises.mkdir(paths.appHome, { recursive: true });
     await fs.promises.writeFile(statePath,
       jsonStringifyWithWhiteSpace(this.externalState),
       { mode: 0o600 });


### PR DESCRIPTION
Closes #2437.
Closes #3260.

Things done in this PR:
- Cleanup of the application name. Previously we were setting it via `app.setName`, which was problematic because there were things that were using it before it was set. In these cases it was defaulting to `rancher-desktop`, rather than `Rancher Desktop`. Now, the application name is set via `productName` in package.json.
- Closing the window no longer quits Rancher Desktop on Linux. The user can exit via the file menu or the icon in the tray.
- Removed call to `app.requestSingleInstanceLock` in logging.ts. This was unnecessary and was part of the confusion that led to the call to `app.requestSingleInstanceLock` in background.ts not working as expected.