### PR TITLE
nerdctl: Fix nerdctl cp

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/nerdctl
+++ b/pkg/rancher-desktop/assets/scripts/nerdctl
@@ -3,4 +3,16 @@ export CONTAINERD_ADDRESS=/run/k3s/containerd/containerd.sock
 if [ -f /usr/local/openresty/nginx/conf/allowed-images.conf ]; then
   export HTTPS_PROXY=http://127.0.0.1:3128
 fi
+
+# On WSL, we need to enter the correct pid &c. namespace for nerdctl to work
+# correctly.
+
+if [ -r /run/wsl-init.pid ]; then
+  parent="$(cat /run/wsl-init.pid)"
+  pid="$(ps -o pid,ppid,comm | awk '$2 == "'"${parent}"'" && $3 == "init" { print $1 }')"
+  if [ -n "${pid}" ]; then
+    exec /usr/bin/nsenter -p -m -n -t "${pid}" /usr/local/libexec/nerdctl/nerdctl "$@"
+  fi
+fi
+
 exec /usr/local/libexec/nerdctl/nerdctl "$@"

--- a/src/go/nerdctl-stub/command_handlers.go
+++ b/src/go/nerdctl-stub/command_handlers.go
@@ -3,9 +3,21 @@ package main
 import (
 	"log"
 	"regexp"
+	"strings"
 )
 
 // This file contains handlers for specific commands.
+
+// Run the given cleanup functions; this is meant for aborting a command handler
+// early.
+func runCleanups(cleanups []cleanupFunc) {
+	for _, cleanup := range cleanups {
+		cleanupErr := cleanup()
+		if cleanupErr != nil {
+			log.Printf("Error cleaning up: %s", cleanupErr)
+		}
+	}
+}
 
 // imageBuildHandler handles `nerdctl image build`
 func imageBuildHandler(c *commandDefinition, args []string) (*parsedArgs, error) {
@@ -24,13 +36,48 @@ func imageBuildHandler(c *commandDefinition, args []string) (*parsedArgs, error)
 	}
 	newPath, cleanups, err := filePathArgHandler(args[0])
 	if err != nil {
-		for _, cleanup := range cleanups {
-			cleanupErr := cleanup()
-			if cleanupErr != nil {
-				log.Printf("Error cleaning up: %s", cleanupErr)
-			}
-		}
+		runCleanups(cleanups)
 		return nil, err
 	}
 	return &parsedArgs{args: append([]string{newPath}, args[1:]...), cleanup: cleanups}, nil
+}
+
+// containerCopyHandler handles `nerdctl container cp`
+func containerCopyHandler(c *commandDefinition, args []string) (*parsedArgs, error) {
+	var resultArgs []string
+	var cleanups []cleanupFunc
+
+	// Positional arguments `nerdctl container cp` are all paths, whether inside
+	// the container or outside.
+
+	for _, arg := range args {
+		if arg == "-" {
+			// flag for stdin/stdout; don't need to deal with that.
+			resultArgs = append(resultArgs, arg)
+			continue
+		}
+		// There are three possible cases for the arg:
+		// - There are no `:`s in the string -- a host-side relative path.
+		// - Any single character before `:` -- assume a drive letter.
+		// - Any other sequence before `:` -- container specification.
+		// Note that the latter case means a container with a single-letter name
+		// will not correctly; but that's probably acceptable for now.
+		parts := strings.SplitN(arg, ":", 2)
+		if len(parts) != 2 || len(parts[0]) == 1 {
+			// This is a host-side file path (first two cases above).
+			newPath, newCleanups, err := filePathArgHandler(arg)
+			if err != nil {
+				cleanups = append(cleanups, newCleanups...)
+				runCleanups(cleanups)
+				return nil, err
+			}
+			resultArgs = append(resultArgs, newPath)
+		} else {
+			// This is a container-side path (third case above).
+			// Just pass it in to nerdctl directly.
+			resultArgs = append(resultArgs, arg)
+		}
+	}
+
+	return &parsedArgs{args: resultArgs, cleanup: cleanups}, nil
 }

