### PR TITLE
Merge integrations if they exist during initialization

### DIFF
--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -156,8 +156,16 @@ export const actions = {
     );
     commit('SET_PREFERENCES', newPreferences);
   },
-  setWslIntegrations({ commit }: PrefActionContext, integrations: { [distribution: string]: string | boolean}) {
-    commit('SET_WSL_INTEGRATIONS', integrations);
+  setWslIntegrations({ commit, state }: PrefActionContext, integrations: { [distribution: string]: string | boolean}) {
+    /**
+     * Merge integrations if they exist during initialization.
+     *
+     * Issue #3232: First-time render of tabs causes the entire DOM tree to
+     * refresh, causing Preferences to initialize more than once.
+     */
+    const updatedIntegrations = _.merge({}, integrations, state.wslIntegrations);
+
+    commit('SET_WSL_INTEGRATIONS', updatedIntegrations);
   },
   updateWslIntegrations({ commit, state }: PrefActionContext, args: {distribution: string, value: boolean}) {
     const { distribution, value } = args;


### PR DESCRIPTION
This ensures that a copy of WSL Integrations is merged into any existing changes so that changes made by the user will not get overwritten. 

This bug can be traced back to #3232, where the existence of tabs will cause the entire DOM tree to re-render, ultimately prompting preferences to "initialize" for a second time. The second initialization overwrites any selections made by the user because this routine was assumed to run once.

closes #3911 