### PR TITLE
WiX: Fix upgrade install of per-user installs.

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -20,7 +20,8 @@
     </Condition>
     <MajorUpgrade
       AllowSameVersionUpgrades="yes"
-      DowngradeErrorMessage='A newer version of [ProductName] is already installed.' />
+      DowngradeErrorMessage='A newer version of [ProductName] is already installed.'
+      Schedule="afterInstallInitialize" />
     <MediaTemplate CompressionLevel="{{compressionLevel}}" EmbedCab="yes" />
     <UIRef Id="WixUI_RD" />
 

--- a/build/wix/scope.wxs
+++ b/build/wix/scope.wxs
@@ -43,12 +43,7 @@
         </Control>
         <Control Id="Next" Type="PushButton" Default="yes" Text="!(loc.WixUINext)"
           X="236" Y="243" Width="56" Height="17">
-          <Publish Order="1" Property="MSIINSTALLPERUSER" Value="{}">MSIINSTALLPERUSER = 0</Publish>
-          <Publish Order="2" Property="ALLUSERS" Value="{}">MSIINSTALLPERUSER</Publish>
-          <Publish Order="3" Property="ALLUSERS" Value="1">
-            <![CDATA[MSIINSTALLPERUSER <> 1]]>
-          </Publish>
-          <Publish Order="4" Event="NewDialog" Value="RDVerifyReadyDlg">1</Publish>
+          <Publish Order="1" Event="NewDialog" Value="RDVerifyReadyDlg">1</Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>

--- a/build/wix/verify.wxs
+++ b/build/wix/verify.wxs
@@ -27,7 +27,7 @@
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
         <Control Id="Back" Type="PushButton" X="156" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">
-          <Publish Order="1" Event="NewDialog" Value="RDInstallScopeDlg">1</Publish>
+          <Publish Order="1" Event="NewDialog" Value="RDInstallScopeDlg">WSLKERNELINSTALLED</Publish>
           <Publish Order="2" Event="NewDialog" Value="RDWelcomeDlg">NOT WSLKERNELINSTALLED</Publish>
         </Control>
 
@@ -35,27 +35,41 @@
           X="212" Y="243" Width="80" Height="17"
           Default="yes" Hidden="yes"
           Text="!(loc.VerifyReadyDlgInstall)">
-          <Condition Action="show">ALLUSERS</Condition>
-          <Publish Event="EndDialog" Value="Return">
+          <Condition Action="show">
+            <![CDATA[ MSIINSTALLPERUSER <> 1]]>
+          </Condition>
+          <Publish Order="1" Property="MSIINSTALLPERUSER" Value="{}">1</Publish>
+          <Publish Order="2" Property="ALLUSERS" Value="1">1</Publish>
+          <Publish Order="3" Event="EndDialog" Value="Return">
             <![CDATA[OutOfDiskSpace <> 1]]>
           </Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
-          <Publish Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
-          <Publish Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
+          <Publish Order="4" Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
+          <Publish Order="5" Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Order="6" Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Order="7" Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
         </Control>
         <Control Id="InstallNoShield" Type="PushButton" ElevationShield="no"
           X="212" Y="243" Width="80" Height="17"
           Default="yes" Hidden="yes"
           Text="!(loc.VerifyReadyDlgInstall)">
-          <Condition Action="show">NOT ALLUSERS</Condition>
-          <Publish Event="EndDialog" Value="Return">
+          <Condition Action="show">MSIINSTALLPERUSER = 1</Condition>
+          <Publish Order="1" Property="ALLUSERS" Value="{}">1</Publish>
+          <!--
+            - When running with full UI, the installer initially assumes we're
+            - going to install per-machine. This means that when we looked for
+            - older products to upgrade from (by matching UpgradeCode), per-user
+            - installs were ignored. Now that we have confirmed we're about to
+            - install per-user, re-do FindRelatedProducts so that we can find
+            - any existing installs we need to upgrade from.
+           -->
+          <Publish Order="2" Event="DoAction" Value="FindRelatedProducts">1</Publish>
+          <Publish Order="3" Event="EndDialog" Value="Return">
             <![CDATA[OutOfDiskSpace <> 1]]>
           </Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
-          <Publish Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
-          <Publish Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
+          <Publish Order="4" Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
+          <Publish Order="5" Event="EndDialog" Value="Return">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Order="6" Event="EnableRollback" Value="False">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"</Publish>
+          <Publish Order="7" Event="SpawnDialog" Value="OutOfDiskDlg">(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")</Publish>
         </Control>
 
         <Control Id="Cancel" Type="PushButton" Cancel="yes"


### PR DESCRIPTION
When we run the installer with full UI (i.e. the default mode), we are initially set up as if we're going to do a per-machine installation, and then this gets changed as the user steps through the dialogs.  This means that when it initially runs the `FindRelatedProducts` step (looking for old installations to upgrade from), this happens in the per-machine context, and will skip over per-user installations.  If the user chooses a per-user installation, this eventually leads to us not uninstalling the previous installation before installing a major upgrade (in our case, this means any other build).

Fix this by manually running `FindRelatedProducts` from the UI, once the final confirmation before installation happens, after we have fixed up the `ALLUSERS` / `MSIINSTALLPERUSER` properties to be a per-user installation.  At that point the engine will pick up the previous per-user install and therefore uninstall the previous installation before installing the new build.

This PR also moves setting the per-machine/per-user properties at the same place (after the user confirms installation) rather than where it was previously (right after the scope selection dialog).  This is to fix an issue where if the user chooses per-machine, move forward, then back again, the UI gets confused (because the properties no longer exactly match one of the expected values) and loses the selection.  We also now explicitly add ordering to all the steps we do at install confirmation; it was previously using implicit ordering (based on the position in the XML file).

Additionally, this moves uninstalling the previous version to just after `InstallInitialize` (as opposed to just before, where it used to be), so that it will roll back correctly on failure.

Fixes #3533.