### PR TITLE
Remove underline from focused tabs

### DIFF
--- a/pkg/rancher-desktop/components/Tabbed/RdTabbed.vue
+++ b/pkg/rancher-desktop/components/Tabbed/RdTabbed.vue
@@ -27,6 +27,10 @@ export default Vue.extend({
     flex-direction: column;
     max-height: 100%;
 
+    ::v-deep .tabs:focus .tab.active {
+      text-decoration: none;
+    }
+
     ::v-deep .tabs {
       border-bottom: 1px solid var(--border);
 


### PR DESCRIPTION
This removes the underline by setting `text-decoration: none` for active/focused tabs.

closes #3988 