### PR TITLE
wsl-exec: ensure we use the pid of /sbin/init

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-exec
+++ b/pkg/rancher-desktop/assets/scripts/wsl-exec
@@ -16,6 +16,15 @@ if [ -z "${pid}" ]; then
     exit 1
 fi
 
+# If the pid is _not_ /sbin/init, find the child that is.
+command="$(ps -o pid,args | awk "\$1 == $pid { print \$2 }")"
+if [ "$command" != "/sbin/init" ]; then
+  newpid="$(ps -o pid,ppid,args | awk "\$2 == $pid && \$3 == \"/sbin/init\" { print \$1 }")"
+  if [ -n "${newpid}" ]; then
+    pid="${newpid}"
+  fi
+fi
+
 if [ $# -eq 0 ]; then
   set -- /bin/sh
 fi


### PR DESCRIPTION
When _not_ using network namespaces, the pid written (from `wsl-init`) is the pid of the `unshare` process that is the parent of `/sbin/init`.  While that seems to mostly work (`/sbin/init` is pid 1, and we can't see the rest of the pids), it somehow breaks `rc-service` (it finds the services but treats them as unsupervised).  However, if we manually enter the pid namespace of `/sbin/init` it works fine:

```
# /usr/bin/nsenter -t 1 /sbin/rc-service buildkitd status
 * status: unsupervised
# /usr/bin/nsenter -p -t 1 /sbin/rc-service buildkitd status
 * status: started
```

Fix this by switching to using `/sbin/init` (rather than `unshare`) in the initial `nsenter` call, even though it looks the same from a glance.

This trips up BATS runs on Windows.