### PR TITLE
Automate testing the path-management preferences on 3 shells.

### DIFF
--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -38,3 +38,6 @@ export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 teardown_file() {
     run rdctl shutdown
 }
+
+# Bug workarounds go here. The goal is to make this an empty file
+source "$helpers/workarounds.bash"

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -31,9 +31,6 @@ source "$PATH_BATS_HELPERS/vm.bash"
 source "$PATH_BATS_HELPERS/kubernetes.bash"
 source "$PATH_BATS_HELPERS/commands.bash"
 
-# Bug workarounds go here. The goal is to make this an empty file
-source "$PATH_BATS_HELPERS/workarounds.bash"
-
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
@@ -43,4 +40,4 @@ teardown_file() {
 }
 
 # Bug workarounds go here. The goal is to make this an empty file
-source "$helpers/workarounds.bash"
+source "$PATH_BATS_HELPERS/workarounds.bash"

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -31,6 +31,9 @@ source "$PATH_BATS_HELPERS/vm.bash"
 source "$PATH_BATS_HELPERS/kubernetes.bash"
 source "$PATH_BATS_HELPERS/commands.bash"
 
+# Bug workarounds go here. The goal is to make this an empty file
+source "$PATH_BATS_HELPERS/workarounds.bash"
+
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 

--- a/bats/tests/helpers/workarounds.bash
+++ b/bats/tests/helpers/workarounds.bash
@@ -1,0 +1,10 @@
+ensure_dotfiles_are_completed_BUG_BUG_BUG_4519() {
+    # BUG BUG BUG
+    # BUG 4519
+    # Looks like the rcfiles don't get updated via `rdctl start`
+    # BUG BUG BUG
+    if is_unix; then
+        rdctl set --application.path-management-strategy manual
+        rdctl set --application.path-management-strategy rcfiles
+    fi
+}

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -27,7 +27,7 @@ teardown_file() {
 
 # Running `bash -l -c` causes bats to hang
 @test 'bash managed' {
-    if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
+    if command -v bash >/dev/null; then
         run bash -l -c "which rdctl" 3>&-
         assert_output --partial "$HOME/.rd/bin/rdctl"
     else
@@ -36,7 +36,7 @@ teardown_file() {
 }
 
 @test 'zsh managed' {
-    if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
+    if command -v zsh >/dev/null; then
         run zsh -i -c "which rdctl"
         assert_success
         assert_output --partial "$HOME/.rd/bin/rdctl"
@@ -69,7 +69,7 @@ no_bashrc_path_manager() {
 }
 
 @test 'bash unmanaged' {
-    if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
+    if command -v bash >/dev/null; then
         run bash -l -c "which rdctl" 3>&-
         # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
         refute_output --partial "$HOME/.rd/bin/rdctl"
@@ -79,7 +79,7 @@ no_bashrc_path_manager() {
 }
 
 @test 'zsh unmanaged' {
-    if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
+    if command -v zsh >/dev/null; then
         run zsh -i -c "which rdctl"
         refute_output --partial "$HOME/.rd/bin/rdctl"
     else

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -25,10 +25,11 @@ teardown_file() {
     ensure_dotfiles_are_completed_BUG_BUG_BUG_4519
 }
 
-# Running `bash -l -c` causes bats to hang
+# Running `bash -l -c` can cause bats to hang, so close the output file descriptor with '3>&-'
 @test 'bash managed' {
     if command -v bash >/dev/null; then
         run bash -l -c "which rdctl" 3>&-
+        assert_success
         assert_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'bash not found or ~/.bashrc does not exist'
@@ -41,7 +42,7 @@ teardown_file() {
         assert_success
         assert_output --partial "$HOME/.rd/bin/rdctl"
     else
-        skip 'zsh not found or ~/.zshrc does not exist'
+        skip 'zsh not found'
     fi
 }
 
@@ -74,7 +75,7 @@ no_bashrc_path_manager() {
         # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
         refute_output --partial "$HOME/.rd/bin/rdctl"
     else
-        skip 'bash not found or ~/.bashrc does not exist'
+        skip 'bash not found'
     fi
 }
 
@@ -83,7 +84,7 @@ no_bashrc_path_manager() {
         run zsh -i -c "which rdctl"
         refute_output --partial "$HOME/.rd/bin/rdctl"
     else
-        skip 'zsh not found or ~/.zshrc does not exist'
+        skip 'zsh not found'
     fi
 }
 

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -33,7 +33,7 @@ teardown_file() {
         assert_success
         assert_output --partial "$HOME/.rd/bin/rdctl"
     else
-        skip 'bash not found or ~/.bashrc does not exist'
+        skip 'bash not found'
     fi
 }
 

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -54,8 +54,7 @@ setup() {
 # This bashrc test assumes that this test will succeed, but it frees us
 # from sleeping after changing application.path-management-strategy
 no_bashrc_path_manager() {
-    run grep --silent 'MANAGED BY RANCHER DESKTOP START' "$HOME/.bashrc"
-    assert_failure
+    ! grep --silent 'MANAGED BY RANCHER DESKTOP START' "$HOME/.bashrc"
 }
 
 @test 'move to manual path-management' {

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -1,12 +1,13 @@
 # Test case 30
 
+load '../helpers/load'
+# Ensure subshells don't inherit a path that includes ~/.rd/bin
+export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
+
 setup() {
-    load '../helpers/load'
     if is_windows; then
         skip "test not applicable on Windows"
     fi
-    # Ensure subshells don't inherit a path that includes ~/.rd/bin
-    export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
 }
 
 teardown_file() {

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -29,7 +29,7 @@ teardown_file() {
 @test 'bash managed' {
     if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
         run bash -l -c "which rdctl" 3>&-
-        assert_output --partial '.rd/bin/rdctl'
+        assert_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'bash not found or ~/.bashrc does not exist'
     fi
@@ -39,7 +39,7 @@ teardown_file() {
     if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
         run ksh -c "which rdctl"
         assert_success
-        assert_output --partial '.rd/bin/rdctl'
+        assert_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'ksh not found or ~/.kshrc does not exist'
     fi
@@ -49,7 +49,7 @@ teardown_file() {
     if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
         run zsh -i -c "which rdctl"
         assert_success
-        assert_output --partial '.rd/bin/rdctl'
+        assert_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'zsh not found or ~/.zshrc does not exist'
     fi
@@ -59,7 +59,7 @@ teardown_file() {
     if command -v fish >/dev/null; then
         run fish -c "which rdctl"
         assert_success
-        assert_output --partial '.rd/bin/rdctl'
+        assert_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'fish not found'
     fi
@@ -82,7 +82,7 @@ no_bashrc_path_manager() {
     if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
         run bash -l -c "which rdctl" 3>&-
         # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
-        refute_output --partial '.rd/bin/rdctl'
+        refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'bash not found or ~/.bashrc does not exist'
     fi
@@ -92,7 +92,7 @@ no_bashrc_path_manager() {
     if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
         run ksh -c "which rdctl"
         # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
-        refute_output --partial '.rd/bin/rdctl'
+        refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'ksh not found or ~/.kshrc does not exist'
     fi
@@ -101,7 +101,7 @@ no_bashrc_path_manager() {
 @test 'zsh unmanaged' {
     if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
         run zsh -i -c "which rdctl"
-        refute_output --partial '.rd/bin/rdctl'
+        refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'zsh not found or ~/.zshrc does not exist'
     fi
@@ -110,7 +110,7 @@ no_bashrc_path_manager() {
 @test 'fish unmanaged' {
     if command -v fish >/dev/null; then
         run fish -c "which rdctl"
-        refute_output --partial '.rd/bin/rdctl'
+        refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'fish not found'
     fi

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -27,8 +27,12 @@ teardown_file() {
 
 # Running `bash -l -c` causes bats to hang
 @test 'bash managed' {
-    run bash -l -c "which rdctl" 3>&-
-    assert_output --partial '.rd/bin/rdctl'
+    if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
+        run bash -l -c "which rdctl" 3>&-
+        assert_output --partial '.rd/bin/rdctl'
+    else
+        skip 'bash not found or ~/.bashrc does not exist'
+    fi
 }
 
 @test 'ksh managed' {
@@ -75,8 +79,13 @@ no_bashrc_path_manager() {
 }
 
 @test 'bash unmanaged' {
-    run bash -l -c "which rdctl" 3>&-
-    assert_failure
+    if command -v bash >/dev/null && [ -f "$HOME/.bashrc" ]; then
+        run bash -l -c "which rdctl" 3>&-
+        # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
+        refute_output --partial '.rd/bin/rdctl'
+    else
+        skip 'bash not found or ~/.bashrc does not exist'
+    fi
 }
 
 @test 'ksh unmanaged' {

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -10,12 +10,6 @@ setup() {
     fi
 }
 
-teardown_file() {
-    load '../helpers/load'
-    run rdctl shutdown
-    assert_nothing
-}
-
 @test 'factory reset' {
     factory_reset
 }

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -35,16 +35,6 @@ teardown_file() {
     fi
 }
 
-@test 'ksh managed' {
-    if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
-        run ksh -c "which rdctl"
-        assert_success
-        assert_output --partial "$HOME/.rd/bin/rdctl"
-    else
-        skip 'ksh not found or ~/.kshrc does not exist'
-    fi
-}
-
 @test 'zsh managed' {
     if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
         run zsh -i -c "which rdctl"
@@ -85,16 +75,6 @@ no_bashrc_path_manager() {
         refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'bash not found or ~/.bashrc does not exist'
-    fi
-}
-
-@test 'ksh unmanaged' {
-    if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
-        run ksh -c "which rdctl"
-        # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
-        refute_output --partial "$HOME/.rd/bin/rdctl"
-    else
-        skip 'ksh not found or ~/.kshrc does not exist'
     fi
 }
 

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -1,0 +1,108 @@
+# Test case 30
+
+setup() {
+    load '../helpers/load'
+    if is_windows; then
+        skip "test not applicable on Windows"
+    fi
+    # Ensure subshells don't inherit a path that includes ~/.rd/bin
+    export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
+}
+
+teardown_file() {
+    load '../helpers/load'
+    run rdctl shutdown
+    assert_nothing
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start app and fix dotfiles' {
+    start_container_engine
+    wait_for_container_engine
+    ensure_dotfiles_are_completed_BUG_BUG_BUG_4519
+}
+
+# Running `bash -l -c` causes bats to hang
+@test 'bash managed' {
+    run bash -l -c "which rdctl" 3>&-
+    assert_output --partial '.rd/bin/rdctl'
+}
+
+@test 'ksh managed' {
+    if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
+        run ksh -c "which rdctl"
+        assert_success
+        assert_output --partial '.rd/bin/rdctl'
+    else
+        skip 'ksh not found or ~/.kshrc does not exist'
+    fi
+}
+
+@test 'zsh managed' {
+    if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
+        run zsh -i -c "which rdctl"
+        assert_success
+        assert_output --partial '.rd/bin/rdctl'
+    else
+        skip 'zsh not found or ~/.zshrc does not exist'
+    fi
+}
+
+@test 'fish managed' {
+    if command -v fish >/dev/null; then
+        run fish -c "which rdctl"
+        assert_success
+        assert_output --partial '.rd/bin/rdctl'
+    else
+        skip 'fish not found'
+    fi
+}
+
+# This bashrc test assumes that this test will succeed, but it frees us
+# from sleeping after changing application.path-management-strategy
+no_bashrc_path_manager() {
+    run grep --silent 'MANAGED BY RANCHER DESKTOP START' "$HOME/.bashrc"
+    assert_failure
+}
+
+@test 'move to manual path-management' {
+    rdctl set --application.path-management-strategy=manual
+    try --max 5 --delay 2 no_bashrc_path_manager
+    assert_success
+}
+
+@test 'bash unmanaged' {
+    run bash -l -c "which rdctl" 3>&-
+    assert_failure
+}
+
+@test 'ksh unmanaged' {
+    if command -v ksh >/dev/null && [ -f "$HOME/.kshrc" ]; then
+        run ksh -c "which rdctl"
+        # Can't assert success or failure because rdctl might be in a directory other than ~/.rd/bin
+        refute_output --partial '.rd/bin/rdctl'
+    else
+        skip 'ksh not found or ~/.kshrc does not exist'
+    fi
+}
+
+@test 'zsh unmanaged' {
+    if command -v zsh >/dev/null && [ -f "$HOME/.zshrc" ]; then
+        run zsh -i -c "which rdctl"
+        refute_output --partial '.rd/bin/rdctl'
+    else
+        skip 'zsh not found or ~/.zshrc does not exist'
+    fi
+}
+
+@test 'fish unmanaged' {
+    if command -v fish >/dev/null; then
+        run fish -c "which rdctl"
+        refute_output --partial '.rd/bin/rdctl'
+    else
+        skip 'fish not found'
+    fi
+}


### PR DESCRIPTION
Automates test plan test #30

Note that if I try running the bash subshell the test hangs, probably because `bats` is doing something with process management.

The ruby code in `setup` is to ensure that the subprocesses don't inherit a path that includes `~/.rd/bin` . Let me know if it's a problem that it's in ruby and I'll rewrite in perl. The ruby code is easier to follow.