### PR TITLE
RDX: Fix missing import

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 
-import { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
+import Electron, { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import _ from 'lodash';
 
 import { ExtensionImpl } from './extensions';


### PR DESCRIPTION
We need `Electron` imported so we can call `Electron.shell.openExternal`, etc. But this was accidentally removed in 38abcedc9f84 during a rebase (picking a commit that dropped a use of it).