### PR TITLE
Rename virtualMachine.experimental.socketVMNet → experimental.virtualMachine.socketVMNet

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -121,7 +121,7 @@ test.describe.serial('KubernetesBackend', () => {
       /** Platform-specific changes to `newSettings`. */
       const platformSettings: Partial<Record<NodeJS.Platform, RecursivePartial<Settings>>> = {
         win32:  { virtualMachine: { hostResolver: getAlternateSetting(currentSettings, 'virtualMachine.hostResolver', true, false) } },
-        darwin: { virtualMachine: { experimental: { socketVMNet: getAlternateSetting(currentSettings, 'virtualMachine.experimental.socketVMNet', true, false) } } },
+        darwin: { experimental: { virtualMachine: { socketVMNet: getAlternateSetting(currentSettings, 'experimental.virtualMachine.socketVMNet', true, false) } } },
       };
 
       _.merge(newSettings, platformSettings[process.platform] ?? {});
@@ -154,7 +154,7 @@ test.describe.serial('KubernetesBackend', () => {
       /** Platform-specific additions to `expectedDefinition`. */
       const platformExpectedDefinitions: Partial<Record<NodeJS.Platform, ExpectedDefinition>> = {
         win32:  { 'virtualMachine.hostResolver': false },
-        darwin: { 'virtualMachine.experimental.socketVMNet': false },
+        darwin: { 'experimental.virtualMachine.socketVMNet': false },
       };
 
       _.merge(expectedDefinition, platformExpectedDefinitions[process.platform] ?? {});

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -694,14 +694,14 @@ test.describe('Command server', () => {
           ['application.path-management-strategy', 'rcfiles'],
           ['virtual-machine.memory-in-gb', 10],
           ['virtual-machine.number-cpus', 10],
-          ['virtual-machine.experimental.socket-vmnet', true],
+          ['experimental.virtual-machine.socket-vmnet', true],
         ],
         darwin: [
           ['virtual-machine.host-resolver', true],
         ],
         linux: [
           ['virtual-machine.host-resolver', true],
-          ['virtual-machine.experimental.socket-vmnet', true],
+          ['experimental.virtual-machine.socket-vmnet', true],
         ],
       };
       const unsupportedOptions = unsupportedPrefsByPlatform[os.platform()] ?? [];
@@ -805,7 +805,7 @@ test.describe('Command server', () => {
           switch (os.platform()) {
           case 'darwin':
             body.kubernetes.experimental ??= {};
-            body.kubernetes.experimental.socketVMNet = !oldSettings.virtualMachine.experimental.socketVMNet;
+            body.kubernetes.experimental.socketVMNet = !oldSettings.experimental.virtualMachine.socketVMNet;
             break;
           case 'win32':
             body.kubernetes.WSLIntegrations ??= {};

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -289,12 +289,6 @@ components:
             hostResolver:
               type: boolean
               x-rd-platforms: ['win32']
-            experimental:
-              type: object
-              properties:
-                socketVMNet:
-                  type: boolean
-                  x-rd-platforms: ['darwin']
         kubernetes:
           type: object
           properties:
@@ -322,6 +316,15 @@ components:
                     Use to disable flannel so you can install your own CNI.
                   x-rd-aliases:
                     - "flannel-enabled"
+        experimental:
+          type: object
+          properties:
+            virtualMachine:
+              type: object
+              properties:
+                socketVMNet:
+                  type: boolean
+                  x-rd-platforms: ['darwin']
         WSL:
           type: object
           x-rd-platforms: ['win32']

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1544,7 +1544,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
    * @precondition The VM configuration is correct.
    */
   protected async startVM() {
-    const vmnet = this.cfg?.virtualMachine?.experimental.socketVMNet ? VMNet.SOCKET : VMNet.VDE;
+    const vmnet = this.cfg?.experimental?.virtualMachine?.socketVMNet ? VMNet.SOCKET : VMNet.VDE;
     let allowRoot = this.#adminAccess;
 
     // We need both the lima config + the lima network config to correctly check if we need sudo
@@ -1902,11 +1902,11 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
       return reasons; // No need to restart if nothing exists
     }
     if (process.platform === 'darwin') {
-      if (typeof cfg.virtualMachine?.experimental?.socketVMNet !== 'undefined') {
-        if (this.cfg.virtualMachine?.experimental.socketVMNet !== cfg.virtualMachine.experimental.socketVMNet) {
-          reasons['virtualMachine.experimental.socketVMNet'] = {
-            current:  this.cfg.virtualMachine.experimental.socketVMNet,
-            desired:  cfg.virtualMachine.experimental.socketVMNet,
+      if (typeof cfg.experimental?.virtualMachine?.socketVMNet !== 'undefined') {
+        if (this.cfg.experimental?.virtualMachine?.socketVMNet !== cfg.experimental.virtualMachine.socketVMNet) {
+          reasons['experimental.virtualMachine.socketVMNet'] = {
+            current:  this.cfg.experimental.virtualMachine.socketVMNet,
+            desired:  cfg.experimental.virtualMachine.socketVMNet,
             severity: 'restart',
           };
         }

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -34,10 +34,10 @@ describe('updateFromCommandLine', () => {
         memoryInGB:   4,
         numberCPUs:   2,
         hostResolver: true,
-        experimental: { socketVMNet: true },
       },
-      WSL:        { integrations: {} },
-      kubernetes: {
+      experimental: { virtualMachine: { socketVMNet: true } },
+      WSL:          { integrations: {} },
+      kubernetes:   {
         version: '1.23.5',
         port:    6443,
         enabled: true,

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -69,13 +69,6 @@ export const defaultSettings = {
      * is handled by host-resolver on Windows platform only.
      */
     hostResolver: true,
-    /**
-     * Experimental settings - there should not be any UI for these.
-     */
-    experimental: {
-      /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
-      socketVMNet: false,
-    },
   },
   WSL:        { integrations: {} as Record<string, boolean> },
   kubernetes: {
@@ -98,6 +91,15 @@ export const defaultSettings = {
   startInBackground:    false,
   hideNotificationIcon: false,
   window:               { quitOnClose: false },
+  /**
+   * Experimental settings - there should not be any UI for these.
+   */
+  experimental:         {
+    virtualMachine: {
+      /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
+      socketVMNet: false,
+    },
+  },
 };
 
 export type Settings = typeof defaultSettings;
@@ -422,11 +424,11 @@ const updateTable: Record<number, (settings: any) => void> = {
       updater:                { enabled: settings.updater },
     };
     settings.virtualMachine = {
-      experimental: settings.kubernetes.experimental,
       hostResolver: settings.kubernetes.hostResolver,
       memoryInGB:   settings.kubernetes.memoryInGB,
       numberCPUs:   settings.kubernetes.numberCPUs,
     };
+    settings.experimental = { virtualMachine: { socketVMNet: settings.kubernetes.experimental.socketVMNet } };
     settings.WSL = { integrations: settings.kubernetes.WSLIntegrations };
     settings.containerEngine.name = settings.kubernetes.containerEngine;
 

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -77,7 +77,7 @@ describe(SettingsValidator, () => {
         'virtualMachine.memoryInGB':               'darwin',
         'virtualMachine.numberCPUs':               'linux',
         'application.adminAccess':                 'linux',
-        'virtualMachine.experimental.socketVMNet': 'darwin',
+        'experimental.virtualMachine.socketVMNet': 'darwin',
       };
 
       const spyValidateSettings = jest.spyOn(subject, 'validateSettings');

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -77,10 +77,10 @@ export default class SettingsValidator {
         memoryInGB:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
         numberCPUs:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
         hostResolver: this.checkPlatform('win32', this.checkBoolean),
-        experimental: { socketVMNet: this.checkPlatform('darwin', this.checkBoolean) },
       },
-      WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
-      kubernetes: {
+      experimental: { virtualMachine: { socketVMNet: this.checkPlatform('darwin', this.checkBoolean) } },
+      WSL:          { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
+      kubernetes:   {
         version: this.checkKubernetesVersion,
         port:    this.checkNumber(1, 65535),
         enabled: this.checkBoolean,


### PR DESCRIPTION
Because we want `experimental.` to be the top level, so they are grouped together in `rdctl set --help` output.