### PR TITLE
`rdNetworking` rename

### DIFF
--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -228,7 +228,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
           }
           await util.promisify(timers.setTimeout)(1_000);
         }
-        const rdNetworking = `--rd-networking=${ config?.experimental.rdNetworking }`;
+        const rdNetworking = `--rd-networking=${ config?.experimental.virtualMachine.networkingTunnel }`;
 
         await this.k3sHelper.updateKubeconfig(
           async() => await this.vm.execCommand({ capture: true }, await this.vm.getWSLHelperPath(), 'k3s', 'kubeconfig', rdNetworking));


### PR DESCRIPTION
Tests are failing because a `rdNetworking` renaming in `virtualMachine.networkingTunnel` is missing:

```
ERROR in /home/ranchertest/src/pkg/rancher-desktop/backend/kube/wsl.ts(231,71)
      TS2339: Property 'rdNetworking' does not exist on type 'RecursiveReadonly<{ virtualMachine: { socketVMNet: boolean; mount: { type: MountType; '9p': { securityModel: SecurityModel; protocolVersion: ProtocolVersion; msizeInKB: number; cacheMode: CacheMode; }; }; networkingTunnel: boolean; }; }>'.�[39m�[22m
    at /home/ranchertest/src/scripts/lib/build-utils.ts:186:25
```