### PR TITLE
Add descriptions to all the `rdctl set` options

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -8,8 +8,7 @@ paths:
       operationId: factoryReset
       summary: Factory reset Rancher Desktop, losing user data
       requestBody:
-        description: >-
-          JSON block giving factory reset options.
+        description: JSON block giving factory reset options.
         content:
           application/json:
             schema:
@@ -41,9 +40,7 @@ paths:
         required: true
       responses:
         '202':
-          description: >-
-            A description of the effects of the proposed settings on the
-            backend.
+          description: A description of the effects of the proposed settings on the backend.
           content:
             application/json:
               schema:
@@ -57,8 +54,7 @@ paths:
                       type: string
                       enum: [ restart, reset ]
         '400':
-          description: >-
-            The proposed settings were not valid.
+          description: The proposed settings were not valid.
           content:
             text/plain:
               schema:
@@ -71,8 +67,7 @@ paths:
       summary:  List the current preference settings
       responses:
         '200':
-          description: >-
-            The current preferences in JSON format
+          description: The current preferences in JSON format
           content:
             application/json:
               schema:
@@ -91,15 +86,13 @@ paths:
         required: true
       responses:
         '202':
-          description: >-
-            The settings were accepted.
+          description: The settings were accepted.
           content:
             text/plain:
               schema:
                 type: string
         '400':
-          description: >-
-            The proposed settings were not valid.
+          description: The proposed settings were not valid.
           content:
             text/plain:
               schema:
@@ -111,8 +104,7 @@ paths:
       summary:  Shuts down Rancher Desktop
       responses:
         '202':
-          description: >-
-            The application is in the process of shutting down.
+          description: The application is in the process of shutting down.
           content:
             text/plain:
               schema:
@@ -121,12 +113,10 @@ paths:
   /v1/diagnostic_categories:
     get:
       operationId: diagnosticCategories
-      summary: >-
-        Return a list of the category names for the Diagnostics component. Takes no parameters.
+      summary: Return a list of the category names for the Diagnostics component. Takes no parameters.
       responses:
         '200':
-          description: >-
-            A list of the category names.
+          description: A list of the category names.
           content:
             application/json:
               schema:
@@ -147,8 +137,7 @@ paths:
         name: category
       responses:
         '200':
-          description: >-
-            A list of the check IDs for the specified category.
+          description: A list of the check IDs for the specified category.
           content:
             application/json:
               schema:
@@ -162,8 +151,7 @@ paths:
   /v1/diagnostic_checks:
     get:
       operationId: diagnosticChecks
-      summary: >-
-        Return all the checks, optionally filtered by specified category and/or checkID.
+      summary: Return all the checks, optionally filtered by specified category and/or checkID.
       parameters:
       - in: query
         name: category
@@ -171,8 +159,7 @@ paths:
         name: checkID
       responses:
         '200':
-          description: >-
-            A list of check objects. An invalid or unrecognized query parameter returns (200, empty array)
+          description: A list of check objects. An invalid or unrecognized query parameter returns (200, empty array)
           content:
             application/json:
               schema:
@@ -182,8 +169,7 @@ paths:
       summary: Run all diagnostic checks, and return any results.
       responses:
         '200':
-          description: >-
-            A list of check results.
+          description: A list of check results.
           content:
             application/json:
               schema:
@@ -195,8 +181,7 @@ paths:
       summary:  List the current transient settings
       responses:
         '200':
-          description: >-
-            The current transient settings in JSON format
+          description: The current transient settings in JSON format
           content:
             application/json:
               schema:
@@ -205,8 +190,7 @@ paths:
       operationId: updateTransientSettings
       summary:  Updates application transient settings
       requestBody:
-        description: >-
-          JSON block consisting of transient settings
+        description: JSON block consisting of transient settings
         content:
           application/json:
             schema:
@@ -214,15 +198,13 @@ paths:
         required: true
       responses:
         '202':
-          description: >-
-            The settings were accepted.
+          description: The settings were accepted.
           content:
             text/plain:
               schema:
                 type: string
         '400':
-          description: >-
-            The proposed transient settings were not valid.
+          description: The proposed transient settings were not valid.
           content:
             text/plain:
               schema:
@@ -239,48 +221,62 @@ components:
             adminAccess:
               type: boolean
               x-rd-platforms: [darwin, linux] # Only in the specified platforms
+              x-rd-usage: enable privileged operations
             debug:
               type: boolean
