### PR TITLE
backend: nerdctl client: Fix making temporary files

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
@@ -126,7 +127,7 @@ export class NerdctlClient implements ContainerEngineClient {
       await this.vm.execCommand('/usr/bin/tar', ...args);
 
       // Copy the archive to the host
-      const workDir = await fs.promises.mkdtemp('rd-nerdctl-copy-');
+      const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-copy-'));
 
       cleanups.push(() => fs.promises.rm(workDir, { recursive: true }));
       const hostArchive = path.join(workDir, 'copy-file.tgz');


### PR DESCRIPTION
The temporary directory should be created in /tmp or equivalent, rather than current working directory.

This is a commit extracted from #4147.