### PR TITLE
E2E: Fix playwright trace generation

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -83,7 +83,7 @@ export async function teardown(app: ElectronApplication, filename: string) {
   const pid = proc.pid;
 
   try {
-    await context.tracing.stop({ path: reportAsset(__filename) });
+    await context.tracing.stop({ path: reportAsset(filename) });
     await packageLogs(filename);
     await app.close();
   } finally {


### PR DESCRIPTION
We were previously passing in the wrong file name (always "TestUtils.ts"), causing the traces for each test suite to overwrite each other.