### PR TITLE
Render RDX content in main window

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -520,6 +520,11 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 mainEvents.on('settings-write', writeSettings);
 
 ipcMainProxy.on('extensions/list', listExtensionsMetadata);
+
+ipcMainProxy.on('extensions/open', (_event, id) => {
+  window.openExtension(id);
+});
+
 ipcMainProxy.handle('transient-settings-fetch', () => {
   return Promise.resolve(TransientSettings.value);
 });

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -28,7 +28,9 @@
         <template #before>
           <img :src="imageUri(extension.id)">
         </template>
-        {{ extension.metadata.ui['dashboard-tab'].title }}
+        <a @click="openExtension(extension.id)">
+          {{ extension.metadata.ui['dashboard-tab'].title }}
+        </a>
       </nav-item>
     </template>
   </nav>
@@ -39,6 +41,7 @@ import os from 'os';
 
 import { NuxtApp } from '@nuxt/types/app';
 import { BadgeState } from '@rancher/components';
+import { ipcRenderer } from 'electron';
 import { RouteRecordPublic } from 'vue-router';
 
 import NavItem from './NavItem.vue';
@@ -104,6 +107,10 @@ export default {
   methods: {
     imageUri(id: string): string {
       return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
+    },
+    openExtension(id: string): void {
+      console.log('OPEN EXTENSION', { id: hexEncode(id) });
+      ipcRenderer.send('extensions/open', hexEncode(id));
     },
   },
 };

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,13 +24,12 @@
       <nav-item
         v-for="extension in extensions"
         :key="extension.id"
+        @click="openExtension(extension.id)"
       >
         <template #before>
           <img :src="imageUri(extension.id)">
         </template>
-        <a @click="openExtension(extension.id)">
-          {{ extension.metadata.ui['dashboard-tab'].title }}
-        </a>
+        {{ extension.metadata.ui['dashboard-tab'].title }}
       </nav-item>
     </template>
   </nav>

--- a/pkg/rancher-desktop/components/NavItem.vue
+++ b/pkg/rancher-desktop/components/NavItem.vue
@@ -4,7 +4,10 @@ export default Vue.extend({});
 </script>
 
 <template>
-  <div class="nav-item">
+  <div
+    class="nav-item"
+    v-on="$listeners"
+  >
     <div
       v-if="$slots.before"
       class="before"
@@ -29,6 +32,10 @@ export default Vue.extend({});
     display: flex;
     gap: 0.5rem;
     align-items: center;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   .before {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -77,7 +77,10 @@ export interface IpcMainEvents {
 
   'help/preferences/open-url': () => void;
 
+  // #region Extensions
   'extensions/list': () => void;
+  'extensions/open': (id: string) => void;
+  // #endregion
 }
 
 /**
@@ -146,5 +149,6 @@ export interface IpcRendererEvents {
 
   // #region extensions
   'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
+  'extensions/open': (id: string) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -182,6 +182,8 @@ export function openMain() {
   app.dock?.show();
 }
 
+let view: Electron.BrowserView;
+
 export function openExtension(id: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
@@ -192,22 +194,24 @@ export function openExtension(id: string) {
     return;
   }
 
-  const view = new BrowserView();
   const windowSize = window?.getContentSize();
 
-  window?.setBrowserView(view);
+  if (!view) {
+    view = new BrowserView();
+    window?.setBrowserView(view);
 
-  const x = 230;
-  const y = 55;
+    const x = 230;
+    const y = 55;
 
-  view.setBounds({
-    x,
-    y,
-    width:  windowSize[0] - x,
-    height: windowSize[1] - y,
-  });
+    view.setBounds({
+      x,
+      y,
+      width:  windowSize[0] - x,
+      height: windowSize[1] - y,
+    });
 
-  view.setAutoResize({ width: true, height: true });
+    view.setAutoResize({ width: true, height: true });
+  }
 
   const url = `x-rd-extension://${ id }/ui/dashboard-tab/ui/index.html`;
 
@@ -216,21 +220,6 @@ export function openExtension(id: string) {
     .catch((err) => {
       console.error(`Can't load the dashboard URL ${ url }: `, err);
     });
-
-  // createWindow(
-  //   `extension:${ id }`,
-  //   `x-rd-extension://${ id }/ui/dashboard-tab/ui/index.html`,
-  //   {
-  //     width:          800,
-  //     height:         600,
-  //     parent:         getWindow('main') ?? undefined,
-  //     webPreferences: {
-  //       devTools:         true,
-  //       nodeIntegration:  false,
-  //       contextIsolation: true,
-  //       // preload:          preloadPath,
-  //     },
-  //   });
 }
 
 /**

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import path from 'path';
 
-import Electron, { BrowserWindow, app, shell } from 'electron';
+import Electron, { BrowserWindow, app, shell, BrowserView } from 'electron';
 
 import * as K8s from '@pkg/backend/k8s';
 import { load as loadSettings } from '@pkg/config/settings';
@@ -180,6 +180,57 @@ export function openMain() {
   });
 
   app.dock?.show();
+}
+
+export function openExtension(id: string) {
+  // const preloadPath = path.join(paths.resources, 'preload.js');
+  console.debug(`openExtension(${ id })`);
+
+  const window = getWindow('main') ?? undefined;
+
+  if (!window) {
+    return;
+  }
+
+  const view = new BrowserView();
+  const windowSize = window?.getContentSize();
+
+  window?.setBrowserView(view);
+
+  const x = 230;
+  const y = 55;
+
+  view.setBounds({
+    x,
+    y,
+    width:  windowSize[0] - x,
+    height: windowSize[1] - y,
+  });
+
+  view.setAutoResize({ width: true, height: true });
+
+  const url = `x-rd-extension://${ id }/ui/dashboard-tab/ui/index.html`;
+
+  view.webContents
+    .loadURL(url)
+    .catch((err) => {
+      console.error(`Can't load the dashboard URL ${ url }: `, err);
+    });
+
+  // createWindow(
+  //   `extension:${ id }`,
+  //   `x-rd-extension://${ id }/ui/dashboard-tab/ui/index.html`,
+  //   {
+  //     width:          800,
+  //     height:         600,
+  //     parent:         getWindow('main') ?? undefined,
+  //     webPreferences: {
+  //       devTools:         true,
+  //       nodeIntegration:  false,
+  //       contextIsolation: true,
+  //       // preload:          preloadPath,
+  //     },
+  //   });
 }
 
 /**


### PR DESCRIPTION
This renders an installed extension in the main window via an electron BrowserView. 

TODO:

- [ ] Update navigation when routing to extensions
- [ ] Destroy extension BrowserView when navigating to Rancher Desktop core routes