### PR TITLE
Implement "Hide Notification Icon" behavior

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -29,7 +29,7 @@ import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import mainEvents from '@pkg/main/mainEvents';
 import buildApplicationMenu from '@pkg/main/mainmenu';
 import setupNetworking from '@pkg/main/networking';
-import setupTray from '@pkg/main/tray';
+import { Tray } from '@pkg/main/tray';
 import setupUpdate from '@pkg/main/update';
 import { spawnFile } from '@pkg/utils/childProcess';
 import getCommandLineArgs from '@pkg/utils/commandLine';
@@ -196,7 +196,9 @@ Electron.app.whenReady().then(async() => {
       iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
     });
 
-    setupTray();
+    if (!cfg.hideNotificationIcon) {
+      Tray.getInstance().setup();
+    }
 
     if (!cfg.application.startInBackground) {
       window.openMain();

--- a/background.ts
+++ b/background.ts
@@ -128,6 +128,13 @@ mainEvents.on('settings-update', async(newSettings) => {
     await pathManager.enforce();
   }
 
+  if (newSettings.application.hideNotificationIcon) {
+    Tray.getInstance().hide();
+  } else {
+    Tray.getInstance().show();
+    mainEvents.emit('k8s-check-state', k8smanager);
+  }
+
   await runRdctlSetup(newSettings);
 });
 
@@ -196,8 +203,8 @@ Electron.app.whenReady().then(async() => {
       iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
     });
 
-    if (!cfg.hideNotificationIcon) {
-      Tray.getInstance().setup();
+    if (!cfg.application.hideNotificationIcon) {
+      Tray.getInstance().show();
     }
 
     if (!cfg.application.startInBackground) {

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -39,6 +39,7 @@ export class Tray {
   private settings: Settings = load();
   private currentNetworkStatus: networkStatus = networkStatus.CHECKING;
   private static instance: Tray;
+  private abortController: AbortController | undefined;
 
   protected contextMenuItems: Electron.MenuItemConstructorOptions[] = [
     {
@@ -130,13 +131,13 @@ export class Tray {
    * triggered, close the watcher and restart after a duration (one second).
    */
   private async watchForChanges() {
-    const abortController = new AbortController();
+    this.abortController = new AbortController();
     const paths = await kubeconfig.getKubeConfigPaths();
     const options: fs.WatchOptions = {
       persistent: false,
       recursive:  !this.isLinux(), // Recursive not implemented in Linux
       encoding:   'utf-8',
-      signal:     abortController.signal,
+      signal:     this.abortController.signal,
     };
 
     paths.map(filepath => fs.watch(filepath, options, async(eventType) => {
@@ -149,7 +150,7 @@ export class Tray {
         }
       }
 
-      abortController.abort();
+      this.abortController?.abort();
       this.buildFromConfig();
 
       setTimeout(this.watchForChanges.bind(this), 1_000);
@@ -218,6 +219,7 @@ export class Tray {
    */
   public hide() {
     this.trayMenu.destroy();
+    this.abortController?.abort();
     mainEvents.off('k8s-check-state', this.k8sStateChangedEvent);
     mainEvents.off('settings-update', this.settingsUpdateEvent);
     ipcMainProxy.removeListener('update-network-status', this.updateNetworkStatusEvent);

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -205,13 +205,16 @@ export class Tray {
   }
 
   /**
-   * Destroy the tray menu.
+   * Hide the tray menu.
    */
-  public destroy() {
+  public hide() {
     this.trayMenu.destroy();
   }
 
-  public setup() {
+  /**
+   * Show the tray menu.
+   */
+  public show() {
     if (this.trayMenu.isDestroyed()) {
       Tray.instance = new Tray();
     }


### PR DESCRIPTION
This toggles the notification icon depending on the selected value for the "Hide Notification Icon" preference (`hideNotificationIcon`).

I opted to treat the Tray as a singleton so it will be easier to setup and destroy tray instances. I also think that a singleton is appropriate here because we shouldn't ever have more than one tray icon to manage while running Rancher Desktop.

## NOTE

Network status will remain in a "Network status: checking..." state until we navigate to to the General page. I'm treating this as a separate issue, as described in #4030.