### PR TITLE
Stop stomping on the background.log file from the renderer process.

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -12,7 +12,7 @@ import paths from '@pkg/utils/paths';
 import { CommandOrControl, Shortcuts } from '@pkg/utils/shortcuts';
 import { openPreferences } from '@pkg/window/preferences';
 
-const console = Logging[`window_${ process.type || 'main' }`];
+const console = Logging[`window_${ process.type || 'unknown' }`];
 
 /**
  * A mapping of window key (which is our own construct) to a window ID (which is

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -12,7 +12,7 @@ import paths from '@pkg/utils/paths';
 import { CommandOrControl, Shortcuts } from '@pkg/utils/shortcuts';
 import { openPreferences } from '@pkg/window/preferences';
 
-const console = Logging.background;
+const console = Logging[`window-${ process.pid }`];
 
 /**
  * A mapping of window key (which is our own construct) to a window ID (which is

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -12,7 +12,7 @@ import paths from '@pkg/utils/paths';
 import { CommandOrControl, Shortcuts } from '@pkg/utils/shortcuts';
 import { openPreferences } from '@pkg/window/preferences';
 
-const console = Logging[`window-${ process.pid }`];
+const console = Logging[`window_${ process.type || 'main' }`];
 
 /**
  * A mapping of window key (which is our own construct) to a window ID (which is


### PR DESCRIPTION
This stops the first part of `background.log` from being overwritten by a line of null bytes.

The overwriting happens when a module in the renderer process tries to create a log stream bound
to a file that's already opened for logging in the main process. The contention causes loss of data.

The first step is to move the log file to a different name, in this case `window.log`. But there will still be
the same loss of data in that file now. So the next step is to determine which process `console` is 
being initialized in `window/index.ts`, and bind it accordingly to either `window.log` or `window_renderer.log`

This technique was found to work in dev builds, packaged builds, and e2e tests.