### PR TITLE
E2E: Force kill electron

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -8,7 +8,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 import semver from 'semver';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from './utils/TestUtils';
 
 import { Settings, ContainerEngine } from '@pkg/config/settings';
 import fetch from '@pkg/utils/fetch';
@@ -45,11 +45,7 @@ test.describe.serial('KubernetesBackend', () => {
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -5,7 +5,7 @@ import { test, expect } from '@playwright/test';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, packageLogs, reportAsset, tool } from './utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown, tool } from './utils/TestUtils';
 
 import { Settings } from '@pkg/config/settings';
 
@@ -42,11 +42,7 @@ test.describe.serial('Container Engine', () => {
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('wait for the container engine to be ready', async() => {
     const navPage = new NavPage(page);

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -34,7 +34,7 @@ import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, getFullPathForTool, packageLogs, reportAsset, tool,
+  createDefaultSettings, getFullPathForTool, reportAsset, teardown, tool,
 } from './utils/TestUtils';
 
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
@@ -267,11 +267,7 @@ describeWithCreds('Credentials server', () => {
     }
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -5,7 +5,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, packageLogs,
+  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, teardown,
 } from './utils/TestUtils';
 
 let page: Page;
@@ -44,11 +44,7 @@ test.describe.serial('Helm Deployment Test', () => {
    */
   test.afterAll(tearDownHelm);
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should start loading the background services', async() => {
     const navPage = new NavPage(page);

--- a/e2e/kubectl.e2e.spec.ts
+++ b/e2e/kubectl.e2e.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, kubectl, packageLogs, reportAsset } from './utils/TestUtils';
+import { createDefaultSettings, kubectl, reportAsset, teardown } from './utils/TestUtils';
 
 let page: Page;
 
@@ -35,11 +35,7 @@ test.describe.serial('K8s Deployment Test', () => {
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should start loading the background services', async() => {
     const navPage = new NavPage(page);

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from './utils/TestUtils';
 
 let page: Page;
 
@@ -39,11 +39,7 @@ test.describe.serial('Main App Test', () => {
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -6,7 +6,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import { PreferencesPage } from './pages/preferences';
-import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from './utils/TestUtils';
 
 let page: Page;
 
@@ -47,11 +47,7 @@ test.describe.serial('Main App Test', () => {
     preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should open preferences modal', () => {
     expect(preferencesWindow).toBeDefined();

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -29,7 +29,7 @@ import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, packageLogs, reportAsset, tool,
+  createDefaultSettings, kubectl, reportAsset, teardown, tool,
 } from './utils/TestUtils';
 
 import { ContainerEngine, Settings } from '@pkg/config/settings';
@@ -129,11 +129,7 @@ test.describe('Command server', () => {
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should load Kubernetes API', async() => {
     const navPage = new NavPage(page);

--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -10,7 +10,7 @@ import { expect, test } from '@playwright/test';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, packageLogs, reportAsset } from './utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from './utils/TestUtils';
 
 import { spawnFile } from '@pkg/utils/childProcess';
 
@@ -171,11 +171,7 @@ test.describe('WSL Integrations', () => {
     await context.tracing.start({ screenshots: true, snapshots: true });
     page = await electronApp.firstWindow();
   });
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('should list integrations', async() => {
     await page.reload();

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -5,7 +5,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 
 import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
-import { createDefaultSettings, packageLogs, reportAsset } from '../e2e/utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from '../e2e/utils/TestUtils';
 import { MainWindowScreenshots, PreferencesScreenshots } from './Screenshots';
 
 import { isWin } from '@pkg/utils/platform';
@@ -47,11 +47,7 @@ test.describe.serial('Main App Test', () => {
     await navPage.progressBecomesReady();
   });
 
-  test.afterAll(async() => {
-    await context.tracing.stop({ path: reportAsset(__filename) });
-    await packageLogs(__filename);
-    await electronApp.close();
-  });
+  test.afterAll(() => teardown(electronApp, __filename));
 
   test('Main Page', async({ colorScheme }) => {
     const screenshot = new MainWindowScreenshots(page, { directory: `${ colorScheme }/main` });


### PR DESCRIPTION
This is some work that happened while figuring out what was going wrong with the E2E tests that still might be useful.

- ~Import `@playwright/test` instead of `playwright`, according to advice Eric received.~ removed
- Manually kill the Electron processes when we're done with them (after graceful shutdown), as sometimes they seem to stick around past when they should.

It may be useful in the future to extract out the common startup bits too, but that would be in a different PR (if we ever end up doing it).