### PR TITLE
Preferences, add new settings

### DIFF
--- a/e2e/pages/preferences/application.ts
+++ b/e2e/pages/preferences/application.ts
@@ -4,10 +4,14 @@ export class ApplicationNav {
   readonly nav: Locator;
   readonly tabBehavior: Locator;
   readonly tabEnvironment: Locator;
+  readonly tabGeneral: Locator;
   readonly administrativeAccess: Locator;
   readonly automaticUpdates: Locator;
   readonly automaticUpdatesCheckbox: Locator;
   readonly statistics: Locator;
+  readonly autoStart: Locator;
+  readonly background: Locator;
+  readonly notificationIcon: Locator;
   readonly pathManagement: Locator;
 
   constructor(page: Page) {
@@ -15,10 +19,14 @@ export class ApplicationNav {
     this.nav = page.locator('[data-test="nav-application"]');
     this.tabBehavior = page.locator('.tab >> text=Behavior');
     this.tabEnvironment = page.locator('.tab >> text=Environment');
+    this.tabGeneral = page.locator('.tab >> text=General');
     this.administrativeAccess = page.locator('[data-test="administrativeAccess"]');
     this.automaticUpdates = page.locator('[data-test="automaticUpdates"]');
     this.automaticUpdatesCheckbox = page.locator('[data-test="automaticUpdatesCheckbox"]');
     this.statistics = page.locator('[data-test="statistics"]');
+    this.autoStart = page.locator('[data-test="autoStart"]');
+    this.background = page.locator('[data-test="background"]');
+    this.notificationIcon = page.locator('[data-test="notificationIcon"]');
     this.pathManagement = page.locator('[data-test="pathManagement"]');
   }
 }

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -57,21 +57,35 @@ test.describe.serial('Main App Test', () => {
     expect(preferencesWindow).toBeDefined();
   });
 
-  test('should show application page', async() => {
+  test('should show application page and render general tab', async() => {
     const { application } = new PreferencesPage(preferencesWindow);
 
     await expect(application.nav).toHaveClass('preferences-nav-item active');
 
     if (!os.platform().startsWith('win')) {
-      await expect(application.tabBehavior).toHaveText('Behavior');
-      await expect(application.administrativeAccess).toBeVisible();
+      await expect(application.tabEnvironment).toBeVisible();
     } else {
-      await expect(application.tabBehavior).not.toBeVisible();
       await expect(application.tabEnvironment).not.toBeVisible();
     }
 
+    await expect(application.tabGeneral).toHaveText('General');
+    await expect(application.tabBehavior).toBeVisible();
+
     await expect(application.automaticUpdates).toBeVisible();
     await expect(application.statistics).toBeVisible();
+    await expect(application.autoStart).not.toBeVisible();
+    await expect(application.pathManagement).not.toBeVisible();
+  });
+
+  test('should render behavior tab', async() => {
+    const { application } = new PreferencesPage(preferencesWindow);
+
+    await application.tabBehavior.click();
+
+    await expect(application.autoStart).toBeVisible();
+    await expect(application.background).toBeVisible();
+    await expect(application.notificationIcon).toBeVisible();
+    await expect(application.administrativeAccess).not.toBeVisible();
     await expect(application.pathManagement).not.toBeVisible();
   });
 

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -32,7 +32,7 @@ import {
   createDefaultSettings, kubectl, packageLogs, reportAsset, tool,
 } from './utils/TestUtils';
 
-import { ContainerEngine, Settings } from '@pkg/config/settings';
+import { ContainerEngine, Settings, defaultSettings } from '@pkg/config/settings';
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { spawnFile } from '@pkg/utils/childProcess';
 import paths from '@pkg/utils/paths';
@@ -97,9 +97,7 @@ test.describe('Command server', () => {
   }
 
   function verifySettingsKeys(settings: Record<string, any>) {
-    expect(new Set(['version', 'containerEngine', 'kubernetes', 'portForwarding', 'images', 'telemetry',
-      'updater', 'debug', 'pathManagementStrategy', 'diagnostics']))
-      .toEqual(new Set(Object.keys(settings)));
+    expect(Object.keys(defaultSettings)).toEqual(Object.keys(settings));
   }
 
   test.describe.configure({ mode: 'serial' });
@@ -638,7 +636,7 @@ test.describe('Command server', () => {
           stdout: '',
         });
         expect(stderr).toContain('Usage:');
-        expect(stderr.split(/\n/).filter(line => /^\s+--/.test(line)).length).toBe(26);
+        expect(stderr.split(/\n/).filter(line => /^\s+--/.test(line)).length).toBe(30);
       });
 
       test('complains when option value missing', async() => {

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -327,6 +327,18 @@ components:
             mutedChecks:
               type: object
               additionalProperties: true
+        autoStart:
+          type: boolean
+        startInBackground:
+          type: boolean
+        hideNotificationIcon:
+          type: boolean
+        window:
+          type: object
+          properties:
+            quitOnClose:
+              type: boolean
+
     diagnostics:
       type: object
       properties:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -260,6 +260,24 @@ about:
   downloadCLI:
     title: CLI Downloads
 
+application:
+  behavior:
+    autoStart:
+      legendText: Startup
+      label: Automatically start at login
+    background:
+      legendText: Background
+      legendTooltip: >
+        Hide the app window when Rancher Desktop is running in the background.
+        It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+    startInBackground:
+      label: Start in the background
+    windowQuitOnClose:
+      label: Keep running in the background when closing application window
+    notificationIcon:
+      legendText: Notification Icon
+      label: Hide Notification Icon
+
 containerEngine:
   label: Container Engine
   options:

--- a/pkg/rancher-desktop/components/Preferences/ApplicationBehavior.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationBehavior.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { Checkbox } from '@rancher/components';
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
 
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
@@ -18,34 +17,9 @@ export default Vue.extend({
       required: true,
     },
   },
-  data() {
-    return {
-      sudoAllowedTooltip: `
-        If checked, Rancher Desktop will attempt to acquire administrative
-        credentials ("sudo access") when starting for some operations.  This
-        allows for enhanced functionality, including bridged networking and
-        default docker socket support.  Changes will only be applied next time
-        Rancher Desktop starts.
-      `,
-      automaticUpdates: true,
-      statistics:       false,
-    };
-  },
-  computed: {
-    ...mapGetters('preferences', ['isPlatformWindows']),
-    isSudoAllowed(): boolean {
-      return !(this.preferences?.kubernetes?.suppressSudo ?? false);
-    },
-    canAutoUpdate(): boolean {
-      return this.preferences?.updater || false;
-    },
-  },
   methods: {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
-    },
-    onSudoAllowedChange(val: boolean) {
-      this.$store.dispatch('applicationSettings/commitSudoAllowed', val);
     },
   },
 });
@@ -54,36 +28,40 @@ export default Vue.extend({
 <template>
   <div class="application-behavior">
     <rd-fieldset
-      v-if="!isPlatformWindows"
-      data-test="administrativeAccess"
-      legend-text="Administrative Access"
-      :legend-tooltip="sudoAllowedTooltip"
+      data-test="autoStart"
+      :legend-text="t('application.behavior.autoStart.legendText')"
     >
       <checkbox
-        label="Allow Rancher Desktop to acquire administrative credentials (sudo access)"
-        :value="isSudoAllowed"
-        @input="onChange('kubernetes.suppressSudo', !$event)"
+        :label="t('application.behavior.autoStart.label')"
+        :value="preferences.autoStart"
+        @input="onChange('autoStart', $event)"
       />
     </rd-fieldset>
     <rd-fieldset
-      data-test="automaticUpdates"
-      legend-text="Automatic Updates"
+      data-test="background"
+      :legend-text="t('application.behavior.background.legendText')"
+      :legend-tooltip="t('application.behavior.background.legendTooltip')"
+      class="checkbox-group"
     >
       <checkbox
-        data-test="automaticUpdatesCheckbox"
-        label="Check for updates automatically"
-        :value="canAutoUpdate"
-        @input="onChange('updater', $event)"
+        :label="t('application.behavior.startInBackground.label')"
+        :value="preferences.startInBackground"
+        @input="onChange('startInBackground', $event)"
+      />
+      <checkbox
+        :label="t('application.behavior.windowQuitOnClose.label')"
+        :value="preferences.window.quitOnClose"
+        @input="onChange('window.quitOnClose', $event)"
       />
     </rd-fieldset>
     <rd-fieldset
-      data-test="statistics"
-      legend-text="Statistics"
+      data-test="notificationIcon"
+      :legend-text="t('application.behavior.notificationIcon.legendText')"
     >
       <checkbox
-        label="Allow collection of anonymous statistics to help us improve Rancher Desktop"
-        :value="preferences.telemetry"
-        @input="onChange('telemetry', $event)"
+        :label="t('application.behavior.notificationIcon.label')"
+        :value="preferences.hideNotificationIcon"
+        @input="onChange('hideNotificationIcon', $event)"
       />
     </rd-fieldset>
   </div>
@@ -94,5 +72,11 @@ export default Vue.extend({
     display: flex;
     flex-direction: column;
     gap: 1rem;
+
+    .checkbox-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
   }
 </style>

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -1,0 +1,95 @@
+<script lang="ts">
+import { Checkbox } from '@rancher/components';
+import Vue from 'vue';
+import { mapGetters } from 'vuex';
+
+import RdFieldset from '@pkg/components/form/RdFieldset.vue';
+import { Settings } from '@pkg/config/settings';
+import { RecursiveTypes } from '@pkg/utils/typeUtils';
+
+import type { PropType } from 'vue';
+
+export default Vue.extend({
+  name:       'preferences-application-general',
+  components: { Checkbox, RdFieldset },
+  props:      {
+    preferences: {
+      type:     Object as PropType<Settings>,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      sudoAllowedTooltip: `
+        If checked, Rancher Desktop will attempt to acquire administrative
+        credentials ("sudo access") when starting for some operations.  This
+        allows for enhanced functionality, including bridged networking and
+        default docker socket support.  Changes will only be applied next time
+        Rancher Desktop starts.
+      `,
+      automaticUpdates: true,
+      statistics:       false,
+    };
+  },
+  computed: {
+    ...mapGetters('preferences', ['isPlatformWindows']),
+    isSudoAllowed(): boolean {
+      return !(this.preferences?.kubernetes?.suppressSudo ?? false);
+    },
+    canAutoUpdate(): boolean {
+      return this.preferences?.updater || false;
+    },
+  },
+  methods: {
+    onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
+      this.$store.dispatch('preferences/updatePreferencesData', { property, value });
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="application-general">
+    <rd-fieldset
+      v-if="!isPlatformWindows"
+      data-test="administrativeAccess"
+      legend-text="Administrative Access"
+      :legend-tooltip="sudoAllowedTooltip"
+    >
+      <checkbox
+        label="Allow to acquire administrative credentials (sudo access)"
+        :value="isSudoAllowed"
+        @input="onChange('kubernetes.suppressSudo', !$event)"
+      />
+    </rd-fieldset>
+    <rd-fieldset
+      data-test="automaticUpdates"
+      legend-text="Automatic Updates"
+    >
+      <checkbox
+        data-test="automaticUpdatesCheckbox"
+        label="Check for updates automatically"
+        :value="canAutoUpdate"
+        @input="onChange('updater', $event)"
+      />
+    </rd-fieldset>
+    <rd-fieldset
+      data-test="statistics"
+      legend-text="Statistics"
+    >
+      <checkbox
+        label="Allow collection of anonymous statistics to help us improve Rancher Desktop"
+        :value="preferences.telemetry"
+        @input="onChange('telemetry', $event)"
+      />
+    </rd-fieldset>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .application-general {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/pkg/rancher-desktop/components/Preferences/BodyApplication.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyApplication.vue
@@ -5,6 +5,7 @@ import { mapGetters, mapState } from 'vuex';
 
 import PreferencesApplicationBehavior from '@pkg/components/Preferences/ApplicationBehavior.vue';
 import PreferencesApplicationEnvironment from '@pkg/components/Preferences/ApplicationEnvironment.vue';
+import PreferencesApplicationGeneral from '@pkg/components/Preferences/ApplicationGeneral.vue';
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
 import Tab from '@pkg/components/Tabbed/Tab.vue';
 import { Settings } from '@pkg/config/settings';
@@ -21,6 +22,7 @@ export default Vue.extend({
     Tab,
     PreferencesApplicationBehavior,
     PreferencesApplicationEnvironment,
+    PreferencesApplicationGeneral,
   },
   props: {
     preferences: {
@@ -60,7 +62,6 @@ export default Vue.extend({
 
 <template>
   <rd-tabbed
-    v-if="!isPlatformWindows"
     v-bind="$attrs"
     class="action-tabs"
     :no-content="true"
@@ -69,6 +70,7 @@ export default Vue.extend({
   >
     <template #tabs>
       <tab
+        v-if="!isPlatformWindows"
         label="Environment"
         name="environment"
         :weight="1"
@@ -77,6 +79,11 @@ export default Vue.extend({
         label="Behavior"
         name="behavior"
         :weight="2"
+      />
+      <tab
+        label="General"
+        name="general"
+        :weight="3"
       />
     </template>
     <div class="application-content">
@@ -87,12 +94,6 @@ export default Vue.extend({
       />
     </div>
   </rd-tabbed>
-  <div v-else class="application-content">
-    <preferences-application-behavior
-      :preferences="preferences"
-      v-on="$listeners"
-    />
-  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -51,6 +51,10 @@ describe('updateFromCommandLine', () => {
         showMuted:   false,
         mutedChecks: { },
       },
+      autoStart:            false,
+      startInBackground:    false,
+      hideNotificationIcon: false,
+      window:               { quitOnClose: false },
     };
     origPrefs = clone(prefs);
   });

--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -29,6 +29,7 @@ class PreferencesHelp {
     Application:                       'ui/preferences/application',
     'Application-behavior':            'ui/preferences/application#behavior',
     'Application-environment':         'ui/preferences/application#environment',
+    'Application-general':             'ui/preferences/application#general',
     'Virtual Machine':                 'ui/preferences/virtual-machine',
     'Container Engine-general':        'ui/preferences/container-engine#general',
     'Container Engine-allowed-images': 'ui/preferences/container-engine#allowed-images',

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -87,6 +87,10 @@ export const defaultSettings = {
     showMuted:   false,
     mutedChecks: {} as Record<string, boolean>,
   },
+  autoStart:            false,
+  startInBackground:    false,
+  hideNotificationIcon: false,
+  window:               { quitOnClose: false },
 };
 
 export type Settings = typeof defaultSettings;

--- a/pkg/rancher-desktop/config/transientSettings.ts
+++ b/pkg/rancher-desktop/config/transientSettings.ts
@@ -18,7 +18,7 @@ export const defaultTransientSettings = {
     navItem: {
       current:     'Application' as NavItemName,
       currentTabs: {
-        Application:        'behavior',
+        Application:        'general',
         'Container Engine': 'general',
       } as Record<NavItemName, string | undefined>,
     },

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -91,6 +91,10 @@ export default class SettingsValidator {
         mutedChecks: this.checkBooleanMapping,
         showMuted:   this.checkBoolean,
       },
+      autoStart:            this.checkBoolean,
+      startInBackground:    this.checkBoolean,
+      hideNotificationIcon: this.checkBoolean,
+      window:               { quitOnClose: this.checkBoolean },
     };
     this.canonicalizeSynonyms(newSettings);
     const errors: Array<string> = [];

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -15,7 +15,7 @@ interface NavItems {
 export const preferencesNavItems: NavItems[] = [
   {
     name: 'Application',
-    tabs: ['behavior', 'environment'],
+    tabs: ['general', 'behavior', 'environment'],
   },
   { name: process.platform === 'win32' ? 'WSL' : 'Virtual Machine' },
   {


### PR DESCRIPTION
Fixes #3262

- new settings:
    application.autoStart
    application.startInBackground
    application.window.quitOnClose
    application.hideNotificationIcon
- add new `Application/General` tab in preferences dialog
- update e2e tests
- update command-api.yaml

Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>


