### PR TITLE
Get creds.bats working on Windows

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -2,7 +2,7 @@ EXE=""
 PLATFORM=$OS
 if is_windows; then
     PLATFORM=linux
-    if [ -n "${RD_USE_WINDOWS_EXE:-}" ]; then
+    if using_windows_exe; then
         EXE=".exe"
         PLATFORM=win32
     fi
@@ -21,9 +21,15 @@ elif is_windows; then
 fi
 
 if is_macos; then
-    CRED_HELPER="docker-credential-osxkeychain"
+    CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-osxkeychain"
 elif is_linux; then
-    CRED_HELPER="docker-credential-pass"
+    CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-pass"
+elif is_windows; then
+    if using_windows_exe; then
+        CRED_HELPER="$PATH_RESOURCES/win32/bin/docker-credential-wincred.exe"
+    else
+        CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-pass"
+    fi
 fi
 
 if is_windows; then
@@ -75,4 +81,7 @@ rdshell() {
 }
 rdsudo() {
     rdshell sudo "$@"
+}
+rc_service() {
+    rdsudo $RC_SERVICE "$@"
 }

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -4,3 +4,11 @@
 : "${RD_RANCHER_IMAGE_TAG:=v2.7.0}"
 
 : "${RD_USE_IMAGE_ALLOW_LIST:=false}"
