### PR TITLE
Actions: Add workflow for E2E Windows tests

### DIFF
--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -11,18 +11,16 @@ jobs:
 
   e2e-tests:
     timeout-minutes: 90
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, win11]
     steps:
       - run: wsl --unregister rancher-desktop
         continue-on-error: true
       - run: wsl --unregister rancher-desktop-data
         continue-on-error: true
-      - run: >
-          Remove-Item -Path "~/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
-      - run: >
-          Remove-Item -Path "~/AppData/Roaming/rancher-desktop" -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item -Path "$HOME/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item -Path "$HOME/AppData/Roaming/rancher-desktop" -Recurse -Force -ErrorAction Ignore
       - name: Remove golang module cache
-        run: Remove-Item -Path ~/go/pkg/mod -Recurse -Force -ErrorAction Ignore
+        run: Remove-Item -Path "$HOME/go/pkg/mod" -Recurse -Force -ErrorAction Ignore
       - uses: actions/checkout@v3
         with:
           persist-credentials: false

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -21,6 +21,8 @@ jobs:
           Remove-Item -Path "~/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
       - run: >
           Remove-Item -Path "~/AppData/Roaming/rancher-desktop" -Recurse -Force -ErrorAction Ignore
+      - name: Remove golang module cache
+        run: Remove-Item -Path ~/go/pkg/mod -Recurse -Force -ErrorAction Ignore
       - uses: actions/checkout@v3
         with:
           persist-credentials: false

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -1,0 +1,49 @@
+name: e2e tests on Windows
+
+on:
+  schedule:
+    - cron: '13 5 * * 1-5'
+  workflow_dispatch: {}
+defaults:
+  run:
+    shell: powershell
+jobs:
+
+  e2e-tests:
+    timeout-minutes: 90
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - run: wsl --unregister rancher-desktop
+        continue-on-error: true
+      - run: wsl --unregister rancher-desktop-data
+        continue-on-error: true
+      - run: >
+          Remove-Item -Path "~/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
+      - run: >
+          Remove-Item -Path "~/AppData/Roaming/rancher-desktop" -Recurse -Force -ErrorAction Ignore
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          cache: npm
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18'
+          cache: 'true'
+          # This appears to only allow caching one dependency; pick one at
+          # random.
+          cache-dependency-path: src/go/rdctl/go.sum
+      - name: Install dependencies
+        run: npm ci
+      - name: Run e2e Tests
+        run: npm run test:e2e
+        env:
+          RD_DEBUG_ENABLED: '1'
+      - name: Upload failure reports
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: e2etest-artifacts
+          path: ./e2e/reports/*


### PR DESCRIPTION
This uses a new self-hosted Windows test runner (because the GitHub- provided ones do not allow running VMs).

This will be initially set as draft until we've got the runner set up.