### PR TITLE
Fix versioning API endpoints from the client.

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -1150,6 +1150,21 @@ test.describe('Command server', () => {
         expect(stderr).not.toContain('Usage:');
       });
 
+      test('complains on invalid unversioned endpoint', async() => {
+        const endpoint = '/v1/shazbat';
+        const { stdout, stderr, error } = await rdctl(['api', endpoint]);
+
+        expect({
+          stdout, stderr, error,
+        }).toEqual({
+          error:  expect.any(Error),
+          stderr: expect.stringContaining(`Unknown command: GET ${ endpoint }`),
+          stdout: expect.stringMatching(/{".+?":".+"}/),
+        });
+        expect(JSON.parse(stdout)).toEqual({ message: '404 Not Found' });
+        expect(stderr).not.toContain('Usage:');
+      });
+
       test.describe('getting endpoints', () => {
         test('no paths should return all supported endpoints', async() => {
           const { stdout, stderr } = await rdctl(['api', '/']);

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -71,7 +71,10 @@ func init() {
 
 func versionCommand(version string, command string) string {
 	if version == "" {
-		return fmt.Sprintf("%s/%s", apiVersion, command)
+		version = apiVersion
+	}
+	if strings.HasPrefix(command, "/") {
+		return fmt.Sprintf("%s%s", version, command)
 	}
 	return fmt.Sprintf("%s/%s", version, command)
 }


### PR DESCRIPTION
Fixes #3965

* Be more careful when prepending the version string.
* Write a test that a versioned non-existent endpoint is correctly flagged.