+: "${RD_USE_WINDOWS_EXE:=false}"
+
+using_image_allow_list() {
+    is_true "$RD_USE_IMAGE_ALLOW_LIST"
+}
+using_windows_exe() {
+    is_true "$RD_USE_WINDOWS_EXE"
+}

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -1,6 +1,7 @@
 is_true() {
     # case-insensitive check; false values: '', '0', 'no', and 'false'
-    if [[ "${1,,}" =~ ^(0|no|false)?$ ]]; then
+    local value="$(echo "$1" | tr '[A-Z]' '[a-z]')"
+    if [[ "$value" =~ ^(0|no|false)?$ ]]; then
         false
     else
         true

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -1,13 +1,77 @@
 setup() {
     load '../helpers/load'
-    REGISTRY_IMAGE=registry:2.8.1
-    REGISTRY_HOST=registry.internal
-    REGISTRY_PORT=5050
-    REGISTRY=$REGISTRY_HOST:$REGISTRY_PORT
+    REGISTRY_IMAGE="registry:2.8.1"
+    REGISTRY_PORT="5050"
 
-    AUTH_DIR=/tmp/auth
-    CAROOT=/tmp/caroot
-    CERTS_DIR=/tmp/certs
+    TEMP=/tmp
+    if is_windows; then
+        # We need to use a directory that exists on the Win32 filesystem
+        # so the ctrctl clients can correctly map the bind mounts.
+        TEMP="$(win32env TEMP)"
+    fi
+
+    AUTH_DIR="$TEMP/auth"
+    CAROOT="$TEMP/caroot"
+    CERTS_DIR="$TEMP/certs"
+
+    AUTH_DIR_VOLUME="$AUTH_DIR"
+    CERTS_DIR_VOLUME="$CERTS_DIR"
+    if using_windows_exe; then
+        mkdir -p "$AUTH_DIR_VOLUME"
+        mkdir -p "$CERTS_DIR_VOLUME"
+        AUTH_DIR_VOLUME="$(wslpath -w "$AUTH_DIR_VOLUME")"
+        CERTS_DIR_VOLUME="$(wslpath -w "$CERTS_DIR_VOLUME")"
+    fi
+
+    if is_windows && using_docker; then
+        # BUG BUG BUG
+        # docker service on Windows cannot be restarted, so we can't register
+        # a new CA. `localhost` is an insecure registry, not requiring certs.
+        # https://github.com/rancher-sandbox/rancher-desktop/issues/3878
+        # BUG BUG BUG
+        REGISTRY_HOST="localhost"
+    else
+        if is_windows; then
+            # In WSL all distros have the same IP address
+            ipaddr="$(ip a show eth0 | awk '/inet / {sub("/.*",""); print $2}')"
+        else
+            # Lima uses a fixed hard-coded IP address
+            ipaddr="192.168.5.15"
+        fi
+        REGISTRY_HOST="registry.$ipaddr.sslip.io"
+    fi
+    REGISTRY="$REGISTRY_HOST:$REGISTRY_PORT"
+}
+
+create_registry() {
+    run ctrctl rm -f registry
+    ctrctl run \
+          --detach \
+          --name registry \
+          --restart always \
+          -p "$REGISTRY_PORT:$REGISTRY_PORT" \
+          -e "REGISTRY_HTTP_ADDR=0.0.0.0:$REGISTRY_PORT" \
+          -v "$CERTS_DIR_VOLUME:/certs" \
+          -e "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/$REGISTRY_HOST.pem" \
+          -e "REGISTRY_HTTP_TLS_KEY=/certs/$REGISTRY_HOST-key.pem" \
+          "$@" \
+          "$REGISTRY_IMAGE"
+    wait_for_registry
+}
+
+wait_for_registry() {
+    # registry port is forwarded to host
+    try --max 10 --delay 5 curl -k --silent --show-error "https://localhost:$REGISTRY_PORT/v2/_catalog"
+}
+
+using_insecure_registry() {
+    [ "$REGISTRY_HOST" = "localhost" ]
+}
+
+skip_for_insecure_registry() {
+    if using_insecure_registry; then
+        skip "BUG: docker on Windows can only use insecure registry"
+    fi
 }
 
 @test 'factory reset' {
@@ -15,85 +79,76 @@ setup() {
 }
 
 @test 'start container engine' {
-    # rdctl start \
-    #       --container-engine "$RD_CONTAINER_ENGINE" \
-    #       --kubernetes-enabled=false \  <=== broken in 1.4.1
-    #       --suppress-sudo               <=== not implemented
     start_container_engine
-    # we rely on start_container_engine to have added $REGISTRY_HOST to host
-    # resover config because it is not configurable via settings, and openresty
-    # will no use /etc/hosts to resolve upstream registry names.
-    wait_for_shell
-    if [ "${RD_USE_IMAGE_ALLOW_LIST}" != "false" ]; then
-        rdctl api -X PUT -b "{\"containerEngine\":{\"imageAllowList\":{\"enabled\":true,\"patterns\":[\"$REGISTRY\",\"docker.io/registry\"]}}}" settings
+
+    if using_image_allow_list; then
+        rdctl api -X PUT -b <<EOF settings
+{
+  "containerEngine": {
+    "imageAllowList": {
+      "enabled": true,
+      "patterns": ["$REGISTRY", "docker.io/registry"]
+    }
+  }
+}
+EOF
     fi
+}
+
+@test 'wait for container engine' {
+    wait_for_container_engine
 }
 
 @test 'verify image-allow-list config' {
-    wait_for_container_engine
-    run ctrctl pull busybox
-    if [ "${RD_USE_IMAGE_ALLOW_LIST}" == "false" ]; then
-        assert_success
-    else
+    run ctrctl pull --quiet busybox
+    if using_image_allow_list; then
         assert_failure
         assert_output --regexp "(unauthorized|Forbidden)"
+    else
+        assert_success
     fi
-}
-
-@test 'configure registry hostname' {
-    rdsudo sh -c "printf '%s\t%s\n' \$(hostname -i) $REGISTRY_HOST >> /etc/hosts"
-    # rdshell cat /etc/hosts >&3
 }
 
 @test 'create server certs for registry' {
     rdsudo apk add mkcert --force-broken-world --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing
-    rdshell mkdir -p $CAROOT
-    rdshell CAROOT=$CAROOT TRUST_STORES=none mkcert -install
+    rdshell mkdir -p "$CAROOT"
+    rdshell "CAROOT=$CAROOT" TRUST_STORES=none mkcert -install
     rdshell sh -c "mkdir -p $CERTS_DIR; cd $CERTS_DIR; CAROOT=$CAROOT mkcert $REGISTRY_HOST"
 }
 
-create_registry() {
-    wait_for_container_engine
-    run ctrctl rm -f registry
-    ctrctl run \
-          --detach \
-          --name registry \
-          --restart always \
-          -p $REGISTRY_PORT:$REGISTRY_PORT \
-          -e REGISTRY_HTTP_ADDR=0.0.0.0:$REGISTRY_PORT \
-          -v "$CERTS_DIR:/certs" \
-          -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/$REGISTRY_HOST.pem \
-          -e REGISTRY_HTTP_TLS_KEY=/certs/$REGISTRY_HOST-key.pem \
-          "$@" \
-          $REGISTRY_IMAGE
-    wait_for_registry
-}
-
-wait_for_registry() {
-    # registry port is forwarded to host
-    try --max 10 --delay 5 curl -k --silent --show-error https://localhost:$REGISTRY_PORT/v2/_catalog
+@test 'pull registry image' {
+    ctrctl pull --quiet $REGISTRY_IMAGE
 }
 
 @test 'create plain registry' {
     create_registry
 }
 
+@test 'tag image with registry' {
+    ctrctl tag "$REGISTRY_IMAGE" "$REGISTRY/$REGISTRY_IMAGE"
+}
+
 @test 'expect push image to registry to fail because CA cert has not been installed' {
-    ctrctl tag $REGISTRY_IMAGE $REGISTRY/$REGISTRY_IMAGE
-    run ctrctl push $REGISTRY/$REGISTRY_IMAGE
+    skip_for_insecure_registry
+
+    run ctrctl push "$REGISTRY/$REGISTRY_IMAGE"
     assert_failure
     # we don't get cert errors when going through the proxy; they turn into 502's
     assert_output --regexp "(certificate signed by unknown authority|502 Bad Gateway)"
 }
 
 @test 'install CA cert' {
+    skip_for_insecure_registry
+
     rdsudo cp "$CAROOT/rootCA.pem" /usr/local/share/ca-certificates/
     rdsudo update-ca-certificates
 }
 
 @test 'restart container engine to refresh certs' {
-    rdsudo $RC_SERVICE "$CONTAINER_ENGINE_SERVICE" restart
-    rdsudo $RC_SERVICE --ifstarted openresty restart
+    skip_for_insecure_registry
+
+    rc_service "$CONTAINER_ENGINE_SERVICE" restart
+    rc_service --ifstarted openresty restart
     wait_for_container_engine
     # when Moby is stopped, the containers are stopped as well
     if using_docker; then
@@ -102,51 +157,58 @@ wait_for_registry() {
 }
 
 @test 'expect push image to registry to succeed now' {
-    ctrctl push $REGISTRY/$REGISTRY_IMAGE
+    ctrctl push "$REGISTRY/$REGISTRY_IMAGE"
 }
 
 @test 'create registry with basic auth' {
     # note: docker htpasswd **must** use bcrypt algorithm, i.e. `htpasswd -nbB user password`
-    rdshell mkdir -p $AUTH_DIR
-    rdshell sh -c "echo 'user:\$2y\$05\$pd/kWjYSW9x48yaPQgrl.eLn02DdMPyoYPUy/yac601k6w.okKgmG' > $AUTH_DIR/htpasswd"
+    HTPASSWD='user:$2y$05$pd/kWjYSW9x48yaPQgrl.eLn02DdMPyoYPUy/yac601k6w.okKgmG'
+    rdshell mkdir -p "$AUTH_DIR"
+    echo "$HTPASSWD" | rdshell tee "$AUTH_DIR/htpasswd" > /dev/null
     create_registry \
-        -v $AUTH_DIR:/auth \
+        -v "$AUTH_DIR_VOLUME:/auth" \
         -e REGISTRY_AUTH=htpasswd \
         -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
         -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm"
 }
 
 @test 'verify that registry requires basic auth' {
-    run rdshell curl --silent --show-error https://$REGISTRY/v2/_catalog
+    local curl_options=(--silent --show-error)
+    if using_insecure_registry; then
+        curl_options+=(--insecure)
+    fi
+
+    local registry_url="https://$REGISTRY/v2/_catalog"
+    run rdshell curl "${curl_options[@]}" "$registry_url"
     assert_success
     assert_output --partial '"message":"authentication required"'
 
-    run rdshell curl --silent --show-error --user user:password https://$REGISTRY/v2/_catalog
+    run rdshell curl "${curl_options[@]}" --user user:password "$registry_url"
     assert_success
     assert_output '{"repositories":[]}'
 }
 
 @test 'verify that pushing fails when not logged in' {
-    run bash -c "echo $REGISTRY | $CRED_HELPER erase"
-    run ctrctl push $REGISTRY/$REGISTRY_IMAGE
+    run bash -c "echo $REGISTRY | \"$CRED_HELPER\" erase"
+    run ctrctl push "$REGISTRY/$REGISTRY_IMAGE"
     assert_failure
     assert_output --regexp "(401 Unauthorized|no basic auth credentials)"
 }
 
 @test 'verify that pushing succeeds after logging in' {
-    run ctrctl login -u user -p password $REGISTRY
+    run ctrctl login -u user -p password "$REGISTRY"
     assert_success
     assert_output --partial "Login Succeeded"
 
-    ctrctl push $REGISTRY/$REGISTRY_IMAGE
+    ctrctl push "$REGISTRY/$REGISTRY_IMAGE"
 }
 
 @test 'verify credentials in host cred store' {
-    run bash -c "echo $REGISTRY | $CRED_HELPER get"
+    run bash -c "echo $REGISTRY | \"$CRED_HELPER\" get"
     assert_success
     assert_output --partial '"Secret":"password"'
 
-    ctrctl logout $REGISTRY
-    run bash -c "echo $REGISTRY | $CRED_HELPER get"
+    ctrctl logout "$REGISTRY"
+    run bash -c "echo $REGISTRY | \"$CRED_HELPER\" get"
     refute_output --partial '"Secret":"password"'
 }


### PR DESCRIPTION
Some issues addressed/worked around are:

* mounted directories need to exist on Win32 filesystem
* docker daemon cannot be restarted, so CA cannot be registered
* `rdctl shell` has a quoting bug on Windows
* `rdctl start` does not terminate until RD itself quits
