### PR TITLE
Filter out checksum lines that end with .json

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -26,7 +26,7 @@ function exeName(context: DownloadContext, name: string) {
  */
 async function findChecksum(checksumURL: string, executableName: string): Promise<string> {
   const allChecksums = await getResource(checksumURL);
-  const desiredChecksums = allChecksums.split(/\r?\n/).filter(line => line.includes(executableName));
+  const desiredChecksums = allChecksums.split(/\r?\n/).filter(line => line.endsWith(executableName));
 
   if (desiredChecksums.length < 1) {
     throw new Error(`Couldn't find a matching SHA for [${ executableName }] in [${ allChecksums }]`);
@@ -265,7 +265,7 @@ export class Steve extends GithubVersionGetter implements Dependency, Unreleased
     const steveExecutable = `steve-${ context.goPlatform }-${ arch }`;
     const steveURL = `${ steveURLBase }/${ steveExecutable }.tar.gz`;
     const stevePath = path.join(context.internalDir, exeName(context, 'steve'));
-    const steveSHA = await findChecksum(`${ steveURL }.sha512sum`, steveExecutable);
+    const steveSHA = await findChecksum(`${ steveURL }.sha512sum`, `${ steveExecutable }.tar.gz`);
 
     await downloadTarGZ(
       steveURL,
@@ -310,7 +310,7 @@ export class RancherDashboard extends GithubVersionGetter implements Dependency,
     const executableName = 'rancher-dashboard-desktop-embed';
     const url = `${ baseURL }/${ executableName }.tar.gz`;
     const destPath = path.join(context.resourcesDir, 'rancher-dashboard.tgz');
-    const expectedChecksum = await findChecksum(`${ url }.sha512sum`, executableName);
+    const expectedChecksum = await findChecksum(`${ url }.sha512sum`, `${ executableName }.tar.gz`);
     const rancherDashboardDir = path.join(context.resourcesDir, 'rancher-dashboard');
 
     if (fs.existsSync(rancherDashboardDir)) {


### PR DESCRIPTION
Fixes #3720.

I went through the release assets of the other dependencies that use `findChecksum` and didn't find anything that will break as a result of this change.