### PR TITLE
BATS: Fix starting on Windows

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -20,13 +20,17 @@ factory_reset() {
 }
 
 start_container_engine() {
-    # TODO why is --path option required for Windows
-    if is_windows; then
-        set - --path "$(wslpath -w "$PATH_EXECUTABLE")" "$@"
-    fi
+    local args=(
+        --application.updater.enabled=false
+        --container-engine="$RD_CONTAINER_ENGINE"
+        --kubernetes-enabled=false
+    )
     if is_unix; then
-        set - --application.admin-access=false "$@"
-        set - --application.path-management-strategy rcfiles "$@"
+        args+=(
+            --application.admin-access=false
+            --application.path-management-strategy rcfiles
+            --virtual-machine.memory-in-gb 6
+        )
     fi
 
     # TODO containerEngine.allowedImages.patterns and WSL.integrations
@@ -52,12 +56,7 @@ EOF
 
     # Detach `rdctl start` because on Windows the process may not exit until
     # Rancher Desktop itself quits.
-    rdctl start \
-        --application.updater.enabled=false \
-        --container-engine="$RD_CONTAINER_ENGINE" \
-        --kubernetes-enabled=false \
-        --virtual-machine.memory-in-gb 6 \
-        "$@" &
+    rdctl start "${args[@]}" "$@" &
 }
 
 start_kubernetes() {


### PR DESCRIPTION
On Windows, we shouldn't pass `--virtual-machine.memory` (because we don't run an explicit VM manually and have no control over the WSL VM; `rdctl.exe` will error out when it is passed).

We can drop `--path` as well, since that has been fixed in #3798 which was merged in 72e6a808f6eb0d585e4f08a8d2c6d7b34ede4d7c.