### PR TITLE
Add screenshots for extension pages

### DIFF
--- a/e2e/pages/extensions-page.ts
+++ b/e2e/pages/extensions-page.ts
@@ -4,10 +4,14 @@ export class ExtensionsPage {
   readonly page: Page;
   readonly cardEpinio: Locator;
   readonly buttonInstall: Locator;
+  readonly tabInstalled: Locator;
+  readonly tabCatalog: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.cardEpinio = page.locator('[data-test="extension-card-epinio"]');
     this.buttonInstall = page.locator('[data-test="button-install"]');
+    this.tabInstalled = page.locator('.tab >> text=Installed');
+    this.tabCatalog = page.locator('.tab >> text=Catalog');
   }
 }

--- a/e2e/pages/extensions-page.ts
+++ b/e2e/pages/extensions-page.ts
@@ -1,0 +1,13 @@
+import type { Page, Locator } from '@playwright/test';
+
+export class ExtensionsPage {
+  readonly page: Page;
+  readonly cardEpinio: Locator;
+  readonly buttonInstall: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.cardEpinio = page.locator('[data-test="extension-card-epinio"]');
+    this.buttonInstall = page.locator('[data-test="button-install"]');
+  }
+}

--- a/e2e/pages/extensions-page.ts
+++ b/e2e/pages/extensions-page.ts
@@ -6,6 +6,7 @@ export class ExtensionsPage {
   readonly buttonInstall: Locator;
   readonly tabInstalled: Locator;
   readonly tabCatalog: Locator;
+  readonly navEpinio: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -13,5 +14,6 @@ export class ExtensionsPage {
     this.buttonInstall = page.locator('[data-test="button-install"]');
     this.tabInstalled = page.locator('.tab >> text=Installed');
     this.tabCatalog = page.locator('.tab >> text=Catalog');
+    this.navEpinio = page.locator('[data-test="extension-nav-epinio"]');
   }
 }

--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -1,5 +1,6 @@
 
 import { DiagnosticsPage } from './diagnostics-page';
+import { ExtensionsPage } from './extensions-page';
 import { ImagesPage } from './images-page';
 import { K8sPage } from './k8s-page';
 import { PortForwardPage } from './portforward-page';
