### PR TITLE
Move to v1 of the backend API

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -178,7 +178,7 @@ test.describe.serial('KubernetesBackend', () => {
         expected[key] = entry;
       }
 
-      await expect(put('/v0/propose_settings', newSettings)).resolves.toEqual(expected);
+      await expect(put('/v1/propose_settings', newSettings)).resolves.toEqual(expected);
     });
 
     test('should handle WSL integrations', async() => {
@@ -193,10 +193,10 @@ test.describe.serial('KubernetesBackend', () => {
         },
       };
 
-      await expect(put('/v0/propose_settings', newSettings)).resolves.toMatchObject({
+      await expect(put('/v1/propose_settings', newSettings)).resolves.toMatchObject({
         'WSL.integrations': {
-          current: {},
-          desired: newSettings.WSL?.integrations,
+          desired:  newSettings.WSL?.integrations,
+          severity: 'restart',
         },
       });
     });

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -104,7 +104,7 @@ test.describe.serial('KubernetesBackend', () => {
     }
 
     test('should detect changes', async() => {
-      const currentSettings = (await get('/v0/settings')) as Settings;
+      const currentSettings = (await get('/v1/settings')) as Settings;
 
       const newSettings: RecursivePartial<Settings> = {
         containerEngine: { name: getAlternateSetting(currentSettings, 'containerEngine.name', ContainerEngine.CONTAINERD, ContainerEngine.MOBY) },

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -315,7 +315,7 @@ test.describe('Command server', () => {
     let resp = await doRequest('/v0/settings');
 
     expect(resp.ok).toBeTruthy();
-    const telemetry = (await resp.json() as Settings).application.telemetry.enabled;
+    const telemetry = (await resp.json()).application.telemetry.enabled;
 
     resp = await doRequest('/v0/settings', JSON.stringify({ version: CURRENT_SETTINGS_VERSION, application: { telemetry: { enabled: !telemetry } } }), 'PUT');
     expect(resp.ok).toBeTruthy();

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -315,7 +315,7 @@ test.describe('Command server', () => {
     let resp = await doRequest('/v1/settings');
 
     expect(resp.ok).toBeTruthy();
-    const telemetry = (await resp.json()).application.telemetry.enabled;
+    const telemetry = (await resp.json() as Settings).application.telemetry.enabled;
 
     resp = await doRequest('/v1/settings', JSON.stringify({ version: CURRENT_SETTINGS_VERSION, application: { telemetry: { enabled: !telemetry } } }), 'PUT');
     expect(resp.ok).toBeTruthy();

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -577,13 +577,6 @@ test.describe('Command server', () => {
     });
   });
 
-  /**
-   * getAltString returns the setting that isn't the same as the existing setting.
-   */
-  const getAltString = (currentSettings: Settings, setting: string, altOne: string, altTwo: string) => {
-    return _.get(currentSettings, setting) === altOne ? altTwo : altOne;
-  };
-
   test.describe('rdctl', () => {
     test.describe('config-file and parameters', () => {
       test.describe("when the config-file doesn't exist", () => {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -155,7 +155,7 @@ test.describe('Command server', () => {
   });
 
   test('should require authentication, settings request', async() => {
-    const url = `http://127.0.0.1:${ serverState.port }/v0/settings`;
+    const url = `http://127.0.0.1:${ serverState.port }/v1/settings`;
     const resp = await fetch(url);
 
     expect(resp).toEqual(expect.objectContaining({
@@ -165,7 +165,7 @@ test.describe('Command server', () => {
   });
 
   test('should emit CORS headers, settings request', async() => {
-    const resp = await doRequest('/v0/settings', '', 'OPTIONS');
+    const resp = await doRequest('/v1/settings', '', 'OPTIONS');
 
     expect({
       ...resp,
@@ -182,7 +182,7 @@ test.describe('Command server', () => {
   });
 
   test('should be able to get settings', async() => {
-    const resp = await doRequest('/v0/settings');
+    const resp = await doRequest('/v1/settings');
 
     expect({
       ...resp,
@@ -200,10 +200,10 @@ test.describe('Command server', () => {
   });
 
   test('setting existing settings should be a no-op', async() => {
-    let resp = await doRequest('/v0/settings');
+    let resp = await doRequest('/v1/settings');
     const rawSettings = resp.body.read().toString();
 
-    resp = await doRequest('/v0/settings', rawSettings, 'PUT');
+    resp = await doRequest('/v1/settings', rawSettings, 'PUT');
     expect({
       ok:     resp.ok,
       status: resp.status,
@@ -216,7 +216,7 @@ test.describe('Command server', () => {
   });
 
   test('should not update values when the /settings payload has errors', async() => {
-    let resp = await doRequest('/v0/settings');
+    let resp = await doRequest('/v1/settings');
     const settings = await resp.json();
     const desiredEnabled = !settings.kubernetes.enabled;
     const desiredEngine = 'flip';
@@ -232,13 +232,13 @@ test.describe('Command server', () => {
         version: desiredVersion,
       },
     });
-    const resp2 = await doRequest('/v0/settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/settings');
+    resp = await doRequest('/v1/settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(settings);
@@ -256,7 +256,7 @@ test.describe('Command server', () => {
       WSL:             { integrations: "ceci n'est pas un objet" },
       portForwarding:  'bob',
     };
-    const resp2 = await doRequest('/v0/settings', JSON.stringify(newSettings), 'PUT');
+    const resp2 = await doRequest('/v1/settings', JSON.stringify(newSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
@@ -282,7 +282,7 @@ test.describe('Command server', () => {
   });
 
   test('should reject invalid JSON, settings request', async() => {
-    const resp = await doRequest('/v0/settings', '{"missing": "close-brace"', 'PUT');
+    const resp = await doRequest('/v1/settings', '{"missing": "close-brace"', 'PUT');
 
     expect(resp.ok).toBeFalsy();
     expect(resp.status).toEqual(400);
@@ -292,7 +292,7 @@ test.describe('Command server', () => {
   });
 
   test('should reject empty payload, settings request', async() => {
-    const resp = await doRequest('/v0/settings', '', 'PUT');
+    const resp = await doRequest('/v1/settings', '', 'PUT');
 
     expect(resp.ok).toBeFalsy();
     expect(resp.status).toEqual(400);
@@ -312,18 +312,18 @@ test.describe('Command server', () => {
   });
 
   test('should not restart on unrelated changes', async() => {
-    let resp = await doRequest('/v0/settings');
+    let resp = await doRequest('/v1/settings');
 
     expect(resp.ok).toBeTruthy();
     const telemetry = (await resp.json()).application.telemetry.enabled;
 
-    resp = await doRequest('/v0/settings', JSON.stringify({ version: CURRENT_SETTINGS_VERSION, application: { telemetry: { enabled: !telemetry } } }), 'PUT');
+    resp = await doRequest('/v1/settings', JSON.stringify({ version: CURRENT_SETTINGS_VERSION, application: { telemetry: { enabled: !telemetry } } }), 'PUT');
     expect(resp.ok).toBeTruthy();
     await expect(resp.text()).resolves.toContain('no restart required');
   });
 
   test('should complain about a missing version field', async() => {
-    let resp = await doRequest('/v0/settings');
+    let resp = await doRequest('/v1/settings');
 
     expect(resp.ok).toBeTruthy();
 
@@ -333,13 +333,13 @@ test.describe('Command server', () => {
     if (body?.application?.telemetry) {
       body.application.telemetry.enabled = !body.application.telemetry.enabled;
     }
-    resp = await doRequest('/v0/settings', JSON.stringify(body), 'PUT');
+    resp = await doRequest('/v1/settings', JSON.stringify(body), 'PUT');
     expect(resp.ok).toBeFalsy();
     await expect(resp.text()).resolves.toContain(`updating settings requires specifying version = ${ CURRENT_SETTINGS_VERSION }, but no version was specified`);
   });
 
   test('should complain about an invalid version field', async() => {
-    let resp = await doRequest('/v0/settings');
+    let resp = await doRequest('/v1/settings');
 
     expect(resp.ok).toBeTruthy();
 
@@ -351,13 +351,13 @@ test.describe('Command server', () => {
     if (body?.application?.telemetry) {
       body.application.telemetry.enabled = !body.application.telemetry.enabled;
     }
-    resp = await doRequest('/v0/settings', JSON.stringify(body), 'PUT');
+    resp = await doRequest('/v1/settings', JSON.stringify(body), 'PUT');
     expect(resp.ok).toBeFalsy();
     await expect(resp.text()).resolves.toContain(`updating settings requires specifying version = ${ CURRENT_SETTINGS_VERSION }, but received version ${ CURRENT_SETTINGS_VERSION - 1 }`);
   });
 
   test('should require authentication, transient settings request', async() => {
-    const url = `http://127.0.0.1:${ serverState.port }/v0/transient_settings`;
+    const url = `http://127.0.0.1:${ serverState.port }/v1/transient_settings`;
     const resp = await fetch(url);
 
     expect(resp).toEqual(expect.objectContaining({
@@ -367,7 +367,7 @@ test.describe('Command server', () => {
   });
 
   test('should emit CORS headers, transient settings request', async() => {
-    const resp = await doRequest('/v0/transient_settings', '', 'OPTIONS');
+    const resp = await doRequest('/v1/transient_settings', '', 'OPTIONS');
 
     expect({
       ...resp,
@@ -384,7 +384,7 @@ test.describe('Command server', () => {
   });
 
   test('should be able to get transient settings', async() => {
-    const resp = await doRequest('/v0/transient_settings');
+    const resp = await doRequest('/v1/transient_settings');
 
     expect({
       ...resp,
@@ -402,10 +402,10 @@ test.describe('Command server', () => {
   });
 
   test('setting existing transient settings should be a no-op', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const rawSettings = resp.body.read().toString();
 
-    resp = await doRequest('/v0/transient_settings', rawSettings, 'PUT');
+    resp = await doRequest('/v1/transient_settings', rawSettings, 'PUT');
     expect({
       ok:     resp.ok,
       status: resp.status,
@@ -418,58 +418,58 @@ test.describe('Command server', () => {
   });
 
   test('should not update values when the /transient_settings navItem payload is invalid', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge({}, transientSettings, { preferences: { navItem: { current: 'foo', bar: 'bar' } } });
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should not update values when the /transient_settings payload has invalid current navItem name', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge({}, transientSettings, { preferences: { navItem: { current: 'foo' } } });
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should not update values when the /transient_settings payload has invalid sub-tabs for Application preference page', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge({}, transientSettings, { preferences: { navItem: { current: 'Application', currentTabs: { Application: 'foo' } } } });
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should not update values when the /transient_settings payload has invalid sub-tabs for Container Engine preference page', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge(
@@ -477,20 +477,20 @@ test.describe('Command server', () => {
       transientSettings,
       { preferences: { navItem: { currentTabs: { 'Container Engine': 'behavior' } } } },
     );
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should not update values when the /transient_settings payload contains sub-tabs for a page not supporting sub-tabs: WSL / Virtual Machine', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge(
@@ -498,20 +498,20 @@ test.describe('Command server', () => {
       transientSettings,
       { preferences: { navItem: { currentTabs: { [process.platform === 'win32' ? 'WSL' : 'Virtual Machine']: 'behavior' } } } },
     );
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should not update values when the /transient_settings payload contains sub-tabs for a page not supporting sub-tabs: Kubernetes', async() => {
-    let resp = await doRequest('/v0/transient_settings');
+    let resp = await doRequest('/v1/transient_settings');
     const transientSettings = await resp.json();
 
     const requestedSettings = _.merge(
@@ -519,20 +519,20 @@ test.describe('Command server', () => {
       transientSettings,
       { preferences: { navItem: { currentTabs: { Kubernetes: 'behavior' } } } },
     );
-    const resp2 = await doRequest('/v0/transient_settings', JSON.stringify(requestedSettings), 'PUT');
+    const resp2 = await doRequest('/v1/transient_settings', JSON.stringify(requestedSettings), 'PUT');
 
     expect(resp2.ok).toBeFalsy();
     expect(resp2.status).toEqual(400);
 
     // Now verify that the specified values did not get updated.
-    resp = await doRequest('/v0/transient_settings');
+    resp = await doRequest('/v1/transient_settings');
     const refreshedSettings = await resp.json();
 
     expect(refreshedSettings).toEqual(transientSettings);
   });
 
   test('should reject invalid JSON, transient settings request', async() => {
-    const resp = await doRequest('/v0/transient_settings', '{"missing": "close-brace"', 'PUT');
+    const resp = await doRequest('/v1/transient_settings', '{"missing": "close-brace"', 'PUT');
 
     expect(resp.ok).toBeFalsy();
     expect(resp.status).toEqual(400);
@@ -542,7 +542,7 @@ test.describe('Command server', () => {
   });
 
   test('should reject empty payload, transient settings request', async() => {
-    const resp = await doRequest('/v0/transient_settings', '', 'PUT');
+    const resp = await doRequest('/v1/transient_settings', '', 'PUT');
 
     expect(resp.ok).toBeFalsy();
     expect(resp.status).toEqual(400);
@@ -550,6 +550,39 @@ test.describe('Command server', () => {
 
     expect(body).toContain('no settings specified in the request');
   });
+
+  test.describe('v0 API', () => {
+    const endpoints = {
+      GET:  ['diagnostic_categories', 'diagnostic_checks', 'diagnostic_ids', 'settings', 'transient_settings'],
+      PUT:  ['factory_reset', 'propose_settings', 'settings', 'shutdown', 'transient_settings'],
+      POST: ['diagnostic_checks'],
+    };
+
+    test('should no longer work', async() => {
+      for (const method in endpoints) {
+        for (const endpoint of endpoints[method as 'GET'|'PUT']) {
+          const resp = await doRequest(`/v0/${ endpoint }`, '', method);
+
+          expect({
+            ok:     resp.ok,
+            status: resp.status,
+            body:   resp.body.read().toString(),
+          }).toEqual({
+            ok:     false,
+            status: 400,
+            body:   `Invalid version /v0 for endpoint "${ method } /v0/${ endpoint }" - use "/v1/${ endpoint }"`,
+          });
+        }
+      }
+    });
+  });
+
+  /**
+   * getAltString returns the setting that isn't the same as the existing setting.
+   */
+  const getAltString = (currentSettings: Settings, setting: string, altOne: string, altTwo: string) => {
+    return _.get(currentSettings, setting) === altOne ? altTwo : altOne;
+  };
 
   test.describe('rdctl', () => {
     test.describe('config-file and parameters', () => {
@@ -768,7 +801,7 @@ test.describe('Command server', () => {
             body.kubernetes.WSLIntegrations.bosco = true;
             body.kubernetes.hostResolver = !oldSettings.virtualMachine.hostResolver;
           }
-          const { stdout, stderr, error } = await rdctl(['api', '/v0/settings', '-X', 'PUT', '-b', JSON.stringify(body)]);
+          const { stdout, stderr, error } = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(body)]);
 
           expect({
             stdout, stderr, error,
@@ -803,7 +836,7 @@ test.describe('Command server', () => {
             // This field is in to force a restart
             kubernetes: { port: oldSettings.kubernetes.port + 1 },
           };
-          const { stdout, stderr, error } = await rdctl(['api', '/v0/settings', '-X', 'PUT', '-b', JSON.stringify(body)]);
+          const { stdout, stderr, error } = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(body)]);
 
           expect({
             stdout, stderr, error,
@@ -817,7 +850,7 @@ test.describe('Command server', () => {
           expect(newSettings).toEqual(_.merge(oldSettings, body));
 
           // And now reinstate the old prefs so other tests that count on them will pass.
-          const result = await rdctl(['api', '/v0/settings', '-X', 'PUT', '-b', JSON.stringify(oldSettings)]);
+          const result = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(oldSettings)]);
 
           expect(result.stderr).toEqual('');
         });
@@ -895,7 +928,7 @@ test.describe('Command server', () => {
         });
 
         test('complains when more than one endpoint is given', async() => {
-          const endpoints = ['settings', '/v0/settings'];
+          const endpoints = ['settings', '/v1/settings'];
           const { stdout, stderr, error } = await rdctl(['api', ...endpoints]);
 
           expect({
@@ -912,7 +945,7 @@ test.describe('Command server', () => {
       test.describe('settings', () => {
         test.describe('options:', () => {
           test.describe('GET', () => {
-            for (const endpoint of ['settings', '/v0/settings']) {
+            for (const endpoint of ['settings', '/v1/settings']) {
               for (const methodSpecs of [[], ['-X', 'GET'], ['--method', 'GET']]) {
                 const args = ['api', endpoint, ...methodSpecs];
 
@@ -936,7 +969,7 @@ test.describe('Command server', () => {
             test.describe('from stdin', () => {
               const settingsFile = path.join(paths.config, 'settings.json');
 
-              for (const endpoint of ['settings', '/v0/settings']) {
+              for (const endpoint of ['settings', '/v1/settings']) {
                 for (const methodSpec of ['-X', '--method']) {
                   for (const inputSpec of [['--input', '-'], ['--input=-']]) {
                     const args = ['api', endpoint, methodSpec, 'PUT', ...inputSpec];
@@ -959,7 +992,7 @@ test.describe('Command server', () => {
             test.describe('--input', () => {
               const settingsFile = path.join(paths.config, 'settings.json');
 
-              for (const endpoint of ['settings', '/v0/settings']) {
+              for (const endpoint of ['settings', '/v1/settings']) {
                 for (const methodSpecs of [['-X', 'PUT'], ['--method', 'PUT'], []]) {
                   for (const inputSource of [['--input', settingsFile], [`--input=${ settingsFile }`]]) {
                     const args = ['api', endpoint, ...methodSpecs, ...inputSource];
@@ -996,7 +1029,7 @@ test.describe('Command server', () => {
             test.describe('from body', () => {
               const settingsFile = path.join(paths.config, 'settings.json');
 
-              for (const endpoint of ['settings', '/v0/settings']) {
+              for (const endpoint of ['settings', '/v1/settings']) {
                 for (const methodSpecs of [[], ['-X', 'PUT'], ['--method', 'PUT']]) {
                   for (const inputOption of ['--body', '-b']) {
                     const args = ['api', endpoint, ...methodSpecs, inputOption];
@@ -1092,43 +1125,53 @@ test.describe('Command server', () => {
           expect(JSON.parse(stdout)).toEqual([
             'GET /',
             'GET /v0',
-            'GET /v0/diagnostic_categories',
-            'GET /v0/diagnostic_checks',
-            'POST /v0/diagnostic_checks',
-            'GET /v0/diagnostic_ids',
-            'PUT /v0/factory_reset',
-            'PUT /v0/propose_settings',
-            'GET /v0/settings',
-            'PUT /v0/settings',
-            'PUT /v0/shutdown',
-            'GET /v0/transient_settings',
-            'PUT /v0/transient_settings',
+            'GET /v1',
+            'GET /v1/diagnostic_categories',
+            'GET /v1/diagnostic_checks',
+            'POST /v1/diagnostic_checks',
+            'GET /v1/diagnostic_ids',
+            'PUT /v1/factory_reset',
+            'PUT /v1/propose_settings',
+            'GET /v1/settings',
+            'PUT /v1/settings',
+            'PUT /v1/shutdown',
+            'GET /v1/transient_settings',
+            'PUT /v1/transient_settings',
           ]);
         });
 
-        test('version-only path should return all endpoints in that version only', async() => {
+        test('version-only path for v0 should return only itself', async() => {
           const { stdout, stderr } = await rdctl(['api', '/v0']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toEqual([
             'GET /v0',
-            'GET /v0/diagnostic_categories',
-            'GET /v0/diagnostic_checks',
-            'POST /v0/diagnostic_checks',
-            'GET /v0/diagnostic_ids',
-            'PUT /v0/factory_reset',
-            'PUT /v0/propose_settings',
-            'GET /v0/settings',
-            'PUT /v0/settings',
-            'PUT /v0/shutdown',
-            'GET /v0/transient_settings',
-            'PUT /v0/transient_settings',
           ]);
         });
-        test('/v1 should fail', async() => {
+
+        test('version-only path for v1 should return all endpoints in that version only', async() => {
           const { stdout, stderr } = await rdctl(['api', '/v1']);
 
-          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'Unknown command: GET /v1' });
+          expect(stderr).toEqual('');
+          expect(JSON.parse(stdout)).toEqual([
+            'GET /v1',
+            'GET /v1/diagnostic_categories',
+            'GET /v1/diagnostic_checks',
+            'POST /v1/diagnostic_checks',
+            'GET /v1/diagnostic_ids',
+            'PUT /v1/factory_reset',
+            'PUT /v1/propose_settings',
+            'GET /v1/settings',
+            'PUT /v1/settings',
+            'PUT /v1/shutdown',
+            'GET /v1/transient_settings',
+            'PUT /v1/transient_settings',
+          ]);
+        });
+        test('/v2 should fail', async() => {
+          const { stdout, stderr } = await rdctl(['api', '/v2']);
+
+          expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'Unknown command: GET /v2' });
         });
       });
 
@@ -1136,31 +1179,31 @@ test.describe('Command server', () => {
         let categories: string[];
 
         test('categories', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_categories']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_categories']);
 
           expect(stderr).toEqual('');
           categories = JSON.parse(stdout);
           expect(categories).toEqual(expect.arrayContaining(['Networking']));
         });
         test.skip('it finds the IDs for Utilities', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_ids?category=Utilities']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_ids?category=Utilities']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toEqual(expect.arrayContaining(['RD_BIN_IN_BASH_PATH', 'RD_BIN_SYMLINKS']));
         });
         test('it finds the IDs for Networking', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_ids?category=Networking']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_ids?category=Networking']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toEqual(expect.arrayContaining(['CONNECTED_TO_INTERNET']));
         });
         test('it 404s for a non-existent category', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_ids?category=cecinestpasuncategory']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_ids?category=cecinestpasuncategory']);
 
           expect({ stdout: JSON.parse(stdout), stderr: stderr.trim() }).toMatchObject({ stdout: { message: '404 Not Found' }, stderr: 'No diagnostic checks found in category cecinestpasuncategory' });
         });
         test('it finds a diagnostic check', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Networking&id=CONNECTED_TO_INTERNET']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?category=Networking&id=CONNECTED_TO_INTERNET']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toMatchObject({
@@ -1172,7 +1215,7 @@ test.describe('Command server', () => {
           });
         });
         test('it finds all diagnostic checks', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toMatchObject({
@@ -1189,7 +1232,7 @@ test.describe('Command server', () => {
           });
         });
         test.skip('it finds all diagnostic checks for a category', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Utilities']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?category=Utilities']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toEqual({
@@ -1216,7 +1259,7 @@ test.describe('Command server', () => {
           });
         });
         test('it finds a diagnostic check by checkID', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?id=CONNECTED_TO_INTERNET']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?id=CONNECTED_TO_INTERNET']);
 
           expect(stderr).toEqual('');
           expect(JSON.parse(stdout)).toMatchObject({
@@ -1231,22 +1274,22 @@ test.describe('Command server', () => {
           });
         });
         test('it returns an empty array for a non-existent category', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=not*a*category']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?category=not*a*category']);
 
           expect({ stdout: JSON.parse(stdout), stderr } ).toMatchObject({ stdout: { checks: [] }, stderr: '' });
         });
         test('it returns an empty array for a non-existent category with a valid ID', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=not*a*category&id=CONNECTED_TO_INTERNET']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?category=not*a*category&id=CONNECTED_TO_INTERNET']);
 
           expect({ stdout: JSON.parse(stdout), stderr } ).toMatchObject({ stdout: { checks: [] }, stderr: '' });
         });
         test('it returns an empty array for a non-existent checkID with a valid category', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?category=Utilities&id=CONNECTED_TO_INTERNET']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?category=Utilities&id=CONNECTED_TO_INTERNET']);
 
           expect({ stdout: JSON.parse(stdout), stderr } ).toMatchObject({ stdout: { checks: [] }, stderr: '' });
         });
         test('it returns an empty array for a non-existent checkID when no category is specified', async() => {
-          const { stdout, stderr } = await rdctl(['api', '/v0/diagnostic_checks?&id=blip']);
+          const { stdout, stderr } = await rdctl(['api', '/v1/diagnostic_checks?&id=blip']);
 
           expect({ stdout: JSON.parse(stdout), stderr } ).toMatchObject({ stdout: { checks: [] }, stderr: '' });
         });
@@ -1307,7 +1350,7 @@ test.describe('Command server', () => {
         };
         const navPage = new NavPage(page);
 
-        await tool('rdctl', 'api', '/v0/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));
+        await tool('rdctl', 'api', '/v1/settings', '--method', 'PUT', '--body', JSON.stringify(payloadObject));
         await expect(navPage.progressBar).not.toBeHidden();
         await navPage.progressBecomesReady();
         await expect(navPage.progressBar).toBeHidden();

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -3,7 +3,7 @@ info:
   title: "Rancher Desktop API"
   version: 0.0.1
 paths:
-  /v0/factory_reset:
+  /v1/factory_reset:
     put:
       operationId: factoryReset
       summary: Factory reset Rancher Desktop, losing user data
@@ -24,7 +24,7 @@ paths:
         '400':
           description: An error occurred
 
-  /v0/propose_settings:
+  /v1/propose_settings:
     put:
       operationId: proposeSettings
       summary: >-
@@ -65,7 +65,7 @@ paths:
                 type: string
 
 
-  /v0/settings:
+  /v1/settings:
     get:
       operationId: listSettings
       summary:  List the current preference settings
@@ -105,7 +105,7 @@ paths:
               schema:
                 type: string
 
-  /v0/shutdown:
+  /v1/shutdown:
     put:
       operationId: shutdownApp
       summary:  Shuts down Rancher Desktop
@@ -118,7 +118,7 @@ paths:
               schema:
                 type: string
 
-  /v0/diagnostic_categories:
+  /v1/diagnostic_categories:
     get:
       operationId: diagnosticCategories
       summary: >-
@@ -134,7 +134,7 @@ paths:
                 items:
                   type: string
 
-  /v0/diagnostic_ids:
+  /v1/diagnostic_ids:
     get:
       operationId: diagnosticIDsForCategory
       summary: >-
@@ -159,7 +159,7 @@ paths:
           description: The category is not recognized.
 
 
-  /v0/diagnostic_checks:
+  /v1/diagnostic_checks:
     get:
       operationId: diagnosticChecks
       summary: >-
@@ -189,7 +189,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/diagnostics"
 
-  /v0/transient_settings:
+  /v1/transient_settings:
     get:
       operationId: listTransientSettings
       summary:  List the current transient settings

--- a/pkg/rancher-desktop/store/diagnostics.ts
+++ b/pkg/rancher-desktop/store/diagnostics.ts
@@ -14,7 +14,7 @@ interface DiagnosticsState {
   inError: boolean;
 }
 
-const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v0/${ pathRemainder }`;
+const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v1/${ pathRemainder }`;
 
 /**
  * Updates the muted property for diagnostic results.

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -30,9 +30,9 @@ interface CommitArgs extends ServerState {
   payload?: RecursivePartial<Settings>;
 }
 
-const uri = (port: number) => `http://localhost:${ port }/v0/settings`;
+const uri = (port: number) => `http://localhost:${ port }/v1/settings`;
 
-const proposedSettings = (port: number) => `http://localhost:${ port }/v0/propose_settings`;
+const proposedSettings = (port: number) => `http://localhost:${ port }/v1/propose_settings`;
 
 export const state: () => PreferencesState = () => (
   {

--- a/pkg/rancher-desktop/store/transientSettings.ts
+++ b/pkg/rancher-desktop/store/transientSettings.ts
@@ -14,7 +14,7 @@ interface CommitArgs extends ServerState {
   payload?: RecursivePartial<TransientSettings>;
 }
 
-const uri = (port: number) => `http://localhost:${ port }/v0/transient_settings`;
+const uri = (port: number) => `http://localhost:${ port }/v1/transient_settings`;
 
 export const state: () => TransientSettings = () => _.cloneDeep(defaultTransientSettings);
 

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -37,7 +37,7 @@ type APIError struct {
 }
 
 const clientVersion = "1.1.0"
-const apiVersion = "v0"
+const apiVersion = "v1"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Fixes #3756

All /v0 endpoints are now errors (except for the `/v0` endpoint which just returns an array containing itself).

Signed-off-by: Eric Promislow <epromislow@suse.com>