### PR TITLE
Don't write image-allow-list.conf unless the feature is enabled

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -933,12 +933,20 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       return ['no changes necessary', ''];
     }
 
-    // Update image allow list patterns, just in case the backend doesn't need restarting
-    const allowListConf = BackendHelper.createImageAllowListConf(cfg.containerEngine.imageAllowList);
+    const imageAllowListConf = '/usr/local/openresty/nginx/conf/image-allow-list.conf';
     const rcService = k8smanager.backend === 'wsl' ? 'wsl-service' : 'rc-service';
 
-    await k8smanager.executor.writeFile(`/usr/local/openresty/nginx/conf/image-allow-list.conf`, allowListConf, 0o644);
-    await k8smanager.executor.execCommand({ root: true }, rcService, '--ifstarted', 'openresty', 'reload');
+    // Update image allow list patterns, just in case the backend doesn't need restarting
+    // TODO: review why this block is needed at all
+    if (cfg.containerEngine.imageAllowList.enabled) {
+      const allowListConf = BackendHelper.createImageAllowListConf(cfg.containerEngine.imageAllowList);
+
+      await k8smanager.executor.writeFile(imageAllowListConf, allowListConf, 0o644);
+      await k8smanager.executor.execCommand({ root: true }, rcService, '--ifstarted', 'openresty', 'reload');
+    } else {
+      await k8smanager.executor.execCommand({ root: true }, rcService, '--ifstarted', 'openresty', 'stop');
+      await k8smanager.executor.execCommand({ root: true }, 'rm', '-f', imageAllowListConf);
+    }
 
     // Check if the newly applied preferences demands a restart of the backend.
     const restartReasons = await k8smanager.requiresRestartReasons(cfg);


### PR DESCRIPTION
The mere presence of the file causes `HTTPS_PROXY` to be set for `nerdctl`, which will then fail unless `openresty` is actually running.

Fixes #3738

The issue includes repro instructions!

I've added a task to #3237 to investigate why the code block exists at all.