### PR TITLE
Decouple the deployment-profile reader from the settings module.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -23,6 +23,7 @@ import { CommandWorkerInterface, HttpCommandServer } from '@pkg/main/commandServ
 import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
 import { HttpCredentialHelperServer } from '@pkg/main/credentialServer/httpCredentialHelperServer';
 import { DashboardServer } from '@pkg/main/dashboardServer';
+import { readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
 import { DiagnosticsManager, DiagnosticsResultCollection } from '@pkg/main/diagnostics/diagnostics';
 import { ImageEventHandler } from '@pkg/main/imageEvents';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
@@ -161,7 +162,12 @@ Electron.app.whenReady().then(async() => {
     await httpCommandServer.init();
     await httpCredentialHelperServer.init();
     await setupNetworking();
-    cfg = settings.load();
+    let deploymentProfiles: settings.DeploymentProfileType = { defaults: {}, locked: {} };
+
+    try {
+      deploymentProfiles = readDeploymentProfiles();
+    } catch { }
+    cfg = settings.load(deploymentProfiles);
 
     if (commandLineArgs.length) {
       try {

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -6,6 +6,7 @@ import * as settings from '../settings';
 import { CacheMode, MountType, ProtocolVersion, SecurityModel } from '../settings';
 
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
+import { readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
 import clone from '@pkg/utils/clone';
 import paths from '@pkg/utils/paths';
 import { RecursiveKeys } from '@pkg/utils/typeUtils';
@@ -321,7 +322,9 @@ describe('settings', () => {
             .mockImplementation(createMocker(ProfileTypes.None, ProfileTypes.None));
         });
         test('all fields are unlocked', () => {
-          settings.load();
+          const deploymentProfile = readDeploymentProfiles();
+
+          settings.load(deploymentProfile);
           verifyAllFieldsAreUnlocked(settings.getLockedSettings());
         });
       });
@@ -348,7 +351,9 @@ describe('settings', () => {
             ({ system, user, shouldLock }) => {
               mock = jest.spyOn(fs, 'readFileSync')
                 .mockImplementation(createMocker(system, user));
-              settings.load();
+              const deploymentProfile = readDeploymentProfiles();
+
+              settings.load(deploymentProfile);
               if (shouldLock) {
                 verifyAllFieldsAreLocked(settings.getLockedSettings());
               } else {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -9,7 +9,6 @@ import _ from 'lodash';
 
 import { TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
-import { readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
 import clone from '@pkg/utils/clone';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
@@ -359,13 +358,9 @@ export function updateFromCommandLine(cfg: Settings, commandLineArgs: string[]):
  * Load the settings file or create it if not present.  If the settings have
  * already been loaded, return it without re-loading from disk.
  */
-export function load(): Settings {
-  let deploymentProfiles: DeploymentProfileType = { defaults: {}, locked: {} };
+export function load(deploymentProfiles: DeploymentProfileType): Settings {
   let setDefaultMemory = false;
 
-  try {
-    deploymentProfiles = readDeploymentProfiles();
-  } catch { }
   try {
     settings ??= loadFromDisk();
   } catch (err: any) {

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -36,7 +36,7 @@ enum networkStatus {
 export class Tray {
   protected trayMenu: Electron.Tray;
   protected kubernetesState = State.STOPPED;
-  private settings: Settings = load();
+  private settings: Settings = load({ defaults: {}, locked: {} });
   private currentNetworkStatus: networkStatus = networkStatus.CHECKING;
   private static instance: Tray;
   private abortController: AbortController | undefined;

--- a/pkg/rancher-desktop/store/applicationSettings.ts
+++ b/pkg/rancher-desktop/store/applicationSettings.ts
@@ -16,7 +16,7 @@ type State = {
 export const state: () => State = () => {
   // While we load the settings from disk here, we only otherwise interact with
   // the settings only via ipcRenderer.
-  const cfg = loadSettings();
+  const cfg = loadSettings({ defaults: {}, locked: {} });
 
   return {
     pathManagementStrategy: cfg.application.pathManagementStrategy,

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -169,7 +169,7 @@ export function openMain() {
   }
 
   window.on('closed', () => {
-    const cfg = loadSettings();
+    const cfg = loadSettings({ defaults: {}, locked: {} });
 
     if (cfg.application.window.quitOnClose) {
       BrowserWindow.getAllWindows().forEach((window) => {


### PR DESCRIPTION
Before this change the UI would load the settings module to get some data or type info. That would then load the dependent module 'deploymentProfiles.ts', which loads 'native-reg', which can't be run from the renderer process on Windows.