### PR TITLE
Add version to help menu docs url

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -30,7 +30,6 @@ import buildApplicationMenu from '@pkg/main/mainmenu';
 import setupNetworking from '@pkg/main/networking';
 import setupTray from '@pkg/main/tray';
 import setupUpdate from '@pkg/main/update';
-import * as childProcess from '@pkg/utils/childProcess';
 import getCommandLineArgs from '@pkg/utils/commandLine';
 import DockerDirManager from '@pkg/utils/dockerDirManager';
 import { arrayCustomizer } from '@pkg/utils/filters';
@@ -39,6 +38,7 @@ import paths from '@pkg/utils/paths';
 import { setupProtocolHandler, protocolRegistered } from '@pkg/utils/protocols';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
+import { getVersion } from '@pkg/utils/version';
 import * as window from '@pkg/window';
 import { closeDashboard, openDashboard } from '@pkg/window/dashboard';
 import { preferencesSetDirtyFlag } from '@pkg/window/preferences';
@@ -672,36 +672,6 @@ Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.M
 
   return response;
 });
-
-function getProductionVersion() {
-  try {
-    return Electron.app.getVersion();
-  } catch (err) {
-    console.log(`Can't get app version: ${ err }`);
-
-    return '?';
-  }
-}
-
-async function getDevVersion() {
-  try {
-    const { stdout } = await childProcess.spawnFile('git', ['describe', '--tags'], { stdio: ['ignore', 'pipe', 'inherit'] });
-
-    return stdout.trim();
-  } catch (err) {
-    console.log(`Can't get app version: ${ err }`);
-
-    return '?';
-  }
-}
-
-async function getVersion() {
-  if (process.env.NODE_ENV === 'production' || process.env.MOCK_FOR_SCREENSHOTS) {
-    return getProductionVersion();
-  }
-
-  return await getDevVersion();
-}
 
 function showErrorDialog(title: string, message: string, fatal?: boolean) {
   Electron.dialog.showErrorBox(title, message);

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -1,5 +1,7 @@
 import { ipcRenderer } from 'electron';
 
+import { parseDocsVersion } from '@pkg/utils/version';
+
 const baseUrl = 'https://docs.rancherdesktop.io';
 
 const paths: Record<string, string> = {
@@ -18,9 +20,7 @@ class HelpImpl {
 
   constructor() {
     ipcRenderer.on('get-app-version', (_event, version) => {
-      const releasePattern = /^v?(\d+\.\d+)\.\d+$/;
-
-      this.version = releasePattern.exec(version)?.[1] ?? 'next';
+      this.version = parseDocsVersion(version);
     });
 
     ipcRenderer.send('get-app-version');

--- a/pkg/rancher-desktop/main/mainmenu.ts
+++ b/pkg/rancher-desktop/main/mainmenu.ts
@@ -5,12 +5,12 @@ import { openMain } from '@pkg/window';
 
 const baseUrl = `https://docs.rancherdesktop.io`;
 
-const versionedDocsUrl = async() => {
+async function versionedDocsUrl() {
   const version = await getVersion();
   const parsed = parseDocsVersion(version);
 
   return `${ baseUrl }/${ parsed }`;
-};
+}
 
 export default function buildApplicationMenu(): void {
   const menuItems: Array<MenuItem> = getApplicationMenu();

--- a/pkg/rancher-desktop/main/mainmenu.ts
+++ b/pkg/rancher-desktop/main/mainmenu.ts
@@ -62,7 +62,7 @@ function getHelpMenu(isMac: boolean): MenuItem {
       { type: 'separator' } as MenuItemConstructorOptions,
     ] : []),
     {
-      label: 'Get &Help',
+      label: isMac ? 'Rancher Desktop &Help' : 'Get &Help',
       click: async() => {
         shell.openExternal(await versionedDocsUrl());
       },

--- a/pkg/rancher-desktop/main/mainmenu.ts
+++ b/pkg/rancher-desktop/main/mainmenu.ts
@@ -1,6 +1,16 @@
 import Electron, { Menu, MenuItem, MenuItemConstructorOptions, shell } from 'electron';
 
+import { getVersion, parseDocsVersion } from '@pkg/utils/version';
 import { openMain } from '@pkg/window';
+
+const baseUrl = `https://docs.rancherdesktop.io`;
+
+const versionedDocsUrl = async() => {
+  const version = await getVersion();
+  const parsed = parseDocsVersion(version);
+
+  return `${ baseUrl }/${ parsed }`;
+};
 
 export default function buildApplicationMenu(): void {
   const menuItems: Array<MenuItem> = getApplicationMenu();
@@ -53,8 +63,8 @@ function getHelpMenu(isMac: boolean): MenuItem {
     ] : []),
     {
       label: 'Get &Help',
-      click() {
-        shell.openExternal('https://docs.rancherdesktop.io');
+      click: async() => {
+        shell.openExternal(await versionedDocsUrl());
       },
     },
     {

--- a/pkg/rancher-desktop/utils/version.ts
+++ b/pkg/rancher-desktop/utils/version.ts
@@ -1,0 +1,39 @@
+import { app } from 'electron';
+
+import { spawnFile } from '@pkg/utils/childProcess';
+
+function getProductionVersion() {
+  try {
+    return app.getVersion();
+  } catch (err) {
+    console.log(`Can't get app version: ${ err }`);
+
+    return '?';
+  }
+}
+
+async function getDevVersion() {
+  try {
+    const { stdout } = await spawnFile('git', ['describe', '--tags'], { stdio: ['ignore', 'pipe', 'inherit'] });
+
+    return stdout.trim();
+  } catch (err) {
+    console.log(`Can't get app version: ${ err }`);
+
+    return '?';
+  }
+}
+
+export async function getVersion() {
+  if (process.env.NODE_ENV === 'production' || process.env.MOCK_FOR_SCREENSHOTS) {
+    return getProductionVersion();
+  }
+
+  return await getDevVersion();
+}
+
+export function parseDocsVersion(version: string) {
+  const releasePattern = /^v?(\d+\.\d+)\.\d+$/;
+
+  return releasePattern.exec(version)?.[1] ?? 'next';
+}


### PR DESCRIPTION
This adds a versioned docs url for the help menu by parsing the version number in the same way that we do for help buttons. We create a new version util for getting the Rancher Desktop version so that we can easily invoke `getVersion` from `mainmenu.ts`

I opted to delay removing the Search function from macOS because this feature is provided by the `help` role via electron. I figured that updating the docs was more important at this time.

closes #3524 