### PR TITLE
Modified check_installation function to verify factory-reset on windows

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -3,7 +3,7 @@ setup() {
 }
 
 @test 'factory-reset when Rancher Desktop is not running' {
-    factory_reset
+    rdctl factory-reset --verbose
     start_application
     rdctl shutdown
     rdctl_factory_reset --remove-kubernetes-cache=false --verbose
@@ -96,23 +96,23 @@ check_installation() {
         ${assert}_not_exists "$dir"
     done
 
-    #Check if rancher-desktop WSL distros are deleted on Windows
+    # Check if rancher-desktop WSL distros are deleted on Windows
     if is_windows; then
-        run wsl --list
-        ${refute}_output "rancher-desktop"
-        ${refute}_output "rancher-desktop-data"
+        run powershell.exe -c "wsl.exe --list"
+        ${refute}_line "rancher-desktop-data"
+        ${refute}_line "rancher-desktop"
     fi
 
-    # Check if docker-X symlinks were deleted
     if is_unix; then
+
+        # Check if docker-X symlinks were deleted
         for dfile in docker-buildx docker-compose; do
             run readlink "$HOME/.docker/cli-plugins/$dfile"
             ${refute}_output "$HOME/.rd/bin/$dfile"
         done
-    fi
 
-    # Check if ./rd/bin was removed from the path
-    if is_unix; then
+        # Check if ./rd/bin was removed from the path
+
         # TODO add check for config.fish
         env_profiles=(
             "$HOME/.bashrc"
@@ -137,19 +137,15 @@ check_installation() {
             run grep "PATH.\"$HOME/.rd/bin" "$profile"
             ${assert}_failure
         done
-    fi
 
-    # Check if the rancher-desktop docker context has been removed
-    if is_unix; then
+        # Check if the rancher-desktop docker context has been removed
         if using_docker; then
             echo "$assert that the docker context rancher-desktop does not exist"
             run grep -r rancher-desktop "$HOME/.docker/contexts/meta"
             ${assert}_failure
         fi
-    fi
 
-    # Check if VM was killed
-    if is_unix; then
+        # Check if VM was killed
         run limactl ls
         ${assert}_output --partial "No instance found"
     fi

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -104,10 +104,12 @@ check_installation() {
     fi
 
     # Check if docker-X symlinks were deleted
+    if is_unix; then
     for dfile in docker-buildx docker-compose; do
         run readlink "$HOME/.docker/cli-plugins/$dfile"
         ${refute}_output "$HOME/.rd/bin/$dfile"
     done
+    fi
 
     # Check if ./rd/bin was removed from the path
     if is_unix; then

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -2,11 +2,28 @@ setup() {
     load '../helpers/load'
 }
 
-@test 'factory-reset when Rancher Desktop is not running' {
-    rdctl factory-reset --verbose
-    start_application
+@test 'factory-reset - pre-condition to factory-reset when Rancher Desktop is not running' {
+    factory_reset
+}
+
+@test 'restart application' {
+    run start_application
+    assert_success
+}
+
+@test 'verify application before factory-reset' {
+    check_installation before
+}
+
+@test 'shutdown Rancher Desktop' {
     rdctl shutdown
+}
+
+@test 'factory-reset after shutdown Rancher Desktop' {
     rdctl_factory_reset --remove-kubernetes-cache=false --verbose
+}
+
+@test 'verify factory-reset worked after shutdown Rancher Desktop' {
     check_installation
 }
 
@@ -40,7 +57,6 @@ start_application() {
         rdctl set --application.path-management-strategy rcfiles
     fi
 
-    check_installation before
 }
 
 rdctl_factory_reset() {

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -46,7 +46,7 @@ start_application() {
 rdctl_factory_reset() {
     rdctl factory-reset "$@"
 
-    if [[ "${1:-}" == "--remove-kubernetes-cache=true" ]]; then
+    if [[ ${1-} == "--remove-kubernetes-cache=true" ]]; then
         assert_not_exist "$PATH_CACHE"
     else
         assert_exists "$PATH_CACHE"
@@ -105,10 +105,10 @@ check_installation() {
 
     # Check if docker-X symlinks were deleted
     if is_unix; then
-    for dfile in docker-buildx docker-compose; do
-        run readlink "$HOME/.docker/cli-plugins/$dfile"
-        ${refute}_output "$HOME/.rd/bin/$dfile"
-    done
+        for dfile in docker-buildx docker-compose; do
+            run readlink "$HOME/.docker/cli-plugins/$dfile"
+            ${refute}_output "$HOME/.rd/bin/$dfile"
+        done
     fi
 
     # Check if ./rd/bin was removed from the path
@@ -131,15 +131,13 @@ check_installation() {
         done
 
         for profile in "${env_profiles[@]}"; do
-        echo "$assert that $profile does not add ~/.rd/bin to the PATH"
-        # cshrc: setenv PATH "/Users/jan/.rd/bin"\:"$PATH"
-        # posix: export PATH="/Users/jan/.rd/bin:$PATH"
-        run grep "PATH.\"$HOME/.rd/bin" "$profile"
-        ${assert}_failure
+            echo "$assert that $profile does not add ~/.rd/bin to the PATH"
+            # cshrc: setenv PATH "/Users/jan/.rd/bin"\:"$PATH"
+            # posix: export PATH="/Users/jan/.rd/bin:$PATH"
+            run grep "PATH.\"$HOME/.rd/bin" "$profile"
+            ${assert}_failure
         done
     fi
-
-
 
     # Check if the rancher-desktop docker context has been removed
     if is_unix; then

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -47,6 +47,8 @@ if is_windows; then
     PATH_DATA="$LOCALAPPDATA/rancher-desktop"
     PATH_CACHE="$PATH_DATA/cache"
     PATH_LOGS="$PATH_DATA/logs"
+    PATH_DISTRO="$PATH_DATA/distro"
+    PATH_DISTRO_DATA="$PATH_DATA/distro-data"
     PATH_EXTENSIONS="$PATH_DATA/extensions"
     if test -d "$PROGRAMFILES/Rancher Desktop"; then
         PATH_EXECUTABLE="$PROGRAMFILES/Rancher Desktop/Rancher Desktop.exe"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -8,7 +8,7 @@ wait_for_shell() {
 }
 
 factory_reset() {
-    rdctl factory-reset
+    rdctl factory-reset --verbose
 
     if is_windows; then
         run sudo ip link delete docker0

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -55,9 +55,8 @@ EOF
     rdctl start \
         --application.updater.enabled=false \
         --container-engine.name="$RD_CONTAINER_ENGINE" \
-        --kubernetes.enabled=true \
-        #--virtual-machine.memory-in-gb 6 \
-        "$@" &
+        --kubernetes.enabled=true
+    "$@" &
 }
 
 start_kubernetes() {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -54,16 +54,16 @@ EOF
     # Rancher Desktop itself quits.
     rdctl start \
         --application.updater.enabled=false \
-        --container-engine="$RD_CONTAINER_ENGINE" \
-        --kubernetes-enabled=false \
-        --virtual-machine.memory-in-gb 6 \
+        --container-engine.name="$RD_CONTAINER_ENGINE" \
+        --kubernetes.enabled=true \
+        #--virtual-machine.memory-in-gb 6 \
         "$@" &
 }
 
 start_kubernetes() {
     start_container_engine \
-        --kubernetes-enabled \
-        --kubernetes-version "$RD_KUBERNETES_PREV_VERSION"
+        --kubernetes.enabled \
+        --kubernetes.version "$RD_KUBERNETES_PREV_VERSION"
 }
 
 container_engine_info() {


### PR DESCRIPTION
factory-reset.bats verifies the behaviour of `rdctl factory-reset` only for MacOS and Linux. Adding steps to validate such feature on Windows