### PR TITLE
Fix rdctl set error from setting networkTunnel

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1521,7 +1521,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       return Promise.resolve({});
     }
 
-    return Promise.resolve(this.kubeBackend.requiresRestartReasons(this.cfg, cfg, { 'experimental.virtualMachine.networkingTunnel': undefined }));
+    return Promise.resolve(this.kubeBackend.requiresRestartReasons(
+      this.cfg, cfg, { 'experimental.virtualMachine.networkingTunnel': { current: this.cfg.experimental.virtualMachine.networkingTunnel } }));
   }
 
   /**


### PR DESCRIPTION
Setting `networkTunnel` from rdctl was causing as exception that prevented RD from restarting after setting change. 

```
rdctl set --experimental.virtual-machine.networking-tunnel=true
```

```
2023-03-06T22:54:07.399Z: updateSettings: exception when updating: Error: Invalid requiresRestartReasons extra key experimental.virtualMachine.networkingTunnel
...
```