### PR TITLE
Position and scale the extensions browserview based on renderer content

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -6,7 +6,7 @@
       :items="routes"
       :extensions="extensions"
     />
-    <the-title />
+    <the-title ref="rdx-title" />
     <main class="body">
       <Nuxt />
     </main>
@@ -86,10 +86,22 @@ export default {
       this.extensions = extensions || [];
     });
     ipcRenderer.send('extensions/list');
+
+    ipcRenderer.on('extensions/getContentArea', () => {
+      const rect = this.$refs['rdx-title'].$el.getBoundingClientRect();
+
+      const payload = {
+        x: rect.left,
+        y: rect.top,
+      };
+
+      ipcRenderer.send('ok:extensions/getContentArea', payload);
+    });
   },
 
   beforeDestroy() {
     ipcRenderer.off('k8s-check-state');
+    ipcRenderer.off('extensions/getContentArea');
   },
 
   methods: {

--- a/pkg/rancher-desktop/main/mainmenu.ts
+++ b/pkg/rancher-desktop/main/mainmenu.ts
@@ -119,9 +119,27 @@ function getMacApplicationMenu(): Array<MenuItem> {
     Electron.app.isPackaged ? new MenuItem({
       label:   'View',
       submenu: [
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
+        {
+          label:       'Actual Size',
+          accelerator: 'CmdOrCtrl+0',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, 0, '0');
+          },
+        },
+        {
+          label:       'Zoom In',
+          accelerator: 'CmdOrCtrl+Plus',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, 0.5, 'Plus');
+          },
+        },
+        {
+          label:       'Zoom Out',
+          accelerator: 'CmdOrCtrl+-',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, -0.5, '-');
+          },
+        },
         { type: 'separator' },
         { role: 'togglefullscreen' },
       ],
@@ -161,9 +179,27 @@ function getWindowsApplicationMenu(): Array<MenuItem> {
           { role: 'toggleDevTools', label: 'Toggle &Developer Tools' },
           { type: 'separator' },
         ] as MenuItemConstructorOptions[]),
-        { role: 'resetZoom', label: '&Actual Size' },
-        { role: 'zoomIn', label: 'Zoom &In' },
-        { role: 'zoomOut', label: 'Zoom &Out' },
+        {
+          label:       '&Actual Size',
+          accelerator: 'CmdOrCtrl+0',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, 0, '0');
+          },
+        },
+        {
+          label:       'Zoom &In',
+          accelerator: 'CmdOrCtrl+Plus',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, 0.5, 'Plus');
+          },
+        },
+        {
+          accelerator: 'CmdOrCtrl+-',
+          label:       'Zoom &Out',
+          click(_item, focusedWindow) {
+            setZoomLevel(focusedWindow, -0.5, '-');
+          },
+        },
         { type: 'separator' },
         { role: 'togglefullscreen', label: 'Toggle Full &Screen' },
       ],
@@ -187,4 +223,38 @@ function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
     },
     { type: 'separator' },
   ];
+}
+
+/**
+ * Adjusts the zoom level for the focused window by the desired increment. Also
+ * adjusts the zoom level for an attached browser view if one exists.
+ * @param focusedWindow The window that has focus
+ * @param zoomLevelAdjustment The desired increment to adjust the zoom level by
+ * @param keyEventKeyCode The key code associated with the zoom level adjustment
+ */
+function setZoomLevel(focusedWindow: Electron.BrowserWindow | undefined, zoomLevelAdjustment: number, keyEventKeyCode: string) {
+  if (!focusedWindow) {
+    return;
+  }
+
+  const { webContents } = focusedWindow;
+  const currentZoomLevel = webContents.getZoomLevel();
+  const view = focusedWindow.getBrowserView();
+
+  if (!view) {
+    const desiredZoomLevel = zoomLevelAdjustment === 0 ? zoomLevelAdjustment : currentZoomLevel + zoomLevelAdjustment;
+
+    webContents.setZoomLevel(desiredZoomLevel);
+    focusedWindow.getBrowserView()?.webContents.setZoomLevel(desiredZoomLevel);
+
+    return;
+  }
+
+  const event: Electron.KeyboardInputEvent = {
+    type:      'keyDown',
+    keyCode:   keyEventKeyCode,
+    modifiers: ['ctrl', 'control'],
+  };
+
+  webContents.sendInputEvent(event);
 }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -81,6 +81,7 @@ export interface IpcMainEvents {
   'extensions/list': () => void;
   'extensions/open': (id: string, path: string) => void;
   'extensions/close': () => void;
+  'ok:extensions/getContentArea': (payload: { x: number, y: number }) => void;
   // #endregion
 }
 

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -224,6 +224,16 @@ const updateView = (window: any, payload: any) => {
   }
 };
 
