### PR TITLE
rdctl: factory-reset: Manually handle killing processes.

### DIFF
--- a/src/go/rdctl/pkg/directories/directories_windows_test.go
+++ b/src/go/rdctl/pkg/directories/directories_windows_test.go
@@ -23,6 +23,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+func TestGetApplicationDirectory(t *testing.T) {
+	_, err := GetApplicationDirectory()
+	assert.NoError(t, err)
+	// `go test` makes a temporary directory, so we can't sensibly test the
+	// return value.
+}
+
 func TestGetKnownFolder(t *testing.T) {
 	t.Run("AppData", func(t *testing.T) {
 		expected := os.Getenv("APPDATA")

--- a/src/go/rdctl/pkg/factoryreset/delete_data.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data.go
@@ -121,12 +121,19 @@ func deleteLinuxData(removeKubernetesCache bool) error {
 
 func unregisterAndDeleteWindowsData(removeKubernetesCache bool) error {
 	if err := unregisterWSL(); err != nil {
+		logrus.Errorf("could not unregister WSL: %s", err)
 		return err
 	}
 	if err := deleteWindowsData(!removeKubernetesCache, "rancher-desktop"); err != nil {
+		logrus.Errorf("could not delete data: %s", err)
 		return err
 	}
-	return clearDockerContext()
+	if err := clearDockerContext(); err != nil {
+		logrus.Errorf("could not clear docker context: %s", err)
+		return err
+	}
+	logrus.Infoln("successfully cleared data.")
+	return nil
 }
 
 // Most of the errors in this function are reported, but we continue to try to delete things,

--- a/src/go/rdctl/pkg/factoryreset/empty.go
+++ b/src/go/rdctl/pkg/factoryreset/empty.go
@@ -24,7 +24,8 @@ func GetLockfilePath(_ string) (string, error) {
 	return "", fmt.Errorf("internal error: GetLockfilePath shouldn't be called")
 }
 
-func KillRancherDesktop() {
+func KillRancherDesktop() error {
+	return fmt.Errorf("internal error: KillRancherDesktop shouldn't be called")
 }
 
 func deleteWindowsData(_ bool, _ string) error {


### PR DESCRIPTION
When invoked from the GUI, `rdctl` is a child process of the main Rancher Desktop process.  This means that invoking `taskkill ... /T` will also terminate rdctl, which aborts the factory reset.

Instead, manually iterate through processes and terminating the ones that are part of the application (that is, has an executable image that lives within the application directory).  This is close enough to what we want to achieve (and correctly kills `vtunnel` and `host-resolver`).

Also includes fixes to correctly bubble errors up.

Fixes #3519