### PR TITLE
Perserve SSH_AUTH_SOCK env variable for nerdctl

### DIFF
--- a/resources/darwin/bin/nerdctl
+++ b/resources/darwin/bin/nerdctl
@@ -11,5 +11,5 @@ if ! LIMA_HOME="$HOME/Library/Application Support/rancher-desktop/lima" "${scrip
   echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
   exit 1
 else
-  "${scriptdir}/rdctl" shell sudo nerdctl "$@"
+  "${scriptdir}/rdctl" shell sudo --preserve-env=SSH_AUTH_SOCK nerdctl "$@"
 fi

--- a/resources/linux/bin/nerdctl
+++ b/resources/linux/bin/nerdctl
@@ -14,6 +14,6 @@ else
     echo "Rancher Desktop is not running. Please start Rancher Desktop to use nerdctl";
     exit 1
   else
-    "${scriptdir}/rdctl" shell sudo nerdctl "$@"
+    "${scriptdir}/rdctl" shell sudo --preserve-env=SSH_AUTH_SOCK nerdctl "$@"
   fi
 fi


### PR DESCRIPTION
`SSH_AUTH_SOCK` is only set in the user's environment, but `nerdctl` runs as `root`. This change is required so you can use

    nerdctl run --ssh default ...

instead of

    nerdctl run --ssh default=/run/host-services/ssh-auth.sock ...

All assuming you have enabled ssh agent forwarding in Lima.

See also #2072