### PR TITLE
Bats automate test 64, 65, 67: Image-allow lists

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -1,0 +1,86 @@
+setup() {
+    load '../helpers/load'
+    RD_USE_IMAGE_ALLOW_LIST=true
+}
+
+teardown_file() {
+    load '../helpers/load'
+    run rdctl shutdown
+    assert_nothing
+}
+
+@test 'start' {
+    factory_reset
+    start_kubernetes
+    wait_for_apiserver
+}
+
+@test 'update the list of patterns first time' {
+    update_allowed_patterns true '"nginx", "busybox", "python"'
+}
+
+@test 'verify pull nginx succeeds' {
+    ctrctl pull --quiet nginx
+}
+
+@test 'verify pull busybox succeeds' {
+    ctrctl pull --quiet busybox
+}
+
+@test 'verify pull python succeeds' {
+    ctrctl pull --quiet python
+}
+
+@test 'verify pull ruby fails' {
+    run ctrctl pull ruby
+    assert_failure
+}
+
+@test 'drop python from the allowed-image list, add ruby' {
+    update_allowed_patterns true '"nginx", "busybox", "ruby"'
+}
+
+@test 'clear images' {
+    for image in nginx busybox python; do
+        ctrctl rmi "$image"
+    done
+}
+
+@test 'verify pull python fails' {
+    run ctrctl pull --quiet python
+    assert_failure
+}
+
+@test 'verify pull ruby succeeds' {
+    ctrctl pull --quiet ruby
+}
+
+@test 'clear all patterns' {
+    update_allowed_patterns true ''
+}
+
+@test 'can run kubectl' {
+    wait_for_apiserver
+    kubectl run nginx --image=nginx:latest --port=8080
+}
+
+verify_no_nginx() {
+    run kubectl get pods
+    assert_success
+    assert_output --partial "ImagePullBackOff"
+}
+
+@test 'but fails to stand up a pod for forbidden image' {
+    try --max 18 --delay 10 verify_no_nginx
+    assert_success
+}
+
+@test 'set patterns with the allowed list disabled' {
+    update_allowed_patterns false '"nginx", "busybox", "ruby"'
+    # containerEngine.allowedImages.enabled changed, so wait for a restart
+    wait_for_apiserver "$RD_KUBERNETES_PREV_VERSION"
+}
+
+@test 'verify pull python succeeds because allowedImages filter is disabled' {
+    ctrctl pull --quiet python
+}

--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -13,6 +13,7 @@ teardown_file() {
     factory_reset
     start_kubernetes
     wait_for_apiserver
+    wait_for_container_engine
 }
 
 @test 'update the list of patterns first time' {

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -58,3 +58,20 @@ try() {
         count=$((count + 1))
     done
 }
+
+update_allowed_patterns() {
+    local enabled=$1
+    local patterns=$2
+    cat <<EOF |
+{
+  "version": 6,
+  "containerEngine": {
+    "allowedImages": {
+      "enabled": $enabled,
+      "patterns": [$patterns]
+    }
+  }
+}
+EOF
+    rdctl api settings -X PUT --input -
+}

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -62,9 +62,9 @@ try() {
 update_allowed_patterns() {
     local enabled=$1
     local patterns=$2
-    cat <<EOF |
+    rdctl api settings -X PUT --input - <<EOF
 {
-  "version": 6,
+  "version": 7,
   "containerEngine": {
     "allowedImages": {
       "enabled": $enabled,
@@ -73,5 +73,4 @@ update_allowed_patterns() {
   }
 }
 EOF
-        rdctl api settings -X PUT --input -
 }

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -73,5 +73,5 @@ update_allowed_patterns() {
   }
 }
 EOF
-    rdctl api settings -X PUT --input -
+        rdctl api settings -X PUT --input -
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -43,7 +43,7 @@ start_container_engine() {
     mkdir -p "$PATH_CONFIG"
     cat <<EOF >"$PATH_CONFIG_FILE"
 {
-  "version": 6,
+  "version": 7,
   "WSL": { "integrations": $wsl_integrations },
   "containerEngine": {
     "allowedImages": {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -62,7 +62,8 @@ EOF
 start_kubernetes() {
     start_container_engine \
         --kubernetes-enabled \
-        --kubernetes-version "$RD_KUBERNETES_PREV_VERSION"
+        --kubernetes-version "$RD_KUBERNETES_PREV_VERSION" \
+        "$@"
 }
 
 container_engine_info() {

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -94,17 +94,7 @@ skip_for_insecure_registry() {
 
     if using_image_allow_list; then
         wait_for_shell
-        rdctl api -X PUT --input - settings <<EOF
-{
-  "version": 6,
-  "containerEngine": {
-    "allowedImages": {
-      "enabled": true,
-      "patterns": ["$REGISTRY", "docker.io/registry"]
-    }
-  }
-}
-EOF
+        update_allowed_patterns true "$(printf '"%s" "docker.io/registry"' "$REGISTRY")"
     fi
 }
 


### PR DESCRIPTION
Automate the non-UI parts of testing image-allow-lists from tests 64 and 65 

Note that I found a bug in the settings validator, so the package will need to be rebuilt on macOS and Linux before running bats.