### PR TITLE
Center port forwarding icon buttons

### DIFF
--- a/pkg/rancher-desktop/components/PortForwarding.vue
+++ b/pkg/rancher-desktop/components/PortForwarding.vue
@@ -60,13 +60,13 @@
         </div>
         <div v-else-if="serviceBeingEditedIs(row.row)" class="action-div">
           <button
-            class="btn btn-sm role-tertiary"
+            class="btn btn-sm role-tertiary btn-icon"
             @click="emitCancelEditPortForward(row.row)"
           >
             <span class="icon icon-x icon-lg" />
           </button>
           <button
-            class="btn btn-sm role-tertiary"
+            class="btn btn-sm role-tertiary btn-icon"
             @click="emitUpdatePortForward()"
           >
             <span class="icon icon-checkmark icon-lg" />
@@ -227,6 +227,13 @@ export default Vue.extend({
 </script>
 
 <style>
+  .btn-icon {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
+
   .action-div {
     display: flex;
     flex-direction: row-reverse;


### PR DESCRIPTION
This uses css flexbox to center the tertiary icon buttons. 

The root cause of this issue seems to be related to #2415. 

I was able to reproduce in both Windows 10 and Linux. I suspect that this is consistently out of alignment on all platforms.

## Before

![image](https://user-images.githubusercontent.com/835961/220982309-6b54315c-ea9e-4994-82d3-0ef4ac9ea73d.png)

## After

![image](https://user-images.githubusercontent.com/835961/220982178-d236aad5-c356-481d-a2fb-bb9313224379.png)


closes #3602 