### PR TITLE
Disable drop shadow in macOS screenshots

### DIFF
--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -55,7 +55,7 @@ export class Screenshots {
 
   protected osCommand(file: string): string {
     if (os.platform() === 'darwin') {
-      return `screencapture -l $(GetWindowID  "${ this.appBundleTitle }" "${ this.windowTitle }") ${ file }`;
+      return `screencapture -o -l $(GetWindowID  "${ this.appBundleTitle }" "${ this.windowTitle }") ${ file }`;
     }
     if (os.platform() === 'win32') {
       return `${ path.resolve(process.cwd(), 'resources', 'ShareX', 'sharex') } -p -s -ActiveWindow`;


### PR DESCRIPTION
This disables the drop shadow for macOS screenshots by supplying the `-o` flag to `screencapture`.

closes #3431 