### PR TITLE
RDX: Implement ddClient.extension.vm.service

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -294,5 +294,16 @@ test.describe.serial('Extensions', () => {
         ]));
       });
     });
+
+    test.describe('ddClient.vm.service', () => {
+      test.skip('can fetch from the backend', () => {
+      });
+      test('can fetch from external sources', async() => {
+        const url = 'http://127.0.0.1:6120/LICENSES'; // dashboard
+        const result = evalInView(`ddClient.extension.vm.service.get("${ url }")`);
+
+        await expect(result).resolves.toContain('Copyright');
+      });
+    });
   });
 });

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -261,37 +261,39 @@ class Client implements v1.DockerDesktopClient {
    * makeRequest is a helper for ddClient.extension.vm.service.<HTTP method>
    * that wraps ddClient.extension.vm.service.request().
    */
-  protected makeRequest(method: string, url: string, data?: any) {
-    return this.extension.vm?.service?.request({
+  protected makeRequest(method: string, url: string, data?: any): Promise<unknown> {
+    return this.request({
       method, url, data, headers: {},
-    }) ?? Promise.reject(`Failed to ${ method } ${ url }: properties missing`);
+    });
+  }
+
+  protected async request(config: v1.RequestConfig): Promise<unknown> {
+    try {
+      const result = await ipcRenderer.invoke('extensions/vm/http-fetch', config);
+
+      // Parse as JSON if possible (API is unclear).
+      try {
+        return JSON.parse(result);
+      } catch {
+        return result;
+      }
+    } catch (ex) {
+      console.debug(`${ config.method } ${ config.url } error:`, ex);
+      throw ex;
+    }
   }
 
   extension: v1.Extension = {
     vm: {
       cli:     { exec: getExec('container') },
       service: {
-        request: async(config: v1.RequestConfig): Promise<unknown> => {
-          try {
-            const result = await ipcRenderer.invoke('extensions/vm/http-fetch', config);
-
-            // Parse as JSON if possible (API is unclear).
-            try {
-              return JSON.parse(result);
-            } catch {
-              return result;
-            }
-          } catch (ex) {
-            console.debug(`${ config.method } ${ config.url } error:`, ex);
-            throw ex;
-          }
-        },
-        get:    (url: string) => this.makeRequest('GET', url),
-        post:   (url: string, data: any) => this.makeRequest('POST', url, data),
-        put:    (url: string, data: any) => this.makeRequest('PUT', url, data),
-        patch:  (url: string, data: any) => this.makeRequest('PATCH', url, data),
-        delete: (url: string) => this.makeRequest('DELETE', url),
-        head:   (url: string) => this.makeRequest('HEAD', url),
+        request: (config: v1.RequestConfig) => this.request(config),
+        get:     (url: string) => this.makeRequest('GET', url),
+        post:    (url: string, data: any) => this.makeRequest('POST', url, data),
+        put:     (url: string, data: any) => this.makeRequest('PUT', url, data),
+        patch:   (url: string, data: any) => this.makeRequest('PATCH', url, data),
+        delete:  (url: string) => this.makeRequest('DELETE', url),
+        head:    (url: string) => this.makeRequest('HEAD', url),
       },
     },
     host:  { cli: { exec: getExec('host') } },

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -118,6 +118,8 @@ export interface IpcMainInvokeEvents {
   /** Execute the given command and return the results. */
   'extensions/spawn/blocking': (options: import('@pkg/main/extensions/types').SpawnOptions) => import('@pkg/main/extensions/types').SpawnResult;
   'extensions/ui/show-open': (options: import('electron').OpenDialogOptions) => import('electron').OpenDialogReturnValue;
+  /** Fetch data from the backend, or arbitrary host ignoring CORS. */
+  'extensions/vm/http-fetch': (config: import('@docker/extension-api-client-types').v1.RequestConfig) => any;
   // #endregion
 }
 

--- a/pkg/rancher-desktop/utils/fetch.ts
+++ b/pkg/rancher-desktop/utils/fetch.ts
@@ -6,6 +6,8 @@ import util from 'util';
 
 import _fetch, { RequestInit } from 'node-fetch';
 
+export { RequestInit } from 'node-fetch';
+
 /**
  * CertificateVerificationError is a custom Error class that describes a TLS
  * certificate that failed verification.


### PR DESCRIPTION
Note that we're still missing the implementation to directly fetch from a backend using relative URLs.

Running commands in containers (`ddClient.extension.vm.cli`) is also missing.

Fixes #4360.