### PR TITLE
Roll back to @nuxtjs/eslint-config-typescript 11.0.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,6 +206,18 @@ Object.assign(module.exports.rules, {
       },
     ],
   }],
+  camelcase:                         'error',
+  'import/first':                    'error',
+  'import/no-named-as-default':      'error',
+  'n/no-callback-literal':           'error',
+  'no-control-regex':                'error',
+  'no-redeclare':                    'error',
+  'no-use-before-define':            'error',
+  'no-useless-constructor':          'error',
+  'prefer-const':                    'error',
+  'valid-typeof':                    'error',
+  '@typescript-eslint/ban-types':    'error',
+  '@typescript-eslint/no-namespace': 'error',
 
   // Existing code only follows a subset of settings for no-unused-vars.
   '@typescript-eslint/no-unused-vars':                 ['warn', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@nuxt/types": "^2.15.2",
         "@nuxt/typescript-build": "^2.1.0",
         "@nuxtjs/eslint-config": "^10.0.0",
-        "@nuxtjs/eslint-config-typescript": "^12.0.0",
+        "@nuxtjs/eslint-config-typescript": "^11.0.0",
         "@nuxtjs/router-extras": "^1.1.1",
         "@nuxtjs/style-resources": "^1.2.1",
         "@octokit/rest": "^19.0.5",
@@ -3370,9 +3370,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3397,9 +3397,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3550,25 +3550,16 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -5696,36 +5687,34 @@
       }
     },
     "node_modules/@nuxtjs/eslint-config-typescript": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-12.0.0.tgz",
-      "integrity": "sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-11.0.0.tgz",
+      "integrity": "sha512-hmFjGtXT524ql8eTbK8BaRkamcXB6Z8YOW8nSQhosTP6oBw9WtOFUeWr7holyE278UhOmx+wDFG90BnyM9D+UA==",
       "dev": true,
       "dependencies": {
-        "@nuxtjs/eslint-config": "^12.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.42.1",
-        "@typescript-eslint/parser": "^5.42.1",
-        "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-vue": "^9.7.0"
+        "@nuxtjs/eslint-config": "^11.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.1",
+        "@typescript-eslint/parser": "^5.36.1",
+        "eslint-import-resolver-typescript": "^3.5.0",
+        "eslint-plugin-import": "^2.26.0"
       },
       "peerDependencies": {
         "eslint": "^8.23.0"
       }
     },
     "node_modules/@nuxtjs/eslint-config-typescript/node_modules/@nuxtjs/eslint-config": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-12.0.0.tgz",
-      "integrity": "sha512-ewenelo75x0eYEUK+9EBXjc/OopQCvdkmYmlZuoHq5kub/vtiRpyZ/autppwokpHUq8tiVyl2ejMakoiHiDTrg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-11.0.0.tgz",
+      "integrity": "sha512-o4zFOpU8gJgwrC/gLE7c2E0XEjkv2fEixCGG1y+dZYzBPyzTorkQmfxskSF3WRXcZkpkS9uUYlRkeOSdYB7z0w==",
       "dev": true,
       "dependencies": {
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-n": "^15.5.1",
+        "eslint-plugin-n": "^15.2.5",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-unicorn": "^44.0.2",
-        "eslint-plugin-vue": "^9.7.0",
-        "local-pkg": "^0.4.2"
+        "eslint-plugin-promise": "^6.0.1",
+        "eslint-plugin-unicorn": "^43.0.2",
+        "eslint-plugin-vue": "^9.4.0"
       },
       "peerDependencies": {
         "eslint": "^8.23.0"
@@ -5741,18 +5730,18 @@
       }
     },
     "node_modules/@nuxtjs/eslint-config-typescript/node_modules/eslint-plugin-unicorn": {
-      "version": "44.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
-      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "version": "43.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-43.0.2.tgz",
+      "integrity": "sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.19.1",
-        "ci-info": "^3.4.0",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "ci-info": "^3.3.2",
         "clean-regexp": "^1.0.0",
         "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
-        "is-builtin-module": "^3.2.0",
+        "is-builtin-module": "^3.1.0",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
@@ -5768,7 +5757,7 @@
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.1"
+        "eslint": ">=8.18.0"
       }
     },
     "node_modules/@nuxtjs/eslint-config/node_modules/eslint-plugin-vue": {
@@ -17518,14 +17507,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -17541,14 +17530,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -18217,9 +18206,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.7.0.tgz",
-      "integrity": "sha512-DrOO3WZCZEwcLsnd3ohFwqCoipGRSTKTBTnLwdhqAbYZtzWl0o7D+D8ZhlmiZvABKTEl8AFsqH1GHGdybyoQmw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
@@ -25659,18 +25648,6 @@
       },
       "bin": {
         "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/local-pkg": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
-      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -41010,9 +40987,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -41031,9 +41008,9 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -41180,19 +41157,14 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
-    },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA=="
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -42860,33 +42832,31 @@
       }
     },
     "@nuxtjs/eslint-config-typescript": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-12.0.0.tgz",
