### PR TITLE
Workflows: suppress workflows if secret is unset.

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -8,7 +8,16 @@ permissions:
   issues: write
 
 jobs:
+  check-for-token:
+    outputs:
+      has-token: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'true'
+
   check-docker-cli:
+    needs: check-for-token
+    if: needs.check-for-token.outputs.has-token == 'true'
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -9,7 +9,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-for-token:
+    outputs:
+      has-token: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: 'true'
+
   check-update-versions:
+    needs: check-for-token
+    if: needs.check-for-token.outputs.has-token == 'true'
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -8,10 +8,18 @@ permissions:
   issues: write
 
 jobs:
-  check-unreleased-changes:
+  check-for-token:
+    outputs:
+      has-token: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
     runs-on: ubuntu-latest
     steps:
+    - run: 'true'
 
+  check-unreleased-changes:
+    needs: check-for-token
+    if: needs.check-for-token.outputs.has-token == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
These workflows are run on a schedule, but also require a GitHub secret to be set.  This change prevents them from running if the secret was not set, as to reduce useless job failed warnings on forks.

This should still run on `rancher-sandbox/rancher-desktop` (or any fork with the secret set).