### PR TITLE
Preserve whitespace in dot files when adding and removing managed lines.

### DIFF
--- a/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
@@ -23,110 +23,117 @@ afterEach(async() => {
   }
 });
 
-test("Create file when true and it doesn't yet exist", async() => {
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], true);
-  const content = await fs.promises.readFile(rcFilePath, 'utf8');
-  const expectedContents = `${ START_LINE }
+describe('managedDotFiles', () => {
+  test("Create file when true and it doesn't yet exist", async() => {
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], true);
+    const content = await fs.promises.readFile(rcFilePath, 'utf8');
+    const expectedContents = `${ START_LINE }
 ${ TEST_LINE_1 }
-${ END_LINE }`;
+${ END_LINE }
+`;
 
-  expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
-});
+    expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
+  });
 
-test('Delete file when false and it contains only the managed lines', async() => {
-  const data = `${ START_LINE }
+  test('Delete file when false and it contains only the managed lines', async() => {
+    const data = `${ START_LINE }
 ${ TEST_LINE_1 }
-${ END_LINE }`;
+${ END_LINE }
+`;
 
-  await fs.promises.writeFile(rcFilePath, data, { mode: 0o644 });
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
-  expect(fs.promises.readFile(rcFilePath, 'utf8')).rejects.toHaveProperty('code', 'ENOENT');
-});
+    await fs.promises.writeFile(rcFilePath, data, { mode: 0o644 });
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
+    expect(fs.promises.readFile(rcFilePath, 'utf8')).rejects.toHaveProperty('code', 'ENOENT');
+  });
 
-test('Put lines in file that exists and has content', async() => {
-  const data = 'this is already present in the file\n';
+  test('Put lines in file that exists and has content', async() => {
+    const data = 'this is already present in the file\n';
 
-  await fs.promises.writeFile(rcFilePath, data, { mode: 0o644 });
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], true);
-  const content = await fs.promises.readFile(rcFilePath, 'utf8');
-  const expectedContents = `${ data }
+    await fs.promises.writeFile(rcFilePath, data, { mode: 0o644 });
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], true);
+    const content = await fs.promises.readFile(rcFilePath, 'utf8');
+    const expectedContents = `${ data }
 ${ START_LINE }
 ${ TEST_LINE_1 }
-${ END_LINE }`;
+${ END_LINE }
+`;
 
-  expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
-});
+    expect(content.replace(/\r\n/g, '\n')).toBe(expectedContents.replace(/\r\n/g, '\n'));
+  });
 
-test('Remove lines from file that exists and has content', async() => {
-  const unmanagedContents = 'this is already present in the file\n';
-  const contents = `${ unmanagedContents }
+  test('Remove lines from file that exists and has content', async() => {
+    const unmanagedContents = 'this is already present in the file\n';
+    const contents = `${ unmanagedContents }
 ${ START_LINE }
 ${ TEST_LINE_1 }
-${ END_LINE }`;
+${ END_LINE }
+`;
 
-  await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
-  const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
+    await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
+    const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
 
-  expect(newContents.replace(/\r\n/g, '\n')).toBe(unmanagedContents.replace(/\r\n/g, '\n'));
-});
+    expect(newContents.replace(/\r\n/g, '\n')).toBe(unmanagedContents.replace(/\r\n/g, '\n'));
+  });
 
-test('Update managed lines', async() => {
-  const topUnmanagedContents = 'this is at the top of the file\n';
-  const bottomUnmanagedContents = 'this is at the bottom of the file\n';
-  const contents = `${ topUnmanagedContents }
+  test('Update managed lines', async() => {
+    const topUnmanagedContents = 'this is at the top of the file\n';
+    const bottomUnmanagedContents = 'this is at the bottom of the file\n';
+    const contents = `${ topUnmanagedContents }
 ${ START_LINE }
 ${ TEST_LINE_1 }
 ${ END_LINE }
 ${ bottomUnmanagedContents }`;
 
-  await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1, TEST_LINE_2], true);
-  const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
-  const expectedNewContents = `${ topUnmanagedContents }
+    await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1, TEST_LINE_2], true);
+    const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
+    const expectedNewContents = `${ topUnmanagedContents }
 ${ START_LINE }
 ${ TEST_LINE_1 }
 ${ TEST_LINE_2 }
 ${ END_LINE }
 ${ bottomUnmanagedContents }`;
 
