### PR TITLE
Add height to header-middle div

### DIFF
--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -401,10 +401,11 @@ export default {
     display: flex;
     align-items: flex-end;
     gap: 1rem;
+    height: 100%;
   }
 
   .all-images {
-    margin-bottom: 11px;
+    margin-bottom: 12px;
   }
 
   .imagesTable::v-deep .search-box {

--- a/pkg/rancher-desktop/components/PortForwarding.vue
+++ b/pkg/rancher-desktop/components/PortForwarding.vue
@@ -22,12 +22,15 @@
       :row-actions-width="parseInt(95, 10)"
     >
       <template #header-middle>
-        <Checkbox
-          :label="'Include Kubernetes services'"
-          :value="includeKubernetesServices"
-          :disabled="!isRunning || kubernetesIsDisabled"
-          @input="handleCheckbox"
-        />
+        <div class="header-middle">
+          <Checkbox
+            class="kubernetes-services"
+            :label="'Include Kubernetes services'"
+            :value="includeKubernetesServices"
+            :disabled="!isRunning || kubernetesIsDisabled"
+            @input="handleCheckbox"
+          />
+        </div>
       </template>
       <template #col:listenPort="{row}">
         <div v-if="serviceBeingEditedIs(row)" class="listen-port-div">
@@ -224,20 +227,35 @@ export default Vue.extend({
 </script>
 
 <style>
-.action-div {
-  display: flex;
-  flex-direction: row-reverse;
-  gap: 0.5rem;
-}
-.listen-port-div {
-  height: 100%;
-  width: 6rem;
-}
-.listen-port-input {
-  max-height: 30px;
-  margin: 8px 0;
-}
-.listen-port-p {
-  margin: 15px 11px;
-}
+  .action-div {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 0.5rem;
+  }
+
+  .listen-port-div {
+    height: 100%;
+    width: 6rem;
+  }
+
+  .listen-port-input {
+    max-height: 30px;
+    margin: 8px 0;
+  }
+
+  .listen-port-p {
+    margin: 15px 11px;
+  }
+
+  .header-middle {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+    height: 100%;
+  }
+
+  .kubernetes-services {
+    margin-bottom: 12px;
+  }
+
 </style>


### PR DESCRIPTION
This fixes an alignment issue with the "All Images" checkbox. This was only an issue when the moby container runtime was active because there's not namespaces dropdown to fill the empty space. 

This also adds another pixel to the bottom margin of the checkbox so that its label better aligns with the content of the adjacent elements.

closes #3544

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>