### PR TITLE
Disable auto-update for local and CI builds

### DIFF
--- a/pkg/rancher-desktop/utils/version.ts
+++ b/pkg/rancher-desktop/utils/version.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 
 import { spawnFile } from '@pkg/utils/childProcess';
 
-function getProductionVersion() {
+export function getProductionVersion() {
   try {
     return app.getVersion();
   } catch (err) {


### PR DESCRIPTION
Dev and CI build use an incorrect version number that semantically sorts before the previous release, so the auto-updater would always download the previous release and then attempt to "upgrade" (actually downgrade). It normally fails anyways, but either way is undesired.

Fixes #2312