+              x-rd-usage: generate more verbose logging
             pathManagementStrategy:
               type: string
               enum: [manual, rcfiles]
               x-rd-platforms: [darwin, linux]
+              x-rd-usage: update PATH to include ~/.rd/bin
             telemetry:
               type: object
               properties:
                 enabled:
                   type: boolean
+                  x-rd-usage: allow collection of anonymous statistics
             updater:
               type: object
               properties:
                 enabled:
                   type: boolean
+                  x-rd-usage: automatically update to the latest release
             autoStart:
               type: boolean
+              x-rd-usage: start app when logging in
             startInBackground:
               type: boolean
+              x-rd-usage: start app without window
             hideNotificationIcon:
               type: boolean
+              x-rd-usage: don't show notification icon
             window:
               type: object
               properties:
                 quitOnClose:
                   type: boolean
+                  x-rd-usage: terminate app when the main window is closed
         containerEngine:
           type: object
           properties:
             name:
               type: string
+              # TODO "docker" setting should be a hidden alias of "moby".
+              # Why have two values for exactly the same thing?
               enum: [containerd, docker, moby]
-              x-rd-usage: Set engine to containerd or moby (aka docker).
               x-rd-aliases: [container-engine]
+              x-rd-usage: set engine
             allowedImages:
               type: object
               properties:
                 enabled:
                   type: boolean
+                  x-rd-usage: only allow images to be pulled that match the allowed patterns
                 patterns:
                   type: array
+                  # TODO It is not yet possible to specify array/list values with `rdctl set`
+                  x-rd-usage: allowed image names
                   items:
                     type: string
         virtualMachine:
@@ -290,37 +286,40 @@ components:
               type: integer
               minimum: 1
               x-rd-platforms: [darwin, linux]
+              x-rd-usage: reserved RAM size
             numberCPUs:
               type: integer
               minimum: 1
               x-rd-platforms: [darwin, linux]
+              x-rd-usage: reserved number of CPUs
             hostResolver:
               type: boolean
               x-rd-platforms: [win32]
+              x-rd-usage: resolve DNS queries on the host and not inside the VM
         kubernetes:
           type: object
           properties:
             version:
               type: string
-              x-rd-usage: Choose which version of kubernetes to run.
               x-rd-aliases: [kubernetes-version]
+              x-rd-usage: choose which version of Kubernetes to run
             port:
               type: integer
+              x-rd-usage: apiserver port
             enabled:
               type: boolean
-              x-rd-usage: Control whether kubernetes runs in the backend.
               x-rd-aliases: [kubernetes-enabled]
+              x-rd-usage: run Kubernetes
             options:
               type: object
               properties:
                 traefik:
                   type: boolean
+                  x-rd-usage: install and run traefik
                 flannel:
                   type: boolean
-                  x-rd-usage: >-
-                    Control whether flannel is enabled.
-                    Use to disable flannel so you can install your own CNI.
                   x-rd-aliases: [flannel-enabled]
+                  x-rd-usage: use flannel networking; disable to install your own CNI
         experimental:
           type: object
           properties:
@@ -330,6 +329,7 @@ components:
                 socketVMNet:
                   type: boolean
                   x-rd-platforms: [darwin]
+                  x-rd-usage: use socket-vmnet instead of vde-vmnet
                 mount:
                   type: object
                   x-rd-platforms: [darwin, linux]
@@ -337,6 +337,7 @@ components:
                     type:
                       type: string
                       enum: [reverse-sshfs, 9p]
+                      x-rd-usage: how directories are shared
                     9p:
                       type: object
                       properties:
@@ -349,15 +350,19 @@ components:
                         msizeInKB:
                           type: integer
                           minimum: 4
+                          x-rd-usage: maximum packet size
                         cacheMode:
                           type: string
                           enum: [none, loose, fscache, mmap]
                 networkingTunnel:
                   type: boolean
                   x-rd-platforms: [win32]
+                  x-rd-usage: tunnel networking so it originates from the host
         WSL:
           type: object
           x-rd-platforms: [win32]
+          # TODO It is not yet possible to configure this via `rdctl set`.
+          x-rd-usage: make container engine and Kubernetes available in these WSL2 distros
           properties:
             integrations:
               type: object
@@ -367,20 +372,26 @@ components:
           properties:
             includeKubernetesServices:
               type: boolean
+              x-rd-usage: show Kubernetes system services on Port Forwarding page
         images:
           type: object
           properties:
             showAll:
               type: boolean
+              x-rd-usage: show system images on Images page
             namespace:
               type: string
