### PR TITLE
Remove isDowngrade parameter from KubeBackend.install method

### DIFF
--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -102,7 +102,7 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
   /**
    * Install a pre-downloaded version of Kubernetes.
    */
-  install(config: BackendSettings, kubernetesVersion: semver.SemVer, isDowngrade: boolean, allowSudo: boolean): Promise<void>;
+  install(config: BackendSettings, kubernetesVersion: semver.SemVer, allowSudo: boolean): Promise<void>;
 
   /**
    * Start running a pre-installed version of Kubernetes.

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -184,7 +184,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     }
   }
 
-  async install(config: BackendSettings, version: semver.SemVer) {
+  async install(config: BackendSettings, version: semver.SemVer, allowSudo: boolean) {
     await this.vm.runInstallScript(INSTALL_K3S_SCRIPT,
       'install-k3s', version.raw, await this.vm.wslify(path.join(paths.cache, 'k3s')));
   }

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1628,7 +1628,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           await this.startService('docker');
         }
         if (kubernetesVersion) {
-          await this.kubeBackend.install(config, kubernetesVersion, isDowngrade, this.#allowSudo);
+          await this.kubeBackend.install(config, kubernetesVersion, this.#allowSudo);
         }
 
         await this.progressTracker.action('Installing Buildkit', 50, this.writeBuildkitScripts());

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1068,7 +1068,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     const config = this.cfg = _.defaultsDeep(clone(config_),
       { kubernetes: { containerEngine: ContainerEngine.NONE } }) as BackendSettings;
     let kubernetesVersion: semver.SemVer | undefined;
-    let isDowngrade = false;
 
     await this.setState(State.STARTING);
     this.currentAction = Action.STARTING;
@@ -1084,7 +1083,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
         if (config.kubernetes.enabled) {
           prepActions.push((async() => {
-            [kubernetesVersion, isDowngrade] = await this.kubeBackend.download(config);
+            [kubernetesVersion] = await this.kubeBackend.download(config);
           })());
         }
 
@@ -1216,7 +1215,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           installerActions.push(
             this.progressTracker.action('Installing k3s', 100, async() => {
               await this.kubeBackend.deleteIncompatibleData(version);
-              await this.kubeBackend.install(config, version, isDowngrade, false);
+              await this.kubeBackend.install(config, version, false);
             }));
         }
         try {


### PR DESCRIPTION
It is not being used by either the lima nor the wsl implementation, and the signature for the lima variant was missing it already, using the isDowngrade value for allowSudo instead.
