### PR TITLE
Move to v5 settings

### DIFF
--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -33,18 +33,20 @@ jobs:
           mkdir -p $HOME/.rd/bin
           cp -rf $HOME/actions-runner/_work/rancher-desktop/rancher-desktop/resources/darwin/bin/ $HOME/.rd/bin/
           export PATH="$HOME/.rd/bin:$PATH"
-      - name: Suppress sudo before start up
+      - name: Disable admin-access before start up
         run: |
           mkdir -p $HOME/Library/Preferences/rancher-desktop
           touch $HOME/Library/Preferences/rancher-desktop/settings.json
           cat <<EOF > $HOME/Library/Preferences/rancher-desktop/settings.json
           {
-            "version": 4,
-            "kubernetes": {
-              "memoryInGB": 6,
-              "suppressSudo": true
+            "version": 5,
+            "application": {
+              "adminAccess": false
+              "updater":  { "enabled": false },
             },
-            "updater": false,
+            "virtualMachine" {
+              "memoryInGB": 6,
+            },
             "pathManagementStrategy": "rcfiles"
           }
           EOF
@@ -93,5 +95,3 @@ jobs:
           done
           ps auxww | grep rancher | grep -vi -e goland
         if: always()
-
-

--- a/background.ts
+++ b/background.ts
@@ -110,7 +110,7 @@ Electron.app.on('second-instance', async() => {
 // when settings change
 mainEvents.on('settings-update', async(newSettings) => {
   console.log(`mainEvents settings-update: ${ JSON.stringify(newSettings) }`);
-  const runInDebugMode = settings.runInDebugMode(newSettings.debug);
+  const runInDebugMode = settings.runInDebugMode(newSettings.application.debug);
 
   if (runInDebugMode) {
     setLogLevel('debug');
@@ -119,9 +119,9 @@ mainEvents.on('settings-update', async(newSettings) => {
   }
   k8smanager.debug = runInDebugMode;
 
-  if (pathManager.strategy !== newSettings.pathManagementStrategy) {
+  if (pathManager.strategy !== newSettings.application.pathManagementStrategy) {
     await pathManager.remove();
-    pathManager = getPathManagerFor(newSettings.pathManagementStrategy);
+    pathManager = getPathManagerFor(newSettings.application.pathManagementStrategy);
     await pathManager.enforce();
   }
 });
@@ -159,12 +159,12 @@ Electron.app.whenReady().then(async() => {
         console.log(`Failed to update command from argument ${ commandLineArgs } `, err);
       }
     }
-    pathManager = getPathManagerFor(cfg.pathManagementStrategy);
+    pathManager = getPathManagerFor(cfg.application.pathManagementStrategy);
     mainEvents.emit('settings-update', cfg);
 
     // Set up the updater; we may need to quit the app if an update is already
     // queued.
-    if (await setupUpdate(cfg.updater, true)) {
+    if (await setupUpdate(cfg.application.updater.enabled, true)) {
       gone = true;
       // The update code will trigger a restart; don't do it here, as it may not
       // be ready yet.
@@ -200,11 +200,11 @@ Electron.app.whenReady().then(async() => {
     dockerDirManager.ensureCredHelperConfigured();
 
     // Path management strategy will need to be selected after an upgrade
-    if (!os.platform().startsWith('win') && cfg.pathManagementStrategy === PathManagementStrategy.NotSet) {
+    if (!os.platform().startsWith('win') && cfg.application.pathManagementStrategy === PathManagementStrategy.NotSet) {
       if (!noModalDialogs) {
         await window.openPathUpdate();
       } else {
-        cfg.pathManagementStrategy = PathManagementStrategy.RcFiles;
+        cfg.application.pathManagementStrategy = PathManagementStrategy.RcFiles;
       }
     }
 
@@ -327,9 +327,9 @@ async function startBackend(cfg: settings.Settings) {
  * @note Callers are responsible for handling errors thrown from here.
  */
 async function startK8sManager() {
-  const changedContainerEngine = currentContainerEngine !== cfg.kubernetes.containerEngine;
+  const changedContainerEngine = currentContainerEngine !== cfg.containerEngine.name;
 
-  currentContainerEngine = cfg.kubernetes.containerEngine;
+  currentContainerEngine = cfg.containerEngine.name;
   enabledK8s = cfg.kubernetes.enabled;
 
   if (changedContainerEngine) {
@@ -349,7 +349,7 @@ async function startK8sManager() {
  */
 
 function setupImageProcessor() {
-  const imageProcessor = getImageProcessor(cfg.kubernetes.containerEngine, k8smanager.executor);
+  const imageProcessor = getImageProcessor(cfg.containerEngine.name, k8smanager.executor);
 
   currentImageProcessor?.deactivate();
   if (!imageEventHandler) {
@@ -359,7 +359,7 @@ function setupImageProcessor() {
   currentImageProcessor = imageProcessor;
   currentImageProcessor.activate();
   currentImageProcessor.namespace = cfg.images.namespace;
-  window.send('k8s-current-engine', cfg.kubernetes.containerEngine);
+  window.send('k8s-current-engine', cfg.containerEngine.name);
 }
 
 interface K8sError {
@@ -557,7 +557,7 @@ ipcMainProxy.on('k8s-restart', async() => {
   if (cfg.kubernetes.port !== k8smanager.kubeBackend.desiredPort) {
     // On port change, we need to wipe the VM.
     return doK8sReset('wipe', { interactive: true });
-  } else if (cfg.kubernetes.containerEngine !== currentContainerEngine || cfg.kubernetes.enabled !== enabledK8s) {
+  } else if (cfg.containerEngine.name !== currentContainerEngine || cfg.kubernetes.enabled !== enabledK8s) {
     return doK8sReset('fullRestart', { interactive: true });
   }
   try {
@@ -608,7 +608,7 @@ ipcMainProxy.on('k8s-integrations', async() => {
 });
 
 ipcMainProxy.on('k8s-integration-set', (event, name, newState) => {
-  writeSettings({ kubernetes: { WSLIntegrations: { [name]: newState } } });
+  writeSettings({ WSL: { integrations: { [name]: newState } } });
 });
 
 mainEvents.on('integration-update', (state) => {
@@ -630,7 +630,7 @@ async function doFactoryReset(keepSystemImages: boolean) {
   const outfile = await fs.promises.open(path.join(tmpdir, 'rdctl-stdout.txt'), 'w');
   const args = ['factory-reset', `--remove-kubernetes-cache=${ (!keepSystemImages) ? 'true' : 'false' }`];
 
-  if (cfg.debug) {
+  if (cfg.application.debug) {
     args.push('--verbose=true');
   }
   const rdctl = spawn(path.join(paths.resources, os.platform(), 'bin', 'rdctl'), args,

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -65,7 +65,7 @@ EOF
   "virtualMachine": {
     "memoryInGB": 6,
   },
-  "wsl": { "integrations": $wsl_integrations },
+  "WSL": { "integrations": $wsl_integrations },
   "containerEngine": {
     "imageAllowList": {
       "enabled": $image_allow_list,

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -56,14 +56,16 @@ EOF
     mkdir -p "$PATH_CONFIG"
     cat <<EOF > "$PATH_CONFIG_FILE"
 {
-  "version": 4,
-  "kubernetes": {
-    "memoryInGB": 6,
-    "suppressSudo": true,
-    "WSLIntegrations": $wsl_integrations
+  "version": 5,
+  "application": {
+    "adminAccess":            false,
+    "pathManagementStrategy": "$path_management",
+    "updater":                { "enabled": false },
   },
-  "updater": false,
-  "pathManagementStrategy": "$path_management",
+  "virtualMachine": {
+    "memoryInGB": 6,
+  },
+  "wsl": { "integrations": $wsl_integrations },
   "containerEngine": {
     "imageAllowList": {
       "enabled": $image_allow_list,
@@ -92,8 +94,8 @@ start_container_engine() {
     fi
 
     rdctl start \
-          --kubernetes.suppress-sudo \
-          --updater=false \
+          --kubernetes.admin-access=false \
+          --application.updater.enabled=false \
           --container-engine="$RD_CONTAINER_ENGINE" \
           --kubernetes-enabled=false \
           "$@" \

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -127,19 +127,19 @@ test.describe.serial('KubernetesBackend', () => {
       };
       /** Platform-specific changes to `newSettings`. */
       const platformSettings: Partial<Record<NodeJS.Platform, RecursivePartial<Settings>>> = {
-        win32:  { kubernetes: { hostResolver: getAlt('kubernetes.hostResolver', true, false) } },
-        darwin: { kubernetes: { experimental: { socketVMNet: getAlt('kubernetes.experimental.socketVMNet', true, false) } } },
+        win32:  { virtualMachine: { hostResolver: getAlt('virtualMachine.hostResolver', true, false) } },
+        darwin: { virtualMachine: { experimental: { socketVMNet: getAlt('virtualMachine.experimental.socketVMNet', true, false) } } },
       };
 
       _.merge(newSettings, platformSettings[process.platform] ?? {});
       if (['darwin', 'linux'].includes(process.platform)) {
         // Lima-specific changes to `newSettings`.
         _.merge(newSettings, {
-          kubernetes: {
-            numberCPUs:   getAlt('kubernetes.numberCPUs', 1, 2),
-            memoryInGB:   getAlt('kubernetes.memoryInGB', 3, 4),
-            suppressSudo: getAlt('kubernetes.suppressSudo', true, false),
+          virtualMachine: {
+            numberCPUs: getAlt('virtualMachine.numberCPUs', 1, 2),
+            memoryInGB: getAlt('virtualMachine.memoryInGB', 3, 4),
           },
+          application: { adminAccess: getAlt('application.adminAccess', false, true) },
         });
       }
 
@@ -152,7 +152,7 @@ test.describe.serial('KubernetesBackend', () => {
       const expectedDefinition: ExpectedDefinition = {
         'kubernetes.version':         semver.lt(newSettings.kubernetes?.version ?? '0.0.0', currentSettings.kubernetes.version),
         'kubernetes.port':            false,
-        'kubernetes.containerEngine': false,
+        'containerEngine.name':       false,
         'kubernetes.enabled':         false,
         'kubernetes.options.traefik': false,
         'kubernetes.options.flannel': false,
@@ -160,17 +160,17 @@ test.describe.serial('KubernetesBackend', () => {
 
       /** Platform-specific additions to `expectedDefinition`. */
       const platformExpectedDefinitions: Partial<Record<NodeJS.Platform, ExpectedDefinition>> = {
-        win32:  { 'kubernetes.hostResolver': false },
-        darwin: { 'kubernetes.experimental.socketVMNet': false },
+        win32:  { 'virtualMachine.hostResolver': false },
+        darwin: { 'virtualMachine.experimental.socketVMNet': false },
       };
 
       _.merge(expectedDefinition, platformExpectedDefinitions[process.platform] ?? {});
 
       if (['darwin', 'linux'].includes(process.platform)) {
         // Lima additions to expectedDefinition
-        expectedDefinition['kubernetes.suppressSudo'] = false;
-        expectedDefinition['kubernetes.numberCPUs'] = false;
-        expectedDefinition['kubernetes.memoryInGB'] = false;
+        expectedDefinition['application.adminAccess'] = false;
+        expectedDefinition['virtualMachine.numberCPUs'] = false;
+        expectedDefinition['virtualMachine.memoryInGB'] = false;
       }
 
       const expected: Record<string, {current: any, desired: any, severity: 'reset' | 'restart'}> = {};
@@ -192,8 +192,8 @@ test.describe.serial('KubernetesBackend', () => {
       test.skip(os.platform() !== 'win32', 'WSL integration only supported on Windows');
       const random = `${ Date.now() }${ Math.random() }`;
       const newSettings: RecursivePartial<Settings> = {
-        kubernetes: {
-          WSLIntegrations: {
+        WSL: {
+          integrations: {
             [`true-${ random }`]:  true,
             [`false-${ random }`]: false,
           },
@@ -201,9 +201,9 @@ test.describe.serial('KubernetesBackend', () => {
       };
 
       await expect(put('/v0/propose_settings', newSettings)).resolves.toMatchObject({
-        'kubernetes.WSLIntegrations': {
+        'WSL.integrations': {
           current: {},
-          desired: newSettings.kubernetes?.WSLIntegrations,
+          desired: newSettings.WSL?.integrations,
         },
       });
     });

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -114,12 +114,12 @@ test.describe.serial('KubernetesBackend', () => {
       };
 
       const newSettings: RecursivePartial<Settings> = {
-        kubernetes: {
-          version:         getAlt('kubernetes.version', '1.23.6', '1.23.5'),
-          port:            getAlt('kubernetes.port', 6443, 6444),
-          containerEngine: getAlt('kubernetes.containerEngine', ContainerEngine.CONTAINERD, ContainerEngine.MOBY),
-          enabled:         getAlt('kubernetes.enabled', true, false),
-          options:         {
+        containerEngine: { name: getAlt('containerEngine.name', ContainerEngine.CONTAINERD, ContainerEngine.MOBY) },
+        kubernetes:      {
+          version: getAlt('kubernetes.version', '1.23.6', '1.23.5'),
+          port:    getAlt('kubernetes.port', 6443, 6444),
+          enabled: getAlt('kubernetes.enabled', true, false),
+          options: {
             traefik: getAlt('kubernetes.options.traefik', true, false),
             flannel: getAlt('kubernetes.options.flannel', true, false),
           },

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -21,7 +21,7 @@ test.describe.serial('Container Engine', () => {
   let context: BrowserContext;
 
   test.beforeAll(async() => {
-    createDefaultSettings({ kubernetes: { suppressSudo: true } });
+    createDefaultSettings({ application: { adminAccess: false } });
 
     electronApp = await _electron.launch({
       args: [
@@ -58,7 +58,7 @@ test.describe.serial('Container Engine', () => {
     // and then switch to the other.
     const navPage = new NavPage(page);
     const settings: Settings = JSON.parse(await tool('rdctl', 'list-settings'));
-    const engine = settings.kubernetes.containerEngine;
+    const engine = settings.containerEngine.name;
     const [otherEngine, toolName, otherToolName] = engine === 'containerd' ? ['moby', 'nerdctl', 'docker'] : ['containerd', 'docker', 'nerdctl'];
 
     // Run `uname -m` on two platforms using a more complex syntax

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -35,7 +35,6 @@ import { ContainerEngine, Settings, defaultSettings } from '@pkg/config/settings
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { spawnFile } from '@pkg/utils/childProcess';
 import paths from '@pkg/utils/paths';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 import type { ElectronApplication, BrowserContext, Page } from '@playwright/test';
 
@@ -1171,9 +1170,7 @@ test.describe('Command server', () => {
       const settings: Settings = JSON.parse(stdout);
 
       if (settings.containerEngine.name !== ContainerEngine.CONTAINERD) {
-        const payloadObject = {
-          containerEngine: { name: ContainerEngine.CONTAINERD },
-        };
+        const payloadObject = { containerEngine: { name: ContainerEngine.CONTAINERD } };
         const navPage = new NavPage(page);
 
         await tool('rdctl', 'api', '/v0/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -35,6 +35,7 @@ import { ContainerEngine, Settings, defaultSettings } from '@pkg/config/settings
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { spawnFile } from '@pkg/utils/childProcess';
 import paths from '@pkg/utils/paths';
+import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 import type { ElectronApplication, BrowserContext, Page } from '@playwright/test';
 
@@ -1170,7 +1171,7 @@ test.describe('Command server', () => {
       const settings: Settings = JSON.parse(stdout);
 
       if (settings.containerEngine.name !== ContainerEngine.CONTAINERD) {
-        const payloadObject = { containerEngine: { name: ContainerEngine.CONTAINERD } };
+        const payloadObject: RecursivePartial<Settings> = { containerEngine: { name: ContainerEngine.CONTAINERD } };
         const navPage = new NavPage(page);
 
         await tool('rdctl', 'api', '/v0/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -98,7 +98,8 @@ test.describe('Command server', () => {
   }
 
   function verifySettingsKeys(settings: Record<string, any>) {
-    expect(Object.keys(defaultSettings)).toEqual(Object.keys(settings));
+    expect(new Set(Object.keys(defaultSettings)))
+      .toEqual(new Set(Object.keys(settings)));
   }
 
   test.describe.configure({ mode: 'serial' });
@@ -220,12 +221,14 @@ test.describe('Command server', () => {
     const desiredEngine = 'flip';
     const desiredVersion = /1.23.4/.test(settings.kubernetes.version) ? 'v1.19.1' : 'v1.23.4';
     const requestedSettings = _.merge({}, settings, {
-      kubernetes:
-        {
-          enabled:         desiredEnabled,
-          containerEngine: desiredEngine,
-          version:         desiredVersion,
-        },
+      containerEngine: {
+        name:           { desiredEngine },
+        imageAllowList: { locked: !settings.containerEngine.imageAllowList.locked },
+      },
+      kubernetes: {
+        enabled: desiredEnabled,
+        version: desiredVersion,
+      },
     });
     const resp2 = await doRequest('/v0/settings', JSON.stringify(requestedSettings), 'PUT');
 
@@ -241,14 +244,14 @@ test.describe('Command server', () => {
 
   test('should return multiple error messages, settings request', async() => {
     const newSettings: Record<string, any> = {
-      kubernetes: {
-        WSLIntegrations: "ceci n'est pas un objet",
-        stoinks:         'yikes!', // should be ignored
-        memoryInGB:      'carl',
-        containerEngine: { status: 'should be a scalar' },
+      application: {
+        stoinks:   'yikes!', // should be ignored
+        telemetry: { enabled: { oops: 15 } },
       },
-      portForwarding: 'bob',
-      telemetry:      { oops: 15 },
+      containerEngine: { name: { status: 'should be a scalar' } },
+      virtualMachine:  { memoryInGB: 'carl' },
+      WSL:             { integrations: "ceci n'est pas un objet" },
+      portForwarding:  'bob',
     };
     const resp2 = await doRequest('/v0/settings', JSON.stringify(newSettings), 'PUT');
 
@@ -256,19 +259,20 @@ test.describe('Command server', () => {
     expect(resp2.status).toEqual(400);
     const body = resp2.body.read().toString();
     const expectedWSL = {
-      win32: "Proposed field kubernetes.WSLIntegrations should be an object, got <ceci n'est pas un objet>.",
-      lima:  "Changing field kubernetes.WSLIntegrations via the API isn't supported.",
+      win32: "Proposed field WSL.integrations should be an object, got <ceci n'est pas un objet>.",
+      lima:  "Changing field WSL.integrations via the API isn't supported.",
     }[os.platform() === 'win32' ? 'win32' : 'lima'];
     const expectedMemory = {
-      win32: "Changing field kubernetes.memoryInGB via the API isn't supported.",
-      lima:  'Invalid value for kubernetes.memoryInGB: <"carl">',
+      win32: "Changing field virtualMachine.memoryInGB via the API isn't supported.",
+      lima:  'Invalid value for virtualMachine.memoryInGB: <"carl">',
     }[os.platform() === 'win32' ? 'win32' : 'lima'];
     const expectedLines = [
+      'errors in attempt to update settings:',
       expectedWSL,
       expectedMemory,
-      `Invalid value for kubernetes.containerEngine: <{"status":"should be a scalar"}>; must be 'containerd', 'docker', or 'moby'`,
+      `Invalid value for containerEngine.name: <{"status":"should be a scalar"}>; must be 'containerd', 'docker', or 'moby'`,
       'Setting portForwarding should wrap an inner object, but got <bob>.',
-      'Invalid value for telemetry: <{"oops":15}>',
+      'Invalid value for application.telemetry.enabled: <{"oops":15}>',
     ];
 
     expect(body.split(/\r?\n/g)).toEqual(expect.arrayContaining(expectedLines));
@@ -306,11 +310,11 @@ test.describe('Command server', () => {
 
   test('should not restart on unrelated changes', async() => {
     let resp = await doRequest('/v0/settings');
-    let telemetry = false;
 
     expect(resp.ok).toBeTruthy();
-    telemetry = (await resp.json() as Settings).telemetry;
-    resp = await doRequest('/v0/settings', JSON.stringify({ telemetry: !telemetry }), 'PUT');
+    const telemetry = (await resp.json() as Settings).application.telemetry.enabled;
+
+    resp = await doRequest('/v0/settings', JSON.stringify({ application: { telemetry: { enabled: !telemetry } } }), 'PUT');
     expect(resp.ok).toBeTruthy();
     await expect(resp.text()).resolves.toContain('no restart required');
   });
@@ -609,7 +613,7 @@ test.describe('Command server', () => {
 
       verifySettingsKeys(settings);
 
-      const args = ['set', '--container-engine', settings.kubernetes.containerEngine,
+      const args = ['set', '--container-engine', settings.containerEngine.name,
         `--kubernetes-enabled=${ !!settings.kubernetes.enabled }`,
         '--kubernetes-version', settings.kubernetes.version];
       const result = await rdctl(args);
@@ -669,7 +673,7 @@ test.describe('Command server', () => {
           stdout, stderr, error,
         }).toEqual({
           error:  expect.any(Error),
-          stderr: expect.stringContaining(`invalid value for option --container-engine: <"${ myEngine }">; must be 'containerd', 'docker', or 'moby'`),
+          stderr: expect.stringContaining(`Error: invalid value for option --container-engine: <"${ myEngine }">; must be 'containerd', 'docker', or 'moby'`),
           stdout: '',
         });
         expect(stderr).not.toContain('Error: errors in attempt to update settings:');
@@ -918,14 +922,14 @@ test.describe('Command server', () => {
             });
 
             test('invalid setting is specified', async() => {
-              const newSettings = { kubernetes: { containerEngine: 'beefalo' } };
+              const newSettings = { containerEngine: { name: 'beefalo' } };
               const { stdout, stderr, error } = await rdctl(['api', 'settings', '-b', JSON.stringify(newSettings)]);
 
               expect({
                 stdout, stderr, error,
               }).toEqual({
                 error:  expect.any(Error),
-                stderr: expect.stringMatching(/errors in attempt to update settings:\s+Invalid value for kubernetes.containerEngine: <"beefalo">; must be 'containerd', 'docker', or 'moby'/),
+                stderr: expect.stringMatching(/errors in attempt to update settings:\s+Invalid value for containerEngine.name: <"beefalo">; must be 'containerd', 'docker', or 'moby'/),
                 stdout: expect.stringMatching(/{.*}/s),
               });
               expect(stderr).not.toContain('Usage:');
@@ -1165,13 +1169,11 @@ test.describe('Command server', () => {
     test('should verify nerdctl can talk to containerd', async() => {
       const { stdout } = await rdctl(['list-settings']);
       const settings: Settings = JSON.parse(stdout);
-      const payloadObject: RecursivePartial<Settings> = { };
 
-      if (settings.kubernetes.containerEngine !== ContainerEngine.CONTAINERD) {
-        payloadObject.kubernetes = {};
-        payloadObject.kubernetes.containerEngine = ContainerEngine.CONTAINERD;
-      }
-      if (Object.keys(payloadObject).length > 0) {
+      if (settings.containerEngine.name !== ContainerEngine.CONTAINERD) {
+        const payloadObject = {
+          containerEngine: { name: ContainerEngine.CONTAINERD },
+        };
         const navPage = new NavPage(page);
 
         await tool('rdctl', 'api', '/v0/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -21,9 +21,11 @@ import { RecursivePartial } from '@pkg/utils/typeUtils';
  */
 export function createDefaultSettings(overrides: RecursivePartial<Settings> = {}) {
   const defaultOverrides: RecursivePartial<Settings> = {
-    kubernetes:             { enabled: true, version: '1.25.4' },
-    debug:                  true,
-    pathManagementStrategy: PathManagementStrategy.Manual,
+    kubernetes:  { enabled: true, version: '1.25.4' },
+    application: {
+      debug:                  true,
+      pathManagementStrategy: PathManagementStrategy.Manual,
+    },
   };
   const settingsData: Settings = _.merge({}, defaultSettings, defaultOverrides, overrides);
 

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -233,9 +233,35 @@ components:
     preferences:
       type: object
       properties:
+        application:
+          type: object
+          properties:
+            adminAccess:
+              type: boolean
+            debug:
+              type: boolean
+            pathManagementStrategy:
+              type: string
+              enum: ['manual', 'rcfiles']
+            telemetry:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+            updater:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
         containerEngine:
           type: object
           properties:
+            name:
+              type: string
+              enum: ['containerd', 'docker', 'moby']
+              x-rd-usage: Set engine to containerd or moby (aka docker).
+              x-rd-aliases:
+                - "container-engine"
             imageAllowList:
               type: object
               properties:
@@ -247,6 +273,22 @@ components:
                   type: array
                   items:
                     type: string
+        virtualMachine:
+          type: object
+          properties:
+            memoryInGB:
+              type: integer
+              minimum: 1
+            numberCPUs:
+              type: integer
+              minimum: 1
+            hostResolver:
+              type: boolean
+            experimental:
+              type: object
+              properties:
+                socketVMNet:
+                  type: boolean
         kubernetes:
           type: object
           properties:
@@ -255,28 +297,13 @@ components:
               x-rd-usage: Choose which version of kubernetes to run.
               x-rd-aliases:
                 - "kubernetes-version"
-            memoryInGB:
-              type: integer
-              minimum: 1
-            numberCPUs:
-              type: integer
-              minimum: 1
             port:
               type: integer
-            containerEngine:
-              type: string
-              enum: ['containerd', 'docker', 'moby']
-              x-rd-usage: Set engine to containerd or moby (aka docker).
-              x-rd-aliases:
-                - "container-engine"
             enabled:
               type: boolean
               x-rd-usage: Control whether kubernetes runs in the backend.
               x-rd-aliases:
                 - "kubernetes-enabled"
-            WSLIntegrations:
-              type: object
-              additionalProperties: true
             options:
               type: object
               properties:
@@ -289,15 +316,12 @@ components:
                     Use to disable flannel so you can install your own CNI.
                   x-rd-aliases:
                     - "flannel-enabled"
-            suppressSudo:
-              type: boolean
-            hostResolver:
-              type: boolean
-            experimental:
+        WSL:
+          type: object
+          properties:
+            integrations:
               type: object
-              properties:
-                socketVMNet:
-                  type: boolean
+              additionalProperties: true
         portForwarding:
           type: object
           properties:
@@ -310,15 +334,6 @@ components:
               type: boolean
             namespace:
               type: string
-        telemetry:
-          type: boolean
-        updater:
-          type: boolean
-        debug:
-          type: boolean
-        pathManagementStrategy:
-          type: string
-          enum: ['manual', 'rcfiles']
         diagnostics:
           type: object
           properties:

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -5,7 +5,7 @@ import { ServiceEntry } from './client';
 import { ExtraRequiresReasons } from './k3sHelper';
 
 import EventEmitter from '@pkg/utils/eventEmitter';
-import { RecursiveReadonly } from '@pkg/utils/typeUtils';
+import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 export { State, BackendError as KubernetesError } from './backend';
 export type {
@@ -123,7 +123,7 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
    * Calculate any reasons that may require us to restart the backend, had the
    * given new configuration been applied on top of the existing old configuration.
    */
-  requiresRestartReasons(oldConfig: BackendSettings, newConfig: RecursiveReadonly<BackendSettings>, extras?: ExtraRequiresReasons): Promise<RestartReasons>;
+  requiresRestartReasons(oldConfig: BackendSettings, newConfig: RecursivePartial<BackendSettings>, extras?: ExtraRequiresReasons): Promise<RestartReasons>;
 }
 
 export interface KubernetesBackendPortForwarder {

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -5,7 +5,7 @@ import { ServiceEntry } from './client';
 import { ExtraRequiresReasons } from './k3sHelper';
 
 import EventEmitter from '@pkg/utils/eventEmitter';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
+import { RecursiveReadonly } from '@pkg/utils/typeUtils';
 
 export { State, BackendError as KubernetesError } from './backend';
 export type {
@@ -123,7 +123,7 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
    * Calculate any reasons that may require us to restart the backend, had the
    * given new configuration been applied on top of the existing old configuration.
    */
-  requiresRestartReasons(oldConfig: BackendSettings, newConfig: RecursivePartial<BackendSettings>, extras?: ExtraRequiresReasons): Promise<RestartReasons>;
+  requiresRestartReasons(oldConfig: BackendSettings, newConfig: RecursiveReadonly<BackendSettings>, extras?: ExtraRequiresReasons): Promise<RestartReasons>;
 }
 
 export interface KubernetesBackendPortForwarder {

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -341,7 +341,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   protected async writeServiceScript(cfg: BackendSettings, allowSudo: boolean) {
     const config: Record<string, string> = {
       PORT:            this.desiredPort.toString(),
-      ENGINE:          cfg.kubernetes.containerEngine ?? ContainerEngine.NONE,
+      ENGINE:          cfg.containerEngine.name ?? ContainerEngine.NONE,
       ADDITIONAL_ARGS: `--node-ip ${ await this.vm.ipAddress }`,
       LOG_DIR:         paths.logs,
     };
@@ -362,7 +362,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     await this.vm.writeFile('/etc/init.d/cri-dockerd', SERVICE_CRI_DOCKERD_SCRIPT, 0o755);
     await this.vm.writeConf('cri-dockerd', {
       LOG_DIR: paths.logs,
-      ENGINE:  cfg.kubernetes.containerEngine ?? ContainerEngine.NONE,
+      ENGINE:  cfg.containerEngine.name ?? ContainerEngine.NONE,
     });
     await this.vm.writeFile('/etc/init.d/k3s', SERVICE_K3S_SCRIPT, 0o755);
     await this.vm.writeConf('k3s', config);
@@ -398,13 +398,13 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
 
           return 'restart';
         },
+        'application.adminAccess':                undefined,
+        'containerEngine.imageAllowList.enabled': undefined,
+        'containerEngine.name':                   undefined,
         'kubernetes.port':                        undefined,
-        'kubernetes.containerEngine':             undefined,
         'kubernetes.enabled':                     undefined,
         'kubernetes.options.traefik':             undefined,
         'kubernetes.options.flannel':             undefined,
-        'kubernetes.suppressSudo':                undefined,
-        'containerEngine.imageAllowList.enabled': undefined,
       },
       extra,
     );

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -194,7 +194,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     }
     this.cfg = config;
 
-    const executable = config.kubernetes.containerEngine === ContainerEngine.MOBY ? 'docker' : 'nerdctl';
+    const executable = config.containerEngine.name === ContainerEngine.MOBY ? 'docker' : 'nerdctl';
 
     await this.vm.verifyReady(executable, 'images');
 
@@ -306,12 +306,12 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
           return 'restart';
         },
         'kubernetes.port':                        undefined,
-        'kubernetes.containerEngine':             undefined,
+        'containerEngine.name':                   undefined,
         'kubernetes.enabled':                     undefined,
-        'kubernetes.WSLIntegrations':             undefined,
+        'WSL.integrations':                       undefined,
         'kubernetes.options.traefik':             undefined,
         'kubernetes.options.flannel':             undefined,
-        'kubernetes.hostResolver':                undefined,
+        'virtualMachine.hostResolver':            undefined,
         'containerEngine.imageAllowList.enabled': undefined,
       },
       extras,

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -265,6 +265,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
   protected readonly CONFIG_PATH = path.join(paths.lima, '_config', `${ MACHINE_NAME }.yaml`);
 
+  /** The current config state. */
   protected cfg: BackendSettings | undefined;
 
   /** The current architecture. */
@@ -277,7 +278,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   protected activeVersion: semver.SemVer | null = null;
 
   /** Whether we can prompt the user for administrative access - this setting persists in the config. */
-  #allowSudo = true;
+  #adminAccess = true;
 
   /** A transient property that prevents prompting via modal UI elements. */
   #noModalDialogs = false;
@@ -299,7 +300,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    */
   currentAction: Action = Action.NONE;
 
-  writeSetting(changed: RecursivePartial<typeof this.cfg>) {
+  writeSetting(changed: RecursivePartial<BackendSettings>) {
     if (changed) {
       mainEvents.emit('settings-write', changed);
     }
@@ -560,8 +561,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         location: this.baseDiskImage,
         arch:     this.arch,
       }],
-      cpus:   this.cfg?.kubernetes?.numberCPUs || 4,
-      memory: (this.cfg?.kubernetes?.memoryInGB || 4) * 1024 * 1024 * 1024,
+      cpus:   this.cfg?.virtualMachine.numberCPUs || 4,
+      memory: (this.cfg?.virtualMachine.memoryInGB || 4) * 1024 * 1024 * 1024,
       mounts: [
         { location: path.join(paths.cache, 'k3s'), writable: false },
         { location: paths.logs, writable: true },
@@ -842,13 +843,13 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    * @return Whether the user wants to allow the prompt.
    */
   protected async showSudoReason(this: Readonly<this> & this, explanations: Record<string, string[]>): Promise<boolean> {
-    if (this.noModalDialogs || this.cfg?.kubernetes?.suppressSudo) {
+    if (this.noModalDialogs || !this.cfg?.application.adminAccess) {
       return false;
     }
     const neverAgain = await openSudoPrompt(explanations);
 
     if (neverAgain && this.cfg) {
-      this.writeSetting({ kubernetes: { suppressSudo: true } });
+      this.writeSetting({ application: { adminAccess: false } });
 
       return false;
     }
@@ -899,7 +900,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       this.showSudoReason(explanations));
 
     if (!allowed) {
-      this.#allowSudo = false;
+      this.#adminAccess = false;
 
       return false;
     }
@@ -913,7 +914,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       await this.sudoExec(`/bin/sh -xec '${ singleCommand }'`);
     } catch (err) {
       if (err instanceof Error && err.message === 'User did not grant permission.') {
-        this.#allowSudo = false;
+        this.#adminAccess = false;
         console.error('Failed to execute sudo, falling back to unprivileged operation', err);
 
         return false;
@@ -1171,7 +1172,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   protected async configureDockerSocket(this: Readonly<this> & this): Promise<SudoCommand | undefined> {
-    if (this.cfg?.kubernetes?.containerEngine !== ContainerEngine.MOBY) {
+    if (this.cfg?.containerEngine.name !== ContainerEngine.MOBY) {
       return;
     }
     const realPath = await this.evalSymlink(DEFAULT_DOCKER_SOCK_LOCATION);
@@ -1371,7 +1372,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
       await this.execCommand({ root: true }, 'mkdir', '-p', '/etc/cni/net.d');
 
-      if (this.cfg?.kubernetes?.options.flannel) {
+      if (this.cfg?.kubernetes.options.flannel) {
         await this.writeFile('/etc/cni/net.d/10-flannel.conflist', FLANNEL_CONFLIST);
       }
       await this.writeFile('/etc/containerd/config.toml', CONTAINERD_CONFIG);
@@ -1437,7 +1438,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     } else {
       const sharedIP = await this.getInterfaceAddr('rd1');
 
-      if (!this.cfg?.kubernetes?.suppressSudo) {
+      if (this.cfg?.application.adminAccess) {
         await this.noBridgedNetworkDialog(sharedIP);
       }
       if (sharedIP) {
@@ -1539,8 +1540,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    * @precondition The VM configuration is correct.
    */
   protected async startVM() {
-    const vmnet = this.cfg?.kubernetes?.experimental.socketVMNet ? VMNet.SOCKET : VMNet.VDE;
-    let allowRoot = this.#allowSudo;
+    const vmnet = this.cfg?.virtualMachine?.experimental.socketVMNet ? VMNet.SOCKET : VMNet.VDE;
+    let allowRoot = this.#adminAccess;
 
     // We need both the lima config + the lima network config to correctly check if we need sudo
     // access; but if it's denied, we need to regenerate both again to account for the change.
@@ -1584,7 +1585,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
     await this.setState(State.STARTING);
     this.currentAction = Action.STARTING;
-    this.#allowSudo = !config_.kubernetes?.suppressSudo;
+    this.#adminAccess = config_.application.adminAccess ?? true;
     await this.progressTracker.action('Starting Backend', 10, async() => {
       try {
         await this.ensureArchitectureMatch();
@@ -1603,7 +1604,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
         await this.startVM();
 
-        if (config.kubernetes?.enabled) {
+        if (config.kubernetes.enabled) {
           [kubernetesVersion, isDowngrade] = await this.kubeBackend.download(config);
 
           if (typeof (kubernetesVersion) === 'undefined') {
@@ -1649,13 +1650,13 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         if (config.containerEngine.imageAllowList.enabled) {
           await this.startService('openresty');
         }
-        if (config.kubernetes.containerEngine === ContainerEngine.CONTAINERD) {
+        if (config.containerEngine.name === ContainerEngine.CONTAINERD) {
           await this.startService('containerd');
-        } else if (config.kubernetes.containerEngine === ContainerEngine.MOBY) {
+        } else if (config.containerEngine.name === ContainerEngine.MOBY) {
           await this.startService('docker');
         }
         if (kubernetesVersion) {
-          await this.kubeBackend.install(config, kubernetesVersion, this.#allowSudo);
+          await this.kubeBackend.install(config, kubernetesVersion, this.#adminAccess);
         }
 
         await this.progressTracker.action('Installing Buildkit', 50, this.writeBuildkitScripts());
@@ -1681,12 +1682,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           k3sEndpoint = await this.kubeBackend.start(config, kubernetesVersion);
         }
 
-        if (config.kubernetes.containerEngine === ContainerEngine.MOBY) {
+        if (config.containerEngine.name === ContainerEngine.MOBY) {
           await this.dockerDirManager.ensureDockerContextConfigured(
-            this.#allowSudo,
+            this.#adminAccess,
             path.join(paths.altAppHome, 'docker.sock'),
             k3sEndpoint);
-        } else if (config.kubernetes.containerEngine === ContainerEngine.CONTAINERD) {
+        } else if (config.containerEngine.name === ContainerEngine.CONTAINERD) {
           await this.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'buildkitd', 'start');
         }
 
@@ -1805,7 +1806,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         existingConfig = {};
       }
       merge(existingConfig, defaultConfig);
-      if (this.cfg?.kubernetes?.containerEngine === ContainerEngine.CONTAINERD) {
+      if (this.cfg?.containerEngine.name === ContainerEngine.CONTAINERD) {
         existingConfig = BackendHelper.ensureDockerAuth(existingConfig);
       }
       await this.writeFile(ROOT_DOCKER_CONFIG_PATH, jsonStringifyWithWhiteSpace(existingConfig), 0o644);
@@ -1833,7 +1834,7 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
         const status = await this.status;
 
         if (defined(status) && status.status === 'Running') {
-          if (this.cfg?.kubernetes?.enabled) {
+          if (this.cfg?.kubernetes.enabled) {
             try {
               await this.execCommand({ root: true, expectFailure: true }, '/sbin/rc-service', '--ifstarted', 'k3s', 'stop');
             } catch (ex) {
@@ -1897,11 +1898,11 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       return reasons; // No need to restart if nothing exists
     }
     if (process.platform === 'darwin') {
-      if (typeof cfg.kubernetes?.experimental?.socketVMNet !== 'undefined') {
-        if (this.cfg.kubernetes?.experimental.socketVMNet !== cfg.kubernetes.experimental.socketVMNet) {
-          reasons['kubernetes.experimental.socketVMNet'] = {
-            current:  this.cfg.kubernetes.experimental.socketVMNet,
-            desired:  cfg.kubernetes.experimental.socketVMNet,
+      if (typeof cfg.virtualMachine?.experimental.socketVMNet !== 'undefined') {
+        if (this.cfg.virtualMachine?.experimental.socketVMNet !== cfg.virtualMachine?.experimental.socketVMNet) {
+          reasons['virtualMachine.experimental.socketVMNet'] = {
+            current:  this.cfg.virtualMachine.experimental.socketVMNet,
+            desired:  cfg.virtualMachine.experimental.socketVMNet,
             severity: 'restart',
           };
         }
@@ -1909,8 +1910,8 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     }
     if (limaConfig) {
       Object.assign(reasons, await this.kubeBackend.requiresRestartReasons(this.cfg, cfg, {
-        'kubernetes.numberCPUs': { current: limaConfig.cpus ?? 2 },
-        'kubernetes.memoryInGB': { current: (limaConfig.memory ?? 4 * GiB) / GiB },
+        'virtualMachine.numberCPUs': { current: limaConfig.cpus ?? 2 },
+        'virtualMachine.memoryInGB': { current: (limaConfig.memory ?? 4 * GiB) / GiB },
       }));
     }
 

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1898,8 +1898,8 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       return reasons; // No need to restart if nothing exists
     }
     if (process.platform === 'darwin') {
-      if (typeof cfg.virtualMachine?.experimental.socketVMNet !== 'undefined') {
-        if (this.cfg.virtualMachine?.experimental.socketVMNet !== cfg.virtualMachine?.experimental.socketVMNet) {
+      if (typeof cfg.virtualMachine?.experimental?.socketVMNet !== 'undefined') {
+        if (this.cfg.virtualMachine?.experimental.socketVMNet !== cfg.virtualMachine.experimental.socketVMNet) {
           reasons['virtualMachine.experimental.socketVMNet'] = {
             current:  this.cfg.virtualMachine.experimental.socketVMNet,
             desired:  cfg.virtualMachine.experimental.socketVMNet,

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -14,7 +14,7 @@ import ProgressTracker from './progressTracker';
 import { Settings } from '@pkg/config/settings';
 import { ChildProcess } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
+import { RecursiveReadonly } from '@pkg/utils/typeUtils';
 
 const console = Logging.mock;
 
@@ -91,7 +91,7 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
 
   noModalDialogs = true;
 
-  requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons> {
+  requiresRestartReasons(config: RecursiveReadonly<BackendSettings>): Promise<RestartReasons> {
     if (!this.cfg) {
       return Promise.resolve({});
     }

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -14,7 +14,7 @@ import ProgressTracker from './progressTracker';
 import { Settings } from '@pkg/config/settings';
 import { ChildProcess } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
-import { RecursiveReadonly } from '@pkg/utils/typeUtils';
+import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 const console = Logging.mock;
 
@@ -91,7 +91,7 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
 
   noModalDialogs = true;
 
-  requiresRestartReasons(config: RecursiveReadonly<BackendSettings>): Promise<RestartReasons> {
+  requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons> {
     if (!this.cfg) {
       return Promise.resolve({});
     }

--- a/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
@@ -36,8 +36,8 @@ export default Vue.extend({
   >
     <path-management-selector
       :show-label="false"
-      :value="preferences.pathManagementStrategy"
-      @input="onChange('pathManagementStrategy', $event)"
+      :value="preferences.application.pathManagementStrategy"
+      @input="onChange('application.pathManagementStrategy', $event)"
     />
   </rd-fieldset>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -34,10 +34,10 @@ export default Vue.extend({
   computed: {
     ...mapGetters('preferences', ['isPlatformWindows']),
     isSudoAllowed(): boolean {
-      return !(this.preferences?.kubernetes?.suppressSudo ?? false);
+      return !(this.preferences?.application?.adminAccess ?? true);
     },
     canAutoUpdate(): boolean {
-      return this.preferences?.updater || false;
+      return this.preferences?.application.updater.enabled ?? false;
     },
   },
   methods: {
@@ -59,7 +59,7 @@ export default Vue.extend({
       <checkbox
         label="Allow to acquire administrative credentials (sudo access)"
         :value="isSudoAllowed"
-        @input="onChange('kubernetes.suppressSudo', !$event)"
+        @input="onChange('application.adminAccess', $event)"
       />
     </rd-fieldset>
     <rd-fieldset
@@ -70,7 +70,7 @@ export default Vue.extend({
         data-test="automaticUpdatesCheckbox"
         label="Check for updates automatically"
         :value="canAutoUpdate"
-        @input="onChange('updater', $event)"
+        @input="onChange('application.updater.enabled', $event)"
       />
     </rd-fieldset>
     <rd-fieldset
@@ -79,8 +79,8 @@ export default Vue.extend({
     >
       <checkbox
         label="Allow collection of anonymous statistics to help us improve Rancher Desktop"
-        :value="preferences.telemetry"
-        @input="onChange('telemetry', $event)"
+        :value="preferences.application.telemetry.enabled"
+        @input="onChange('application.telemetry.enabled', $event)"
       />
     </rd-fieldset>
   </div>

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -34,7 +34,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters('preferences', ['isPlatformWindows']),
     isSudoAllowed(): boolean {
-      return !(this.preferences?.application?.adminAccess ?? true);
+      return this.preferences?.application?.adminAccess ?? false;
     },
     canAutoUpdate(): boolean {
       return this.preferences?.application.updater.enabled ?? false;

--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -44,14 +44,14 @@ export default Vue.extend({
   <div class="preferences-content">
     <system-preferences
       v-if="hasSystemPreferences"
-      :memory-in-g-b="preferences.kubernetes.memoryInGB"
-      :number-c-p-us="preferences.kubernetes.numberCPUs"
+      :memory-in-g-b="preferences.virtualMachine.memoryInGB"
+      :number-c-p-us="preferences.virtualMachine.numberCPUs"
       :avail-memory-in-g-b="availMemoryInGB"
       :avail-num-c-p-us="availNumCPUs"
       :reserved-memory-in-g-b="6"
       :reserved-num-c-p-us="1"
-      @update:memory="onChange('kubernetes.memoryInGB', $event)"
-      @update:cpu="onChange('kubernetes.numberCPUs', $event)"
+      @update:memory="onChange('virtualMachine.memoryInGB', $event)"
+      @update:cpu="onChange('virtualMachine.numberCPUs', $event)"
     />
   </div>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/BodyWsl.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyWsl.vue
@@ -22,7 +22,7 @@ export default Vue.extend({
   computed: { ...mapGetters('preferences', ['getWslIntegrations']) },
   methods:  {
     onChange(distro: string, value: boolean) {
-      const property: keyof RecursiveTypes<Settings> = `kubernetes.WSLIntegrations["${ distro }"]` as any;
+      const property: keyof RecursiveTypes<Settings> = `WSL.integrations["${ distro }"]` as any;
 
       this.$store.dispatch('preferences/updateWslIntegrations', { distribution: `["${ distro }"]`, value });
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
@@ -39,8 +39,8 @@ export default Vue.extend({
       :legend-text="t('containerEngine.label')"
     >
       <engine-selector
-        :container-engine="preferences.kubernetes.containerEngine"
-        @change="onChange('kubernetes.containerEngine', $event)"
+        :container-engine="preferences.containerEngine.name"
+        @change="onChange('containerEngine.name', $event)"
       />
     </rd-fieldset>
   </div>

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -13,40 +13,45 @@ describe('updateFromCommandLine', () => {
   beforeEach(() => {
     jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
     prefs = {
-      version:         4,
+      version:     5,
+      application: {
+        adminAccess:            true,
+        debug:                  true,
+        pathManagementStrategy: PathManagementStrategy.NotSet,
+        telemetry:              { enabled: true },
+        /** Whether we should check for updates and apply them. */
+        updater:                { enabled: true },
+      },
       containerEngine: {
         imageAllowList: {
           enabled:  false,
           locked:   false,
           patterns: [],
         },
+        name: settings.ContainerEngine.MOBY,
       },
+      virtualMachine: {
+        memoryInGB:   4,
+        numberCPUs:   2,
+        hostResolver: true,
+        experimental: { socketVMNet: true },
+      },
+      WSL:        { integrations: {} },
       kubernetes: {
-        version:         '1.23.5',
-        memoryInGB:      4,
-        numberCPUs:      2,
-        port:            6443,
-        containerEngine: settings.ContainerEngine.MOBY,
-        enabled:         true,
-        WSLIntegrations: {},
-        options:         {
+        version: '1.23.5',
+        port:    6443,
+        enabled: true,
+        options: {
           traefik: true,
           flannel: false,
         },
-        suppressSudo: false,
-        hostResolver: true,
-        experimental: { socketVMNet: true },
       },
       portForwarding: { includeKubernetesServices: false },
       images:         {
         showAll:   true,
         namespace: 'k8s.io',
       },
-      telemetry:              true,
-      updater:                true,
-      debug:                  true,
-      pathManagementStrategy: PathManagementStrategy.NotSet,
-      diagnostics:            {
+      diagnostics: {
         showMuted:   false,
         mutedChecks: { },
       },
@@ -128,11 +133,11 @@ describe('updateFromCommandLine', () => {
   });
 
   test('boolean option set to implicit true should change only that value', () => {
-    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.suppressSudo']);
+    const newPrefs = settings.updateFromCommandLine(prefs, ['--kubernetes.options.flannel']);
 
-    expect(origPrefs.kubernetes.suppressSudo).toBeFalsy();
-    expect(newPrefs.kubernetes.suppressSudo).toBeTruthy();
-    newPrefs.kubernetes.suppressSudo = false;
+    expect(origPrefs.kubernetes.options.flannel).toBeFalsy();
+    expect(newPrefs.kubernetes.options.flannel).toBeTruthy();
+    newPrefs.kubernetes.options.flannel = false;
     expect(newPrefs).toEqual(origPrefs);
   });
 
@@ -157,22 +162,22 @@ describe('updateFromCommandLine', () => {
   test('should change several values (and no others)', () => {
     const newPrefs = settings.updateFromCommandLine(prefs, [
       '--kubernetes.options.traefik=false',
-      '--kubernetes.suppressSudo',
+      '--application.adminAccess=false',
       '--portForwarding.includeKubernetesServices=true',
-      '--kubernetes.containerEngine=containerd',
+      '--containerEngine.name=containerd',
       '--kubernetes.port', '6444',
     ]);
 
     expect(newPrefs.kubernetes.options.traefik).toBeFalsy();
-    expect(newPrefs.kubernetes.suppressSudo).toBeTruthy();
+    expect(newPrefs.application.adminAccess).toBeFalsy();
     expect(newPrefs.portForwarding.includeKubernetesServices).toBeTruthy();
-    expect(newPrefs.kubernetes.containerEngine).toBe('containerd');
+    expect(newPrefs.containerEngine.name).toBe('containerd');
     expect(newPrefs.kubernetes.port).toBe(6444);
 
     newPrefs.kubernetes.options.traefik = true;
-    newPrefs.kubernetes.suppressSudo = false;
+    newPrefs.application.adminAccess = true;
     newPrefs.portForwarding.includeKubernetesServices = false;
-    newPrefs.kubernetes.containerEngine = settings.ContainerEngine.MOBY;
+    newPrefs.containerEngine.name = settings.ContainerEngine.MOBY;
     newPrefs.kubernetes.port = 6443;
     expect(newPrefs).toEqual(origPrefs);
   });
@@ -232,7 +237,7 @@ describe('updateFromCommandLine', () => {
   });
 
   test('should complain about a missing numeric value', () => {
-    const arg = '--kubernetes.memoryInGB';
+    const arg = '--virtualMachine.memoryInGB';
 
     expect(() => {
       settings.updateFromCommandLine(prefs, ['--kubernetes.version', '1.2.3', arg]);
@@ -259,7 +264,7 @@ describe('updateFromCommandLine', () => {
 
   test('should complain about type mismatches', () => {
     const optionList = [
-      ['--kubernetes.memoryInGB', 'true', 'boolean', 'number'],
+      ['--virtualMachine.memoryInGB', 'true', 'boolean', 'number'],
       ['--kubernetes.enabled', '7', 'number', 'boolean'],
     ];
 

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -21,7 +21,7 @@ const console = Logging.settings;
 // it will be picked up from the default settings object.
 // Version incrementing is for when a breaking change is introduced in the settings object.
 
-export const CURRENT_SETTINGS_VERSION = 5;
+export const CURRENT_SETTINGS_VERSION = 5 as const;
 
 export enum ContainerEngine {
   NONE = '',

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -21,7 +21,7 @@ const console = Logging.settings;
 // it will be picked up from the default settings object.
 // Version incrementing is for when a breaking change is introduced in the settings object.
 
-export const CURRENT_SETTINGS_VERSION = 5 as const;
+export const CURRENT_SETTINGS_VERSION = 5;
 
 export enum ContainerEngine {
   NONE = '',
@@ -400,6 +400,37 @@ const updateTable: Record<number, (settings: any) => void> = {
   },
   3: (_) => {
     // With settings v5, all traces of the kim builder are gone now, so no need to update it.
+  },
+  4: (settings) => {
+    settings.application = {
+      adminAccess:            !settings.kubernetes.suppressSudo,
+      debug:                  settings.debug,
+      pathManagementStrategy: settings.pathManagementStrategy,
+      telemetry:              { enabled: settings.telemetry },
+      updater:                { enabled: settings.updater },
+    };
+    settings.virtualMachine = {
+      experimental: settings.kubernetes.experimental,
+      hostResolver: settings.kubernetes.hostResolver,
+      memoryInGB:   settings.kubernetes.memoryInGB,
+      numberCPUs:   settings.kubernetes.numberCPUs,
+    };
+    settings.WSL = { integrations: settings.kubernetes.WSLIntegrations };
+    settings.containerEngine.name = settings.kubernetes.containerEngine;
+
+    delete settings.kubernetes.containerEngine;
+    delete settings.kubernetes.experimental;
+    delete settings.kubernetes.hostResolver;
+    delete settings.kubernetes.checkForExistingKimBuilder;
+    delete settings.kubernetes.memoryInGB;
+    delete settings.kubernetes.numberCPUs;
+    delete settings.kubernetes.suppressSudo;
+    delete settings.kubernetes.WSLIntegrations;
+
+    delete settings.debug;
+    delete settings.pathManagementStrategy;
+    delete settings.telemetry;
+    delete settings.updater;
   },
 };
 

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -21,7 +21,7 @@ const console = Logging.settings;
 // it will be picked up from the default settings object.
 // Version incrementing is for when a breaking change is introduced in the settings object.
 
-const CURRENT_SETTINGS_VERSION = 4;
+export const CURRENT_SETTINGS_VERSION = 5 as const;
 
 export enum ContainerEngine {
   NONE = '',
@@ -36,7 +36,15 @@ export const ContainerEngineNames: Record<ContainerEngine, string> = {
 };
 
 export const defaultSettings = {
-  version:         CURRENT_SETTINGS_VERSION,
+  version:     CURRENT_SETTINGS_VERSION,
+  application: {
+    adminAccess:            true,
+    debug:                  false,
+    pathManagementStrategy: PathManagementStrategy.NotSet,
+    telemetry:              { enabled: true },
+    /** Whether we should check for updates and apply them. */
+    updater:                { enabled: true },
+  },
   containerEngine: {
     imageAllowList: {
       enabled:  false,
@@ -47,42 +55,38 @@ export const defaultSettings = {
       locked:   false,
       patterns: [] as Array<string>,
     },
+    name: ContainerEngine.CONTAINERD,
   },
-  kubernetes: {
-    /** The version of Kubernetes to launch, as a semver (without v prefix). */
-    version:         '',
-    memoryInGB:      2,
-    numberCPUs:      2,
-    port:            6443,
-    containerEngine: ContainerEngine.CONTAINERD,
-    enabled:         true,
-    WSLIntegrations: {} as Record<string, boolean>,
-    options:         { traefik: true, flannel: true },
-    suppressSudo:    false,
+  virtualMachine: {
+    memoryInGB:   2,
+    numberCPUs:   2,
     /**
      * when set to true Dnsmasq is disabled and all DNS resolution
      * is handled by host-resolver on Windows platform only.
      */
-    hostResolver:    true,
+    hostResolver: true,
     /**
      * Experimental settings - there should not be any UI for these.
      */
-    experimental:    {
+    experimental: {
       /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
       socketVMNet: false,
     },
+  },
+  WSL:        { integrations: {} as Record<string, boolean> },
+  kubernetes: {
+    /** The version of Kubernetes to launch, as a semver (without v prefix). */
+    version: '',
+    port:    6443,
+    enabled: true,
+    options: { traefik: true, flannel: true },
   },
   portForwarding: { includeKubernetesServices: false },
   images:         {
     showAll:   true,
     namespace: 'k8s.io',
   },
-  telemetry:              true,
-  /** Whether we should check for updates and apply them. */
-  updater:                true,
-  debug:                  false,
-  pathManagementStrategy: PathManagementStrategy.NotSet,
-  diagnostics:            {
+  diagnostics: {
     showMuted:   false,
     mutedChecks: {} as Record<string, boolean>,
   },
@@ -115,9 +119,9 @@ function loadFromDisk(): Settings {
   // clone settings because we check to see if the returned value is different
   const cfg = updateSettings(clone(settings));
 
-  if (!Object.values(ContainerEngine).map(String).includes(cfg.kubernetes.containerEngine)) {
-    console.warn(`Replacing unrecognized saved container engine pref of '${ cfg.kubernetes.containerEngine }' with ${ ContainerEngine.CONTAINERD }`);
-    cfg.kubernetes.containerEngine = ContainerEngine.CONTAINERD;
+  if (!Object.values(ContainerEngine).map(String).includes(cfg.containerEngine.name)) {
+    console.warn(`Replacing unrecognized saved container engine pref of '${ cfg.containerEngine.name }' with ${ ContainerEngine.CONTAINERD }`);
+    cfg.containerEngine.name = ContainerEngine.CONTAINERD;
     save(cfg);
   } else if (!_.isEqual(cfg, settings)) {
     save(cfg);
@@ -287,11 +291,11 @@ export function load(): Settings {
         const totalMemoryInGB = os.totalmem() / 2 ** 30;
 
         // 25% of available ram up to a maximum of 6gb
-        settings.kubernetes.memoryInGB = Math.min(6, Math.round(totalMemoryInGB / 4.0));
+        settings.virtualMachine.memoryInGB = Math.min(6, Math.round(totalMemoryInGB / 4.0));
       }
     }
     if (os.platform() === 'linux' && !process.env['APPIMAGE']) {
-      settings.updater = false;
+      settings.application.updater.enabled = false;
     }
     save(settings);
   }

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -73,7 +73,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
 
   constructor() {
     mainEvents.on('settings-update', (settings) => {
-      this.wslHelperDebugArgs = runInDebugMode(settings.debug) ? ['--verbose'] : [];
+      this.wslHelperDebugArgs = runInDebugMode(settings.application.debug) ? ['--verbose'] : [];
       this.settings = clone(settings);
       this.sync();
     });
@@ -234,7 +234,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       reason = 'not enforcing';
     } else if (!this.backendReady) {
       reason = 'backend not ready';
-    } else if (this.settings.kubernetes?.containerEngine !== ContainerEngine.MOBY) {
+    } else if (this.settings.containerEngine?.name !== ContainerEngine.MOBY) {
       reason = `unsupported container engine ${ this.settings.kubernetes?.containerEngine }`;
     }
 
@@ -260,7 +260,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
    */
   protected async syncDistroSocketProxy(distro: string, shouldRun: boolean) {
     console.debug(`Syncing ${ distro } socket proxy: ${ shouldRun ? 'should' : 'should not' } run.`);
-    if (shouldRun && this.settings.kubernetes?.WSLIntegrations?.[distro] === true) {
+    if (shouldRun && this.settings.WSL?.integrations?.[distro] === true) {
       const executable = await this.getLinuxToolPath(distro, 'wsl-helper');
       const logStream = Logging[`wsl-helper.${ distro }`];
 
@@ -288,7 +288,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       this.distroSocketProxyProcesses[distro].start();
     } else {
       await this.distroSocketProxyProcesses[distro]?.stop();
-      if (!(distro in (this.settings.kubernetes?.WSLIntegrations ?? {}))) {
+      if (!(distro in (this.settings.WSL?.integrations ?? {}))) {
         delete this.distroSocketProxyProcesses[distro];
       }
     }
@@ -328,7 +328,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
     const srcPath = await this.getLinuxToolPath(distro, 'bin', 'docker-compose');
     const destDir = '$HOME/.docker/cli-plugins';
     const destPath = `${ destDir }/docker-compose`;
-    const state = this.settings.kubernetes?.WSLIntegrations?.[distro] === true;
+    const state = this.settings.WSL?.integrations?.[distro] === true;
 
     console.debug(`Syncing ${ distro } docker compose: ${ srcPath } -> ${ destDir }`);
     if (state) {
@@ -362,7 +362,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   }
 
   protected async syncDistroKubeconfig(distro: string, kubeconfigPath: string) {
-    const state = this.settings.kubernetes?.WSLIntegrations?.[distro] === true;
+    const state = this.settings.WSL?.integrations?.[distro] === true;
 
     try {
       console.debug(`Syncing ${ distro } kubeconfig`);
@@ -449,7 +449,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       return `Rancher Desktop can only integrate with v2 WSL distributions (this is v${ distro.version }).`;
     }
     if (!this.settings.kubernetes?.enabled) {
-      return this.settings.kubernetes?.WSLIntegrations?.[distro.name] ?? false;
+      return this.settings.WSL?.integrations?.[distro.name] ?? false;
     }
     try {
       const executable = await this.getLinuxToolPath(distro.name, 'wsl-helper');

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -235,7 +235,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
     } else if (!this.backendReady) {
       reason = 'backend not ready';
     } else if (this.settings.containerEngine?.name !== ContainerEngine.MOBY) {
-      reason = `unsupported container engine ${ this.settings.kubernetes?.containerEngine }`;
+      reason = `unsupported container engine ${ this.settings.containerEngine?.name }`;
     }
 
     console.debug(`Syncing Win32 socket proxy: ${ reason ? `should not run (${ reason })` : 'should run' }`);

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -11,8 +11,8 @@ const cfg = _.merge(
   {},
   settings.defaultSettings,
   {
-    kubernetes:             { version: '1.23.4' },
-    pathManagementStrategy: PathManagementStrategy.Manual,
+    kubernetes:  { version: '1.23.4' },
+    application: { pathManagementStrategy: PathManagementStrategy.Manual },
   });
 
 const subject = new SettingsValidator();
@@ -41,15 +41,15 @@ describe(SettingsValidator, () => {
     it('should want to apply changes when valid new settings are proposed', () => {
       const newEnabled = !cfg.kubernetes.enabled;
       const newVersion = subject.k8sVersions[1];
-      const newEngine = cfg.kubernetes.containerEngine === 'moby' ? 'containerd' : 'moby';
+      const newEngine = cfg.containerEngine.name === 'moby' ? 'containerd' : 'moby';
       const newFlannelEnabled = !cfg.kubernetes.options.flannel;
       const newConfig = _.merge({}, cfg, {
+        containerEngine: { name: newEngine },
         kubernetes:
           {
-            enabled:         newEnabled,
-            version:         newVersion,
-            containerEngine: newEngine,
-            options:         { flannel: newFlannelEnabled },
+            enabled: newEnabled,
+            version: newVersion,
+            options: { flannel: newFlannelEnabled },
           },
       });
       const [needToUpdate, errors] = subject.validateSettings(cfg, newConfig);
@@ -64,20 +64,20 @@ describe(SettingsValidator, () => {
       // Special fields that cannot be checked here; this includes enums and maps.
       const specialFields = [
         ['containerEngine', 'imageAllowList', 'locked'],
-        ['kubernetes', 'containerEngine'],
-        ['kubernetes', 'WSLIntegrations'],
+        ['containerEngine', 'name'],
+        ['WSL', 'integrations'],
         ['kubernetes', 'version'],
-        ['pathManagementStrategy'],
+        ['application', 'pathManagementStrategy'],
         ['version'],
       ];
 
       // Fields that can only be set on specific platforms.
       const platformSpecificFields: Record<string, ReturnType<typeof os.platform>> = {
-        'kubernetes.hostResolver':             'win32',
-        'kubernetes.memoryInGB':               'darwin',
-        'kubernetes.numberCPUs':               'linux',
-        'kubernetes.suppressSudo':             'linux',
-        'kubernetes.experimental.socketVMNet': 'darwin',
+        'virtualMachine.hostResolver':             'win32',
+        'virtualMachine.memoryInGB':               'darwin',
+        'virtualMachine.numberCPUs':               'linux',
+        'application.adminAccess':                 'linux',
+        'virtualMachine.experimental.socketVMNet': 'darwin',
       };
 
       const spyValidateSettings = jest.spyOn(subject, 'validateSettings');
@@ -202,13 +202,13 @@ describe(SettingsValidator, () => {
       });
     });
 
-    describe('kubernetes.containerEngine', () => {
+    describe('containerEngine.name', () => {
       function configWithValue(value: string | settings.ContainerEngine): settings.Settings {
         return {
           ...cfg,
-          kubernetes: {
-            ...cfg.kubernetes,
-            containerEngine: value as settings.ContainerEngine,
+          containerEngine: {
+            ...cfg.containerEngine,
+            name: value as settings.ContainerEngine,
           },
         };
       }
@@ -220,7 +220,7 @@ describe(SettingsValidator, () => {
           const typedKey = key as keyof typeof settings.ContainerEngine;
           const [needToUpdate, errors] = subject.validateSettings(
             configWithValue(settings.ContainerEngine.NONE),
-            { kubernetes: { containerEngine: settings.ContainerEngine[typedKey] } },
+            { containerEngine: { name: settings.ContainerEngine[typedKey] } },
           );
 
           expect({ needToUpdate, errors }).toEqual({
@@ -231,11 +231,11 @@ describe(SettingsValidator, () => {
       });
 
       it('should reject setting to NONE', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { containerEngine: settings.ContainerEngine.NONE } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { containerEngine: { name: settings.ContainerEngine.NONE } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <"">;')],
+          errors:       [expect.stringContaining('Invalid value for containerEngine.name: <"">;')],
         });
       });
 
@@ -245,7 +245,7 @@ describe(SettingsValidator, () => {
         it.each(aliases)('%s', (alias) => {
           const [needToUpdate, errors] = subject.validateSettings(
             configWithValue(settings.ContainerEngine.NONE),
-            { kubernetes: { containerEngine: alias as settings.ContainerEngine } });
+            { containerEngine: { name: alias as settings.ContainerEngine } });
 
           expect({ needToUpdate, errors }).toEqual({
             needToUpdate: true,
@@ -255,56 +255,53 @@ describe(SettingsValidator, () => {
       });
 
       it('should reject invalid values', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { containerEngine: 'pikachu' as settings.ContainerEngine } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { containerEngine: { name: 'pikachu' as settings.ContainerEngine } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [expect.stringContaining('Invalid value for kubernetes.containerEngine: <"pikachu">;')],
+          errors:       [expect.stringContaining('Invalid value for containerEngine.name: <"pikachu">;')],
         });
       });
     });
 
-    describe('kubernetes.WSLIntegrations', () => {
+    describe('WSL.integrations', () => {
       beforeEach(() => {
         spyPlatform.mockReturnValue('win32');
       });
 
       it('should reject invalid values', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { WSLIntegrations: 3 as unknown as Record<string, boolean> } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: 3 as unknown as Record<string, boolean> } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       ['Proposed field kubernetes.WSLIntegrations should be an object, got <3>.'],
+          errors:       ['Proposed field WSL.integrations should be an object, got <3>.'],
         });
       });
 
       it('should reject being set on non-Windows', () => {
         spyPlatform.mockReturnValue('haiku');
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { WSLIntegrations: { foo: true } } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { foo: true } } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       ["Changing field kubernetes.WSLIntegrations via the API isn't supported."],
+          errors:       ["Changing field WSL.integrations via the API isn't supported."],
         });
       });
 
       it('should reject invalid configuration', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { kubernetes: { WSLIntegrations: { distribution: 3 as unknown as boolean } } });
+        const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { distribution: 3 as unknown as boolean } } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       ['Invalid value for kubernetes.WSLIntegrations.distribution: <3>'],
+          errors:       ['Invalid value for WSL.integrations.distribution: <3>'],
         });
       });
 
       it('should allow being changed', () => {
         const [needToUpdate, errors] = subject.validateSettings({
           ...cfg,
-          kubernetes: {
-            ...cfg.kubernetes,
-            WSLIntegrations: { distribution: false },
-          },
-        }, { kubernetes: { WSLIntegrations: { distribution: true } } });
+          WSL: { integrations: { distribution: false } },
+        }, { WSL: { integrations: { distribution: true } } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: true,
@@ -366,8 +363,11 @@ describe(SettingsValidator, () => {
           const value = PathManagementStrategy[strategy as keyof typeof PathManagementStrategy];
           const [needToUpdate, errors] = subject.validateSettings({
             ...cfg,
-            pathManagementStrategy: PathManagementStrategy.NotSet,
-          }, { pathManagementStrategy: value });
+            application: {
+              ...cfg.application,
+              pathManagementStrategy: PathManagementStrategy.NotSet,
+            },
+          }, { application: { pathManagementStrategy: value } });
 
           expect({ needToUpdate, errors }).toEqual({
             needToUpdate: true,
@@ -377,20 +377,22 @@ describe(SettingsValidator, () => {
       });
 
       it('should reject invalid values', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { pathManagementStrategy: 'invalid value' as PathManagementStrategy });
+        const [needToUpdate, errors] = subject.validateSettings(cfg,
+          { application: { pathManagementStrategy: 'invalid value' as PathManagementStrategy } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [`pathManagementStrategy: "invalid value" is not a valid strategy`],
+          errors:       [`application.pathManagementStrategy: "invalid value" is not a valid strategy`],
         });
       });
 
       it('should reject setting as NotSet', () => {
-        const [needToUpdate, errors] = subject.validateSettings(cfg, { pathManagementStrategy: PathManagementStrategy.NotSet });
+        const [needToUpdate, errors] = subject.validateSettings(cfg,
+          { application: { pathManagementStrategy: PathManagementStrategy.NotSet } });
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [`pathManagementStrategy: "notset" is not a valid strategy`],
+          errors:       [`application.pathManagementStrategy: "notset" is not a valid strategy`],
         });
       });
     });
@@ -398,8 +400,8 @@ describe(SettingsValidator, () => {
     it('should complain about unchangeable fields', () => {
       const unchangeableFieldsAndValues = { version: -1 };
 
-      // Check that we _don't_ ask for update when we  have errors.
-      const input = { telemetry: !cfg.telemetry };
+      // Check that we _don't_ ask for update when we have errors.
+      const input = { application: { telemetry: { enabled: !cfg.application.telemetry.enabled } } };
 
       for (const [path, value] of Object.entries(unchangeableFieldsAndValues)) {
         _.set(input, path, value);
@@ -421,17 +423,17 @@ describe(SettingsValidator, () => {
       expect(errors[0]).toContain('Setting kubernetes should wrap an inner object, but got <5>');
 
       [needToUpdate, errors] = subject.validateSettings(cfg, {
-        kubernetes: {
-          containerEngine: { expected: 'a string' } as unknown as settings.ContainerEngine,
-          version:         { expected: 'a string' } as unknown as string,
-          options:         "ceci n'est pas un objet" as unknown as Record<string, boolean>,
-          enabled:         true,
+        containerEngine: { name: { expected: 'a string' } as unknown as settings.ContainerEngine },
+        kubernetes:      {
+          version: { expected: 'a string' } as unknown as string,
+          options: "ceci n'est pas un objet" as unknown as Record<string, boolean>,
+          enabled: true,
         },
       });
       expect(needToUpdate).toBeFalsy();
       expect(errors).toHaveLength(3);
       expect(errors).toEqual([
-        `Invalid value for kubernetes.containerEngine: <{"expected":"a string"}>; must be 'containerd', 'docker', or 'moby'`,
+        `Invalid value for containerEngine.name: <{"expected":"a string"}>; must be 'containerd', 'docker', or 'moby'`,
         'Kubernetes version "[object Object]" not found.',
         "Setting kubernetes.options should wrap an inner object, but got <ceci n'est pas un objet>.",
       ]);

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -55,7 +55,15 @@ export default class SettingsValidator {
   validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
     this.isKubernetesDesired = typeof newSettings.kubernetes?.enabled !== 'undefined' ? newSettings.kubernetes.enabled : currentSettings.kubernetes.enabled;
     this.allowedSettings ||= {
-      version:         this.checkUnchanged,
+      version:     this.checkUnchanged,
+      application: {
+        adminAccess:            this.checkLima(this.checkBoolean),
+        debug:                  this.checkBoolean,
+        pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
+        telemetry:              { enabled: this.checkBoolean },
+        /** Whether we should check for updates and apply them. */
+        updater:                { enabled: this.checkBoolean },
+      },
       containerEngine: {
         imageAllowList: {
           // TODO (maybe): `patterns` and `enabled` should be immutable if `locked` is true
@@ -63,30 +71,27 @@ export default class SettingsValidator {
           locked:   this.checkUnchanged,
           patterns: this.checkStringArray,
         },
+        name: this.checkContainerEngine,
       },
+      virtualMachine: {
+        memoryInGB:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
+        numberCPUs:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
+        hostResolver: this.checkPlatform('win32', this.checkBoolean),
+        experimental: { socketVMNet: this.checkPlatform('darwin', this.checkBoolean) },
+      },
+      WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
       kubernetes: {
-        version:         this.checkKubernetesVersion,
-        memoryInGB:      this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
-        numberCPUs:      this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
-        port:            this.checkNumber(1, 65535),
-        containerEngine: this.checkContainerEngine,
-        enabled:         this.checkBoolean,
-        WSLIntegrations: this.checkPlatform('win32', this.checkBooleanMapping),
-        options:         { traefik: this.checkBoolean, flannel: this.checkBoolean },
-        suppressSudo:    this.checkLima(this.checkBoolean),
-        hostResolver:    this.checkPlatform('win32', this.checkBoolean),
-        experimental:    { socketVMNet: this.checkPlatform('darwin', this.checkBoolean) },
+        version: this.checkKubernetesVersion,
+        port:    this.checkNumber(1, 65535),
+        enabled: this.checkBoolean,
+        options: { traefik: this.checkBoolean, flannel: this.checkBoolean },
       },
       portForwarding: { includeKubernetesServices: this.checkBoolean },
       images:         {
         showAll:   this.checkBoolean,
         namespace: this.checkString,
       },
-      telemetry:              this.checkBoolean,
-      updater:                this.checkBoolean,
-      debug:                  this.checkBoolean,
-      pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
-      diagnostics:            {
+      diagnostics: {
         mutedChecks: this.checkBooleanMapping,
         showMuted:   this.checkBoolean,
       },
@@ -397,10 +402,8 @@ export default class SettingsValidator {
 
   canonicalizeSynonyms(newSettings: settingsLike): void {
     this.synonymsTable ||= {
-      kubernetes: {
-        version:         this.canonicalizeKubernetesVersion,
-        containerEngine: this.canonicalizeContainerEngine,
-      },
+      containerEngine: { name: this.canonicalizeContainerEngine },
+      kubernetes:      { version: this.canonicalizeKubernetesVersion },
     };
     this.canonicalizeSettings(this.synonymsTable, newSettings, []);
   }

--- a/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
+++ b/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
@@ -9,10 +9,10 @@ import Logging from '@pkg/utils/logging';
 
 const console = Logging.diagnostics;
 
-let kubernetesMemory = Number.POSITIVE_INFINITY;
+let virtualMachineMemory = Number.POSITIVE_INFINITY;
 
 mainEvents.on('settings-update', (cfg) => {
-  kubernetesMemory = cfg.kubernetes.memoryInGB;
+  virtualMachineMemory = cfg.virtualMachine.memoryInGB;
 });
 
 /**
@@ -49,7 +49,7 @@ const CheckLimaDarwin: DiagnosticsChecker = {
         result.description = `There was an error determining your macOS version.  Virtual memory may be limited to 3GiB.`;
       }
     }
-    if (Math.ceil(kubernetesMemory) <= 3) {
+    if (Math.ceil(virtualMachineMemory) <= 3) {
       // If we're not using more than 3GB of memory, consider this a pass.
       result.passed = true;
     }

--- a/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
+++ b/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
@@ -16,7 +16,7 @@ const pathOutputDelimiter = 'Rancher Desktop Diagnostics PATH:';
 let pathStrategy = PathManagementStrategy.NotSet;
 
 mainEvents.on('settings-update', (cfg) => {
-  pathStrategy = cfg.pathManagementStrategy;
+  pathStrategy = cfg.application.pathManagementStrategy;
 });
 
 export class RDBinInShellPath implements DiagnosticsChecker {

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -54,7 +54,7 @@ export class Tray {
     {
       id:      'container-engine',
       enabled: false,
-      label:   `Container engine: ${ this.settings.kubernetes.containerEngine }`,
+      label:   `Container engine: ${ this.settings.containerEngine.name }`,
       type:    'normal',
       icon:    '',
     },
@@ -265,7 +265,7 @@ export class Tray {
     const containerEngineMenu = this.contextMenuItems.find(item => item.id === 'container-engine');
 
     if (containerEngineMenu) {
-      const { containerEngine } = this.settings.kubernetes;
+      const containerEngine = this.settings.containerEngine.name;
 
       containerEngineMenu.label = containerEngine === 'containerd' ? containerEngine : `dockerd (${ containerEngine })`;
       containerEngineMenu.icon = containerEngine === 'containerd' ? path.join(paths.resources, 'icons', 'containerd-icon-color.png') : '';

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -172,7 +172,7 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
 }
 
 mainEvent.on('settings-update', (settings: Settings) => {
-  if (settings.updater && state === State.CONFIGURED) {
+  if (settings.application.updater.enabled && state === State.CONFIGURED) {
     // We have a configured updater, but haven't done the actual check yet.
     // This means the setting was disabled when we configured the updater.
     // Start checking now.

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -38,7 +38,7 @@
       </select>
     </label>
     <engine-selector
-      :container-engine="settings.kubernetes.containerEngine"
+      :container-engine="settings.containerEngine.name"
       @change="onChangeEngine"
     />
     <path-management-selector
@@ -127,7 +127,7 @@ export default Vue.extend({
       ipcRenderer.send('dialog/ready');
     });
     ipcRenderer.on('settings-update', (event, config) => {
-      this.settings.kubernetes.containerEngine = config.kubernetes.containerEngine;
+      this.settings.containerEngine.name = config.containerEngine.name;
       this.settings.kubernetes.enabled = config.kubernetes.enabled;
     });
     ipcRenderer.send('k8s-versions');
@@ -140,8 +140,8 @@ export default Vue.extend({
       ipcRenderer.invoke(
         'settings-write',
         {
-          kubernetes:             { version: this.settings.kubernetes.version },
-          pathManagementStrategy: this.pathManagementStrategy,
+          kubernetes:  { version: this.settings.kubernetes.version },
+          application: { pathManagementStrategy: this.pathManagementStrategy },
         });
     },
     close() {
@@ -152,7 +152,7 @@ export default Vue.extend({
       try {
         ipcRenderer.invoke(
           'settings-write',
-          { kubernetes: { containerEngine: desiredEngine } },
+          { containerEngine: { name: desiredEngine } },
         );
       } catch (err) {
         console.log('invoke settings-write failed: ', err);

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -68,7 +68,8 @@ import { mapGetters } from 'vuex';
 import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
-import type { Settings, ContainerEngine } from '@pkg/config/settings';
+import { defaultSettings } from '@pkg/config/settings';
+import type { ContainerEngine } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -79,7 +80,7 @@ export default Vue.extend({
   layout: 'dialog',
   data() {
     return {
-      settings: { kubernetes: {} } as Settings,
+      settings: defaultSettings,
       versions: [] as VersionEntry[],
 
       // If cachedVersionsOnly is true, it means we're offline and showing only the versions in the cache,

--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -15,7 +15,7 @@
     </div>
     <hr>
     <update-status
-      :enabled="settings.updater"
+      :enabled="settings.application.updater.enabled"
       :update-state="updateState"
       :version="version"
       @enabled="onUpdateEnabled"
@@ -23,7 +23,7 @@
     />
     <hr>
     <telemetry-opt-in
-      :telemetry="settings.telemetry"
+      :telemetry="settings.application.telemetry.enabled"
       @updateTelemetry="updateTelemetry"
     />
     <hr>
@@ -107,7 +107,7 @@ export default {
       this.$data.settings = settings;
     },
     onUpdateEnabled(value) {
-      ipcRenderer.invoke('settings-write', { updater: value });
+      ipcRenderer.invoke('settings-write', { application: { telemetry: { updater: value } } });
     },
     onUpdateApply() {
       ipcRenderer.send('update-apply');
@@ -116,7 +116,7 @@ export default {
       this.$data.updateState = state;
     },
     updateTelemetry(value) {
-      ipcRenderer.invoke('settings-write', { telemetry: value });
+      ipcRenderer.invoke('settings-write', { application: { telemetry: { enabled: value } } });
     },
     onNetworkUpdate(status) {
       ipcRenderer.send('update-network-status', status);

--- a/pkg/rancher-desktop/pages/PathUpdate.vue
+++ b/pkg/rancher-desktop/pages/PathUpdate.vue
@@ -42,7 +42,7 @@ export default Vue.extend({
       window.close();
     },
     onSettingsUpdate(settings: Settings) {
-      this.$store.dispatch('applicationSettings/setSudoAllowed', !settings.kubernetes.suppressSudo);
+      this.$store.dispatch('applicationSettings/setAdminAccess', settings.application.adminAccess);
     },
   },
 });

--- a/pkg/rancher-desktop/pages/Troubleshooting.vue
+++ b/pkg/rancher-desktop/pages/Troubleshooting.vue
@@ -89,7 +89,7 @@ export default {
   data:       () => ({
     state:           ipcRenderer.sendSync('k8s-state'),
     settings:        defaultSettings,
-    isDebugging:     runInDebugMode(defaultSettings.debug),
+    isDebugging:     runInDebugMode(defaultSettings.application.debug),
     alwaysDebugging: runInDebugMode(false),
   }),
   computed: {
@@ -107,7 +107,7 @@ export default {
     });
     ipcRenderer.on('settings-read', (_, newSettings) => {
       this.$data.settings = newSettings;
-      this.$data.isDebugging = runInDebugMode(newSettings.debug);
+      this.$data.isDebugging = runInDebugMode(newSettings.application.debug);
     });
     ipcRenderer.on('settings-update', (_, newSettings) => {
       this.$data.settings = newSettings;
@@ -151,7 +151,7 @@ export default {
     },
     updateDebug(value) {
       this.$data.isDebugging = runInDebugMode(value);
-      ipcRenderer.invoke('settings-write', { debug: value });
+      ipcRenderer.invoke('settings-write', { application: { debug: value } });
     },
     async resetKubernetes() {
       const cancelPosition = 1;

--- a/pkg/rancher-desktop/store/applicationSettings.ts
+++ b/pkg/rancher-desktop/store/applicationSettings.ts
@@ -10,7 +10,7 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
  */
 type State = {
   pathManagementStrategy: PathManagementStrategy;
-  sudoAllowed: boolean;
+  adminAccess: boolean;
 };
 
 export const state: () => State = () => {
@@ -19,8 +19,8 @@ export const state: () => State = () => {
   const cfg = loadSettings();
 
   return {
-    pathManagementStrategy: cfg.pathManagementStrategy,
-    sudoAllowed:            !cfg.kubernetes.suppressSudo,
+    pathManagementStrategy: cfg.application.pathManagementStrategy,
+    adminAccess:            cfg.application.adminAccess,
   };
 };
 
@@ -28,8 +28,8 @@ export const mutations: MutationsType<State> = {
   SET_PATH_MANAGEMENT_STRATEGY(state: State, strategy: PathManagementStrategy) {
     state.pathManagementStrategy = strategy;
   },
-  SET_SUDO_ALLOWED(state: State, allowed: boolean) {
-    state.sudoAllowed = allowed;
+  SET_ADMIN_ACCESS(state: State, allowed: boolean) {
+    state.adminAccess = allowed;
   },
 } as const;
 
@@ -41,17 +41,17 @@ export const actions = {
   },
   async commitPathManagementStrategy({ commit }: AppActionContext, strategy: PathManagementStrategy) {
     commit('SET_PATH_MANAGEMENT_STRATEGY', strategy);
-    await ipcRenderer.invoke('settings-write', { pathManagementStrategy: strategy });
+    await ipcRenderer.invoke('settings-write', { application: { pathManagementStrategy: strategy } });
   },
-  setSudoAllowed({ commit, state }: AppActionContext, allowed: boolean) {
-    if (allowed !== state.sudoAllowed) {
-      commit('SET_SUDO_ALLOWED', allowed);
+  setAdminAccess({ commit, state }: AppActionContext, allowed: boolean) {
+    if (allowed !== state.adminAccess) {
+      commit('SET_ADMIN_ACCESS', allowed);
     }
   },
-  async commitSudoAllowed({ commit, state }: AppActionContext, allowed: boolean) {
-    if (allowed !== state.sudoAllowed) {
-      commit('SET_SUDO_ALLOWED', allowed);
-      await ipcRenderer.invoke('settings-write', { kubernetes: { suppressSudo: !allowed } });
+  async commitAdminAccess({ commit, state }: AppActionContext, allowed: boolean) {
+    if (allowed !== state.adminAccess) {
+      commit('SET_ADMIN_ACCESS', allowed);
+      await ipcRenderer.invoke('settings-write', { application: { adminAccess: allowed } });
     }
   },
 };
@@ -60,7 +60,7 @@ export const getters = {
   pathManagementStrategy({ pathManagementStrategy }: State) {
     return pathManagementStrategy;
   },
-  sudoAllowed({ sudoAllowed }: State) {
-    return sudoAllowed;
+  adminAccess({ adminAccess }: State) {
+    return adminAccess;
   },
 };

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -19,7 +19,7 @@ test.describe.serial('Main App Test', () => {
 
   test.beforeAll(async({ colorScheme }) => {
     createDefaultSettings({
-      updater:         true,
+      application:     { updater: { enabled: true } },
       containerEngine: { imageAllowList: { enabled: true, patterns: ['rancher/example'] } },
       diagnostics:     { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
     });


### PR DESCRIPTION
Fixes #3746
Fixes #3747

Define the v5 settings schema and, in a separate commit, migrate existing preferences to that version.

The first commit defines the new schema, and the rest is mostly mechanical, updating the schema references.

The second commit updates existing settings.

Then there are a few commits driven by typescript, and picking up a dropped file (command-api.yaml).