### PR TITLE
A few cosmetic changes (see body)

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -989,7 +989,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   ): Promise<[string, string]> {
     const [needToUpdate, errors] = this.settingsValidator.validateTransientSettings(TransientSettings.value, newTransientSettings);
 
-    return Promise.resolve((() => {
+    return Promise.resolve(((): [string, string] => {
       if (errors.length > 0) {
         return ['', `errors in attempt to update Transient Settings:\n${ errors.join('\n') }`];
       }

--- a/screenshots/playwright-config.ts
+++ b/screenshots/playwright-config.ts
@@ -12,8 +12,8 @@ process.env.MOCK_FOR_SCREENSHOTS = 'true';
 const config: Config<PlaywrightTestOptions> = {
   testDir,
   outputDir,
-  timeout:       300_000 * timeScale,
-  globalTimeout: 900_000 * timeScale,
+  timeout:       5 * 60 * 1000 * timeScale,
+  globalTimeout: 30 * 60 * 1000 * timeScale,
   workers:       1,
   reporter:      'list',
   use:           { colorScheme },


### PR DESCRIPTION
1. Use `number minutes` * `60  * 1000` rather than a very large # so it's easy to figure out how many minutes were intended to be expressed.

2. Add a specific array type my IDE wants. 