### PR TITLE
Disable recursive option in Linux

### DIFF
--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -99,6 +99,10 @@ export class Tray {
     return os.platform() === 'darwin';
   };
 
+  private isLinux = () => {
+    return os.platform() === 'linux';
+  };
+
   private readonly trayIconsMacOs = {
     stopped:  path.join(paths.resources, 'icons', 'logo-tray-stopped-Template@2x.png'),
     starting: path.join(paths.resources, 'icons', 'logo-tray-starting-Template@2x.png'),
@@ -126,7 +130,7 @@ export class Tray {
     const paths = await kubeconfig.getKubeConfigPaths();
     const options: fs.WatchOptions = {
       persistent: false,
-      recursive:  true,
+      recursive:  !this.isLinux(), // Recursive not implemented in Linux
       encoding:   'utf-8',
       signal:     abortController.signal,
     };


### PR DESCRIPTION
This resolves an issue with Kubernetes contexts updating in the tray menu by disabling the recursive option in Linux. 

I had originally attempted upgrading to Node.js 18 in #3958 but the issue still persisted. The recursive options should be supported in node 18, so we will have to circle back to understand why this approach failed.

closes #3765