### PR TITLE
Exclude limactl-*.tgz from electron builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,6 +6,7 @@ asar: true
 extraResources:
 - resources/
 - '!resources/darwin/lima-*.tgz'
+- '!resources/darwin/limactl-*.tgz'
 - '!resources/linux/lima-*.tgz'
 - '!resources/host/'
 files:


### PR DESCRIPTION
The file contains the Ventura version of limactl. The tarball is already unpacked, so doesn't need to be included in the packaged build. It also breaks notarization on macOS because the binary inside the tarball is not signed.