### PR TITLE
nerdctl-stub: fix test for darwin

### DIFF
--- a/src/go/nerdctl-stub/main_shared.go
+++ b/src/go/nerdctl-stub/main_shared.go
@@ -1,7 +1,4 @@
-//go:build linux || windows
-// +build linux windows
-
-// This file contains routines shared between Windows and Linux.
+// This file contains shared routines for managing arguments.
 
 package main
 


### PR DESCRIPTION
As nothing in the shared file has platform-specific dependencies, we can just use it directly on darwin as well.