### PR TITLE
Automatically mount /var/folders and /Volumes on macOS

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -568,6 +568,10 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         { location: paths.logs, writable: true },
         { location: '~', writable: true },
         { location: '/tmp/rancher-desktop', writable: true },
+        ...(os.platform() === 'darwin') ? [
+          { location: '/Volumes', writable: true },
+          { location: '/var/folders', writable: true },
+        ] : [],
       ],
       ssh:          { localPort: await this.sshPort },
       hostResolver: {


### PR DESCRIPTION
This allows the user to mount the $TMPDIR folder, as well as any additional filesystems mounted on the host into containers.

Fixes #3820