### PR TITLE
Explicitly set --node-external-ip to bridged or shared IP address

### DIFF
--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -350,9 +350,12 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
 
     if (allowSudo && os.platform() === 'darwin') {
       if (cfg.kubernetes.options.flannel) {
-        const iface = await this.vm.getListeningInterface();
+        const { iface, addr } = await this.vm.getListeningInterface();
 
         config.ADDITIONAL_ARGS += ` --flannel-iface ${ iface }`;
+        if (addr) {
+          config.ADDITIONAL_ARGS += ` --node-external-ip ${ addr }`;
+        }
       } else {
         console.log(`Disabling flannel and network policy`);
         config.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1549,8 +1549,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   /**
-   * Get the network interface to listen on for services; used for flannel
-   * configuration.
+   * Get the network interface name and address to listen on for services;
+   * used for flannel configuration.
    */
   async getListeningInterface() {
     const bridgedIP = await this.getInterfaceAddr('rd0');
@@ -1558,23 +1558,21 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     if (bridgedIP) {
       console.log(`Using ${ bridgedIP } on bridged network rd0`);
 
-      return 'rd0';
-    } else {
-      const sharedIP = await this.getInterfaceAddr('rd1');
-
-      if (this.cfg?.application.adminAccess) {
-        await this.noBridgedNetworkDialog(sharedIP);
-      }
-      if (sharedIP) {
-        console.log(`Using ${ sharedIP } on shared network rd1`);
-
-        return 'rd1';
-      } else {
-        console.log(`Neither bridged network rd0 nor shared network rd1 have an IPv4 address`);
-
-        return 'eth0';
-      }
+      return { iface: 'rd0', addr: bridgedIP };
     }
+    const sharedIP = await this.getInterfaceAddr('rd1');
+
+    if (this.cfg?.application.adminAccess) {
+      await this.noBridgedNetworkDialog(sharedIP);
+    }
+    if (sharedIP) {
+      console.log(`Using ${ sharedIP } on shared network rd1`);
+
+      return { iface: 'rd1', addr: sharedIP };
+    }
+    console.log(`Neither bridged network rd0 nor shared network rd1 have an IPv4 address`);
+
+    return { iface: 'eth0', addr: await this.ipAddress };
   }
 
   /**


### PR DESCRIPTION
In #3816 we set `--node-ip` to the internal (non-routable) address on `eth0` so that the apiserver certs remain valid (they are never regenerated).

But that also causes the loadbalancers to use the node-ip instead of the IP of the flannel interface, so we have to provide the IP explicitly.

Fixes #4128 

Note that there is still a problem when the external IP address changes (e.g. by roaming to a different bridged network): the existing load balancer addresses will not be updated automatically. But that is not a regression against 1.7, so can be addressed later (#4131).
