### PR TITLE
Use `@pkg` alias for preferences imports

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/ModalFooter.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalFooter.vue
@@ -2,7 +2,7 @@
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import PreferencesAlert from '@/components/Preferences/Alert.vue';
+import PreferencesAlert from '@pkg/components/Preferences/Alert.vue';
 
 export default Vue.extend({
   name:       'preferences-footer',

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -6,6 +6,7 @@ import { mapGetters, mapState } from 'vuex';
 
 import EmptyState from '@pkg/components/EmptyState.vue';
 import PreferencesBody from '@pkg/components/Preferences/ModalBody.vue';
+import PreferencesFooter from '@pkg/components/Preferences/ModalFooter.vue';
 import PreferencesHeader from '@pkg/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@pkg/components/Preferences/ModalNav.vue';
 import type { TransientSettings } from '@pkg/config/transientSettings';
@@ -13,8 +14,6 @@ import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 import { preferencesNavItems } from '@pkg/window/preferences';
-
-import PreferencesFooter from '@/components/Preferences/ModalFooter.vue';
 
 export default Vue.extend({
   name:       'preferences-modal',


### PR DESCRIPTION
This updates imports for preferences components so that they use the `@pkg` alias. It will be important to stick to the `@pkg` alias for extensions development.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>