### PR TITLE
Add experimental options for vm-type and use-rosetta

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -568,13 +568,9 @@ async function doK8sReset(arg: 'fast' | 'wipe' | 'fullRestart', context: Command
       await startK8sManager();
       break;
     case 'wipe':
-      await k8smanager.stop();
-
-      console.log(`Stopped Kubernetes backend cleanly.`);
       console.log('Deleting VM to reset...');
       await k8smanager.del();
       console.log(`Deleted VM to reset exited cleanly.`);
-
       await startK8sManager();
       break;
     }

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -13,5 +13,7 @@
         <true/>
         <key>com.apple.security.hypervisor</key>
         <true/>
+        <key>com.apple.security.virtualization</key>
+        <true/>
     </dict>
 </plist>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -11,5 +11,7 @@
         <true/>
         <key>com.apple.security.hypervisor</key>
         <true/>
+        <key>com.apple.security.virtualization</key>
+        <true/>
     </dict>
 </plist>

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -40,6 +40,7 @@ import {
   CacheMode,
   ProtocolVersion,
   SecurityModel,
+  VMType,
 } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ServerState } from '@pkg/main/commandServer/httpCommandServer';
@@ -707,6 +708,8 @@ test.describe('Command server', () => {
           ['experimental.virtual-machine.mount.9p.security-model', SecurityModel.NONE],
           ['experimental.virtual-machine.mount.type', MountType.NINEP],
           ['experimental.virtual-machine.socket-vmnet', true],
+          ['experimental.virtual-machine.use-rosetta', true],
+          ['experimental.virtual-machine.type', VMType.VZ],
           ['virtual-machine.memory-in-gb', 10],
           ['virtual-machine.number-cpus', 10],
         ],
@@ -715,6 +718,8 @@ test.describe('Command server', () => {
         ],
         linux: [
           ['experimental.virtual-machine.socket-vmnet', true],
+          ['experimental.virtual-machine.use-rosetta', true],
+          ['experimental.virtual-machine.type', VMType.VZ],
           ['virtual-machine.host-resolver', true],
         ],
       };

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -367,11 +367,11 @@ components:
                   x-rd-usage: tunnel networking so it originates from the host
                 type:
                   type: string
-                  enum: ['qemu', 'vz']
-                  x-rd-platforms: ['darwin']
+                  enum: [qemu, vz]
+                  x-rd-platforms: [darwin]
                 useRosetta:
                   type: boolean
-                  x-rd-platforms: ['darwin']
+                  x-rd-platforms: [darwin]
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -343,7 +343,7 @@ components:
                   properties:
                     type:
                       type: string
-                      enum: [reverse-sshfs, 9p]
+                      enum: [reverse-sshfs, 9p, virtiofs]
                       x-rd-usage: how directories are shared
                     9p:
                       type: object
@@ -365,6 +365,13 @@ components:
                   type: boolean
                   x-rd-platforms: [win32]
                   x-rd-usage: tunnel networking so it originates from the host
+                type:
+                  type: string
+                  enum: ['qemu', 'vz']
+                  x-rd-platforms: ['darwin']
+                useRosetta:
+                  type: boolean
+                  x-rd-platforms: ['darwin']
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -754,19 +754,17 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     }
   }
 
-  protected getLimaConfig(): Promise<LimaConfiguration | undefined> {
-    return (async() => {
-      try {
-        const configPath = path.join(paths.lima, MACHINE_NAME, 'lima.yaml');
-        const configRaw = await fs.promises.readFile(configPath, 'utf-8');
+  protected async getLimaConfig(): Promise<LimaConfiguration | undefined> {
+    try {
+      const configPath = path.join(paths.lima, MACHINE_NAME, 'lima.yaml');
+      const configRaw = await fs.promises.readFile(configPath, 'utf-8');
 
-        return yaml.parse(configRaw) as LimaConfiguration;
-      } catch (ex) {
-        if ((ex as NodeJS.ErrnoException).code === 'ENOENT') {
-          return undefined;
-        }
+      return yaml.parse(configRaw) as LimaConfiguration;
+    } catch (ex) {
+      if ((ex as NodeJS.ErrnoException).code === 'ENOENT') {
+        return undefined;
       }
-    })();
+    }
   }
 
   protected static get limactl() {
@@ -956,26 +954,22 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     })();
   }
 