+              x-rd-usage: select only images from this namespace (containerd only)
         diagnostics:
           type: object
           properties:
             showMuted:
               type: boolean
+              x-rd-usage: unhide muted diagnostics
             mutedChecks:
               type: object
+              # TODO It is not possible to modify this setting via `rdctl set`.
+              x-rd-usage: diagnostic ids that have been muted
               additionalProperties: true
 
     diagnostics:

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -1,6 +1,6 @@
-openapi: "3.0.0"
+openapi: 3.0.0
 info:
-  title: "Rancher Desktop API"
+  title: Rancher Desktop API
   version: 0.0.1
 paths:
   /v1/factory_reset:
@@ -45,7 +45,7 @@ paths:
             A description of the effects of the proposed settings on the
             backend.
           content:
-            "application/json":
+            application/json:
               schema:
                 type: object
                 additionalProperties:
@@ -60,7 +60,7 @@ paths:
           description: >-
             The proposed settings were not valid.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
 
@@ -94,14 +94,14 @@ paths:
           description: >-
             The settings were accepted.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
         '400':
           description: >-
             The proposed settings were not valid.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
 
@@ -114,7 +114,7 @@ paths:
           description: >-
             The application is in the process of shutting down.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
 
@@ -128,7 +128,7 @@ paths:
           description: >-
             A list of the category names.
           content:
-            "application/json":
+            application/json:
               schema:
                 type: array
                 items:
@@ -143,14 +143,14 @@ paths:
         Specifying an exiting category with no checks
         will return status code 200 and an empty array.
       parameters:
-        - in: query
-          name: category
+      - in: query
+        name: category
       responses:
         '200':
           description: >-
             A list of the check IDs for the specified category.
           content:
-            "application/json":
+            application/json:
               schema:
                 type: array
                 items:
@@ -165,10 +165,10 @@ paths:
       summary: >-
         Return all the checks, optionally filtered by specified category and/or checkID.
       parameters:
-        - in: query
-          name: category
-        - in: query
-          name: checkID
+      - in: query
+        name: category
+      - in: query
+        name: checkID
       responses:
         '200':
           description: >-
@@ -217,14 +217,14 @@ paths:
           description: >-
             The settings were accepted.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
         '400':
           description: >-
             The proposed transient settings were not valid.
           content:
-            "text/plain":
+            text/plain:
               schema:
                 type: string
 
@@ -238,13 +238,13 @@ components:
           properties:
             adminAccess:
               type: boolean
-              x-rd-platforms: ['darwin', 'linux'] # Only in the specified platforms
+              x-rd-platforms: [darwin, linux] # Only in the specified platforms
             debug:
               type: boolean
             pathManagementStrategy:
               type: string
-              enum: ['manual', 'rcfiles']
-              x-rd-platforms: ['darwin', 'linux']
+              enum: [manual, rcfiles]
+              x-rd-platforms: [darwin, linux]
             telemetry:
               type: object
               properties:
@@ -271,10 +271,9 @@ components:
           properties:
             name:
               type: string
-              enum: ['containerd', 'docker', 'moby']
+              enum: [containerd, docker, moby]
               x-rd-usage: Set engine to containerd or moby (aka docker).
-              x-rd-aliases:
-                - "container-engine"
+              x-rd-aliases: [container-engine]
             allowedImages:
               type: object
               properties:
@@ -290,29 +289,27 @@ components:
             memoryInGB:
               type: integer
               minimum: 1
-              x-rd-platforms: ['darwin', 'linux']
+              x-rd-platforms: [darwin, linux]
             numberCPUs:
               type: integer
               minimum: 1
-              x-rd-platforms: ['darwin', 'linux']
+              x-rd-platforms: [darwin, linux]
             hostResolver:
               type: boolean
-              x-rd-platforms: ['win32']
+              x-rd-platforms: [win32]
         kubernetes:
           type: object
           properties:
             version:
               type: string
               x-rd-usage: Choose which version of kubernetes to run.
-              x-rd-aliases:
-                - "kubernetes-version"
+              x-rd-aliases: [kubernetes-version]
             port:
               type: integer
             enabled:
               type: boolean
               x-rd-usage: Control whether kubernetes runs in the backend.
-              x-rd-aliases:
-                - "kubernetes-enabled"
+              x-rd-aliases: [kubernetes-enabled]
             options:
               type: object
               properties:
@@ -323,8 +320,7 @@ components:
                   x-rd-usage: >-
                     Control whether flannel is enabled.
                     Use to disable flannel so you can install your own CNI.
