### PR TITLE
Don't start OpenResty explicitly

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1226,7 +1226,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         }
 
         await this.progressTracker.action('Running provisioning scripts', 100, this.runProvisioningScripts());
-        await this.progressTracker.action('Starting image proxy', 100, this.startService('openresty'));
         await this.progressTracker.action('Starting container engine', 0, this.startService(config.kubernetes.containerEngine === ContainerEngine.MOBY ? 'docker' : 'containerd'));
 
         if (kubernetesVersion) {


### PR DESCRIPTION
It will be started by OpenRC because both containerd and docker services have `need openresty` in their `depend` functions.
