### PR TITLE
RDX: Fix various issues

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -175,7 +175,7 @@ export class MobyClient implements ContainerEngineClient {
     if (options?.name) {
       args.push('--project-name', options.name);
     }
-    args.push('up', '--quiet-pull', '--wait');
+    args.push('up', '--quiet-pull', '--wait', '--remove-orphans');
 
     const result = await this.runTool({ env: options?.env ?? {} }, 'docker-compose', ...args);
 

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -154,7 +154,11 @@ export class NerdctlClient implements ContainerEngineClient {
         sourceName = path.posix.basename(sourcePath);
         sourceDir = path.posix.join(imageDir, path.posix.dirname(sourcePath));
       }
-      const args = ['--create', '--gzip', '--file', archive, '--directory', sourceDir, resolveSymlinks ? '--dereference' : undefined, sourceName].filter(defined);
+      const args = [
+        '--create', '--gzip', '--file', archive, '--directory', sourceDir,
+        resolveSymlinks ? '--dereference' : undefined,
+        '--one-file-system', '--sparse', sourceName,
+      ].filter(defined);
 
       await this.vm.execCommand({ root: true }, '/usr/bin/tar', ...args);
 

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -406,7 +406,7 @@ export class NerdctlClient implements ContainerEngineClient {
       }
 
       args.push(...[
-        ['exec'],
+        ['exec', '--tty=false'],
         options.user ? ['--user', options.user] : [],
         options.workdir ? ['--workdir', options.workdir] : [],
         [options.service, ...options.command],

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -330,7 +330,7 @@ export class ExtensionImpl implements Extension {
     return this.client.composeExec(path.join(this.dir, 'compose'), {
       name:      this.containerName,
       namespace: this.extensionNamespace,
-      env:       { ...options.env, DESKTOP_PLUGIN_NAME: this.id },
+      env:       { ...options.env, DESKTOP_PLUGIN_IMAGE: this.id },
       service,
       command:   options.command,
       ...options.cwd ? { workdir: options.cwd } : {},

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -277,10 +277,10 @@ class ExtensionManagerImpl implements ExtensionManager {
       throw new Error(`Could not find calling extension ${ extensionId }`);
     }
 
-    return spawn(this.client.executable, options.command, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      ..._.pick(options, ['cwd', 'env']),
-    });
+    return this.client.runClient(
+      options.command,
+      'stream',
+      _.pick(options, ['cwd', 'env', 'namespace']));
   }
 
   /** Spawn a process in the container context. */

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -322,7 +322,7 @@ class ExtensionManagerImpl implements ExtensionManager {
           return;
         }
         resolve({
-          cmd:    `${ process.spawnfile } ${ process.spawnargs.join(' ') }`,
+          cmd:    process.spawnargs.join(' '),
           result: signal ?? code ?? 0,
           stdout: Buffer.concat(stdout).toString('utf-8'),
           stderr: Buffer.concat(stderr).toString('utf-8'),


### PR DESCRIPTION
- bbd91e6217c715d7d17a2f45d09161f7f8cda5d9: `compose up` was sometimes failing when using moby due to conflicting stale containers. Added `--remove-orphans` to fix this.
- d595e4936208eda73f2a31e94b1c1514f67b48fd: `nerdctl compose exec` was having issues because we didn't pass in `DOESKTOP_PLUGIN_IMAGE`.
- 0e8d0321b2ff209ad7723b28c55850714d2e7c11: We were repeating the executable name in the executable result command information.
- af71c67afd3a72f86696ab84ff0cccca3760fb40: Ensure that when we ran tools in the `docker-cli` context, the namespace was passed in correctly for `nerdctl`.
- 1c0758b319bff0a8516fc159b4f741ba536cabff: When doing `compose exec`, force `nerdctl` to not use a tty.  Otherwise `nerdctl` crashes because it assumes the passed-in fds are ttys.
- afe1667b58e1e120c18017ad36644fda8f9c65d1: When we copy files out of the image using `nerdctl`, limit it to files within the image (and don't follow symlinks outside).

Fixes #4375, primarily via d595e4936208eda73f2a31e94b1c1514f67b48fd, af71c67afd3a72f86696ab84ff0cccca3760fb40, and 1c0758b319bff0a8516fc159b4f741ba536cabff.