### PR TITLE
Fixes rdctl shell rd networking

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-exec
+++ b/pkg/rancher-desktop/assets/scripts/wsl-exec
@@ -16,4 +16,7 @@ if [ -z "${pid}" ]; then
     exit 1
 fi
 
+if [ $# -eq 0 ]; then
+  set -- /bin/sh
+fi
 exec /usr/bin/nsenter -n -p -m -t "${pid}" "$@"

--- a/pkg/rancher-desktop/assets/scripts/wsl-exec
+++ b/pkg/rancher-desktop/assets/scripts/wsl-exec
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# wsl-exec is used to execute user-issued shell commands from
+# rdctl shell ... in a correct namespace. If the experimental
+# rancher desktop networking is enabled all the resulting
+# shell from rdctl shell will be executed in the new namespace
+# associated with the rd networking, otherwise, it will be executed
+# in the default namespace.
+
+set -o errexit -o nounset
+
+pid="$(cat /run/wsl-init.pid)"
+
+if [ -z "${pid}" ]; then
+    echo "Could not find wsl-init process" >&2
+    exit 1
+fi
+
+exec /usr/bin/nsenter -n -p -m -t "${pid}" "$@"

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -39,6 +39,7 @@ import SERVICE_SCRIPT_K3S from '@pkg/assets/scripts/service-k3s.initd';
 import SERVICE_VTUNNEL_PEER from '@pkg/assets/scripts/service-vtunnel-peer.initd';
 import SERVICE_SCRIPT_DOCKERD from '@pkg/assets/scripts/service-wsl-dockerd.initd';
 import SCRIPT_DATA_WSL_CONF from '@pkg/assets/scripts/wsl-data.conf';
+import WSL_EXEC from '@pkg/assets/scripts/wsl-exec';
 import WSL_INIT_SCRIPT from '@pkg/assets/scripts/wsl-init';
 import WSL_INIT_RD_NETWORKING_SCRIPT from '@pkg/assets/scripts/wsl-init-rd-networking';
 import { ContainerEngine } from '@pkg/config/settings';
@@ -1277,6 +1278,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               },
             ]);
 
+            await this.writeFile('/usr/local/bin/wsl-exec', WSL_EXEC, 0o755);
             await this.runInit();
           }),
           this.progressTracker.action('Installing image scanner', 100, this.installTrivy()),

--- a/src/go/rdctl/cmd/shell.go
+++ b/src/go/rdctl/cmd/shell.go
@@ -70,7 +70,10 @@ func doShellCommand(cmd *cobra.Command, args []string) error {
 			// No further output wanted, so just exit with the desired status.
 			os.Exit(1)
 		}
-		args = append([]string{"--distribution", distroName}, args...)
+		args = append([]string{
+			"--distribution", distroName,
+			"--exec", "/usr/local/bin/wsl-exec"},
+			args...)
 	} else {
 		if err := directories.SetupLimaHome(); err != nil {
 			return err


### PR DESCRIPTION
The problem was when rancher desktop networking was enabled `rdctl shell ...` was being executed in the default namespace which was rendering the commands ineffective. This PR adds `wsl-exec` which acts as a proxy script to determine the correct namespace.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4112