### PR TITLE
Add notes about running on Windows and setting version to screenshots README

### DIFF
--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -28,6 +28,10 @@ Extract the `ShareX-15.0.0-portable.zip` into the resources directory, so that t
 
 ## Running
 
+> ℹ️ SETTING THE VERSION NUMBER
+>
+> Customize the version displayed by updating the version in `package.json` before running screenshots. This is useful for populating documentation before release activities are finalized.
+
 First, install dependencies with:
 
 ```

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -19,6 +19,8 @@ Screenshots are either produced in light & dark mode.
 
 `ShareX` is required. See https://github.com/ShareX/ShareX
 
+Extract the `ShareX-15.0.0-portable.zip` into the resources directory, so that the `ShareX.exe` is located under `{path-to-rancher-desktop}\resources\ShareX\ShareX.exe`. 
+
 ### Linux
 
 `gnome-screenshot` is required. See https://github.com/GNOME/gnome-screenshot
@@ -48,6 +50,14 @@ Dark mode only:
 
 ```
 npm run screenshots:dark
+```
+
+### Windows
+
+Use the `RD_ENV_SCREENSHOT_SLEEP` environment variable to allow the script enough time to write and copy each screenshot before moving to the next:
+
+```
+$Env:RD_ENV_SCREENSHOT_SLEEP = 5000; npm run screenshots
 ```
 
 ## Output


### PR DESCRIPTION
This adds a few more notes about working with ShareX in Windows, in addition to setting the version number before running the screenshots script