### PR TITLE
RDX: run containers as specified

### DIFF
--- a/pkg/rancher-desktop/backend/backend.ts
+++ b/pkg/rancher-desktop/backend/backend.ts
@@ -238,6 +238,14 @@ export interface VMExecutor {
   writeFile(filePath: string, fileContents: string, permissions: fs.Mode): Promise<void>;
 
   /**
+   * Copy the given file from the host into the VM.
+   * @param hostPath The source path, on the host.
+   * @param vmPath The destination path, inside the VM.
+   * @note The behaviour of copying a directory is undefined.
+   */
+  copyFileIn(hostPath: string, vmPath: string): Promise<void>;
+
+  /**
    * Copy the given file from the VM into the host.
    * @param vmPath The source path, inside the VM.
    * @param hostPath The destination path, on the host.

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -1,10 +1,13 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
+import util from 'util';
 
 import _ from 'lodash';
+import tar from 'tar-stream';
 
-import { ContainerComposeUpOptions, ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
+import { ContainerComposeOptions, ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
 
 import { VMExecutor } from '@pkg/backend/backend';
 import { spawnFile } from '@pkg/utils/childProcess';
@@ -29,16 +32,16 @@ export class NerdctlClient implements ContainerEngineClient {
   /**
    * Run nerdctl with the given arguments, returning the standard output.
    */
-  protected async runTool(...args: string[]): Promise<string>;
-  protected async runTool(options: { env?: Record<string, string>}, ...args: string[]): Promise<string>;
-  protected async runTool(optionOrArg: any, ...args: string[]): Promise<string> {
+  protected async nerdctl(...args: string[]): Promise<string>;
+  protected async nerdctl(options: { env?: Record<string, string>}, ...args: string[]): Promise<string>;
+  protected async nerdctl(optionOrArg: any, ...args: string[]): Promise<string> {
     const finalArgs = args.concat();
     const options: { env?: Record<string, string> } = {};
 
     if (typeof optionOrArg === 'string') {
       finalArgs.unshift(optionOrArg);
     } else {
-      _.merge(options, _.pick(options, 'env'));
+      _.merge(options, { env: { ...process.env, ...optionOrArg.env } });
     }
 
     const { stdout } = await spawnFile(
@@ -68,6 +71,9 @@ export class NerdctlClient implements ContainerEngineClient {
    * @param imageID The ID of the image to mount.
    * @returns The path that the image has been mounted on, plus an array of
    * cleanup functions that must be called in reverse order when done.
+   * @note Due to https://github.com/containerd/nerdctl/issues/1058 we can't
+   * just do `nerdctl create` + `nerdctl cp`.  Instead, we need to make mounts
+   * manually.
    */
   protected async mountImage(imageID: string, namespace?: string): Promise<[string, (() => Promise<void>)[]]> {
     const cleanups: (() => Promise<void>)[] = [];
@@ -113,11 +119,6 @@ export class NerdctlClient implements ContainerEngineClient {
   readFile(imageID: string, filePath: string, options: { encoding?: BufferEncoding, namespace?: string }): Promise<string>;
   async readFile(imageID: string, filePath: string, options?: { encoding?: BufferEncoding, namespace?: string }): Promise<string> {
     const encoding = options?.encoding ?? 'utf-8';
-
-    // Due to https://github.com/containerd/nerdctl/issues/1058 we can't just
-    // do `nerdctl create` + `nerdctl cp`.  Instead, we need to make mounts
-    // manually.
-
     const [workdir, cleanups] = await this.mountImage(imageID, options?.namespace);
 
     try {
@@ -184,20 +185,78 @@ export class NerdctlClient implements ContainerEngineClient {
     }
     args.push(imageID);
 
-    return (await this.runTool(...args)).trim();
+    return (await this.nerdctl(...args)).trim();
   }
 
-  async composeUp(composeDir: string, options?: ContainerComposeUpOptions) {
-    // We need to copy into a directory in /tmp/ for lima
+  async composeUp(composeDir: string, options?: ContainerComposeOptions) {
     const cleanups: (() => Promise<void>)[] = [];
 
     try {
-      const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-'));
+      const workDir = (await this.vm.execCommand({ capture: true },
+        '/bin/mktemp', '--directory', '--tmpdir', 'rd-nerdctl-compose-up-XXXXXX')).trim();
 
-      cleanups.push(() => fs.promises.rm(workDir, { recursive: true }));
-      await fs.promises.cp(composeDir, workDir, { recursive: true, dereference: true });
+      cleanups.push(() => this.vm.execCommand('/bin/rm', '-rf', workDir));
 
-      const args = ['compose', '--project-directory', workDir];
+      const hostDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-'));
+
+      cleanups.push(() => fs.promises.rm(hostDir, { recursive: true }));
+
+      const hostPath = path.join(hostDir, 'compose.tar');
+      const tarStream = fs.createWriteStream(hostPath);
+      const archive = tar.pack();
+      const archiveFinished = util.promisify(stream.finished)(archive);
+      const newEntry = util.promisify(archive.entry.bind(archive));
+      const baseHeader: Partial<tar.Headers> = {
+        mode:  0o755,
+        uid:   0,
+        uname: 'root',
+        gname: 'wheel',
+        type:  'directory',
+      };
+      const walk = async(dir: string) => {
+        const fullPath = path.normalize(path.join(composeDir, dir));
+
+        for (const basename of await fs.promises.readdir(fullPath)) {
+          const name = path.normalize(path.join(dir, basename));
+          const info = await fs.promises.lstat(path.join(fullPath, basename));
+
+          if (info.isDirectory()) {
+            await newEntry({ ...baseHeader, name });
+            await walk(path.join(dir, basename));
+          } else if (info.isFile()) {
+            const readStream = fs.createReadStream(path.join(fullPath, basename));
+            const entry = archive.entry({
+              ...baseHeader,
+              ..._.pick(info, 'mode', 'mtime', 'size'),
+              type: 'file',
+              name,
+            });
+            const entryFinished = util.promisify(stream.finished)(entry);
+
+            readStream.pipe(entry);
+            await entryFinished;
+          } else if (info.isSymbolicLink()) {
+            await newEntry({
+              ...baseHeader,
+              ..._.pick(info, 'mode', 'mtime'),
+              name,
+              type:     'symlink',
+              linkname: await fs.promises.readlink(path.join(fullPath, basename)),
+            });
+          }
+        }
+      };
+
+      archive.pipe(tarStream);
+      await walk('.');
+      archive.finalize();
+      await archiveFinished;
+
+      await this.vm.copyFileIn(hostPath, path.posix.join(workDir, 'compose.tar'));
+      await this.vm.execCommand('/bin/mkdir', path.posix.join(workDir, 'extract'));
+      await this.vm.execCommand('/usr/bin/tar', 'xf', path.posix.join(workDir, 'compose.tar'), '-C', path.posix.join(workDir, 'extract'));
+
+      const args = ['compose', '--project-directory', path.posix.join(workDir, 'extract')];
 
       if (options?.name) {
         args.push('--project-name', options.name);
@@ -206,20 +265,18 @@ export class NerdctlClient implements ContainerEngineClient {
         args.unshift('--namespace', options.namespace);
       }
       if (options?.env) {
-        const envDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-env-'));
-        const envFile = path.join(envDir, 'compose.env');
+        const envFile = path.join(hostDir, 'compose.env');
         const envData = Object.entries(options.env)
           .map(([k, v]) => `${ k }='${ v.replaceAll("'", "\\'") }'\n`)
           .join('');
 
-        cleanups.push(() => fs.promises.rm(envDir, { recursive: true }));
         await fs.promises.writeFile(envFile, envData);
         args.push('--env-file', envFile);
       }
       // nerdctl doesn't support --wait, so make do with --detach.
       args.push('up', '--quiet-pull', '--detach');
 
-      const result = await this.runTool({ env: options?.env ?? {} }, ...args);
+      const result = await this.nerdctl({ env: options?.env ?? {} }, ...args);
 
       console.log('ran nerdctl compose up', result);
     } finally {
@@ -237,18 +294,18 @@ export class NerdctlClient implements ContainerEngineClient {
     }
 
     if (options?.delete && options.force) {
-      await this.runTool(...addNS('container', 'rm', '--force', container));
+      await this.nerdctl(...addNS('container', 'rm', '--force', container));
 
       return;
     }
 
-    await this.runTool(...addNS('container', 'stop', container));
+    await this.nerdctl(...addNS('container', 'stop', container));
     if (options?.delete) {
-      await this.runTool(...addNS('container', 'rm', container));
+      await this.nerdctl(...addNS('container', 'rm', container));
     }
   }
 
-  async composeDown(composeDir: string, options?: ContainerComposeUpOptions): Promise<void> {
+  async composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void> {
     const cleanups: (() => Promise<void>)[] = [];
     const args = [
       options?.namespace ? ['--namespace', options.namespace] : [],
@@ -269,7 +326,7 @@ export class NerdctlClient implements ContainerEngineClient {
         await fs.promises.writeFile(envFile, envData);
         args.push('--env-file', envFile);
       }
-      const result = await this.runTool(...args);
+      const result = await this.nerdctl(...args);
 
       console.debug('ran nerdctl compose down:', result);
     } finally {

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -2,7 +2,9 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
+import _ from 'lodash';
+
+import { ContainerComposeUpOptions, ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
 
 import { VMExecutor } from '@pkg/backend/backend';
 import { spawnFile } from '@pkg/utils/childProcess';
@@ -27,11 +29,22 @@ export class NerdctlClient implements ContainerEngineClient {
   /**
    * Run nerdctl with the given arguments, returning the standard output.
    */
-  protected async runTool(...args: string[]): Promise<string> {
+  protected async runTool(...args: string[]): Promise<string>;
+  protected async runTool(options: { env?: Record<string, string>}, ...args: string[]): Promise<string>;
+  protected async runTool(optionOrArg: any, ...args: string[]): Promise<string> {
+    const finalArgs = args.concat();
+    const options: { env?: Record<string, string> } = {};
+
+    if (typeof optionOrArg === 'string') {
+      finalArgs.unshift(optionOrArg);
+    } else {
+      _.merge(options, _.pick(options, 'env'));
+    }
+
     const { stdout } = await spawnFile(
       executable('nerdctl'),
-      args,
-      { stdio: ['ignore', 'pipe', console] },
+      finalArgs,
+      { stdio: ['ignore', 'pipe', console], ...options },
     );
 
     return stdout;
@@ -127,8 +140,15 @@ export class NerdctlClient implements ContainerEngineClient {
       const archive = (await this.vm.execCommand({ capture: true }, '/bin/mktemp', '-t', 'rd-nerdctl-cp-XXXXXX')).trim();
 
       cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', archive));
-      const sourceDir = path.dirname(path.posix.join(imageDir, sourcePath));
-      const sourceName = path.basename(sourcePath);
+      let sourceName: string, sourceDir: string;
+
+      if (sourcePath.endsWith('/')) {
+        sourceName = '.';
+        sourceDir = path.posix.join(imageDir, sourcePath);
+      } else {
+        sourceName = path.posix.basename(sourcePath);
+        sourceDir = path.posix.join(imageDir, path.posix.dirname(sourcePath));
+      }
       const args = ['--create', '--gzip', '--file', archive, '--directory', sourceDir, resolveSymlinks ? '--dereference' : undefined, sourceName].filter(defined);
 
       await this.vm.execCommand('/usr/bin/tar', ...args);
@@ -167,6 +187,46 @@ export class NerdctlClient implements ContainerEngineClient {
     return (await this.runTool(...args)).trim();
   }
 
+  async composeUp(composeDir: string, options?: ContainerComposeUpOptions) {
+    // We need to copy into a directory in /tmp/ for lima
+    const cleanups: (() => Promise<void>)[] = [];
+
+    try {
+      const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-'));
+
+      cleanups.push(() => fs.promises.rm(workDir, { recursive: true }));
+      await fs.promises.cp(composeDir, workDir, { recursive: true, dereference: true });
+
+      const args = ['compose', '--project-directory', workDir];
+
+      if (options?.name) {
+        args.push('--project-name', options.name);
+      }
+      if (options?.namespace) {
+        args.unshift('--namespace', options.namespace);
+      }
+      if (options?.env) {
+        const envDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-env-'));
+        const envFile = path.join(envDir, 'compose.env');
+        const envData = Object.entries(options.env)
+          .map(([k, v]) => `${ k }='${ v.replaceAll("'", "\\'") }'\n`)
+          .join('');
+
+        cleanups.push(() => fs.promises.rm(envDir, { recursive: true }));
+        await fs.promises.writeFile(envFile, envData);
+        args.push('--env-file', envFile);
+      }
+      // nerdctl doesn't support --wait, so make do with --detach.
+      args.push('up', '--quiet-pull', '--detach');
+
+      const result = await this.runTool({ env: options?.env ?? {} }, ...args);
+
+      console.log('ran nerdctl compose up', result);
+    } finally {
+      await this.runCleanups(cleanups);
+    }
+  }
+
   async stop(container: string, options?: ContainerStopOptions): Promise<void> {
     function addNS(...args: string[]) {
       if (options?.namespace) {
@@ -185,6 +245,35 @@ export class NerdctlClient implements ContainerEngineClient {
     await this.runTool(...addNS('container', 'stop', container));
     if (options?.delete) {
       await this.runTool(...addNS('container', 'rm', container));
+    }
+  }
+
+  async composeDown(composeDir: string, options?: ContainerComposeUpOptions): Promise<void> {
+    const cleanups: (() => Promise<void>)[] = [];
+    const args = [
+      options?.namespace ? ['--namespace', options.namespace] : [],
+      ['compose'],
+      options?.name ? ['--project-name', options.name] : [],
+      ['--project-directory', composeDir, 'down'],
+    ].flat();
+
+    try {
+      if (options?.env) {
+        const envDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-env-'));
+        const envFile = path.join(envDir, 'compose.env');
+        const envData = Object.entries(options.env)
+          .map(([k, v]) => `${ k }='${ v.replaceAll("'", "\\'") }'\n`)
+          .join('');
+
+        cleanups.push(() => fs.promises.rm(envDir, { recursive: true }));
+        await fs.promises.writeFile(envFile, envData);
+        args.push('--env-file', envFile);
+      }
+      const result = await this.runTool(...args);
+
+      console.debug('ran nerdctl compose down:', result);
+    } finally {
+      await this.runCleanups(cleanups);
     }
   }
 }

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -39,9 +39,10 @@ export interface ContainerEngineClient {
    * @param imageID The ID of the image to read.
    * @param filePath The file to read, relative to the root of the container.
    * @param [options.encoding='utf-8'] The encoding to read.
+   * @param [options.namespace] Namespace the image is in, if supported.
    */
   readFile(imageID: string, filePath: string): Promise<string>;
-  readFile(imageID: string, filePath: string, options: { encoding?: BufferEncoding }): Promise<string>;
+  readFile(imageID: string, filePath: string, options: { encoding?: BufferEncoding, namespace?: string }): Promise<string>;
 
   /**
    * Copy the given file to disk.
@@ -51,10 +52,11 @@ export interface ContainerEngineClient {
    * This is always the parent directory; the base name of the output will be
    * the base name of the sourcePath.
    * @param [options.resolveSymlinks] Follow symlinks in the source; default true.
+   * @param [options.namespace] Namespace the image is in, if supported.
    * @note Symbolic links might not be copied correctly (for example, the host might be Windows).
    */
   copyFile(imageID: string, sourcePath: string, destinationDir: string): Promise<void>;
-  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { resolveSymlinks: false }): Promise<void>;
+  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { resolveSymlinks?: false, namespace?: string }): Promise<void>;
 
   /**
    * Start a container.

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -28,7 +28,12 @@ export type ContainerStopOptions = ContainerBasicOptions & {
   delete?: true;
 };
 
-export type ContainerComposeUpOptions = ContainerBasicOptions & {
+/**
+ * ContainerComposeOptions are options that can be passed to
+ * ContainerEngineClient.composeUp() and .composeDown().  All fields are
+ * optional.
+ */
+export type ContainerComposeOptions = ContainerBasicOptions & {
   /** The name of the project */
   name?: string;
   /** Environment variables to set on build */
@@ -79,14 +84,14 @@ export interface ContainerEngineClient {
    * Start containers via `docker compose` / `nerdctl compose`.
    * @param composeDir The path containing the compose file.
    */
-  composeUp(composeDir: string, options?: ContainerComposeUpOptions): Promise<void>;
+  composeUp(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
 
   /**
    * Stop the given container, if it exists and is running.
    */
   stop(container: string, options?: ContainerStopOptions): Promise<void>;
 
-  composeDown(composeDir: string, options?: ContainerComposeUpOptions): Promise<void>;
+  composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
 
   /** Escape hatch (for now): the executable to run */
   readonly executable: string;

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1590,6 +1590,10 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     }
   }
 
+  copyFileIn(hostPath: string, vmPath: string): Promise<void> {
+    return this.lima('copy', hostPath, `${ MACHINE_NAME }:${ vmPath }`);
+  }
+
   copyFileOut(vmPath: string, hostPath: string): Promise<void> {
     return this.lima('copy', `${ MACHINE_NAME }:${ vmPath }`, hostPath);
   }

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -146,6 +146,10 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
     return Promise.resolve();
   }
 
+  copyFileIn(hostPath: string, vmPath: string): Promise<void> {
+    return Promise.reject('MockBackend#copyFileIn() not implemented');
+  }
+
   copyFileOut(vmPath: string, hostPath: string): Promise<void> {
     return Promise.reject('MockBackend#copyFileOut() not implemented');
   }

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -679,6 +679,12 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     await this.writeFileWSL(filePath, fileContents, { permissions });
   }
 
+  async copyFileIn(hostPath: string, vmPath: string): Promise<void> {
+    const windowsPath = (await this.execCommand({ capture: true }, '/bin/wslpath', '-w', vmPath)).trim();
+
+    await fs.promises.copyFile(windowsPath, hostPath);
+  }
+
   async copyFileOut(vmPath: string, hostPath: string): Promise<void> {
     const windowsPath = (await this.execCommand({ capture: true }, '/bin/wslpath', '-w', vmPath)).trim();
 


### PR DESCRIPTION
This runs the container as specified in the extension metadata:
- If the extension has a `.vm.image`, that image is run
- If the extension has a `.vm.composefile`, that's run instead.

This PR includes a BATS test.

There are two commits in this PR; it's easiest to review commit-by-commit.

Note that currently we have issues using `compose` with `nerdctl`/`containerd` as we're not passing environment variables down correctly (#2356).  That part of the test is currently skipped.

Fixes #4220.