-      "integrity": "sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-11.0.0.tgz",
+      "integrity": "sha512-hmFjGtXT524ql8eTbK8BaRkamcXB6Z8YOW8nSQhosTP6oBw9WtOFUeWr7holyE278UhOmx+wDFG90BnyM9D+UA==",
       "dev": true,
       "requires": {
-        "@nuxtjs/eslint-config": "^12.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.42.1",
-        "@typescript-eslint/parser": "^5.42.1",
-        "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-vue": "^9.7.0"
+        "@nuxtjs/eslint-config": "^11.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.1",
+        "@typescript-eslint/parser": "^5.36.1",
+        "eslint-import-resolver-typescript": "^3.5.0",
+        "eslint-plugin-import": "^2.26.0"
       },
       "dependencies": {
         "@nuxtjs/eslint-config": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-12.0.0.tgz",
-          "integrity": "sha512-ewenelo75x0eYEUK+9EBXjc/OopQCvdkmYmlZuoHq5kub/vtiRpyZ/autppwokpHUq8tiVyl2ejMakoiHiDTrg==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@nuxtjs/eslint-config/-/eslint-config-11.0.0.tgz",
+          "integrity": "sha512-o4zFOpU8gJgwrC/gLE7c2E0XEjkv2fEixCGG1y+dZYzBPyzTorkQmfxskSF3WRXcZkpkS9uUYlRkeOSdYB7z0w==",
           "dev": true,
           "requires": {
             "eslint-config-standard": "^17.0.0",
             "eslint-plugin-import": "^2.26.0",
-            "eslint-plugin-n": "^15.5.1",
+            "eslint-plugin-n": "^15.2.5",
             "eslint-plugin-node": "^11.1.0",
-            "eslint-plugin-promise": "^6.1.1",
-            "eslint-plugin-unicorn": "^44.0.2",
-            "eslint-plugin-vue": "^9.7.0",
-            "local-pkg": "^0.4.2"
+            "eslint-plugin-promise": "^6.0.1",
+            "eslint-plugin-unicorn": "^43.0.2",
+            "eslint-plugin-vue": "^9.4.0"
           }
         },
         "ci-info": {
@@ -42896,18 +42866,18 @@
           "dev": true
         },
         "eslint-plugin-unicorn": {
-          "version": "44.0.2",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
-          "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+          "version": "43.0.2",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-43.0.2.tgz",
+          "integrity": "sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "ci-info": "^3.4.0",
+            "@babel/helper-validator-identifier": "^7.18.6",
+            "ci-info": "^3.3.2",
             "clean-regexp": "^1.0.0",
             "eslint-utils": "^3.0.0",
             "esquery": "^1.4.0",
             "indent-string": "^4.0.0",
-            "is-builtin-module": "^3.2.0",
+            "is-builtin-module": "^3.1.0",
             "lodash": "^4.17.21",
             "pluralize": "^8.0.0",
             "read-pkg-up": "^7.0.1",
@@ -52352,14 +52322,14 @@
       }
     },
     "eslint": {
-      "version": "8.23.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
-      "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "requires": {
-        "@eslint/eslintrc": "^1.3.2",
-        "@humanwhocodes/config-array": "^0.10.4",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -52375,14 +52345,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -52973,9 +52943,9 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.7.0.tgz",
-      "integrity": "sha512-DrOO3WZCZEwcLsnd3ohFwqCoipGRSTKTBTnLwdhqAbYZtzWl0o7D+D8ZhlmiZvABKTEl8AFsqH1GHGdybyoQmw==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.8.0.tgz",
+      "integrity": "sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
@@ -58363,12 +58333,6 @@
           }
         }
       }
-    },
-    "local-pkg": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
-      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
-      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@nuxt/types": "^2.15.2",
     "@nuxt/typescript-build": "^2.1.0",
     "@nuxtjs/eslint-config": "^10.0.0",
-    "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@nuxtjs/eslint-config-typescript": "^11.0.0",
     "@nuxtjs/router-extras": "^1.1.1",
     "@nuxtjs/style-resources": "^1.2.1",
     "@octokit/rest": "^19.0.5",

--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -126,7 +126,7 @@ export default {
 
   data() {
     return {
-      currentCommand:   null,
+      currentCommand: null,
       headers:
       [
         {


### PR DESCRIPTION
Fixes #3516

For some reason, many (but not all) of our `eslint-disable-*` directives aren't used, or they are reported as not being needed.

This issue is that using `"@nuxtjs/eslint-config-typescript` v 12.0.0 has the effect of sort of enabling the `--report-unused-disable-directives` flag for eslint, although problems are reported as warnings, not errors, and if that's the only thing `eslint` reports, it returns with status 0, which is why this isn't a problem for CI.

Signed-off-by: Eric Promislow <epromislow@suse.com>