### PR TITLE
Fix typings for Electron IPC

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -548,12 +548,14 @@ ipcMainProxy.handle('service-fetch', (_, namespace) => {
 });
 
 ipcMainProxy.handle('service-forward', async(_, service, state) => {
+  const namespace = service.namespace ?? 'default';
+
   if (state) {
     const hostPort = service.listenPort ?? 0;
 
-    await k8smanager.kubeBackend.forwardPort(service.namespace, service.name, service.port, hostPort);
+    await k8smanager.kubeBackend.forwardPort(namespace, service.name, service.port, hostPort);
   } else {
-    await k8smanager.kubeBackend.cancelForward(service.namespace, service.name, service.port);
+    await k8smanager.kubeBackend.cancelForward(namespace, service.name, service.port);
   }
 });
 

--- a/pkg/rancher-desktop/backend/client.ts
+++ b/pkg/rancher-desktop/backend/client.ts
@@ -172,7 +172,7 @@ export type ServiceEntry = {
   /** The name of the port within the service. */
   portName?: string;
   /** The internal port number (or name) of the service. */
-  port?: number | string;
+  port: number | string;
   /** The forwarded port on localhost (on the host), if any. */
   listenPort?: number;
 };

--- a/pkg/rancher-desktop/components/BackendProgress.vue
+++ b/pkg/rancher-desktop/components/BackendProgress.vue
@@ -19,11 +19,11 @@
 </template>
 
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 import Component from 'vue-class-component';
 
 import Progress from '@pkg/components/Progress.vue';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 @Component({ components: { Progress } })
 class BackendProgress extends Vue {

--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -83,10 +83,10 @@
 
 import SortableTable from '@pkg/components/SortableTable';
 import { Card, Checkbox } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 
 import ImagesOutputWindow from '@pkg/components/ImagesOutputWindow.vue';
 import getImageOutputCuller from '@pkg/utils/imageOutputCuller';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { parseSi } from '@pkg/utils/units';
 
 export default {

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -1,8 +1,8 @@
 <script>
 import { Banner } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 
 import LoadingIndicator from '@pkg/components/LoadingIndicator.vue';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   name: 'images-output-window',

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 
 import { Checkbox } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
 import { VersionEntry } from '@pkg/backend/k8s';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
 import type { PropType } from 'vue';

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -1,5 +1,4 @@
-import { ipcRenderer } from 'electron';
-
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { parseDocsVersion } from '@pkg/utils/version';
 
 const baseUrl = 'https://docs.rancherdesktop.io';

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -14,7 +14,6 @@
 
 <script>
 
-import { ipcRenderer } from 'electron';
 import { mapGetters, mapState } from 'vuex';
 
 import ActionMenu from '@pkg/components/ActionMenu.vue';
@@ -22,6 +21,7 @@ import BackendProgress from '@pkg/components/BackendProgress.vue';
 import Header from '@pkg/components/Header.vue';
 import Nav from '@pkg/components/Nav.vue';
 import TheTitle from '@pkg/components/TheTitle.vue';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   name:       'App',

--- a/pkg/rancher-desktop/layouts/dialog.vue
+++ b/pkg/rancher-desktop/layouts/dialog.vue
@@ -18,8 +18,9 @@
 </template>
 
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 export default Vue.extend({
   head() {
     // If dark-mode is set to auto (follow system-prefs) this is all we need

--- a/pkg/rancher-desktop/layouts/preferences.vue
+++ b/pkg/rancher-desktop/layouts/preferences.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name: 'preferences-layout',

--- a/pkg/rancher-desktop/pages/DenyRoot.vue
+++ b/pkg/rancher-desktop/pages/DenyRoot.vue
@@ -20,8 +20,9 @@
 </template>
 
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   layout: 'dialog',

--- a/pkg/rancher-desktop/pages/Dialog.vue
+++ b/pkg/rancher-desktop/pages/Dialog.vue
@@ -2,8 +2,9 @@
 import os from 'os';
 
 import { Checkbox } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name:       'rd-dialog',

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -62,15 +62,15 @@
 import os from 'os';
 
 import { Checkbox } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
 import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
-import { Settings } from '@pkg/config/settings';
+import type { Settings, ContainerEngine } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   components: {
@@ -148,7 +148,7 @@ export default Vue.extend({
       this.onChange();
       window.close();
     },
-    onChangeEngine(desiredEngine: string) {
+    onChangeEngine(desiredEngine: ContainerEngine) {
       try {
         ipcRenderer.invoke(
           'settings-write',

--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -35,11 +35,10 @@
 
 <script>
 
-import { ipcRenderer } from 'electron';
-
 import TelemetryOptIn from '@pkg/components/TelemetryOptIn.vue';
 import UpdateStatus from '@pkg/components/UpdateStatus.vue';
 import { defaultSettings } from '@pkg/config/settings';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   name:       'General',

--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -17,13 +17,13 @@
 </template>
 
 <script>
-import { ipcRenderer } from 'electron';
 import _ from 'lodash';
 import { mapGetters } from 'vuex';
 
 import { State as K8sState } from '@pkg/backend/backend';
 import Images from '@pkg/components/Images.vue';
 import { defaultSettings } from '@pkg/config/settings';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   components: { Images },

--- a/pkg/rancher-desktop/pages/KubernetesError.vue
+++ b/pkg/rancher-desktop/pages/KubernetesError.vue
@@ -38,8 +38,9 @@
 <script lang="ts">
 import os from 'os';
 
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   layout: 'dialog',

--- a/pkg/rancher-desktop/pages/LegacyIntegrationNotification.vue
+++ b/pkg/rancher-desktop/pages/LegacyIntegrationNotification.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import paths from '@pkg/utils/paths';
 
 export default Vue.extend({

--- a/pkg/rancher-desktop/pages/PathUpdate.vue
+++ b/pkg/rancher-desktop/pages/PathUpdate.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
 import type { Settings } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name:       'path-update',

--- a/pkg/rancher-desktop/pages/PortForwarding.vue
+++ b/pkg/rancher-desktop/pages/PortForwarding.vue
@@ -21,12 +21,12 @@
 </template>
 
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
 import type { ServiceEntry } from '@pkg/backend/k8s';
 import PortForwarding from '@pkg/components/PortForwarding.vue';
 import { defaultSettings, Settings } from '@pkg/config/settings';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   components: { PortForwarding },
@@ -138,7 +138,9 @@ export default Vue.extend({
 
     handleUpdatePortForward(): void {
       this.errorMessage = null;
-      ipcRenderer.invoke('service-forward', this.serviceBeingEdited, true);
+      if (this.serviceBeingEdited) {
+        ipcRenderer.invoke('service-forward', this.serviceBeingEdited, true);
+      }
       this.serviceBeingEdited = null;
     },
 

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import os from 'os';
 
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
@@ -11,6 +10,7 @@ import PreferencesHeader from '@pkg/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@pkg/components/Preferences/ModalNav.vue';
 import type { TransientSettings } from '@pkg/config/transientSettings';
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 import { preferencesNavItems } from '@pkg/window/preferences';
 

--- a/pkg/rancher-desktop/pages/SudoPrompt.vue
+++ b/pkg/rancher-desktop/pages/SudoPrompt.vue
@@ -35,8 +35,9 @@
 
 <script lang="ts">
 import { Checkbox } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 type SudoReason = 'networking' | 'docker-socket';
 

--- a/pkg/rancher-desktop/pages/images/add.vue
+++ b/pkg/rancher-desktop/pages/images/add.vue
@@ -32,13 +32,12 @@
 
 <script>
 
-import { ipcRenderer } from 'electron';
-
 import Alert from '@pkg/components/Alert.vue';
 import ImageAddTabs from '@pkg/components/ImageAddTabs.vue';
 import ImagesFormAdd from '@pkg/components/ImagesFormAdd.vue';
 import ImagesOutputWindow from '@pkg/components/ImagesOutputWindow.vue';
 import getImageOutputCuller from '@pkg/utils/imageOutputCuller';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   components: {

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -37,12 +37,12 @@
 <script>
 
 import { Banner } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 
 import ImagesOutputWindow from '@pkg/components/ImagesOutputWindow.vue';
 import ImagesScanResults from '@pkg/components/ImagesScanResults.vue';
 import LoadingIndicator from '@pkg/components/LoadingIndicator.vue';
 import getImageOutputCuller from '@pkg/utils/imageOutputCuller';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   name: 'images-scan-details',

--- a/pkg/rancher-desktop/store/applicationSettings.ts
+++ b/pkg/rancher-desktop/store/applicationSettings.ts
@@ -1,9 +1,9 @@
-import { ipcRenderer } from 'electron';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
 import { load as loadSettings } from '@pkg/config/settings';
 import type { PathManagementStrategy } from '@pkg/integrations/pathManager';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 /**
  * State is the type of the state we are maintaining in this store.

--- a/pkg/rancher-desktop/store/credentials.ts
+++ b/pkg/rancher-desktop/store/credentials.ts
@@ -1,8 +1,8 @@
-import { ipcRenderer } from 'electron';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 interface CredentialsState {
   credentials: ServerState;

--- a/pkg/rancher-desktop/store/k8sManager.js
+++ b/pkg/rancher-desktop/store/k8sManager.js
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export const state = () => ({ k8sState: ipcRenderer.sendSync('k8s-state') });
 

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -1,10 +1,10 @@
-import { ipcRenderer } from 'electron';
 import _ from 'lodash';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
 import { defaultSettings, Settings } from '@pkg/config/settings';
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { RecursiveKeys, RecursivePartial, RecursiveTypes } from '@pkg/utils/typeUtils';
 
 import type { GetterTree } from 'vuex';

--- a/pkg/rancher-desktop/utils/ipcRenderer.ts
+++ b/pkg/rancher-desktop/utils/ipcRenderer.ts
@@ -1,0 +1,43 @@
+/**
+ * This is a typed version of Electron.ipcRenderer
+ */
+
+import { ipcRenderer as ipcRendererImpl } from 'electron';
+
+import { IpcMainEvents, IpcMainInvokeEvents, IpcRendererEvents } from '@pkg/typings/electron-ipc';
+
+interface IpcRenderer {
+  on<eventName extends keyof IpcRendererEvents>(
+    channel: eventName,
+    listener: (event: Electron.IpcRendererEvent, ...args: globalThis.Parameters<IpcRendererEvents[eventName]>) => void
+  ): this;
+
+  once<eventName extends keyof IpcRendererEvents>(
+    channel: eventName,
+    listener: (event: Electron.IpcRendererEvent, ...args: globalThis.Parameters<IpcRendererEvents[eventName]>) => void
+  ): this;
+
+  removeListener<eventName extends keyof IpcRendererEvents>(
+    channel: eventName,
+    listener: (event: Electron.IpcRendererEvent, ...args: globalThis.Parameters<IpcRendererEvents[eventName]>) => void
+  ): this;
+
+  removeAllListeners<eventName extends keyof IpcRendererEvents>(channel?: eventName): this;
+
+  send<eventName extends keyof IpcMainEvents>(channel: eventName, ...args: Parameters<IpcMainEvents[eventName]>): void;
+  sendSync<eventName extends keyof IpcMainEvents>(channel: eventName, ...args: Parameters<IpcMainEvents[eventName]>): void;
+
+  // When the renderer side is implement in JavaScript (rather than TypeScript),
+  // the type checking for arguments seems to fail and always prefers the
+  // generic overload (which we want to avoid) rather than the specific overload
+  // we provide here.  Until we convert all of the Vue components to TypeScript,
+  // for now we will need to forego checking the arguments.
+  invoke<eventName extends keyof IpcMainInvokeEvents>(
+    channel: eventName,
+    ...args: Parameters<IpcMainInvokeEvents[eventName]>
+  ): Promise<ReturnType<IpcMainInvokeEvents[eventName]>>;
+}
+
+export const ipcRenderer: IpcRenderer = ipcRendererImpl as unknown as IpcRenderer;
+
+export default ipcRenderer;


### PR DESCRIPTION
This fixes our typing code for Electron IPC stuff (`ipcMain`, `ipcRenderer`) to ensure we don't introduce typos.

For `ipcRenderer`, this means adding a stub to change the import type.

Fixes #1961