--- a/src/go/nerdctl-stub/command_handlers.go
+++ b/src/go/nerdctl-stub/command_handlers.go
@@ -1,26 +1,15 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"regexp"
 	"strings"
 )
 
 // This file contains handlers for specific commands.
 
-// Run the given cleanup functions; this is meant for aborting a command handler
-// early.
-func runCleanups(cleanups []cleanupFunc) {
-	for _, cleanup := range cleanups {
-		cleanupErr := cleanup()
-		if cleanupErr != nil {
-			log.Printf("Error cleaning up: %s", cleanupErr)
-		}
-	}
-}
-
 // imageBuildHandler handles `nerdctl image build`
-func imageBuildHandler(c *commandDefinition, args []string) (*parsedArgs, error) {
+func imageBuildHandler(c *commandDefinition, args []string, argHandlers argHandlersType) (*parsedArgs, error) {
 	// The first argument is the directory to build; the rest are ignored.
 	if len(args) < 1 {
 		// This will return an error
@@ -34,7 +23,7 @@ func imageBuildHandler(c *commandDefinition, args []string) (*parsedArgs, error)
 		// input is a URL
 		return &parsedArgs{args: args}, nil
 	}
-	newPath, cleanups, err := filePathArgHandler(args[0])
+	newPath, cleanups, err := argHandlers.filePathArgHandler(args[0])
 	if err != nil {
 		runCleanups(cleanups)
 		return nil, err
@@ -42,40 +31,119 @@ func imageBuildHandler(c *commandDefinition, args []string) (*parsedArgs, error)
 	return &parsedArgs{args: append([]string{newPath}, args[1:]...), cleanup: cleanups}, nil
 }
 
+// hostPathResult is the return value of a hostPathDeterminerFunc that is used
+// in containerCopyHandler for determining which argument is the host path that
+// must be munged.
+type hostPathResult int
+
+const (
+	hostPathUnknown = hostPathResult(iota)
+	hostPathCurrent = hostPathResult(iota)
+	hostPathOther   = hostPathResult(iota)
+	hostPathNeither = hostPathResult(iota)
+)
+
 // containerCopyHandler handles `nerdctl container cp`
-func containerCopyHandler(c *commandDefinition, args []string) (*parsedArgs, error) {
+func containerCopyHandler(c *commandDefinition, args []string, argHandlers argHandlersType) (*parsedArgs, error) {
 	var resultArgs []string
 	var cleanups []cleanupFunc
+	var paths []string
 
 	// Positional arguments `nerdctl container cp` are all paths, whether inside
 	// the container or outside.
 
 	for _, arg := range args {
-		if arg == "-" {
-			// flag for stdin/stdout; don't need to deal with that.
+		if arg == "-" || !strings.HasPrefix(arg, "-") {
+			// If the arg is "-" (stdin/stdout) or doesn't start with -, it's a path.
+			paths = append(paths, arg)
+		} else {
 			resultArgs = append(resultArgs, arg)
-			continue
 		}
-		// There are three possible cases for the arg:
-		// - There are no `:`s in the string -- a host-side relative path.
-		// - Any single character before `:` -- assume a drive letter.
-		// - Any other sequence before `:` -- container specification.
-		// Note that the latter case means a container with a single-letter name
-		// will not correctly; but that's probably acceptable for now.
-		parts := strings.SplitN(arg, ":", 2)
-		if len(parts) != 2 || len(parts[0]) == 1 {
-			// This is a host-side file path (first two cases above).
-			newPath, newCleanups, err := filePathArgHandler(arg)
+	}
+
+	if len(paths) != 2 {
+		// We should have exactly one source and one destination... just fail
+		runCleanups(cleanups)
+		return nil, fmt.Errorf("accepts 2 args, received %d", len(paths))
+	}
+
+	hostPathDeterminerFuncs := []func(i int, p string) (hostPathResult, error){
+		func(i int, p string) (hostPathResult, error) {
+			if p == "-" {
+				// If one argument is "-", the other must be a container path, so
+				// neither needs to be modified.
+				return hostPathNeither, nil
+			}
+			return hostPathUnknown, nil
+		},
+		func(i int, p string) (hostPathResult, error) {
+			colon := strings.Index(p, ":")
+			if colon < 1 {
+				// If there's no colon in the path specification at all, or if the
+				// string starts with a colon (which is invalid), then this must not be
+				// a container path (and therefore the other one is).
+				return hostPathCurrent, nil
+			}
+			return hostPathUnknown, nil
+		},
+		func(i int, p string) (hostPathResult, error) {
+			colon := strings.Index(p, ":")
+			if colon > 1 {
+				// There's multiple characters before the first colon; this is a container
+				// path specification (foo:/path/in/container), so the other must be a
+				// host path specification.
+				return hostPathOther, nil
+			}
+			return hostPathUnknown, nil
+		},
+		func(i int, p string) (hostPathResult, error) {
+			colon := strings.Index(p, ":")
+			if colon != 1 {
+				// Shouldn't get here -- one of the two previous functions should have
+				// found something already.
+				panic(fmt.Sprintf("Expected path %q to start with a character followed by a colon!", p))
+			}
+			// Fall back: the first element should be treated as the container path.
+			if i == 0 {
+				return hostPathOther, nil
+			}
+			return hostPathCurrent, nil
+		},
+	}
+
+functionLoop:
+	for _, f := range hostPathDeterminerFuncs {
+		for i, p := range paths {
+			result, err := f(i, p)
+			if err != nil {
+				return nil, err
+			}
+			hostPathIndex := i
+			switch result {
+			case hostPathNeither:
+				resultArgs = append(resultArgs, paths...)
+				break functionLoop
+			case hostPathUnknown:
+				continue
+			case hostPathOther:
+				hostPathIndex = 1 - i
+			}
+
+			// If we reach here, we found the host path to munge.
+			if hostPathIndex == 1 {
+				resultArgs = append(resultArgs, paths[0])
+			}
+			newPath, newCleanups, err := argHandlers.filePathArgHandler(paths[hostPathIndex])
 			if err != nil {
 				cleanups = append(cleanups, newCleanups...)
 				runCleanups(cleanups)
 				return nil, err
 			}
 			resultArgs = append(resultArgs, newPath)
-		} else {
-			// This is a container-side path (third case above).
-			// Just pass it in to nerdctl directly.
-			resultArgs = append(resultArgs, arg)
+			if hostPathIndex != 1 {
+				resultArgs = append(resultArgs, paths[1])
+			}
+			break functionLoop
 		}
 	}
 

--- a/src/go/nerdctl-stub/command_handlers.go
+++ b/src/go/nerdctl-stub/command_handlers.go
@@ -74,36 +74,36 @@ func containerCopyHandler(c *commandDefinition, args []string, argHandlers argHa
 		return nil, err
 	}
 
-	hostPathDeterminerFuncs := []func(i int, p string) (hostPathResult, error){
-		func(i int, p string) (hostPathResult, error) {
+	hostPathDeterminerFuncs := []func(i int, p string) hostPathResult{
+		func(i int, p string) hostPathResult {
 			if p == "-" {
 				// If one argument is "-", the other must be a container path, so
 				// neither needs to be modified.
-				return hostPathNeither, nil
+				return hostPathNeither
 			}
-			return hostPathUnknown, nil
+			return hostPathUnknown
 		},
-		func(i int, p string) (hostPathResult, error) {
+		func(i int, p string) hostPathResult {
 			colon := strings.Index(p, ":")
 			if colon < 1 {
 				// If there's no colon in the path specification at all, or if the
 				// string starts with a colon (which is invalid), then this must not be
 				// a container path (and therefore the other one is).
-				return hostPathCurrent, nil
+				return hostPathCurrent
 			}
-			return hostPathUnknown, nil
+			return hostPathUnknown
 		},
-		func(i int, p string) (hostPathResult, error) {
+		func(i int, p string) hostPathResult {
 			colon := strings.Index(p, ":")
 			if colon > 1 {
 				// There's multiple characters before the first colon; this is a container
 				// path specification (foo:/path/in/container), so the other must be a
 				// host path specification.
-				return hostPathOther, nil
+				return hostPathOther
 			}
-			return hostPathUnknown, nil
+			return hostPathUnknown
 		},
-		func(i int, p string) (hostPathResult, error) {
+		func(i int, p string) hostPathResult {
 			colon := strings.Index(p, ":")
 			if colon != 1 {
 				// Shouldn't get here -- one of the two previous functions should have
@@ -112,19 +112,16 @@ func containerCopyHandler(c *commandDefinition, args []string, argHandlers argHa
 			}
 			// Fall back: the first element should be treated as the container path.
 			if i == 0 {
-				return hostPathOther, nil
+				return hostPathOther
 			}
-			return hostPathCurrent, nil
+			return hostPathCurrent
 		},
 	}
 
 functionLoop:
 	for _, f := range hostPathDeterminerFuncs {
 		for i, p := range paths {
-			result, err := f(i, p)
-			if err != nil {
-				return nil, err
-			}
+			result := f(i, p)
 			hostPathIndex := i
 			switch result {
 			case hostPathNeither:

--- a/src/go/nerdctl-stub/command_handlers_test.go
+++ b/src/go/nerdctl-stub/command_handlers_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerCopyHandler(t *testing.T) {
+	t.Parallel()
+	type testCaseType struct {
+		input    []string
+		expected []string
+		err      string
+	}
+
+	testCases := []testCaseType{
+		{
+			input:    []string{"-", "c:file"},
+			expected: []string{"-", "c:file"},
+		},
+		{
+			input:    []string{"c:file", "-"},
+			expected: []string{"c:file", "-"},
+		},
+		{
+			input:    []string{"input", "c:file"},
+			expected: []string{"<input>", "c:file"},
+		},
+		{
+			input:    []string{"c:file", "input"},
+			expected: []string{"c:file", "<input>"},
+		},
+		{
+			input:    []string{"container:path", "c:file"},
+			expected: []string{"container:path", "<c:file>"},
+		},
+		{
+			input:    []string{"c:file", "container:path"},
+			expected: []string{"<c:file>", "container:path"},
+		},
+		{
+			// Check fallback: if ambiguous, assume copying out of a container.
+			input:    []string{"c:file", "d:file"},
+			expected: []string{"c:file", "<d:file>"},
+		},
+		{
+			input: []string{"missing argument"},
+			err:   "accepts 2 args, received 1",
+		},
+		{
+			input: []string{"missing positional argument", "-flag"},
+			err:   "accepts 2 args, received 1",
+		},
+		{
+			input:    []string{"-flag1", "c:file", "-flag2", "input", "-flag3"},
+			expected: []string{"-flag1", "-flag2", "-flag3", "c:file", "<input>"},
+		},
+	}
+
+	handlers := argHandlersType{
+		filePathArgHandler: func(s string) (string, []cleanupFunc, error) {
+			return fmt.Sprintf("<%s>", s), nil, nil
+		},
+	}
+
+	for _, testCase := range testCases {
+		func(testCase testCaseType) {
+			t.Run(strings.Join(testCase.input, "/"), func(t *testing.T) {
+				t.Parallel()
+				result, err := containerCopyHandler(nil, testCase.input, handlers)
+				if testCase.err != "" {
+					assert.EqualError(t, err, testCase.err)
+				} else {
+					assert.NoError(t, err, "Unexpected error running copy handler")
+					assert.Equal(t, testCase.expected, result.args)
+					assert.Empty(t, result.cleanup)
+				}
+			})
+		}(testCase)
+	}
+}

--- a/src/go/nerdctl-stub/main_linux.go
+++ b/src/go/nerdctl-stub/main_linux.go
@@ -231,3 +231,12 @@ func outputPathArgHandler(arg string) (string, []cleanupFunc, error) {
 func builderCacheArgHandler(arg string) (string, []cleanupFunc, error) {
 	return builderCacheProcessor(arg, filePathArgHandler, outputPathArgHandler)
 }
+
+// argHandlers is the table of argument handlers.
+var argHandlers = argHandlersType{
+	volumeArgHandler:       volumeArgHandler,
+	filePathArgHandler:     filePathArgHandler,
+	outputPathArgHandler:   outputPathArgHandler,
+	mountArgHandler:        mountArgHandler,
+	builderCacheArgHandler: builderCacheArgHandler,
+}

--- a/src/go/nerdctl-stub/main_unsupported.go
+++ b/src/go/nerdctl-stub/main_unsupported.go
@@ -10,11 +10,14 @@ func unhandledArgHandler(arg string) (string, []cleanupFunc, error) {
 	panic("Platform is unsupported")
 }
 
-var volumeArgHandler = unhandledArgHandler
-var filePathArgHandler = unhandledArgHandler
-var outputPathArgHandler = unhandledArgHandler
-var mountArgHandler = unhandledArgHandler
-var builderCacheArgHandler = unhandledArgHandler
+// argHandlers is the table of argument handlers.
+var argHandlers = argHandlersType{
+	volumeArgHandler:       unhandledArgHandler,
+	filePathArgHandler:     unhandledArgHandler,
+	outputPathArgHandler:   unhandledArgHandler,
+	mountArgHandler:        unhandledArgHandler,
+	builderCacheArgHandler: unhandledArgHandler,
+}
 
 func spawn(opts spawnOptions) error {
 	panic("Platform is unsupported")

--- a/src/go/nerdctl-stub/main_windows.go
+++ b/src/go/nerdctl-stub/main_windows.go
@@ -123,3 +123,12 @@ func outputPathArgHandler(arg string) (string, []cleanupFunc, error) {
 func builderCacheArgHandler(arg string) (string, []cleanupFunc, error) {
 	return builderCacheProcessor(arg, filePathArgHandler, outputPathArgHandler)
 }
+
+// argHandlers is the table of argument handlers.
+var argHandlers = argHandlersType{
+	volumeArgHandler:       volumeArgHandler,
+	filePathArgHandler:     filePathArgHandler,
+	outputPathArgHandler:   outputPathArgHandler,
+	mountArgHandler:        mountArgHandler,
+	builderCacheArgHandler: builderCacheArgHandler,
+}

--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -320,6 +320,7 @@ func init() {
 
 	// Set up command handlers
 	registerCommandHandler("image build", imageBuildHandler)
+	registerCommandHandler("container cp", containerCopyHandler)
 
 	// Set up aliases
 	aliasCommand("commit", "container commit")

--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -20,6 +20,20 @@ type parsedArgs struct {
 // argHandler is the type of a function that handles some argument.
 type argHandler func(string) (string, []cleanupFunc, error)
 
+// argHandlersType defines the functions passed in command handlers.
+type argHandlersType struct {
+	volumeArgHandler       argHandler
+	filePathArgHandler     argHandler
+	outputPathArgHandler   argHandler
+	mountArgHandler        argHandler
+	builderCacheArgHandler argHandler
+}
+
+// commandHandlerType is the type of commandDefinition.handler, which is used
+// to handle positional arguments (and special subcommands).
+// The passed-in arguments include any flags given after positional arguments.
+type commandHandlerType func(*commandDefinition, []string, argHandlersType) (*parsedArgs, error)
+
 type commandDefinition struct {
 	// commands points to the global command map; if this is null, then the global
 	// variable named "commands" is used instead.
@@ -34,7 +48,7 @@ type commandDefinition struct {
 	// handler for any positional arguments and subcommands.  This should not
 	// include the name of the subcommand itself.  If this is not given, all
 	// subcommands are searched for, and positional arguments are ignored.
-	handler func(*commandDefinition, []string) (*parsedArgs, error)
+	handler commandHandlerType
 }
 
 // parseOption takes an argument (that is known to start with `-` or `--`) plus
@@ -145,7 +159,7 @@ func (c commandDefinition) parse(args []string) (*parsedArgs, error) {
 		} else {
 			// Handler positional arguments and subcommands.
 			if c.handler != nil {
-				childResult, err := c.handler(&c, args[argIndex:])
+				childResult, err := c.handler(&c, args[argIndex:], argHandlers)
 				if err != nil {
 					return nil, err
 				}
@@ -179,16 +193,6 @@ func (c commandDefinition) parse(args []string) (*parsedArgs, error) {
 		}
 	}
 	return &result, nil
-}
-
-type optionDefinition struct {
-	// long name for the argument
-	long string
-	// short name for the argument (optional)
-	short string
-	// handler to convert values; if unset, this argument does not take a value.
-	// It returns the converted value, plus any cleanup functions.
-	handler func(string) (string, []func(*parsedArgs) error, error)
 }
 
 // parseArgs parses the process arguments (os.Args) and returns them with any
@@ -227,7 +231,7 @@ func registerArgHandler(command, option string, handler argHandler) {
 
 // registerCommandHandler sets handlers for positional arguments.  This should
 // be called from init().
-func registerCommandHandler(command string, handler func(*commandDefinition, []string) (*parsedArgs, error)) {
+func registerCommandHandler(command string, handler commandHandlerType) {
 	// Do some extra checking to guard against typos.
 	if _, ok := commands[command]; !ok {
 		panic(fmt.Sprintf("unknown command %q", command))
@@ -284,39 +288,39 @@ func aliasCommand(alias, target string) {
 
 func init() {
 	// Set up the argument handlers
-	registerArgHandler("builder build", "--cache-from", builderCacheArgHandler)
-	registerArgHandler("builder build", "--cache-to", builderCacheArgHandler)
-	registerArgHandler("builder build", "--file", filePathArgHandler)
-	registerArgHandler("builder build", "--iidfile", outputPathArgHandler)
-	registerArgHandler("builder debug", "--file", filePathArgHandler)
-	registerArgHandler("builder debug", "-f", filePathArgHandler)
-	registerArgHandler("compose", "--file", filePathArgHandler)
-	registerArgHandler("compose", "-f", filePathArgHandler)
-	registerArgHandler("compose", "--project-directory", filePathArgHandler)
-	registerArgHandler("compose", "--env-file", filePathArgHandler)
-	registerArgHandler("compose run", "--volume", volumeArgHandler)
-	registerArgHandler("compose run", "-v", volumeArgHandler)
-	registerArgHandler("container create", "--cidfile", outputPathArgHandler)
-	registerArgHandler("container create", "--cosign-key", filePathArgHandler)
-	registerArgHandler("container create", "--env-file", filePathArgHandler)
-	registerArgHandler("container create", "--label-file", filePathArgHandler)
-	registerArgHandler("container create", "--mount", mountArgHandler)
-	registerArgHandler("container create", "--pidfile", outputPathArgHandler)
-	registerArgHandler("container create", "--volume", volumeArgHandler)
-	registerArgHandler("container create", "-v", volumeArgHandler)
-	registerArgHandler("container run", "--cidfile", outputPathArgHandler)
-	registerArgHandler("container run", "--cosign-key", filePathArgHandler)
-	registerArgHandler("container run", "--env-file", filePathArgHandler)
-	registerArgHandler("container run", "--label-file", filePathArgHandler)
-	registerArgHandler("container run", "--mount", mountArgHandler)
-	registerArgHandler("container run", "--pidfile", outputPathArgHandler)
-	registerArgHandler("container run", "--volume", volumeArgHandler)
-	registerArgHandler("container run", "-v", volumeArgHandler)
-	registerArgHandler("image build", "--file", filePathArgHandler)
-	registerArgHandler("image build", "-f", filePathArgHandler)
-	registerArgHandler("image convert", "--estargz-record-in", filePathArgHandler)
-	registerArgHandler("image load", "--input", filePathArgHandler)
-	registerArgHandler("image save", "--output", outputPathArgHandler)
+	registerArgHandler("builder build", "--cache-from", argHandlers.builderCacheArgHandler)
+	registerArgHandler("builder build", "--cache-to", argHandlers.builderCacheArgHandler)
+	registerArgHandler("builder build", "--file", argHandlers.filePathArgHandler)
+	registerArgHandler("builder build", "--iidfile", argHandlers.outputPathArgHandler)
+	registerArgHandler("builder debug", "--file", argHandlers.filePathArgHandler)
+	registerArgHandler("builder debug", "-f", argHandlers.filePathArgHandler)
+	registerArgHandler("compose", "--file", argHandlers.filePathArgHandler)
+	registerArgHandler("compose", "-f", argHandlers.filePathArgHandler)
+	registerArgHandler("compose", "--project-directory", argHandlers.filePathArgHandler)
+	registerArgHandler("compose", "--env-file", argHandlers.filePathArgHandler)
+	registerArgHandler("compose run", "--volume", argHandlers.volumeArgHandler)
+	registerArgHandler("compose run", "-v", argHandlers.volumeArgHandler)
+	registerArgHandler("container create", "--cidfile", argHandlers.outputPathArgHandler)
+	registerArgHandler("container create", "--cosign-key", argHandlers.filePathArgHandler)
+	registerArgHandler("container create", "--env-file", argHandlers.filePathArgHandler)
+	registerArgHandler("container create", "--label-file", argHandlers.filePathArgHandler)
+	registerArgHandler("container create", "--mount", argHandlers.mountArgHandler)
+	registerArgHandler("container create", "--pidfile", argHandlers.outputPathArgHandler)
+	registerArgHandler("container create", "--volume", argHandlers.volumeArgHandler)
+	registerArgHandler("container create", "-v", argHandlers.volumeArgHandler)
+	registerArgHandler("container run", "--cidfile", argHandlers.outputPathArgHandler)
+	registerArgHandler("container run", "--cosign-key", argHandlers.filePathArgHandler)
+	registerArgHandler("container run", "--env-file", argHandlers.filePathArgHandler)
+	registerArgHandler("container run", "--label-file", argHandlers.filePathArgHandler)
+	registerArgHandler("container run", "--mount", argHandlers.mountArgHandler)
+	registerArgHandler("container run", "--pidfile", argHandlers.outputPathArgHandler)
+	registerArgHandler("container run", "--volume", argHandlers.volumeArgHandler)
+	registerArgHandler("container run", "-v", argHandlers.volumeArgHandler)
+	registerArgHandler("image build", "--file", argHandlers.filePathArgHandler)
+	registerArgHandler("image build", "-f", argHandlers.filePathArgHandler)
+	registerArgHandler("image convert", "--estargz-record-in", argHandlers.filePathArgHandler)
+	registerArgHandler("image load", "--input", argHandlers.filePathArgHandler)
+	registerArgHandler("image save", "--output", argHandlers.outputPathArgHandler)
 
 	// Set up command handlers
 	registerCommandHandler("image build", imageBuildHandler)

--- a/src/go/nerdctl-stub/parse_args_test.go
+++ b/src/go/nerdctl-stub/parse_args_test.go
@@ -186,7 +186,7 @@ func TestParse(t *testing.T) {
 		t.Parallel()
 		run := false
 		c := commandDefinition{
-			handler: func(c *commandDefinition, args []string) (*parsedArgs, error) {
+			handler: func(c *commandDefinition, args []string, argHandlers argHandlersType) (*parsedArgs, error) {
 				run = true
 				assert.Equal(t, []string{"positional", "arguments"}, args)
 				return &parsedArgs{}, nil
@@ -214,7 +214,7 @@ func TestParse(t *testing.T) {
 		}
 		localCommands["subcommand"] = commandDefinition{
 			commands: &localCommands,
-			handler: func(c *commandDefinition, args []string) (*parsedArgs, error) {
+			handler: func(c *commandDefinition, args []string, argHandlers argHandlersType) (*parsedArgs, error) {
 				run = true
 				assert.Equal(t, []string{"a", "b"}, args)
 				return &parsedArgs{}, nil


### PR DESCRIPTION
- Implement argument handling for `nerdctl container cp`
- Run `nerdctl` inside the pid namespace; fixes https://github.com/containerd/nerdctl/issues/1143

This is enough to run `nerdctl cp <container>:<path> <host path>`.  Note that `nerdctl cp` doesn't like working with containers that are not running (i.e. `nerdctl create` + `nerdctl cp` without `nerdctl run`).