### PR TITLE
Finish the v4 migration and write tests verifying the old prefs no longer work

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -86,7 +86,7 @@ start_container_runtime() {
     local container_runtime="${1:-$RD_CONTAINER_RUNTIME}"
     if is_macos; then
         open -a "Rancher Desktop" --args \
-             --kubernetes-containerEngine "$container_runtime" \
+             --container-engine.name="$container_runtime" \
              --kubernetes-enabled=false
     elif is_linux; then
         $RDCTL start \

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -109,7 +109,7 @@ test.describe.serial('KubernetesBackend', () => {
     }
 
     test('should detect changes', async() => {
-      const currentSettings = (await get('/v0/settings')) as Settings;
+      const currentSettings = (await get('/v1/settings')) as Settings;
       /**
        * getAlt returns the setting that isn't the same as the existing setting.
        */
@@ -189,7 +189,7 @@ test.describe.serial('KubernetesBackend', () => {
         expected[key] = entry;
       }
 
-      await expect(put('/v0/propose_settings', newSettings)).resolves.toEqual(expected);
+      await expect(put('/v1/propose_settings', newSettings)).resolves.toEqual(expected);
     });
 
     test('should handle WSL integrations', async() => {
@@ -204,7 +204,7 @@ test.describe.serial('KubernetesBackend', () => {
         },
       };
 
-      await expect(put('/v0/propose_settings', newSettings)).resolves.toMatchObject({
+      await expect(put('/v1/propose_settings', newSettings)).resolves.toMatchObject({
         'WSL.Integrations': {
           current: {},
           desired: newSettings.WSL?.integrations,

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -36,7 +36,6 @@ import { ContainerEngine, Settings } from '@pkg/config/settings';
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { spawnFile } from '@pkg/utils/childProcess';
 import paths from '@pkg/utils/paths';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 test.describe('Command server', () => {
   let electronApp: ElectronApplication;
@@ -774,7 +773,7 @@ test.describe('Command server', () => {
         test('accepts new settings', async() => {
           const oldSettings: Settings = JSON.parse((await rdctl(['list-settings'])).stdout);
           const body = {
-            virtualMachine:  {
+            virtualMachine: {
               memoryInGB:   oldSettings.virtualMachine.memoryInGB + 1,
               numberCPUs:   oldSettings.virtualMachine.numberCPUs + 1,
               suppressSudo: oldSettings.application.adminAccess,
@@ -1294,14 +1293,9 @@ test.describe('Command server', () => {
     test('should verify nerdctl can talk to containerd', async() => {
       const { stdout } = await rdctl(['list-settings']);
       const settings: Settings = JSON.parse(stdout);
-      const payloadObject: RecursivePartial<Settings> = { };
 
       if (settings.containerEngine.name !== ContainerEngine.CONTAINERD) {
-        payloadObject.kubernetes = {};
-        payloadObject.containerEngine ??= {};
-        payloadObject.containerEngine.name = ContainerEngine.CONTAINERD;
-      }
-      if (Object.keys(payloadObject).length > 0) {
+        const payloadObject = { containerEngine: { name: ContainerEngine.CONTAINERD } };
         const navPage = new NavPage(page);
 
         await tool('rdctl', 'api', '/v1/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -774,7 +774,6 @@ test.describe('Command server', () => {
         test('accepts new settings', async() => {
           const oldSettings: Settings = JSON.parse((await rdctl(['list-settings'])).stdout);
           const body = {
-            containerEngine: { name: getAltString(oldSettings, oldSettings.containerEngine.name, 'containerd', 'moby') },
             virtualMachine:  {
               memoryInGB:   oldSettings.virtualMachine.memoryInGB + 1,
               numberCPUs:   oldSettings.virtualMachine.numberCPUs + 1,
@@ -801,6 +800,11 @@ test.describe('Command server', () => {
           const newSettings: Settings = JSON.parse((await rdctl(['list-settings'])).stdout);
 
           expect(newSettings).toEqual(_.merge(oldSettings, body));
+
+          // And now reinstate the old prefs so other tests that count on them will pass.
+          const result = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(oldSettings)]);
+
+          expect(result.stderr).toEqual('');
         });
       });
     });

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -3,7 +3,7 @@ info:
   title: "Rancher Desktop API"
   version: 0.0.1
 paths:
-  /v0/factory_reset:
+  /v1/factory_reset:
     put:
       operationId: factoryReset
       summary: Factory reset Rancher Desktop, losing user data
@@ -24,7 +24,7 @@ paths:
         '400':
           description: An error occurred
 
-  /v0/propose_settings:
+  /v1/propose_settings:
     put:
       operationId: proposeSettings
       summary: >-
@@ -65,7 +65,7 @@ paths:
                 type: string
 
 
-  /v0/settings:
+  /v1/settings:
     get:
       operationId: listSettings
       summary:  List the current preference settings
@@ -105,7 +105,7 @@ paths:
               schema:
                 type: string
 
-  /v0/shutdown:
+  /v1/shutdown:
     put:
       operationId: shutdownApp
       summary:  Shuts down Rancher Desktop
@@ -118,7 +118,7 @@ paths:
               schema:
                 type: string
 
-  /v0/diagnostic_categories:
+  /v1/diagnostic_categories:
     get:
       operationId: diagnosticCategories
       summary: >-
@@ -134,7 +134,7 @@ paths:
                 items:
                   type: string
 
-  /v0/diagnostic_ids:
+  /v1/diagnostic_ids:
     get:
       operationId: diagnosticIDsForCategory
       summary: >-
@@ -159,7 +159,7 @@ paths:
           description: The category is not recognized.
 
 
-  /v0/diagnostic_checks:
+  /v1/diagnostic_checks:
     get:
       operationId: diagnosticChecks
       summary: >-
@@ -189,7 +189,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/diagnostics"
 
-  /v0/transient_settings:
+  /v1/transient_settings:
     get:
       operationId: listTransientSettings
       summary:  List the current transient settings

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1070,7 +1070,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
   async start(config_: BackendSettings): Promise<void> {
     const config = this.cfg = _.defaultsDeep(clone(config_),
-      { kubernetes: { containerEngine: ContainerEngine.NONE } }) as BackendSettings;
+      { containerEngine: { name: ContainerEngine.NONE } });
     let kubernetesVersion: semver.SemVer | undefined;
 
     await this.setState(State.STARTING);

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -44,12 +44,12 @@ describe(SettingsValidator, () => {
       const newEngine = cfg.containerEngine.name === 'moby' ? 'containerd' : 'moby';
       const newFlannelEnabled = !cfg.kubernetes.options.flannel;
       const newConfig = _.merge({}, cfg, {
+        containerEngine: { name: newEngine },
         kubernetes:
           {
-            enabled:         newEnabled,
-            version:         newVersion,
-            containerEngine: newEngine,
-            options:         { flannel: newFlannelEnabled },
+            enabled: newEnabled,
+            version: newVersion,
+            options: { flannel: newFlannelEnabled },
           },
       });
       const [needToUpdate, errors] = subject.validateSettings(cfg, newConfig);

--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -15,7 +15,7 @@
     </div>
     <hr>
     <update-status
-      :enabled="settings.updater"
+      :enabled="settings.application.updater.enabled"
       :update-state="updateState"
       :version="version"
       @enabled="onUpdateEnabled"
@@ -23,7 +23,7 @@
     />
     <hr>
     <telemetry-opt-in
-      :telemetry="settings.telemetry"
+      :telemetry="settings.application.telemetry.enabled"
       @updateTelemetry="updateTelemetry"
     />
     <hr>
@@ -107,7 +107,7 @@ export default {
       this.$data.settings = settings;
     },
     onUpdateEnabled(value) {
-      ipcRenderer.invoke('settings-write', { updater: value });
+      ipcRenderer.invoke('settings-write', { application: { telemetry: { updater: value } } });
     },
     onUpdateApply() {
       ipcRenderer.send('update-apply');

--- a/pkg/rancher-desktop/store/diagnostics.ts
+++ b/pkg/rancher-desktop/store/diagnostics.ts
@@ -14,7 +14,7 @@ interface DiagnosticsState {
   inError: boolean;
 }
 
-const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v0/${ pathRemainder }`;
+const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v1/${ pathRemainder }`;
 
 /**
  * Updates the muted property for diagnostic results.

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -30,9 +30,9 @@ interface CommitArgs extends ServerState {
   payload?: RecursivePartial<Settings>;
 }
 
-const uri = (port: number) => `http://localhost:${ port }/v0/settings`;
+const uri = (port: number) => `http://localhost:${ port }/v1/settings`;
 
-const proposedSettings = (port: number) => `http://localhost:${ port }/v0/propose_settings`;
+const proposedSettings = (port: number) => `http://localhost:${ port }/v1/propose_settings`;
 
 export const state: () => PreferencesState = () => (
   {

--- a/pkg/rancher-desktop/store/transientSettings.ts
+++ b/pkg/rancher-desktop/store/transientSettings.ts
@@ -14,7 +14,7 @@ interface CommitArgs extends ServerState {
   payload?: RecursivePartial<TransientSettings>;
 }
 
-const uri = (port: number) => `http://localhost:${ port }/v0/transient_settings`;
+const uri = (port: number) => `http://localhost:${ port }/v1/transient_settings`;
 
 export const state: () => TransientSettings = () => _.cloneDeep(defaultTransientSettings);
 


### PR DESCRIPTION
Fixes #3747

Adding tests that should have been done in PR #3800

I created a new PR because PR 3800 uses the /v0 API and we might as well use the /v1 API

Signed-off-by: Eric Promislow <epromislow@suse.com>