### PR TITLE
Proxy support for WSL backend with moproxy

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -18,3 +18,4 @@ hostResolver: 0.1.5
 mobyOpenAPISpec: "1.43"
 wix: wix3112rtm
 hostSwitch: 0.1.0
+moproxy: 0.5.0

--- a/pkg/rancher-desktop/assets/scripts/moproxy.initd
+++ b/pkg/rancher-desktop/assets/scripts/moproxy.initd
@@ -1,0 +1,79 @@
+#!/sbin/openrc-run
+
+name=moproxy
+
+description="A transparent TCP to SOCKSv5/HTTP proxy."
+
+extra_started_commands="enable disable reload"
+description_enable="Start redirecting the network traffic to the HTTP proxy."
+description_disable="Stop redirecting the network traffic to the HTTP proxy."
+description_reload="Reload the proxy list."
+
+# TCP Listen address
+: ${host:=${MOPROXY_HOST:-"::"}}
+# TCP Listen port
+: ${port:=${MOPROXY_PORT:-"2080"}}
+# List of backend proxy servers
+: ${proxy_list:=${MOPROXY_PROXYLIST:-"/etc/moproxy/proxy.ini"}}
+# Additional arguments to pass to moproxy
+: ${moproxy_args:=${MOPROXY_ARGS:-""}}
+# Comma-seperated list of port traffic to redirect to moproxy
+: ${ports_redirected:=${MOPROXY_REDIRECTED_PORT:-"80,443"}}
+
+command="'${MOPROXY_BINARY:-/usr/sbin/moproxy}'"
+command_args="--host ${host} --port ${port} --list ${proxy_list} ${moproxy_args}"
+command_background="yes"
+pidfile="/run/${name}.pid"
+
+MOPROXY_LOGFILE="${MOPROXY_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
+output_log="'${MOPROXY_LOGFILE}'"
+error_log="'${MOPROXY_LOGFILE}'"
+
+iptables_cmd() {
+	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --jump REDIRECT --to-port "${port}"
+}
+
+add_rule_to_chain() {
+	if ! iptables_cmd check $1 &> /dev/null
+	then
+		iptables_cmd append $1
+	else
+		einfo "Rule already in table"
+	fi
+}
+
+remove_rule_from_chain() {
+	while iptables_cmd check $1 &> /dev/null
+	do
+		iptables_cmd delete $1
+	done
+}
+
+depend() {
+    after iptables ip6tables
+}
+
+enable() {
+	einfo "Starting the iptables rules to start redirection of ports ${ports_redirected} to ${name}"
+	add_rule_to_chain OUTPUT
+	add_rule_to_chain PREROUTING
+}
+
+disable() {
+	einfo "Removing all the iptables rules to stop redirection to ${name}"
+	remove_rule_from_chain OUTPUT
+	remove_rule_from_chain PREROUTING
+}
+
+start_post() {
+	enable
+}
+
+stop_pre() {
+	disable
+}
+
+reload() {
+	ebegin "Reloading ${name}"
+	start-stop-daemon --signal HUP --pidfile "$pidfile"
+}

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -1,4 +1,3 @@
-openapi: 3.0.0
 info:
   title: Rancher Desktop API
   version: 0.0.1
@@ -492,6 +491,26 @@ components:
                 useRosetta:
                   type: boolean
                   x-rd-platforms: [darwin]
+                proxy:
+                  type: object
+                  x-rd-platforms: [win32]
+                  x-rd-usage: configure proxy address
+                  properties:
+                    enabled:
+                      type: boolean
+                      x-rd-usage: redirect the traffic to the configured proxy address
+                    address:
+                      type: string
+                      x-rd-usage: proxy address
+                    password:
+                      type: string
+                      x-rd-usage: if needed the password to connect to the proxy
+                    port:
+                      type: integer
+                      x-rd-usage: proxy port
+                    username:
+                      type: string
+                      x-rd-usage: if needed the username to connect to the proxy
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -342,6 +342,15 @@ virtualMachine:
         virtiofs:
           label: virtiofs
           description: Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+  proxy:
