### PR TITLE
Catch limactl errors during shutdown.

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1822,9 +1822,9 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
           await this.dockerDirManager.clearDockerContext();
         }
         await this.setState(State.STOPPED);
-      } catch (ex) {
+      } catch (ex: any) {
         await this.setState(State.ERROR);
-        throw ex;
+        console.log(`Ignoring error while stopping lima: ${ ex }: `, ex);
       } finally {
         this.currentAction = Action.NONE;
       }


### PR DESCRIPTION
Fixes #3553 

I temporarily stopped deleting logs after factory-reset so I could see that since we stopped waiting for the app to
stop, and just do a forced close, this exception wasn't being caught in both dev and package builds:

```
==> lima.log <==
2022-12-06T00:42:32.611Z: Lima: executing: sudo /sbin/rc-service --ifstarted buildkitd stop: Error: /Users/ericp/workspace/rancher/desktop/resources/darwin/lima/bin/limactl exited with code 255
2022-12-06T00:42:32.614Z: Ignoring error while stopping lima: Error: /Users/ericp/workspace/rancher/desktop/resources/darwin/lima/bin/limactl exited with code 255:  Error: /Users/ericp/workspace/rancher/desktop/resources/darwin/lima/bin/limactl exited with code 255
    at ChildProcess.<anonymous> (/Users/ericp/workspace/rancher/desktop/dist/app/background.js:56064:27)
    at ChildProcess.emit (node:events:390:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12) {
  stdout: '',
  stderr: '',
  code: 255,
  command: [
    '/Users/ericp/workspace/rancher/desktop/resources/darwin/lima/bin/limactl',
    'shell',
    '--workdir=.',
    '0',
    'sudo',
    '/sbin/rc-service',
    '--ifstarted',
    'buildkitd',
    'stop'
  ]
}
```

I don't think it makes sense to allow these exceptions to stop a shutdown. The only other way is to require the factory-reset procedure to ensure the app has shut down before starting to delete files.

Signed-off-by: Eric Promislow <epromislow@suse.com>