### PR TITLE
Need to add 'networkingTunnel' to the expected object on Windows.

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -164,6 +164,8 @@ test.describe.serial('KubernetesBackend', () => {
         expectedDefinition['application.adminAccess'] = false;
         expectedDefinition['virtualMachine.numberCPUs'] = false;
         expectedDefinition['virtualMachine.memoryInGB'] = false;
+      } else if (process.platform === 'win32') {
+        expectedDefinition['experimental.virtualMachine.networkingTunnel'] = false;
       }
 
       const expected: Record<string, {current: any, desired: any, severity: 'reset' | 'restart'}> = {};


### PR DESCRIPTION
Fixes #4245

Bug discovered when trying to run e2e tests on Windows