### PR TITLE
E2E: Add strategic retries

### DIFF
--- a/e2e/helm.e2e.spec.ts
+++ b/e2e/helm.e2e.spec.ts
@@ -5,7 +5,7 @@ import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, teardown,
+  createDefaultSettings, kubectl, helm, tearDownHelm, reportAsset, teardown, retry,
 } from './utils/TestUtils';
 
 let page: Page;
@@ -54,7 +54,7 @@ test.describe.serial('Helm Deployment Test', () => {
   });
 
   test('should check kubernetes API is ready', async() => {
-    const output = await kubectl('cluster-info');
+    const output = await retry(() => kubectl('cluster-info'));
 
     expect(output).toMatch(/is running at ./);
   });

--- a/e2e/kubectl.e2e.spec.ts
+++ b/e2e/kubectl.e2e.spec.ts
@@ -4,7 +4,9 @@ import { test, expect } from '@playwright/test';
 import { ElectronApplication, BrowserContext, _electron, Page } from 'playwright';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, kubectl, reportAsset, teardown } from './utils/TestUtils';
+import {
+  createDefaultSettings, kubectl, reportAsset, retry, teardown,
+} from './utils/TestUtils';
 
 let page: Page;
 
@@ -45,7 +47,7 @@ test.describe.serial('K8s Deployment Test', () => {
   });
 
   test('should run Kubernetes on Rancher Desktop (kubectl)', async() => {
-    const output = await kubectl('cluster-info');
+    const output = await retry(() => kubectl('cluster-info'));
 
     expect(output).toMatch(/is running at ./);
   });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -29,7 +29,7 @@ import { BrowserContext, ElectronApplication, Page, _electron } from 'playwright
 
 import { NavPage } from './pages/nav-page';
 import {
-  createDefaultSettings, kubectl, reportAsset, teardown, tool,
+  createDefaultSettings, kubectl, reportAsset, retry, teardown, tool,
 } from './utils/TestUtils';
 
 import { ContainerEngine, Settings, defaultSettings } from '@pkg/config/settings';
@@ -1190,7 +1190,7 @@ test.describe('Command server', () => {
       await expect(navPage.progressBar).not.toBeHidden();
       await navPage.progressBecomesReady();
       await expect(navPage.progressBar).toBeHidden();
-      const output = await tool('docker', 'info');
+      const output = await retry(() => tool('docker', 'info'));
 
       expect(output).toMatch(/Server Version:\s+v?[.0-9]+/);
     });


### PR DESCRIPTION
For some E2E tests, it would be useful for us to retry things before declaring things as having failed.  In particular, this is for things like waiting for some other piece to be ready (e.g. waiting for Kubernetes to finish starting up).  This PR adds a generic retry facility and a few uses of it.