### PR TITLE
RDX: Don't send events to dead frames

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -335,7 +335,7 @@ class ExtensionManagerImpl implements ExtensionManager {
    * Helper for event.senderFrame.send() to add checking of channel names.
    */
   protected sendToFrame<K extends keyof IpcRendererEvents>(event: IpcMainEvent, channel: K, ...args: Parameters<IpcRendererEvents[K]>) {
-    event.senderFrame.send(channel, ...args as any);
+    event.senderFrame?.send?.(channel, ...args as any);
   }
 
   /**


### PR DESCRIPTION
If the user navigates away from the extension (causing the BrowserView to be destroyed), we can't send things to that frame anymore.  But we might still get results back from the process in that case.  Just ignore it in that case.

We're not terminating the process here as it may be a long-running process (e.g. `helm install ...`) that the user was just bored of monitoring; it's likely that we should let it remain.

Fixes #4405.

As an alternative, we may want to have distinct `BrowserView`s per extension, and only show/hide them as we switch.  This would let the extension frontend maintain state; however, that comes was significant resource use and probably doesn't match the user's mental model.