### PR TITLE
Update path for extension view

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -521,8 +521,8 @@ mainEvents.on('settings-write', writeSettings);
 
 ipcMainProxy.on('extensions/list', listExtensionsMetadata);
 
-ipcMainProxy.on('extensions/open', (_event, id) => {
-  window.openExtension(id);
+ipcMainProxy.on('extensions/open', (_event, id, path) => {
+  window.openExtension(id, path);
 });
 
 ipcMainProxy.handle('transient-settings-fetch', () => {

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,7 +24,7 @@
       <nav-item
         v-for="extension in extensions"
         :key="extension.id"
-        @click="openExtension(extension.id)"
+        @click="openExtension(extension)"
       >
         <template #before>
           <img :src="imageUri(extension.id)">
@@ -107,9 +107,11 @@ export default {
     imageUri(id: string): string {
       return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
     },
-    openExtension(id: string): void {
+    openExtension({ id, metadata }: { id: string, metadata: any}): void {
       console.log('OPEN EXTENSION', { id: hexEncode(id) });
-      ipcRenderer.send('extensions/open', hexEncode(id));
+      const { ui: { 'dashboard-tab': { root, src } } } = metadata;
+
+      ipcRenderer.send('extensions/open', hexEncode(id), `${ root }/${ src }`);
     },
   },
 };

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -40,11 +40,11 @@ import os from 'os';
 
 import { NuxtApp } from '@nuxt/types/app';
 import { BadgeState } from '@rancher/components';
-import { ipcRenderer } from 'electron';
 import { RouteRecordPublic } from 'vue-router';
 
 import NavItem from './NavItem.vue';
 
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { hexEncode } from '@pkg/utils/string-encode';
 
 export default {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -79,7 +79,7 @@ export interface IpcMainEvents {
 
   // #region Extensions
   'extensions/list': () => void;
-  'extensions/open': (id: string) => void;
+  'extensions/open': (id: string, path: string) => void;
   // #endregion
 }
 
@@ -149,6 +149,6 @@ export interface IpcRendererEvents {
 
   // #region extensions
   'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
-  'extensions/open': (id: string) => void;
+  'extensions/open': (id: string, path: string) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -194,11 +194,11 @@ export function openExtension(id: string, path: string) {
     return;
   }
 
-  const windowSize = window?.getContentSize();
+  const windowSize = window.getContentSize();
 
   if (!view) {
     view = new BrowserView();
-    window?.setBrowserView(view);
+    window.setBrowserView(view);
 
     const x = 230;
     const y = 55;

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -184,7 +184,7 @@ export function openMain() {
 
 let view: Electron.BrowserView;
 
-export function openExtension(id: string) {
+export function openExtension(id: string, path: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
 
@@ -213,7 +213,7 @@ export function openExtension(id: string) {
     view.setAutoResize({ width: true, height: true });
   }
 
-  const url = `x-rd-extension://${ id }/ui/dashboard-tab/ui/index.html`;
+  const url = `x-rd-extension://${ id }/ui/dashboard-tab/${ path }`;
 
   view.webContents
     .loadURL(url)


### PR DESCRIPTION
This derives the path for an installed extension from the `root` & `src` properties specified in metadata.

This also addresses some feedback not initially addressed in #4267

