### PR TITLE
Set extension view background color

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 
 import Electron, {
-  BrowserWindow, app, shell, BrowserView, ipcMain,
+  BrowserWindow, app, shell, BrowserView, ipcMain, nativeTheme,
 } from 'electron';
 
 import * as K8s from '@pkg/backend/k8s';
@@ -200,6 +200,10 @@ const createView = () => {
     },
   });
   getWindow('main')?.setBrowserView(view);
+
+  const backgroundColor = nativeTheme.shouldUseDarkColors ? '#202c33' : '#f4f4f6';
+
+  view.setBackgroundColor(backgroundColor);
 };
 
 /**


### PR DESCRIPTION
This sets a background color for extensions that might not have one defined. The colors chosen are designed to match existing background color in extensions like Epinio.