### PR TITLE
Translate shortcuts using new pattern

### DIFF
--- a/pkg/rancher-desktop/pages/Dialog.vue
+++ b/pkg/rancher-desktop/pages/Dialog.vue
@@ -21,9 +21,6 @@ export default Vue.extend({
       cancelId:        0,
     };
   },
-  beforeMount() {
-    window.addEventListener('keydown', this.handleKeypress, true);
-  },
   mounted() {
     ipcRenderer.on('dialog/options', (_event, options: any) => {
       this.message = options.message;
@@ -36,20 +33,12 @@ export default Vue.extend({
 
     ipcRenderer.send('dialog/mounted');
   },
-  beforeDestroy() {
-    window.removeEventListener('keydown', this.handleKeypress, true);
-  },
   methods: {
     close(index: number) {
       ipcRenderer.send('dialog/close', { response: index, checkboxChecked: this.checkboxChecked });
     },
     isDarwin() {
       return os.platform().startsWith('darwin');
-    },
-    handleKeypress(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        this.close(this.cancelId);
-      }
     },
   },
 });

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -46,12 +46,6 @@ export default Vue.extend({
       return preferencesNavItems.map(({ name }) => name);
     },
   },
-  beforeMount() {
-    window.addEventListener('keydown', this.handleKeypress, true);
-  },
-  beforeDestroy() {
-    window.removeEventListener('keydown', this.handleKeypress, true);
-  },
   methods: {
     async navChanged(current: string) {
       await this.$store.dispatch(
@@ -113,11 +107,6 @@ export default Vue.extend({
     },
     reloadPreferences() {
       window.location.reload();
-    },
-    handleKeypress(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        this.closePreferences();
-      }
     },
   },
 });

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -208,6 +208,19 @@ export function openDialog(id: string, opts?: Electron.BrowserWindowConstructorO
     }
   });
 
+  if (Shortcuts.isRegistered(window)) {
+    return window;
+  }
+
+  Shortcuts.register(
+    window,
+    { key: 'Escape' },
+    () => {
+      window.close();
+    },
+    'Close dialog',
+  );
+
   return window;
 }
 

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -69,7 +69,7 @@ export function openPreferences() {
       () => {
         window.close();
       },
-      'close preferences dialog',
+      'Close preferences dialog',
     );
   }
 

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -62,6 +62,15 @@ export function openPreferences() {
       },
       'preferences help',
     );
+
+    Shortcuts.register(
+      window,
+      { key: 'Escape' },
+      () => {
+        window.close();
+      },
+      'close preferences dialog',
+    );
   }
 
   window.webContents.on('ipc-message', (_event, channel) => {


### PR DESCRIPTION
This replaces key handlers from Vue components and implements the Shortcuts in the background. 

The only key handlers remaining at this time appear to be for pressing `Escape` for Preferences and Dialogs.

Fixes #3734

Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>