### PR TITLE
Only use proxy when image allow list is enabled

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -866,11 +866,12 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       return ['no changes necessary', ''];
     }
 
+    // Update image allow list patterns, just in case the backend doesn't need restarting
     const allowListConf = BackendHelper.createImageAllowListConf(cfg.containerEngine.imageAllowList);
     const rcService = k8smanager.backend === 'wsl' ? 'wsl-service' : 'rc-service';
 
     await k8smanager.executor.writeFile(`/usr/local/openresty/nginx/conf/image-allow-list.conf`, allowListConf, 0o644);
-    await k8smanager.executor.execCommand({ root: true }, rcService, 'openresty', 'reload');
+    await k8smanager.executor.execCommand({ root: true }, rcService, '--ifstarted', 'openresty', 'reload');
 
     // Check if the newly applied preferences demands a restart of the backend.
     const restartReasons = await k8smanager.requiresRestartReasons(cfg);

--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -128,10 +128,12 @@ provision:
     # openresty is backgrounding itself (and writes its own pid file)
     sed -i 's/^command_background/#command_background/' /etc/init.d/openresty
 
+    # configure proxy only when image-allow-list exists
+    ial=/usr/local/openresty/nginx/conf/image-allow-list.conf
+    setproxy="[ -f $ial ] && supervise_daemon_args=\"-e HTTPS_PROXY=http://127.0.0.1:3128 \$supervise_daemon_args\""
     for svc in containerd docker; do
-      sed -i 's/-e HTTPS_PROXY.*--stderr/--stderr/' /etc/init.d/$svc
-      sed -i 's/--stderr/-e HTTPS_PROXY=http:\/\/127.0.0.1:3128 --stderr/' /etc/init.d/$svc
-      sed -i -E '/openresty/!s/^([ \t]*need.*)/\1 openresty/' /etc/init.d/$svc
+      sed -i "\#-f $ial#d" /etc/init.d/$svc
+      sed -i "/^supervise_daemon_args/a $setproxy" /etc/init.d/$svc
     done
 
     # Make sure openresty log directory exists

--- a/pkg/rancher-desktop/assets/scripts/configure-image-allow-list
+++ b/pkg/rancher-desktop/assets/scripts/configure-image-allow-list
@@ -18,12 +18,11 @@ mkcert -install
 mkcert localhost
 chown -R nobody:nobody $CAROOT
 
-# Configure containerd to pull images via OpenResty proxy.
-sed -i 's/-e HTTPS_PROXY.*--stderr/--stderr/' /etc/init.d/containerd
-sed -i 's/--stderr/-e HTTPS_PROXY=http:\/\/127.0.0.1:3128 --stderr/' /etc/init.d/containerd
-
-# Make sure openresty is started before containerd
-sed -i -E '/openresty/!s/^([ \t]*need.*)/\1 openresty/' /etc/init.d/containerd
+# configure proxy only when image-allow-list exists
+ial=/usr/local/openresty/nginx/conf/image-allow-list.conf
+setproxy="[ -f $ial ] && supervise_daemon_args=\"-e HTTPS_PROXY=http://127.0.0.1:3128 \$supervise_daemon_args\""
+sed -i "\#-f $ial#d" /etc/init.d/containerd
+sed -i "/^supervise_daemon_args/a $setproxy" /etc/init.d/containerd
 
 # openresty is backgrounding itself (and writes its own pid file)
 sed -i 's/^command_background/#command_background/' /etc/init.d/openresty

--- a/pkg/rancher-desktop/assets/scripts/nerdctl
+++ b/pkg/rancher-desktop/assets/scripts/nerdctl
@@ -1,4 +1,6 @@
 #!/bin/sh
 export CONTAINERD_ADDRESS=/run/k3s/containerd/containerd.sock
-export HTTPS_PROXY=http://127.0.0.1:3128
+if [ -f /usr/local/openresty/nginx/conf/image-allow-list.conf ]; then
+  export HTTPS_PROXY=http://127.0.0.1:3128
+fi
 exec /usr/local/libexec/nerdctl/nerdctl "$@"

--- a/pkg/rancher-desktop/assets/scripts/service-wsl-dockerd.initd
+++ b/pkg/rancher-desktop/assets/scripts/service-wsl-dockerd.initd
@@ -9,7 +9,9 @@ name="Rancher Desktop Docker Daemon"
 description="Starts dockerd for Rancher Desktop"
 
 supervisor=supervise-daemon
