### PR TITLE
Bump `@rancher/components` to v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@docker/extension-api-client-types": "0.3.4",
         "@kubernetes/client-node": "0.18.0",
         "@nuxtjs/eslint-module": "3.1.0",
-        "@rancher/components": "0.1.0-alpha.10",
+        "@rancher/components": "0.1.1",
         "@rancher/shell": "0.1.3",
         "agent-base": "6.0.2",
         "bufferutil": "4.0.7",
@@ -6209,8 +6209,9 @@
       }
     },
     "node_modules/@rancher/components": {
-      "version": "0.1.0-alpha.10",
-      "license": "Apache-2.0",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.1.tgz",
+      "integrity": "sha512-jR/8ce1JWjtKMrVnSSDkvtqfZAMGFVra61RJh3GN39jtRREipEoyQxEHsM9BPfw7Va83BhZkdBkkKupJ1Vs0dA==",
       "dependencies": {
         "lodash.debounce": "4.0.8"
       },
@@ -39193,7 +39194,9 @@
       "version": "2.11.6"
     },
     "@rancher/components": {
-      "version": "0.1.0-alpha.10",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.1.tgz",
+      "integrity": "sha512-jR/8ce1JWjtKMrVnSSDkvtqfZAMGFVra61RJh3GN39jtRREipEoyQxEHsM9BPfw7Va83BhZkdBkkKupJ1Vs0dA==",
       "requires": {
         "lodash.debounce": "4.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@docker/extension-api-client-types": "0.3.4",
     "@kubernetes/client-node": "0.18.0",
     "@nuxtjs/eslint-module": "3.1.0",
-    "@rancher/components": "0.1.0-alpha.10",
+    "@rancher/components": "0.1.1",
     "@rancher/shell": "0.1.3",
     "agent-base": "6.0.2",
     "bufferutil": "4.0.7",

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -64,6 +64,7 @@ export default {
     // First-party
     '~/plugins/i18n',
     '~/plugins/directives',
+    '~/plugins/clean-html-directive',
     { src: '~/plugins/extend-router' },
   ],
   router: {

--- a/pkg/rancher-desktop/plugins/clean-html-directive.js
+++ b/pkg/rancher-desktop/plugins/clean-html-directive.js
@@ -1,0 +1,34 @@
+import DOMPurify from 'dompurify';
+import Vue from 'vue';
+
+const ALLOWED_TAGS = [
+  'code',
+  'li',
+  'a',
+  'p',
+  'b',
+  'br',
+  'ul',
+  'pre',
+  'span',
+  'div',
+  'i',
+  'em',
+  'strong',
+];
+
+const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+
+export const cleanHtmlDirective = {
+  inserted(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  componentUpdated(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  unbind(el) {
+    el.innerHTML = '';
+  },
+};
+
+Vue.directive('clean-html', cleanHtmlDirective);


### PR DESCRIPTION
This bumps `@rancher/components` to v0.1.1. 

## Changelog

https://github.com/rancher/dashboard/releases/tag/components-v0.1.1

## 🗒️ Note

We are porting the `v-clean-html` directive from Dashboard. This is something that we will need work on properly packaging and sharing in the future.