### PR TITLE
fix the double scroll bar on preferences body

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/ModalBody.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalBody.vue
@@ -58,11 +58,14 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
   .preferences-body {
+    position: relative;
     display: flex;
     flex-direction: column;
 
     .help {
-      margin: auto 0.75rem 0.75rem auto;
+      position: absolute;
+      bottom: 0.75rem;
+      right: 0.75rem;
     }
   }
 </style>


### PR DESCRIPTION
This fixes the issue https://github.com/rancher-sandbox/rancher-desktop/issues/4326

On the preferences body with a lot of information displayed, a double scrollbar can appear on the preference modal body.
This change the help button to 'float over' the rest of the content of the preference body instead of taking space at the bottom of the modal body.

![image](https://user-images.githubusercontent.com/4118134/229807218-260fa98d-ee80-48f4-ab31-69bba143c3cd.png)
