### PR TITLE
RDX: Implement protocol handler

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -41,7 +41,7 @@ import { isDevEnv } from '@pkg/utils/environment';
 import { arrayCustomizer } from '@pkg/utils/filters';
 import Logging, { setLogLevel, clearLoggingDirectory } from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
-import { setupProtocolHandler, protocolRegistered } from '@pkg/utils/protocols';
+import { setupProtocolHandlers, protocolsRegistered } from '@pkg/utils/protocols';
 import { executable } from '@pkg/utils/resources';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
@@ -105,7 +105,7 @@ process.on('unhandledRejection', (reason: any, promise: any) => {
 });
 
 Electron.app.on('second-instance', async() => {
-  await protocolRegistered;
+  await protocolsRegistered;
   console.warn('A second instance was started');
   if (firstRunDialogComplete) {
     window.openMain();
@@ -145,11 +145,19 @@ mainEvents.handle('settings-fetch', () => {
   return Promise.resolve(cfg);
 });
 
+Electron.protocol.registerSchemesAsPrivileged([{ scheme: 'app' }, {
+  scheme:     'x-rd-extension',
+  privileges: {
+    standard:        true,
+    supportFetchAPI: true,
+  },
+}]);
+
 Electron.app.whenReady().then(async() => {
   try {
     const commandLineArgs = getCommandLineArgs();
 
-    setupProtocolHandler();
+    setupProtocolHandlers();
 
     // Needs to happen before any file is written, otherwise that file
     // could be owned by root, which will lead to future problems.
@@ -448,7 +456,7 @@ Electron.app.on('activate', async() => {
 
     return;
   }
-  await protocolRegistered;
+  await protocolsRegistered;
   window.openMain();
 });
 

--- a/e2e/extensions-protocol.e2e.spec.ts
+++ b/e2e/extensions-protocol.e2e.spec.ts
@@ -8,7 +8,9 @@ import path from 'path';
 import { ElectronApplication, Page, test, expect } from '@playwright/test';
 
 import { NavPage } from './pages/nav-page';
-import { createDefaultSettings, retry, startRancherDesktop, teardown } from './utils/TestUtils';
+import {
+  createDefaultSettings, getResourceBinDir, retry, startRancherDesktop, teardown,
+} from './utils/TestUtils';
 
 import { ContainerEngine, Settings } from '@pkg/config/settings';
 import { spawnFile } from '@pkg/utils/childProcess';
@@ -42,7 +44,14 @@ test.describe.serial('Extensions protocol handler', () => {
       }
     }
 
-    return await spawnFile(tool, args, { stdio: 'pipe' });
+    return await spawnFile(tool, args,
+      {
+        stdio: 'pipe',
+        env:   {
+          ...process.env,
+          PATH: `${ process.env.PATH }${ path.delimiter }${ getResourceBinDir() }`,
+        },
+      });
   }
 
   test.beforeAll(async() => {

--- a/e2e/extensions-protocol.e2e.spec.ts
+++ b/e2e/extensions-protocol.e2e.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * This tests the extension protocol handler.
+ * An E2E test is required to have access to the web page context.
+ */
+
+import path from 'path';
+
+import { ElectronApplication, Page, test, expect } from '@playwright/test';
+
+import { NavPage } from './pages/nav-page';
+import { createDefaultSettings, retry, startRancherDesktop, teardown } from './utils/TestUtils';
+
+import { ContainerEngine, Settings } from '@pkg/config/settings';
+import { spawnFile } from '@pkg/utils/childProcess';
+
+/** The top level source directory, assuming we're always from the tree */
+const srcDir = path.dirname(path.dirname(__filename));
+const rdctl = executable('rdctl');
+
+/**
+ * Get the given executable. Similar to @pkg/utils/resources, but does not use
+ * Electron.app (which doesn't work during the test).
+ */
+function executable(name: string) {
+  const exeName = name + (process.platform === 'win32' ? '.exe' : '');
+
+  return path.join(srcDir, 'resources', process.platform, 'bin', exeName);
+}
+
+test.describe.serial('Extensions protocol handler', () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let isContainerd = false;
+
+  async function ctrctl(...args: string[]) {
+    let tool = executable('nerdctl');
+
+    if (!isContainerd) {
+      tool = executable('docker');
+      args = ['--context', 'rancher-desktop'].concat(args);
+    }
+
+    return await spawnFile(tool, args, { stdio: 'pipe' });
+  }
+
+  test.beforeAll(async() => {
+    createDefaultSettings();
+    app = await startRancherDesktop(__filename, { mock: false });
+    page = await app.firstWindow();
+  });
+
+  test.afterAll(() => teardown(app, __filename));
+
+  test('should load backend', async() => {
+    await (new NavPage(page)).progressBecomesReady();
+  });
+
+  test('determine container engine in use', async() => {
+    const { stdout } = await spawnFile(rdctl, ['list-settings'], { stdio: 'pipe' });
+    const settings: Settings = JSON.parse(stdout);
+
+    expect(settings.containerEngine.name).toMatch(/^(?:containerd|moby)$/);
+    isContainerd = settings.containerEngine.name === ContainerEngine.CONTAINERD;
+  });
+
+  test('wait for buildkit', async() => {
+    test.skip(!isContainerd, 'Not running containerd, no need to wait for buildkit');
+
+    await retry(() => spawnFile(rdctl, ['shell', 'buildctl', 'debug', 'info']));
+  });
+
+  test('build and install testing extension', async() => {
+    const dataDir = path.join(srcDir, 'bats', 'tests', 'extensions', 'testdata');
+
+    await ctrctl('build', '--tag', 'rd/extension/ui', '--build-arg', 'variant=ui', dataDir);
+    await spawnFile(rdctl, ['api', '-XPOST', '/v1/extensions/install?id=rd/extension/ui']);
+  });
+
+  test('use extension protocol handler', async() => {
+    const result = await page.evaluate(async() => {
+      const data = await fetch('x-rd-extension://72642f657874656e73696f6e2f7569/dashboard-tab/ui/index.html');
+
+      return await data.text();
+    });
+
+    expect(result).toContain('ddClient');
+  });
+});

--- a/e2e/extensions-protocol.e2e.spec.ts
+++ b/e2e/extensions-protocol.e2e.spec.ts
@@ -15,7 +15,7 @@ import {
 import { ContainerEngine, Settings } from '@pkg/config/settings';
 import { spawnFile } from '@pkg/utils/childProcess';
 
-/** The top level source directory, assuming we're always from the tree */
+/** The top level source directory, assuming we're always running from the tree */
 const srcDir = path.dirname(path.dirname(__filename));
 const rdctl = executable('rdctl');
 
@@ -77,6 +77,8 @@ test.describe.serial('Extensions protocol handler', () => {
   test('wait for buildkit', async() => {
     test.skip(!isContainerd, 'Not running containerd, no need to wait for buildkit');
 
+    // `buildctl debug info` talks to the backend (to fetch info about it), so
+    // if it succeeds it means the backend is up and can respond to requests.
     await retry(() => spawnFile(rdctl, ['shell', 'buildctl', 'debug', 'info']));
   });
 

--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -80,7 +80,7 @@ test.describe('Locked fields', () => {
       { containerEngine: { allowedImages: { enabled: true } } },
       { containerEngine: { allowedImages: { enabled: true } } },
     );
-    electronApp = await startRancherDesktop(__filename, true);
+    electronApp = await startRancherDesktop(__filename);
     context = electronApp.context();
 
     await context.tracing.start({

--- a/e2e/quit-on-close.e2e.spec.ts
+++ b/e2e/quit-on-close.e2e.spec.ts
@@ -15,7 +15,7 @@ test.describe.serial('quitOnClose setting', () => {
 
   test('should quit when quitOnClose is true and window is closed', async() => {
     createDefaultSettings({ application: { window: { quitOnClose: true } } });
-    const electronApp = await startRancherDesktop(__filename, false);
+    const electronApp = await startRancherDesktop(__filename, { tracing: false });
 
     await electronApp.firstWindow();
 
@@ -24,7 +24,7 @@ test.describe.serial('quitOnClose setting', () => {
 
   test('should not quit when quitOnClose is false and window is closed', async() => {
     createDefaultSettings({ application: { window: { quitOnClose: false } } });
-    const electronApp = await startRancherDesktop(__filename, true);
+    const electronApp = await startRancherDesktop(__filename);
 
     await electronApp.firstWindow();
 

--- a/e2e/start-in-background.e2e.spec.ts
+++ b/e2e/start-in-background.e2e.spec.ts
@@ -15,7 +15,7 @@ test.describe.serial('startInBackground setting', () => {
 
   test('window should appear when startInBackground is false', async() => {
     createDefaultSettings({ application: { startInBackground: false } });
-    const electronApp = await startRancherDesktop(__filename, true);
+    const electronApp = await startRancherDesktop(__filename);
 
     await expect(checkWindowOpened(electronApp)).resolves.toBe(true);
     const tracePath = path.join(__dirname, 'reports', `${ path.basename(__filename) }-startInBackgroundFalse.zip`);
@@ -26,7 +26,7 @@ test.describe.serial('startInBackground setting', () => {
 
   test('window should not appear when startInBackground is true', async() => {
     createDefaultSettings({ application: { startInBackground: true } });
-    const electronApp = await startRancherDesktop(__filename, true);
+    const electronApp = await startRancherDesktop(__filename);
 
     await expect(checkWindowOpened(electronApp)).resolves.toBe(false);
     const tracePath = path.join(__dirname, 'reports', `${ path.basename(__filename) }-startInBackgroundTrue.zip`);

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -158,11 +158,16 @@ export async function tearDownHelm() {
   await kubectl('delete', 'deploy', 'nginx-sample', '--namespace', 'default');
 }
 
-export function getFullPathForTool(tool: string): string {
+export function getResourceBinDir(): string {
   const srcDir = path.dirname(__dirname);
+
+  return path.join(srcDir, '..', 'resources', os.platform(), 'bin');
+}
+
+export function getFullPathForTool(tool: string): string {
   const filename = os.platform().startsWith('win') ? `${ tool }.exe` : tool;
 
-  return path.join(srcDir, '..', 'resources', os.platform(), 'bin', filename);
+  return path.join(getResourceBinDir(), filename);
 }
 
 /**

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -70,6 +70,7 @@ export function createDefaultSettings(overrides: RecursivePartial<Settings> = {}
     application: {
       debug:                  true,
       pathManagementStrategy: PathManagementStrategy.Manual,
+      startInBackground:      false,
     },
   };
   const settingsData: Settings = _.merge({}, defaultSettings, defaultOverrides, overrides);

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -230,9 +230,10 @@ export async function retry<T>(proc: () => Promise<T>, options?: { delay?: numbe
  * Run Rancher Desktop; return promise that resolves to commonly-used
  * playwright objects when it has started.
  * @param testPath The path to the test file.
- * @param tracing Whether to start tracing.
+ * @param options.tracing Whether to start tracing (defaults to true).
+ * @param options.mock Whether to use the mock backend (defaults to true).
  */
-export async function startRancherDesktop(testPath: string, tracing: boolean): Promise<ElectronApplication> {
+export async function startRancherDesktop(testPath: string, options?: { tracing?: boolean, mock?: boolean }): Promise<ElectronApplication> {
   const electronApp = await _electron.launch({
     args: [
       path.join(__dirname, '../../'),
@@ -244,12 +245,12 @@ export async function startRancherDesktop(testPath: string, tracing: boolean): P
     ],
     env: {
       ...process.env,
-      RD_LOGS_DIR:     reportAsset(testPath, 'log'),
-      RD_MOCK_BACKEND: '1',
+      RD_LOGS_DIR: reportAsset(testPath, 'log'),
+      ...options?.mock ?? true ? { RD_MOCK_BACKEND: '1' } : {},
     },
   });
 
-  if (tracing) {
+  if (options?.tracing ?? true) {
     await electronApp.context().tracing.start({ screenshots: true, snapshots: true });
   }
 

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1547,7 +1547,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         proc.on('error', reject);
         proc.on('exit', (code, signal) => {
           if (code || signal) {
-            return reject(`Failed to read ${ filePath }: /bin/cat exited with ${ code || signal }`);
+            return reject(new Error(`Failed to read ${ filePath }: /bin/cat exited with ${ code || signal }`));
           }
           resolve();
         });

--- a/pkg/rancher-desktop/utils/protocols.ts
+++ b/pkg/rancher-desktop/utils/protocols.ts
@@ -92,7 +92,7 @@ function setupAppProtocolHandler() {
  * Set up protocol handler for x-rd-extension://
  *
  * This handler is used for extensions; the format is:
- * x-rd-extensions://<extension id>/...
+ * x-rd-extension://<extension id>/...
  * Where the extension id is the extension image id, hex encoded (to avoid
  * issues with slashes).  Base64 was not available in Vue.
  */

--- a/pkg/rancher-desktop/utils/protocols.ts
+++ b/pkg/rancher-desktop/utils/protocols.ts
@@ -8,7 +8,7 @@ import Latch from '@pkg/utils/latch';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 
-const console = Logging.background;
+const console = Logging['protocol-handler'];
 
 /**
  * Create a URL that consists of a base combined with the provided path

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -72,7 +72,7 @@ export function createWindow(name: string, url: string, options: Electron.Browse
   }
 
   const isInternalURL = (url: string) => {
-    return url.startsWith(`${ webRoot }/`);
+    return url.startsWith(`${ webRoot }/`) || url.startsWith('x-rd-extension://');
   };
 
   window = new BrowserWindow(options);
@@ -93,7 +93,7 @@ export function createWindow(name: string, url: string, options: Electron.Browse
     return { action: 'deny' };
   });
   window.webContents.on('did-fail-load', (event, errorCode, errorDescription, url) => {
-    console.log(`Failed to load ${ url }: ${ errorCode } (${ errorDescription })`);
+    console.log(`Failed to load ${ url }: ${ errorCode } (${ errorDescription })`, event);
   });
   console.debug('createWindow() name:', name, ' url:', url);
   window.loadURL(url);


### PR DESCRIPTION
This implements a protocol handler so that the frontend may show any extension UI requested (once the user clicks on whatever UI to do so).

Comes with E2E test where we `fetch()` something over the protocol to make sure it works.

Fixes #4157.