### PR TITLE
Refactor factory-reset.bats breaking it down into smaller check tests.

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -1,5 +1,7 @@
 setup() {
     load '../helpers/load'
+    assert=assert
+    refute=refute
 }
 
 @test 'factory reset' {
@@ -11,47 +13,27 @@ setup() {
 }
 
 @test 'Verify that the expected directories were created' {
-    check_directories before
+    before check_directories
 }
 
 @test 'Verify that docker symlinks were created' {
-    if is_unix; then
-        check_docker_symlinks before
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    before check_docker_symlinks
 }
 
 @test 'Verify that path management was set' {
-    if is_unix; then
-        check_path before
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    before check_path
 }
 
 @test 'Verify that rancher desktop context was created' {
-    if is_unix; then
-        check_rd_context before
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    before check_rd_context
 }
 
 @test 'Verify that lima VM was created' {
-    if is_unix; then
-        check_lima before
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    before check_lima
 }
 
 @test 'Verify that WSL distributions were created' {
-    if is_windows; then
-        check_WSL before
-    else
-        skip "This test is not applicable on MacOS/Linux. Skipping..."
-    fi
+    before check_WSL
 }
 
 @test 'Shutdown Rancher Desktop' {
@@ -66,43 +48,23 @@ setup() {
 }
 
 @test 'Verify that docker symlinks were deleted' {
-    if is_unix; then
-        check_docker_symlinks
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_docker_symlinks
 }
 
 @test 'Verify that path management was unset' {
-    if is_unix; then
-        check_path
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_path
 }
 
 @test 'Verify that rancher desktop context was deleted' {
-    if is_unix; then
-        check_rd_context
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_rd_context
 }
 
 @test 'Verify that lima VM was deleted' {
-    if is_unix; then
-        check_lima
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_lima
 }
 
 @test 'Verify that WSL distributions were deleted' {
-    if is_windows; then
-        check_WSL
-    else
-        skip "This test is not applicable on MacOS/Linux. Skipping..."
-    fi
+    check_WSL
 }
 
 @test 'Start Rancher Desktop 2' {
@@ -118,43 +80,23 @@ setup() {
 }
 
 @test 'Verify that docker symlinks were deleted 2' {
-    if is_unix; then
-        check_docker_symlinks
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_docker_symlinks
 }
 
 @test 'Verify that path management was unset 2' {
-    if is_unix; then
-        check_path
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_path
 }
 
 @test 'Verify that rancher desktop context was deleted 2' {
-    if is_unix; then
-        check_rd_context
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_rd_context
 }
 
 @test 'Verify that lima VM was deleted 2' {
-    if is_unix; then
-        check_lima
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_lima
 }
 
 @test 'Verify that WSL distributions were deleted 2' {
-    if is_windows; then
-        check_WSL
-    else
-        skip "This test is not applicable on MacOS/Linux. Skipping..."
-    fi
+    check_WSL
 }
 
 @test 'Start Rancher Desktop 3' {
@@ -170,43 +112,23 @@ setup() {
 }
 
 @test 'Verify that docker symlinks were deleted 3' {
-    if is_unix; then
-        check_docker_symlinks
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_docker_symlinks
 }
 
 @test 'Verify that path management was unset 3' {
-    if is_unix; then
-        check_path
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_path
 }
 
 @test 'Verify that rancher desktop context was deleted 3' {
-    if is_unix; then
-        check_rd_context
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_rd_context
 }
 
 @test 'Verify that lima VM was deleted 3' {
-    if is_unix; then
-        check_lima
-    else
-        skip "This test is not applicable on Windows. Skipping..."
-    fi
+    check_lima
 }
 
 @test 'Verify that WSL distributions were deleted 3' {
-    if is_windows; then
-        check_WSL
-    else
-        skip "This test is not applicable on MacOS/Linux. Skipping..."
-    fi
+    check_WSL
 }
 
 rdctl_factory_reset() {
@@ -230,14 +152,13 @@ refute_not_exists() {
     assert_exists "$@"
 }
 
-check_directories() {
-    local assert=assert
-    local refute=refute
+before() {
+    assert=refute
+    refute=assert
+    "$@"
+}
 
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+check_directories() {
     # Check if all expected directories are created after starting application/ are deleted after a factory reset
     delete_dir=("$PATH_APP_HOME" "$PATH_CONFIG")
     if is_unix; then
@@ -261,33 +182,21 @@ check_directories() {
 
     for dir in "${delete_dir[@]}"; do
         echo "$assert that $dir does not exist"
-        "${assert}"_not_exists "$dir"
+        "${assert}_not_exists" "$dir"
     done
 }
 
 check_docker_symlinks() {
-    local assert=assert
-    local refute=refute
-
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+    skip_on_windows
     # Check if docker-X symlinks were deleted
     for dfile in docker-buildx docker-compose; do
         run readlink "$HOME/.docker/cli-plugins/$dfile"
-        "${refute}"_output "$HOME/.rd/bin/$dfile"
+        "${refute}_output" "$HOME/.rd/bin/$dfile"
     done
 }
 
 check_path() {
-    local assert=assert
-    local refute=refute
-
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+    skip_on_windows
     # Check if ./rd/bin was removed from the path
     # TODO add check for config.fish
     env_profiles=(
@@ -311,49 +220,31 @@ check_path() {
         # cshrc: setenv PATH "/Users/jan/.rd/bin"\:"$PATH"
         # posix: export PATH="/Users/jan/.rd/bin:$PATH"
         run grep "PATH.\"$HOME/.rd/bin" "$profile"
-        "${assert}"_failure
+        "${assert}_failure"
     done
 }
 
 check_rd_context() {
-    local assert=assert
-    local refute=refute
-
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+    skip_on_windows
     # Check if the rancher-desktop docker context has been removed
     if using_docker; then
         echo "$assert that the docker context rancher-desktop does not exist"
         run grep -r rancher-desktop "$HOME/.docker/contexts/meta"
-        "${assert}"_failure
+        "${assert}_failure"
     fi
 }
 
 check_lima() {
-    local assert=assert
-    local refute=refute
-
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+    skip_on_windows
     # Check if VM was killed
     run limactl ls
-    "${assert}"_output --partial "No instance found"
+    "${assert}_output" --partial "No instance found"
 }
 
 check_WSL() {
-    local assert=assert
-    local refute=refute
-
-    if [ "${1-}" == "before" ]; then
-        assert=refute
-        refute=assert
-    fi
+    skip_on_unix
     # Check if rancher-desktop WSL distros are deleted on Windows
     run powershell.exe -c "wsl.exe --list"
-    "${refute}"_line --partial "rancher-desktop-data"
-    "${refute}"_line --partial "rancher-desktop"
+    "${refute}_output" --partial "rancher-desktop-data"
+    "${refute}_output" --partial "rancher-desktop"
 }

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -2,45 +2,211 @@ setup() {
     load '../helpers/load'
 }
 
-@test 'factory-reset when Rancher Desktop is not running' {
-    rdctl factory-reset --verbose
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'Start up Rancher Desktop' {
     start_application
+}
+
+@test 'Verify that the expected directories were created' {
+    check_directories before
+}
+
+@test 'Verify that docker symlinks were created' {
+    if is_unix; then
+        check_docker_symlinks before
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that path management was set' {
+    if is_unix; then
+        check_path before
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that rancher desktop context was created' {
+    if is_unix; then
+        check_rd_context before
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that lima VM was created' {
+    if is_unix; then
+        check_lima before
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that WSL distributions were created' {
+    if is_windows; then
+        check_WSL before
+    else
+        skip "This test is not applicable on MacOS/Linux. Skipping..."
+    fi
+}
+
+@test 'Shutdown Rancher Desktop' {
     rdctl shutdown
-    rdctl_factory_reset --remove-kubernetes-cache=false --verbose
-    check_installation
+}
+@test 'factory-reset when Rancher Desktop is not running' {
+    rdctl_factory_reset --verbose
+}
+
+@test 'Verify that the expected directories were deleted' {
+    check_directories
+}
+
+@test 'Verify that docker symlinks were deleted' {
+    if is_unix; then
+        check_docker_symlinks
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that path management was unset' {
+    if is_unix; then
+        check_path
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that rancher desktop context was deleted' {
+    if is_unix; then
+        check_rd_context
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that lima VM was deleted' {
+    if is_unix; then
+        check_lima
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that WSL distributions were deleted' {
+    if is_windows; then
+        check_WSL
+    else
+        skip "This test is not applicable on MacOS/Linux. Skipping..."
+    fi
+}
+
+@test 'Start Rancher Desktop 2' {
+    start_application
 }
 
 @test 'factory reset - keep cached k8s images' {
-    start_application
     rdctl_factory_reset --remove-kubernetes-cache=false --verbose
-    check_installation
+}
+
+@test 'Verify that the expected directories were deleted 2' {
+    check_directories
+}
+
+@test 'Verify that docker symlinks were deleted 2' {
+    if is_unix; then
+        check_docker_symlinks
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that path management was unset 2' {
+    if is_unix; then
+        check_path
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that rancher desktop context was deleted 2' {
+    if is_unix; then
+        check_rd_context
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that lima VM was deleted 2' {
+    if is_unix; then
+        check_lima
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that WSL distributions were deleted 2' {
+    if is_windows; then
+        check_WSL
+    else
+        skip "This test is not applicable on MacOS/Linux. Skipping..."
+    fi
+}
+
+@test 'Start Rancher Desktop 3' {
+    start_application
 }
 
 @test 'factory reset - delete cached k8s images' {
-    start_application
     rdctl_factory_reset --remove-kubernetes-cache=true --verbose
-    check_installation
 }
 
-start_application() {
-    start_kubernetes
-    wait_for_apiserver
+@test 'Verify that the expected directories were deleted 3' {
+    check_directories
+}
 
-    # the docker context "rancher-desktop" may not have been written
-    # even though the apiserver is already running
-    if using_docker; then
-        wait_for_container_engine
-    fi
-
-    # BUG BUG BUG
-    # Looks like the rcfiles don't get updated via `rdctl start`
-    # BUG BUG BUG
+@test 'Verify that docker symlinks were deleted 3' {
     if is_unix; then
-        rdctl set --application.path-management-strategy manual
-        rdctl set --application.path-management-strategy rcfiles
+        check_docker_symlinks
+    else
+        skip "This test is not applicable on Windows. Skipping..."
     fi
+}
 
-    check_installation before
+@test 'Verify that path management was unset 3' {
+    if is_unix; then
+        check_path
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that rancher desktop context was deleted 3' {
+    if is_unix; then
+        check_rd_context
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that lima VM was deleted 3' {
+    if is_unix; then
+        check_lima
+    else
+        skip "This test is not applicable on Windows. Skipping..."
+    fi
+}
+
+@test 'Verify that WSL distributions were deleted 3' {
+    if is_windows; then
+        check_WSL
+    else
+        skip "This test is not applicable on MacOS/Linux. Skipping..."
+    fi
 }
 
 rdctl_factory_reset() {
@@ -48,6 +214,9 @@ rdctl_factory_reset() {
 
     if [[ $1 == "--remove-kubernetes-cache=true" ]]; then
         assert_not_exist "$PATH_CACHE"
+        if is_windows; then
+            assert_not_exist "$PATH_DATA"
+        fi
     else
         assert_exists "$PATH_CACHE"
     fi
@@ -61,7 +230,7 @@ refute_not_exists() {
     assert_exists "$@"
 }
 
-check_installation() {
+check_directories() {
     local assert=assert
     local refute=refute
 
@@ -69,8 +238,7 @@ check_installation() {
         assert=refute
         refute=assert
     fi
-
-    # Check if all expected directories were deleted and k8s cache was preserved
+    # Check if all expected directories are created after starting application/ are deleted after a factory reset
     delete_dir=("$PATH_APP_HOME" "$PATH_CONFIG")
     if is_unix; then
         delete_dir+=("$HOME/.rd")
@@ -86,57 +254,106 @@ check_installation() {
         # this one only exists after an update has been downloaded
         # ~/Library/Application Support/Caches/rancher-desktop-updater
     fi
+
+    if is_windows; then
+        delete_dir+=("$PATH_LOGS" "$PATH_DISTRO" "$PATH_DISTRO_DATA")
+    fi
+
     for dir in "${delete_dir[@]}"; do
         echo "$assert that $dir does not exist"
-        ${assert}_not_exists "$dir"
+        "${assert}"_not_exists "$dir"
     done
+}
 
+check_docker_symlinks() {
+    local assert=assert
+    local refute=refute
+
+    if [ "${1-}" == "before" ]; then
+        assert=refute
+        refute=assert
+    fi
     # Check if docker-X symlinks were deleted
     for dfile in docker-buildx docker-compose; do
         run readlink "$HOME/.docker/cli-plugins/$dfile"
-        ${refute}_output "$HOME/.rd/bin/$dfile"
+        "${refute}"_output "$HOME/.rd/bin/$dfile"
     done
+}
 
-    # Check if ./rd/bin was removed from the path
-    if is_unix; then
-        # TODO add check for config.fish
-        env_profiles=(
-            "$HOME/.bashrc"
-            "$HOME/.zshrc"
-            "$HOME/.cshrc"
-            "$HOME/.tcshrc"
-        )
-        for candidate in .bash_profile .bash_login .profile; do
-            if [ -e "$HOME/$candidate" ]; then
-                env_profiles+=("$HOME/$candidate")
-                # Only the first candidate that exists will be modified
-                if [ "${1-}" = "before" ]; then
-                    break
-                fi
-            fi
-        done
+check_path() {
+    local assert=assert
+    local refute=refute
+
+    if [ "${1-}" == "before" ]; then
+        assert=refute
+        refute=assert
     fi
+    # Check if ./rd/bin was removed from the path
+    # TODO add check for config.fish
+    env_profiles=(
+        "$HOME/.bashrc"
+        "$HOME/.zshrc"
+        "$HOME/.cshrc"
+        "$HOME/.tcshrc"
+    )
+    for candidate in .bash_profile .bash_login .profile; do
+        if [ -e "$HOME/$candidate" ]; then
+            env_profiles+=("$HOME/$candidate")
+            # Only the first candidate that exists will be modified
+            if [ "${assert}" = "refute" ]; then
+                break
+            fi
+        fi
+    done
 
     for profile in "${env_profiles[@]}"; do
         echo "$assert that $profile does not add ~/.rd/bin to the PATH"
         # cshrc: setenv PATH "/Users/jan/.rd/bin"\:"$PATH"
         # posix: export PATH="/Users/jan/.rd/bin:$PATH"
         run grep "PATH.\"$HOME/.rd/bin" "$profile"
-        ${assert}_failure
+        "${assert}"_failure
     done
+}
 
+check_rd_context() {
+    local assert=assert
+    local refute=refute
+
+    if [ "${1-}" == "before" ]; then
+        assert=refute
+        refute=assert
+    fi
     # Check if the rancher-desktop docker context has been removed
     if using_docker; then
-        if is_unix; then
-            echo "$assert that the docker context rancher-desktop does not exist"
-            run grep -r rancher-desktop "$HOME/.docker/contexts/meta"
-            ${assert}_failure
-        fi
+        echo "$assert that the docker context rancher-desktop does not exist"
+        run grep -r rancher-desktop "$HOME/.docker/contexts/meta"
+        "${assert}"_failure
     fi
+}
 
-    # Check if VM was killed
-    if is_unix; then
-        run limactl ls
-        ${assert}_output --partial "No instance found"
+check_lima() {
+    local assert=assert
+    local refute=refute
+
+    if [ "${1-}" == "before" ]; then
+        assert=refute
+        refute=assert
     fi
+    # Check if VM was killed
+    run limactl ls
+    "${assert}"_output --partial "No instance found"
+}
+
+check_WSL() {
+    local assert=assert
+    local refute=refute
+
+    if [ "${1-}" == "before" ]; then
+        assert=refute
+        refute=assert
+    fi
+    # Check if rancher-desktop WSL distros are deleted on Windows
+    run powershell.exe -c "wsl.exe --list"
+    "${refute}"_line --partial "rancher-desktop-data"
+    "${refute}"_line --partial "rancher-desktop"
 }

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -1,3 +1,5 @@
+# https://www.shellcheck.net/wiki/SC2120 -- disabled due to complaining about not referencing arguments that are optional on functions is_platformName
+# shellcheck disable=SC2120
 UNAME=$(uname)
 ARCH=$(uname -m)
 

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -44,3 +44,13 @@ is_windows() {
 is_unix() {
     ! is_windows "$@"
 }
+skip_on_windows() {
+    if is_windows; then
+        skip "This test is not applicable on Windows."
+    fi
+}
+skip_on_unix() {
+    if is_unix; then
+        skip "This test is not applicable on MacOS/Linux."
+    fi
+}

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -17,7 +17,7 @@ fi
 if is_linux; then
     PATH_APP_HOME="$HOME/.config/rancher-desktop"
     PATH_CONFIG="$HOME/.config/rancher-desktop"
-    PATH_CACHE="$HOME/.local/cache/rancher-desktop"
+    PATH_CACHE="$HOME/.cache/rancher-desktop"
     PATH_DATA="$HOME/.local/share/rancher-desktop"
     PATH_LOGS="$PATH_DATA/logs"
     PATH_EXTENSIONS="$PATH_DATA/extensions"

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -47,6 +47,8 @@ if is_windows; then
     PATH_DATA="$LOCALAPPDATA/rancher-desktop"
     PATH_CACHE="$PATH_DATA/cache"
     PATH_LOGS="$PATH_DATA/logs"
+    PATH_DISTRO="$PATH_DATA/distro"
+    PATH_DISTRO_DATA="$PATH_DATA/distro-data"
     PATH_EXTENSIONS="$PATH_DATA/extensions"
     if test -d "$PROGRAMFILES/Rancher Desktop"; then
         PATH_EXECUTABLE="$PROGRAMFILES/Rancher Desktop/Rancher Desktop.exe"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -1,8 +1,10 @@
 wait_for_shell() {
     if is_unix; then
         try --max 24 --delay 5 rdctl shell test -f /var/run/lima-boot-done
+        assert_success
         # wait until sshfs mounts are done
         try --max 12 --delay 5 rdctl shell test -d "$HOME/.rd"
+        assert_success
     fi
     rdctl shell sync
 }
@@ -65,6 +67,25 @@ start_kubernetes() {
         --kubernetes-version "$RD_KUBERNETES_PREV_VERSION"
 }
 
+start_application() {
+    start_kubernetes
+    wait_for_apiserver
+
+    # the docker context "rancher-desktop" may not have been written
+    # even though the apiserver is already running
+    if using_docker; then
+        wait_for_container_engine
+    fi
+
+    # BUG BUG BUG
+    # Looks like the rcfiles don't get updated via `rdctl start`
+    # BUG BUG BUG
+    if is_unix; then
+        rdctl set --application.path-management-strategy manual
+        rdctl set --application.path-management-strategy rcfiles
+    fi
+}
+
 container_engine_info() {
     run ctrctl info
     assert_success
@@ -85,10 +106,13 @@ buildkitd_is_running() {
 
 wait_for_container_engine() {
     try --max 12 --delay 10 container_engine_info
+    assert_success
     if using_docker; then
         try --max 30 --delay 5 docker_context_exists
+        assert_success
     else
         try --max 30 --delay 5 buildkitd_is_running
+        assert_success
     fi
 }
 


### PR DESCRIPTION
Added start_application function to vm.bash and PATHs to the WSL distros on windows.
Refactor was necessary to debug the test failures on Windows.