### PR TITLE
Add Experimental to Allowed Image Patterns label

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -269,7 +269,7 @@ containerEngine:
       description: Namespaces for container images; use with nerdctl.
 
 allowedImages:
-  label: Allowed Image Patterns
+  label: Allowed Image Patterns (Experimental)
   patterns:
     placeholder: Type the image pattern
   errors:


### PR DESCRIPTION
This adds "Experimental" to the label for Allowed Image Patterns.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>