### PR TITLE
Redo Windows registry-based deployment profile reading.

### DIFF
--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -144,7 +144,6 @@ function readProfileFiles(rootPath: string, defaultsPath: string, lockedPath: st
  * @returns null, or the registry data as an object.
  */
 function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): RecursivePartial<settings.Settings>|null {
-  let regValue: any = null;
   let newObject: RecursivePartial<settings.Settings>|null = null;
 
   const schemaKeys = Object.keys(schemaObj);
@@ -154,6 +153,7 @@ function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): Recurs
 
   for (const k of commonKeys) {
     const schemaVal = schemaObj[k];
+    let regValue: any = null;
 
     if (typeof schemaVal === 'object') {
       if (!Array.isArray(schemaVal)) {
@@ -175,11 +175,10 @@ function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): Recurs
         const multiSzValue = nativeReg.queryValueRaw(regKey, k);
 
         if (multiSzValue) {
+          // Registry value can be a single-string or even a DWORD and parseMultiString will handle it.
           const arrayValue = nativeReg.parseMultiString(multiSzValue as nativeReg.Value);
 
           regValue = arrayValue.length ? arrayValue : null;
-        } else {
-          regValue = null;
         }
       }
     } else {
@@ -196,8 +195,6 @@ function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): Recurs
     if (regValue !== null) {
       newObject ??= {};
       (newObject as Record<string, any>)[k] = regValue;
-      // Set it to null for the next round
-      regValue = null;
     }
   }
 

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -175,13 +175,8 @@ function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): Recurs
         const multiSzValue = nativeReg.queryValueRaw(regKey, k);
 
         if (multiSzValue) {
-          // parseMultiString d oesn't work exactly as advertised
-          // https://github.com/simonbuchan/native-reg#parsemultistring
-          let arrayValue = nativeReg.parseMultiString(multiSzValue as nativeReg.Value);
+          const arrayValue = nativeReg.parseMultiString(multiSzValue as nativeReg.Value);
 
-          if (arrayValue?.length === 1 && arrayValue[0].includes('\\0')) {
-            arrayValue = arrayValue[0].split('\\0').filter(s => s);
-          }
           regValue = arrayValue.length ? arrayValue : null;
         } else {
           regValue = null;

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -141,7 +141,7 @@ function readProfileFiles(rootPath: string, defaultsPath: string, lockedPath: st
  * Windows only. Read settings values from registry using schemaObj as a template.
  * @param schemaObj the object used as a template for navigating registry.
  * @param regKey the registry key obtained from nativeReg.openKey().
- * @returns undefined, or the registry data as an object.
+ * @returns null, or the registry data as an object.
  */
 function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): RecursivePartial<settings.Settings>|null {
   let regValue: any = null;


### PR DESCRIPTION
Fixes #4144 

To test this, you might want to create a new multi-string value in the registry.

According to stackoverflow, there are many ways to do this, running the gamut from powershell and VBS to high-grade ATL/C++. But I just added the values in the regedit textbox, one per line, and made sure that there was an empty line after all the values.