### PR TITLE
Make the command to modify ssh MaxSessions more robust

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -49,7 +49,7 @@ provision:
   script: |
     #!/bin/sh
     set -o errexit -o nounset -o xtrace
-    sed -i 's/#MaxSessions 10/MaxSessions 25/g' /etc/ssh/sshd_config
+    sed -i -E 's/^#?MaxSessions +[0-9]+/MaxSessions 25/g' /etc/ssh/sshd_config
     rc-service --ifstarted sshd reload
 - # Persist /root directory on data volume
   mode: system


### PR DESCRIPTION
In case we change the limit again in the future, the command needs to handle both the default config as well as the config from an upgraded instance.