### PR TITLE
Remove all port proxies upon shutdown

### DIFF
--- a/src/go/privileged-service/go.mod
+++ b/src/go/privileged-service/go.mod
@@ -3,17 +3,16 @@ module github.com/rancher-sandbox/rancher-desktop/src/go/privileged-service
 go 1.18
 
 require (
+	github.com/Microsoft/go-winio v0.5.2
+	github.com/docker/go-connections v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher-sandbox/rancher-desktop-agent v0.2.1-0.20220914185110-0a48c21fc77b
 	github.com/spf13/cobra v1.5.0
 	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6
 )
 
-require github.com/stretchr/testify v1.7.0 // indirect
-
 require (
-	github.com/Microsoft/go-winio v0.5.2
-	github.com/docker/go-connections v0.4.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/src/go/privileged-service/go.mod
+++ b/src/go/privileged-service/go.mod
@@ -13,7 +13,7 @@ require github.com/stretchr/testify v1.7.0 // indirect
 
 require (
 	github.com/Microsoft/go-winio v0.5.2
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/src/go/privileged-service/pkg/port/portproxy.go
+++ b/src/go/privileged-service/pkg/port/portproxy.go
@@ -51,20 +51,20 @@ func (p *proxy) exec(portMapping types.PortMapping) error {
 		connectAddrs: portMapping.ConnectAddrs,
 	}
 	if portMapping.Remove {
-		return p.deleteProxy(portProxy)
+		return p.delete(portProxy)
 	}
-	return p.addProxy(portProxy)
+	return p.add(portProxy)
 }
 
 func (p *proxy) removeAll() {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	for _, proxy := range p.portMappings {
-		_ = p.deleteProxy(proxy)
+		_ = p.delete(proxy)
 	}
 }
 
-func (p *proxy) addProxy(portProxy portProxy) error {
+func (p *proxy) add(portProxy portProxy) error {
 	for _, v := range portProxy.ports {
 		for _, addr := range v {
 			wslIP, err := getConnectAddr(addr.HostIP, portProxy.connectAddrs)
@@ -87,7 +87,7 @@ func (p *proxy) addProxy(portProxy portProxy) error {
 	return nil
 }
 
-func (p *proxy) deleteProxy(portProxy portProxy) error {
+func (p *proxy) delete(portProxy portProxy) error {
 	for _, v := range portProxy.ports {
 		for _, addr := range v {
 			args, err := portProxyDeleteArgs(addr.HostPort, addr.HostIP)

--- a/src/go/privileged-service/pkg/port/portproxy.go
+++ b/src/go/privileged-service/pkg/port/portproxy.go
@@ -186,7 +186,6 @@ func portProxyAddArgs(listenPort, listenAddr, connectAddr string) ([]string, err
 }
 
 func getHash(portProxy portProxy) string {
-	h := md5.New()
-	s := fmt.Sprintf("%v", portProxy)
-	return fmt.Sprintf("%x", h.Sum([]byte(s)))
+	data := fmt.Sprintf("%v", portProxy)
+	return fmt.Sprintf("%x", md5.Sum([]byte(data)))
 }

--- a/src/go/privileged-service/pkg/port/portproxy_test.go
+++ b/src/go/privileged-service/pkg/port/portproxy_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package port
+
+import (
+	"testing"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
+)
+
+func TestGetHash(t *testing.T) {
+	wslConnectAddrs := []types.ConnectAddrs{{Network: "tcp", Addr: "192.168.0.1"}}
+	ports1 := portProxy{
+		PortMap: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "192.168.0.10",
+					HostPort: "443",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+
+	ports2 := portProxy{
+		PortMap: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "192.168.0.10",
+					HostPort: "443",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+
+	ports3 := portProxy{
+		PortMap: nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "80",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+
+	ports4 := portProxy{
+		PortMap: nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+
+	ports5 := portProxy{
+		PortMap: nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+			},
+		},
+		ConnectAddrs: []types.ConnectAddrs{
+			{Network: "tcp", Addr: "192.168.0.1"},
+			{Network: "tcp", Addr: "192.168.0.2"},
+			{Network: "tcp", Addr: "192.168.0.3"},
+		},
+	}
+
+	ports6 := portProxy{
+		PortMap: nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+			},
+		},
+		ConnectAddrs: []types.ConnectAddrs{
+			{Network: "tcp", Addr: "192.168.0.2"},
+			{Network: "tcp", Addr: "192.168.0.1"},
+			{Network: "tcp", Addr: "192.168.0.3"},
+		},
+	}
+
+	ports7 := portProxy{
+		PortMap: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "192.168.0.10",
+					HostPort: "443",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+
+	ports8 := portProxy{
+		PortMap: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "192.168.0.11",
+					HostPort: "443",
+				},
+			},
+		},
+		ConnectAddrs: wslConnectAddrs,
+	}
+	ports9 := portProxy{
+		PortMap: nat.PortMap{
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "80",
+				},
+			},
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "443",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "443",
+				},
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "443",
+				},
+			},
+		},
+		ConnectAddrs: []types.ConnectAddrs{
+			{Network: "tcp", Addr: "192.168.0.2"},
+			{Network: "tcp", Addr: "192.168.0.1"},
+			{Network: "tcp", Addr: "192.168.0.3"},
+		},
+	}
+	ports10 := portProxy{
+		PortMap: nat.PortMap{
+			"443/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "443",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "443",
+				},
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "443",
+				},
+			},
+			"80/tcp": []nat.PortBinding{
+				{
+					HostIP:   "127.0.0.2",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: "80",
+				},
+				{
+					HostIP:   "127.0.0.3",
+					HostPort: "80",
+				},
+			},
+		},
+		ConnectAddrs: []types.ConnectAddrs{
+			{Network: "tcp", Addr: "192.168.0.1"},
+			{Network: "tcp", Addr: "192.168.0.2"},
+			{Network: "tcp", Addr: "192.168.0.3"},
+		},
+	}
+
+	ports11 := portProxy{
+		PortMap:      nil,
+		ConnectAddrs: nil,
+	}
+
+	ports12 := portProxy{
+		PortMap:      nil,
+		ConnectAddrs: nil,
+	}
+
+	ports13 := portProxy{
+		PortMap:      make(nat.PortMap),
+		ConnectAddrs: []types.ConnectAddrs{},
+	}
+
+	ports14 := portProxy{
+		PortMap:      make(nat.PortMap),
+		ConnectAddrs: []types.ConnectAddrs{},
+	}
+
+	tests := []struct {
+		description string
+		actual      portProxy
+		expect      portProxy
+		shouldMatch bool
+		expectedErr error
+	}{
+		{
+			description: "simple obejcts",
+			actual:      ports1,
+			expect:      ports2,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+		{
+			description: "When port maps are not in the same order",
+			actual:      ports3,
+			expect:      ports4,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+		{
+			description: "When connect Addrs are not in the same order",
+			actual:      ports5,
+			expect:      ports6,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+		{
+			description: "When port maps are not the same",
+			actual:      ports7,
+			expect:      ports8,
+			shouldMatch: false,
+			expectedErr: nil,
+		},
+		{
+			description: "When port maps keys are not in the same order",
+			actual:      ports9,
+			expect:      ports10,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+		{
+			description: "When both port maps and connect Addrs are nil",
+			actual:      ports11,
+			expect:      ports12,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+		{
+			description: "When both port maps and connect Addrs are empty",
+			actual:      ports13,
+			expect:      ports14,
+			shouldMatch: true,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			actualHash, err := getHash(tt.actual)
+			if err != tt.expectedErr {
+				t.Fatalf("did not expect an error, but got: %s", err)
+			}
+			expectedHash, err := getHash(tt.expect)
+			if err != tt.expectedErr {
+				t.Fatalf("did not expect an error, but got: %s", err)
+			}
+			result := actualHash == expectedHash
+			if result != tt.shouldMatch {
+				t.Fatalf("%s: expected to match: %s", actualHash, expectedHash)
+			}
+		})
+	}
+}

--- a/src/go/privileged-service/pkg/port/server.go
+++ b/src/go/privileged-service/pkg/port/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -104,7 +104,9 @@ func (s *Server) handleEvent(conn net.Conn) {
 
 // Stop shuts down the server gracefully
 func (s *Server) Stop() {
-	s.proxy.removeAll()
+	if err := s.proxy.removeAll(); err != nil {
+		s.eventLogger.Warning(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), err.Error())
+	}
 	close(s.quit)
 	s.listener.Close()
 	s.stopped = true


### PR DESCRIPTION
Currently, privileged services leave behind all the port proxies that it creates, this change allows to clean up during shutdown. Privileged service manages this by keeping track of all the added/deleted port proxies in a map using the hash of the port mapping struct as a map key, this is so that we can avoid the recursive lookups. 

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3567