### PR TITLE
Fix RD_USE_IMAGE_ALLOW_LIST usage in registry/creds.bats

### DIFF
--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -84,8 +84,10 @@ skip_for_insecure_registry() {
     start_container_engine
 
     if using_image_allow_list; then
-        rdctl api -X PUT -b settings <<EOF
+        wait_for_shell
+        rdctl api -X PUT --input - settings <<EOF
 {
+  "version": 6,
   "containerEngine": {
     "allowedImages": {
       "enabled": true,


### PR DESCRIPTION
This code was broken during refactoring to make the test Windows compatible in 4660780.

It also needs to specify the settings version for RD 1.8.1.