### PR TITLE
rdctl: Correctly kill Rancher Desktop on darwin.

### DIFF
--- a/src/go/rdctl/pkg/shutdown/shutdown.go
+++ b/src/go/rdctl/pkg/shutdown/shutdown.go
@@ -111,11 +111,23 @@ func checkProcessQemu() bool {
 }
 
 func pkillQemu() {
-	exec.Command("pkill", "-9", "-f", RancherDesktopQemuCommand).Run()
+	cmd := exec.Command("pkill", "-9", "-f", RancherDesktopQemuCommand)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		logrus.Errorf("Failed to kill qemu: %s", err)
+	}
 }
 
 func pkillDarwin() {
-	exec.Command("pkill", "-9", "-f", "Contents/MacOS/Rancher Desktop").Run()
+	cmd := exec.Command("/usr/bin/pkill", "-9", "-a", "-l", "-f", "Contents/MacOS/Rancher Desktop")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		logrus.Errorf("Failed to kill Rancher Desktop: %s", err)
+	}
 }
 
 func pkillLinux() {


### PR DESCRIPTION
On darwin, `pkill` by default does not kill ancestors of `pkill`.  However, we spawn it from `rdctl`, which in turn was spawned from the Rancher Desktop main process.  This means that we would fail to kill Rancher Desktop.  Fix this by passing in the `-a` flag (only on darwin) to make it consider ancestors.  Note that this is not an issue for `qemu`, since that isn't an ancestor of `pkill`.  Also, `pkill` on Linux (on my machine, from `procps-ng`) doesn't have the same ancestor-avoiding behaviour, and doesn't take `-a` either.

From `man pkill` on macOS:
> -a                Include process ancestors in the match list.  By default, the current pgrep or pkill process and all of its ancestors are excluded (unless -v is used).


Fixes #3553.