### PR TITLE
RDX: Fix listImages for nerdctl

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -324,7 +324,8 @@ class ExtensionManagerImpl implements ExtensionManager {
     }
 
     return this.client.runClient(
-      options.command,
+      // For docker compatibility, strip quotes for any arguments.
+      options.command.map(arg => (/^(["'])(.*)\1$/.exec(arg) ?? ['', '', arg])[2]),
       'stream',
       _.pick(options, ['cwd', 'env', 'namespace']));
   }


### PR DESCRIPTION
There were issues with `listImages` when running with `nerdctl`, because it was emitting different output.

Also fixes an issue when re-running an already installed extension (e.g. on restart) because we added too many identical volumes.