### PR TITLE
Use "Open window" instead of "Show window"

### DIFF
--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -61,7 +61,7 @@ export class Tray {
     { type: 'separator' },
     {
       id:    'main',
-      label: 'Show main window',
+      label: 'Open main window',
       type:  'normal',
       click() {
         openMain();
@@ -69,14 +69,14 @@ export class Tray {
     },
     {
       id:    'preferences',
-      label: 'Show preferences dialog',
+      label: 'Open preferences dialog',
       type:  'normal',
       click: openPreferences,
     },
     {
       id:      'dashboard',
       enabled: false,
-      label:   'Show cluster dashboard',
+      label:   'Open cluster dashboard',
       type:    'normal',
       click:   openDashboard,
     },


### PR DESCRIPTION
"Open" is the proper opposite to "Close"; "Show" would imply that the window has been hidden or minimized, but that is not the case: the window has been destroyed and the app may not even be displayed in the dock or taskbar anymore.

We also use "File | Close Window" in the app menu.

Fixes #4024