### PR TITLE
Add note about developing on M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Then you can install dependencies with:
 npm install
 ```
 
+> ### ⚠️ Working on a mac with an M1 chip?
+> 
+> You will need to set the `M1` environment variable before installing dependencies and running any npm scripts:
+>
+> ```
+> export M1=1
+> npm install
+> ```
+>
+> You will want to run `git clean -fdx` to clean out any cached assets and re-downloaded with the correct arch before running `npm install` if you previously installed dependencies without setting `M1` first.
+
 ### Linux
 
 Ensure you have the following installed:


### PR DESCRIPTION
This adds a note to the developer docs about developing on a mac with an M1 chip.