### PR TITLE
Revert "Bump limaAndQemu from 1.28 to 1.29"

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-limaAndQemu: "1.29"
+limaAndQemu: "1.28"
 alpineLimaISO:
   isoVersion: 0.2.25.rd2
   alpineVersion: 3.16.0


### PR DESCRIPTION
The new version doesn't seem to be working on macOS, even though it passed all CI checks.

This reverts commit b0f4c8fee9e2398c60ee5000ebd3db79857063b8.
