### PR TITLE
Add extra logging

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1339,29 +1339,25 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       (async() => {
         const linuxPath = await this.wslify(provisioningPath);
 
-        await this.execCommand('/bin/sh', '-c', `
-          set -o errexit -o nounset
+        // Stop the service if it's already running for some reason.
+        // This should never be the case (because we tore down init).
+        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
 
-          # Stop the service if it's already running for some reason.
-          # This should never be the case (because we tore down init).
-          /usr/local/bin/wsl-service --ifstarted local stop
+        // Clobber /etc/local.d and replace it with a symlink to our desired
+        // path.  This is needed as /etc/init.d/local does not support
+        // overriding the script directory.
+        await this.execCommand('rm', '-r', '-f', '/etc/local.d');
+        await this.execCommand('ln', '-s', '-f', '-T', linuxPath, '/etc/local.d');
 
-          # Clobber /etc/local.d and replace it with a symlink to our desired
-          # path.  This is needed as /etc/init.d/local does not support
-          # overriding the script directory.
-          rm -r -f /etc/local.d
-          ln -s -f -T "${ linuxPath }" /etc/local.d
+        // Ensure all scripts are executable; Windows mounts are unlikely to
+        // have it set by default.
+        await this.execCommand('/usr/bin/find',
+          '/etc/local.d',
+          '(', '-name', '*.start', '-o', '-name', '*.stop', ')',
+          '-print', '-exec', 'chmod', 'a+x', '{}', ';');
 
-          # Ensure all scripts are executable; Windows mounts are unlikely to
-          # have it set by default.
-          /usr/bin/find \
-            /etc/local.d/ \
-            '(' -name '*.start' -o -name '*.stop' ')' \
-            -print -exec chmod a+x '{}' ';'
-
-          # Run the script.
-          exec /usr/local/bin/wsl-service local start
-        `.replace(/\r/g, ''));
+        // Run the script.
+        await this.execCommand('/usr/local/bin/wsl-service', 'local', 'start');
       })(),
     ]);
   }

--- a/src/go/vtunnel/cmd/root.go
+++ b/src/go/vtunnel/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,9 @@ The host process on windows forwards the TCP payload to a given address over TCP
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	writer := logrus.New().Writer()
+	defer writer.Close()
+	rootCmd.SetErr(writer)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)


### PR DESCRIPTION
This adds some extra logging so it's more helpful for post-mortem debugging if we have logs from things going wrong (in particular, for E2E tests on CI).  Each commit is self-contained.

- Use logrus for logging in vtunnel, so that if things go wrong (from the command-level `RunE`) the messages will get timestamps.  This is useful when trying to line up when things happened.
- When we run a command, explicitly log something in `wsl-exec.log` if a custom logger was not provided.  This is so it includes a timestamp, so if things go wrong we can see when that happened.
- Dump the output from `/sbin/init` into its own log file.  It looks like it (or possibly OpenRC) manages to seek to the start of the file when logging, so it clobbers some of the other logs.
- We currently run provisioning with an inlined shell script.  This makes it difficult to determine what went wrong when the whole block fails.  We move this to run each command separately, so that we can see the issue better (though sometimes that still doesn't help).
- When the Win32 docker socket proxy stops, print _why_ it is stopping, for debugging.