### PR TITLE
Change `rdNetworking` key in dependencies.yaml to `hostSwitch` to match `HostSwitch.name`

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -17,4 +17,4 @@ ECRCredentialHelper: 0.6.0
 hostResolver: 0.1.5
 mobyOpenAPISpec: "1.43"
 wix: wix3112rtm
-rdNetworking: 0.1.0
+hostSwitch: 0.1.0

--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -35,12 +35,12 @@ export class HostSwitch implements Dependency, GithubDependency {
 
   async download(context: DownloadContext): Promise<void> {
     const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
-    const tarName = `rancher-desktop-networking-v${ context.versions.rdNetworking }.tar.gz`;
-    const rdNetworkingURL = `${ baseURL }/v${ context.versions.rdNetworking }/${ tarName }`;
+    const tarName = `rancher-desktop-networking-v${ context.versions.hostSwitch }.tar.gz`;
+    const hostSwitchURL = `${ baseURL }/v${ context.versions.hostSwitch }/${ tarName }`;
     const hostSwitchPath = path.join(context.internalDir, tarName);
 
     await download(
-      rdNetworkingURL,
+      hostSwitchURL,
       hostSwitchPath,
       { access: fs.constants.W_OK });
 

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -48,7 +48,7 @@ export type DependencyVersions = {
   hostResolver: string;
   mobyOpenAPISpec: string;
   wix: string;
-  rdNetworking: string;
+  hostSwitch: string;
 };
 
 export async function readDependencyVersions(path: string): Promise<DependencyVersions> {


### PR DESCRIPTION
`rddepman` gets the current version of a given `Dependency` from dependencies.yaml. It uses `Dependency.name` as the key. `HostSwitch.name` is set to `hostSwitch`, but (unless I'm mistaken) the corresponding key in dependencies.yaml was `rdNetworking`. So when `rddepman` ran, it got `undefined` for the current version of `HostSwitch`.

Here is an example of the error that this results in: https://github.com/rancher-sandbox/rancher-desktop/actions/runs/4317854534/jobs/7535440173