### PR TITLE
The Linux paths should be set only when running on Linux.

### DIFF
--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -43,10 +43,6 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
     defaults: {},
     locked:   {},
   };
-  const linuxPaths = {
-    [paths.deploymentProfileSystem]: ['defaults.json', 'locked.json'],
-    [paths.deploymentProfileUser]:   ['rancher-desktop.defaults.json', 'rancher-desktop.locked.json'],
-  };
 
   switch (os.platform()) {
   case 'win32':
@@ -84,7 +80,12 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
       }
     }
     break;
-  case 'linux':
+  case 'linux': {
+    const linuxPaths = {
+      [paths.deploymentProfileSystem]: ['defaults.json', 'locked.json'],
+      [paths.deploymentProfileUser]:   ['rancher-desktop.defaults.json', 'rancher-desktop.locked.json'],
+    };
+
     for (const configDir in linuxPaths) {
       const [defaults, locked] = linuxPaths[configDir];
 
@@ -93,6 +94,7 @@ export function readDeploymentProfiles(): settings.DeploymentProfileType {
         break;
       }
     }
+  }
     break;
   case 'darwin':
     for (const rootPath of [paths.deploymentProfileSystem, paths.deploymentProfileUser]) {


### PR DESCRIPTION
Fixes #4233

This fixes an exception when run on Windows.