### PR TITLE
Use k3s --docker option whenever possible

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -21,7 +21,7 @@ import { RecursivePartial, RecursiveTypes } from '@pkg/utils/typeUtils';
  */
 export function createDefaultSettings(overrides: RecursivePartial<Settings> = {}) {
   const defaultOverrides: RecursivePartial<Settings> = {
-    kubernetes:  { enabled: true, version: '1.25.4' },
+    kubernetes:  { enabled: true },
     application: {
       debug:                  true,
       pathManagementStrategy: PathManagementStrategy.Manual,

--- a/pkg/rancher-desktop/assets/scripts/service-k3s.initd
+++ b/pkg/rancher-desktop/assets/scripts/service-k3s.initd
@@ -23,9 +23,10 @@ fi
 
 # ENGINE configuration variable is either "moby" or "containerd"
 ENGINE="${ENGINE:-containerd}"
+USE_CRI_DOCKERD="${USE_CRI_DOCKERD:-false}"
 
 depend() {
-  if [ "${ENGINE}" == "moby" ]; then
+  if [ "${USE_CRI_DOCKERD}" == "true" ]; then
       need cri-dockerd
   fi
   after network-online
@@ -60,7 +61,11 @@ name=k3s
 command=/usr/local/bin/k3s
 command_args="server --https-listen-port ${PORT} ${ADDITIONAL_ARGS:-}"
 if [ "${ENGINE}" == "moby" ]; then
-  command_args="${command_args} --container-runtime-endpoint /run/cri-dockerd.sock"
+  if [ "${USE_CRI_DOCKERD}" == "true" ]; then
+    command_args="${command_args} --container-runtime-endpoint /run/cri-dockerd.sock"
+  else
+    command_args="${command_args} --docker"
+  fi
 elif [ "${ENGINE}" == "containerd" ]; then
   command_args="${command_args} --container-runtime-endpoint /run/k3s/containerd/containerd.sock"
 fi

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -1,6 +1,8 @@
 import merge from 'lodash/merge';
+import semver from 'semver';
 
 import { BackendSettings } from '@pkg/backend/backend';
+import { ContainerEngine } from '@pkg/config/settings';
 
 export default class BackendHelper {
   /**
@@ -105,5 +107,13 @@ export default class BackendHelper {
     }
 
     return patterns;
+  }
+
+  /**
+   * k3s versions 1.24.1 to 1.24.3 don't support the --docker option and need to talk to
+   * a cri_dockerd endpoint when using the moby engine.
+   */
+  static requiresCRIDockerd(engineName: string, kubeVersion: string | semver.SemVer): boolean {
+    return engineName === ContainerEngine.MOBY && semver.gte(kubeVersion, '1.24.1') && semver.lte(kubeVersion, '1.24.3');
   }
 }

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -9,6 +9,7 @@ import semver from 'semver';
 import yaml from 'yaml';
 
 import { Architecture, BackendSettings, RestartReasons } from '../backend';
+import BackendHelper from '../backendHelper';
 import K3sHelper, { ExtraRequiresReasons, NoCachedK3sVersionsError, ShortVersion } from '../k3sHelper';
 import LimaBackend, { Action } from '../lima';
 
@@ -344,6 +345,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
       ENGINE:          cfg.containerEngine.name ?? ContainerEngine.NONE,
       ADDITIONAL_ARGS: `--node-ip ${ await this.vm.ipAddress }`,
       LOG_DIR:         paths.logs,
+      USE_CRI_DOCKERD: BackendHelper.requiresCRIDockerd(cfg.containerEngine.name, cfg.kubernetes.version).toString(),
     };
 
     if (allowSudo && os.platform() === 'darwin') {

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1218,6 +1218,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               'export IPTABLES_MODE': 'legacy',
               ENGINE:                 config.containerEngine.name,
               ADDITIONAL_ARGS:        config.kubernetes.options.traefik ? '' : '--disable traefik',
+              USE_CRI_DOCKERD:        BackendHelper.requiresCRIDockerd(config.containerEngine.name, config.kubernetes.version).toString(),
             };
 
             if (!config.kubernetes.options.flannel) {


### PR DESCRIPTION
Only 1.24.1, 1.24.2, and 1.24.3 require the use of an explicit cri-dockerd service. The version of cri-dockerd bundled with Rancher Desktop is not compatible with 1.26.1+.

Fixes #3928 
Fixes #3678
Fixes #3743

### Acceptance test

Please verify on Windows (I've already tested the Lima branch on macOS) that you can use both 1.24.3 and 1.26.1 with the moby engine!