### PR TITLE
Give more information when nerdctl fails.

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -7,9 +7,14 @@ while [ -L "${scriptname}" ]; do
 done
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
-if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
-  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
-  exit 1
-else
-  "${scriptdir}/rdctl" shell sudo nerdctl "$@"
-fi
+export LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima"
+
+status=$( "${scriptdir}/../lima/bin/limactl" ls 0 -f '{{.Status}}' 2>/dev/null)
+case "${status:-Nonexistent}" in
+  Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
+  Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
+  Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
+  Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
+  *) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
+     echo "Unexpected VM status of ${status}" ;;
+esac

--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -3,18 +3,20 @@ set -eu -o pipefail
 
 scriptname="${BASH_SOURCE[0]}"
 while [ -L "${scriptname}" ]; do
-    scriptname="$(readlink "${scriptname}")"
+  scriptname="$(readlink "${scriptname}")"
 done
 scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
 
 export LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima"
 
-status=$( "${scriptdir}/../lima/bin/limactl" ls 0 -f '{{.Status}}' 2>/dev/null)
+status=$("${scriptdir}/../lima/bin/limactl" ls 0 -f '{{.Status}}' 2>/dev/null)
 case "${status:-Nonexistent}" in
-  Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
-  Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
-  Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
-  Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
-  *) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
-     echo "Unexpected VM status of ${status}" ;;
+Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
+Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
+Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
+Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
+*)
+  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"
+  echo "Unexpected VM status of ${status}"
+  ;;
 esac

--- a/resources/linux/bin/nerdctl
+++ b/resources/linux/bin/nerdctl
@@ -2,18 +2,23 @@
 
 if grep -q -i 'microsoft.*wsl' /proc/version; then
   exec /mnt/wsl/rancher-desktop/bin/nerdctl "$@"
-else
-  limaloc="${XDG_DATA_HOME:-$HOME/.local/share}/rancher-desktop"
-  scriptname="$0"
-  while [ -L "${scriptname}" ]; do
-    scriptname="$(readlink "${scriptname}")"
-  done
-  scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
-
-  if ! LIMA_HOME="${limaloc}/lima" "${scriptdir}/../lima/bin/limactl" ls --json | grep '"name":"0"' | grep -q '"status":"Running"'; then
-    echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
-    exit 1
-  else
-    "${scriptdir}/rdctl" shell sudo nerdctl "$@"
-  fi
 fi
+
+limaloc="${XDG_DATA_HOME:-$HOME/.local/share}/rancher-desktop"
+scriptname="$0"
+while [ -L "${scriptname}" ]; do
+  scriptname="$(readlink "${scriptname}")"
+done
+scriptdir="$(cd "$(dirname "${scriptname}")" && pwd)"
+
+export LIMA_HOME="${limaloc}/lima"
+
+status=$("${scriptdir}/../lima/bin/limactl" ls 0 -f '{{.Status}}' 2>/dev/null)
+case "${status:-Nonexistent}" in
+  Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
+  Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
+  Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
+  Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
+  *) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
+     echo "Unexpected VM status of ${status}" ;;
+esac

--- a/resources/linux/bin/nerdctl
+++ b/resources/linux/bin/nerdctl
@@ -15,10 +15,12 @@ export LIMA_HOME="${limaloc}/lima"
 
 status=$("${scriptdir}/../lima/bin/limactl" ls 0 -f '{{.Status}}' 2>/dev/null)
 case "${status:-Nonexistent}" in
-  Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
-  Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
-  Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
-  Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
-  *) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
-     echo "Unexpected VM status of ${status}" ;;
+Running) "${scriptdir}/rdctl" shell sudo nerdctl "$@" ;;
+Nonexistent) echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl" ;;
+Stopped) echo "The Rancher Desktop VM is currently stopped. Either Rancher Desktop is not running, or [Troubleshooting|Restart] should be run." ;;
+Broken) echo 'The Rancher Desktop VM is corrupted. Running `rdctl factory-reset` should fix it (workloads will be deleted).' ;;
+*)
+  echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl"
+  echo "Unexpected VM status of ${status}"
+  ;;
 esac


### PR DESCRIPTION
Right now when `nerdctl` fails (on the host), we give a generic error message stating that Rancher Desktop isn't running.

We should give more information, to make it easier for people running into this problem to get us timely data.