### PR TITLE
Frontend validation, `vuelidate`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nuxtjs/eslint-module": "3.1.0",
         "@rancher/components": "0.1.0-alpha.10",
         "@rancher/shell": "0.1.3",
+        "@types/vuelidate": "^0.7.16",
         "agent-base": "6.0.2",
         "bufferutil": "4.0.7",
         "cookie-universal-nuxt": "2.2.2",
@@ -53,6 +54,7 @@
         "vue-select": "3.20.0",
         "vue-shortkey": "3.1.7",
         "vue-slider-component": "3.2.20",
+        "vuelidate": "^0.7.7",
         "which": "3.0.0",
         "xdg-app-paths": "5.5.1",
         "yaml": "2.1.3"
@@ -8041,6 +8043,14 @@
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
       "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
       "optional": true
+    },
+    "node_modules/@types/vuelidate": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/@types/vuelidate/-/vuelidate-0.7.16.tgz",
+      "integrity": "sha512-yatsSHkTSucAOX7HJCdgjegK3TGS+LJ9GNMSxdGp3HEoPabP3XYUWGL+RhtjaYHcEsD51cwOSMbhrud8MR+b6g==",
+      "dependencies": {
+        "vue": "^2.6.11"
+      }
     },
     "node_modules/@types/webpack": {
       "version": "4.41.28",
@@ -32437,6 +32447,15 @@
         "sortablejs": "1.10.2"
       }
     },
+    "node_modules/vuelidate": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.7.tgz",
+      "integrity": "sha512-pT/U2lDI67wkIqI4tum7cMSIfGcAMfB+Phtqh2ttdXURwvHRBJEAQ0tVbUsW9Upg83Q5QH59bnCoXI7A9JDGnA==",
+      "engines": {
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/vuex": {
       "version": "3.6.2",
       "license": "MIT",
@@ -40389,6 +40408,14 @@
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
       "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
       "optional": true
+    },
+    "@types/vuelidate": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/@types/vuelidate/-/vuelidate-0.7.16.tgz",
+      "integrity": "sha512-yatsSHkTSucAOX7HJCdgjegK3TGS+LJ9GNMSxdGp3HEoPabP3XYUWGL+RhtjaYHcEsD51cwOSMbhrud8MR+b6g==",
+      "requires": {
+        "vue": "^2.6.11"
+      }
     },
     "@types/webpack": {
       "version": "4.41.28",
@@ -56267,6 +56294,11 @@
       "requires": {
         "sortablejs": "1.10.2"
       }
+    },
+    "vuelidate": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.7.tgz",
+      "integrity": "sha512-pT/U2lDI67wkIqI4tum7cMSIfGcAMfB+Phtqh2ttdXURwvHRBJEAQ0tVbUsW9Upg83Q5QH59bnCoXI7A9JDGnA=="
     },
     "vuex": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@nuxtjs/eslint-module": "3.1.0",
     "@rancher/components": "0.1.0-alpha.10",
     "@rancher/shell": "0.1.3",
+    "@types/vuelidate": "^0.7.16",
     "agent-base": "6.0.2",
     "bufferutil": "4.0.7",
     "cookie-universal-nuxt": "2.2.2",
@@ -94,6 +95,7 @@
     "vue-select": "3.20.0",
     "vue-shortkey": "3.1.7",
     "vue-slider-component": "3.2.20",
+    "vuelidate": "^0.7.7",
     "which": "3.0.0",
     "xdg-app-paths": "5.5.1",
     "yaml": "2.1.3"

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -60,6 +60,7 @@ export default {
     '~/plugins/tooltip',
     '~/plugins/v-select',
     '~/plugins/vue-js-modal',
+    '~/plugins/vuelidate',
 
     // First-party
     '~/plugins/i18n',

--- a/pkg/rancher-desktop/plugins/vuelidate.js
+++ b/pkg/rancher-desktop/plugins/vuelidate.js
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import Vuelidate from 'vuelidate';
+
+Vue.use(Vuelidate);


### PR DESCRIPTION
contributes to #4003

`vuelidate` is a model-based validation library for Vue.js.

- Vue 3.x: https://vuelidate-next.netlify.app/
- Vue 2.x: https://vuelidate.js.org/#getting-started , https://www.npmjs.com/package/vuelidate

## Todo

- Create `mixins` model
- Create css rules for error's messages
