### PR TITLE
rdctl start should not inherit any handles when starting RD

### DIFF
--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -20,14 +20,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
-	"strings"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/options/generated"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -104,30 +101,6 @@ func doStartCommand(cmd *cobra.Command) error {
 		}
 	}
 	return launchApp(applicationPath, commandLineArgs)
-}
-
-func launchApp(applicationPath string, commandLineArgs []string) error {
-	var commandName string
-	var args []string
-
-	if runtime.GOOS == "darwin" {
-		commandName = "/usr/bin/open"
-		args = []string{"-a", applicationPath}
-		if len(commandLineArgs) > 0 {
-			args = append(args, "--args")
-			args = append(args, commandLineArgs...)
-		}
-	} else {
-		commandName = applicationPath
-		args = commandLineArgs
-	}
-	// Include this output because there's a delay before the UI comes up.
-	// Without this line, it might look like the command doesn't work.
-	logrus.Infof("About to launch %s %s ...\n", commandName, strings.Join(args, " "))
-	cmd := exec.Command(commandName, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Start()
 }
 
 func moveToParent(fullPath string, numberTimes int) string {

--- a/src/go/rdctl/cmd/start_darwin.go
+++ b/src/go/rdctl/cmd/start_darwin.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func launchApp(applicationPath string, commandLineArgs []string) error {
+	commandName := "/usr/bin/open"
+	args := []string{"-a", applicationPath}
+	if len(commandLineArgs) > 0 {
+		args = append(args, "--args")
+		args = append(args, commandLineArgs...)
+	}
+	// Include this output because there's a delay before the UI comes up.
+	// Without this line, it might look like the command doesn't work.
+	logrus.Infof("About to launch %s %s ...\n", commandName, strings.Join(args, " "))
+	cmd := exec.Command(commandName, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
+}

--- a/src/go/rdctl/cmd/start_linux.go
+++ b/src/go/rdctl/cmd/start_linux.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func launchApp(applicationPath string, commandLineArgs []string) error {
+	// Include this output because there's a delay before the UI comes up.
+	// Without this line, it might look like the command doesn't work.
+	logrus.Infof("About to launch %s %s ...\n", applicationPath, strings.Join(commandLineArgs, " "))
+	cmd := exec.Command(applicationPath, commandLineArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
+}

--- a/src/go/rdctl/cmd/start_windows.go
+++ b/src/go/rdctl/cmd/start_windows.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+func launchApp(applicationPath string, commandLineArgs []string) error {
+	// Include this output because there's a delay before the UI comes up.
+	// Without this line, it might look like the command doesn't work.
+	logrus.Infof("About to launch %s %s ...\n", applicationPath, strings.Join(commandLineArgs, " "))
+	cmd := exec.Command(applicationPath, commandLineArgs...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		NoInheritHandles: true,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Start()
+}

--- a/src/go/rdctl/go.mod
+++ b/src/go/rdctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/rdctl
 
-go 1.17
+go 1.18
 
 require (
 	github.com/docker/docker v20.10.22+incompatible


### PR DESCRIPTION
Otherwise those handles might be kept open for a long time, as Rancher Desktop detaches from the parent process.
