### PR TITLE
WiX: Don't override MSIINSTALLPERUSER in the server.

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -55,8 +55,8 @@
     <SetProperty Id="ALLUSERS" Sequence="both" After="ValidateProductID" Value="1">
       NOT WSLKERNELINSTALLED AND NOT Installed
     </SetProperty>
-    <SetProperty Id="MSIINSTALLPERUSER" Sequence="both" After="ValidateProductID" Value="0">
-      NOT Installed
+    <SetProperty Id="MSIINSTALLPERUSER" Sequence="first" After="ValidateProductID" Value="0">
+      (NOT WSLKERNELINSTALLED OR NOT MSIINSTALLPERUSER) AND NOT Installed
     </SetProperty>
     <SetProperty Id="PowerShellExe" Sequence="execute" Before="SetInstallWSL"
       Value="&quot;[System64Folder]\WindowsPowerShell\v1.0\powershell.exe&quot;" />


### PR DESCRIPTION
MSI runs with UI first, and then reruns itself as the server.  After the user has selected the configuration in the UI, all configuration is passed to the server and the installer is run essentially as a silent install. In that second run, we should not override MSIINSTALLPER user coming from the first run.

To do so, we:
- Switch the `<SetProperty>` to `Sequence="first"`
- As a safeguard, only do so if either `WSLKERNELINSTALLED` or `MSIINSTALLPERUSER` is unset.  This ensures we do not regress bff47ac55f83781bc16a9e01482a1c45cc8b15c3.

Fixes #3529 