### PR TITLE
mainEvents: drop deprecated emit/on

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -43,7 +43,7 @@ import paths from '@pkg/utils/paths';
 import { setupProtocolHandler, protocolRegistered } from '@pkg/utils/protocols';
 import { executable } from '@pkg/utils/resources';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
+import { RecursivePartial, RecursiveReadonly } from '@pkg/utils/typeUtils';
 import { getVersion } from '@pkg/utils/version';
 import * as window from '@pkg/window';
 import { closeDashboard, openDashboard } from '@pkg/window/dashboard';
@@ -484,7 +484,7 @@ ipcMainProxy.on('preferences-set-dirty', (_event, dirtyFlag) => {
   preferencesSetDirtyFlag(dirtyFlag);
 });
 
-function writeSettings(arg: RecursivePartial<settings.Settings>) {
+function writeSettings(arg: RecursivePartial<RecursiveReadonly<settings.Settings>>) {
   // arrayCustomizer is necessary to properly merge array of strings
   _.mergeWith(cfg, arg, arrayCustomizer);
   settings.save(cfg);

--- a/background.ts
+++ b/background.ts
@@ -528,22 +528,9 @@ ipcMainProxy.on('k8s-reset', async(_, arg) => {
   await doK8sReset(arg, { interactive: true });
 });
 
-ipcMainProxy.on('api-get-credentials', () => {
-  mainEvents.emit('api-get-credentials');
-});
-
-Electron.ipcMain.handle('api-get-credentials', () => {
-  return new Promise<void>((resolve) => {
-    mainEvents.once('api-credentials', resolve);
-    mainEvents.emit('api-get-credentials');
-  });
-});
+ipcMainProxy.handle('api-get-credentials', () => mainEvents.invoke('api-get-credentials'));
 
 ipcMainProxy.handle('get-locked-fields', () => settings.getLockedSettings());
-
-mainEvents.on('api-credentials', (credentials) => {
-  window.send('api-credentials', credentials);
-});
 
 function backendIsBusy() {
   return [K8s.State.STARTING, K8s.State.STOPPING].includes(k8smanager.state);

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -72,9 +72,7 @@ export class HttpCommandServer {
 
   constructor(commandWorker: CommandWorkerInterface) {
     this.commandWorker = commandWorker;
-    mainEvents.on('api-get-credentials', () => {
-      mainEvents.emit('api-credentials', this.interactiveState);
-    });
+    mainEvents.handle('api-get-credentials', () => Promise.resolve(this.interactiveState));
   }
 
   async init() {

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -83,18 +83,13 @@ interface MainEventNames {
   'integration-update'(state: Record<string, boolean | string>): void;
 
   /**
-   * Emitted as a request to get the credentials for API access.
-   */
-  'api-get-credentials'(): void;
-
-  /**
-   * Emitted as a reply to 'api-get-credentials'; the credentials can be used
-   * via HTTP basic auth on localhost.
+   * Fetch the API credentials that can be used for HTTP basic auth on localhost
+   * to talk to the backend.
    *
    * @note These credentials are meant for the UI; using them may require user
    * interaction.
    */
-  'api-credentials'(credentials: { user: string, password: string, port: number }): void;
+  'api-get-credentials'(): { user: string, password: string, port: number };
 
   /**
    * Force trigger diagnostics with the given id.
@@ -155,7 +150,16 @@ interface MainEvents extends EventEmitter {
     event: IsHandler<eventName> extends false ? eventName : never,
     ...args: Parameters<MainEventNames[eventName]>
   ): boolean;
+
   on<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    listener: (...args: Parameters<MainEventNames[eventName]>) => void
+  ): this;
+  once<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    listener: (...args: Parameters<MainEventNames[eventName]>) => void
+  ): this;
+  off<eventName extends keyof MainEventNames>(
     event: IsHandler<eventName> extends false ? eventName : never,
     listener: (...args: Parameters<MainEventNames[eventName]>) => void
   ): this;
@@ -197,6 +201,24 @@ class MainEventsImpl extends EventEmitter implements MainEvents {
 
   on(eventName: string, listener: (...args: any[]) => void) {
     return super.on(eventName, listener);
+  }
+
+  once<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    listener: (...args: Parameters<MainEventNames[eventName]>) => void
+  ): this;
+
+  once(eventName: string, listener: (...args: any[]) => void) {
+    return super.once(eventName, listener);
+  }
+
+  off<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    listener: (...args: Parameters<MainEventNames[eventName]>) => void
+  ): this;
+
+  off(eventName: string, listener: (...args: any[]) => void) {
+    return super.off(eventName, listener);
   }
 
   async invoke<eventName extends keyof MainEventNames>(

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -155,14 +155,10 @@ interface MainEvents extends EventEmitter {
     event: IsHandler<eventName> extends false ? eventName : never,
     ...args: Parameters<MainEventNames[eventName]>
   ): boolean;
-  /** @deprecated */ // Via eslint deprecation/deprecation: prevent usage of unrecognized events.
-  emit(eventName: string | symbol, ...args: any[]): boolean;
   on<eventName extends keyof MainEventNames>(
     event: IsHandler<eventName> extends false ? eventName : never,
     listener: (...args: Parameters<MainEventNames[eventName]>) => void
   ): this;
-  /** @deprecated */ // Via eslint deprecation/deprecation: prevent usage of unrecognized events.
-  on(event: string | symbol, listener: (...args: any[]) => void): this;
 
   /**
    * Invoke a handler that returns a promise of a result.
@@ -184,6 +180,24 @@ class MainEventsImpl extends EventEmitter implements MainEvents {
   handlers: {
     [eventName in keyof MainEventNames]?: HandlerType<eventName> | undefined;
   } = {};
+
+  emit<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    ...args: Parameters<MainEventNames[eventName]>
+  ): boolean;
+
+  emit(eventName: string, ...args: any[]): boolean {
+    return super.emit(eventName, ...args);
+  }
+
+  on<eventName extends keyof MainEventNames>(
+    event: IsHandler<eventName> extends false ? eventName : never,
+    listener: (...args: Parameters<MainEventNames[eventName]>) => void
+  ): this;
+
+  on(eventName: string, listener: (...args: any[]) => void) {
+    return super.on(eventName, listener);
+  }
 
   async invoke<eventName extends keyof MainEventNames>(
     event: IsHandler<eventName> extends true ? eventName : never,

--- a/pkg/rancher-desktop/store/credentials.ts
+++ b/pkg/rancher-desktop/store/credentials.ts
@@ -5,14 +5,13 @@ import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 interface CredentialsState {
-  credentials: ServerState;
+  credentials: Omit<ServerState, 'pid'>;
 }
 
 export const state: () => CredentialsState = () => (
   {
     credentials: {
       password: '',
-      pid:      0,
       port:     0,
       user:     '',
     },
@@ -28,7 +27,7 @@ export const mutations: MutationsType<CredentialsState> = {
 type CredActionContext = ActionContext<CredentialsState>;
 
 export const actions = {
-  async fetchCredentials({ commit }: CredActionContext): Promise<ServerState> {
+  async fetchCredentials({ commit }: CredActionContext): Promise<Omit<ServerState, 'pid'>> {
     const result = await ipcRenderer.invoke('api-get-credentials');
 
     commit('SET_CREDENTIALS', result);

--- a/pkg/rancher-desktop/store/diagnostics.ts
+++ b/pkg/rancher-desktop/store/diagnostics.ts
@@ -14,6 +14,8 @@ interface DiagnosticsState {
   inError: boolean;
 }
 
+type Credentials = Omit<ServerState, 'pid'>;
+
 const uri = (port: number, pathRemainder: string) => `http://localhost:${ port }/v1/${ pathRemainder }`;
 
 /**
@@ -51,7 +53,7 @@ export const mutations: MutationsType<DiagnosticsState> = {
 type DiagActionContext = ActionContext<DiagnosticsState>;
 
 export const actions = {
-  async fetchDiagnostics({ commit, rootState }: DiagActionContext, args: ServerState) {
+  async fetchDiagnostics({ commit, rootState }: DiagActionContext, args: Credentials) {
     const {
       port,
       user,
@@ -80,7 +82,7 @@ export const actions = {
     commit('SET_DIAGNOSTICS', checks);
     commit('SET_TIME_LAST_RUN', new Date(result.last_update));
   },
-  async runDiagnostics({ commit, rootState }:DiagActionContext, credentials: ServerState) {
+  async runDiagnostics({ commit, rootState }:DiagActionContext, credentials: Credentials) {
     const { port, user, password } = credentials;
     const response = await fetch(
       uri(port, 'diagnostic_checks'),
@@ -121,7 +123,7 @@ export const actions = {
     await dispatch(
       'preferences/commitPreferences',
       {
-        ...rootState.credentials.credentials as ServerState,
+        ...rootState.credentials.credentials as Credentials,
         payload: {
           version:     CURRENT_SETTINGS_VERSION,
           diagnostics: { mutedChecks: { [rowToUpdate.id]: isMuted } },

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -26,7 +26,9 @@ interface PreferencesState {
   canApply: boolean;
 }
 
-interface CommitArgs extends ServerState {
+type Credentials = Omit<ServerState, 'pid'>;
+
+interface CommitArgs extends Credentials {
   payload?: RecursivePartial<Settings>;
 }
 
@@ -118,7 +120,7 @@ export const actions = {
     commit('SET_PREFERENCES', _.cloneDeep(preferences));
     commit('SET_INITIAL_PREFERENCES', _.cloneDeep(preferences));
   },
-  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: ServerState) {
+  async fetchPreferences({ dispatch, commit }: PrefActionContext, args: Credentials) {
     const { port, user, password } = args;
 
     const response = await fetch(
@@ -178,7 +180,7 @@ export const actions = {
 
     await dispatch(
       'preferences/proposePreferences',
-      { ...rootState.credentials.credentials as ServerState },
+      { ...rootState.credentials.credentials as Credentials },
       { root: true },
     );
   },
@@ -258,7 +260,7 @@ export const actions = {
     await dispatch(
       'preferences/commitPreferences',
       {
-        ...rootState.credentials.credentials as ServerState,
+        ...rootState.credentials.credentials as Credentials,
         payload: {
           version:     CURRENT_SETTINGS_VERSION,
           diagnostics: { showMuted: isMuted },

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -66,9 +66,6 @@ export interface IpcMainEvents {
 
   'show-logs': () => void;
 
-  /** @deprecated */
-  'api-get-credentials': () => void;
-
   'dashboard-open': () => void;
   'dashboard-close': () => void;
 
@@ -94,7 +91,7 @@ export interface IpcMainInvokeEvents {
   'get-app-version': () => string;
   'show-message-box': (options: Electron.MessageBoxOptions) => Electron.MessageBoxReturnValue;
   'show-message-box-rd': (options: Electron.MessageBoxOptions, modal?: boolean) => any;
-  'api-get-credentials': () => { user: string, password: string, port: number, pid: number };
+  'api-get-credentials': () => { user: string, password: string, port: number };
   'k8s-progress': () => Readonly<{current: number, max: number, description?: string, transitionTime?: Date}>;
 
   // #region main/imageEvents
@@ -138,10 +135,6 @@ export interface IpcRendererEvents {
   'dialog/size': (size: {width: number, height: number}) => void;
   'dialog/options': (...args: any) => void;
   'dashboard-open': () => void;
-  // #endregion
-
-  // #region api
-  'api-credentials': (credentials: {user: string, password: string, port: number}) => void;
   // #endregion
 
   // #region tab navigation

--- a/pkg/rancher-desktop/typings/store.d.ts
+++ b/pkg/rancher-desktop/typings/store.d.ts
@@ -28,14 +28,11 @@ declare module 'vuex/types' {
         type: action,
         payload: Parameters<storeActions[action]>[0],
         options?: DispatchOptions
-      ): Promise<ReturnType<storeActions[action]>>;
+      ): Promise<Awaited<ReturnType<storeActions[action]>>>;
 
     <action extends keyof storeActions>
       (
         type: action,
-      ): Promise<ReturnType<storeActions[action]>>;
-
-    /** @deprecated */
-    (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
+      ): Promise<Awaited<ReturnType<storeActions[action]>>>;
   }
 }


### PR DESCRIPTION
Drop the generic versions of `emit()` and `on()`, which are confusing because it's not always clear why they are deprecated.  Instead, implement the `MainEvents` interface by forwarding to the methods from `EventEmitter` manually.  This should reduce confusion about why a call isn't working (since TypeScript can better guess which one is expected and emit better errors about any arguments that are incorrect).