### PR TITLE
RDX: Set up the API synchronously.

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import Electron, { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+import { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import _ from 'lodash';
 
 import { ExtensionImpl } from './extensions';
@@ -94,12 +94,6 @@ class ExtensionManagerImpl implements ExtensionManager {
 
   async init(config: RecursiveReadonly<Settings>) {
     // Handle events from the renderer process.
-    this.setMainHandler('extensions/host-info', () => ({
-      platform: process.platform,
-      arch:     Electron.app.runningUnderARM64Translation ? 'arm64' : process.arch,
-      hostname: os.hostname(),
-    }));
-
     this.setMainListener('extensions/open-external', (...[, url]) => {
       Electron.shell.openExternal(url);
     });

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -267,7 +267,7 @@ class Client implements v1.DockerDesktopClient {
       ipcRenderer.send('extensions/open-external', url);
     },
     platform: process.platform,
-    arch:     process.arch,
+    arch:     '<unknown>',
     hostname: '<unknown>',
   };
 

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -230,7 +230,7 @@ ipcRenderer.on('extensions/spawn/close', (_, id, returnValue) => {
 });
 
 class Client implements v1.DockerDesktopClient {
-  constructor(info: {platform: string, arch: string, hostname: string}) {
+  constructor(info: {arch: string, hostname: string}) {
     Object.assign(this.host, info);
   }
 
@@ -266,18 +266,18 @@ class Client implements v1.DockerDesktopClient {
     openExternal: (url: string) => {
       ipcRenderer.send('extensions/open-external', url);
     },
-    platform: '<unknown>',
-    arch:     '<unknown>',
+    platform: process.platform,
+    arch:     process.arch,
     hostname: '<unknown>',
   };
 
   docker = {} as v1.Docker;
 }
 
-export default async function initExtensions(): Promise<void> {
+export default function initExtensions(): void {
   if (document.location.protocol === 'x-rd-extension:') {
-    const info = await ipcRenderer.invoke('extensions/host-info');
-    const ddClient = new Client(info);
+    const hostInfo: { arch: string, hostname: string } = JSON.parse(process.argv.slice(-1).pop() ?? '{}');
+    const ddClient = new Client(hostInfo);
 
     Electron.contextBridge.exposeInMainWorld('ddClient', ddClient);
   } else {

--- a/pkg/rancher-desktop/preload/index.ts
+++ b/pkg/rancher-desktop/preload/index.ts
@@ -1,10 +1,12 @@
 import initExtensions from './extensions';
 
-async function init() {
-  await initExtensions();
+function init() {
+  initExtensions();
 }
 
-init().catch((ex) => {
+try {
+  init();
+} catch (ex) {
   console.error(ex);
   throw ex;
-});
+}

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -114,7 +114,6 @@ export interface IpcMainInvokeEvents {
   // #endregion
 
   // #region extensions
-  'extensions/host-info': () => {platform: string, arch: string, hostname: string};
   /** Execute the given command and return the results. */
   'extensions/spawn/blocking': (options: import('@pkg/main/extensions/types').SpawnOptions) => import('@pkg/main/extensions/types').SpawnResult;
   'extensions/ui/show-open': (options: import('electron').OpenDialogOptions) => import('electron').OpenDialogReturnValue;

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -192,11 +192,18 @@ let extPath = '';
  * Attaches a browser view to the main window
  */
 const createView = () => {
+  const hostInfo = {
+    arch:     Electron.app.runningUnderARM64Translation ? 'arm64' : process.arch,
+    hostname: os.hostname(),
+  };
+
   view = new BrowserView({
     webPreferences: {
-      nodeIntegration:  false,
-      contextIsolation: true,
-      preload:          path.join(paths.resources, 'preload.js'),
+      nodeIntegration:     false,
+      contextIsolation:    true,
+      preload:             path.join(paths.resources, 'preload.js'),
+      sandbox:             true,
+      additionalArguments: [JSON.stringify(hostInfo)],
     },
   });
   getWindow('main')?.setBrowserView(view);
@@ -336,7 +343,6 @@ function extensionGetContentAreaListener(_event: Electron.IpcMainEvent, args: an
  * @param relPath The relative path to the extension root
  */
 export function openExtension(id: string, relPath: string) {
-  // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
 
   const window = getWindow('main') ?? undefined;


### PR DESCRIPTION
It looks like some extensions expect the API to be ready immediately, so we can't wait around for the main process to pass info in before setting it up.  Instead, get the main process to pass everything in as arguments to the window (via `process.argv`).

Fixes #4320.  Probably a bit lower priority than various API implementations.