### PR TITLE
Remove extension version from slug if it exists

### DIFF
--- a/pkg/rancher-desktop/pages/marketplace/details.vue
+++ b/pkg/rancher-desktop/pages/marketplace/details.vue
@@ -167,7 +167,12 @@ export default {
       return JSON.parse(screenshots)[0].url || '';
     },
     versionedExtension() {
-      return `${ this.extension }:${ this.extensionDetails.version }`;
+      return `${ this.extensionWithoutVersion }:${ this.extensionDetails?.version }`;
+    },
+    extensionWithoutVersion() {
+      const index = this.extension.lastIndexOf(':');
+
+      return this.extension.substring(0, index) || this.extension;
     },
   },
 
@@ -178,7 +183,7 @@ export default {
       this.$router.push('/marketplace');
     }
 
-    this.metadata = demoMetadata[this.extension];
+    this.metadata = demoMetadata[this.extensionWithoutVersion];
 
     if (!this.metadata) {
       return;
@@ -187,13 +192,13 @@ export default {
     this.$store.dispatch('page/setHeader', {
       title:
         this.metadata?.LatestVersion.Labels['org.opencontainers.image.title'] ||
-        this.extension,
+        this.extensionWithoutVersion,
     });
 
     this.extensionDetails = {
       name:
         this.metadata?.LatestVersion.Labels['org.opencontainers.image.title'] ||
-        this.extension,
+        this.extensionWithoutVersion,
       icon:
         this.metadata?.LatestVersion.Labels[
           'com.docker.desktop.extension.icon'

--- a/pkg/rancher-desktop/pages/marketplace/details.vue
+++ b/pkg/rancher-desktop/pages/marketplace/details.vue
@@ -127,7 +127,7 @@ export default {
       }
 
       response.json().then((res) => {
-        this.isInstalled = Object.keys(res).includes(this.extension);
+        this.isInstalled = Object.keys(res).includes(this.versionedExtension);
       });
     });
   },


### PR DESCRIPTION
The extension ID used to render the details page can come with version information depending on the source of the `slug` params (extension metadata stored on filesystem vs. extension metadata from API). We need to strip out this version if it exists in our params if we wish to properly fetch data for the details page. 

Alternatively, we can strip the version string before routing to the details page in 'installed.vue'. 

closes #4422 