### PR TITLE
Add rd networking k3s config

### DIFF
--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -228,8 +228,10 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
           }
           await util.promisify(timers.setTimeout)(1_000);
         }
+        const rdNetworking = `--rd-networking=${ config?.experimental.rdNetworking }`;
+
         await this.k3sHelper.updateKubeconfig(
-          async() => await this.vm.execCommand({ capture: true }, await this.vm.getWSLHelperPath(), 'k3s', 'kubeconfig'));
+          async() => await this.vm.execCommand({ capture: true }, await this.vm.getWSLHelperPath(), 'k3s', 'kubeconfig', rdNetworking));
       });
 
     const client = this.client = new KubeClient();

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -42,7 +42,10 @@ type kubeConfig struct {
 	Extras map[string]interface{} `yaml:",inline"`
 }
 
-var k3sKubeconfigViper = viper.New()
+var (
+	k3sKubeconfigViper = viper.New()
+	rdNetworking       bool
+)
 
 // k3sKubeconfigCmd represents the `k3s kubeconfig` command.
 var k3sKubeconfigCmd = &cobra.Command{
@@ -83,37 +86,16 @@ var k3sKubeconfigCmd = &cobra.Command{
 			return err
 		}
 
-		// Find the IP address of eth0.
-		iface, err := net.InterfaceByName("eth0")
-		if err != nil {
-			// Use a random interface, assuming we're testing on Windows.
-			ifaces, err := net.Interfaces()
-			if err != nil {
-				return err
-			}
-			iface = &ifaces[0]
-			fmt.Fprintf(os.Stderr, "Could not find eth0, using fallback interface %s\n", iface.Name)
+		if rdNetworking {
+			// vm-switch in rdNetworking binds to localhost:Port by default.
+			// Since k3s.yaml comes with servers preset at 127.0.0.1, there
+			// is nothing for us to do here, just write the config and return.
+			return yaml.NewEncoder(os.Stdout).Encode(config)
 		}
-		addrs, err := iface.Addrs()
+		ip, err := getClusterIP()
 		if err != nil {
 			return err
 		}
-		var ip net.IP
-		for _, addr := range addrs {
-			// addr.String() gives "192.2.3.4/16", so we need to chop off the netmask
-			ip = net.ParseIP(strings.SplitN(addr.String(), "/", 2)[0])
-			if ip == nil {
-				continue
-			}
-			ip = ip.To4()
-			if ip != nil {
-				break
-			}
-		}
-		if ip == nil {
-			return fmt.Errorf("could not find IPv4 address on interface %s", iface.Name)
-		}
-
 		// Fix up any clusters at 127.0.0.1, using the IP address we found.
 		for clusterIdx, cluster := range config.Clusters {
 			server, err := url.Parse(cluster.Cluster.Server)
@@ -131,7 +113,6 @@ var k3sKubeconfigCmd = &cobra.Command{
 			}
 			config.Clusters[clusterIdx].Cluster.Server = server.String()
 		}
-
 		// Emit the result
 		err = yaml.NewEncoder(os.Stdout).Encode(config)
 		if err != nil {
@@ -142,8 +123,43 @@ var k3sKubeconfigCmd = &cobra.Command{
 	},
 }
 
+func getClusterIP() (net.IP, error) {
+	var ip net.IP
+	// Find the IP address of eth0.
+	iface, err := net.InterfaceByName("eth0")
+	if err != nil {
+		// Use a random interface, assuming we're testing on Windows.
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			return nil, err
+		}
+		iface = &ifaces[0]
+		fmt.Fprintf(os.Stderr, "Could not find eth0, using fallback interface %s\n", iface.Name)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		// addr.String() gives "192.2.3.4/16", so we need to chop off the netmask
+		ip = net.ParseIP(strings.SplitN(addr.String(), "/", 2)[0])
+		if ip == nil {
+			continue
+		}
+		ip = ip.To4()
+		if ip != nil {
+			break
+		}
+	}
+	if ip == nil {
+		return nil, fmt.Errorf("could not find IPv4 address on interface %s", iface.Name)
+	}
+	return ip, nil
+}
+
 func init() {
 	k3sKubeconfigCmd.Flags().String("k3sconfig", "/etc/rancher/k3s/k3s.yaml", "Path to k3s kubeconfig")
+	k3sKubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
 	k3sKubeconfigViper.AutomaticEnv()
 	k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
 	k3sCmd.AddCommand(k3sKubeconfigCmd)


### PR DESCRIPTION
This PR allows changing the Cluster IP address in k3s kubeconfig depending on if Rancher Desktop Networking is set to false or true. We set the cluster IP to `127.0.0.1` if `rd-networking` is `true` since the `IP:Port` binding occurs at the localhost level by default in the virtual network otherwise it defaults to the old mechanism which is getting the IP address for `eth0`

Also, this PR is related to: https://github.com/rancher-sandbox/rancher-desktop/issues/3957