### PR TITLE
Use dot-separated names in rdctl set and start subcommands.

### DIFF
--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -76,7 +76,7 @@ describe('updateFromCommandLine', () => {
       expect(accessor).toBe('kubernetes');
     });
     test('returns a partial pref with an internal accessor', () => {
-      const result = settings.getUpdatableNode(prefs, 'kubernetes-options-flannel') as [Record<string, any>, string];
+      const result = settings.getUpdatableNode(prefs, 'kubernetes.options.flannel') as [Record<string, any>, string];
 
       expect(result).not.toBeNull();
       const [lhs, accessor] = result;
@@ -100,7 +100,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('one option with embedded equal sign should change only one value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes-version=1.23.6']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.version=1.23.6']);
 
     expect(newPrefs.kubernetes.version).toBe('1.23.6');
     newPrefs.kubernetes.version = origPrefs.kubernetes.version;
@@ -108,7 +108,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('one option over two args should change only one value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes-version', '1.23.7']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.version', '1.23.7']);
 
     expect(newPrefs.kubernetes.version).toBe('1.23.7');
     newPrefs.kubernetes.version = origPrefs.kubernetes.version;
@@ -116,7 +116,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('boolean option to true should change only that value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes-options-flannel=true']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.options.flannel=true']);
 
     expect(origPrefs.kubernetes.options.flannel).toBeFalsy();
     expect(newPrefs.kubernetes.options.flannel).toBeTruthy();
@@ -125,7 +125,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('boolean option set to implicit true should change only that value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes-suppressSudo']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.suppressSudo']);
 
     expect(origPrefs.kubernetes.suppressSudo).toBeFalsy();
     expect(newPrefs.kubernetes.suppressSudo).toBeTruthy();
@@ -134,7 +134,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('boolean option set to false should change only that value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes-options-traefik=false']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.options.traefik=false']);
 
     expect(origPrefs.kubernetes.options.traefik).toBeTruthy();
     expect(newPrefs.kubernetes.options.traefik).toBeFalsy();
@@ -143,7 +143,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('nothing after an = should set target to empty string', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--images-namespace=']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--images.namespace=']);
 
     expect(origPrefs.images.namespace).not.toBe('');
     expect(newPrefs.images.namespace).toBe('');
@@ -153,11 +153,11 @@ describe('updateFromCommandLine', () => {
 
   test('should change several values (and no others)', () => {
     const newPrefs = settings.updateFromCommandLine(prefs, [
-      '--kubernetes-options-traefik=false',
-      '--kubernetes-suppressSudo',
-      '--portForwarding-includeKubernetesServices=true',
-      '--kubernetes-containerEngine=containerd',
-      '--kubernetes-port', '6444',
+      '--kubernetes.options.traefik=false',
+      '--kubernetes.suppressSudo',
+      '--portForwarding.includeKubernetesServices=true',
+      '--kubernetes.containerEngine=containerd',
+      '--kubernetes.port', '6444',
     ]);
 
     expect(newPrefs.kubernetes.options.traefik).toBeFalsy();
@@ -175,21 +175,21 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should ignore non-option arguments', () => {
-    const arg = 'doesnt-start-with-dash-dash=some-value';
+    const arg = 'doesnt.start.with.dash.dash=some-value';
     const newPrefs = settings.updateFromCommandLine(prefs, [arg]);
 
     expect(newPrefs).toEqual(origPrefs);
   });
 
   test('should ignore an unrecognized option', () => {
-    const arg = '--kubernetes-zipperhead';
+    const arg = '--kubernetes.zipperhead';
     const newPrefs = settings.updateFromCommandLine(prefs, [arg]);
 
     expect(newPrefs).toEqual(origPrefs);
   });
 
   test('should ignore leading options and arguments', () => {
-    const args = ['--kubernetes-zipperhead', '--another-unknown-option', 'its-argument', '--dont-know-what-this-is-either'];
+    const args = ['--kubernetes.zipperhead', '--another.unknown.option', 'its.argument', '--dont.know.what.this.is.either'];
     const newPrefs = settings.updateFromCommandLine(prefs, args);
 
     expect(TransientSettings.value.noModalDialogs).toEqual(false);
@@ -197,7 +197,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about an unrecognized ignore after a recognized one', () => {
-    const args = ['--ignore-this-one', '--kubernetes-enabled', '--complain-about-this'];
+    const args = ['--ignore.this.one', '--kubernetes.enabled', '--complain.about.this'];
 
     expect(() => {
       settings.updateFromCommandLine(prefs, args);
@@ -205,7 +205,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about non-options after recognizing an option', () => {
-    const args = ['--kubernetes-enabled', 'doesnt-start-with-dash-dash=some-value'];
+    const args = ['--kubernetes.enabled', 'doesnt.start.with.dash.dash=some-value'];
 
     expect(() => {
       settings.updateFromCommandLine(prefs, args);
@@ -213,7 +213,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should refuse to overwrite a non-leaf node', () => {
-    const arg = '--kubernetes-options';
+    const arg = '--kubernetes.options';
 
     expect(() => {
       settings.updateFromCommandLine(prefs, [arg, '33']);
@@ -221,7 +221,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about a missing string value', () => {
-    const arg = '--kubernetes-version';
+    const arg = '--kubernetes.version';
 
     expect(() => {
       settings.updateFromCommandLine(prefs, [arg]);
@@ -229,15 +229,15 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about a missing numeric value', () => {
-    const arg = '--kubernetes-memoryInGB';
+    const arg = '--kubernetes.memoryInGB';
 
     expect(() => {
-      settings.updateFromCommandLine(prefs, ['--kubernetes-version', '1.2.3', arg]);
+      settings.updateFromCommandLine(prefs, ['--kubernetes.version', '1.2.3', arg]);
     }).toThrow(`No value provided for option ${ arg }`);
   });
 
   test('should complain about a non-boolean value', () => {
-    const arg = '--kubernetes-enabled';
+    const arg = '--kubernetes.enabled';
     const value = 'nope';
 
     expect(() => {
@@ -246,7 +246,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about a non-numeric value', () => {
-    const arg = '--kubernetes-port';
+    const arg = '--kubernetes.port';
     const value = 'angeles';
 
     expect(() => {
@@ -256,8 +256,8 @@ describe('updateFromCommandLine', () => {
 
   test('should complain about type mismatches', () => {
     const optionList = [
-      ['--kubernetes-memoryInGB', 'true', 'boolean', 'number'],
-      ['--kubernetes-enabled', '7', 'number', 'boolean'],
+      ['--kubernetes.memoryInGB', 'true', 'boolean', 'number'],
+      ['--kubernetes.enabled', '7', 'number', 'boolean'],
     ];
 
     for (const [arg, finalValue, currentType, desiredType] of optionList) {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -155,7 +155,7 @@ export async function clear() {
  *  Clients calling this routine expect to use it like so:
  *  ```
  *  const prefsTree = {a: {b: c: {d: 1, e: 2}}};
- *  const result = getUpdatableNode(prefsTree, 'a-b-c-d');
+ *  const result = getUpdatableNode(prefsTree, 'a.b.c.d');
  *  expect(result).toEqual([{d: 1, e: 2}, 'd']);
  *  const [subtree, finalFieldName] = result;
  *  subtree[finalFieldName] = newValue;
@@ -170,7 +170,7 @@ export async function clear() {
  *          `null` if fqFieldAccessor doesn't point to a node in the settings tree.
  */
 export function getUpdatableNode(cfg: Settings, fqFieldAccessor: string): [Record<string, any>, string] | null {
-  const optionParts = fqFieldAccessor.split('-');
+  const optionParts = fqFieldAccessor.split('.');
   const finalOptionPart = optionParts.pop() ?? '';
   let currentConfig: Record<string, any> = cfg;
 

--- a/scripts/assets/options.go.templ
+++ b/scripts/assets/options.go.templ
@@ -84,10 +84,11 @@ func enumStringCheck(option string, specified string, allowedValues []string) er
 }
 
 func UpdateCommonStartAndSetCommands(cmd *cobra.Command) {
-  <%_ for (const { flagType, capitalizedName, propertyName, defaultValue, usageNote, aliasFor } of commandFlags) { _%>
-    cmd.Flags().<%- flagType %>Var(&specifiedSettings.<%- capitalizedName %>, "<%- propertyName %>", <%- defaultValue %>, "<%- usageNote %>")
+  <%_ for (const { flagType, capitalizedName, propertyName, defaultValue, usageNote, aliasFor } of commandFlags) {
+      const kebabPropertyName = kebabConvert(propertyName); _%>
+    cmd.Flags().<%- flagType %>Var(&specifiedSettings.<%- capitalizedName %>, "<%- kebabPropertyName %>", <%- defaultValue %>, "<%- usageNote %>")
     <%_ if (aliasFor) { _%>
-    cmd.Flags().MarkHidden("<%- propertyName %>")
+    cmd.Flags().MarkHidden("<%- kebabPropertyName %>")
     <%_ } _%>
   <%_ } _%>
 }
@@ -95,10 +96,11 @@ func UpdateCommonStartAndSetCommands(cmd *cobra.Command) {
 func UpdateFieldsForJSON(flags *pflag.FlagSet) (*serverSettingsForJSON, error) {
   var specifiedSettingsForJSON serverSettingsForJSON
 	changedSomething := false
-	<%_ for (const { propertyName, capitalizedName, enums }  of commandFlags) { _%>
-	  if flags.Changed("<%- propertyName %>") {
+	<%_ for (const { propertyName, capitalizedName, enums }  of commandFlags) {
+	  const kebabPropertyName = kebabConvert(propertyName); _%>
+	  if flags.Changed("<%- kebabPropertyName %>") {
 	    <%_ if (enums) { _%>
-        if err := enumStringCheck("--<%- propertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
+        if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
           return nil, err
         }
 	    <%_ } _%>
@@ -115,11 +117,12 @@ func UpdateFieldsForJSON(flags *pflag.FlagSet) (*serverSettingsForJSON, error) {
 func GetCommandLineArgsForStartCommand(flags *pflag.FlagSet) ([]string, error) {
 	var commandLineArgs []string
   <%_ for (const { propertyName, capitalizedName, aliasFor, enums, valuePart } of commandFlags) {
+      const kebabPropertyName = kebabConvert(propertyName);
       const actualPropertyName = aliasFor || propertyName;
   _%>
-    if flags.Changed("<%- propertyName %>") {
+    if flags.Changed("<%- kebabPropertyName %>") {
 	    <%_ if (enums) { _%>
-      if err := enumStringCheck("--<%- propertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
+      if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
         return commandLineArgs, err
       }
 	    <%_ } _%>

--- a/scripts/assets/options.go.templ
+++ b/scripts/assets/options.go.templ
@@ -11,7 +11,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+		http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -48,12 +48,12 @@ import (
  */
 
 type serverSettingsForJSON struct {
-  <%- linesForJSON %>
+	<%- linesForJSON %>
 }
 
 
 type serverSettings struct {
-  <%- linesWithoutJSON %>
+	<%- linesWithoutJSON %>
 }
 
 var specifiedSettings serverSettings
@@ -69,65 +69,66 @@ func enumStringCheck(option string, specified string, allowedValues []string) er
 		if specified == val {
 			return nil
 		}
-	  singleQuotedAllowedValues[i] = fmt.Sprintf("'%s'", val)
+		singleQuotedAllowedValues[i] = fmt.Sprintf("'%s'", val)
 	}
 	var allowedString string
 	if numVals == 1 {
-	  allowedString = singleQuotedAllowedValues[0]
+		allowedString = singleQuotedAllowedValues[0]
 	} else if numVals == 2 {
-	  allowedString = strings.Join(singleQuotedAllowedValues, " or ")
+		allowedString = strings.Join(singleQuotedAllowedValues, " or ")
 	} else {
-	  firstPart := strings.Join(singleQuotedAllowedValues[:numVals - 1], ", ")
-	  allowedString = fmt.Sprintf("%s, or %s", firstPart,  singleQuotedAllowedValues[numVals - 1])
+		firstPart := strings.Join(singleQuotedAllowedValues[:numVals - 1], ", ")
+		allowedString = fmt.Sprintf("%s, or %s", firstPart,  singleQuotedAllowedValues[numVals - 1])
 	}
 	return fmt.Errorf(`invalid value for option %s: <"%s">; must be %s`, option, specified, allowedString)
 }
 
 func UpdateCommonStartAndSetCommands(cmd *cobra.Command) {
-  <%_ for (const { flagType, capitalizedName, propertyName, defaultValue, usageNote, aliasFor } of commandFlags) {
-      const kebabPropertyName = kebabConvert(propertyName); _%>
-    cmd.Flags().<%- flagType %>Var(&specifiedSettings.<%- capitalizedName %>, "<%- kebabPropertyName %>", <%- defaultValue %>, "<%- usageNote %>")
-    <%_ if (aliasFor) { _%>
-    cmd.Flags().MarkHidden("<%- kebabPropertyName %>")
-    <%_ } _%>
-  <%_ } _%>
+	<%_ for (const { flagType, capitalizedName, propertyName, defaultValue, usageNote, aliasFor } of commandFlags) {
+			const kebabPropertyName = kebabCase(propertyName); _%>
+		cmd.Flags().<%- flagType %>Var(&specifiedSettings.<%- capitalizedName %>, "<%- kebabPropertyName %>", <%- defaultValue %>, "<%- usageNote %>")
+		<%_ if (aliasFor) { _%>
+		cmd.Flags().MarkHidden("<%- kebabPropertyName %>")
+		<%_ } _%>
+	<%_ } _%>
 }
 
 func UpdateFieldsForJSON(flags *pflag.FlagSet) (*serverSettingsForJSON, error) {
-  var specifiedSettingsForJSON serverSettingsForJSON
+	var specifiedSettingsForJSON serverSettingsForJSON
 	changedSomething := false
 	<%_ for (const { propertyName, capitalizedName, enums }  of commandFlags) {
-	  const kebabPropertyName = kebabConvert(propertyName); _%>
-	  if flags.Changed("<%- kebabPropertyName %>") {
-	    <%_ if (enums) { _%>
-        if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
-          return nil, err
-        }
-	    <%_ } _%>
-	    specifiedSettingsForJSON.<%- capitalizedName %> = &specifiedSettings.<%- capitalizedName %>
-	    changedSomething = true
-    }
-  <% } %>
-  if changedSomething {
-    return &specifiedSettingsForJSON, nil
-  }
+		const kebabPropertyName = kebabCase(propertyName); _%>
+		if flags.Changed("<%- kebabPropertyName %>") {
+			<%_ if (enums) { _%>
+				if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
+					return nil, err
+				}
+			<%_ } _%>
+			specifiedSettingsForJSON.<%- capitalizedName %> = &specifiedSettings.<%- capitalizedName %>
+			changedSomething = true
+		}
+	<% } %>
+	if changedSomething {
+		return &specifiedSettingsForJSON, nil
+	}
 	return nil, nil
 }
 
 func GetCommandLineArgsForStartCommand(flags *pflag.FlagSet) ([]string, error) {
 	var commandLineArgs []string
-  <%_ for (const { propertyName, capitalizedName, aliasFor, enums, valuePart } of commandFlags) {
-      const kebabPropertyName = kebabConvert(propertyName);
-      const actualPropertyName = aliasFor || propertyName;
-  _%>
-    if flags.Changed("<%- kebabPropertyName %>") {
-	    <%_ if (enums) { _%>
-      if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
-        return commandLineArgs, err
-      }
-	    <%_ } _%>
-      commandLineArgs = append(commandLineArgs, "--<%- actualPropertyName %>"<%- valuePart %>)
-    }
-  <% } %>
+	<%_ for (const { propertyName, capitalizedName, aliasFor, enums, valuePart } of commandFlags) {
+			const kebabPropertyName = kebabCase(propertyName);
+			// The app and backend use dot-separated [Cc]amelCase names, not kebab-case, so pass in the camelCase name (a few lines down)
+			const actualPropertyName = aliasFor || propertyName;
+	_%>
+		if flags.Changed("<%- kebabPropertyName %>") {
+			<%_ if (enums) { _%>
+			if err := enumStringCheck("--<%- kebabPropertyName %>", specifiedSettings.<%- capitalizedName %>, <%- enums %>) ; err != nil {
+				return commandLineArgs, err
+			}
+			<%_ } _%>
+			commandLineArgs = append(commandLineArgs, "--<%- actualPropertyName %>"<%- valuePart %>)
+		}
+	<% } %>
 	return commandLineArgs, nil
 }

--- a/scripts/generateCliCode.ts
+++ b/scripts/generateCliCode.ts
@@ -95,6 +95,14 @@ function capitalizeParts(s: string) {
   return s.split('.').map(capitalize).join('.');
 }
 
+function kebabCase(s: string) {
+  return s.replace(/(?<=[a-z])([A-Z]+)/g, m => `-${ m.toLowerCase() }`);
+}
+
+function kebabConvert(s: string) {
+  return s.split('.').map(part => kebabCase(part)).join('.');
+}
+
 function lastName(s: string): string {
   return s.split('.').pop() ?? '';
 }
@@ -142,6 +150,7 @@ class Generator {
       commandFlags:     this.commandFlags,
       linesForJSON:     linesForJSON.join('\n'),
       linesWithoutJSON: linesWithoutJSON.join('\n'),
+      kebabConvert,
     };
     const renderedContent = await ejs.renderFile(templateFile, data, options);
 

--- a/scripts/generateCliCode.ts
+++ b/scripts/generateCliCode.ts
@@ -95,12 +95,14 @@ function capitalizeParts(s: string) {
   return s.split('.').map(capitalize).join('.');
 }
 
+/**
+ * Replace each sequence of capital letters after a lower-case one with a "-"
+ * followed by its lower-case conversion. Different from lodash.kebabCase,
+ * which assumes the last upper-case letter in a squence starts the next
+ * inner word-part, and would convert `numberCPUs` to `number-cp-us`
+ */
 function kebabCase(s: string) {
   return s.replace(/(?<=[a-z])([A-Z]+)/g, m => `-${ m.toLowerCase() }`);
-}
-
-function kebabConvert(s: string) {
-  return s.split('.').map(part => kebabCase(part)).join('.');
 }
 
 function lastName(s: string): string {
@@ -150,7 +152,7 @@ class Generator {
       commandFlags:     this.commandFlags,
       linesForJSON:     linesForJSON.join('\n'),
       linesWithoutJSON: linesWithoutJSON.join('\n'),
-      kebabConvert,
+      kebabCase,
     };
     const renderedContent = await ejs.renderFile(templateFile, data, options);
 


### PR DESCRIPTION
Does the name change from #3783 for the current v4 settings

- Each of the parts (like 'A') is kebab-case now

Note that the old style command-line arguments are now dot-separated and use kebabCase names, like `--kubernetes.memory-in-gb`. But using `rdctl api /settings -X PUT -b ` requires `{ "kubernetes": {"memoryInGB":...}}`

Signed-off-by: Eric Promislow <epromislow@suse.com>