### PR TITLE
Create dynamic routes for RDX

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -525,6 +525,10 @@ ipcMainProxy.on('extensions/open', (_event, id, path) => {
   window.openExtension(id, path);
 });
 
+ipcMainProxy.on('extensions/close', () => {
+  window.closeExtension();
+});
+
 ipcMainProxy.handle('transient-settings-fetch', () => {
   return Promise.resolve(TransientSettings.value);
 });

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -113,7 +113,7 @@ export default {
       const { ui: { 'dashboard-tab': { root, src } } } = metadata;
 
       return {
-        name:   'extensions-root-src-id',
+        name:   'rdx-root-src-id',
         params: {
           root,
           src,

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -21,16 +21,19 @@
         </template>
         Extensions
       </nav-item>
-      <nav-item
-        v-for="extension in extensions"
-        :key="extension.id"
-        @click="openExtension(extension)"
-      >
-        <template #before>
-          <img :src="imageUri(extension.id)">
-        </template>
-        {{ extension.metadata.ui['dashboard-tab'].title }}
-      </nav-item>
+      <template v-for="extension in extensions">
+        <nuxt-link
+          :key="extension.id"
+          :to="extensionRoute(extension.id)"
+        >
+          <nav-item>
+            <template #before>
+              <img :src="imageUri(extension.id)">
+            </template>
+            {{ extension.metadata.ui['dashboard-tab'].title }}
+          </nav-item>
+        </nuxt-link>
+      </template>
     </template>
   </nav>
 </template>
@@ -44,7 +47,6 @@ import { RouteRecordPublic } from 'vue-router';
 
 import NavItem from './NavItem.vue';
 
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { hexEncode } from '@pkg/utils/string-encode';
 
 export default {
@@ -107,11 +109,11 @@ export default {
     imageUri(id: string): string {
       return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
     },
-    openExtension({ id, metadata }: { id: string, metadata: any}): void {
-      console.log('OPEN EXTENSION', { id: hexEncode(id) });
-      const { ui: { 'dashboard-tab': { root, src } } } = metadata;
-
-      ipcRenderer.send('extensions/open', hexEncode(id), `${ root }/${ src }`);
+    extensionRoute(id: string) {
+      return {
+        name:   'extensions-id',
+        params: { id: hexEncode(id) },
+      };
     },
   },
 };
@@ -151,6 +153,15 @@ ul {
     }
 }
 
+a {
+  &:hover {
+    text-decoration: none;
+  }
+
+  &.nuxt-link-active::v-deep div {
+    background-color: var(--nav-active);
+  }
+}
 .nav-badge {
   line-height: initial;
   letter-spacing: initial;

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,7 +24,7 @@
       <template v-for="extension in extensions">
         <nuxt-link
           :key="extension.id"
-          :to="extensionRoute(extension.id)"
+          :to="extensionRoute(extension)"
         >
           <nav-item>
             <template #before>
@@ -109,10 +109,16 @@ export default {
     imageUri(id: string): string {
       return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
     },
-    extensionRoute(id: string) {
+    extensionRoute({ id, metadata }: { id: string, metadata: any }) {
+      const { ui: { 'dashboard-tab': { root, src } } } = metadata;
+
       return {
-        name:   'extensions-id',
-        params: { id: hexEncode(id) },
+        name:   'extensions-root-src-id',
+        params: {
+          root,
+          src,
+          id: hexEncode(id),
+        },
       };
     },
   },

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -70,6 +70,13 @@ export default {
     mode:          'hash',
     prefetchLinks: false,
     middleware:    ['i18n', 'indexRedirect'],
+    extendRoutes(routes, resolve) {
+      routes.push({
+        name:      'rdx-root-src-id',
+        path:      '/extensions/:root(.*)/:src/:id',
+        component: resolve(__dirname, 'pages/extensions/_root/_src/_id.vue'),
+      });
+    },
   },
   ssr:            false,
   styleResources: {

--- a/pkg/rancher-desktop/pages/extensions/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_id.vue
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { ipcRenderer } from 'electron';
+import Vue from 'vue';
+
+export default Vue.extend({
+  beforeRouteEnter(to, _from, next) {
+    const { params: { id } } = to;
+
+    next((vm: any) => {
+      vm.openExtension(id);
+    });
+  },
+  beforeRouteUpdate(to, _from, next) {
+    const { params: { id } } = to;
+
+    this.openExtension(id);
+
+    next();
+  },
+  beforeRouteLeave(_to, _from, next) {
+    this.closeExtensionView();
+    next();
+  },
+  methods: {
+    openExtension(id: string): void {
+      ipcRenderer.send('extensions/open', id);
+    },
+    closeExtensionView(): void {
+      ipcRenderer.send('extensions/close');
+    },
+  },
+});
+</script>
+
+<template>
+  <div>
+    <slot></slot>
+  </div>
+</template>

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -4,16 +4,16 @@ import Vue from 'vue';
 
 export default Vue.extend({
   beforeRouteEnter(to, _from, next) {
-    const { params: { id } } = to;
+    const { params: { root, src, id } } = to;
 
     next((vm: any) => {
-      vm.openExtension(id);
+      vm.openExtension(id, root, src);
     });
   },
   beforeRouteUpdate(to, _from, next) {
-    const { params: { id } } = to;
+    const { params: { root, src, id } } = to;
 
-    this.openExtension(id);
+    this.openExtension(id, root, src);
 
     next();
   },
@@ -22,8 +22,8 @@ export default Vue.extend({
     next();
   },
   methods: {
-    openExtension(id: string): void {
-      ipcRenderer.send('extensions/open', id);
+    openExtension(id: string, root: string, src: string): void {
+      ipcRenderer.send('extensions/open', id, `${ root }/${ src }`);
     },
     closeExtensionView(): void {
       ipcRenderer.send('extensions/close');

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -80,6 +80,7 @@ export interface IpcMainEvents {
   // #region Extensions
   'extensions/list': () => void;
   'extensions/open': (id: string, path: string) => void;
+  'extensions/close': () => void;
   // #endregion
 }
 
@@ -150,5 +151,6 @@ export interface IpcRendererEvents {
   // #region extensions
   'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
   'extensions/open': (id: string, path: string) => void;
+  'extensions/close': () => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -182,7 +182,7 @@ export function openMain() {
   app.dock?.show();
 }
 
-let view: Electron.BrowserView;
+let view: Electron.BrowserView | undefined;
 
 export function openExtension(id: string, path: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
@@ -220,6 +220,15 @@ export function openExtension(id: string, path: string) {
     .catch((err) => {
       console.error(`Can't load the dashboard URL ${ url }: `, err);
     });
+}
+
+export function closeExtension() {
+  if (!view) {
+    return;
+  }
+
+  getWindow('main')?.removeBrowserView(view);
+  view = undefined;
 }
 
 /**


### PR DESCRIPTION
This updates active routes and allows for navigating away from RDX into Rancher Desktop routes by creating dynamic routes for each installed extension. The dynamic route works by rendering a component in the background while the the RDX `BrowserView` overlays the main content area. This component watches the active route an emits events to either update or destroy the `BrowserView` depending on the destination.

We also extend our routes to allow for a `root` param that can contain forward slashes. 

closes #4276
closes #4274