-supervise_daemon_args="-e HTTPS_PROXY=http:\/\/127.0.0.1:3128"
+if [ -f /usr/local/openresty/nginx/conf/image-allow-list.conf ]; then
+  supervise_daemon_args="-e HTTPS_PROXY=http://127.0.0.1:3128"
+fi
 command="'${WSL_HELPER_BINARY:-/usr/local/bin/wsl-helper}'"
 command_args="docker-proxy start"
 
@@ -20,7 +22,7 @@ error_log="'${DOCKER_LOGFILE}'"
 rc_ulimit="${DOCKER_ULIMIT:--c unlimited -n 1048576 -u unlimited}"
 
 depend() {
-    need sysfs cgroups openresty
+    need sysfs cgroups
     after iptables ip6tables
 }
 

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -38,16 +38,14 @@ export default class BackendHelper {
      * a newline. The '0' means that this pattern is **not** forbidden (the table defaults to '1').
      */
 
-    if (!imageAllowList.enabled) {
-      // Return a pattern allowing **any** image name.
-      return '"~*^.*$" 0;\n';
-    }
-
     // TODO: remove hard-coded defaultSandboxImage from cri-dockerd
-    let patterns = '"~*^registry\\.k8s\\.io(:443)?/pause:[^/]+$" 0;\n';
+    let patterns = '"~*^registry\\.k8s\\.io(:443)?/v2/pause/manifests/[^/]+$" 0;\n';
+
+    // TODO: remove hardcoded CDN redirect target for registry.k8s.io
+    patterns += '"~*^[^./]+\\.pkg\\.dev(:443)?/v2/.+/manifests/[^/]+$" 0;\n';
 
     // TODO: remove hard-coded sandbox_image from our /etc/containerd/config.toml
-    patterns += '"~*^registry-1\\.docker\\.io(:443)?/rancher/mirrored-pause:[^/]+$" 0;\n';
+    patterns += '"~*^registry-1\\.docker\\.io(:443)?/v2/rancher/mirrored-pause/manifests/[^/]+$" 0;\n';
 
     for (const pattern of imageAllowList.patterns) {
       let host = 'registry-1.docker.io';
@@ -60,7 +58,7 @@ export default class BackendHelper {
         if (host === 'docker.io') {
           host = 'registry-1.docker.io';
           // 'docker.io/busybox' means 'registry-1.docker.io/library/busybox'
-          if (repo.length < 2) {
+          if (repo.length === 1) {
             repo.unshift('library');
           }
         }

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -424,12 +424,13 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
 
           return 'restart';
         },
-        'kubernetes.port':            undefined,
-        'kubernetes.containerEngine': undefined,
-        'kubernetes.enabled':         undefined,
-        'kubernetes.options.traefik': undefined,
-        'kubernetes.options.flannel': undefined,
-        'kubernetes.suppressSudo':    undefined,
+        'kubernetes.port':                        undefined,
+        'kubernetes.containerEngine':             undefined,
+        'kubernetes.enabled':                     undefined,
+        'kubernetes.options.traefik':             undefined,
+        'kubernetes.options.flannel':             undefined,
+        'kubernetes.suppressSudo':                undefined,
+        'containerEngine.imageAllowList.enabled': undefined,
       },
       extra,
     );

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -314,13 +314,14 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
 
           return 'restart';
         },
-        'kubernetes.port':            undefined,
-        'kubernetes.containerEngine': undefined,
-        'kubernetes.enabled':         undefined,
-        'kubernetes.WSLIntegrations': undefined,
-        'kubernetes.options.traefik': undefined,
-        'kubernetes.options.flannel': undefined,
-        'kubernetes.hostResolver':    undefined,
+        'kubernetes.port':                        undefined,
+        'kubernetes.containerEngine':             undefined,
+        'kubernetes.enabled':                     undefined,
+        'kubernetes.WSLIntegrations':             undefined,
+        'kubernetes.options.traefik':             undefined,
+        'kubernetes.options.flannel':             undefined,
+        'kubernetes.hostResolver':                undefined,
+        'containerEngine.imageAllowList.enabled': undefined,
       },
       extras,
     ));


### PR DESCRIPTION
The proxy functionality doesn't seem stable enough to use it all the time, so it should only be enabled when it is actually used/needed.

Fixes #3604