### PR TITLE
Hide dock when starting in background

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -200,6 +200,8 @@ Electron.app.whenReady().then(async() => {
 
     if (!cfg.startInBackground) {
       window.openMain();
+    } else if (Electron.app.dock) {
+      Electron.app.dock.hide();
     }
 
     dockerDirManager.ensureCredHelperConfigured();


### PR DESCRIPTION
This hides the Rancher Desktop dock icon when `cfg.startInBackground === true` and a dock present.

closes #4019 