+    legend: WSL Proxy
+    label: Enable the proxy used by rancher-desktop
+    addressTitle: Proxy address
+    address: Address
+    port: Port
+    authTitle: Authentication information
+    username: Username
+    password: Password
   socketVmNet:
     legend: Enable socket-vmnet
     label: Use socket-vmnet instead of vde-vmnet

--- a/pkg/rancher-desktop/backend/backend.ts
+++ b/pkg/rancher-desktop/backend/backend.ts
@@ -148,6 +148,11 @@ export interface VMBackend extends EventEmitter<BackendEvents> {
   reset(config: BackendSettings): Promise<void>;
 
   /**
+   * Apply the settings update that does not require a backend restart.
+   */
+  handleSettingsUpdate(config: BackendSettings): Promise<void>;
+
+  /**
    * Check if applying the given settings would require the backend to restart.
    */
   requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons>;

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -2101,6 +2101,8 @@ CREDFWD_URL='http://${ hostIPAddr }:${ stateInfo.port }'
     });
   }
 
+  async handleSettingsUpdate(_: BackendSettings): Promise<void> {}
+
   async requiresRestartReasons(cfg: RecursivePartial<BackendSettings>): Promise<RestartReasons> {
     const GiB = 1024 * 1024 * 1024;
     const limaConfig = await this.getLimaConfig();

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -97,6 +97,8 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
 
   noModalDialogs = true;
 
+  async handleSettingsUpdate(_: BackendSettings): Promise<void> {}
+
   requiresRestartReasons(config: RecursivePartial<BackendSettings>): Promise<RestartReasons> {
     if (!this.cfg) {
       return Promise.resolve({});

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1578,6 +1578,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     });
   }
 
