### PR TITLE
Change the location and name of the linux deployment profile files.

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -29,7 +29,7 @@ export async function createUserProfile(userProfile: RecursivePartial<Settings>|
 }
 
 async function createLinuxUserProfile(userProfile: RecursivePartial<Settings>|null, lockedFields:LockedSettingsType|null) {
-  const userProfilePath = path.join(paths.deploymentProfileUser, 'rancher-desktop.profile.json');
+  const userProfilePath = path.join(paths.deploymentProfileUser, 'rancher-desktop.defaults.json');
   const userLocksPath = path.join(paths.deploymentProfileUser, 'rancher-desktop.locked.json');
 
   if (userProfile && Object.keys(userProfile).length > 0) {

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -29,8 +29,8 @@ export async function createUserProfile(userProfile: RecursivePartial<Settings>|
 }
 
 async function createLinuxUserProfile(userProfile: RecursivePartial<Settings>|null, lockedFields:LockedSettingsType|null) {
-  const userProfilePath = path.join(paths.deploymentProfileUser, 'profile.json');
-  const userLocksPath = path.join(paths.deploymentProfileUser, 'locked.json');
+  const userProfilePath = path.join(paths.deploymentProfileUser, 'rancher-desktop.profile.json');
+  const userLocksPath = path.join(paths.deploymentProfileUser, 'rancher-desktop.locked.json');
 
   if (userProfile && Object.keys(userProfile).length > 0) {
     await fs.promises.writeFile(userProfilePath, JSON.stringify(userProfile, undefined, 2));

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -43,6 +43,10 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
     defaults: {},
     locked:   {},
   };
+  const linuxPaths = {
+    [paths.deploymentProfileSystem]: ['defaults.json', 'locked.json'],
+    [paths.deploymentProfileUser]:   ['rancher-desktop.defaults.json', 'rancher-desktop.locked.json'],
+  };
 
   switch (os.platform()) {
   case 'win32':
@@ -81,9 +85,10 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
     }
     break;
   case 'linux':
-    for (const rootPath of [paths.deploymentProfileSystem, paths.deploymentProfileUser]) {
-      profiles = readProfileFiles(rootPath, 'rancher-desktop.defaults.json', 'rancher-desktop.locked.json', JSON);
+    for (const configDir in linuxPaths) {
+      const basenames = linuxPaths[configDir];
 
+      profiles = readProfileFiles(configDir, basenames[0], basenames[1], JSON);
       if (typeof profiles.defaults !== 'undefined' || typeof profiles.locked !== 'undefined') {
         break;
       }

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -86,9 +86,9 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
     break;
   case 'linux':
     for (const configDir in linuxPaths) {
-      const basenames = linuxPaths[configDir];
+      const [defaults, locked] = linuxPaths[configDir];
 
-      profiles = readProfileFiles(configDir, basenames[0], basenames[1], JSON);
+      profiles = readProfileFiles(configDir, defaults, locked, JSON);
       if (typeof profiles.defaults !== 'undefined' || typeof profiles.locked !== 'undefined') {
         break;
       }

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -82,7 +82,7 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
     break;
   case 'linux':
     for (const rootPath of [paths.deploymentProfileSystem, paths.deploymentProfileUser]) {
-      profiles = readProfileFiles(rootPath, 'defaults.json', 'locked.json', JSON);
+      profiles = readProfileFiles(rootPath, 'rancher-desktop.defaults.json', 'rancher-desktop.locked.json', JSON);
 
       if (typeof profiles.defaults !== 'undefined' || typeof profiles.locked !== 'undefined') {
         break;

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -85,7 +85,7 @@ describe('paths', () => {
     },
     deploymentProfileUser: {
       win32:  new Error('Windows profiles will be read from Registry'),
-      linux:  '%HOME%/.config/rancher-desktop',
+      linux:  '%HOME%/.config',
       darwin: '%HOME%/Library/Preferences',
     },
     extensionRoot: {

--- a/pkg/rancher-desktop/utils/paths.ts
+++ b/pkg/rancher-desktop/utils/paths.ts
@@ -129,7 +129,7 @@ export class LinuxPaths extends ProvidesResources implements Paths {
   readonly integration = path.join(this.altAppHome, 'bin');
   readonly oldIntegration = path.join(os.homedir(), '.local', 'bin');
   readonly deploymentProfileSystem = path.join('/etc', APP_NAME);
-  readonly deploymentProfileUser = path.join(this.configHome, APP_NAME);
+  readonly deploymentProfileUser = path.join(this.configHome);
   readonly extensionRoot = path.join(this.dataHome, APP_NAME, 'extensions');
 
   get wslDistro(): string {


### PR DESCRIPTION
They can't go in `~/.config/rancher-desktop` because they need to survive factory-resets (and uninstalls).