### PR TITLE
Check for network updates on an interval while tray is shown

### DIFF
--- a/pkg/rancher-desktop/integrations/__tests__/pathManager.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/pathManager.spec.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { START_LINE, END_LINE } from '@pkg/integrations/manageLinesInFile';
 import { RcFilePathManager } from '@pkg/integrations/pathManager';
+jest.mock('../../main/mainEvents');
 
 const describeUnix = os.platform() === 'win32' ? describe.skip : describe;
 let testDir = '';

--- a/pkg/rancher-desktop/integrations/pathManager.ts
+++ b/pkg/rancher-desktop/integrations/pathManager.ts
@@ -124,8 +124,8 @@ export class RcFilePathManager implements PathManager {
       return manageLinesInFile(rcPath, [pathLine], desiredPresent);
     }));
 
-    mainEvents.emit('diagnostics-trigger', 'RD_BIN_IN_BASH_PATH');
-    mainEvents.emit('diagnostics-trigger', 'RD_BIN_IN_ZSH_PATH');
+    mainEvents.invoke('diagnostics-trigger', 'RD_BIN_IN_BASH_PATH');
+    mainEvents.invoke('diagnostics-trigger', 'RD_BIN_IN_ZSH_PATH');
   }
 
   protected async manageCsh(desiredPresent: boolean): Promise<void> {

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -72,6 +72,16 @@ export class DiagnosticsManager {
         await this.runChecker(checker);
       }
     });
+
+    mainEvents.handle('diagnostics-trigger', async(id) => {
+      const checker = (await this.checkers).find(checker => checker.id === id);
+
+      if (checker) {
+        await this.runChecker(checker);
+
+        return this.results[checker.id];
+      }
+    });
   }
 
   /**

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -65,13 +65,6 @@ export class DiagnosticsManager {
         this.checkerIdByCategory[checker.category]?.push(checker.id);
       }
     });
-    mainEvents.on('diagnostics-trigger', async(id) => {
-      const checker = (await this.checkers).find(checker => checker.id === id);
-
-      if (checker) {
-        await this.runChecker(checker);
-      }
-    });
 
     mainEvents.handle('diagnostics-trigger', async(id) => {
       const checker = (await this.checkers).find(checker => checker.id === id);

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from 'events';
 import type { VMBackend } from '@pkg/backend/backend';
 import type { Settings } from '@pkg/config/settings';
 import type { TransientSettings } from '@pkg/config/transientSettings';
+import { DiagnosticsCheckerResult } from '@pkg/main/diagnostics/types';
 import { RecursivePartial, RecursiveReadonly } from '@pkg/utils/typeUtils';
 
 /**
@@ -103,6 +104,15 @@ interface MainEventNames {
    * checker).
    */
   'diagnostics-trigger'(id: string): void;
+
+  /**
+   * Force trigger diagnostics with the given id.
+   * This is used when something has changed that might affect whether the given
+   * diagnostic needs to be re-run.
+   * @note This does not update the last run time (since it only runs a single
+   * checker).
+   */
+  'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
 
   /**
    * Emitted on application quit.  Note that at this point we're committed to

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -103,15 +103,6 @@ interface MainEventNames {
    * @note This does not update the last run time (since it only runs a single
    * checker).
    */
-  'diagnostics-trigger'(id: string): void;
-
-  /**
-   * Force trigger diagnostics with the given id.
-   * This is used when something has changed that might affect whether the given
-   * diagnostic needs to be re-run.
-   * @note This does not update the last run time (since it only runs a single
-   * checker).
-   */
   'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
 
   /**

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -40,6 +40,7 @@ export class Tray {
   private currentNetworkStatus: networkStatus = networkStatus.CHECKING;
   private static instance: Tray;
   private abortController: AbortController | undefined;
+  private networkState: boolean | undefined;
 
   protected contextMenuItems: Electron.MenuItemConstructorOptions[] = [
     {
@@ -187,7 +188,13 @@ export class Tray {
     setInterval(async() => {
       const networkDiagnostic = await mainEvents.invoke('diagnostics-trigger', 'CONNECTED_TO_INTERNET');
 
-      this.handleUpdateNetworkStatus(networkDiagnostic?.passed || false).catch((err: any) => {
+      if (this.networkState === networkDiagnostic?.passed) {
+        return; // network state hasn't changed since last check
+      }
+
+      this.networkState = !!networkDiagnostic?.passed;
+
+      this.handleUpdateNetworkStatus(this.networkState).catch((err: any) => {
         console.log('Error updating network status: ', err);
       });
     }, 5000);

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -41,6 +41,7 @@ export class Tray {
   private static instance: Tray;
   private abortController: AbortController | undefined;
   private networkState: boolean | undefined;
+  private networkInterval: NodeJS.Timer;
 
   protected contextMenuItems: Electron.MenuItemConstructorOptions[] = [
     {
@@ -185,7 +186,7 @@ export class Tray {
      * updates the network status in the tray if there's a change in the network
      * state.
      */
-    setInterval(async() => {
+    this.networkInterval = setInterval(async() => {
       const networkDiagnostic = await mainEvents.invoke('diagnostics-trigger', 'CONNECTED_TO_INTERNET');
 
       if (this.networkState === networkDiagnostic?.passed) {
@@ -234,6 +235,7 @@ export class Tray {
     mainEvents.off('k8s-check-state', this.k8sStateChangedEvent);
     mainEvents.off('settings-update', this.settingsUpdateEvent);
     ipcMainProxy.removeListener('update-network-status', this.updateNetworkStatusEvent);
+    clearInterval(this.networkInterval);
   }
 
   /**


### PR DESCRIPTION
This checks for a change in the network state by invoking the `CONNECTED_TO_INTERNET` handler on a 5 second interval. 

I opted to use an interval in an attempt to keep the approach simple. I imagine that we might want to consider if it makes sense to reduce the frequency of checks after the state has settled, but that might require more discussion on the desired design. 

closes #4030 