### PR TITLE
Allow doc version to be `1.9-tech-preview`

### DIFF
--- a/pkg/rancher-desktop/utils/version.ts
+++ b/pkg/rancher-desktop/utils/version.ts
@@ -37,7 +37,17 @@ export async function getVersion() {
 }
 
 export function parseDocsVersion(version: string) {
-  const releasePattern = /^v?(\d+\.\d+)\.\d+$/;
+  // Match '1.9.0-tech-preview' (returns '1.9-tech-preview'), but not '1.9.0-123-g1234567' (returns 'next')
+  const releasePattern = /^v?(\d+\.\d+)\.\d+(-[a-z].*)?$/;
+  const matches = releasePattern.exec(version);
 
-  return releasePattern.exec(version)?.[1] ?? 'next';
+  if (matches) {
+    if (matches[2]) {
+      return matches[1].concat(matches[2]);
+    }
+
+    return matches[1];
+  }
+
+  return 'next';
 }


### PR DESCRIPTION
For testing download a build from https://github.com/rancher-sandbox/rancher-desktop/actions/runs/4691378070 and verify that the docs links go to `1.9-test-release2` and not `next`.