### PR TITLE
Fix assertion in extension/install.bats test

### DIFF
--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -66,10 +66,10 @@ namespace_arg() {
     for extension in "${variants[@]}"; do
         ctrctl $(namespace_arg) build --tag rd/extension/$extension --build-arg variant=$extension "$TESTDATA_DIR"
     done
+    run ctrctl $(namespace_arg) image list --format '{{ .Repository }}'
+    assert_success
     for extension in "${variants[@]}"; do
-        run ctrctl $(namespace_arg) image list --format '{{ .Repository }}'
-        assert_success
-        assert_line "rd/extension/${variants[@]}"
+        assert_line "rd/extension/$extension"
     done
 }
 


### PR DESCRIPTION
The test did not fail before because interpolating an array inside a string turns it into multiple arguments, and assert_line ignores everything after the first. So each loop would always check for the first variant, and the rest would remain untested.