-  expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents.replace(/\r\n/g, '\n'));
-});
+    expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents.replace(/\r\n/g, '\n'));
+  });
 
-test('Remove managed lines from between unmanaged lines', async() => {
-  const topUnmanagedContents = 'this is at the top of the file\n';
-  const bottomUnmanagedContents = 'this is at the bottom of the file\n';
-  const contents = `${ topUnmanagedContents }
+  test('Remove managed lines from between unmanaged lines', async() => {
+    const topUnmanagedContents = 'this is at the top of the file\n';
+    const bottomUnmanagedContents = 'this is at the bottom of the file\n';
+    const contents = `${ topUnmanagedContents }
 ${ START_LINE }
 ${ TEST_LINE_1 }
 ${ END_LINE }
 ${ bottomUnmanagedContents }`;
 
-  await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
-  const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
-  const expectedNewContents = `${ topUnmanagedContents }
+    await fs.promises.writeFile(rcFilePath, contents, { mode: 0o644 });
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
+    const newContents = await fs.promises.readFile(rcFilePath, 'utf8');
+    const expectedNewContents = `${ topUnmanagedContents }
 ${ bottomUnmanagedContents }`;
 
-  expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents);
-});
+    expect(newContents.replace(/\r\n/g, '\n')).toBe(expectedNewContents);
+  });
 
-test('File mode should not be changed when updating a file', async() => {
-  const unmanagedContents = 'this is already present in the file\n';
-  const contents = `${ unmanagedContents }
+  test('File mode should not be changed when updating a file', async() => {
+    const unmanagedContents = 'this is already present in the file\n';
+    const contents = `${ unmanagedContents }
 ${ START_LINE }
 ${ TEST_LINE_1 }
-${ END_LINE }`;
+${ END_LINE }
+`;
 
-  await fs.promises.writeFile(rcFilePath, contents, { mode: 0o623 });
-  const oldFileMode = (await fs.promises.stat(rcFilePath)).mode;
+    await fs.promises.writeFile(rcFilePath, contents, { mode: 0o623 });
+    const oldFileMode = (await fs.promises.stat(rcFilePath)).mode;
 
-  await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
-  const newFileMode = (await fs.promises.stat(rcFilePath)).mode;
+    await manageLinesInFile(rcFilePath, [TEST_LINE_1], false);
+    const newFileMode = (await fs.promises.stat(rcFilePath)).mode;
 
-  expect(newFileMode).toBe(oldFileMode);
-});
+    expect(newFileMode).toBe(oldFileMode);
+  });
 
-test('Do nothing when desiredPresent is false and file does not exist', async() => {
-  await expect(manageLinesInFile(rcFilePath, [TEST_LINE_1], false)).resolves.not.toThrow();
+  test('Do nothing when desiredPresent is false and file does not exist', async() => {
+    await expect(manageLinesInFile(rcFilePath, [TEST_LINE_1], false)).resolves.not.toThrow();
+  });
 });