-  protected imageInfo(fileName: string): Promise<QEMUImageInfo> {
-    return (async() => {
-      try {
-        const { stdout } = await this.spawnWithCapture(LimaBackend.qemuImg, 'info', '--output=json', '--force-share', fileName);
+  protected async imageInfo(fileName: string): Promise<QEMUImageInfo> {
+    try {
+      const { stdout } = await this.spawnWithCapture(LimaBackend.qemuImg, 'info', '--output=json', '--force-share', fileName);
 
-        return JSON.parse(stdout) as QEMUImageInfo;
-      } catch {
-        return { format: 'unknown' } as QEMUImageInfo;
-      }
-    })();
+      return JSON.parse(stdout) as QEMUImageInfo;
+    } catch {
+      return { format: 'unknown' } as QEMUImageInfo;
+    }
   }
 
-  protected convertToRaw(fileName: string): Promise<void> {
-    return (async() => {
-      const rawFileName = `${ fileName }.raw`;
+  protected async convertToRaw(fileName: string): Promise<void> {
+    const rawFileName = `${ fileName }.raw`;
 
-      await this.spawnWithCapture(LimaBackend.qemuImg, 'convert', fileName, rawFileName);
-      await fs.promises.unlink(fileName);
-      await fs.promises.rename(rawFileName, fileName);
-    })();
+    await this.spawnWithCapture(LimaBackend.qemuImg, 'convert', fileName, rawFileName);
+    await fs.promises.unlink(fileName);
+    await fs.promises.rename(rawFileName, fileName);
   }
 
   protected get isRegistered(): Promise<boolean> {

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -269,7 +269,7 @@ const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-l
 // Name of the forward compatible limactl binary installed by the lima dependencies script.
 const fwdCompatLimactlBin = 'limactl.ventura';
 // Version of Darwin the forward compatible limactl binary was built for.
-const fwdCompatLimactlDarwinVer = '22.2.0';
+const fwdCompatLimactlDarwinVer = '22.1.0';
 
 /**
  * LimaBackend implements all the Lima-specific functionality for Rancher

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1695,7 +1695,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         await this.ensureArchitectureMatch();
         await Promise.all([
           this.progressTracker.action('Ensuring virtualization is supported', 50, this.ensureVirtualizationSupported()),
-          this.progressTracker.action('Updating cluster configuration', 50, this.updateConfig()),
+          this.progressTracker.action('Updating cluster configuration', 50, this.updateConfig(this.#adminAccess)),
         ]);
 
         if (this.currentAction !== Action.STARTING) {

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1973,17 +1973,13 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     });
   }
 
-  async del(force = false): Promise<void> {
+  async del(): Promise<void> {
     try {
-      const delArgs = ['delete'];
-
-      force ? delArgs.push('--force', MACHINE_NAME) : delArgs.push(MACHINE_NAME);
       if (await this.isRegistered) {
-        await this.stop();
         await this.progressTracker.action(
-          'Deleting Kubernetes VM',
+          'Deleting virtual machine',
           10,
-          this.lima(...delArgs));
+          this.lima('delete', '--force', MACHINE_NAME));
       }
     } catch (ex) {
       await this.setState(State.ERROR);

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -24,6 +24,10 @@ const console = Logging.settings;
 
 export const CURRENT_SETTINGS_VERSION = 6 as const;
 
+export enum VMType {
+  QEMU = 'qemu',
+  VZ = 'vz',
+}
 export enum ContainerEngine {
   NONE = '',
   CONTAINERD = 'containerd',
@@ -114,6 +118,10 @@ export const defaultSettings = {
    */
   experimental: {
     virtualMachine: {
+      /** can only be set to VMType.VZ on macOS Ventura and later */
+      type:        VMType.QEMU,
+      /** can only be used when type is VMType.VZ, and only on aarch64 */
+      useRosetta:  false,
       /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
       socketVMNet: false,
       mount:       {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -43,6 +43,7 @@ export const ContainerEngineNames: Record<ContainerEngine, string> = {
 export enum MountType {
   NINEP = '9p',
   REVERSE_SSHFS = 'reverse-sshfs',
+  VIRTIOFS = 'virtiofs',
 }
 
 export enum ProtocolVersion {

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -73,6 +73,8 @@ describe(SettingsValidator, () => {
       ['experimental', 'virtualMachine', 'mount', '9p', 'protocolVersion'],
       ['experimental', 'virtualMachine', 'mount', '9p', 'securityModel'],
       ['experimental', 'virtualMachine', 'mount', 'type'],
+      ['experimental', 'virtualMachine', 'type'],
+      ['experimental', 'virtualMachine', 'useRosetta'],
       ['kubernetes', 'version'],
       ['version'],
       ['WSL', 'integrations'],

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -273,7 +273,7 @@ export default class SettingsValidator {
   protected checkRosetta(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
     if (desiredValue) {
       if (mergedSettings.experimental.virtualMachine.type !== VMType.VZ) {
-        errors.push(`Setting ${ fqname } can only be enabled when experimental.virtual-machine.vm-type is "${ VMType.VZ }".`);
+        errors.push(`Setting ${ fqname } can only be enabled when experimental.virtual-machine.type is "${ VMType.VZ }".`);
 
         return false;
       }
@@ -299,7 +299,7 @@ export default class SettingsValidator {
 
   protected checkMountType(mergedSettings: Settings, currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
     if (desiredValue === MountType.VIRTIOFS && mergedSettings.experimental.virtualMachine.type !== VMType.VZ) {
-      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that experimental.virtual-machine.vm-type is "${ VMType.VZ }".`);
+      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that experimental.virtual-machine.type is "${ VMType.VZ }".`);
 
       return false;
     }

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -1,9 +1,10 @@
 import os from 'os';
 
+import Electron from 'electron';
 import _ from 'lodash';
 
 import {
-  CacheMode, defaultSettings, LockedSettingsType, MountType, ProtocolVersion, SecurityModel, Settings,
+  CacheMode, defaultSettings, LockedSettingsType, MountType, ProtocolVersion, SecurityModel, Settings, VMType,
 } from '@pkg/config/settings';
 import { NavItemName, navItemNames, TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
@@ -101,6 +102,11 @@ export default class SettingsValidator {
           },
           socketVMNet:      this.checkPlatform('darwin', this.checkBoolean),
           networkingTunnel: this.checkPlatform('win32', this.checkBoolean),
+          useRosetta:       this.checkPlatform('darwin', this.checkRosetta),
+          type:             this.checkPlatform('darwin', this.checkMulti(
+            this.checkEnum(...Object.values(VMType)),
+            this.checkVMType),
+          ),
         },
       },
       WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
@@ -192,7 +198,8 @@ export default class SettingsValidator {
 
       if (!(k in allowedSettings)) {
         continue;
-      } else if (typeof (allowedSettings[k]) === 'object') {
+      }
+      if (typeof (allowedSettings[k]) === 'object') {
         if (typeof (newSettings[k]) === 'object') {
           changeNeeded = this.checkProposedSettings(mergedSettings, allowedSettings[k], currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
         } else {
@@ -253,6 +260,33 @@ export default class SettingsValidator {
     };
   }
 
+  protected checkRosetta(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
+    if (desiredValue) {
+      if (mergedSettings.experimental.virtualMachine.type !== VMType.VZ) {
+        errors.push(`Setting ${ fqname } can only be enabled when experimental.virtual-machine.vm-type is "${ VMType.VZ }".`);
+
+        return false;
+      }
+      if (!Electron.app.runningUnderARM64Translation && os.arch() !== 'arm64') {
+        errors.push(`Setting ${ fqname } can only be enabled on aarch64 systems.`);
+
+        return false;
+      }
+    }
+
+    return currentValue !== desiredValue;
+  }
+
+  protected checkVMType(mergedSettings: Settings, currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
+    if (desiredValue === VMType.VZ && parseInt(os.release()) < 22) {
+      errors.push(`Setting ${ fqname } to "${ VMType.VZ }" requires macOS 13.0 (Ventura) or later.`);
+
+      return false;
+    }
+
+    return currentValue !== desiredValue;
+  }
+
   protected checkPlatform<C, D>(platform: NodeJS.Platform, validator: ValidatorFunc<Settings, C, D>) {
     return (mergedSettings: Settings, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
       if (!_.isEqual(currentValue, desiredValue)) {
@@ -278,6 +312,18 @@ export default class SettingsValidator {
       }
 
       return validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
+    };
+  }
+
+  protected checkMulti<S, C, D>(...validators: ValidatorFunc<S, C, D>[]) {
+    return (mergedSettings: S, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
+      let retval = false;
+
+      for (const validator of validators) {
+        retval ||= validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
+      }
+
+      return retval;
     };
   }
 


### PR DESCRIPTION
Add `experimental.virtualMachine.type` and `experimental.virtualMachine.useRosetta` options for use on macOS 13 (Ventura).

The persistent volume will be converted from QCOW2 to RAW format the first time the vm type is set to `vz`. It is possible to switch back to `qemu` while keeping the disk in RAW format.

Shutting down a `vz` VM takes an additional 3 minutes due to a crash in the bindings: https://github.com/lima-vm/lima/issues/1381. Contrary to the Lima bug description, the delay is not always limited to the first stopping of the VM.

Fixes #3944 