### PR TITLE
Add `--experimental.virtual-machine.mount.9p.*` settings

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -32,7 +32,14 @@ import {
 } from './utils/TestUtils';
 
 import {
-  ContainerEngine, Settings, defaultSettings, CURRENT_SETTINGS_VERSION, MountType,
+  ContainerEngine,
+  Settings,
+  defaultSettings,
+  CURRENT_SETTINGS_VERSION,
+  MountType,
+  CacheMode,
+  ProtocolVersion,
+  SecurityModel,
 } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
@@ -695,10 +702,10 @@ test.describe('Command server', () => {
         win32: [
           ['application.admin-access', true],
           ['application.path-management-strategy', 'rcfiles'],
-          ['experimental.virtual-machine.mount.9p.cache-mode', 'mmap'],
+          ['experimental.virtual-machine.mount.9p.cache-mode', CacheMode.MMAP],
           ['experimental.virtual-machine.mount.9p.msize-in-kb', 128],
-          ['experimental.virtual-machine.mount.9p.protocol-version', '9p2000.L'],
-          ['experimental.virtual-machine.mount.9p.security-model', 'none'],
+          ['experimental.virtual-machine.mount.9p.protocol-version', ProtocolVersion.NINEP2000_L],
+          ['experimental.virtual-machine.mount.9p.security-model', SecurityModel.NONE],
           ['experimental.virtual-machine.mount.type', MountType.NINEP],
           ['experimental.virtual-machine.socket-vmnet', true],
           ['virtual-machine.memory-in-gb', 10],

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -336,6 +336,28 @@ components:
                 socketVMNet:
                   type: boolean
                   x-rd-platforms: ['darwin']
+                mount:
+                  type: object
+                  x-rd-platforms: ['darwin', 'linux']
+                  properties:
+                    type:
+                      type: string
+                      enum: ['reverse-sshfs', '9p']
+                    9p:
+                      type: object
+                      properties:
+                        securityModel:
+                          type: string
+                          enum: ['passthrough', 'mapped-xattr', 'mapped-file', 'none']
+                        protocolVersion:
+                          type: string
+                          enum: ['9p2000', '9p2000.u', '9p2000.L']
+                        msizeInKB:
+                          type: integer
+                          minimum: 4
+                        cacheMode:
+                          type: string
+                          enum: ['none', 'loose', 'fscache', 'mmap']
         WSL:
           type: object
           x-rd-platforms: ['win32']

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
 
 import { BackendSettings, RestartReasons } from './backend';
-import { ExtraRequiresReasons } from './k3sHelper';
+import K3sHelper, { ExtraRequiresReasons } from './k3sHelper';
 
 import EventEmitter from '@pkg/utils/eventEmitter';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
@@ -125,6 +125,8 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
    * given new configuration been applied on top of the existing old configuration.
    */
   requiresRestartReasons(oldConfig: BackendSettings, newConfig: RecursivePartial<BackendSettings>, extras?: ExtraRequiresReasons): Promise<RestartReasons>;
+
+  readonly k3sHelper: K3sHelper;
 }
 
 export interface KubernetesBackendPortForwarder {

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -271,7 +271,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   protected currentPort = 0;
 
   /** Helper object to manage available K3s versions. */
-  protected readonly k3sHelper: K3sHelper;
+  readonly k3sHelper: K3sHelper;
 
   protected client: KubeClient | null = null;
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -34,7 +34,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
   protected cfg: BackendSettings | undefined;
   protected vm: WSLBackend;
   /** Helper object to manage available K3s versions. */
-  protected k3sHelper = new K3sHelper('x86_64');
+  readonly k3sHelper = new K3sHelper('x86_64');
   protected client: KubeClient | null = null;
 
   /** The version of Kubernetes currently running. */

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -69,7 +69,7 @@ enum VMNet {
 }
 
 /**
- * Lima configuration
+ * Lima mount
  */
 export type LimaMount = {
   location: string;
@@ -82,6 +82,9 @@ export type LimaMount = {
   }
 };
 
+/**
+ * Lima configuration
+ */
 export type LimaConfiguration = {
   arch?: 'x86_64' | 'aarch64';
   images: {
@@ -570,12 +573,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     })();
   }
 
-  protected getMounts(): LimaConfiguration['mounts'] {
-    let mounts: LimaConfiguration['mounts'] = [];
-    let locations = [path.join(paths.cache, 'k3s'), paths.logs, '~', '/tmp/rancher-desktop'];
+  protected getMounts(): LimaMount[] {
+    const mounts: LimaMount[] = [];
+    const locations = [path.join(paths.cache, 'k3s'), paths.logs, '~', '/tmp/rancher-desktop'];
 
     if (os.platform() === 'darwin') {
-      locations = locations.concat('/Volumes', '/var/folders');
+      locations.push('/Volumes', '/var/folders');
     }
 
     for (const location of locations) {
@@ -591,7 +594,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           cache:           nineP.cacheMode,
         };
       }
-      mounts = mounts.concat(mount);
+      mounts.push(mount);
     }
 
     return mounts;

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -12,6 +12,7 @@ import { ContainerEngineClient } from './containerClient';
 import { KubernetesBackend, KubernetesError, KubernetesBackendEvents } from './k8s';
 import ProgressTracker from './progressTracker';
 
+import K3sHelper from '@pkg/backend/k3sHelper';
 import { Settings } from '@pkg/config/settings';
 import { ChildProcess } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
@@ -174,6 +175,8 @@ class MockKubernetesBackend extends events.EventEmitter implements KubernetesBac
   readonly availableVersions = Promise.resolve([{ version: new semver.SemVer('0.0.0'), channels: ['latest'] }]);
   version = '';
   desiredPort = 9443;
+
+  readonly k3sHelper = new K3sHelper('x86_64');
 
   cachedVersionsOnly(): Promise<boolean> {
     return Promise.resolve(false);

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 import * as settings from '../settings';
-import { MountType } from '../settings';
+import { CacheMode, MountType, ProtocolVersion, SecurityModel } from '../settings';
 
 import { TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
@@ -45,10 +45,10 @@ describe('updateFromCommandLine', () => {
           mount: {
             type: MountType.REVERSE_SSHFS,
             '9p': {
-              securityModel:   'none',
-              protocolVersion: '9p2000.L',
+              securityModel:   SecurityModel.NONE,
+              protocolVersion: ProtocolVersion.NINEP2000_L,
               msizeInKB:       128,
-              cacheMode:       'mmap',
+              cacheMode:       CacheMode.MMAP,
             },
           },
           socketVMNet: true,

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import * as settings from '../settings';
+import { MountType } from '../settings';
 
 import { TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
@@ -39,9 +40,22 @@ describe('updateFromCommandLine', () => {
         numberCPUs:   2,
         hostResolver: true,
       },
-      experimental: { virtualMachine: { socketVMNet: true } },
-      WSL:          { integrations: {} },
-      kubernetes:   {
+      experimental: {
+        virtualMachine: {
+          mount: {
+            type: MountType.REVERSE_SSHFS,
+            '9p': {
+              securityModel:   'none',
+              protocolVersion: '9p2000.L',
+              msizeInKB:       128,
+              cacheMode:       'mmap',
+            },
+          },
+          socketVMNet: true,
+        },
+      },
+      WSL:        { integrations: {} },
+      kubernetes: {
         version: '1.23.5',
         port:    6443,
         enabled: true,

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -30,15 +30,36 @@ export enum ContainerEngine {
   MOBY = 'moby',
 }
 
-export enum MountType {
-  NINEP = '9p',
-  REVERSE_SSHFS = 'reverse-sshfs',
-}
 export const ContainerEngineNames: Record<ContainerEngine, string> = {
   [ContainerEngine.NONE]:       '',
   [ContainerEngine.CONTAINERD]: 'containerd',
   [ContainerEngine.MOBY]:       'dockerd',
 };
+
+export enum MountType {
+  NINEP = '9p',
+  REVERSE_SSHFS = 'reverse-sshfs',
+}
+
+export enum ProtocolVersion {
+  NINEP2000 = '9p2000',
+  NINEP2000_U = '9p2000.u',
+  NINEP2000_L = '9p2000.L',
+}
+
+export enum SecurityModel {
+  PASSTHROUGH ='passthrough',
+  MAPPED_XATTR = 'mapped-xattr',
+  MAPPED_FILE = 'mapped-file',
+  NONE = 'none',
+}
+
+export enum CacheMode {
+  NONE = 'none',
+  LOOSE = 'loose',
+  FSCACHE = 'fscache',
+  MMAP = 'mmap',
+}
 
 export const defaultSettings = {
   version:     CURRENT_SETTINGS_VERSION,
@@ -102,10 +123,10 @@ export const defaultSettings = {
       mount:       {
         type: MountType.REVERSE_SSHFS,
         '9p': {
-          securityModel:   'none',
-          protocolVersion: '9p2000.L',
+          securityModel:   SecurityModel.NONE,
+          protocolVersion: ProtocolVersion.NINEP2000_L,
           msizeInKB:       128,
-          cacheMode:       'mmap',
+          cacheMode:       CacheMode.MMAP,
         },
       },
     },

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -30,6 +30,10 @@ export enum ContainerEngine {
   MOBY = 'moby',
 }
 
+export enum MountType {
+  NINEP = '9p',
+  REVERSE_SSHFS = 'reverse-sshfs',
+}
 export const ContainerEngineNames: Record<ContainerEngine, string> = {
   [ContainerEngine.NONE]:       '',
   [ContainerEngine.CONTAINERD]: 'containerd',
@@ -95,6 +99,15 @@ export const defaultSettings = {
     virtualMachine: {
       /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
       socketVMNet: false,
+      mount:       {
+        type: MountType.REVERSE_SSHFS,
+        '9p': {
+          securityModel:   'none',
+          protocolVersion: '9p2000.L',
+          msizeInKB:       128,
+          cacheMode:       'mmap',
+        },
+      },
     },
   },
 };

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -63,21 +63,26 @@ describe(SettingsValidator, () => {
     describe('all standard fields', () => {
       // Special fields that cannot be checked here; this includes enums and maps.
       const specialFields = [
+        ['application', 'pathManagementStrategy'],
         ['containerEngine', 'allowedImages', 'locked'],
         ['containerEngine', 'name'],
-        ['WSL', 'integrations'],
+        ['experimental', 'virtualMachine', 'mount', '9p', 'cacheMode'],
+        ['experimental', 'virtualMachine', 'mount', '9p', 'msizeInKB'],
+        ['experimental', 'virtualMachine', 'mount', '9p', 'protocolVersion'],
+        ['experimental', 'virtualMachine', 'mount', '9p', 'securityModel'],
+        ['experimental', 'virtualMachine', 'mount', 'type'],
         ['kubernetes', 'version'],
-        ['application', 'pathManagementStrategy'],
         ['version'],
+        ['WSL', 'integrations'],
       ];
 
       // Fields that can only be set on specific platforms.
       const platformSpecificFields: Record<string, ReturnType<typeof os.platform>> = {
+        'application.adminAccess':                 'linux',
+        'experimental.virtualMachine.socketVMNet': 'darwin',
         'virtualMachine.hostResolver':             'win32',
         'virtualMachine.memoryInGB':               'darwin',
         'virtualMachine.numberCPUs':               'linux',
-        'application.adminAccess':                 'linux',
-        'experimental.virtualMachine.socketVMNet': 'darwin',
       };
 
       const spyValidateSettings = jest.spyOn(subject, 'validateSettings');
@@ -259,7 +264,7 @@ describe(SettingsValidator, () => {
 
         expect({ needToUpdate, errors }).toEqual({
           needToUpdate: false,
-          errors:       [expect.stringContaining('Invalid value for containerEngine.name: <"pikachu">;')],
+          errors:       [expect.stringContaining('Invalid value for containerEngine.name: <"pikachu">; must be one of ["containerd","moby","docker"]')],
         });
       });
     });
@@ -433,7 +438,7 @@ describe(SettingsValidator, () => {
       expect(needToUpdate).toBeFalsy();
       expect(errors).toHaveLength(3);
       expect(errors).toEqual([
-        `Invalid value for containerEngine.name: <{"expected":"a string"}>; must be 'containerd', 'docker', or 'moby'`,
+        `Invalid value for containerEngine.name: <{"expected":"a string"}>`,
         'Kubernetes version "[object Object]" not found.',
         "Setting kubernetes.options should wrap an inner object, but got <ceci n'est pas un objet>.",
       ]);

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -2,7 +2,7 @@ import os from 'os';
 
 import _ from 'lodash';
 
-import { defaultSettings, Settings } from '@pkg/config/settings';
+import { defaultSettings, MountType, Settings } from '@pkg/config/settings';
 import { NavItemName, navItemNames, TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
@@ -13,14 +13,15 @@ type settingsLike = Record<string, any>;
 /**
  * ValidatorFunc describes a validation function; it is used to check if a
  * given proposed setting is compatible.
+ * @param mergedSettings The root of the merged settings object.
  * @param currentValue The value of the setting, before changing.
  * @param desiredValue The new value that the user is setting.
  * @param errors An array that any validation errors should be appended to.
  * @param fqname The fully qualified name of the setting, for formatting in error messages.
  * @returns Whether the setting has changed.
  */
-type ValidatorFunc<C, D> =
-  (currentValue: C, desiredValue: D, errors: string[], fqname: string) => boolean;
+type ValidatorFunc<S, C, D> =
+  (mergedSettings: S, currentValue: C, desiredValue: D, errors: string[], fqname: string) => boolean;
 
 /**
  * SettingsValidationMapEntry describes validators that are valid for some
@@ -28,12 +29,12 @@ type ValidatorFunc<C, D> =
  * for that subtree, or an object containing validators for each member of the
  * subtree.
  */
-type SettingsValidationMapEntry<T> = {
+type SettingsValidationMapEntry<S, T> = {
   [k in keyof T]:
   T[k] extends string | Array<string> | number | boolean ?
-  ValidatorFunc<T[k], T[k]> :
+  ValidatorFunc<S, T[k], T[k]> :
   T[k] extends Record<string, infer V> ?
-  SettingsValidationMapEntry<T[k]> | ValidatorFunc<T[k], Record<string, V>> :
+  SettingsValidationMapEntry<S, T[k]> | ValidatorFunc<S, T[k], Record<string, V>> :
   never;
 };
 
@@ -41,19 +42,17 @@ type SettingsValidationMapEntry<T> = {
  * SettingsValidationMap describes the full set of validators that will be used
  * for all settings.
  */
-type SettingsValidationMap = SettingsValidationMapEntry<Settings>;
+type SettingsValidationMap = SettingsValidationMapEntry<Settings, Settings>;
 
-type TransientSettingsValidationMap = SettingsValidationMapEntry<TransientSettings>;
+type TransientSettingsValidationMap = SettingsValidationMapEntry<TransientSettings, TransientSettings>;
 
 export default class SettingsValidator {
   k8sVersions: Array<string> = [];
   allowedSettings: SettingsValidationMap | null = null;
   allowedTransientSettings: TransientSettingsValidationMap | null = null;
   synonymsTable: settingsLike|null = null;
-  isKubernetesDesired = false;
 
   validateSettings(currentSettings: Settings, newSettings: RecursivePartial<Settings>): [boolean, string[]] {
-    this.isKubernetesDesired = typeof newSettings.kubernetes?.enabled !== 'undefined' ? newSettings.kubernetes.enabled : currentSettings.kubernetes.enabled;
     this.allowedSettings ||= {
       version:     this.checkUnchanged,
       application: {
@@ -75,16 +74,30 @@ export default class SettingsValidator {
           locked:   this.checkUnchanged,
           patterns: this.checkStringArray,
         },
-        name: this.checkContainerEngine,
+        // 'docker' has been canonicalized to 'moby' already, but we want to include it as a valid value in the error message
+        name: this.checkEnum('containerd', 'moby', 'docker'),
       },
       virtualMachine: {
-        memoryInGB:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
-        numberCPUs:   this.checkLima(this.checkNumber(0, Number.POSITIVE_INFINITY)),
+        memoryInGB:   this.checkLima(this.checkNumber(1, Number.POSITIVE_INFINITY)),
+        numberCPUs:   this.checkLima(this.checkNumber(1, Number.POSITIVE_INFINITY)),
         hostResolver: this.checkPlatform('win32', this.checkBoolean),
       },
-      experimental: { virtualMachine: { socketVMNet: this.checkPlatform('darwin', this.checkBoolean) } },
-      WSL:          { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
-      kubernetes:   {
+      experimental: {
+        virtualMachine: {
+          mount: {
+            type: this.checkLima(this.checkEnum(...Object.values(MountType))),
+            '9p': {
+              securityModel:   this.checkLima(this.check9P(this.checkEnum('passthrough', 'mapped-xattr', 'mapped-file', 'none'))),
+              protocolVersion: this.checkLima(this.check9P(this.checkEnum('9p2000', '9p2000.u', '9p2000.L'))),
+              msizeInKB:       this.checkLima(this.check9P(this.checkNumber(4, Number.POSITIVE_INFINITY))),
+              cacheMode:       this.checkLima(this.check9P(this.checkEnum('none', 'loose', 'fscache', 'mmap'))),
+            },
+          },
+          socketVMNet: this.checkPlatform('darwin', this.checkBoolean),
+        },
+      },
+      WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
+      kubernetes: {
         version: this.checkKubernetesVersion,
         port:    this.checkNumber(1, 65535),
         enabled: this.checkBoolean,
@@ -102,7 +115,14 @@ export default class SettingsValidator {
     };
     this.canonicalizeSynonyms(newSettings);
     const errors: Array<string> = [];
-    const needToUpdate = this.checkProposedSettings(this.allowedSettings, currentSettings, newSettings, errors, '');
+    const needToUpdate = this.checkProposedSettings(
+      _.merge({}, currentSettings, newSettings),
+      this.allowedSettings,
+      currentSettings,
+      newSettings,
+      errors,
+      '',
+    );
 
     return [needToUpdate && errors.length === 0, errors];
   }
@@ -124,6 +144,7 @@ export default class SettingsValidator {
     this.canonicalizeSynonyms(currentTransientSettings);
     const errors: Array<string> = [];
     const needToUpdate = this.checkProposedSettings(
+      _.merge({}, currentTransientSettings, newTransientSettings),
       this.allowedTransientSettings,
       currentTransientSettings,
       newTransientSettings,
@@ -140,6 +161,7 @@ export default class SettingsValidator {
    * 1. Complains about any fields in the input that aren't in the verifier
    * 2. Recursively walks child-objects in the input and verifier
    * 3. Calls validation functions off the verifier
+   * @param mergedSettings - The root object of the merged current and new settings
    * @param allowedSettings - The verifier
    * @param currentSettings - The current preferences object
    * @param newSettings - User's proposed new settings
@@ -147,7 +169,8 @@ export default class SettingsValidator {
    * @param prefix - For error messages only, e.g. '' for root, 'kubernetes.options', etc.
    * @returns boolean - true if there are changes that need to be applied.
    */
-  protected checkProposedSettings(
+  protected checkProposedSettings<S>(
+    mergedSettings: S,
     allowedSettings: settingsLike,
     currentSettings: settingsLike,
     newSettings: settingsLike,
@@ -164,21 +187,21 @@ export default class SettingsValidator {
         continue;
       } else if (typeof (allowedSettings[k]) === 'object') {
         if (typeof (newSettings[k]) === 'object') {
-          changeNeeded = this.checkProposedSettings(allowedSettings[k], currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
+          changeNeeded = this.checkProposedSettings(mergedSettings, allowedSettings[k], currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
         } else {
           errors.push(`Setting ${ fqname } should wrap an inner object, but got <${ newSettings[k] }>.`);
         }
       } else if (typeof (newSettings[k]) === 'object') {
         if (typeof allowedSettings[k] === 'function') {
           // Special case for things like `.WSLIntegrations` which have unknown fields.
-          changeNeeded = allowedSettings[k].call(this, currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
+          changeNeeded = allowedSettings[k].call(this, mergedSettings, currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
         } else {
           // newSettings[k] should be valid JSON because it came from `JSON.parse(incoming-payload)`.
           // It's an internal error (HTTP Status 500) if it isn't.
           errors.push(`Setting ${ fqname } should be a simple value, but got <${ JSON.stringify(newSettings[k]) }>.`);
         }
       } else if (typeof allowedSettings[k] === 'function') {
-        changeNeeded = allowedSettings[k].call(this, currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
+        changeNeeded = allowedSettings[k].call(this, mergedSettings, currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
       } else {
         errors.push(this.notSupported(fqname));
       }
@@ -195,8 +218,8 @@ export default class SettingsValidator {
    * checkLima ensures that the given parameter is only set on Lima-based platforms.
    * @note This should not be used for things with default values.
    */
-  protected checkLima<C, D>(validator: ValidatorFunc<C, D>) {
-    return (currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
+  protected checkLima<C, D>(validator: ValidatorFunc<Settings, C, D>) {
+    return (mergedSettings: Settings, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
       if (!_.isEqual(currentValue, desiredValue)) {
         if (!['darwin', 'linux'].includes(os.platform())) {
           errors.push(this.notSupported(fqname));
@@ -205,12 +228,12 @@ export default class SettingsValidator {
         }
       }
 
-      return validator.call(this, currentValue, desiredValue, errors, fqname);
+      return validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
     };
   }
 
-  protected checkPlatform<C, D>(platform: NodeJS.Platform, validator: ValidatorFunc<C, D>) {
-    return (currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
+  protected checkPlatform<C, D>(platform: NodeJS.Platform, validator: ValidatorFunc<Settings, C, D>) {
+    return (mergedSettings: Settings, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
       if (!_.isEqual(currentValue, desiredValue)) {
         if (os.platform() !== platform) {
           errors.push(this.notSupported(fqname));
@@ -219,14 +242,30 @@ export default class SettingsValidator {
         }
       }
 
-      return validator.call(this, currentValue, desiredValue, errors, fqname);
+      return validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
+    };
+  }
+
+  protected check9P<C, D>(validator: ValidatorFunc<Settings, C, D>) {
+    return (mergedSettings: Settings, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
+      if (!_.isEqual(currentValue, desiredValue)) {
+        if (mergedSettings.experimental.virtualMachine.mount.type !== MountType.NINEP) {
+          errors.push(`Field ${ fqname } can only be changed when experimental.virtualMachine.mount.type is "${ MountType.NINEP }".`);
+
+          return false;
+        }
+      }
+
+      // any changed settings must be valid, even if we ignore them because the mount.type is not 9p
+      return validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname) &&
+        mergedSettings.experimental.virtualMachine.mount.type === MountType.NINEP;
     };
   }
 
   /**
    * checkBoolean is a generic checker for simple boolean values.
    */
-  protected checkBoolean(currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
+  protected checkBoolean<S>(mergedSettings: S, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
     if (typeof desiredValue !== 'boolean') {
       errors.push(this.invalidSettingMessage(fqname, desiredValue));
 
@@ -240,7 +279,7 @@ export default class SettingsValidator {
    * checkNumber returns a checker for a number in the given range, inclusive.
    */
   protected checkNumber(min: number, max: number) {
-    return (currentValue: number, desiredValue: number, errors: string[], fqname: string) => {
+    return <S>(mergedSettings: S, currentValue: number, desiredValue: number, errors: string[], fqname: string) => {
       if (typeof desiredValue !== 'number') {
         errors.push(this.invalidSettingMessage(fqname, desiredValue));
 
@@ -256,7 +295,24 @@ export default class SettingsValidator {
     };
   }
 
-  protected checkString(currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
+  protected checkEnum(...validValues: string[]) {
+    return <S>(mergedSettings: S, currentValue: string, desiredValue: string, errors: string[], fqname: string) => {
+      if (typeof desiredValue !== 'string') {
+        errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+        return false;
+      }
+      if (!validValues.includes(desiredValue)) {
+        errors.push(`Invalid value for ${ fqname }: <${ JSON.stringify(desiredValue) }>; must be one of ${ JSON.stringify(validValues) }`);
+
+        return false;
+      }
+
+      return currentValue !== desiredValue;
+    };
+  }
+
+  protected checkString<S>(mergedSettings: S, currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
     if (typeof desiredValue !== 'string') {
       errors.push(this.invalidSettingMessage(fqname, desiredValue));
 
@@ -266,23 +322,11 @@ export default class SettingsValidator {
     return currentValue !== desiredValue;
   }
 
-  protected checkContainerEngine(currentValue: string, desiredEngine: string, errors: string[], fqname: string): boolean {
-    if (!['containerd', 'moby'].includes(desiredEngine)) {
-      // The error message says 'docker' is ok, although it should have been converted to 'moby' by now.
-      // But the word "'docker'" is valid in a raw API call.
-      errors.push(`Invalid value for ${ fqname }: <${ JSON.stringify(desiredEngine) }>; must be 'containerd', 'docker', or 'moby'`);
-
-      return false;
-    }
-
-    return currentValue !== desiredEngine;
-  }
-
-  protected checkKubernetesVersion(currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
+  protected checkKubernetesVersion(mergedSettings: Settings, currentValue: string, desiredVersion: string, errors: string[], _: string): boolean {
     /**
      * desiredVersion can be an empty string when Kubernetes is disabled, but otherwise it must be a valid version.
     */
-    if ((this.isKubernetesDesired || desiredVersion !== '') && !this.k8sVersions.includes(desiredVersion)) {
+    if ((mergedSettings.kubernetes.enabled || desiredVersion !== '') && !this.k8sVersions.includes(desiredVersion)) {
       errors.push(`Kubernetes version "${ desiredVersion }" not found.`);
 
       return false;
@@ -295,7 +339,7 @@ export default class SettingsValidator {
     return `Changing field ${ fqname } via the API isn't supported.`;
   }
 
-  protected checkUnchanged(currentValue: any, desiredValue: any, errors: string[], fqname: string): boolean {
+  protected checkUnchanged<S>(mergedSettings: S, currentValue: any, desiredValue: any, errors: string[], fqname: string): boolean {
     if (currentValue !== desiredValue) {
       errors.push(this.notSupported(fqname));
     }
@@ -309,7 +353,7 @@ export default class SettingsValidator {
    * booleans are not unintentionally added to settings like WSLIntegrations
    * and mutedChecks.
    */
-  protected checkBooleanMapping(currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
+  protected checkBooleanMapping<S>(mergedSettings: S, currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
     if (typeof (desiredValue) !== 'object') {
       errors.push(`Proposed field ${ fqname } should be an object, got <${ desiredValue }>.`);
 
@@ -329,7 +373,7 @@ export default class SettingsValidator {
     return errors.length === 0 && changed;
   }
 
-  protected checkStringArray(currentValue: string[], desiredValue: string[], errors: string[], fqname: string): boolean {
+  protected checkStringArray<S>(mergedSettings: S, currentValue: string[], desiredValue: string[], errors: string[], fqname: string): boolean {
     if (!Array.isArray(desiredValue) || desiredValue.some(s => typeof (s) !== 'string')) {
       errors.push(this.invalidSettingMessage(fqname, desiredValue));
 
@@ -339,7 +383,7 @@ export default class SettingsValidator {
     return currentValue.length !== desiredValue.length || currentValue.some((v, i) => v !== desiredValue[i]);
   }
 
-  protected checkPathManagementStrategy(currentValue: PathManagementStrategy,
+  protected checkPathManagementStrategy(mergedSettings: Settings, currentValue: PathManagementStrategy,
     desiredValue: any, errors: string[], fqname: string): boolean {
     if (!(Object.values(PathManagementStrategy).includes(desiredValue))) {
       errors.push(`${ fqname }: "${ desiredValue }" is not a valid strategy`);
@@ -361,6 +405,7 @@ export default class SettingsValidator {
   }
 
   protected checkPreferencesNavItemCurrent(
+    mergedSettings: TransientSettings,
     currentValue: NavItemName,
     desiredValue: NavItemName,
     errors: string[],
@@ -376,6 +421,7 @@ export default class SettingsValidator {
   }
 
   protected checkPreferencesNavItemCurrentTabs(
+    mergedSettings: TransientSettings,
     currentValue: Record<NavItemName, string | undefined>,
     desiredValue: any,
     errors: string[],

--- a/scripts/generateCliCode.ts
+++ b/scripts/generateCliCode.ts
@@ -93,8 +93,12 @@ function assert(predicate: boolean, error: string) {
   }
 }
 
+const digit = ['Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine'];
+
 function capitalize(s: string) {
-  return s[0].toUpperCase() + s.substring(1);
+  // Also turn a leading digit into a string so '9p' becomes 'NineP'
+  return s.replace(/^(\d?)(.)(.*)/,
+    (_, maybeDigit, first, rest) => (digit[maybeDigit] || '') + first.toUpperCase() + rest);
 }
 
 function capitalizeParts(s: string) {
@@ -229,7 +233,7 @@ class Generator {
     const usageParts = [usageNote];
 
     if (rawEnums) {
-      usageParts.push(`(Allowed values: [${ rawEnums.join(', ' ) }].)`);
+      usageParts.push(`(Allowed values: [${ rawEnums.join(', ' ) }])`);
     }
 
     return usageParts.join(' ').trim();


### PR DESCRIPTION
This commit temporarily exports kubeBackend.k3sHelper so that we can call k3sHelper.requiresRestartReasons from the Lima backend.

All the requiresRestartReasons code should be moved to the BackendHelper instead.