### PR TITLE
Add nested virtualization checks for linux

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -280,7 +280,7 @@ async function checkPrerequisites() {
       try {
         const data = await fs.promises.readFile(nestedFile, { encoding: 'utf8' });
 
-        if (data && data.toLowerCase()[0] === 'y' ) {
+        if (data && (data.toLowerCase()[0] === 'y' || data[0] === '1')) {
           messageId = 'ok';
           break;
         }


### PR DESCRIPTION
Fix for #3706

Either 'Y' or '1` is a valid value when enabling nested virtualization. As stated [here](https://www.kernel.org/doc/html/v5.7/virt/kvm/running-nested-guests.html)

Added checks for '1' flag in 'background.ts'