### PR TITLE
Don't mount cache and logs directories

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -575,8 +575,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
   protected getMounts(): LimaMount[] {
     const mounts: LimaMount[] = [];
-    const locations = [path.join(paths.cache, 'k3s'), paths.logs, '~', '/tmp/rancher-desktop'];
+    const locations = ['~', '/tmp/rancher-desktop'];
+    const homeDir = `${ os.homedir() }/`;
 
+    if (!paths.cache.startsWith(homeDir)) {
+      locations.push(path.join(paths.cache), 'k3s');
+    }
+    if (!paths.logs.startsWith(homeDir)) {
+      locations.push(paths.logs);
+    }
     if (os.platform() === 'darwin') {
       locations.push('/Volumes', '/var/folders');
     }


### PR DESCRIPTION
We already mount the home directory afterwards, and both cache and logs are under the home directory, so the mounts will be shadowed once $HOME is mounted anyways. So no need to keep 2 useless sshfs connections around.