+  async handleSettingsUpdate(newConfig: BackendSettings): Promise<void> {}
+
   // The WSL implementation of requiresRestartReasons doesn't need to do
   // anything asynchronously; however, to match the API, we still need to return
   // a Promise.

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1140,15 +1140,34 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   }
 
   /**
+   * Execute a command on a given OpenRC service.
+   *
+   * @param service The name of the OpenRC service to execute.
+   * @param action The name of the OpenRC service action to execute.
+   * @param argument Argument to pass to `wsl-service` (`--ifnotstart`, `--ifstarted`)
+   */
+  async execService(service: string, action: string, argument = '') {
+    await this.execCommand('/usr/local/bin/wsl-service', argument, service, action);
+  }
+
+  /**
    * Start the given OpenRC service.  This should only happen after
    * provisioning, to ensure that provisioning can modify any configuration.
    *
    * @param service The name of the OpenRC service to execute.
    */
   async startService(service: string) {
-    // Run rc-update as we have dynamic dependencies.
     await this.execCommand('/sbin/rc-update', '--update');
-    await this.execCommand('/usr/local/bin/wsl-service', service, 'start');
+    await this.execService(service, 'start', '--ifnotstarted');
+  }
+
+  /**
+   * Stop the given OpenRC service.
+   *
+   * @param service The name of the OpenRC service to stop.
+   */
+  async stopService(service: string) {
+    await this.execService(service, 'stop', '--ifstarted');
   }
 
   /**
@@ -1379,7 +1398,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         switch (config.containerEngine.name) {
         case ContainerEngine.CONTAINERD:
           await this.progressTracker.action('Starting buildkit', 0,
-            this.execCommand('/usr/local/bin/wsl-service', '--ifnotstarted', 'buildkitd', 'start'));
+            this.startService('buildkitd'));
           this.#containerEngineClient = new NerdctlClient(this);
           break;
         case ContainerEngine.MOBY:
@@ -1479,7 +1498,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
         // Stop the service if it's already running for some reason.
         // This should never be the case (because we tore down init).
-        await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
+        await this.stopService('local');
 
         // Clobber /etc/local.d and replace it with a symlink to our desired
         // path.  This is needed as /etc/init.d/local does not support
@@ -1495,7 +1514,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           '-print', '-exec', 'chmod', 'a+x', '{}', ';');
 
         // Run the script.
-        await this.execCommand('/usr/local/bin/wsl-service', 'local', 'start');
+        await this.startService('local');
       })(),
     ]);
   }
@@ -1517,14 +1536,14 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
       await this.progressTracker.action('Shutting Down...', 10, async() => {
         if (await this.isDistroRegistered({ runningOnly: true })) {
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'k3s', 'stop');
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'docker', 'stop');
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'containerd', 'stop');
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'openresty', 'stop');
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'rancher-desktop-guestagent', 'stop');
-          await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'buildkitd', 'stop');
+          await this.stopService('k3s');
+          await this.stopService('docker');
+          await this.stopService('containerd');
+          await this.stopService('openresty');
+          await this.stopService('rancher-desktop-guestagent');
+          await this.stopService('buildkitd');
           try {
-            await this.execCommand('/usr/local/bin/wsl-service', '--ifstarted', 'local', 'stop');
+            await this.stopService('local');
           } catch (ex) {
             // Do not allow errors here to prevent us from stopping.
             console.error('Failed to run user provisioning scripts on stopping:', ex);

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -796,6 +796,22 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     }
   }
 
+  protected async writeProxySettings(proxy: BackendSettings['experimental']['virtualMachine']['proxy']): Promise<void> {
+    if (proxy.address && proxy.port) {
+      // Write to /etc/moproxy/proxy.ini
+      const protocol = proxy.address.startsWith('socks5://') ? 'socks5' : 'http';
+      const address = proxy.address.replace(/(https|http|socks5):\/\//g, '');
+      const contents = `[rancher-desktop-proxy]\naddress=${ address }:${ proxy.port }\nprotocol=${ protocol }\n`;
+      const attributePrefix = protocol === 'socks5' ? 'socks' : 'http';
+      const username = proxy.username ? `${ attributePrefix } username=${ proxy.username }\n` : '';
+      const password = proxy.password ? `${ attributePrefix } password=${ proxy.password }\n` : '';
+
+      await this.writeFile(`/etc/moproxy/proxy.ini`, `${ contents }${ username }${ password }`);
+    } else {
+      await this.writeFile(`/etc/moproxy/proxy.ini`, '; no proxy defined');
+    }
+  }
+
   /**
    * handleUpgrade removes all the left over files that
    * were renamed in between releases.
@@ -1322,6 +1338,9 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                 await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, 0o755);
                 await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF);
               }),
+              this.progressTracker.action('Proxy Config Setup', 50, async() => {
+                await this.writeProxySettings(config.experimental.virtualMachine.proxy);
+              }),
               this.progressTracker.action('Configuring image proxy', 50, async() => {
                 const allowedImagesConf = '/usr/local/openresty/nginx/conf/allowed-images.conf';
                 const resolver = `resolver ${ await this.ipAddress } ipv6=off;\n`;
@@ -1386,6 +1405,10 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         }
 
         await this.progressTracker.action('Running provisioning scripts', 100, this.runProvisioningScripts());
+
+        if (config.experimental.virtualMachine.proxy.enabled && config.experimental.virtualMachine.proxy.address && config.experimental.virtualMachine.proxy.port) {
+          await this.progressTracker.action('Starting proxy', 100, this.startService('moproxy'));
+        }
         if (config.containerEngine.allowedImages.enabled) {
           await this.progressTracker.action('Starting image proxy', 100, this.startService('openresty'));
         }
@@ -1597,7 +1620,17 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     });
   }
 
-  async handleSettingsUpdate(newConfig: BackendSettings): Promise<void> {}
+  async handleSettingsUpdate(newConfig: BackendSettings): Promise<void> {
+    const proxy = newConfig.experimental.virtualMachine.proxy;
+
+    await this.writeProxySettings(proxy);
+    if (proxy.enabled && proxy.address && proxy.port) {
+      await this.execService('moproxy', 'reload', '--ifstarted');
+      await this.startService('moproxy');
+    } else {
+      await this.stopService('moproxy');
+    }
+  }
 
   // The WSL implementation of requiresRestartReasons doesn't need to do
   // anything asynchronously; however, to match the API, we still need to return

--- a/pkg/rancher-desktop/components/Preferences/BodyWsl.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyWsl.vue
@@ -5,6 +5,7 @@ import { mapGetters, mapState } from 'vuex';
 
 import PreferencesWslIntegrations from '@pkg/components/Preferences/WslIntegrations.vue';
 import PreferencesWslNetwork from '@pkg/components/Preferences/WslNetwork.vue';
+import PreferencesWslProxy from '@pkg/components/Preferences/WslProxy.vue';
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
 import Tab from '@pkg/components/Tabbed/Tab.vue';
 import { Settings } from '@pkg/config/settings';
@@ -17,7 +18,7 @@ import type { PropType } from 'vue';
 export default Vue.extend({
   name:       'preferences-body-wsl',
   components: {
-    RdTabbed, Tab, PreferencesWslIntegrations, PreferencesWslNetwork,
+    RdTabbed, Tab, PreferencesWslIntegrations, PreferencesWslNetwork, PreferencesWslProxy,
   },
   props: {
     preferences: {
@@ -29,7 +30,7 @@ export default Vue.extend({
     ...mapGetters('transientSettings', ['getActiveTab']),
     ...mapState('credentials', ['credentials']),
     activeTab(): string {
-      return this.getActiveTab || 'integrations';
+      return this.getActiveTab || 'integration';
     },
   },
   methods: {
@@ -61,14 +62,19 @@ export default Vue.extend({
   >
     <template #tabs>
       <tab
-        label="Integrations"
-        name="integrations"
-        :weight="1"
-      />
-      <tab
         label="Network"
         name="network"
+        :weight="3"
+      />
+      <tab
+        label="Integrations"
+        name="integrations"
         :weight="2"
+      />
+      <tab
+        label="Proxy"
+        name="proxy"
+        :weight="1"
       />
     </template>
     <div class="wsl-content">

--- a/pkg/rancher-desktop/components/Preferences/WslProxy.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslProxy.vue
@@ -1,0 +1,106 @@
+<script lang="ts">
+import { Checkbox } from '@rancher/components';
+import Vue from 'vue';
+
+import RdFieldset from '@pkg/components/form/RdFieldset.vue';
+import { Settings } from '@pkg/config/settings';
+import { RecursiveTypes } from '@pkg/utils/typeUtils';
+
+import type { PropType } from 'vue';
+
+export default Vue.extend({
+  name:       'preferences-wsl-proxy',
+  components: { Checkbox, RdFieldset },
+  props:      {
+    preferences: {
+      type:     Object as PropType<Settings>,
+      required: true,
+    },
+  },
+  computed: {
+    isFieldDisabled() {
+      return !(this.preferences.experimental.virtualMachine.proxy.enabled);
+    },
+  },
+  methods: {
+    onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
+      this.$store.dispatch('preferences/updatePreferencesData', { property, value });
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="preferences-body">
+    <section class="wsl-proxy">
+      <rd-fieldset
+        :legend-text="t('virtualMachine.proxy.legend')"
+        :badge-text="t('prefs.experimental')"
+      >
+        <checkbox
+          :label="t('virtualMachine.proxy.label', { }, true)"
+          :value="preferences.experimental.virtualMachine.proxy.enabled"
+          @input="onChange('experimental.virtualMachine.proxy.enabled', $event)"
+        />
+      </rd-fieldset>
+      <hr>
+      <rd-fieldset
+        class="wsl-proxy-fieldset"
+        :legend-text="t('virtualMachine.proxy.addressTitle', { }, true)"
+      >
+        <input
+          :placeholder="t('virtualMachine.proxy.address', { }, true)"
+          :disabled="isFieldDisabled"
+          :value="preferences.experimental.virtualMachine.proxy.address"
+          class="wsl-proxy-field"
+          @input="onChange('experimental.virtualMachine.proxy.address', $event.target.value)"
+        />
+        <input
+          type="number"
+          :placeholder="t('virtualMachine.proxy.port', { }, true)"
+          :disabled="isFieldDisabled"
+          :value="preferences.experimental.virtualMachine.proxy.port"
+          class="wsl-proxy-field"
+          @input="onChange('experimental.virtualMachine.proxy.port', $event.target.value)"
+        />
+      </rd-fieldset>
+      <rd-fieldset
+        class="wsl-proxy-fieldset"
+        :legend-text="t('virtualMachine.proxy.authTitle', { }, true)"
+      >
+        <input
+          :placeholder="t('virtualMachine.proxy.username', { }, true)"
+          :disabled="isFieldDisabled"
+          :value="preferences.experimental.virtualMachine.proxy.username"
+          class="wsl-proxy-field"
+          @input="onChange('experimental.virtualMachine.proxy.username', $event.target.value)"
+        />
+        <input
+          type="password"
+          :placeholder="t('virtualMachine.proxy.password', { }, true)"
+          :disabled="isFieldDisabled"
+          :value="preferences.experimental.virtualMachine.proxy.password"
+          class="wsl-proxy-field"
+          @input="onChange('experimental.virtualMachine.proxy.password', $event.target.value)"
+        />
+      </rd-fieldset>
+    </section>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .wsl-proxy {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    color: grey;
+  }
+  .wsl-proxy-fieldset {
+    display: flex;
+    flex-direction: row;
+    gap: .5rem;
+  }
+  .wsl-proxy-field {
+    width: 100%;
+  }
+</style>

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -138,6 +138,9 @@ export const defaultSettings = {
       },
       /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
       networkingTunnel: false,
+      proxy:            {
+        enabled: false, address: '', password: '', port: 3128, username: '',
+      },
     },
   },
 };

--- a/pkg/rancher-desktop/config/transientSettings.ts
+++ b/pkg/rancher-desktop/config/transientSettings.ts
@@ -21,6 +21,7 @@ export const defaultTransientSettings = {
         Application:        'general',
         'Virtual Machine':  'hardware',
         'Container Engine': 'general',
+        ...(process.platform === 'win32' && { WSL: 'integration' }),
       } as Record<NavItemName, string | undefined>,
     },
   },

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -85,6 +85,7 @@ describe(SettingsValidator, () => {
       'application.adminAccess':                      'linux',
       'experimental.virtualMachine.socketVMNet':      'darwin',
       'experimental.virtualMachine.networkingTunnel': 'win32',
+      'experimental.virtualMachine.proxy':            'win32',
       'kubernetes.ingress.localhostOnly':             'win32',
       'virtualMachine.hostResolver':                  'win32',
       'virtualMachine.memoryInGB':                    'darwin',

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -169,6 +169,13 @@ export default class SettingsValidator {
             this.checkEnum(...Object.values(VMType)),
             this.checkVMType),
           ),
+          proxy: {
+            enabled:  this.checkBoolean,
+            address:  this.checkString,
+            password: this.checkString,
+            port:     this.checkNumber(1, 65535),
+            username: this.checkString,
+          },
         },
       },
       WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -15,7 +15,7 @@ interface NavItems {
   tabs?: string[];
 }
 
-const wslTabs: string[] = ['integrations', 'network'];
+const wslTabs: string[] = ['integrations', 'network', 'proxy'];
 const vmLinuxTabs: string[] = ['hardware', 'volumes'];
 const vmDarwinTabs: string[] = vmLinuxTabs.concat(['network', 'emulation']);
 

--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -124,6 +124,38 @@ export class HostResolverHost implements Dependency, GithubDependency {
   }
 }
 
+export class Moproxy implements Dependency, GithubDependency {
+  name = 'Moproxy';
+  githubOwner = 'rancher-sandbox';
+  githubRepo = 'moproxy';
+
+  async download(context: DownloadContext): Promise<void> {
+    const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
+    const tarName = `moproxy_${ context.versions.moproxy }_linux_x86_64_musl.bin.tar.gz`;
+    const moproxyURL = `${ baseURL }/v${ context.versions.moproxy }/${ tarName }`;
+    const moproxyPath = path.join(context.internalDir, tarName);
+
+    await download(
+      moproxyURL,
+      moproxyPath,
+      { access: fs.constants.W_OK });
+
+    extract(context.internalDir, moproxyPath, 'moproxy');
+  }
+
+  async getAvailableVersions(includePrerelease = false): Promise<string[]> {
+    return await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
+  }
+
+  versionToTagName(version: string): string {
+    return `v${ version }`;
+  }
+
+  rcompareVersions(version1: string, version2: string): -1 | 0 | 1 {
+    return semver.rcompare(version1, version2);
+  }
+}
+
 export class WSLDistro implements Dependency, GithubDependency {
   name = 'WSLDistro';
   githubOwner = 'rancher-sandbox';

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -49,6 +49,7 @@ export type DependencyVersions = {
   mobyOpenAPISpec: string;
   wix: string;
   hostSwitch: string;
+  moproxy: string;
 };
 
 export async function readDependencyVersions(path: string): Promise<DependencyVersions> {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -7,7 +7,9 @@ import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
-import { WSLDistro, HostResolverHost, HostResolverPeer, HostSwitch } from 'scripts/dependencies/wsl';
+import {
+  WSLDistro, HostResolverHost, HostResolverPeer, HostSwitch, Moproxy,
+} from 'scripts/dependencies/wsl';
 import {
   DependencyPlatform, DependencyVersions, readDependencyVersions, DownloadContext, Dependency,
 } from 'scripts/lib/dependencies';
@@ -41,6 +43,7 @@ const windowsDependencies = [
 // Dependencies that are specific to WSL.
 const wslDependencies = [
   new HostResolverPeer(),
+  new Moproxy(),
   new tools.GuestAgent(),
 ];
 

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -9,7 +9,7 @@ import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
-import { WSLDistro, HostResolverHost, HostSwitch } from 'scripts/dependencies/wsl';
+import { WSLDistro, HostResolverHost, HostSwitch, Moproxy } from 'scripts/dependencies/wsl';
 import {
   DependencyVersions, readDependencyVersions, writeDependencyVersions, Dependency, AlpineLimaISOVersion, getOctokit,
 } from 'scripts/lib/dependencies';
@@ -43,6 +43,7 @@ const dependencies: Dependency[] = [
   new Wix(),
   new MobyOpenAPISpec(),
   new HostSwitch(),
+  new Moproxy(),
 ];
 
 function git(...args: string[]): number | null {


### PR DESCRIPTION
See https://github.com/rancher-sandbox/rancher-desktop/issues/4013 for more information

This PR adds support for proxy inside WSL with the help of [moproxy](https://github.com/sorz/moproxy).  These changes require the modification of the WSL distro to work (see the changes at https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/compare/main...tperale:rancher-desktop-wsl-distro:main)

`moproxy` is configured inside WSL from the rancher-desktop preference window and the `iptables` rules are set to enable/disable to forward the traffic to the proxy.

```mermaid
flowchart  LR;
 subgraph VM["WSL VM"]
   direction LR
   apps{{"Apps"}}
   subgraph vmIptables["iptables"]
   direction LR
     rules{"Rules"}
   end
   moproxy["moproxy"]
   apps -- TCP --> rules
   rules --> moproxy
 end
 proxy((("Proxy")))
 moproxy --> proxy
```

Right now only the port `80` and `443` are forwarded when the proxy is enabled. This makes `docker pull` and `docker push` work behind a proxy.