### PR TITLE
Make sure all run/try calls in BATS are followed by assert/refute

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -4,4 +4,5 @@ all:
 containers:
 	bats --show-output-of-passing-tests ./tests/containers/
 
-
+lint:
+	@./scripts/bats-lint.pl $(shell find tests -name '*.bats')

--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+# This script checks a BATS script to make sure every `run` or `try` call is
+# followed by a call to `assert` or `refute`, or a reference to `$output` or
+# `$status`. `assert` may be a variable reference like `${assert}`.
+#
+# The `run` or `try` call may be followed by blank lines or `if ...` statements
+# before the assert/refute becomes required.
+
+use strict;
+use warnings;
+
+my $problems = 0;
+my $run;
+
+while (<>) {
+    # Matches:
+    # - assert_success
+    # - $assert_success
+    # - $ {assert}_success
+    # - if [ $status -eq 0 ]
+    if (/(\$\{?)?(assert|refute|output\b|status\b)/) {
+        undef $run;
+    }
+    # Doesn't match on:
+    # - "empty lines (just whitespace)"
+    # - if ...
+    if ($run && !/^\s*(if.*)?$/) {
+        print "$ARGV:$.: Expected assert or refute after\n$run\n";
+        undef $run;
+        $problems++;
+    }
+    # Matches any line starting with "run " or "try "
+    if (/^\s*(run|try)\s/) {
+        $run = $_;
+    }
+    # Reset $. line counter for next input file
+    close ARGV if eof;
+}
+
+die "Found $problems problems\n" if $problems;

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -6,6 +6,7 @@ setup() {
 
 teardown_file() {
     run rdctl shutdown
+    assert_nothing
 }
 
 assert_file_contents_equal() { # $have $want

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -7,6 +7,7 @@ is_true() {
         true
     fi
 }
+
 is_false() {
     ! is_true "$1"
 }
@@ -17,6 +18,12 @@ bool() {
     else
         echo "false"
     fi
+}
+
+assert_nothing() {
+    # This is a no-op, used to show that run() has been used to continue the
+    # test even when the command failed, but the failure itself is ignored.
+    true
 }
 
 try() {

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -7,6 +7,7 @@ setup() {
     # If sudo permissions are not present, these tests should be skipped.
     if is_linux; then
         run sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443
+        assert_nothing
     fi
 }
 
@@ -63,5 +64,7 @@ teardown_file() {
     load '../helpers/load'
 
     run helm uninstall rancher --namespace cattle-system --wait
+    assert_nothing
     run helm uninstall cert-manager --namespace cert-manager --wait
+    assert_nothing
 }

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -55,19 +55,22 @@ assert_traefik_pods_are_up() {
 @test 'disable traefik' {
     # First check whether the traefik pods are up from the first launch
     try --max 30 --delay 10 assert_traefik_pods_are_up
+    assert_success
     # Disable traefik
-    run rdctl set --kubernetes.options.traefik=FALSE
+    rdctl set --kubernetes.options.traefik=FALSE
     wait_for_apiserver
     # Check if the traefik pods go down
     try --max 30 --delay 10 assert_traefik_pods_are_down
+    assert_success
 }
 
 @test 'enable traefik' {
      # Enable traefik
-     run rdctl set --kubernetes.options.traefik=TRUE
+     rdctl set --kubernetes.options.traefik=TRUE
      wait_for_apiserver
      # Check if the traefik pods come up
      try --max 30 --delay 10 assert_traefik_pods_are_up
+     assert_success
      run curl "http://$(get_host):80"
      [ "$status" -ne 0 ]
      run curl -k https://$(get_host):443

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -103,8 +103,12 @@ teardown_file() {
     load '../helpers/load'
 
     run ctrctl rm -f nginx
+    assert_nothing
 
     run helm uninstall wordpress --wait
+    assert_nothing
+
     # The database PVC doesn't get deleted by `helm uninstall`.
     run kubectl delete pvc data-wordpress-mariadb-0
+    assert_nothing
 }

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -45,6 +45,7 @@ setup() {
 
 create_registry() {
     run ctrctl rm -f registry
+    assert_nothing
     ctrctl run \
           --detach \
           --name registry \
@@ -62,6 +63,7 @@ create_registry() {
 wait_for_registry() {
     # registry port is forwarded to host
     try --max 10 --delay 5 curl -k --silent --show-error "https://localhost:$REGISTRY_PORT/v2/_catalog"
+    assert_success
 }
 
 using_insecure_registry() {
@@ -190,6 +192,7 @@ EOF
 
 @test 'verify that pushing fails when not logged in' {
     run bash -c "echo $REGISTRY | \"$CRED_HELPER\" erase"
+    assert_nothing
     run ctrctl push "$REGISTRY/$REGISTRY_IMAGE"
     assert_failure
     assert_output --regexp "(401 Unauthorized|no basic auth credentials)"


### PR DESCRIPTION
This PR also adds an `assert_nothing` function when you want to use `run` just to ignore failures in the command, but don't actually care what happened.

Running the script before applying this PR showed these warnings:

```
$ ./scripts/bats-lint.pl $(find tests -name '*.bats')
tests/extensions/install.bats:9: Expected assert or refute after
    run rdctl shutdown

tests/k8s/helm-install-rancher.bats:10: Expected assert or refute after
        run sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443

tests/k8s/helm-install-rancher.bats:66: Expected assert or refute after
    run helm uninstall rancher --namespace cattle-system --wait

tests/k8s/helm-install-rancher.bats:67: Expected assert or refute after
    run helm uninstall cert-manager --namespace cert-manager --wait

tests/k8s/traefik.bats:58: Expected assert or refute after
    try --max 30 --delay 10 assert_traefik_pods_are_up

tests/k8s/traefik.bats:60: Expected assert or refute after
    run rdctl set --kubernetes.options.traefik=FALSE

tests/k8s/traefik.bats:63: Expected assert or refute after
    try --max 30 --delay 10 assert_traefik_pods_are_down

tests/k8s/traefik.bats:68: Expected assert or refute after
     run rdctl set --kubernetes.options.traefik=TRUE

tests/k8s/traefik.bats:71: Expected assert or refute after
     try --max 30 --delay 10 assert_traefik_pods_are_up

tests/k8s/wordpress.bats:107: Expected assert or refute after
    run ctrctl rm -f nginx

tests/k8s/wordpress.bats:108: Expected assert or refute after
    run helm uninstall wordpress --wait

tests/k8s/wordpress.bats:110: Expected assert or refute after
    run kubectl delete pvc data-wordpress-mariadb-0

tests/registry/creds.bats:48: Expected assert or refute after
    run ctrctl rm -f registry

tests/registry/creds.bats:65: Expected assert or refute after
    try --max 10 --delay 5 curl -k --silent --show-error "https://localhost:$REGISTRY_PORT/v2/_catalog"

tests/registry/creds.bats:193: Expected assert or refute after
    run bash -c "echo $REGISTRY | \"$CRED_HELPER\" erase"

Found 15 problems
```