### PR TITLE
Always import our wrapped ipcRenderer.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -683,11 +683,11 @@ ipcMainProxy.on('help/preferences/open-url', async() => {
   Help.preferences.openUrl(await getVersion());
 });
 
-ipcMainProxy.handle('show-message-box', (_event, options: Electron.MessageBoxOptions, modal = false): Promise<Electron.MessageBoxReturnValue> => {
-  return window.showMessageBox(options, modal);
+ipcMainProxy.handle('show-message-box', (_event, options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> => {
+  return window.showMessageBox(options, false);
 });
 
-Electron.ipcMain.handle('show-message-box-rd', async(_event, options: Electron.MessageBoxOptions, modal = false) => {
+ipcMainProxy.handle('show-message-box-rd', async(_event, options: Electron.MessageBoxOptions, modal = false) => {
   const mainWindow = modal ? window.getWindow('main') : null;
 
   const dialog = window.openDialog(

--- a/pkg/rancher-desktop/components/Preferences/Help.vue
+++ b/pkg/rancher-desktop/components/Preferences/Help.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
 import Help from '@pkg/components/Help.vue';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name:       'preferences-help',

--- a/pkg/rancher-desktop/pages/Troubleshooting.vue
+++ b/pkg/rancher-desktop/pages/Troubleshooting.vue
@@ -79,8 +79,7 @@ import { Checkbox } from '@rancher/components';
 
 import TroubleshootingLineItem from '@pkg/components/TroubleshootingLineItem.vue';
 import { defaultSettings, runInDebugMode } from '@pkg/config/settings';
-
-const { ipcRenderer } = require('electron');
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default {
   name:       'Troubleshooting',

--- a/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
+++ b/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
@@ -15,8 +15,9 @@
 </template>
 
 <script lang="ts">
-import { ipcRenderer } from 'electron';
 import Vue from 'vue';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   layout: 'dialog',

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -91,7 +91,8 @@ export interface IpcMainInvokeEvents {
   'service-fetch': (namespace?: string) => import('@pkg/backend/k8s').ServiceEntry[];
   'service-forward': (service: ServiceEntry, state: boolean) => void;
   'get-app-version': () => string;
-  'show-message-box': (options: Electron.MessageBoxOptions) => Promise<Electron.MessageBoxReturnValue>;
+  'show-message-box': (options: Electron.MessageBoxOptions) => Electron.MessageBoxReturnValue;
+  'show-message-box-rd': (options: Electron.MessageBoxOptions, modal?: boolean) => any;
   'api-get-credentials': () => { user: string, password: string, port: number, pid: number };
   'k8s-progress': () => Readonly<{current: number, max: number, description?: string, transitionTime?: Date}>;
 


### PR DESCRIPTION
This ensures that we avoid typos on the event signatures.  This also includes adding a new signature for `show-message-box-rd` which was previously missed.