### PR TITLE
Show error if rendering RDX `BrowserView` fails

### DIFF
--- a/pkg/rancher-desktop/components/ExtensionsError.vue
+++ b/pkg/rancher-desktop/components/ExtensionsError.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+export default Vue.extend({
+  name:  'extensions-error',
+  props: {
+    extensionId: {
+      type:    String,
+      default: '',
+    },
+    error: {
+      type:    Error as PropType<Error | undefined>,
+      default: undefined,
+    },
+  },
+});
+</script>
+
+<template>
+  <div>
+    <h2>Error rendering extension: {{ extensionId }}</h2>
+    <code>
+      {{ error }}
+    </code>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  code {
+    white-space: pre-line;
+  }
+</style>

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -2,8 +2,8 @@
 import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
+import ExtensionsError from '@pkg/components/ExtensionsError.vue';
 import { hexDecode } from '@pkg/utils/string-encode';
-import ExtensionsError from '~/components/ExtensionsError.vue';
 
 interface ExtensionsData {
   error: Error | undefined;

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
     return { error: undefined };
   },
   computed: {
-    extensionId(): string {
+    extensionId(): string | undefined {
       return hexDecode(this.$route.params.id);
     },
   },

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -2,7 +2,15 @@
 import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
+import { hexDecode } from '@pkg/utils/string-encode';
+import ExtensionsError from '~/components/ExtensionsError.vue';
+
+interface ExtensionsData {
+  error: Error | undefined;
+}
+
 export default Vue.extend({
+  components: { ExtensionsError },
   beforeRouteEnter(to, _from, next) {
     const { params: { root, src, id } } = to;
 
@@ -21,6 +29,25 @@ export default Vue.extend({
     this.closeExtensionView();
     next();
   },
+  data(): ExtensionsData {
+    return { error: undefined };
+  },
+  computed: {
+    extensionId(): string {
+      return hexDecode(this.$route.params.id);
+    },
+  },
+  mounted() {
+    this.$store.dispatch(
+      'page/setHeader',
+      { title: this.extensionId },
+    );
+
+    ipcRenderer.on('err:extensions/open', this.extensionError);
+  },
+  beforeDestroy() {
+    ipcRenderer.off('err:extensions/open', this.extensionError);
+  },
   methods: {
     openExtension(id: string, root: string, src: string): void {
       ipcRenderer.send('extensions/open', id, `${ root }/${ src }`);
@@ -28,12 +55,17 @@ export default Vue.extend({
     closeExtensionView(): void {
       ipcRenderer.send('extensions/close');
     },
+    extensionError(_event: any, err: Error): void {
+      this.error = err;
+    },
   },
 });
 </script>
 
 <template>
-  <div>
-    <slot></slot>
-  </div>
+  <extensions-error
+    v-if="error"
+    :error="error"
+    :extension-id="extensionId"
+  />
 </template>

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -166,6 +166,7 @@ export interface IpcRendererEvents {
   // #region extensions
   'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
   'extensions/open': (id: string, path: string) => void;
+  'err:extensions/open': () => void;
   'extensions/close': () => void;
   'extensions/spawn/close': (id: string, code: number) => void;
   'extensions/spawn/error': (id: string, error: Error | NodeJS.Signals) => void;

--- a/pkg/rancher-desktop/utils/string-encode.ts
+++ b/pkg/rancher-desktop/utils/string-encode.ts
@@ -1,3 +1,7 @@
 export const hexEncode = (str: string): string => Array.from(str)
   .map(c => `0${ c.charCodeAt(0).toString(16) }`.slice(-2))
   .join('');
+
+export const hexDecode = (hexString: string): string | undefined => hexString.match(/.{1,2}/g)
+  ?.map(hex => String.fromCharCode(parseInt(hex, 16)))
+  .join('');

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -329,6 +329,7 @@ function extensionGetContentAreaListener(_event: Electron.IpcMainEvent, args: an
       createView();
       window.webContents.on('before-input-event', extensionZoomListener);
     } catch (e) {
+      window.webContents.send('err:extensions/open', e);
       console.error(e);
     }
   }


### PR DESCRIPTION
This renders an error in page when the if the extension `BrowserView` fails to load.

## Screenshot

![image](https://user-images.githubusercontent.com/835961/230484735-282d9014-3862-4fe4-a987-4c39d5ba8ccf.png)

closes #4275 