### PR TITLE
Remove installation of devtools.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -134,7 +134,6 @@ Electron.app.whenReady().then(async() => {
   try {
     const commandLineArgs = getCommandLineArgs();
 
-    installDevtools();
     setupProtocolHandler();
 
     // Needs to happen before any file is written, otherwise that file
@@ -227,19 +226,6 @@ Electron.app.whenReady().then(async() => {
     Electron.app.quit();
   }
 });
-
-function installDevtools() {
-  if (Electron.app.isPackaged) {
-    return;
-  }
-
-  const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
-
-  // No need to wait for it to complete, but handle any errors asynchronously
-  installExtension(VUEJS_DEVTOOLS).catch((err: any) => {
-    console.log(`Error installing VUEJS_DEVTOOLS: ${ err }`);
-  });
-}
 
 async function doFirstRunDialog() {
   if (settings.firstRunDialogNeeded()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "ejs": "3.1.8",
         "electron": "20.3.8",
         "electron-builder": "23.3.3",
-        "electron-devtools-installer": "3.2.0",
         "electron-notarize": "1.2.1",
         "eslint": "8.23.1",
         "eslint-import-resolver-typescript": "3.5.2",
@@ -15569,22 +15568,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/electron-devtools-installer": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.2",
-        "semver": "^7.2.1",
-        "tslib": "^2.1.0",
-        "unzip-crx-3": "^0.2.0"
-      }
-    },
-    "node_modules/electron-devtools-installer/node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/electron-notarize": {
       "version": "1.2.1",
@@ -31816,16 +31799,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/unzip-crx-3": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jszip": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "yaku": "^0.16.6"
-      }
-    },
     "node_modules/upath": {
       "version": "2.0.1",
       "license": "MIT",
@@ -34722,11 +34695,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yaku": {
-      "version": "0.16.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -45522,22 +45490,6 @@
         }
       }
     },
-    "electron-devtools-installer": {
-      "version": "3.2.0",
-      "dev": true,
-      "requires": {
-        "rimraf": "^3.0.2",
-        "semver": "^7.2.1",
-        "tslib": "^2.1.0",
-        "unzip-crx-3": "^0.2.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "dev": true
-        }
-      }
-    },
     "electron-notarize": {
       "version": "1.2.1",
       "dev": true,
@@ -55885,15 +55837,6 @@
     "untildify": {
       "version": "4.0.0"
     },
-    "unzip-crx-3": {
-      "version": "0.2.0",
-      "dev": true,
-      "requires": {
-        "jszip": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "yaku": "^0.16.6"
-      }
-    },
     "upath": {
       "version": "2.0.1"
     },
@@ -57843,10 +57786,6 @@
     },
     "y18n": {
       "version": "5.0.8"
-    },
-    "yaku": {
-      "version": "0.16.7",
-      "dev": true
     },
     "yallist": {
       "version": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "ejs": "3.1.8",
     "electron": "20.3.8",
     "electron-builder": "23.3.3",
-    "electron-devtools-installer": "3.2.0",
     "electron-notarize": "1.2.1",
     "eslint": "8.23.1",
     "eslint-import-resolver-typescript": "3.5.2",


### PR DESCRIPTION
Vue devtools haven't worked since we moved to using the app:// protocol (because Chrome only loads dev tools from http://), and its background page appears to be causing issues with Playwright.

This appears to reduce failure in the E2E tests. When running things locally, I observed that `this.page.evaluate('document.location.href')` sometimes returned `chrome-extension://najkhokfapfdbdjaaakglpkeilmhnigk/_generated_background_page.html` (the URL for the extension background page), which might have caused the failure to locate the backend progress bar. Given that the extension doesn't work for `app://` anyway, it seems like removing it would be a good idea.