### PR TITLE
Show diagnostics error count badge in primary navigation

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -55,7 +55,7 @@ export default {
 
   computed: {
     routes() {
-      return mainRoutes.map(route => route === '/Diagnostics' ? { ...route, error: this.errorCount } : route);
+      return mainRoutes.map(route => route.route === '/Diagnostics' ? { ...route, error: this.errorCount } : route);
     },
     paths() {
       return mainRoutes.map(r => r.route);


### PR DESCRIPTION
In order to perform our comparison, we need to access the `route` property of for each member in `mainRoutes`.

closes #4041 