+function extensionNavigate(id: string, relPath: string) {
+  const url = `x-rd-extension://${ id }/ui/dashboard-tab/${ relPath }`;
+
+  view?.webContents
+    .loadURL(url)
+    .catch((err) => {
+      console.error(`Can't load the dashboard URL ${ url }: `, err);
+    });
+}
+
 export function openExtension(id: string, relPath: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
@@ -243,13 +253,7 @@ export function openExtension(id: string, relPath: string) {
       }
     }
 
-    const url = `x-rd-extension://${ id }/ui/dashboard-tab/${ relPath }`;
-
-    view?.webContents
-      .loadURL(url)
-      .catch((err) => {
-        console.error(`Can't load the dashboard URL ${ url }: `, err);
-      });
+    extensionNavigate(id, relPath);
   });
 
   window.webContents.send('extensions/getContentArea');

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -213,7 +213,8 @@ const updateView = (window: any, payload: any) => {
   }
 
   const windowSize = window.getSize();
-  const titleBarHeight = windowSize[1] - window.getContentSize()[1];
+  const contentSize = window.getContentSize();
+  const titleBarHeight = os.platform().startsWith('darwin') ? windowSize[1] - window.getContentSize()[1] : 0;
 
   const x = Math.round(payload.x * window.webContents.getZoomFactor());
   const y = Math.round((payload.y + titleBarHeight) * window.webContents.getZoomFactor());
@@ -221,8 +222,8 @@ const updateView = (window: any, payload: any) => {
   view.setBounds({
     x,
     y,
-    width:  windowSize[0] - x,
-    height: windowSize[1] - y,
+    width:  contentSize[0] - x,
+    height: (contentSize[1] + titleBarHeight) - y,
   });
 
   view.setAutoResize({ width: true, height: true });

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -234,6 +234,22 @@ function extensionNavigate(id: string, relPath: string) {
     });
 }
 
