### PR TITLE
Bump alpine-lime to 0.2.27.rd3 (revert back to Alpine 3.16)

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,7 +1,7 @@
 limaAndQemu: 1.30.1
 alpineLimaISO:
-  isoVersion: 0.2.27.rd2
-  alpineVersion: 3.17.0
+  isoVersion: 0.2.27.rd3
+  alpineVersion: 3.16.0
 WSLDistro: "0.34"
 kuberlr: 0.4.2
 helm: 3.11.1


### PR DESCRIPTION
This is required for compatibility with Virtualization.Framework on macOS for aarch64.

PR created manually because `rddepman` is currently broken.