### PR TITLE
bats: Fix factory-reset test

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -36,8 +36,8 @@ start_application() {
     # Looks like the rcfiles don't get updated via `rdctl start`
     # BUG BUG BUG
     if is_unix; then
-        rdctl set --path-management-strategy manual
-        rdctl set --path-management-strategy rcfiles
+        rdctl set --application.path-management-strategy manual
+        rdctl set --application.path-management-strategy rcfiles
     fi
 
     check_installation before

--- a/bats/tests/containers/host-connectivity.bats
+++ b/bats/tests/containers/host-connectivity.bats
@@ -1,5 +1,5 @@
 # Test case 36
-# On Windows, You need to create a firewall rule to allow allow communication 
+# On Windows, You need to create a firewall rule to allow allow communication
 # between the host and the container. Please check the below link for instructions.
 # https://docs.rancherdesktop.io/faq#q-can-containers-reach-back-to-host-services-via-hostdockerinternal
 
@@ -27,5 +27,5 @@ verify_host_connectivity() {
 }
 
 @test 'ping host.rancher-desktop.internal from a container' {
-    verify_host_connectivity "host.rancher-desktop.internal" 
+    verify_host_connectivity "host.rancher-desktop.internal"
 }


### PR DESCRIPTION
The rdctl argument to set the path management strategy pref has changed.

Also fixes a couple whitespace issues in an unrelated bats test.