### PR TITLE
List installed extensions in primary nav

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1060,8 +1060,10 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
 
   async listExtensionsMetadata(extensionManager: ExtensionManager) {
     const extensions = await extensionManager.getExtensions();
+    const installedExtensions = Object.keys(await this.listExtensions());
+    const filteredExtensions = extensions.filter(x => installedExtensions.includes(x.id));
 
-    window.send('extensions-list', extensions);
+    window.send('extensions-list', filteredExtensions);
   }
 
   async installExtension(id: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {

--- a/background.ts
+++ b/background.ts
@@ -520,7 +520,7 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 
 mainEvents.on('settings-write', writeSettings);
 
-ipcMainProxy.on('extensions-list', () => {
+ipcMainProxy.on('extensions/list', () => {
   new BackgroundCommandWorker().listExtensionsMetadata();
 });
 
@@ -1077,7 +1077,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     const installedExtensions = Object.keys(await this.listExtensions());
     const filteredExtensions = extensions?.filter(x => installedExtensions.includes(x.id));
 
-    window.send('extensions-list', filteredExtensions);
+    window.send('extensions/list', filteredExtensions);
   }
 
   async installExtension(id: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {

--- a/background.ts
+++ b/background.ts
@@ -1084,7 +1084,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     const em = await this.getExtensionManager();
     const extension = em?.getExtension(id);
 
-    if (!extension || typeof (em) === 'undefined') {
+    if (!extension) {
       console.debug(`Failed to install extension ${ id }: could not get extension.`);
 
       return { status: 503 };

--- a/background.ts
+++ b/background.ts
@@ -520,6 +520,10 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 
 mainEvents.on('settings-write', writeSettings);
 
+ipcMainProxy.on('extensions-list', () => {
+  new BackgroundCommandWorker().listExtensionsMetadata();
+});
+
 ipcMainProxy.handle('transient-settings-fetch', () => {
   return Promise.resolve(TransientSettings.value);
 });

--- a/background.ts
+++ b/background.ts
@@ -519,10 +519,7 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 
 mainEvents.on('settings-write', writeSettings);
 
-ipcMainProxy.on('extensions/list', () => {
-  listExtensionsMetadata();
-});
-
+ipcMainProxy.on('extensions/list', listExtensionsMetadata);
 ipcMainProxy.handle('transient-settings-fetch', () => {
   return Promise.resolve(TransientSettings.value);
 });

--- a/background.ts
+++ b/background.ts
@@ -841,7 +841,7 @@ async function getExtensionManager() {
 
 async function listExtensionsMetadata() {
   const extensionManager = await getExtensionManager();
-  const extensions = await extensionManager?.getExtensions();
+  const extensions = await extensionManager?.getInstalledExtensions();
 
   window.send('extensions/list', extensions);
 }

--- a/background.ts
+++ b/background.ts
@@ -1074,10 +1074,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
   async listExtensionsMetadata() {
     const extensionManager = await this.getExtensionManager();
     const extensions = await extensionManager?.getExtensions();
-    const installedExtensions = Object.keys(await this.listExtensions());
-    const filteredExtensions = extensions?.filter(x => installedExtensions.includes(x.id));
 
-    window.send('extensions/list', filteredExtensions);
+    window.send('extensions/list', extensions);
   }
 
   async installExtension(id: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {

--- a/e2e/extensions-protocol.e2e.spec.ts
+++ b/e2e/extensions-protocol.e2e.spec.ts
@@ -110,7 +110,7 @@ test.describe.serial('Extensions protocol handler', () => {
 
   test('use extension protocol handler', async() => {
     const result = await page.evaluate(async() => {
-      const data = await fetch('x-rd-extension://72642f657874656e73696f6e2f7569/dashboard-tab/ui/index.html');
+      const data = await fetch('x-rd-extension://72642f657874656e73696f6e2f7569/ui/dashboard-tab/ui/index.html');
 
       return await data.text();
     });

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -13,6 +13,19 @@
         </NuxtLink>
       </li>
     </ul>
+    <hr>
+    <nav-item>
+      <template #before>
+        <span class="icon icon-circle-plus"></span>
+      </template>
+      Extensions
+    </nav-item>
+    <nav-item
+      v-for="extension in extensions"
+      :key="extension.id"
+    >
+      {{ extension.name }}
+    </nav-item>
   </nav>
 </template>
 
@@ -23,9 +36,14 @@ import { NuxtApp } from '@nuxt/types/app';
 import { BadgeState } from '@rancher/components';
 import { RouteRecordPublic } from 'vue-router';
 
+import NavItem from './NavItem.vue';
+
 export default {
-  components: { BadgeState },
-  props:      {
+  components: {
+    BadgeState,
+    NavItem,
+  },
+  props: {
     items: {
       type:      Array,
       required:  true,
@@ -47,6 +65,10 @@ export default {
           return result;
         });
       },
+    },
+    extensions: {
+      type:     Array,
+      required: true,
     },
   },
   data() {

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -26,7 +26,7 @@
         :key="extension.id"
       >
         <template #before>
-          <img :src="`x-rd-extension://${ hexEncode(extension.id) }/icon.svg`">
+          <img :src="imageUri(extension.id)">
         </template>
         {{ extension.metadata.ui['dashboard-tab'].title }}
       </nav-item>
@@ -42,6 +42,8 @@ import { BadgeState } from '@rancher/components';
 import { RouteRecordPublic } from 'vue-router';
 
 import NavItem from './NavItem.vue';
+
+import { hexEncode } from '@pkg/utils/string-encode';
 
 export default {
   components: {
@@ -100,16 +102,8 @@ export default {
     },
   },
   methods: {
-    hexEncode(str: string): string {
-      let hex = '';
-
-      for (let i = 0; i < str.length; i++) {
-        const charCode = str.charCodeAt(i).toString(16);
-
-        hex += charCode.length < 2 ? `0${ charCode }` : charCode;
-      }
-
-      return hex;
+    imageUri(id: string): string {
+      return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
     },
   },
 };

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -13,22 +13,24 @@
         </NuxtLink>
       </li>
     </ul>
-    <hr>
-    <nav-item>
-      <template #before>
-        <span class="icon icon-circle-plus"></span>
-      </template>
-      Extensions
-    </nav-item>
-    <nav-item
-      v-for="extension in extensions"
-      :key="extension.id"
-    >
-      <template #before>
-        <img :src="`x-rd-extension://${ hexEncode(extension.id) }/icon.svg`">
-      </template>
-      {{ extension.metadata.ui['dashboard-tab'].title }}
-    </nav-item>
+    <template v-if="featureExtensions">
+      <hr>
+      <nav-item>
+        <template #before>
+          <span class="icon icon-circle-plus"></span>
+        </template>
+        Extensions
+      </nav-item>
+      <nav-item
+        v-for="extension in extensions"
+        :key="extension.id"
+      >
+        <template #before>
+          <img :src="`x-rd-extension://${ hexEncode(extension.id) }/icon.svg`">
+        </template>
+        {{ extension.metadata.ui['dashboard-tab'].title }}
+      </nav-item>
+    </template>
   </nav>
 </template>
 
@@ -90,8 +92,15 @@ export default {
       }, {}),
     };
   },
+  computed: {
+    featureExtensions(): boolean {
+      const nuxt: NuxtApp = (this as any).$nuxt;
+
+      return !!nuxt.$config.featureExtensions;
+    },
+  },
   methods: {
-    hexEncode(str: string) {
+    hexEncode(str: string): string {
       let hex = '';
 
       for (let i = 0; i < str.length; i++) {

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,7 +24,7 @@
       v-for="extension in extensions"
       :key="extension.id"
     >
-      {{ extension.name }}
+      {{ extension.metadata.ui['dashboard-tab'].title }}
     </nav-item>
   </nav>
 </template>

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,6 +24,9 @@
       v-for="extension in extensions"
       :key="extension.id"
     >
+      <template #before>
+        <img :src="`x-rd-extension://${ hexEncode(extension.id) }/icon.svg`">
+      </template>
       {{ extension.metadata.ui['dashboard-tab'].title }}
     </nav-item>
   </nav>
@@ -86,6 +89,19 @@ export default {
         return paths;
       }, {}),
     };
+  },
+  methods: {
+    hexEncode(str: string) {
+      let hex = '';
+
+      for (let i = 0; i < str.length; i++) {
+        const charCode = str.charCodeAt(i).toString(16);
+
+        hex += charCode.length < 2 ? `0${ charCode }` : charCode;
+      }
+
+      return hex;
+    },
   },
 };
 </script>

--- a/pkg/rancher-desktop/components/NavItem.vue
+++ b/pkg/rancher-desktop/components/NavItem.vue
@@ -5,8 +5,13 @@ export default Vue.extend({});
 
 <template>
   <div class="nav-item">
-    <slot name="before">
-    </slot>
+    <div
+      v-if="$slots.before"
+      class="before"
+    >
+      <slot name="before">
+      </slot>
+    </div>
     <slot name="default">
       Extensions
     </slot>
@@ -24,5 +29,18 @@ export default Vue.extend({});
     display: flex;
     gap: 0.25rem;
     align-items: center;
+  }
+
+  .before {
+    min-width: 1.25rem;
+    max-width: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 100%;
+      height: auto;
+    }
   }
 </style>

--- a/pkg/rancher-desktop/components/NavItem.vue
+++ b/pkg/rancher-desktop/components/NavItem.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({});
+</script>
+
+<template>
+  <div class="nav-item">
+    <slot name="before">
+    </slot>
+    <slot name="default">
+      Extensions
+    </slot>
+    <slot name="after"></slot>
+  </div>
+</template>
+
+<style scoped lang="scss">
+  .nav-item {
+    color: var(--body-text);
+    text-decoration: none;
+    line-height: 24px;
+    padding: 7.5px 10px;
+    letter-spacing: 1.4px;
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+  }
+</style>

--- a/pkg/rancher-desktop/components/NavItem.vue
+++ b/pkg/rancher-desktop/components/NavItem.vue
@@ -27,7 +27,7 @@ export default Vue.extend({});
     padding: 7.5px 10px;
     letter-spacing: 1.4px;
     display: flex;
-    gap: 0.25rem;
+    gap: 0.5rem;
     align-items: center;
   }
 

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -82,10 +82,10 @@ export default {
     ipcRenderer.on('route', (event, args) => {
       this.goToRoute(args);
     });
-    ipcRenderer.on('extensions-list', (_event, extensions) => {
+    ipcRenderer.on('extensions/list', (_event, extensions) => {
       this.extensions = extensions || [];
     });
-    ipcRenderer.send('extensions-list');
+    ipcRenderer.send('extensions/list');
   },
 
   beforeDestroy() {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -85,6 +85,7 @@ export default {
     ipcRenderer.on('extensions-list', (_event, extensions) => {
       this.extensions = extensions;
     });
+    ipcRenderer.send('extensions-list');
   },
 
   beforeDestroy() {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -83,7 +83,7 @@ export default {
       this.goToRoute(args);
     });
     ipcRenderer.on('extensions-list', (_event, extensions) => {
-      this.extensions = extensions;
+      this.extensions = extensions || [];
     });
     ipcRenderer.send('extensions-list');
   },

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="wrapper">
     <rd-header class="header" @open-preferences="openPreferences" />
-    <rd-nav class="nav" :items="routes" />
+    <rd-nav
+      class="nav"
+      :items="routes"
+      :extensions="extensions"
+    />
     <the-title />
     <main class="body">
       <Nuxt />
@@ -32,6 +36,10 @@ export default {
     rdNav:    Nav,
     rdHeader: Header,
     TheTitle,
+  },
+
+  data() {
+    return { extensions: [] };
   },
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
@@ -73,6 +81,10 @@ export default {
     });
     ipcRenderer.on('route', (event, args) => {
       this.goToRoute(args);
+    });
+    ipcRenderer.on('extensions-list', (_event, extensions) => {
+      this.extensions = extensions;
+      console.log('EXTENSIONS LIST', { extensions });
     });
   },
 

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -84,7 +84,6 @@ export default {
     });
     ipcRenderer.on('extensions-list', (_event, extensions) => {
       this.extensions = extensions;
-      console.log('EXTENSIONS LIST', { extensions });
     });
   },
 

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -638,6 +638,7 @@ export interface CommandWorkerInterface {
   // #region extensions
   /** List the installed extensions */
   listExtensions(): Promise<Record<string, true>>;
+  listExtensionsMetadata(): Promise<void>;
   /**
    * Install or uninstall the given extension, returning an appropriate HTTP status code.
    * @param state Whether to install or uninstall the extension.

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -638,7 +638,6 @@ export interface CommandWorkerInterface {
   // #region extensions
   /** List the installed extensions */
   listExtensions(): Promise<Record<string, true>>;
-  listExtensionsMetadata(): Promise<void>;
   /**
    * Install or uninstall the given extension, returning an appropriate HTTP status code.
    * @param state Whether to install or uninstall the extension.

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -105,6 +105,7 @@ class ExtensionManagerImpl implements ExtensionManager {
 
   async getExtensions() {
     const extensions = Object.values(this.extensions);
+
     const transformedExtensions = extensions.map(async(current) => {
       const { id, dir } = current;
       const metadata = await current.metadata;

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -104,14 +104,12 @@ class ExtensionManagerImpl implements ExtensionManager {
   }
 
   async getExtensions() {
-    const regex = /\/(.+?)\-/;
     const extensions = Object.values(this.extensions);
     const transformedExtensions = extensions.map(async(current) => {
       const { id, dir } = current;
       const metadata = await current.metadata;
 
       return {
-        name: id.match(regex)?.[1],
         id,
         dir,
         metadata,

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 import { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 
 import { ExtensionImpl } from './extensions';
@@ -7,6 +9,7 @@ import type { Settings } from '@pkg/config/settings';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import type { IpcMainEvents, IpcMainInvokeEvents } from '@pkg/typings/electron-ipc';
 import Logging from '@pkg/utils/logging';
+import paths from '@pkg/utils/paths';
 import type { RecursiveReadonly } from '@pkg/utils/typeUtils';
 
 import type { Extension, ExtensionManager } from './types';
@@ -105,16 +108,23 @@ class ExtensionManagerImpl implements ExtensionManager {
 
   async getExtensions() {
     const extensions = Object.values(this.extensions);
+    const installedExtensions = await fs.promises.readdir(paths.extensionRoot);
 
-    const transformedExtensions = extensions.map(async(current) => {
-      const { id } = current;
-      const metadata = await current.metadata;
+    const transformedExtensions = extensions
+      .filter((extension) => {
+        const encodedExtension = Buffer.from(extension.id).toString('base64url');
 
-      return {
-        id,
-        metadata,
-      };
-    });
+        return installedExtensions.includes(encodedExtension);
+      })
+      .map(async(current) => {
+        const { id } = current;
+        const metadata = await current.metadata;
+
+        return {
+          id,
+          metadata,
+        };
+      });
 
     return await Promise.all(transformedExtensions);
   }

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -106,7 +106,7 @@ class ExtensionManagerImpl implements ExtensionManager {
     return ext;
   }
 
-  async getExtensions() {
+  async getInstalledExtensions() {
     const extensions = Object.values(this.extensions);
     const installedExtensions = await fs.promises.readdir(paths.extensionRoot);
 

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -107,12 +107,11 @@ class ExtensionManagerImpl implements ExtensionManager {
     const extensions = Object.values(this.extensions);
 
     const transformedExtensions = extensions.map(async(current) => {
-      const { id, dir } = current;
+      const { id } = current;
       const metadata = await current.metadata;
 
       return {
         id,
-        dir,
         metadata,
       };
     });

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -103,6 +103,24 @@ class ExtensionManagerImpl implements ExtensionManager {
     return ext;
   }
 
+  async getExtensions() {
+    const regex = /\/(.+?)\-/;
+    const extensions = Object.values(this.extensions);
+    const transformedExtensions = extensions.map(async(current) => {
+      const { id, dir } = current;
+      const metadata = await current.metadata;
+
+      return {
+        name: id.match(regex)?.[1],
+        id,
+        dir,
+        metadata,
+      };
+    });
+
+    return await Promise.all(transformedExtensions);
+  }
+
   shutdown() {
     // Remove our event listeners (to avoid issues when we switch backends).
     for (const untypedChannel in this.eventListeners) {

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -71,7 +71,7 @@ export interface ExtensionManager {
   /**
    * Get a collection of all installed extensions.
    */
-  getExtensions(): Promise<{ id: string; dir: string; metadata: ExtensionMetadata; }[]>;
+  getExtensions(): Promise<{ id: string; dir: string | undefined; metadata: ExtensionMetadata; }[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -71,7 +71,7 @@ export interface ExtensionManager {
   /**
    * Get a collection of all installed extensions.
    */
-  getExtensions(): Promise<{ id: string; dir: string | undefined; metadata: ExtensionMetadata; }[]>;
+  getExtensions(): Promise<{ id: string; metadata: ExtensionMetadata; }[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -71,7 +71,7 @@ export interface ExtensionManager {
   /**
    * Get a collection of all installed extensions.
    */
-  getExtensions(): Promise<{ name: string | undefined; id: string; dir: string; metadata: ExtensionMetadata; }[]>;
+  getExtensions(): Promise<{ id: string; dir: string; metadata: ExtensionMetadata; }[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -71,7 +71,7 @@ export interface ExtensionManager {
   /**
    * Get a collection of all installed extensions.
    */
-  getExtensions(): Promise<{ id: string; metadata: ExtensionMetadata; }[]>;
+  getInstalledExtensions(): Promise<{ id: string; metadata: ExtensionMetadata; }[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -69,6 +69,11 @@ export interface ExtensionManager {
   getExtension(id: string): Extension;
 
   /**
+   * Get a collection of all installed extensions.
+   */
+  getExtensions(): Promise<{ name: string | undefined; id: string; dir: string; metadata: ExtensionMetadata; }[]>;
+
+  /**
    * Shut down the extension manager, doing any clean up necessary.
    */
   shutdown(): Promise<void>;

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -83,5 +83,8 @@ export default {
   },
   target:              'static',
   telemetry:           false,
-  publicRuntimeConfig: { featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1' },
+  publicRuntimeConfig: {
+    featureDiagnosticsFixes: process.env.RD_ENV_DIAGNOSTICS_FIXES === '1',
+    featureExtensions:       process.env.RD_ENV_EXTENSIONS === '1',
+  },
 };

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -6,6 +6,7 @@ import Electron from 'electron';
 
 import type { ServiceEntry } from '@pkg/backend/k8s';
 import type { RecursivePartial, Direction } from '@pkg/utils/typeUtils';
+import type { ExtensionMetadata } from '@pkg/main/extensions/types'
 /**
  * IpcMainEvents describes events the renderer can send to the main process,
  * i.e. ipcRenderer.send() -> ipcMain.on().
@@ -146,5 +147,9 @@ export interface IpcRendererEvents {
 
   // #region tab navigation
   'route': (route: { name?: string, path?: string, direction?: Direction }) => void;
+  // #endregion
+
+  // #region extensions
+  'extensions-list': (extensions: { name: string | undefined; id: string; dir: string; metadata: ExtensionMetadata; }[]) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -150,6 +150,6 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions-list': (extensions: { name: string | undefined; id: string; dir: string; metadata: ExtensionMetadata; }[]) => void;
+  'extensions-list': (extensions: { id: string; dir: string; metadata: ExtensionMetadata; }[]) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -80,7 +80,7 @@ export interface IpcMainEvents {
 
   'help/preferences/open-url': () => void;
 
-  'extensions-list': () => void;
+  'extensions/list': () => void;
 }
 
 /**
@@ -152,6 +152,6 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions-list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
+  'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -150,6 +150,6 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions-list': (extensions: { id: string; dir: string | undefined; metadata: ExtensionMetadata; }[]) => void;
+  'extensions-list': (extensions: { id: string; dir: string | undefined; metadata: ExtensionMetadata; }[] | undefined) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -152,6 +152,6 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions-list': (extensions: { id: string; dir: string | undefined; metadata: ExtensionMetadata; }[] | undefined) => void;
+  'extensions-list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -150,6 +150,6 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions-list': (extensions: { id: string; dir: string; metadata: ExtensionMetadata; }[]) => void;
+  'extensions-list': (extensions: { id: string; dir: string | undefined; metadata: ExtensionMetadata; }[]) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -79,6 +79,8 @@ export interface IpcMainEvents {
   'preferences/load': () => void;
 
   'help/preferences/open-url': () => void;
+
+  'extensions-list': () => void;
 }
 
 /**

--- a/pkg/rancher-desktop/utils/protocols.ts
+++ b/pkg/rancher-desktop/utils/protocols.ts
@@ -103,7 +103,7 @@ function setupExtensionProtocolHandler() {
     // directory traversal etc. issues.
     const extensionID = Buffer.from(url.hostname, 'hex').toString('base64url');
     const resourcePath = path.normalize(url.pathname);
-    const filepath = path.join(paths.extensionRoot, extensionID, 'ui', resourcePath);
+    const filepath = path.join(paths.extensionRoot, extensionID, resourcePath);
     const result = { path: filepath, mimeType: getMimeTypeForPath(filepath) };
 
     callback(result);

--- a/pkg/rancher-desktop/utils/string-encode.ts
+++ b/pkg/rancher-desktop/utils/string-encode.ts
@@ -1,11 +1,3 @@
-export const hexEncode = (str: string): string => {
-  let hex = '';
-
-  for (let i = 0; i < str.length; i++) {
-    const charCode = str.charCodeAt(i).toString(16);
-
-    hex += charCode.length < 2 ? `0${ charCode }` : charCode;
-  }
-
-  return hex;
-};
+export const hexEncode = (str: string): string => Array.from(str)
+  .map(c => `0${ c.charCodeAt(0).toString(16) }`.slice(-2))
+  .join('');

--- a/pkg/rancher-desktop/utils/string-encode.ts
+++ b/pkg/rancher-desktop/utils/string-encode.ts
@@ -1,0 +1,11 @@
+export const hexEncode = (str: string): string => {
+  let hex = '';
+
+  for (let i = 0; i < str.length; i++) {
+    const charCode = str.charCodeAt(i).toString(16);
+
+    hex += charCode.length < 2 ? `0${ charCode }` : charCode;
+  }
+
+  return hex;
+};


### PR DESCRIPTION
This lists installed extensions in the primary navigation by adding a new method to the extension manager that lists all extensions with their metadata. This list is then filtered in the `BackgroundCommandWorker` to include only installed extensions. 

Created a new `NavItem` component, modeled off of existing navigation styles, to allow for flexible rendering of existing navigation elements along with new icons for extensions.  

## Testing notes

- Installed extensions should render in the UI after the backend has been started
- Newly installed extensions should be added to the primary nav
- Extensions should be removed from the nav after uninstalling
- Extensions should render after opening and closing the main window

Activate the feature with:

```
➤ RD_ENV_EXTENSIONS=1 npm run dev
```

closes #4239