### PR TITLE
Add a one-second pause so containerd can get to work successfully.

### DIFF
--- a/e2e/extensions-protocol.e2e.spec.ts
+++ b/e2e/extensions-protocol.e2e.spec.ts
@@ -80,6 +80,8 @@ test.describe.serial('Extensions protocol handler', () => {
     // `buildctl debug info` talks to the backend (to fetch info about it), so
     // if it succeeds it means the backend is up and can respond to requests.
     await retry(() => spawnFile(rdctl, ['shell', 'buildctl', 'debug', 'info']));
+    // On Windows nerdctl needs a bit of time for the containerd socket to be ready
+    await new Promise(resolve => setTimeout(resolve, 1_000));
   });
 
   test('wait for docker context', async() => {


### PR DESCRIPTION
Fixes #4246

I was able to run the code in this test manually, but it always fails when it tries to run `nerdctl build --tag rd/extension/ui --build-arg variant=ui dataDir`

The error message showed that containerd.sock wasn't available.

Obviously when I ran the code interactively I gave the backend time to create the socket file.

If I just run `rdctl shell test -S .../containerd.sock` it fails to run `nerdctl build`, but if I have it wait a second it works.

I'm open to hear about a more reliable way to test that the socket is ready.