### PR TITLE
Increase maximum number of simultaneous ssh connections

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -44,6 +44,13 @@ provision:
     #!/bin/sh
     set -o errexit -o nounset -o xtrace
     fstrim /mnt/data
+- # allow more than 10 sessions over the master control path
+  mode: system
+  script: |
+    #!/bin/sh
+    set -o errexit -o nounset -o xtrace
+    sed -i 's/#MaxSessions 10/MaxSessions 25/g' /etc/ssh/sshd_config
+    rc-service --ifstarted sshd reload
 - # Persist /root directory on data volume
   mode: system
   script: |


### PR DESCRIPTION
During boot, we have multiple installXXX() functions all copying files into the VM via `limactl copy`. They run in parallel via `Promises.All()`, so can sometimes exhaust the number of available sessions.