### PR TITLE
Destroy `BrowserView` contents when closing

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -386,6 +386,12 @@ export function closeExtension() {
     return;
   }
 
+  /**
+   * TODO: ISSUE #4394 Replace undocumented `webContents.destroy()` with
+   * `webcontents.close()`
+   */
+  (view.webContents as any).destroy();
+
   const window = getWindow('main');
 
   window?.removeBrowserView(view);


### PR DESCRIPTION
This prevents the web contents of a `BrowserView` from leaking events by invoking `webContents.destroy()`.

### 🗒️ Notes

- `webContents.destroy()` is an undocumented method
- Electron exposes `webContents.close()` in later versions. We will need to come back at a later to use `webContents.close()` after updating to the latest version of electron. #4394

closes #4393 