### PR TITLE
E2E: rdctl: retry when waiting for cluster to be ready.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -136,7 +136,7 @@ test.describe('Command server', () => {
     await navPage.progressBecomesReady();
     await expect(navPage.progressBar).toBeHidden();
 
-    expect(await kubectl('cluster-info')).toContain('is running at');
+    expect(await retry(() => kubectl('cluster-info'))).toContain('is running at');
   });
 
   test('should emit connection information', async() => {


### PR DESCRIPTION
This is a small extension on top of #3872 to add one more retry to an operation that waits for something to finish.