### PR TITLE
Renames Rancher Desktop Networking settings

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -358,10 +358,9 @@ components:
                         cacheMode:
                           type: string
                           enum: ['none', 'loose', 'fscache', 'mmap']
-            rdNetworking:
-              type: boolean
-              x-rd-platforms: ['win32']
-
+                networkingTunnel:
+                  type: boolean
+                  x-rd-platforms: ['win32']
         WSL:
           type: object
           x-rd-platforms: ['win32']

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1028,7 +1028,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     } catch {
     }
 
-    if (this.cfg?.experimental.rdNetworking) {
+    if (this.cfg?.experimental.virtualMachine.networkingTunnel) {
       await this.writeFile('/usr/local/bin/wsl-init', WSL_INIT_RD_NETWORKING_SCRIPT, 0o755);
     } else {
       await this.writeFile('/usr/local/bin/wsl-init', WSL_INIT_SCRIPT, 0o755);
@@ -1183,7 +1183,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                 await this.installCredentialHelper();
               }),
               this.progressTracker.action('DNS configuration', 50, async() => {
-                if (this.cfg?.experimental.rdNetworking) {
+                if (this.cfg?.experimental.virtualMachine.networkingTunnel) {
                   console.debug(`setting DNS server to 192.168.127.1 for rancher desktop networking`);
                   try {
                     this.hostSwitchProcess.start();
@@ -1521,7 +1521,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       return Promise.resolve({});
     }
 
-    return Promise.resolve(this.kubeBackend.requiresRestartReasons(this.cfg, cfg, { 'experimental.rdNetworking': undefined }));
+    return Promise.resolve(this.kubeBackend.requiresRestartReasons(this.cfg, cfg, { 'experimental.virtualMachine.networkingTunnel': undefined }));
   }
 
   /**

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -51,9 +51,9 @@ describe('updateFromCommandLine', () => {
               cacheMode:       CacheMode.MMAP,
             },
           },
-          socketVMNet: true,
+          socketVMNet:      true,
+          networkingTunnel: false,
         },
-        rdNetworking: false,
       },
       WSL:        { integrations: {} },
       kubernetes: {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -130,9 +130,9 @@ export const defaultSettings = {
           cacheMode:       CacheMode.MMAP,
         },
       },
+      /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
+      networkingTunnel: false,
     },
-    /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
-    rdNetworking: false,
   },
 };
 

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -78,12 +78,12 @@ describe(SettingsValidator, () => {
 
       // Fields that can only be set on specific platforms.
       const platformSpecificFields: Record<string, ReturnType<typeof os.platform>> = {
-        'application.adminAccess':                 'linux',
-        'experimental.virtualMachine.socketVMNet': 'darwin',
-        'experimental.rdNetworking':               'win32',
-        'virtualMachine.hostResolver':             'win32',
-        'virtualMachine.memoryInGB':               'darwin',
-        'virtualMachine.numberCPUs':               'linux',
+        'application.adminAccess':                      'linux',
+        'experimental.virtualMachine.socketVMNet':      'darwin',
+        'experimental.virtualMachine.networkingTunnel': 'win32',
+        'virtualMachine.hostResolver':                  'win32',
+        'virtualMachine.memoryInGB':                    'darwin',
+        'virtualMachine.numberCPUs':                    'linux',
       };
 
       const spyValidateSettings = jest.spyOn(subject, 'validateSettings');

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -95,9 +95,9 @@ export default class SettingsValidator {
               cacheMode:       this.checkLima(this.check9P(this.checkEnum(...Object.values(CacheMode)))),
             },
           },
-          socketVMNet: this.checkPlatform('darwin', this.checkBoolean),
+          socketVMNet:      this.checkPlatform('darwin', this.checkBoolean),
+          networkingTunnel: this.checkPlatform('win32', this.checkBoolean),
         },
-        rdNetworking: this.checkPlatform('win32', this.checkBoolean),
       },
       WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
       kubernetes: {


### PR DESCRIPTION
Previously called `rdNetworking`, it is renamed to `networkingTunnel` under `experimental.virtualMachine`.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4078