### PR TITLE
Don't request legacyBIOS support from qemu

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -3,7 +3,7 @@
 ssh:
   loadDotSSHPubKeys: false
 firmware:
-  legacyBIOS: true
+  legacyBIOS: false
 containerd:
   system: false
   user: false

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -578,6 +578,11 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       },
     });
 
+    // Alpine can boot via UEFI now
+    if (config.firmware) {
+       config.firmware.legacyBIOS = false;
+    }
+
     // RD used to store additional keys in lima.yaml that are not supported by lima (and no longer used by RD).
     // They must be removed because lima intends to switch to strict YAML parsing, so typos can be detected.
     delete (config as Record<string, unknown>).k3s;


### PR DESCRIPTION
The Alpine images now work with UEFI, and we don't include the legacy bios in the lima-and-qemu bundle anymore.
