### PR TITLE
Close all windows and quit when `quitOnClose` is set

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -406,10 +406,6 @@ Electron.app.on('before-quit', async(event) => {
 });
 
 Electron.app.on('window-all-closed', () => {
-  if (cfg.window.quitOnClose) {
-    Electron.app.quit();
-  }
-
   // On macOS, hide the dock icon.
   Electron.app.dock?.hide();
 });

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -142,6 +142,10 @@ export function save(cfg: Settings) {
     const rawdata = JSON.stringify(cfg);
 
     fs.writeFileSync(join(paths.config, 'settings.json'), rawdata);
+
+    // update the in-memory copy so subsequent calls to settings.load() will
+    // return an up to date settings object
+    settings = cfg;
   } catch (err) {
     if (err) {
       const { dialog } = require('electron');

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import Electron, { BrowserWindow, app, shell } from 'electron';
 
 import * as K8s from '@pkg/backend/k8s';
+import { load as loadSettings } from '@pkg/config/settings';
 import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import { isDevEnv } from '@pkg/utils/environment';
 import Logging from '@pkg/utils/logging';
@@ -54,6 +55,15 @@ export const restoreWindow = (window: Electron.BrowserWindow | null): window is 
  */
 export function getWindow(name: string): Electron.BrowserWindow | null {
   return (name in windowMapping) ? BrowserWindow.fromId(windowMapping[name]) : null;
+}
+
+/**
+ * Close all open windows.
+ */
+function closeAll() {
+  for (const name in windowMapping) {
+    getWindow(name)?.close();
+  }
 }
 
 /**
@@ -166,6 +176,15 @@ export function openMain() {
       'switch preferences tabs by cycle [back]',
     );
   }
+
+  window.on('closed', () => {
+    const cfg = loadSettings();
+
+    if (cfg.window.quitOnClose) {
+      closeAll();
+      app.quit();
+    }
+  });
 
   app.dock?.show();
 }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -58,15 +58,6 @@ export function getWindow(name: string): Electron.BrowserWindow | null {
 }
 
 /**
- * Close all open windows.
- */
-function closeAll() {
-  for (const name in windowMapping) {
-    getWindow(name)?.close();
-  }
-}
-
-/**
  * Open a given window; if it is already open, focus it.
  * @param name The window identifier; this controls window re-use.
  * @param url The URL to load into the window.
@@ -181,7 +172,9 @@ export function openMain() {
     const cfg = loadSettings();
 
     if (cfg.window.quitOnClose) {
-      closeAll();
+      BrowserWindow.getAllWindows().forEach((window) => {
+        window.close();
+      });
       app.quit();
     }
   });


### PR DESCRIPTION
This closes all windows and quits Rancher Desktop only when the main window is closing and `quitOnClose` is enabled.

closes #4023 
closes #4032