### PR TITLE
RDX: Change devtools behaviour

### DIFF
--- a/pkg/rancher-desktop/utils/shortcuts.ts
+++ b/pkg/rancher-desktop/utils/shortcuts.ts
@@ -9,7 +9,15 @@ const log = Logging.shortcuts;
 
 const Shortcut = {
   key: (shortcut: Shortcut | Electron.Input) => {
-    return `${ shortcut.meta ? 'Cmd+' : '' }${ shortcut.control ? 'Ctrl+' : '' }${ shortcut.shift ? 'Shift+' : '' }${ shortcut.alt ? 'Alt+' : '' }${ shortcut.key }`;
+    const keyName = shortcut.key.toString();
+
+    return [
+      shortcut.meta ? 'Cmd+' : '',
+      shortcut.control ? 'Ctrl+' : '',
+      shortcut.shift ? 'Shift+' : '',
+      shortcut.alt ? 'Alt+' : '',
+      keyName.length === 1 ? keyName.toUpperCase() : keyName,
+    ].join('');
   },
 };
 

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -223,9 +223,9 @@ export function openExtension(id: string, relPath: string) {
         window, {
           ...CommandOrControl,
           shift: true,
-          key:   'i',
+          key:   'O',
         },
-        () => view?.webContents.openDevTools(),
+        () => view?.webContents.openDevTools({ mode: 'detach' }),
         'open developer tools for the extension',
       );
     }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -223,7 +223,7 @@ export function openExtension(id: string, relPath: string) {
         window, {
           ...CommandOrControl,
           shift: true,
-          key:   'O',
+          key:   'O', // U+004F Latin Capital Letter O
         },
         () => view?.webContents.openDevTools({ mode: 'detach' }),
         'open developer tools for the extension',


### PR DESCRIPTION
- Open devtools on `{Ctrl/Cmd}+Shift+O`
  `Ctrl+Shift+I` was used on Windows/Linux for the main devtools (likely because `Ctrl+Alt` is `AltGr`)
- Make shortcuts upper-case the key (for single-character key names), as this is inconsistent across platforms.
- Force the extensions devtool view to open detached.

Resolves https://github.com/rancher-sandbox/rancher-desktop/pull/4273#pullrequestreview-1363666231
Fixes #4247