--- a/src/go/rdctl/pkg/factoryreset/delete_data_test.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_test.go
@@ -1,0 +1,197 @@
+//go:test !windows
+// +test !windows
+
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package factoryreset
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+/**
+ * Copy all the dotfiles we care about into TMP/rd-dotfiles-copies and TMP/rd-dotfiles-working
+ * Add fake management blocks to each file in TMP/rd-dotfiles-working
+ * One of the files deliberately has no newline between its last line and the management block
+ * Then call the removePathManagement() function on the working dot files
+ * Then verify they're identical to the copied files
+ * Clean up the temp dirs if everything matched
+ */
+
+var tempOriginalDotfilesDir string
+var tempWorkingDotfilesDir string
+
+var filenames []string
+var predefinedContents map[string]string = map[string]string{
+	"ends-with-text-eol":         "# line1a\n# line2a\n",
+	"ends-with-blank-eol":        "# line1b\n# line2b\n\n",
+	"ends-with-no-eol":           "# line1c\n# line2c",
+	"will-have-no-extra-newline": "# line1d\n# line2d\n",
+	"content-no-EOF-newline":     "# line1d\n# line2d\n",
+	"empty-file-no-EOF-newline":  "",
+	"empty-file":                 "",
+}
+
+var expectedAfterContents map[string]string = map[string]string{
+	"ends-with-no-eol": "# line1c\n# line2c\n",
+}
+
+func getExpectedContents(filename string) (string, error) {
+	text, ok := expectedAfterContents[filename]
+	if ok {
+		return text, nil
+	}
+	text, ok = predefinedContents[filename]
+	if ok {
+		return text, nil
+	}
+	return "", fmt.Errorf("Can't find contents for dotfile %s", filename)
+}
+
+func populateFiles() error {
+	for baseName, text := range predefinedContents {
+		fullPath := path.Join(tempWorkingDotfilesDir, baseName)
+		f, err := os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		f.Write([]byte(text))
+		filenames = append(filenames, fullPath)
+		f.Close()
+		// And write the data into the original dir for reference
+		fullPath = path.Join(tempOriginalDotfilesDir, baseName)
+		f, err = os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		f.Write([]byte(text))
+		f.Close()
+	}
+	return nil
+}
+
+func setup() error {
+	tempOriginalDotfilesDir = path.Join(os.TempDir(), "rd-dotfiles-copies")
+	err := os.Mkdir(tempOriginalDotfilesDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	tempWorkingDotfilesDir = path.Join(os.TempDir(), "rd-dotfiles-working")
+	err = os.Mkdir(tempWorkingDotfilesDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return populateFiles()
+}
+
+func shutdown() {
+	for _, dir := range []string{tempOriginalDotfilesDir, tempWorkingDotfilesDir} {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			fmt.Printf("Failed to delete tmpdir %s: %s\n", dir, err)
+			break
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	if err := setup(); err != nil {
+		fmt.Println("Failed to setup...")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	if code != 0 {
+		os.Exit(code)
+	}
+	shutdown()
+}
+
+const startTarget = "### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)"
+const endTarget = "### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)"
+
+func addBlock(dotFile string) error {
+	byteContents, err := os.ReadFile(dotFile)
+	if err != nil {
+		return err
+	}
+	contents := string(byteContents)
+	startPoint := strings.LastIndex(contents, startTarget)
+	if startPoint >= 0 {
+		return nil
+	}
+	// Overwrite the file...
+	filestat, err := os.Stat(dotFile)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(dotFile, os.O_APPEND|os.O_WRONLY, filestat.Mode())
+	if err != nil {
+		return err
+	}
+	if len(contents) > 0 && contents[len(contents)-1] != '\n' {
+		f.Write([]byte("\n"))
+	}
+	if len(contents) > 0 && !strings.HasSuffix(dotFile, "will-have-no-extra-newline") {
+		f.Write([]byte("\n"))
+	}
+	f.Write([]byte(startTarget))
+	f.Write([]byte("\n"))
+	f.Write([]byte("# SHAZBAT!\n"))
+	f.Write([]byte(endTarget))
+	if !strings.HasSuffix(dotFile, "no-EOF-newline") {
+		f.Write([]byte("\n"))
+	}
+	return f.Close()
+}
+
+func TestAddManagedBlock(t *testing.T) {
+	for _, path := range filenames {
+		assert.NoError(t, addBlock(path))
+	}
+	output, err := exec.Command("grep", append([]string{"-l", "MANAGED BY RANCHER DESKTOP"}, filenames...)...).CombinedOutput()
+	assert.NoError(t, err)
+	assert.Equal(t, len(strings.Split(string(output), "\n"))-1, len(filenames))
+}
+
+func verifyMgmtRemoved(t *testing.T, dotFile string) {
+	baseName := path.Base(dotFile)
+	if strings.HasPrefix(baseName, "empty-file") {
+		_, err := os.Stat(dotFile)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		return
+	}
+	byteContents, err := os.ReadFile(dotFile)
+	assert.NoError(t, err)
+	expectedContents, err := getExpectedContents(path.Base(dotFile))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedContents, string(byteContents))
+}
+
+func TestRemoveManagedBlock(t *testing.T) {
+	modifiedFileList := append(filenames, path.Join(tempWorkingDotfilesDir, ".no-such-file"))
+	assert.NoError(t, removePathManagement(modifiedFileList))
+	for _, dotFile := range filenames {
+		verifyMgmtRemoved(t, dotFile)
+	}
+}


### PR DESCRIPTION
Fixes #3633

1. If we're adding a block at the end of the file, ensure the block ends with a newline

2. Normally when adding a block, it's preceded by a new empty line. On removal, if the block is preceded by an empty line, remove it. Otherwise, don't.  This handles files where the user has removed the empty line before the RD block.

Signed-off-by: Eric Promislow <epromislow@suse.com>