@@ -15,6 +16,7 @@ const pageConstructors = {
   Images:          (page: Page) => new ImagesPage(page),
   Troubleshooting: (page: Page) => new TroubleshootingPage(page),
   Diagnostics:     (page: Page) => new DiagnosticsPage(page),
+  Extensions:      (page: Page) => new ExtensionsPage(page),
 };
 
 export class NavPage {

--- a/pkg/rancher-desktop/components/MarketplaceCatalog.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCatalog.vue
@@ -41,8 +41,15 @@ export default Vue.extend({
       {{ t('marketplace.noResults') }}
     </div>
     <div class="extensions-content">
-      <div v-for="item in filteredExtensions" :key="item.slug" :v-if="filteredExtensions">
-        <MarketplaceCard :extension="item" />
+      <div
+        v-for="item in filteredExtensions"
+        :key="item.slug"
+        :v-if="filteredExtensions"
+      >
+        <MarketplaceCard
+          :extension="item"
+          :data-test="`extension-card-${item.name.toLowerCase()}`"
+        />
       </div>
     </div>
   </div>

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -18,6 +18,7 @@
       <template v-for="extension in extensions">
         <nuxt-link
           :key="extension.id"
+          :data-test="`extension-nav-${ extension.metadata.ui['dashboard-tab'].title.toLowerCase() }`"
           :to="extensionRoute(extension)"
         >
           <nav-item :id="`extension:${extension.id}`">

--- a/pkg/rancher-desktop/pages/Extensions.vue
+++ b/pkg/rancher-desktop/pages/Extensions.vue
@@ -4,12 +4,14 @@
       :active-tab="activeTab"
     >
       <tab
+        data-test="extensions-tab-installed"
         :label="t('marketplace.tabs.installed')"
         name="extensions-installed"
         :weight="0"
         @active="tabActivate('extensions-installed')"
       />
       <tab
+        data-test="extensions-tab-catalog"
         :label="t('marketplace.tabs.catalog')"
         name="marketplace-catalog"
         :weight="1"

--- a/pkg/rancher-desktop/pages/marketplace/details.vue
+++ b/pkg/rancher-desktop/pages/marketplace/details.vue
@@ -15,6 +15,7 @@
       </div>
       <div class="extension-content-sidebar">
         <button
+          data-test="button-install"
           :class="['btn', 'btn-xs', 'role-primary']"
           :disabled="loading"
           @click="appInstallation(installationAction)"

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -77,7 +77,17 @@ test.describe.serial('Main App Test', () => {
     const extensionsPage = await navPage.navigateTo('Extensions');
 
     await expect(extensionsPage.cardEpinio).toBeVisible();
-    await screenshot.take('Extensions', navPage);
+    await screenshot.take('Extensions');
+
+    await extensionsPage.tabInstalled.click();
+
+    await screenshot.take('Extensions-Installed');
+
+    await extensionsPage.tabCatalog.click();
+
+    await extensionsPage.cardEpinio.click();
+
+    await screenshot.take('Extensions-Details');
   });
 
   test('Preferences Page', async({ colorScheme }) => {

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -48,15 +48,22 @@ test.describe.serial('Main App Test', () => {
 
     await navPage.progressBecomesReady();
 
-    await tool('rdctl', 'extension', 'install', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
-    await tool('rdctl', 'extension', 'install', 'docker/logs-explorer-extension:0.2.2');
+    await page.waitForTimeout(2500);
+
+    // await tool('rdctl', 'extension', 'install', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
+    // await tool('rdctl', 'extension', 'install', 'docker/logs-explorer-extension:0.2.2');
 
     const navExtension = page.locator('[data-test="extension-nav-epinio"]');
 
-    await expect(navExtension).toBeVisible();
+    await expect(navExtension).toBeVisible({ timeout: 30000 });
   });
 
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(() => {
+    // await tool('rdctl', 'extension', 'uninstall', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
+    // await tool('rdctl', 'extension', 'uninstall', 'docker/logs-explorer-extension:0.2.2');
+
+    return teardown(electronApp, __filename);
+  });
 
   test('Main Page', async({ colorScheme }) => {
     const screenshot = new MainWindowScreenshots(page, { directory: `${ colorScheme }/main` });

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -5,7 +5,7 @@ import { test, expect, _electron } from '@playwright/test';
 
 import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
-import { createDefaultSettings, reportAsset, teardown } from '../e2e/utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown, tool } from '../e2e/utils/TestUtils';
 import { MainWindowScreenshots, PreferencesScreenshots } from './Screenshots';
 
 import type { ElectronApplication, BrowserContext, Page } from '@playwright/test';
@@ -47,15 +47,19 @@ test.describe.serial('Main App Test', () => {
     await page.emulateMedia({ colorScheme });
 
     await navPage.progressBecomesReady();
+
+    await tool('rdctl', 'extension', 'install', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
+    await tool('rdctl', 'extension', 'install', 'docker/logs-explorer-extension:0.2.2');
+
+    const navExtension = page.locator('[data-test="extension-nav-epinio"]');
+
+    await expect(navExtension).toBeVisible();
   });
 
   test.afterAll(() => teardown(electronApp, __filename));
 
   test('Main Page', async({ colorScheme }) => {
     const screenshot = new MainWindowScreenshots(page, { directory: `${ colorScheme }/main` });
-    const navExtension = page.locator('[data-test="extension-nav-epinio"]');
-
-    await expect(navExtension).toBeVisible();
 
     await screenshot.take('General');
     await screenshot.take('PortForwarding', navPage);

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -53,6 +53,9 @@ test.describe.serial('Main App Test', () => {
 
   test('Main Page', async({ colorScheme }) => {
     const screenshot = new MainWindowScreenshots(page, { directory: `${ colorScheme }/main` });
+    const navExtension = page.locator('[data-test="extension-nav-epinio"]');
+
+    await expect(navExtension).toBeVisible();
 
     await screenshot.take('General');
     await screenshot.take('PortForwarding', navPage);
@@ -86,6 +89,9 @@ test.describe.serial('Main App Test', () => {
     await extensionsPage.tabCatalog.click();
 
     await extensionsPage.cardEpinio.click();
+
+    // wait for details to render
+    await page.waitForTimeout(1000);
 
     await screenshot.take('Extensions-Details');
   });

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -73,6 +73,11 @@ test.describe.serial('Main App Test', () => {
     await page.waitForTimeout(1000);
 
     await screenshot.take('Diagnostics');
+
+    const extensionsPage = await navPage.navigateTo('Extensions');
+
+    await expect(extensionsPage.cardEpinio).toBeVisible();
+    await screenshot.take('Extensions', navPage);
   });
 
   test('Preferences Page', async({ colorScheme }) => {

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -5,7 +5,7 @@ import { test, expect, _electron } from '@playwright/test';
 
 import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
-import { createDefaultSettings, reportAsset, teardown, tool } from '../e2e/utils/TestUtils';
+import { createDefaultSettings, reportAsset, teardown } from '../e2e/utils/TestUtils';
 import { MainWindowScreenshots, PreferencesScreenshots } from './Screenshots';
 
 import type { ElectronApplication, BrowserContext, Page } from '@playwright/test';
@@ -50,18 +50,12 @@ test.describe.serial('Main App Test', () => {
 
     await page.waitForTimeout(2500);
 
-    // await tool('rdctl', 'extension', 'install', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
-    // await tool('rdctl', 'extension', 'install', 'docker/logs-explorer-extension:0.2.2');
-
     const navExtension = page.locator('[data-test="extension-nav-epinio"]');
 
     await expect(navExtension).toBeVisible({ timeout: 30000 });
   });
 
   test.afterAll(() => {
-    // await tool('rdctl', 'extension', 'uninstall', 'ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.12');
-    // await tool('rdctl', 'extension', 'uninstall', 'docker/logs-explorer-extension:0.2.2');
-
     return teardown(electronApp, __filename);
   });
 


### PR DESCRIPTION
This updates the screenshots script so that it includes recent additions to extensions. 

## 🗒️ Note

* You will need to have extensions preinstalled before running the script. I attempted to add the commands to install epinio and logs explorer, but this is incompatible with our default settings that include Allowed Images.
* Created issue #4495 to track work for automating install/uninstall of extensions

closes #4418 