### PR TITLE
Remove diagnostics feature flag

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -33,16 +33,14 @@ export default {
     TheTitle,
   },
   async fetch() {
-    if (this.$config.featureDiagnostics) {
-      await this.$store.dispatch('credentials/fetchCredentials');
-      if (!this.credentials.port || !this.credentials.user || !this.credentials.password) {
-        console.log(`Credentials aren't ready for getting diagnostics -- will try later`);
+    await this.$store.dispatch('credentials/fetchCredentials');
+    if (!this.credentials.port || !this.credentials.user || !this.credentials.password) {
+      console.log(`Credentials aren't ready for getting diagnostics -- will try later`);
 
-        return;
-      }
-      await this.$store.dispatch('preferences/fetchPreferences', this.credentials);
-      await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
+      return;
     }
+    await this.$store.dispatch('preferences/fetchPreferences', this.credentials);
+    await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
   },
 
   head() {
@@ -56,21 +54,13 @@ export default {
 
   computed: {
     routes() {
-      const routeTable = [
+      return [
         { route: '/General' },
         { route: '/PortForwarding' },
         { route: '/Images' },
         { route: '/Troubleshooting' },
+        { route: '/Diagnostics', error: this.errorCount },
       ];
-
-      if (this.featureDiagnostics) {
-        routeTable.push({ route: '/Diagnostics', error: this.errorCount });
-      }
-
-      return routeTable;
-    },
-    featureDiagnostics() {
-      return !!this.$config.featureDiagnostics;
     },
     errorCount() {
       return this.diagnostics.filter(diagnostic => !diagnostic.mute).length;

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -83,8 +83,5 @@ export default {
   },
   target:              'static',
   telemetry:           false,
-  publicRuntimeConfig: {
-    featureDiagnostics:      true,
-    featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1',
-  },
+  publicRuntimeConfig: { featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1' },
 };


### PR DESCRIPTION
This removes the `featureDiagnostics` flag. The Diagnostics feature is already implemented and enabled by default. Including the flag at this point only complicates implementation.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>