### PR TITLE
RDX: Implement running commands in containers

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -195,7 +195,7 @@ test.describe.serial('Extensions', () => {
       });
     });
 
-    test.describe('running host commands', () => {
+    test.describe('ddClient.extension.host.cli.exec', () => {
       const wrapperName = process.platform === 'win32' ? 'dummy.cmd' : 'dummy.sh';
 
       test('capturing output', async() => {
@@ -255,8 +255,8 @@ test.describe.serial('Extensions', () => {
       });
     });
 
-    test.describe('running container engine commands', () => {
-      test('can run arbitrary commands', async() => {
+    test.describe('ddClient.docker', () => {
+      test('ddClient.docker.cli.exec', async() => {
         const script = `
           ddClient.docker.cli.exec("info", ["--format", "{{ json . }}"])
           .then(v => v.parseJsonObject())
@@ -274,7 +274,7 @@ test.describe.serial('Extensions', () => {
           OSType:      'linux',
         }));
       });
-      test('can list images', async() => {
+      test('ddClient.docker.listImages', async() => {
         const script = 'ddClient.docker.listImages({digests: true})';
         const result = await evalInView(script);
 
@@ -285,13 +285,28 @@ test.describe.serial('Extensions', () => {
           }),
         ]));
       });
-      test('can list containers', async() => {
+      test('ddClient.docker.listContainers', async() => {
         const script = 'ddClient.docker.listContainers({size: true})';
         const result = await evalInView(script);
 
         expect(result).toEqual(expect.arrayContaining([
           expect.objectContaining({ Image: 'rd/extension/everything' }),
         ]));
+      });
+    });
+
+    test.describe('ddClient.extension.vm.cli.exec', () => {
+      test('capturing output', async() => {
+        const script = `
+          ddClient.extension.vm.cli.exec("/bin/echo", ["xyzzy"])
+          .then(v => JSON.stringify(v))
+        `;
+        const result = JSON.parse(await evalInView(script));
+
+        expect(result).toEqual(expect.objectContaining({
+          stdout: 'xyzzy\n',
+          code:   0,
+        }));
       });
     });
 

--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -5,7 +5,9 @@ import path from 'path';
 import _ from 'lodash';
 
 import {
-  ContainerComposeExecOptions, ContainerComposeOptions, ContainerEngineClient, ContainerRunOptions, ContainerStopOptions,
+  ContainerComposeExecOptions, ContainerComposeExecResult,
+  ContainerComposeOptions, ContainerEngineClient, ContainerRunOptions,
+  ContainerStopOptions,
 } from './types';
 
 import { VMExecutor } from '@pkg/backend/backend';
@@ -167,7 +169,7 @@ export class MobyClient implements ContainerEngineClient {
     }
   }
 
-  async composeUp(composeDir: string, options?: ContainerComposeOptions) {
+  async composeUp(composeDir: string, options?: ContainerComposeOptions): Promise<void> {
     const args = ['--project-directory', composeDir];
 
     if (options?.name) {
@@ -180,7 +182,7 @@ export class MobyClient implements ContainerEngineClient {
     console.debug('ran docker compose up', result);
   }
 
-  async composeDown(composeDir: string, options?: ContainerComposeOptions) {
+  async composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void> {
     const args = [
       options?.name ? ['--project-name', options.name] : [],
       ['--project-directory', composeDir, 'down'],
@@ -190,7 +192,7 @@ export class MobyClient implements ContainerEngineClient {
     console.debug('ran docker compose down', result);
   }
 
-  composeExec(composeDir: string, options: ContainerComposeExecOptions) {
+  composeExec(composeDir: string, options: ContainerComposeExecOptions): Promise<ContainerComposeExecResult> {
     const args = [
       options.name ? ['--project-name', options.name] : [],
       ['--project-directory', composeDir, 'exec'],

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -7,10 +7,13 @@ import util from 'util';
 import _ from 'lodash';
 import tar from 'tar-stream';
 
-import { ContainerComposeOptions, ContainerEngineClient, ContainerRunOptions, ContainerStopOptions } from './types';
+import {
+  ContainerComposeExecOptions, ContainerComposeOptions, ContainerEngineClient,
+  ContainerRunOptions, ContainerStopOptions,
+} from './types';
 
 import { VMExecutor } from '@pkg/backend/backend';
-import { spawnFile } from '@pkg/utils/childProcess';
+import { spawn, spawnFile } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
 import { executable } from '@pkg/utils/resources';
 import { defined } from '@pkg/utils/typeUtils';
@@ -188,21 +191,57 @@ export class NerdctlClient implements ContainerEngineClient {
     return (await this.nerdctl(...args)).trim();
   }
 
-  async composeUp(composeDir: string, options?: ContainerComposeOptions) {
+  async stop(container: string, options?: ContainerStopOptions): Promise<void> {
+    function addNS(...args: string[]) {
+      if (options?.namespace) {
+        return [`--namespace=${ options.namespace }`, ...args];
+      }
+
+      return args;
+    }
+
+    if (options?.delete && options.force) {
+      await this.nerdctl(...addNS('container', 'rm', '--force', container));
+
+      return;
+    }
+
+    await this.nerdctl(...addNS('container', 'stop', container));
+    if (options?.delete) {
+      await this.nerdctl(...addNS('container', 'rm', container));
+    }
+  }
+
+  /**
+   * Copy the given host directory into a temporary directory in the VM
+   * @param hostPath The path on the host to a directory.
+   * @returns The temporary path in the VM holding the results.
+   */
+  protected async copyDirectoryIn(hostPath: string): Promise<string> {
     const cleanups: (() => Promise<void>)[] = [];
+    let succeeded = false;
 
     try {
       const workDir = (await this.vm.execCommand({ capture: true },
-        '/bin/mktemp', '--directory', '--tmpdir', 'rd-nerdctl-compose-up-XXXXXX')).trim();
+        '/bin/mktemp', '--directory', '--tmpdir', 'rd-nerdctl-copy-in-XXXXXX')).trim();
 
       cleanups.push(() => this.vm.execCommand('/bin/rm', '-rf', workDir));
 
-      const hostDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-compose-up-'));
+      const resultDir = (await this.vm.execCommand({ capture: true },
+        '/bin/mktemp', '--directory', '--tmpdir', 'rd-nerdctl-copy-in-XXXXXX')).trim();
+
+      cleanups.push(async() => {
+        if (!succeeded) {
+          await this.vm.execCommand('/bin/rm', '-rf', workDir);
+        }
+      });
+
+      const archiveName = 'nerdctl-copy-in.tar';
+      const hostDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-copy-in-'));
 
       cleanups.push(() => fs.promises.rm(hostDir, { recursive: true }));
 
-      const hostPath = path.join(hostDir, 'compose.tar');
-      const tarStream = fs.createWriteStream(hostPath);
+      const tarStream = fs.createWriteStream(path.join(hostDir, archiveName));
       const archive = tar.pack();
       const archiveFinished = util.promisify(stream.finished)(archive);
       const newEntry = util.promisify(archive.entry.bind(archive));
@@ -214,7 +253,7 @@ export class NerdctlClient implements ContainerEngineClient {
         type:  'directory',
       };
       const walk = async(dir: string) => {
-        const fullPath = path.normalize(path.join(composeDir, dir));
+        const fullPath = path.normalize(path.join(hostPath, dir));
 
         for (const basename of await fs.promises.readdir(fullPath)) {
           const name = path.normalize(path.join(dir, basename));
@@ -252,11 +291,25 @@ export class NerdctlClient implements ContainerEngineClient {
       archive.finalize();
       await archiveFinished;
 
-      await this.vm.copyFileIn(hostPath, path.posix.join(workDir, 'compose.tar'));
-      await this.vm.execCommand('/bin/mkdir', path.posix.join(workDir, 'extract'));
-      await this.vm.execCommand('/usr/bin/tar', 'xf', path.posix.join(workDir, 'compose.tar'), '-C', path.posix.join(workDir, 'extract'));
+      await this.vm.copyFileIn(path.join(hostDir, archiveName), path.posix.join(workDir, archiveName));
+      await this.vm.execCommand('/usr/bin/tar', 'xf', path.posix.join(workDir, archiveName), '-C', resultDir);
+      succeeded = true;
 
-      const args = ['compose', '--project-directory', path.posix.join(workDir, 'extract')];
+      return resultDir;
+    } finally {
+      await this.runCleanups(cleanups);
+    }
+  }
+
+  async composeUp(composeDir: string, options?: ContainerComposeOptions) {
+    const cleanups: (() => Promise<void>)[] = [];
+
+    try {
+      const workDir = await this.copyDirectoryIn(composeDir);
+
+      cleanups.push(() => this.vm.execCommand('/bin/rm', '-rf', workDir));
+
+      const args = ['compose', '--project-directory', workDir];
 
       if (options?.name) {
         args.push('--project-name', options.name);
@@ -265,7 +318,10 @@ export class NerdctlClient implements ContainerEngineClient {
         args.unshift('--namespace', options.namespace);
       }
       if (options?.env) {
-        const envFile = path.posix.join(workDir, 'compose.env');
+        const envFile = (await (this.vm.execCommand({ capture: true },
+          '/bin/mktemp', '--tmpdir', 'rd-nerdctl-compose-up-XXXXXX'))).trim();
+
+        cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', envFile));
         const envData = Object.entries(options.env)
           .map(([k, v]) => `${ k }='${ v.replaceAll("'", "\\'") }'\n`)
           .join('');
@@ -280,28 +336,7 @@ export class NerdctlClient implements ContainerEngineClient {
 
       console.log('ran nerdctl compose up', result);
     } finally {
-      await this.runCleanups(cleanups);
-    }
-  }
-
-  async stop(container: string, options?: ContainerStopOptions): Promise<void> {
-    function addNS(...args: string[]) {
-      if (options?.namespace) {
-        return [`--namespace=${ options.namespace }`, ...args];
-      }
-
-      return args;
-    }
-
-    if (options?.delete && options.force) {
-      await this.nerdctl(...addNS('container', 'rm', '--force', container));
-
-      return;
-    }
-
-    await this.nerdctl(...addNS('container', 'stop', container));
-    if (options?.delete) {
-      await this.nerdctl(...addNS('container', 'rm', container));
+      this.runCleanups(cleanups);
     }
   }
 
@@ -332,6 +367,55 @@ export class NerdctlClient implements ContainerEngineClient {
       const result = await this.nerdctl(...args);
 
       console.debug('ran nerdctl compose down:', result);
+    } finally {
+      await this.runCleanups(cleanups);
+    }
+  }
+
+  async composeExec(composeDir: string, options: ContainerComposeExecOptions) {
+    const cleanups: (() => Promise<void>)[] = [];
+
+    try {
+      const workComposeDir = await this.copyDirectoryIn(composeDir);
+
+      cleanups.push(() => this.vm.execCommand('/bin/rm', '-rf', workComposeDir));
+      const args = [
+        options.namespace ? ['--namespace', options.namespace] : [],
+        ['compose'],
+        options.name ? ['--project-name', options.name] : [],
+        ['--project-directory', workComposeDir],
+      ].flat();
+
+      if (options.env) {
+        const envFile = (await this.vm.execCommand({ capture: true },
+          '/bin/mktemp', '--tmpdir', 'rd-nerdctl-compose-exec-XXXXXX')).trim();
+
+        cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', envFile));
+        const envData = Object.entries(options.env)
+          .map(([k, v]) => `${ k }='${ v.replaceAll("'", "\\'") }'\n`)
+          .join('');
+
+        await this.vm.writeFile(envFile, envData);
+        args.push('--env-file', envFile);
+      }
+
+      args.push(...[
+        ['exec'],
+        options.user ? ['--user', options.user] : [],
+        options.workdir ? ['--workdir', options.workdir] : [],
+        [options.service, ...options.command],
+      ].flat());
+
+      const result = spawn(executable('nerdctl'), args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const delayedCleanups = cleanups.concat();
+
+      // Delay running cleanups until the process has finished to avoid removing
+      // files that may still be necessary.
+      result.on('exit', () => this.runCleanups(delayedCleanups));
+      result.on('error', () => this.runCleanups(delayedCleanups));
+      cleanups.splice(0, cleanups.length);
+
+      return result;
     } finally {
       await this.runCleanups(cleanups);
     }

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -1,3 +1,6 @@
+import type { ChildProcessByStdio } from 'child_process';
+import type { Readable } from 'stream';
+
 type ContainerBasicOptions = {
   /**
    * Namespace the container should be created in.
@@ -40,6 +43,20 @@ export type ContainerComposeOptions = ContainerBasicOptions & {
   env?: Record<string, string>;
 };
 
+export type ContainerComposeExecOptions = ContainerComposeOptions & {
+  /** The service to exec in. */
+  service: string;
+  /** The command (and arguments) to execute. */
+  command: string[];
+  /** Run the command as the given (in-container) user. */
+  user?: string,
+  /** Run the command in the given (in-container) directory */
+  workdir?: string;
+};
+
+/** ContainerComposeExecResult describes the process returned from composeExec */
+type ContainerComposeExecResult = ChildProcessByStdio<null, Readable, Readable>;
+
 /**
  * ContainerEngineClient is used to run commands on the container engine.
  */
@@ -81,17 +98,28 @@ export interface ContainerEngineClient {
   run(imageID: string, options?: ContainerRunOptions): Promise<string>;
 
   /**
+   * Stop the given container, if it exists and is running.
+   */
+  stop(container: string, options?: ContainerStopOptions): Promise<void>;
+
+  /**
    * Start containers via `docker compose` / `nerdctl compose`.
    * @param composeDir The path containing the compose file.
    */
   composeUp(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
 
   /**
-   * Stop the given container, if it exists and is running.
+   * Stop containers via `docker compose` / `nerdctl compose`.
+   * @param composeDir The path containing the compose file.
    */
-  stop(container: string, options?: ContainerStopOptions): Promise<void>;
-
   composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
+
+  /**
+   * Spawn a process using `docker compose exec` / `nerdctl ...`, returning a
+   * raw process that has stdout and stderr set to pipe (but nothing for stdin).
+   * @param composeDir The host path containing the compose file.
+   */
+  composeExec(composeDir: string, options: ContainerComposeExecOptions): Promise<ContainerComposeExecResult>;
 
   /**
    * The client executable to run.  This is used for commands where the two

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -55,7 +55,7 @@ export type ContainerComposeExecOptions = ContainerComposeOptions & {
 };
 
 /** ContainerComposeExecResult describes the process returned from composeExec */
-type ContainerComposeExecResult = ChildProcessByStdio<null, Readable, Readable>;
+export type ContainerComposeExecResult = ChildProcessByStdio<null, Readable, Readable>;
 
 /**
  * ContainerEngineClient is used to run commands on the container engine.

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -1,6 +1,5 @@
 import { ChildProcessByStdio, spawn } from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { Readable } from 'stream';
 
@@ -286,7 +285,14 @@ class ExtensionManagerImpl implements ExtensionManager {
 
   /** Spawn a process in the container context. */
   protected spawnContainer(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): Promise<ReadableChildProcess> {
-    return Promise.reject(new Error('not implemented'));
+    const extensionId = this.getExtensionIdFromEvent(event);
+    const extension = this.getExtension(extensionId) as ExtensionImpl;
+
+    if (!extension) {
+      return Promise.reject(new Error(`Could not find calling extension ${ extensionId }`));
+    }
+
+    return extension.composeExec(options);
   }
 
   /**


### PR DESCRIPTION
Since we unified to always using compose to run images, we can just look for a random service (i.e. container inside compose application) to run the commands on.

Fixes #4357 (implements the API).
Fixes #4022 (by finishing up the last item).