+const extensionZoomListener = (event: Electron.Event, input: Electron.Input) => {
+  const window = getWindow('main');
+
+  if (!window) {
+    return;
+  }
+
+  if (input.type === 'keyDown' && input.control && (input.key === '-' || input.key === '+')) {
+    event.preventDefault();
+    const currentZoomLevel = window.webContents.getZoomLevel();
+    const newZoomLevel = input.key === '-' ? currentZoomLevel - 0.5 : currentZoomLevel + 0.5;
+
+    window.webContents.setZoomLevel(newZoomLevel);
+  }
+};
+
 export function openExtension(id: string, relPath: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
@@ -248,6 +264,7 @@ export function openExtension(id: string, relPath: string) {
     if (!view) {
       try {
         updateView(window, args);
+        window.webContents.on('before-input-event', extensionZoomListener);
       } catch (e) {
         console.error(e);
       }
@@ -265,6 +282,7 @@ export function closeExtension() {
   }
 
   getWindow('main')?.removeBrowserView(view);
+  getWindow('main')?.webContents.removeListener('before-input-event', extensionZoomListener);
   view = undefined;
 }
 

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -212,12 +212,18 @@ const updateView = (window: any, payload: any) => {
     return;
   }
 
+  const isMacOS = os.platform().startsWith('darwin');
+
   const windowSize = window.getSize();
   const contentSize = window.getContentSize();
-  const titleBarHeight = os.platform().startsWith('darwin') ? windowSize[1] - window.getContentSize()[1] : 0;
+  const titleBarHeight = isMacOS ? windowSize[1] - window.getContentSize()[1] : 0;
 
-  const x = Math.round(payload.x * window.webContents.getZoomFactor());
-  const y = Math.round((payload.y + titleBarHeight) * window.webContents.getZoomFactor());
+  const defaultZoomLevel = 0;
+  const currentZoomLevel = window.webContents.getZoomLevel();
+  const yZoomFactor = isMacOS ? 1 + (currentZoomLevel - defaultZoomLevel) / 10 : window.webContents.getZoomFactor();
+
+  const x = Math.round(payload.x * window.webContents.getZoomLevel());
+  const y = Math.round((payload.y + titleBarHeight) * yZoomFactor);
 
   view.setBounds({
     x,

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -185,7 +185,12 @@ export function openMain() {
 }
 
 let view: Electron.BrowserView | undefined;
+let extId = '';
+let extPath = '';
 
+/**
+ * Attaches a browser view to the main window
+ */
 const createView = () => {
   view = new BrowserView({
     webPreferences: {
@@ -197,6 +202,11 @@ const createView = () => {
   getWindow('main')?.setBrowserView(view);
 };
 
+/**
+ * Updates the browser view size and position
+ * @param window The main window
+ * @param payload Payload representing coordinates for view position
+ */
 const updateView = (window: any, payload: any) => {
   if (!view) {
     return;
@@ -218,6 +228,9 @@ const updateView = (window: any, payload: any) => {
   view.setAutoResize({ width: true, height: true });
 };
 
+/**
+ * Navigates to the current desired extension
+ */
 function extensionNavigate() {
   if (!extId || !extPath) {
     return;
@@ -235,6 +248,12 @@ function extensionNavigate() {
     });
 }
 
+/**
+ * Adjusts the zoom level of the main window and attached browser view based on
+ * the given input.
+ * @param event The Electron Event that triggered this listener
+ * @param input The Electron Input associated with the event
+ */
 const extensionZoomListener = (event: Electron.Event, input: Electron.Input) => {
   const window = getWindow('main');
 
@@ -262,9 +281,11 @@ const extensionZoomListener = (event: Electron.Event, input: Electron.Input) => 
   }
 };
 
-let extId = '';
-let extPath = '';
-
+/**
+ * Opens an extension in a browser view and attaches it to the main window
+ * @param id The extension ID
+ * @param relPath The relative path to the extension root
+ */
 export function openExtension(id: string, relPath: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
   console.debug(`openExtension(${ id })`);
@@ -309,6 +330,9 @@ export function openExtension(id: string, relPath: string) {
   }
 }
 
+/**
+ * Removes the extension's browser view from the main window
+ */
 export function closeExtension() {
   if (!view) {
     return;

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -218,13 +218,17 @@ const updateView = (window: any, payload: any) => {
   view.setAutoResize({ width: true, height: true });
 };
 
-function extensionNavigate(id: string, relPath: string) {
-  const url = `x-rd-extension://${ id }/ui/dashboard-tab/${ relPath }`;
+function extensionNavigate() {
+  if (!extId || !extPath) {
+    return;
+  }
+
+  const url = `x-rd-extension://${ extId }/ui/dashboard-tab/${ extPath }`;
 
   view?.webContents
     .loadURL(url)
     .catch((err) => {
-      console.error(`Can't load the dashboard URL ${ url }: `, err);
+      console.error(`Can't load the extension URL ${ url }: `, err);
     });
 }
 
@@ -241,9 +245,13 @@ const extensionZoomListener = (event: Electron.Event, input: Electron.Input) => 
     const newZoomLevel = input.key === '-' ? currentZoomLevel - 0.5 : currentZoomLevel + 0.5;
 
     window.webContents.setZoomLevel(newZoomLevel);
+    view?.webContents.setZoomLevel(newZoomLevel);
     window.webContents.send('extensions/getContentArea');
   }
 };
+
+let extId = '';
+let extPath = '';
 
 export function openExtension(id: string, relPath: string) {
   // const preloadPath = path.join(paths.resources, 'preload.js');
@@ -254,6 +262,9 @@ export function openExtension(id: string, relPath: string) {
   if (!window) {
     return;
   }
+
+  extId = id;
+  extPath = relPath;
 
   if (!ipcMain.eventNames().includes('ok:extensions/getContentArea')) {
     ipcMain.on('ok:extensions/getContentArea', (_event, args) => {
@@ -267,7 +278,7 @@ export function openExtension(id: string, relPath: string) {
       }
 
       updateView(window, args);
-      extensionNavigate(id, relPath);
+      extensionNavigate();
     });
   }
 

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -199,8 +199,8 @@ const updateView = (window: any, payload: any) => {
   const windowSize = window.getSize();
   const titleBarHeight = windowSize[1] - window.getContentSize()[1];
 
-  const x = payload.x;
-  const y = payload.y;
+  const x = Math.round(payload.x * window.webContents.getZoomFactor());
+  const y = Math.round(payload.y * window.webContents.getZoomFactor());
 
   view.setBounds({
     x,
@@ -234,11 +234,13 @@ export function openExtension(id: string, relPath: string) {
     return;
   }
 
-  window.webContents.send('extensions/getContentArea');
-
-  ipcMain.on('ok:extensions/getContentArea', (_event, args) => {
+  ipcMain.once('ok:extensions/getContentArea', (_event, args) => {
     if (!view) {
-      updateView(window, args);
+      try {
+        updateView(window, args);
+      } catch (e) {
+        console.error(e);
+      }
     }
 
     const url = `x-rd-extension://${ id }/ui/dashboard-tab/${ relPath }`;
@@ -249,6 +251,8 @@ export function openExtension(id: string, relPath: string) {
         console.error(`Can't load the dashboard URL ${ url }: `, err);
       });
   });
+
+  window.webContents.send('extensions/getContentArea');
 }
 
 export function closeExtension() {

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -222,7 +222,7 @@ const updateView = (window: any, payload: any) => {
   const currentZoomLevel = window.webContents.getZoomLevel();
   const yZoomFactor = isMacOS ? 1 + (currentZoomLevel - defaultZoomLevel) / 10 : window.webContents.getZoomFactor();
 
-  const x = Math.round(payload.x * window.webContents.getZoomLevel());
+  const x = Math.round(payload.x * window.webContents.getZoomFactor());
   const y = Math.round((payload.y + titleBarHeight) * yZoomFactor);
 
   view.setBounds({

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -239,10 +239,19 @@ const extensionZoomListener = (event: Electron.Event, input: Electron.Input) => 
     return;
   }
 
-  if (input.type === 'keyDown' && input.control && (input.key === '-' || input.key === '+')) {
+  if (input.type === 'keyDown' && input.control && (input.key === '-' || input.key === '+' || input.key === '0')) {
     event.preventDefault();
     const currentZoomLevel = window.webContents.getZoomLevel();
-    const newZoomLevel = input.key === '-' ? currentZoomLevel - 0.5 : currentZoomLevel + 0.5;
+    const newZoomLevel = (() => {
+      switch (input.key) {
+      case '-':
+        return currentZoomLevel - 0.5;
+      case '+':
+        return currentZoomLevel + 0.5;
+      case '0':
+        return 0;
+      }
+    })();
 
     window.webContents.setZoomLevel(newZoomLevel);
     view?.webContents.setZoomLevel(newZoomLevel);

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -227,6 +227,9 @@ function extensionNavigate() {
 
   view?.webContents
     .loadURL(url)
+    .then(() => {
+      view?.webContents.setZoomLevel(getWindow('main')?.webContents.getZoomLevel() ?? 0);
+    })
     .catch((err) => {
       console.error(`Can't load the extension URL ${ url }: `, err);
     });

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -194,8 +194,6 @@ export function openExtension(id: string, relPath: string) {
     return;
   }
 
-  const windowSize = window.getContentSize();
-
   if (!view) {
     view = new BrowserView({
       webPreferences: {
@@ -206,8 +204,11 @@ export function openExtension(id: string, relPath: string) {
     });
     window.setBrowserView(view);
 
+    const windowSize = window.getSize();
+    const titleBarHeight = windowSize[1] - window.getContentSize()[1];
+
     const x = 230;
-    const y = 55;
+    const y = 55 + titleBarHeight;
 
     view.setBounds({
       x,


### PR DESCRIPTION
This positions the extension's browser view by anchoring it to the title element in the main window. I chose to anchor to the title because 

1. It was fairly trivial to get the coordinates of this element
2. It's persistent across every page

Alternative approaches would be to either locate the top left of the extension by locating he primary nav and the header, or supplying some sort of dummy element to anchor the browser view to. Both of these approaches come with a bit more complexity and are a little less direct than anchoring to the title.

## 🗒️ Testing Notes

- Extensions should zoom along with the main window when adjusting zoom levels via `ctrl++`/`ctrl+-`/`ctrl+0`
- Extensions should zoom along with the main windows when adjusting through the application menu via View => Actual Size/Zoom In/Zoom Out

## 👓 Considerations

- Placement and zoom levels work consistently across Windows & Linux
- macOS reliably places content at the default zoom level, but there's some drift that occurs at higher/lower zoom levels. I've introduced `yZoomFactor` to try and accommodate for this drift, but the formula doesn't quite solve the problem. We will need to implement a better solution
- macOS behavior might be related to
  - https://github.com/electron/electron/issues/35994
  - https://github.com/electron/electron/issues/27651


closes #4301 
