### PR TITLE
Refactor `rdctl` code that gets path to main Rancher Desktop executable

### DIFF
--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -82,10 +82,10 @@ func doStartCommand(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	if applicationPath == "" {
-		applicationPath = utils.GetRDPath()
-		if applicationPath == "" {
-			return fmt.Errorf("could not locate main Rancher Desktop executable; please retry with the --path option")
+	if !cmd.Flags().Changed("path") {
+		applicationPath, err = utils.GetRDPath()
+		if err != nil {
+			return fmt.Errorf("failed to locate main Rancher Desktop executable: %w\nplease retry with the --path option", err)
 		}
 	}
 	return launchApp(applicationPath, commandLineArgs)

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -83,11 +83,7 @@ func doStartCommand(cmd *cobra.Command) error {
 		return err
 	}
 	if applicationPath == "" {
-		rdctlPath, err := os.Executable()
-		if err != nil {
-			rdctlPath = ""
-		}
-		applicationPath = utils.GetRDPath(rdctlPath)
+		applicationPath = utils.GetRDPath()
 		if applicationPath == "" {
 			return fmt.Errorf("could not locate main Rancher Desktop executable; please retry with the --path option")
 		}

--- a/src/go/rdctl/pkg/autostart/autostart_darwin.go
+++ b/src/go/rdctl/pkg/autostart/autostart_darwin.go
@@ -84,14 +84,9 @@ func EnsureAutostart(autostartDesired bool) error {
 }
 
 func getDesiredLaunchAgentFileContents() ([]byte, error) {
-	// get path to main Rancher Desktop executable
-	rdctlPath, err := os.Executable()
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to get path to rdctl: %w", err)
-	}
 	rancherDesktopPath, err := utils.GetRDPath()
 	if err != nil {
-		return []byte{}, errors.New("failed to get path to main Rancher Desktop executable: %w", err)
+		return []byte{}, fmt.Errorf("failed to get path to main Rancher Desktop executable: %w", err)
 	}
 
 	// get desired contents of LaunchAgent file

--- a/src/go/rdctl/pkg/autostart/autostart_darwin.go
+++ b/src/go/rdctl/pkg/autostart/autostart_darwin.go
@@ -89,9 +89,9 @@ func getDesiredLaunchAgentFileContents() ([]byte, error) {
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to get path to rdctl: %w", err)
 	}
-	rancherDesktopPath := utils.GetDarwinRDPath(rdctlPath)
-	if rancherDesktopPath == "" {
-		return []byte{}, errors.New("failed to get path to main Rancher Desktop executable")
+	rancherDesktopPath, err := utils.GetRDPath()
+	if err != nil {
+		return []byte{}, errors.New("failed to get path to main Rancher Desktop executable: %w", err)
 	}
 
 	// get desired contents of LaunchAgent file

--- a/src/go/rdctl/pkg/autostart/autostart_windows.go
+++ b/src/go/rdctl/pkg/autostart/autostart_windows.go
@@ -30,7 +30,7 @@ func EnsureAutostart(autostartDesired bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to get path to rdctl: %w", err)
 		}
-		rancherDesktopPath := utils.GetWindowsRDPath(rdctlPath)
+		rancherDesktopPath := utils.GetRDPath(rdctlPath)
 		if rancherDesktopPath == "" {
 			return errors.New("failed to get path to Rancher Desktop.exe")
 		}

--- a/src/go/rdctl/pkg/autostart/autostart_windows.go
+++ b/src/go/rdctl/pkg/autostart/autostart_windows.go
@@ -3,7 +3,6 @@ package autostart
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/utils"
 	"golang.org/x/sys/windows/registry"
@@ -26,11 +25,7 @@ func EnsureAutostart(autostartDesired bool) error {
 	defer autostartKey.Close()
 
 	if autostartDesired {
-		rdctlPath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("failed to get path to rdctl: %w", err)
-		}
-		rancherDesktopPath := utils.GetRDPath(rdctlPath)
+		rancherDesktopPath := utils.GetRDPath()
 		if rancherDesktopPath == "" {
 			return errors.New("failed to get path to Rancher Desktop.exe")
 		}

--- a/src/go/rdctl/pkg/autostart/autostart_windows.go
+++ b/src/go/rdctl/pkg/autostart/autostart_windows.go
@@ -25,9 +25,9 @@ func EnsureAutostart(autostartDesired bool) error {
 	defer autostartKey.Close()
 
 	if autostartDesired {
-		rancherDesktopPath := utils.GetRDPath()
-		if rancherDesktopPath == "" {
-			return errors.New("failed to get path to Rancher Desktop.exe")
+		rancherDesktopPath, err := utils.GetRDPath()
+		if err != nil {
+			return fmt.Errorf("failed to get path to Rancher Desktop.exe: %w", err)
 		}
 		err = autostartKey.SetStringValue(nameValue, rancherDesktopPath)
 		if err != nil {

--- a/src/go/rdctl/pkg/utils/utils.go
+++ b/src/go/rdctl/pkg/utils/utils.go
@@ -1,10 +1,6 @@
 package utils
 
 import (
-	"errors"
-	"fmt"
-	"io/fs"
-	"os"
 	"path/filepath"
 )
 
@@ -15,35 +11,4 @@ func getParentDir(fullPath string, steps int) string {
 		fullPath = filepath.Dir(fullPath)
 	}
 	return fullPath
-}
-
-// Verify that the candidatePath is usable as a Rancher Desktop "executable". This means:
-//   - check that candidatePath exists
-//   - if checkExecutability is true, check that candidatePath is a regular file,
-//     and that it is executable
-//
-// Note that candidatePath may not always be a file; in macOS, it may be a
-// .app directory.
-func checkUsability(candidatePath string, checkExecutability bool) (bool, error) {
-	statResult, err := os.Stat(candidatePath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to get info on %q: %w", candidatePath, err)
-	}
-
-	if !checkExecutability {
-		return true, nil
-	}
-
-	if !statResult.Mode().IsRegular() {
-		return false, nil
-	}
-
-	if statResult.Mode().Perm()&0o111 == 0 {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/src/go/rdctl/pkg/utils/utils.go
+++ b/src/go/rdctl/pkg/utils/utils.go
@@ -8,7 +8,7 @@ import (
 
 // Get the parent (or grandparent, or great-grandparent...) directory of fullPath.
 // numberTimes is the number of steps to ascend in the directory hierarchy.
-func MoveToParent(fullPath string, numberTimes int) string {
+func getParentDir(fullPath string, numberTimes int) string {
 	fullPath = filepath.Clean(fullPath)
 	for ; numberTimes > 0; numberTimes-- {
 		fullPath = filepath.Dir(fullPath)

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -1,23 +1,36 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 // Returns the absolute path to the Rancher Desktop executable.
 // Returns an empty string if the executable was not found.
-func GetRDPath() string {
-	rdctlPath, err := os.Executable()
-	if err == nil {
-		// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
-		// and want to move to the "R D.app" part
-		RDAppParentPath := getParentDir(rdctlPath, 6)
-		if CheckExistence(filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop"), 0o111) != "" {
-			return RDAppParentPath
-		}
+func GetRDPath() (string, error) {
+	rdctlSymlinkPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get path to rdctl: %w", err)
 	}
+	rdctlPath, err := filepath.EvalSymlinks(rdctlSymlinkPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve %q: %w", rdctlSymlinkPath, err)
+	}
+
+	// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
+	// and want to move to the "R D.app" part
+	RDAppParentPath := getParentDir(rdctlPath, 6)
+	if CheckExistence(filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop"), 0o111) != "" {
+		return RDAppParentPath, nil
+	}
+
 	// This fallback is mostly for running `npm run dev` and using the installed app because there is no app
 	// that rdctl would launch directly in dev mode.
-	return CheckExistence(filepath.Join("/Applications", "Rancher Desktop.app"), 0)
+	candidatePath := filepath.Join("/Applications", "Rancher Desktop.app")
+	if len(CheckExistence(candidatePath, 0)) {
+		return candidatePath
+	}
+
+	return "", errors.New("search locations exhausted")
 }

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -23,7 +23,7 @@ func GetRDPath() (string, error) {
 	// and want to move to the "R D.app" part
 	RDAppParentPath := getParentDir(rdctlPath, 6)
 	executablePath := filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop")
-	usable, err := checkUsability(executablePath, true)
+	usable, err := checkUsableApplication(executablePath, true)
 	if err != nil {
 		return "", fmt.Errorf("failed to check usability of %q: %w", executablePath, err)
 	}
@@ -34,7 +34,7 @@ func GetRDPath() (string, error) {
 	// This fallback is mostly for running `npm run dev` and using the installed app because there is no app
 	// that rdctl would launch directly in dev mode.
 	candidatePath := filepath.Join("/Applications", "Rancher Desktop.app")
-	usable, err = checkUsability(candidatePath, false)
+	usable, err = checkUsableApplication(candidatePath, false)
 	if err != nil {
 		return "", fmt.Errorf("failed to check usability of %q: %w", candidatePath, err)
 	}

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"path/filepath"
+)
+
+// Returns the absolute path to the Rancher Desktop executable.
+// Returns an empty string if the executable was not found.
+func GetRDPath(rdctlPath string) string {
+	if rdctlPath != "" {
+		// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
+		// and want to move to the "R D.app" part
+		RDAppParentPath := MoveToParent(rdctlPath, 6)
+		if CheckExistence(filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop"), 0o111) != "" {
+			return RDAppParentPath
+		}
+	}
+	// This fallback is mostly for running `npm run dev` and using the installed app because there is no app
+	// that rdctl would launch directly in dev mode.
+	return CheckExistence(filepath.Join("/Applications", "Rancher Desktop.app"), 0)
+}

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -1,13 +1,15 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
 )
 
 // Returns the absolute path to the Rancher Desktop executable.
 // Returns an empty string if the executable was not found.
-func GetRDPath(rdctlPath string) string {
-	if rdctlPath != "" {
+func GetRDPath() string {
+	rdctlPath, err := os.Executable()
+	if err == nil {
 		// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
 		// and want to move to the "R D.app" part
 		RDAppParentPath := getParentDir(rdctlPath, 6)

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,18 +19,27 @@ func GetRDPath() (string, error) {
 		return "", fmt.Errorf("failed to resolve %q: %w", rdctlSymlinkPath, err)
 	}
 
-	// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
+	// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin/rdctl
 	// and want to move to the "R D.app" part
 	RDAppParentPath := getParentDir(rdctlPath, 6)
-	if CheckExistence(filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop"), 0o111) != "" {
+	executablePath := filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop")
+	usable, err := checkUsability(executablePath, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to check usability of %q: %w", executablePath, err)
+	}
+	if usable {
 		return RDAppParentPath, nil
 	}
 
 	// This fallback is mostly for running `npm run dev` and using the installed app because there is no app
 	// that rdctl would launch directly in dev mode.
 	candidatePath := filepath.Join("/Applications", "Rancher Desktop.app")
-	if len(CheckExistence(candidatePath, 0)) {
-		return candidatePath
+	usable, err = checkUsability(candidatePath, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to check usability of %q: %w", candidatePath, err)
+	}
+	if usable {
+		return RDAppParentPath, nil
 	}
 
 	return "", errors.New("search locations exhausted")

--- a/src/go/rdctl/pkg/utils/utils_darwin.go
+++ b/src/go/rdctl/pkg/utils/utils_darwin.go
@@ -10,7 +10,7 @@ func GetRDPath(rdctlPath string) string {
 	if rdctlPath != "" {
 		// we're at .../Applications/R D.app (could have a different name)/Contents/Resources/resources/darwin/bin
 		// and want to move to the "R D.app" part
-		RDAppParentPath := MoveToParent(rdctlPath, 6)
+		RDAppParentPath := getParentDir(rdctlPath, 6)
 		if CheckExistence(filepath.Join(RDAppParentPath, "Contents", "MacOS", "Rancher Desktop"), 0o111) != "" {
 			return RDAppParentPath
 		}

--- a/src/go/rdctl/pkg/utils/utils_linux.go
+++ b/src/go/rdctl/pkg/utils/utils_linux.go
@@ -18,13 +18,15 @@ func GetRDPath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve %q: %w", rdctlSymlinkPath, err)
 	}
+	// rdctl should be at <installDir>/resources/resources/linux/bin/rdctl.
+	// rancher-desktop should be 5 directories up from that, at <installDir>/rancher-desktop.
 	normalParentPath := getParentDir(rdctlPath, 5)
 	candidatePaths := []string{
 		filepath.Join(normalParentPath, "rancher-desktop"),
 		"/opt/rancher-desktop/rancher-desktop",
 	}
 	for _, candidatePath := range candidatePaths {
-		usable, err := checkUsability(candidatePath, true)
+		usable, err := checkUsableApplication(candidatePath, true)
 		if err != nil {
 			return "", fmt.Errorf("failed to check usability of %q: %w", candidatePath, err)
 		}

--- a/src/go/rdctl/pkg/utils/utils_linux.go
+++ b/src/go/rdctl/pkg/utils/utils_linux.go
@@ -24,7 +24,11 @@ func GetRDPath() (string, error) {
 		"/opt/rancher-desktop/rancher-desktop",
 	}
 	for _, candidatePath := range candidatePaths {
-		if len(CheckExistence(candidatePath, 0o111)) > 0 {
+		usable, err := checkUsability(candidatePath, true)
+		if err != nil {
+			return "", fmt.Errorf("failed to check usability of %q: %w", candidatePath, err)
+		}
+		if usable {
 			return candidatePath, nil
 		}
 	}

--- a/src/go/rdctl/pkg/utils/utils_linux.go
+++ b/src/go/rdctl/pkg/utils/utils_linux.go
@@ -8,7 +8,7 @@ import (
 // Returns an empty string if the executable was not found.
 func GetRDPath(rdctlPath string) string {
 	if rdctlPath != "" {
-		normalParentPath := MoveToParent(rdctlPath, 5)
+		normalParentPath := getParentDir(rdctlPath, 5)
 		candidatePath := CheckExistence(filepath.Join(normalParentPath, "rancher-desktop"), 0o111)
 		if candidatePath != "" {
 			return candidatePath

--- a/src/go/rdctl/pkg/utils/utils_linux.go
+++ b/src/go/rdctl/pkg/utils/utils_linux.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"path/filepath"
+)
+
+// Returns the absolute path to the Rancher Desktop executable.
+// Returns an empty string if the executable was not found.
+func GetRDPath(rdctlPath string) string {
+	if rdctlPath != "" {
+		normalParentPath := MoveToParent(rdctlPath, 5)
+		candidatePath := CheckExistence(filepath.Join(normalParentPath, "rancher-desktop"), 0o111)
+		if candidatePath != "" {
+			return candidatePath
+		}
+	}
+	return CheckExistence("/opt/rancher-desktop/rancher-desktop", 0o111)
+}

--- a/src/go/rdctl/pkg/utils/utils_linux.go
+++ b/src/go/rdctl/pkg/utils/utils_linux.go
@@ -1,13 +1,15 @@
 package utils
 
 import (
+	"os"
 	"path/filepath"
 )
 
 // Returns the absolute path to the Rancher Desktop executable.
 // Returns an empty string if the executable was not found.
-func GetRDPath(rdctlPath string) string {
-	if rdctlPath != "" {
+func GetRDPath() string {
+	rdctlPath, err := os.Executable()
+	if err == nil {
 		normalParentPath := getParentDir(rdctlPath, 5)
 		candidatePath := CheckExistence(filepath.Join(normalParentPath, "rancher-desktop"), 0o111)
 		if candidatePath != "" {

--- a/src/go/rdctl/pkg/utils/utils_unix.go
+++ b/src/go/rdctl/pkg/utils/utils_unix.go
@@ -1,0 +1,39 @@
+//go:build linux || darwin
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/sys/unix"
+	"io/fs"
+	"os"
+)
+
+// Verify that the candidatePath is usable as a Rancher Desktop "executable". This means:
+//   - check that candidatePath exists
+//   - if checkExecutability is true, check that candidatePath is a regular file,
+//     and that it is executable
+//
+// Note that candidatePath may not always be a file; in macOS, it may be a
+// .app directory.
+func checkUsableApplication(candidatePath string, checkExecutability bool) (bool, error) {
+	statResult, err := os.Stat(candidatePath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get info on %q: %w", candidatePath, err)
+	}
+
+	if !checkExecutability {
+		return true, nil
+	}
+
+	if !statResult.Mode().IsRegular() {
+		return false, nil
+	}
+
+	err = unix.Access(candidatePath, unix.X_OK)
+	return err == nil, nil
+}

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -9,15 +10,21 @@ import (
 
 // Returns the absolute path to the Rancher Desktop executable.
 // Returns an empty string if the executable was not found.
-func GetRDPath() string {
-	rdctlPath, err := os.Executable()
-	if err == nil {
-		normalParentPath := getParentDir(rdctlPath, 5)
-		candidatePath := CheckExistence(filepath.Join(normalParentPath, "Rancher Desktop.exe"), 0)
-		if candidatePath != "" {
-			return candidatePath
-		}
+func GetRDPath() (string, error) {
+	rdctlSymlinkPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get path to rdctl: %w", err)
 	}
+	rdctlPath, err := filepath.EvalSymlinks(rdctlSymlinkPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve %q: %w", rdctlSymlinkPath, err)
+	}
+	normalParentPath := getParentDir(rdctlPath, 5)
+	candidatePath := CheckExistence(filepath.Join(normalParentPath, "Rancher Desktop.exe"), 0)
+	if candidatePath != "" {
+		return candidatePath
+	}
+
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		homedir = ""

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -11,7 +11,7 @@ import (
 // Returns an empty string if the executable was not found.
 func GetRDPath(rdctlPath string) string {
 	if rdctlPath != "" {
-		normalParentPath := MoveToParent(rdctlPath, 5)
+		normalParentPath := getParentDir(rdctlPath, 5)
 		candidatePath := CheckExistence(filepath.Join(normalParentPath, "Rancher Desktop.exe"), 0)
 		if candidatePath != "" {
 			return candidatePath

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -9,8 +9,9 @@ import (
 
 // Returns the absolute path to the Rancher Desktop executable.
 // Returns an empty string if the executable was not found.
-func GetRDPath(rdctlPath string) string {
-	if rdctlPath != "" {
+func GetRDPath() string {
+	rdctlPath, err := os.Executable()
+	if err == nil {
 		normalParentPath := getParentDir(rdctlPath, 5)
 		candidatePath := CheckExistence(filepath.Join(normalParentPath, "Rancher Desktop.exe"), 0)
 		if candidatePath != "" {

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
+)
+
+// Returns the absolute path to the Rancher Desktop executable.
+// Returns an empty string if the executable was not found.
+func GetRDPath(rdctlPath string) string {
+	if rdctlPath != "" {
+		normalParentPath := MoveToParent(rdctlPath, 5)
+		candidatePath := CheckExistence(filepath.Join(normalParentPath, "Rancher Desktop.exe"), 0)
+		if candidatePath != "" {
+			return candidatePath
+		}
+	}
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		homedir = ""
+	}
+	dataPaths := []string{}
+	// %LOCALAPPDATA%
+	dir, err := directories.GetLocalAppDataDirectory()
+	if err == nil {
+		dataPaths = append(dataPaths, dir)
+	}
+	// %APPDATA%
+	dir, err = directories.GetRoamingAppDataDirectory()
+	if err == nil {
+		dataPaths = append(dataPaths, dir)
+	}
+	// Add these two paths if the above two fail to find where the program was installed
+	dataPaths = append(
+		dataPaths,
+		filepath.Join(homedir, "AppData", "Local"),
+		filepath.Join(homedir, "AppData", "Roaming"),
+	)
+	for _, dataDir := range dataPaths {
+		candidatePath := CheckExistence(filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe"), 0)
+		if candidatePath != "" {
+			return candidatePath
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Fixes #3953.

This is not high priority for 1.8.0 release, so please ignore this if reviewing it would block more important work.