### PR TITLE
Fix rdctl factory reset

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1512,11 +1512,11 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         }
         if (!this.cfg?.experimental.virtualMachine.networkingTunnel) {
           await this.vtun.stop();
+          await this.resolverHostProcess.stop();
+          await this.invokePrivilegedService('stop');
         }
         this.process?.kill('SIGTERM');
-        await this.resolverHostProcess.stop();
         await this.hostSwitchProcess.stop();
-        await this.invokePrivilegedService('stop');
         if (await this.isDistroRegistered({ runningOnly: true })) {
           await this.execWSL('--terminate', INSTANCE_NAME);
         }

--- a/src/go/rdctl/pkg/factoryreset/service_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/service_windows.go
@@ -20,6 +20,10 @@ func stopPrivilegedService() error {
 		logrus.Tracef("successfully stopped %s", svcName)
 		return nil
 	}
+	if errors.Is(err, windows.ERROR_SERVICE_NOT_ACTIVE) {
+		logrus.Tracef("ignoring failure to stop %s: %s", svcName, err)
+		return nil
+	}
 	if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 		logrus.Tracef("ignoring failure to stop %s: %s", svcName, err)
 		return nil


### PR DESCRIPTION
`rdctl factory-reset` was erroring out when the `networkingTunnel` was enabled, this was due to `rdctl` returning with an error if the privileged service was not running. 