### PR TITLE
Automate testing the back-end of test #20

### DIFF
--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -25,7 +25,7 @@ setup() {
 
 @test "pull rancher" {
     docker run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
-    run docker images --format '{{json .Repository}}
+    run docker ps --format '{{json .Image}}'
     assert_output --partial "rancher/rancher"
 }
 
@@ -33,7 +33,7 @@ setup() {
     rdctl set --container-engine.name=containerd
     wait_for_container_engine
     nerdctl run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
-    run nerdctl images --format '{{json .Repository}}
+    run nerdctl ps --format '{{json .Image}}'
     assert_output --partial "rancher/rancher"
 }
 
@@ -43,12 +43,12 @@ setup() {
 }
 
 @test 'verify the rancher container is gone' {
-    run docker images --format '{{json .Repository}}
+    run docker ps --format '{{json .Image}}'
     refute_output --partial "rancher/rancher"
 }
 
 @test 'switch back to containerd and verify that container is gone' {
     rdctl set --container-engine.name containerd
-    run nerdctl images --format '{{json .Repository}}'
+    run nerdctl ps --format '{{json .Image}}'
     refute_output --partial "rancher/rancher"
 }

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -25,7 +25,7 @@ setup() {
 
 @test "pull rancher" {
     docker run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
-    run docker ps
+    run docker images --format '{{json .Repository}}
     assert_output --partial "rancher/rancher"
 }
 
@@ -33,7 +33,7 @@ setup() {
     rdctl set --container-engine.name=containerd
     wait_for_container_engine
     nerdctl run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
-    run nerdctl ps
+    run nerdctl images --format '{{json .Repository}}
     assert_output --partial "rancher/rancher"
 }
 
@@ -43,12 +43,12 @@ setup() {
 }
 
 @test 'verify the rancher container is gone' {
-    run docker ps
+    run docker images --format '{{json .Repository}}
     refute_output --partial "rancher/rancher"
 }
 
 @test 'switch back to containerd and verify that container is gone' {
     rdctl set --container-engine.name containerd
-    run nerdctl ps
+    run nerdctl images --format '{{json .Repository}}'
     refute_output --partial "rancher/rancher"
 }

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -1,0 +1,54 @@
+# Test case 20
+
+setup() {
+    load '../helpers/load'
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start container engine' {
+    start_container_engine
+    wait_for_container_engine
+}
+
+@test "verify we're on docker" {
+    engineName="$(rdctl list-settings | jq -r .containerEngine.name)"
+    case $engineName in
+    containerd)
+        rdctl set --container-engine.name moby
+        wait_for_container_engine
+        ;;
+    esac
+}
+
+@test "pull rancher" {
+    docker run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
+    run docker ps
+    assert_output --partial "rancher/rancher"
+}
+
+@test "switch to containerd" {
+    rdctl set --container-engine.name=containerd
+    wait_for_container_engine
+    nerdctl run --privileged -d --restart=no -p 8080:80 -p 8443:443 rancher/rancher
+    run nerdctl ps
+    assert_output --partial "rancher/rancher"
+}
+
+@test 'switch back to moby' {
+    rdctl set --container-engine.name moby
+    wait_for_container_engine
+}
+
+@test 'verify the rancher container is gone' {
+    run docker ps
+    refute_output --partial "rancher/rancher"
+}
+
+@test 'switch back to containerd and verify that container is gone' {
+    rdctl set --container-engine.name containerd
+    run nerdctl ps
+    refute_output --partial "rancher/rancher"
+}

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -21,7 +21,9 @@ setup() {
 }
 
 @test "switch to containerd" {
-    rdctl set --container-engine.name=containerd
+    RD_CONTAINER_ENGINE=containerd
+    run rdctl set --container-engine.name=containerd
+    assert_success
     wait_for_container_engine
     nerdctl run -d -p 8086:80 --restart=no nginx
     run nerdctl ps --format '{{json .Image}}'
@@ -29,7 +31,9 @@ setup() {
 }
 
 @test 'switch back to moby' {
-    rdctl set --container-engine.name moby
+    RD_CONTAINER_ENGINE=moby
+    run rdctl set --container-engine.name moby
+    assert_success
     wait_for_container_engine
 }
 
@@ -39,7 +43,14 @@ setup() {
 }
 
 @test 'switch back to containerd and verify that the nginx container is gone' {
-    rdctl set --container-engine.name containerd
+    RD_CONTAINER_ENGINE=containerd
+    run rdctl set --container-engine.name containerd
+    assert_success
+    wait_for_container_engine
     run nerdctl ps --format '{{json .Image}}'
     refute_output --partial "nginx"
+}
+
+@test 'linux-bats is waiting for an rd shutdown before it stops' {
+    rdctl shutdown
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -78,7 +78,7 @@ docker_context_exists() {
 }
 
 buildkitd_is_running() {
-    run rdctl shell rc-service buildkitd status
+    run rdctl shell rc-service --nocolor buildkitd status
     assert_success
     assert_output --partial 'status: started'
 }


### PR DESCRIPTION
Switching between moby & containerd

I don't see a way to directly access the tray menu, so I left a note that this still needs to be tested manually.