### PR TITLE
Check PATH with `zsh -i -l -c`

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
+++ b/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
@@ -81,6 +81,7 @@ export class RDBinInShellPath implements DiagnosticsChecker {
 
 // Use `bash -l` because `bash -i` causes RD to suspend
 const RDBinInBash = new RDBinInShellPath('RD_BIN_IN_BASH_PATH', 'bash', '-l', '-c');
-const RDBinInZsh = new RDBinInShellPath('RD_BIN_IN_ZSH_PATH', 'zsh', '-i', '-c');
+// Use `zsh -i -l` because we can't know if the user manually added the PATH in .zshrc or in .zprofile
+const RDBinInZsh = new RDBinInShellPath('RD_BIN_IN_ZSH_PATH', 'zsh', '-i', '-l', '-c');
 
 export default [RDBinInBash, RDBinInZsh] as DiagnosticsChecker[];


### PR DESCRIPTION
Rancher Desktop will only modify `~/.zshrc`, which is read by any interactive shell. But we can't know if a user elected to manually modify the `PATH` and put the code into `~/.zprofile` instead, so it is read by login shells.

Fixes #3673 
