### PR TITLE
Revert "Remove Epinio from list of extensions on arm"

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -487,10 +487,6 @@ ipcMainProxy.on('dashboard-open', () => {
   openDashboard();
 });
 
-ipcMainProxy.on('arch/checkArm', () => {
-  window.send('ok:arch/checkArm', Electron.app.runningUnderARM64Translation || process.arch.startsWith('arm'));
-});
-
 ipcMainProxy.on('dashboard-close', () => {
   closeDashboard();
 });

--- a/pkg/rancher-desktop/components/MarketplaceCatalog.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCatalog.vue
@@ -10,12 +10,6 @@ type FilteredExtensions = typeof demoMarketplace.summaries;
 export default Vue.extend({
   name:       'marketplace-catalog',
   components: { MarketplaceCard },
-  props:      {
-    isArm: {
-      type:    Boolean,
-      default: false,
-    },
-  },
   data() {
     return {
       searchValue: '',
@@ -24,7 +18,7 @@ export default Vue.extend({
   },
   computed: {
     filteredExtensions(): FilteredExtensions {
-      let tempExtensions = this.extensionsByArch;
+      let tempExtensions = this.extensions;
 
       if (this.searchValue) {
         tempExtensions = tempExtensions.filter((item) => {
@@ -35,15 +29,6 @@ export default Vue.extend({
       }
 
       return tempExtensions;
-    },
-    extensionsByArch(): FilteredExtensions {
-      if (!this.isArm) {
-        return this.extensions;
-      }
-
-      return this.extensions.filter((extension) => {
-        return extension.name !== 'Epinio';
-      });
     },
   },
 });

--- a/pkg/rancher-desktop/pages/Extensions.vue
+++ b/pkg/rancher-desktop/pages/Extensions.vue
@@ -18,7 +18,6 @@
       <div class="marketplace-container">
         <component
           :is="activeTab"
-          :is-arm="isArm"
           @click:browse="tabActivate('marketplace-catalog')"
         />
       </div>
@@ -34,7 +33,6 @@ import Tab from '@pkg/components/Tabbed/Tab.vue';
 import { defaultSettings } from '@pkg/config/settings';
 import { withCredentials } from '@pkg/hocs/withCredentials';
 import ExtensionsInstalled from '@pkg/pages/extensions/installed.vue';
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 const ExtensionsInstalledWithCredentials = withCredentials(ExtensionsInstalled);
 
@@ -52,15 +50,7 @@ export default {
       imageNamespaces:    [],
       supportsNamespaces: true,
       activeTab:          'marketplace-catalog',
-      isArm:              false,
     };
-  },
-  beforeMount() {
-    ipcRenderer.on('ok:arch/checkArm', (_event, isArm) => {
-      this.isArm = isArm;
-    });
-
-    ipcRenderer.send('arch/checkArm');
   },
   mounted() {
     this.$store.dispatch('page/setHeader', {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -89,8 +89,6 @@ export interface IpcMainEvents {
   'extensions/ui/toast': (level: 'success' | 'warning' | 'error', message: string) => void;
   'ok:extensions/getContentArea': (payload: { x: number, y: number }) => void;
   // #endregion
-
-  'arch/checkArm': () => void;
 }
 
 /**
@@ -174,5 +172,4 @@ export interface IpcRendererEvents {
   'extensions/spawn/error': (id: string, error: Error | NodeJS.Signals) => void;
   'extensions/spawn/output': (id: string, data: { stdout: string } | { stderr: string }) => void;
   // #endregion
-  'ok:arch/checkArm': (isArm: boolean) => void;
 }


### PR DESCRIPTION
Even though `paketobuildpacks/builder:full` is only available for amd64, it still seems to work on M1 machines.

This reverts commit fb33d6000904cc301440dfb0ba0bab36a792f436.