### PR TITLE
Windows Deployment-profile validation: add type-checking and make errors fatal

### DIFF
--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -63,10 +63,7 @@ test.describe('Locked fields', () => {
   }
 
   async function restoreUserProfile() {
-    // `deploymentProfile` if `saveUserProfile` throws.
-    if (deploymentProfile) {
-      await createUserProfile(deploymentProfile.defaults, deploymentProfile.locked);
-    }
+    await createUserProfile(deploymentProfile?.defaults ?? null, deploymentProfile?.locked ?? null);
   }
 
   test.describe.configure({ mode: 'serial' });

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -83,7 +83,7 @@ export function createDefaultSettings(overrides: RecursivePartial<Settings> = {}
   if (!fs.existsSync(settingsFullPath)) {
     fs.mkdirSync(paths.config, { recursive: true });
     fs.writeFileSync(path.join(paths.config, fileSettingsName), settingsJson);
-    console.log('Default settings file successfully created on: ', `${ paths.config }/${ fileSettingsName }`, settingsData);
+    console.log(`Default settings file successfully created at ${ paths.config }/${ fileSettingsName }`);
   } else {
     try {
       const contents = fs.readFileSync(settingsFullPath, { encoding: 'utf-8' });

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -1,6 +1,10 @@
+/* eslint object-curly-newline: ["error", {"consistent": true}] */
+
 import fs from 'fs';
+import path from 'path';
 
 import _ from 'lodash';
+import plist from 'plist';
 
 import * as settings from '../settings';
 
@@ -127,120 +131,13 @@ describe('settings', () => {
   };
 
   const jsonProfile = JSON.stringify(fullDefaults);
-  const plistProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>application</key>
-    <dict>
-        <key>adminAccess</key>
-        <false/>
-        <key>pathManagementStrategy</key>
-        <string>rcfiles</string>
-        <key>window</key>
-        <dict>
-            <key>quitOnClose</key>
-            <true/>
-        </dict>
-    </dict>
-    <key>containerEngine</key>
-    <dict>
-      <key>allowedImages</key>
-      <dict>
-        <key>enabled</key>
-        <true/>
-        <key>not_schema</key>
-        <true/>
-        <key>patterns</key>
-        <array/>
-      </dict>
-      <key>name</key>
-      <string>moby</string>
-    </dict>
-    <key>debug</key>
-    <true/>
-    <key>kubernetes</key>
-    <dict>
-      <key>version</key>
-      <string>1.23.15</string>
-      <key>enabled</key>
-      <true/>
-    </dict>
-    <key>portForwarding</key>
-    <dict>
-        <key>includeKubernetesServices</key>
-        <false/>
-    </dict>
-    <key>ignorableTestSettings</key>
-    <dict>
-      <key>testTitle</key>
-      <string>test-title</string>
-      <key>testStruct</key>
-      <dict>
-        <key>title</key>
-        <string>test-struct</string>
-        <key>subStruct</key>
-        <dict>
-          <key>title</key>
-          <string>sub-title</string>
-          <key>locked</key>
-          <true/>
-          <key>subvar</key>
-          <string>sub-var</string>
-        </dict>
-      </dict>
-    </dict>
-    <key>debug</key>
-    <true/>
-    <key>diagnostics</key>
-    <dict>
-        <key>locked</key>
-        <true/>
-        <key>mutedChecks</key>
-        <dict>
-            <key>magog</key>
-            <false/>
-            <key>montreal</key>
-            <true/>
-            <key>riviere du loup</key>
-            <false/>
-        </dict>
-        <key>showMuted</key>
-        <false/>
-    </dict>
-    <key>extensions</key>
-    <dict>
-        <key>bellingham</key>
-        <true/>
-        <key>olympia</key>
-        <false/>
-        <key>seattle</key>
-        <true/>
-        <key>winthrop</key>
-        <true/>
-    </dict>
-    <key>WSL</key>
-    <dict>
-        <key>integrations</key>
-        <dict>
-            <key>kingston</key>
-            <false/>
-            <key>napanee</key>
-            <false/>
-            <key>weed</key>
-            <true/>
-            <key>yarker</key>
-            <true/>
-        </dict>
-    </dict>
-  </dict>
-</plist>`;
-  const unlockedJSONProfile = JSON.stringify({
+  const plistProfile = plist.build(fullDefaults);
+  const unlockedProfile = {
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
     containerEngine: { name: 'should be ignored' },
     kubernetes:      { version: "Shouldn't see this" },
-  });
-  const lockedJSONProfile = JSON.stringify({
+  };
+  const lockedProfile = {
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
     containerEngine: {
       allowedImages: {
@@ -249,104 +146,133 @@ describe('settings', () => {
       },
     },
     kubernetes: { version: "Shouldn't see this" },
-  });
-  const unlockedPlistProfile = `
-  <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>containerEngine</key>
-    <dict>
-      <key>name</key>
-      <string>should be ignored</string>
-    </dict>
-    <key>kubernetes</key>
-    <dict>
-      <key>version</key>
-      <string>Shouldn't see this</string>
-    </dict>
-  </dict>
-</plist>
-`;
-  const lockedPlistProfile = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>version</key>
-    <integer>4</integer>
-    <key>containerEngine</key>
-    <dict>
-      <key>allowedImages</key>
-      <dict>
-        <key>enabled</key>
-        <true/>
-        <key>not_schema</key>
-        <true/>
-        <key>patterns</key>
-        <array>
-        <string>nginx</string>
-        <string>alpine</string>
-        </array>
-      </dict>
-    </dict>
-    <key>kubernetes</key>
-    <dict>
-      <key>version</key>
-      <string>1.23.15</string>
-      <key>containerEngine</key>
-      <string>moby</string>
-      <key>enabled</key>
-      <true/>
-    </dict>
-    <key>testSettings</key>
-    <dict>
-      <key>testTitle</key>
-      <string>test-title</string>
-      <key>testStruct</key>
-      <dict>
-        <key>title</key>
-        <string>test-struct</string>
-        <key>subStruct</key>
-        <dict>
-          <key>title</key>
-          <string>sub-title</string>
-          <key>locked</key>
-          <true/>
-          <key>subvar</key>
-          <string>sub-var</string>
-        </dict>
-      </dict>
-    </dict>
-    <key>debug</key>
-    <true/>
-    <key>diagnostics</key>
-    <dict>
-      <key>showMuted</key>
-      <false/>
-      <key>locked</key>
-      <true/>
-      <key>mutedChecks</key>
-      <dict/>
-    </dict>
-  </dict>
-</plist>
-  `;
-  // TODO: Stop doing this once profiles are implemented on windows
+  };
+  const unlockedJSONProfile = JSON.stringify(unlockedProfile);
+  const lockedJSONProfile = JSON.stringify(lockedProfile);
+  const unlockedPlistProfile = plist.build(unlockedProfile);
+  const lockedPlistProfile = plist.build(lockedProfile);
+
+  // Check structural breakage in this file.
+  const brokenJSONProfile = jsonProfile.slice(0, jsonProfile.length / 2);
+  const brokenPlistProfile = plistProfile.slice(0, plistProfile.length / 2);
+
+  // TODO: Figure out how to implement this on Windows as well
   const describeNotWindows = process.platform === 'win32' ? describe.skip : describe;
 
-  describe('profiles', () => {
-    describeNotWindows('locked fields', () => {
-      const lockedAccessors = ['containerEngine.allowedImages.enabled', 'containerEngine.allowedImages.patterns'];
-      let mock: jest.SpiedFunction<typeof fs['readFileSync']>;
-      const actualSyncReader = fs.readFileSync;
+  describeNotWindows('profiles', () => {
+    const lockedAccessors = ['containerEngine.allowedImages.enabled', 'containerEngine.allowedImages.patterns'];
+    let mock: jest.SpiedFunction<typeof fs['readFileSync']>;
+    const actualSyncReader = fs.readFileSync;
 
-      beforeEach(() => {
-        jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
-      });
-      afterEach(() => {
-        mock.mockRestore();
-      });
+    beforeEach(() => {
+      jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
+    });
+    afterEach(() => {
+      mock.mockRestore();
+    });
 
+    /**
+     * This mocker is used to intercept a call to `fs.readFileSync` and return a specified profile text,
+     * depending on how the mocker is configured.
+     *
+     * The mocker can do four different things when it's triggered via a call to `fs.readFileSync`:
+     *
+     * 1. Return the actual text of the requested file
+     * 2. Throw an ENOENT exception
+     * 3. Return a pre-determined default profile
+     * 4. Return a pre-determined locked-field profile
+     *
+     * The mocker always does option 1 for any file it doesn't care about
+     * The mocker always does option 2 for settings.json to trigger use of any default profile
+     * For requests for profile files, the mocker looks at its main arguments
+     * `useSystemProfile`, and `usePersonalProfile` to determine whether it should return some
+     * predetermined text or throw an ENOENT exception. For example, if `useSystemProfile` is `ProfileTypes.None`,
+     * then any requests for a system profile file should trigger an ENOENT exception.
+     *
+     * This is why `createMocker(ProfileTypes.None, ProfileTypes.None) will throw an exception when asked for
+     * the text of any profile.
+     *
+     * And if we want to verify that the system handles invalid files correctly, the `typeToCorrupt` field
+     * is used to indicate whether to corrupt a defaults or locked-fields profile. Corrupting involves returning
+     * the first half of the predefined text, which causes both json and plist parsers to throw an exception.
+     *
+     * On Linux, system files are (currently) `/etc/rancher-desktop/{defaults,locked}.json`,
+     * while the user files are  `~/.config/rancher-desktop.defaults,locked}.json`
+     *
+     * macOS plist files:
+     * User: `~/Library/Preferences/io.rancherdesktop.profile.{defaults,locked}.plist`
+     * System: `/Library/Preferences/io.rancherdesktop.profile.{defaults,locked}.plist`
+     *
+     * @param useSystemProfile: what to do when a system profile is requested
+     * @param usePersonalProfile:  what to do when a user profile is requested
+     * @param typeToCorrupt: if 'defaults', when a defaults profile is requested, just return the first half of the text.
+     *                       ... similar if it's 'locked'
+     */
+    function createMocker(useSystemProfile: ProfileTypes, usePersonalProfile: ProfileTypes, typeToCorrupt?: 'defaults'|'locked'): (inputPath: any, unused: any) => any {
+      return (inputPath: any, unused: any): any => {
+        if (!inputPath.startsWith(paths.deploymentProfileUser) && !inputPath.startsWith(paths.deploymentProfileSystem)) {
+          return actualSyncReader(inputPath, unused);
+        }
+        const action = inputPath.startsWith(paths.deploymentProfileSystem) ? useSystemProfile : usePersonalProfile;
+
+        if (action === ProfileTypes.None || inputPath === path.join(paths.config, 'settings.json')) {
+          throw new FakeFSError(`File ${ inputPath } not found`, 'ENOENT');
+        }
+        const pathInfo = path.parse(inputPath);
+
+        if (!['.json', '.plist'].includes(pathInfo.ext)) {
+          return actualSyncReader(inputPath, unused);
+        }
+
+        if (pathInfo.base.endsWith('defaults.json')) {
+          return typeToCorrupt === 'defaults' ? brokenJSONProfile : jsonProfile;
+        }
+        if (pathInfo.base.endsWith('defaults.plist')) {
+          return typeToCorrupt === 'defaults' ? brokenPlistProfile : plistProfile;
+        }
+        switch (action) {
+        case ProfileTypes.Unlocked:
+          // These are effectively empty profiles because the validator removes all the fields.
+          // No need to sometimes emulate corruption and return only the first half of the data;
+          // this is done when requesting locked fields below.
+          if (pathInfo.base.endsWith('locked.json')) {
+            return unlockedJSONProfile;
+          } else if (pathInfo.base.endsWith('locked.plist')) {
+            return unlockedPlistProfile;
+          }
+          break;
+        case ProfileTypes.Locked:
+          if (pathInfo.base.endsWith('locked.json')) {
+            return typeToCorrupt === 'locked' ? brokenJSONProfile : lockedJSONProfile;
+          } else if (pathInfo.base.endsWith('locked.plist')) {
+            return typeToCorrupt === 'locked' ? brokenPlistProfile : lockedPlistProfile;
+          }
+        }
+        throw new Error("Shouldn't get here.");
+      };
+    }
+
+    describe('validation', () => {
+      function invalidProfileMessage(basename: string) {
+        if (process.platform === 'darwin') {
+          return new RegExp(`Error loading plist file .*/io.rancherdesktop.profile.${ basename }.plist`);
+        }
+
+        return new RegExp(`Error parsing deployment profile from .*/\\.config/rancher-desktop.${ basename }.json: SyntaxError: Unexpected end of JSON input`);
+      }
+      test('complains about invalid default values', async() => {
+        mock = jest.spyOn(fs, 'readFileSync')
+          .mockImplementation(createMocker(ProfileTypes.None, ProfileTypes.Unlocked, 'defaults'));
+        await expect(readDeploymentProfiles()).rejects.toThrow(invalidProfileMessage('defaults'));
+      });
+      test('complains about invalid locked values', async() => {
+        mock = jest.spyOn(fs, 'readFileSync')
+          .mockImplementation(createMocker(ProfileTypes.None, ProfileTypes.Locked, 'locked'));
+        await expect(readDeploymentProfiles()).rejects.toThrow(invalidProfileMessage('locked'));
+      });
+    });
+
+    describe('locked fields', () => {
       function verifyAllFieldsAreLocked(lockedFields: settings.LockedSettingsType) {
         for (const acc of lockedAccessors) {
           expect(_.get(lockedFields, acc)).toBeTruthy();
@@ -357,41 +283,6 @@ describe('settings', () => {
         for (const acc of lockedAccessors) {
           expect(_.get(lockedFields, acc)).toBeFalsy();
         }
-      }
-
-      function createMocker(useSystemProfile: ProfileTypes, usePersonalProfile: ProfileTypes): (inputPath: any, unused: any) => any {
-        return (inputPath: any, unused: any): any => {
-          if (!inputPath.startsWith(paths.deploymentProfileUser) && !inputPath.startsWith(paths.deploymentProfileSystem)) {
-            return actualSyncReader(inputPath, unused);
-          }
-          const action = inputPath.startsWith(paths.deploymentProfileSystem) ? useSystemProfile : usePersonalProfile;
-
-          if (action === ProfileTypes.None) {
-            throw new FakeFSError(`File ${ inputPath } not found`, 'ENOENT');
-          }
-          if (inputPath.endsWith('defaults.json')) {
-            return jsonProfile;
-          }
-          if (inputPath.endsWith('defaults.plist')) {
-            return plistProfile;
-          }
-          switch (action) {
-          case ProfileTypes.Unlocked:
-            if (inputPath.endsWith('locked.json')) {
-              return unlockedJSONProfile;
-            } else if (inputPath.endsWith('locked.plist')) {
-              return unlockedPlistProfile;
-            }
-            break;
-          case ProfileTypes.Locked:
-            if (inputPath.endsWith('locked.json')) {
-              return lockedJSONProfile;
-            } else if (inputPath.endsWith('locked.plist')) {
-              return lockedPlistProfile;
-            }
-          }
-          throw new Error("Shouldn't get here.");
-        };
       }
 
       describe('when there is no profile', () => {

--- a/pkg/rancher-desktop/config/commandLineOptions.ts
+++ b/pkg/rancher-desktop/config/commandLineOptions.ts
@@ -24,6 +24,8 @@ export class LockedFieldError extends Error {}
  *
  *  * All errors are fatal as this function is like an API for launching the application.
  * @param cfg - current loaded settings - this is updated and also returned
+ * @param lockedFields - current locked fields
+ * @param commandLineArgs - new command-line args to be merged into `cfg` (error if the field is locked)
  * @return updated cfg
  */
 export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSettingsType, commandLineArgs: string[]): Settings {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -238,9 +238,8 @@ export function load(deploymentProfiles: DeploymentProfileType): Settings {
       // This means that we treat an empty hash defaults profile, or an empty registry hive,
       // as if there is no profile in place (for the purposes of setting the first-run entry).
 
-      _.merge(settings, deploymentProfiles.defaults);
+      _.merge(settings, deploymentProfiles.defaults, deploymentProfiles.locked);
       if (Object.keys(deploymentProfiles.defaults).length || Object.keys(deploymentProfiles.locked).length) {
-        // if there's a non-empty deployment profile, don't show the first-run dialog box (_isFirstRun is already false)
         if (!_.has(settings, 'virtualMachine.memoryInGB') && !_.has(deploymentProfiles.locked, 'virtualMachine.memoryInGB')) {
           setDefaultMemory = true;
         }
@@ -270,7 +269,6 @@ export function load(deploymentProfiles: DeploymentProfileType): Settings {
       console.log('updates disabled');
     }
   }
-  _.merge(settings, deploymentProfiles.locked);
   save(settings);
   lockedSettings = determineLockedFields(deploymentProfiles.locked);
 

--- a/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
@@ -5,118 +5,89 @@ import os from 'os';
 import path from 'path';
 
 import * as settings from '@pkg/config/settings';
-import { readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
+import {
+  readDeploymentProfiles,
+  lockableDefaultSettings, validateDeploymentProfile,
+} from '@pkg/main/deploymentProfiles';
 import { spawnFile } from '@pkg/utils/childProcess';
-import Logging from '@pkg/utils/logging';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
-// for some reason `import nativeReg...` => undefined when run in jest on Windows
-// import nativeReg from 'native-reg';
-const nativeReg = require('native-reg');
+const [describeWindows, describeNotWindows] = process.platform === 'win32' ? [describe, describe.skip] : [describe.skip, describe];
 
-const console = Logging.deploymentProfile;
+describe('deployment profiles', () => {
+  describeWindows('windows deployment profiles', () => {
+    // for some reason `import nativeReg...` => undefined when run in jest on Windows
+    // import nativeReg from 'native-reg';
+    const nativeReg = require('native-reg');
 
-// Note that we can't modify the HKLM hive without admin privileges,
-// so this whole test will just work with the user's HKCU hive.
-const REG_PATH_START = ['SOFTWARE', 'Rancher Desktop'];
-const FULL_REG_PATH_START = ['HKEY_CURRENT_USER'].concat(REG_PATH_START);
-const REGISTRY_PATH_PROFILE = REG_PATH_START.concat('TestProfile');
+    let testDir = '';
+    let regFilePath = '';
 
-const NON_PROFILE_PATH = FULL_REG_PATH_START.join('\\');
-const FULL_PROFILE_PATH = FULL_REG_PATH_START.concat('TestProfile').join('\\');
+    // Note that we can't modify the HKLM hive without admin privileges,
+    // so this whole test will just work with the user's HKCU hive.
+    const REG_PATH_START = ['SOFTWARE', 'Rancher Desktop'];
+    const FULL_REG_PATH_START = ['HKEY_CURRENT_USER'].concat(REG_PATH_START);
+    const REGISTRY_PATH_PROFILE = REG_PATH_START.concat('TestProfile');
 
-const describeWindows = process.platform === 'win32' ? describe : describe.skip;
+    const NON_PROFILE_PATH = FULL_REG_PATH_START.join('\\');
+    const FULL_PROFILE_PATH = FULL_REG_PATH_START.concat('TestProfile').join('\\');
+    const FULL_DEFAULTS_PATH = `${ FULL_PROFILE_PATH }\\Defaults`;
+    const FULL_DEFAULTS_PATH_IN_MESSAGE = `HKCU\\${ REG_PATH_START.join('\\') }\\TestProfile\\Defaults`;
 
-let testDir = '';
-let regFilePath = '';
+    // We *could* write a routine that converts json to reg files, but that's not the point of this test.
+    // Better to just hard-wire a few regfiles here.
 
-async function clearRegistry() {
-  try {
-    await spawnFile('reg', ['DELETE', `HKCU\\${ REGISTRY_PATH_PROFILE.join('\\') }`, '/f']);
-  } catch {
-    // Ignore any errors
-  }
-}
-
-async function installInRegistry(regFileContents: string) {
-  await fs.promises.writeFile(regFilePath, regFileContents, { encoding: 'ascii' });
-  try {
-    await spawnFile('reg', ['IMPORT', regFilePath]);
-  } catch (ex: any) {
-    // Use expect to display the error message
-    expect(ex).toBeNull();
-    throw ex;
-  }
-}
-
-// Registry multi-stringSZ settings in a reg file are hard to read, so expand them here.
-// e.g.=> ["abc", "def"] would be ucs-2-encoded as '61,00,62,00,63,00,00,00,64,00,65,00,66,00,00,00,00,00'
-// where null dwords (so two 00 bytes) separate each pair of words and
-// two null dwords ("00 00 00 00") indicate the end of the list
-function stringToMultiStringHexBytes(s: string[]): string {
-  const hexBytes = Buffer.from(s.join('\x00'), 'ucs2')
-    .toString('hex')
-    .split(/(..)/)
-    .filter(x => x)
-    .join(',');
-
-  return `${ hexBytes },00,00,00,00`;
-}
-
-// We *could* write a routine that converts json to reg files, but that's not the point of this test.
-// Better to just hard-wire a few regfiles here.
-
-const defaultsUserRegFile = `Windows Registry Editor Version 5.00
+    const defaultsUserRegFile = `Windows Registry Editor Version 5.00
 
 [${ NON_PROFILE_PATH }]
 
 [${ FULL_PROFILE_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults]
+[${ FULL_DEFAULTS_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application]
+[${ FULL_DEFAULTS_PATH }\\application]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application]
+[${ FULL_DEFAULTS_PATH }\\application]
 "Debug"=dword:1
 "adminAccess"=dword:0
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application\\Telemetry]
+[${ FULL_DEFAULTS_PATH }\\application\\Telemetry]
 "ENABLED"=dword:1
 
-[${ FULL_PROFILE_PATH }\\Defaults\\CONTAINERENGINE]
+[${ FULL_DEFAULTS_PATH }\\CONTAINERENGINE]
 "name"="moby"
 
-[${ FULL_PROFILE_PATH }\\Defaults\\containerEngine\\allowedImages]
+[${ FULL_DEFAULTS_PATH }\\containerEngine\\allowedImages]
 "patterns"=hex(7):${ stringToMultiStringHexBytes(['edmonton', 'calgary', 'red deer', 'bassano']) }
 "enabled"=dword:00000000
 
-[${ FULL_PROFILE_PATH }\\Defaults\\wsl]
+[${ FULL_DEFAULTS_PATH }\\wsl]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\wsl\\integrations]
+[${ FULL_DEFAULTS_PATH }\\wsl\\integrations]
 "kingston"=dword:0
 "napanee"=dword:0
 "yarker"=dword:1
 "weed"=dword:1
 
-[${ FULL_PROFILE_PATH }\\Defaults\\kubernetes]
+[${ FULL_DEFAULTS_PATH }\\kubernetes]
 "version"="867-5309"
 
-[${ FULL_PROFILE_PATH }\\Defaults\\diagnostics]
+[${ FULL_DEFAULTS_PATH }\\diagnostics]
 "showmuted"=dword:1
 
-[${ FULL_PROFILE_PATH }\\Defaults\\diagnostics\\mutedChecks]
+[${ FULL_DEFAULTS_PATH }\\diagnostics\\mutedChecks]
 "montreal"=dword:1
 "riviere du loup"=dword:0
 "magog"=dword:0
 
-[${ FULL_PROFILE_PATH }\\Defaults\\extensions]
+[${ FULL_DEFAULTS_PATH }\\extensions]
 "bellingham"="WA"
 "portland"="OR"
 "shasta"="CA"
 "elko"="NV"
 `;
 
-const lockedUserRegFile = `Windows Registry Editor Version 5.00
+    const lockedUserRegFile = `Windows Registry Editor Version 5.00
 
 [${ NON_PROFILE_PATH }]
 
@@ -131,187 +102,305 @@ const lockedUserRegFile = `Windows Registry Editor Version 5.00
 "patterns"=hex(7):${ stringToMultiStringHexBytes(['busybox', 'nginx']) }
 `;
 
-// Deliberate errors in defaults:
-// * Specifying application/updater=1 instead of application/updater/enabled=1
-// * Specifying application/adminAccess/debug=string when it should be 0 or 1
-// * application/debug should be a number, not a string
-// * containerEngine/name should be a string, not a number
-// * containerEngine/allowedImages/patterns should be a list of strings, not a number
-// * containerEngine/allowedImages/enabled should be a boolean, not a string
-// * images/namespace should be a single string, not a multi-SZ string value
-// * wsl/integrations should be a special-purpose object
-// * diagnostics/mutedChecks should be a special-purpose object
-// * kubernetes/version should be a string, not an object
+    // Deliberate errors in defaults:
+    // * Specifying application/updater=1 instead of application/updater/enabled=1
+    // * Specifying application/adminAccess/debug=string when it should be 0 or 1
+    // * application/debug should be a number, not a string
+    // * containerEngine/name should be a string, not a number
+    // * containerEngine/allowedImages/patterns should be a list of strings, not a number
+    // * containerEngine/allowedImages/enabled should be a boolean, not a string
+    // * images/namespace should be a single string, not a multi-SZ string value
+    // * wsl/integrations should be a special-purpose object
+    // * diagnostics/mutedChecks should be a special-purpose object
+    // * kubernetes/version should be a string, not an object
 
-const incorrectDefaultsUserRegFile = `Windows Registry Editor Version 5.00
+    const incorrectDefaultsUserRegFile = `Windows Registry Editor Version 5.00
 
 [${ NON_PROFILE_PATH }]
 
 [${ FULL_PROFILE_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults]
+[${ FULL_DEFAULTS_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application]
+[${ FULL_DEFAULTS_PATH }\\application]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application]
+[${ FULL_DEFAULTS_PATH }\\application]
 "Debug"="should be a number"
 "Updater"=dword:0
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application\\adminAccess]
+[${ FULL_DEFAULTS_PATH }\\application\\adminAccess]
 "sudo"=dword:1
 
-[${ FULL_PROFILE_PATH }\\Defaults\\application\\Telemetry]
+[${ FULL_DEFAULTS_PATH }\\application\\Telemetry]
 "ENABLED"=dword:1
 
-[${ FULL_PROFILE_PATH }\\Defaults\\CONTAINERENGINE]
+[${ FULL_DEFAULTS_PATH }\\CONTAINERENGINE]
 "name"=dword:5
 
-[${ FULL_PROFILE_PATH }\\Defaults\\containerEngine\\allowedImages]
-"patterns"=DWORD:19
+[${ FULL_DEFAULTS_PATH }\\containerEngine\\allowedImages]
+"patterns"=dword:19
 "enabled"="should be a boolean"
 
-[${ FULL_PROFILE_PATH }\\Defaults\\images]
+[${ FULL_DEFAULTS_PATH }\\images]
 "namespace"=hex(7):${ stringToMultiStringHexBytes(['busybox', 'nginx']) }
 
-[${ FULL_PROFILE_PATH }\\Defaults\\wsl]
+[${ FULL_DEFAULTS_PATH }\\wsl]
 "integrations"="should be a sub-object"
 
-[${ FULL_PROFILE_PATH }\\Defaults\\kubernetes]
+[${ FULL_DEFAULTS_PATH }\\kubernetes]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\kubernetes\\version]
+[${ FULL_DEFAULTS_PATH }\\kubernetes\\version]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\diagnostics]
+[${ FULL_DEFAULTS_PATH }\\diagnostics]
 "showmuted"=dword:1
 "mutedChecks"=dword:42
 `;
 
-const arrayFromSingleStringDefaultsUserRegFile = `Windows Registry Editor Version 5.00
+    const arrayFromSingleStringDefaultsUserRegFile = `Windows Registry Editor Version 5.00
 
 [${ NON_PROFILE_PATH }]
 
 [${ FULL_PROFILE_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults]
+[${ FULL_DEFAULTS_PATH }]
 
-[${ FULL_PROFILE_PATH }\\Defaults\\CONTAINERENGINE]
+[${ FULL_DEFAULTS_PATH }\\CONTAINERENGINE]
 "name"="moby"
 
-[${ FULL_PROFILE_PATH }\\Defaults\\containerEngine\\allowedImages]
+[${ FULL_DEFAULTS_PATH }\\containerEngine\\allowedImages]
 "patterns"="hokey smoke!"
 `;
 
-describeWindows('windows deployment profiles', () => {
-  /* Mock console.error() to capture error messages. */
-  let consoleMock: jest.SpyInstance<void, [message?: any, ...optionalArgs: any[]]>;
+    async function clearRegistry() {
+      try {
+        await spawnFile('reg', ['DELETE', `HKCU\\${ REGISTRY_PATH_PROFILE.join('\\') }`, '/f']);
+      } catch {
+        // Ignore any errors
+      }
+    }
 
-  beforeEach(async() => {
-    nativeReg.deleteTree(nativeReg.HKCU, path.join(...(REGISTRY_PATH_PROFILE)));
-    testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'regtest-'));
-    regFilePath = path.join(testDir, 'import.reg');
-    consoleMock = jest.spyOn(console, 'error');
-  });
-  afterEach(async() => {
-    await fs.promises.rm(testDir, { force: true, recursive: true });
-    consoleMock.mockReset();
-  });
-  // TODO:  Add an `afterAll(clearRegistry)` when we're finished developing.
+    async function installInRegistry(regFileContents: string) {
+      await fs.promises.writeFile(regFilePath, regFileContents, { encoding: 'ascii' });
+      try {
+        await spawnFile('reg', ['IMPORT', regFilePath]);
+      } catch (ex: any) {
+        // Use expect to display the error message
+        expect(ex).toBeNull();
+      }
+    }
 
-  describe('profile', () => {
-    describe('defaults', () => {
-      describe('happy paths', () => {
-        const defaultUserProfile: RecursivePartial<settings.Settings> = {
-          application: {
-            debug:       true,
-            adminAccess: false,
-            telemetry:   { enabled: true },
-          },
-          containerEngine: {
-            allowedImages: {
-              enabled:  false,
-              patterns: ['edmonton', 'calgary', 'red deer', 'bassano'],
+    // Registry multi-stringSZ settings in a reg file are hard to read, so expand them here.
+    // e.g.=> ["abc", "def"] would be ucs-2-encoded as '61,00,62,00,63,00,00,00,64,00,65,00,66,00,00,00,00,00'
+    // where a null 16-bit word (so two 00 bytes) separate each pair of words and
+    // two null 16-bit words ("00 00 00 00") indicate the end of the list
+    function stringToMultiStringHexBytes(s: string[]): string {
+      const hexBytes = Buffer.from(s.join('\x00'), 'ucs2')
+        .toString('hex')
+        .split(/(..)/)
+        .filter(x => x)
+        .join(',');
+
+      return `${ hexBytes },00,00,00,00`;
+    }
+
+    beforeEach(async() => {
+      nativeReg.deleteTree(nativeReg.HKCU, path.join(...(REGISTRY_PATH_PROFILE)));
+      testDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'regtest-'));
+      regFilePath = path.join(testDir, 'import.reg');
+    });
+    afterEach(async() => {
+      await fs.promises.rm(testDir, { force: true, recursive: true });
+    });
+    // TODO:  Add an `afterAll(clearRegistry)` when we're finished developing.
+
+    describe('profile', () => {
+      describe('defaults', () => {
+        describe('happy paths', () => {
+          const defaultUserProfile: RecursivePartial<settings.Settings> = {
+            application: {
+              debug:       true,
+              adminAccess: false,
+              telemetry:   { enabled: true },
             },
-            name: settings.ContainerEngine.MOBY,
-          },
-          WSL:        { integrations: { kingston: false, napanee: false, yarker: true, weed: true } },
-          kubernetes: {
-            version: '867-5309',
-          },
-          diagnostics: {
-            showMuted:   true,
-            mutedChecks: { montreal: true, 'riviere du loup': false, magog: false },
-          },
-          extensions: { bellingham: 'WA', portland: 'OR', shasta: 'CA', elko: 'NV' },
-        };
-        const lockedUserProfile = {
-          containerEngine: {
-            allowedImages: {
-              enabled:  false,
-              patterns: ['busybox', 'nginx'],
+            containerEngine: {
+              allowedImages: {
+                enabled:  false,
+                patterns: ['edmonton', 'calgary', 'red deer', 'bassano'],
+              },
+              name: settings.ContainerEngine.MOBY,
             },
-          },
-        };
+            WSL: {
+              integrations: {
+                kingston: false,
+                napanee:  false,
+                yarker:   true,
+                weed:     true,
+              },
+            },
+            kubernetes: {
+              version: '867-5309',
+            },
+            diagnostics: {
+              showMuted:   true,
+              mutedChecks: {
+                montreal:          true,
+                'riviere du loup': false,
+                magog:             false,
+              },
+            },
+            extensions: {
+              bellingham: 'WA',
+              portland:   'OR',
+              shasta:     'CA',
+              elko:       'NV',
+            },
+          };
+          const lockedUserProfile = {
+            containerEngine: {
+              allowedImages: {
+                enabled:  false,
+                patterns: ['busybox', 'nginx'],
+              },
+            },
+          };
 
-        describe('no system profiles, no user profiles', () => {
-          it('loads nothing', async() => {
-            const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
+          describe('no system profiles, no user profiles', () => {
+            it('loads nothing', async() => {
+              const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
 
-            expect(profile.defaults).toEqual({});
-            expect(profile.locked).toEqual({});
+              expect(profile.defaults).toEqual({});
+              expect(profile.locked).toEqual({});
+            });
           });
-        });
 
-        describe('no system profiles, both user profiles', () => {
-          it('loads both profiles', async() => {
+          describe('no system profiles, both user profiles', () => {
+            it('loads both profiles', async() => {
+              await clearRegistry();
+              await installInRegistry(defaultsUserRegFile);
+              await installInRegistry(lockedUserRegFile);
+              const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
+
+              expect(profile.defaults).toEqual(defaultUserProfile);
+              expect(profile.locked).toEqual(lockedUserProfile);
+            });
+          });
+
+          it('converts a single string into an array', async() => {
             await clearRegistry();
-            await installInRegistry(defaultsUserRegFile);
-            await installInRegistry(lockedUserRegFile);
+            await installInRegistry(arrayFromSingleStringDefaultsUserRegFile);
             const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
 
-            expect(profile.defaults).toEqual(defaultUserProfile);
-            expect(profile.locked).toEqual(lockedUserProfile);
+            expect(profile.defaults).toEqual({
+              containerEngine: { allowedImages: { patterns: ['hokey smoke!'] }, name: 'moby' },
+            });
           });
         });
+        describe('error paths', () => {
+          it('loads a bad profile, complains about all the errors, and keeps only valid entries', async() => {
+            await clearRegistry();
+            await installInRegistry(incorrectDefaultsUserRegFile);
+            const expectedErrors = [
+              `application\\adminAccess': expecting value of type boolean, got a registry object`,
+              `application\\Debug': expecting value of type boolean, got '"should be a number"'`,
+              `application\\Updater': expecting value of type object, got a DWORD, value: '0'`,
+              `containerEngine\\allowedImages\\patterns': expecting value of type array, got '25'`,
+              `containerEngine\\allowedImages\\enabled': expecting value of type boolean, got '"should be a boolean"'`,
+              `containerEngine\\name': expecting value of type string, got '5'`,
+              `diagnostics\\mutedChecks': expecting value of type object, got a DWORD, value: '66'`,
+              `images\\namespace': expecting value of type string, got an array '["busybox","nginx"]'`,
+              `kubernetes\\version': expecting value of type string, got a registry object`,
+              `WSL\\integrations': expecting value of type object, got a SZ, value: '"should be a sub-object"'`,
+            ].map(s => `Error for field '${ FULL_DEFAULTS_PATH_IN_MESSAGE }\\${ s }`);
+            let error: Error | undefined;
 
-        it('converts a single string into an array', async() => {
-          await clearRegistry();
-          await installInRegistry(arrayFromSingleStringDefaultsUserRegFile);
-          const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
-
-          expect(profile.defaults).toEqual({
-            containerEngine: { allowedImages: { patterns: ['hokey smoke!'] }, name: 'moby' },
+            try {
+              await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
+            } catch (ex: any) {
+              error = ex;
+            }
+            expect(error).toBeInstanceOf(Error);
+            expectedErrors.unshift('Error in registry settings:');
+            expect((error?.message ?? '').split('\n')).toEqual(expect.arrayContaining(expectedErrors));
           });
         });
       });
-      describe('error paths', () => {
-        const limitedUserProfile = {
-          application: {
-            telemetry: { enabled: true },
-          },
-          diagnostics: {
-            showMuted: true,
-          },
-        };
+    });
+  });
 
-        it('loads a bad profile, complains about all the errors, and keeps only valid entries', async() => {
-          await clearRegistry();
-          await installInRegistry(incorrectDefaultsUserRegFile);
-          const profile = await readDeploymentProfiles(REGISTRY_PATH_PROFILE);
+  describeNotWindows('non-windows deployment profiles', () => {
+    const invalidDefaultProfile = {
+      application: {
+        debug:                  'should be a boolean',
+        updater:                0,
+        pathManagementStrategy: 'goose',
+        adminAccess:            {
+          sudo: true,
+        },
+      },
+      containerEngine: {
+        name:          5,
+        allowedImages: {
+          patterns: 19,
+          enabled:  'should be a boolean',
+        },
+      },
+      images: {
+        namespace: ['busybox', 'nginx'],
+      },
+      kubernetes: {
+        port: {
+          zoo: ['possums', 'snakes', 'otters'],
+        },
+        version: { },
+        enabled: -7,
+      },
+      diagnostics: {
+        showMuted:   [true],
+        mutedChecks: 'should be an object',
+      },
+    };
 
-          expect(profile.defaults).toEqual(limitedUserProfile);
-          // Remember that sub-objects are processed before values
-          expect(consoleMock.mock.calls).toEqual([
-            [expect.stringMatching(/Expecting registry entry .*?application.adminAccess to be a boolean, but it's a registry object/)],
-            [expect.stringMatching(/Expecting registry entry .*?application.Debug to be a boolean, but it's a SZ/)],
-            [expect.stringMatching(/Expecting registry entry .*?application.Updater to be a registry object, but it's a DWORD, value: 0/)],
-            [expect.stringMatching(/Expecting registry entry .*?containerEngine.allowedImages.enabled to be a boolean, but it's a SZ, value: should be a boolean/)],
-            [expect.stringMatching(/Expecting registry entry .*?containerEngine.name to be a string, but it's a DWORD, value: 5/)],
-            [expect.stringMatching(/Expecting registry entry .*?diagnostics.mutedChecks to be a registry object, but it's a DWORD, value: 66/)],
-            [expect.stringMatching(/Expecting registry entry .*?images.namespace to be a single string, but it's an array of strings, value: busybox,nginx/)],
-            [expect.stringMatching(/Expecting registry entry .*?kubernetes.version to be a string, but it's a registry object/)],
-            [expect.stringMatching(/Expecting registry entry .*?WSL.integrations to be a registry object, but it's a SZ, value: should be a sub-object/)],
-          ]);
-        });
-      });
+    test('complains about invalid default values', () => {
+      const expectedErrors = [
+        'Error in deployment file fake default profile:',
+        `Error for field 'application.debug': expecting value of type boolean, got '"should be a boolean"'`,
+        `Error for field 'application.updater': expecting value of type object, got '0'`,
+        `Error for field 'application.adminAccess': expecting value of type boolean, got '{"sudo":true}'`,
+        `Error for field 'containerEngine.name': expecting value of type string, got '5'`,
+        `Error for field 'containerEngine.allowedImages.patterns': expecting value of type array, got '19'`,
+        `Error for field 'containerEngine.allowedImages.enabled': expecting value of type boolean, got '"should be a boolean"'`,
+        `Error for field 'images.namespace': expecting value of type string, got an array ["busybox","nginx"]`,
+        `Error for field 'kubernetes.port': expecting value of type number, got '{"zoo":["possums","snakes","otters"]}'`,
+        `Error for field 'kubernetes.version': expecting value of type string, got '{}'`,
+        `Error for field 'kubernetes.enabled': expecting value of type boolean, got '-7'`,
+        `Error for field 'diagnostics.showMuted': expecting value of type boolean, got an array [true]`,
+        `Error for field 'diagnostics.mutedChecks': expecting value of type object, got '"should be an object"'`,
+      ];
+      let error: Error | undefined;
+
+      try {
+        validateDeploymentProfile('fake default profile', invalidDefaultProfile, settings.defaultSettings, []);
+      } catch (ex: any) {
+        error = ex;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect((error?.message ?? '').split('\n')).toEqual(expect.arrayContaining(expectedErrors));
+    });
+    test('complains about invalid locked settings', () => {
+      const expectedErrors = [
+        'Error in deployment file fake locked profile:',
+        `Error for field 'containerEngine.allowedImages.patterns': expecting value of type array, got '19'`,
+        `Error for field 'containerEngine.allowedImages.enabled': expecting value of type boolean, got '"should be a boolean"'`,
+      ];
+      let error: Error | undefined;
+
+      try {
+        validateDeploymentProfile('fake locked profile', invalidDefaultProfile, lockableDefaultSettings, []);
+      } catch (ex: any) {
+        error = ex;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect((error?.message ?? '').split('\n')).toEqual(expect.arrayContaining(expectedErrors));
     });
   });
 });


### PR DESCRIPTION
Fixes #4159

The profile reader does syntactic validation (quietly removing unrecognizing fields), and quietly removing fields that are the wrong type.

It should probably complain about different types, or let the standard validator do that.