### PR TITLE
Bump epinio-desktop-extension to 0.0.23.5

### DIFF
--- a/pkg/rancher-desktop/utils/_demo_metadata.js
+++ b/pkg/rancher-desktop/utils/_demo_metadata.js
@@ -4,7 +4,7 @@ export default {
     UpdatedAt:     '2023-02-24T10:40:43.666252815Z',
     Categories:    ['kubernetes'],
     LatestVersion: {
-      Tag:                '0.0.12',
+      Tag:                '0.0.23.5',
       ManifestListDigest:
         'sha256:d74bf36e9ad51fdca0ddfacaf6d0af3c8bd5a984e583e6a081e2907958e11954',
       Platforms: [

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -325,7 +325,9 @@ export default {
       // Build the golang executable
       await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', executablePath, '.', {
         cwd: path.join(this.rootDir, 'src', 'go', 'extension-proxy'),
-        env: { ...process.env, CGO_ENABLED: '0', GOOS: 'linux' },
+        env: {
+          ...process.env, CGO_ENABLED: '0', GOOS: 'linux',
+        },
       });
 
       // Build the layer tarball


### PR DESCRIPTION
This version also works on Windows.

PR also includes an unrelated linter fix that seems to have slipped through in a merged PR.