-                  x-rd-aliases:
-                    - "flannel-enabled"
+                  x-rd-aliases: [flannel-enabled]
         experimental:
           type: object
           properties:
@@ -333,35 +329,35 @@ components:
               properties:
                 socketVMNet:
                   type: boolean
-                  x-rd-platforms: ['darwin']
+                  x-rd-platforms: [darwin]
                 mount:
                   type: object
-                  x-rd-platforms: ['darwin', 'linux']
+                  x-rd-platforms: [darwin, linux]
                   properties:
                     type:
                       type: string
-                      enum: ['reverse-sshfs', '9p']
+                      enum: [reverse-sshfs, 9p]
                     9p:
                       type: object
                       properties:
                         securityModel:
                           type: string
-                          enum: ['passthrough', 'mapped-xattr', 'mapped-file', 'none']
+                          enum: [passthrough, mapped-xattr, mapped-file, none]
                         protocolVersion:
                           type: string
-                          enum: ['9p2000', '9p2000.u', '9p2000.L']
+                          enum: [9p2000, 9p2000.u, 9p2000.L]
                         msizeInKB:
                           type: integer
                           minimum: 4
                         cacheMode:
                           type: string
-                          enum: ['none', 'loose', 'fscache', 'mmap']
+                          enum: [none, loose, fscache, mmap]
                 networkingTunnel:
                   type: boolean
-                  x-rd-platforms: ['win32']
+                  x-rd-platforms: [win32]
         WSL:
           type: object
-          x-rd-platforms: ['win32']
+          x-rd-platforms: [win32]
           properties:
             integrations:
               type: object


### PR DESCRIPTION
Also includes some cleanup of the YAML formatting.

```console
Flags:
      --application.admin-access                                        Enable privileged operations
      --application.auto-start                                          Start app when logging in.
      --application.debug                                               Generate more verbose logging.
      --application.hide-notification-icon                              Don't show notification icon.
      --application.path-management-strategy string                     Update PATH to include ~/.rd/bin. (Allowed values: [manual, rcfiles])
      --application.start-in-background                                 Start app without window.
      --application.telemetry.enabled                                   Allow collection of anonymous statistics.
      --application.updater.enabled                                     Automatically update to the latest release.
      --application.window.quit-on-close                                Terminate app when the main window is closed.
      --container-engine.allowed-images.enabled                         Only allow images to be pulled that match the allowed patterns.
      --container-engine.name string                                    Set engine. (Allowed values: [containerd, docker, moby])
      --diagnostics.show-muted                                          Unhide muted diagnostics.
      --experimental.virtual-machine.mount.9p.cache-mode string         (Allowed values: [none, loose, fscache, mmap])
      --experimental.virtual-machine.mount.9p.msize-in-kb int           Maximum packet size.
      --experimental.virtual-machine.mount.9p.protocol-version string   (Allowed values: [9p2000, 9p2000.u, 9p2000.L])
      --experimental.virtual-machine.mount.9p.security-model string     (Allowed values: [passthrough, mapped-xattr, mapped-file, none])
      --experimental.virtual-machine.mount.type string                  Choose how directories are shared. (Allowed values: [reverse-sshfs, 9p])
      --experimental.virtual-machine.socket-vmnet                       Use socket-vmnet instead of vde-vmnet.
  -h, --help                                                            help for set
      --images.namespace string                                         Select only images from this namespace (containerd only).
      --images.show-all                                                 Show system images on Images page.
      --kubernetes.enabled                                              Control whether kubernetes is started.
      --kubernetes.options.flannel                                      Use flannel networking. Disable to install your own CNI.
      --kubernetes.options.traefik                                      Install and run traefik.
      --kubernetes.port int                                             API server port.
      --kubernetes.version string                                       Choose which version of kubernetes to run.
      --port-forwarding.include-kubernetes-services                     Show Kubernetes system services on Port Forwarding page.
      --virtual-machine.memory-in-gb int                                Reserved RAM size.
      --virtual-machine.number-cpus int                                 Reserved number of CPUs.

Global Flags:
      --config-path string   config file (default /Users/jan/Library/Application Support/rancher-desktop/rd-engine.json)
      --host string          default is localhost; most useful for WSL
      --password string      overrides the password setting in the config file
      --port string          overrides the port setting in the config file
      --user string          overrides the user setting in the config file
```

Style is a bit different between command flags descriptions (start with uppercase letter; trailing dot), and the global flags (lowercase, no trailing dot), but I'll leave that for another day / another PR.

Fixes #4070 