### PR TITLE
RDX: Split extension tag from ID

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -861,7 +861,7 @@ async function getExtensionManager() {
 
 async function listExtensionsMetadata() {
   const extensionManager = await getExtensionManager();
-  const extensions = await extensionManager?.getInstalledExtensions();
+  const extensions = await extensionManager?.getInstalledExtensions() ?? [];
 
   window.send('extensions/list', extensions);
 }
@@ -1088,23 +1088,23 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     })());
   }
 
-  listExtensions(): Promise<Record<string, true>> {
-    const entries = Object.entries(cfg.extensions).filter(([k, v]) => v) as [string, true][];
+  listExtensions(): Promise<Record<string, string>> {
+    const entries = Object.entries(cfg.extensions).filter(([k, v]) => v);
 
     return Promise.resolve(Object.fromEntries(entries));
   }
 
-  async installExtension(id: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {
+  async installExtension(image: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {
     const em = await getExtensionManager();
-    const extension = em?.getExtension(id);
+    const extension = await em?.getExtension(image);
 
     if (!extension) {
-      console.debug(`Failed to install extension ${ id }: could not get extension.`);
+      console.debug(`Failed to install extension ${ image }: could not get extension.`);
 
       return { status: 503 };
     }
     if (state === 'install') {
-      console.debug(`Installing extension ${ id }...`);
+      console.debug(`Installing extension ${ image }...`);
       try {
         if (await extension.install()) {
           return { status: 201 };
@@ -1115,9 +1115,9 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
         if (isExtensionError(ex)) {
           switch (ex.code) {
           case ExtensionErrorCode.INVALID_METADATA:
-            return { status: 422, data: `The image ${ id } has invalid extension metadata` };
+            return { status: 422, data: `The image ${ image } has invalid extension metadata` };
           case ExtensionErrorCode.FILE_NOT_FOUND:
-            return { status: 422, data: `The image ${ id } failed to install: ${ ex.message }` };
+            return { status: 422, data: `The image ${ image } failed to install: ${ ex.message }` };
           }
         }
         throw ex;
@@ -1125,7 +1125,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
         listExtensionsMetadata();
       }
     } else {
-      console.debug(`Uninstalling extension ${ id }...`);
+      console.debug(`Uninstalling extension ${ image }...`);
       try {
         if (await extension.uninstall()) {
           return { status: 201 };
@@ -1136,7 +1136,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
         if (isExtensionError(ex)) {
           switch (ex.code) {
           case ExtensionErrorCode.INVALID_METADATA:
-            return { status: 422, data: `The image ${ id } has invalid extension metadata` };
+            return { status: 422, data: `The image ${ image } has invalid extension metadata` };
           }
         }
         throw ex;

--- a/background.ts
+++ b/background.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import util from 'util';
 
 import Electron from 'electron';
-import _ from 'lodash';
 
 import BackendHelper from '@pkg/backend/backendHelper';
 import K8sFactory from '@pkg/backend/factory';
@@ -503,30 +502,7 @@ ipcMainProxy.on('preferences-set-dirty', (_event, dirtyFlag) => {
 });
 
 function writeSettings(arg: RecursivePartial<RecursiveReadonly<settings.Settings>>) {
-  const customizer = (objValue: any, srcValue: any) => {
-    if (Array.isArray(objValue)) {
-      // If the destination is a array of primitives, just return the source
-      // (i.e. completely overwrite).
-      if (objValue.every(i => typeof i !== 'object')) {
-        return srcValue;
-      }
-    }
-    if (typeof srcValue === 'object' && srcValue) {
-      // For objects, setting a value to `undefined` will remove it.
-      for (const [key, value] of Object.entries(srcValue)) {
-        if (typeof value === 'undefined') {
-          delete srcValue[key];
-          if (typeof objValue === 'object' && objValue) {
-            delete objValue[key];
-          }
-        }
-      }
-      // Don't return anything, let _.mergeWith() do the actual merging.
-    }
-  };
-
-  _.mergeWith(cfg, arg, customizer);
-  settings.save(cfg);
+  settings.save(settings.merge(cfg, arg));
   mainEvents.emit('settings-update', cfg);
 }
 

--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -295,26 +295,27 @@ test.describe.serial('Extensions', () => {
       test('ddClient.docker.listContainers', async() => {
         const script = 'ddClient.docker.listContainers({size: true})';
         const result = await evalInView(script);
+        const container = result.find((r: { Image: string; }) => r.Image.startsWith('rd/extension/everything'));
 
-        expect(result).toEqual(expect.arrayContaining([
-          expect.objectContaining({
-            Id:              expect.any(String),
-            Names:           expect.arrayContaining([expect.any(String)]),
-            Image:           'rd/extension/everything',
-            ImageID:         expect.any(String),
-            Command:         expect.any(String),
-            Created:         expect.any(Number),
-            Ports:           expect.anything(),
-            SizeRw:          expect.any(Number),
-            SizeRootFs:      expect.any(Number),
-            Labels:          expect.any(Object),
-            State:           expect.any(String),
-            Status:          expect.any(String),
-            HostConfig:      expect.any(Object),
-            NetworkSettings: expect.any(Object),
-            Mounts:          expect.any(Array),
-          }),
-        ]));
+        // The playwright copy of expect() produces terrible error messages when
+        // things don't match, making it difficult to find what was wrong.
+        // Match properties individually to make things easier to spot.
+        expect(container).toBeTruthy();
+        expect(container).toHaveProperty('Id', expect.any(String));
+        expect(container).toHaveProperty('Names', expect.arrayContaining([expect.any(String)]));
+        expect(container).toHaveProperty('Image', expect.stringContaining('rd/extension/everything'));
+        expect(container).toHaveProperty('ImageID', expect.any(String));
+        expect(container).toHaveProperty('Command', expect.any(String));
+        expect(container).toHaveProperty('Created', expect.any(Number));
+        expect(container).toHaveProperty('Ports', expect.anything());
+        expect(container).toHaveProperty('SizeRw', expect.any(Number));
+        expect(container).toHaveProperty('SizeRootFs', expect.any(Number));
+        expect(container).toHaveProperty('Labels', expect.any(Object));
+        expect(container).toHaveProperty('State', expect.any(String));
+        expect(container).toHaveProperty('Status', expect.any(String));
+        expect(container).toHaveProperty('HostConfig', expect.any(Object));
+        expect(container).toHaveProperty('NetworkSettings', expect.any(Object));
+        expect(container).toHaveProperty('Mounts', expect.any(Array));
       });
     });
 

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -49,7 +49,8 @@ async function createDarwinUserProfile(userProfile: RecursivePartial<Settings>|n
   const userLocksPath = path.join(paths.deploymentProfileUser, 'io.rancherdesktop.profile.locked.plist');
 
   if (userProfile && Object.keys(userProfile).length > 0) {
-    await fs.promises.writeFile(userProfilePath, plist.build(userProfile));
+    // plist.build() seems to have issues with RecursivePartial<Record<string, string>>, hence cast.
+    await fs.promises.writeFile(userProfilePath, plist.build(userProfile as any));
   } else {
     await fs.promises.rm(userProfilePath, { force: true });
   }

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -131,7 +131,7 @@ paths:
               schema:
                 type: object
                 additionalProperties:
-                  type: boolean
+                  type: string
 
   /v1/extensions/install:
     post:
@@ -521,7 +521,8 @@ components:
         extensions:
           type: object
           x-rd-usage: control which extensions are installed
-          additionalProperties: true
+          additionalProperties:
+            type: string
 
     diagnostics:
       type: object

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -24,6 +24,53 @@ enum ProfileTypes {
 }
 
 describe('settings', () => {
+  describe('merge', () => {
+    test('merges plain objects', () => {
+      const input = {
+        a: 1,
+        b: {
+          c: 2, d: 3, e: { f: 4 },
+        },
+      };
+      const changes = { a: 10, b: { c: 20, e: { } } };
+      const result = settings.merge(input, changes);
+
+      expect(result).toEqual({
+        a: 10,
+        b: {
+          c: 20, d: 3, e: { f: 4 },
+        },
+      },
+      );
+    });
+    test('replaces arrays of primitives', () => {
+      const input = {
+        a: [1, 2, 3, 4, 5], b: 3, c: 5,
+      };
+      const changes = { a: [1, 3, 5, 7], b: 4 };
+      const result = settings.merge(input, changes);
+
+      expect(result).toEqual({
+        a: [1, 3, 5, 7], b: 4, c: 5,
+      });
+    });
+    test('removes values set to undefined', () => {
+      const input = { a: 1, b: { c: 3, d: 4 } };
+      const changes = { b: { c: undefined } };
+      const result = settings.merge(input, changes);
+
+      expect(result).toEqual({ a: 1, b: { d: 4 } });
+    });
+    test('returns merged settings', () => {
+      const input = { a: 1 };
+      const changes = { a: 2 };
+      const result = settings.merge(input, changes);
+
+      expect(result).toBe(input);
+      expect(input).toEqual({ a: 2 });
+    });
+  });
+
   const jsonProfile = JSON.stringify({
     ignoreThis:      { soups: ['gazpacho', 'turtle'] },
     containerEngine: {

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -640,8 +640,8 @@ export interface CommandWorkerInterface {
   updateTransientSettings: (context: commandContext, newTransientSettings: RecursivePartial<TransientSettings>) => Promise<[string, string]>;
 
   // #region extensions
-  /** List the installed extensions */
-  listExtensions(): Promise<Record<string, true>>;
+  /** List the installed extensions with their versions */
+  listExtensions(): Promise<Record<string, string>>;
   /**
    * Install or uninstall the given extension, returning an appropriate HTTP status code.
    * @param state Whether to install or uninstall the extension.

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -499,6 +499,11 @@ export default class SettingsValidator {
     errors: string[],
     fqname: string,
   ): boolean {
+    if (_.isEqual(desiredValue, currentValue)) {
+      // Accept no-op changes
+      return false;
+    }
+
     if (typeof desiredValue !== 'object' || !desiredValue) {
       errors.push(`${ fqname }: "${ desiredValue }" is not a valid mapping`);
 
@@ -546,23 +551,19 @@ export default class SettingsValidator {
       [\w][\w.-]{0,127}
       $
       `;
-    let hasErrors = false;
 
     for (const [name, tag] of Object.entries(desiredValue)) {
       if (!nameRE.test(name)) {
-        errors.push(`${ name } is an invalid name`);
-        hasErrors = true;
+        errors.push(`${ fqname }: "${ name }" is an invalid name`);
       }
       if (typeof tag !== 'string') {
-        errors.push(`${ name } has non-string tag ${ tag }`);
-        hasErrors = true;
+        errors.push(`${ fqname }: "${ name }" has non-string tag "${ tag }"`);
       } else if (!tagRE.test(tag)) {
-        errors.push(`${ name } has invalid tag ${ tag }`);
-        hasErrors = true;
+        errors.push(`${ fqname }: "${ name }" has invalid tag "${ tag }"`);
       }
     }
 
-    return hasErrors;
+    return !_.isEqual(desiredValue, currentValue);
   }
 
   protected checkPreferencesNavItemCurrent(

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -510,11 +510,14 @@ export default class SettingsValidator {
       return false;
     }
 
-    // makeRE is a tagged template for making regular expressions with /x (i.e.
-    // ignoring any whitespace within the regular expression itself).
-    function makeRE(strings: {raw: readonly string[]}, ...subsitutions: any[]) {
-      const subsitutionSources = subsitutions.map(s => s instanceof RegExp ? s.source : s);
-      const raw = String.raw(strings, ...subsitutionSources);
+    /**
+     * makeRE is a tagged template for making regular expressions with /x (i.e.
+     * ignoring any whitespace within the regular expression itself).
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
+     */
+    function makeRE(strings: TemplateStringsArray, ...substitutions: any[]) {
+      const substitutionSources = substitutions.map(s => s instanceof RegExp ? s.source : s);
+      const raw = String.raw(strings, ...substitutionSources);
       const lines = raw.split(/\r?\n/);
       // Drop comments at end of line
       const uncommentedLines = lines.map(line => line.replace(/\s#.*$/, ''));

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -56,6 +56,58 @@ type SettingsValidationMap = SettingsValidationMapEntry<Settings, Settings>;
 
 type TransientSettingsValidationMap = SettingsValidationMapEntry<TransientSettings, TransientSettings>;
 
+/**
+ * ImageNameRegExp is a regular expression that matches a docker image name
+ * (including optional registry and one or more name components).
+ */
+const ImageNameRegExp = (function() {
+  /**
+   * makeRE is a tagged template for making regular expressions with /x (i.e.
+   * ignoring any whitespace within the regular expression itself).
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
+   */
+  function makeRE(strings: TemplateStringsArray, ...substitutions: any[]) {
+    const substitutionSources = substitutions.map(s => s instanceof RegExp ? s.source : s);
+    const raw = String.raw(strings, ...substitutionSources);
+    const lines = raw.split(/\r?\n/);
+    // Drop comments at end of line
+    const uncommentedLines = lines.map(line => line.replace(/\s#.*$/, ''));
+
+    return new RegExp(uncommentedLines.join('').replace(/\s+/g, ''));
+  }
+  const domainComponent = makeRE`
+    # a domain component is alpha-numeric-or-dash, but the start and end
+    # characters may not be a dash.
+    [a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
+    `;
+  const domain = makeRE`
+    # a domain is one or more domain components joined by dot, and optionally
+    # with a colon followed by a port number.
+    ${ domainComponent }(?:\.${ domainComponent })*
+    (?::[0-9]+)?
+    `;
+  const nameComponent = makeRE`
+    # a name component is lower-alpha-numeric things, separated by any one of
+    # a set of separators.
+    [a-z0-9]+(?:(?:\.|_|__|-*)[a-z0-9]+)*
+    `;
+  const nameRE = makeRE`
+    ^
+    (?:${ domain }/)?
+    ${ nameComponent }
+    (?:/${ nameComponent })*
+    $
+    `;
+
+  return nameRE;
+})();
+
+/**
+ * ImageTagRegExp is a regular expression that matches a docker image tag (that
+ * is, only the bit after the colon).
+ */
+const ImageTagRegExp = /^[\w][\w.-]{0,127}$/;
+
 export default class SettingsValidator {
   k8sVersions: Array<string> = [];
   allowedSettings: SettingsValidationMap | null = null;
@@ -510,58 +562,13 @@ export default class SettingsValidator {
       return false;
     }
 
-    /**
-     * makeRE is a tagged template for making regular expressions with /x (i.e.
-     * ignoring any whitespace within the regular expression itself).
-     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
-     */
-    function makeRE(strings: TemplateStringsArray, ...substitutions: any[]) {
-      const substitutionSources = substitutions.map(s => s instanceof RegExp ? s.source : s);
-      const raw = String.raw(strings, ...substitutionSources);
-      const lines = raw.split(/\r?\n/);
-      // Drop comments at end of line
-      const uncommentedLines = lines.map(line => line.replace(/\s#.*$/, ''));
-
-      return new RegExp(uncommentedLines.join('').replace(/\s+/g, ''));
-    }
-
-    // The key should be a name, and the value a tag.
-    const domainComponent = makeRE`
-      # a domain component is alpha-numeric-or-dash, but the start and end
-      # characters may not be a dash.
-      [a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
-      `;
-    const domain = makeRE`
-      # a domain is one or more domain components joined by dot, and optionally
-      # with a colon followed by a port number.
-      ${ domainComponent }(?:\.${ domainComponent })*
-      (?::[0-9]+)?
-      `;
-    const nameComponent = makeRE`
-      # a name component is lower-alpha-numeric things, separated by any one of
-      # a set of separators.
-      [a-z0-9]+(?:(?:\.|_|__|-*)[a-z0-9]+)*
-      `;
-    const nameRE = makeRE`
-      ^
-      (?:${ domain }/)?
-      ${ nameComponent }
-      (?:/${ nameComponent })*
-      $
-      `;
-    const tagRE = makeRE`
-      ^
-      [\w][\w.-]{0,127}
-      $
-      `;
-
     for (const [name, tag] of Object.entries(desiredValue)) {
-      if (!nameRE.test(name)) {
+      if (!ImageNameRegExp.test(name)) {
         errors.push(`${ fqname }: "${ name }" is an invalid name`);
       }
       if (typeof tag !== 'string') {
         errors.push(`${ fqname }: "${ name }" has non-string tag "${ tag }"`);
-      } else if (!tagRE.test(tag)) {
+      } else if (!ImageTagRegExp.test(tag)) {
         errors.push(`${ fqname }: "${ name }" has invalid tag "${ tag }"`);
       }
     }

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -339,17 +339,15 @@ export class ExtensionImpl implements Extension {
     );
   }
 
-  get isInstalled(): Promise<boolean> {
-    return (async() => {
-      try {
-        const filePath = path.join(this.dir, this.VERSION_FILE);
-        const installed = await fs.promises.readFile(filePath, 'utf-8');
+  async isInstalled(): Promise<boolean> {
+    try {
+      const filePath = path.join(this.dir, this.VERSION_FILE);
+      const installed = await fs.promises.readFile(filePath, 'utf-8');
 
-        return installed === this.version;
-      } catch (ex) {
-        return false;
-      }
-    })();
+      return installed === this.version;
+    } catch (ex) {
+      return false;
+    }
   }
 
   _composeFile: Promise<any> | undefined;

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -50,24 +50,32 @@ function isVMTypeComposefile(input: ExtensionMetadata['vm']): input is { compose
 }
 
 export class ExtensionImpl implements Extension {
-  constructor(id: string, client: ContainerEngineClient) {
+  constructor(id: string, tag: string, client: ContainerEngineClient) {
     const encodedId = Buffer.from(id, 'utf-8').toString('base64url');
 
     this.id = id;
+    this.version = tag;
     this.client = client;
     this.dir = path.join(paths.extensionRoot, encodedId);
   }
 
-  /** The extension ID (the image ID) */
+  /** The extension ID (the image ID), excluding the tag */
   id: string;
+  /** The extension image tag */
+  version: string;
   /** The directory this extension will be installed into */
   readonly dir: string;
   protected readonly client: ContainerEngineClient;
   protected _metadata: Promise<ExtensionMetadata> | undefined;
   /** The (nerdctl) namespace to use; shared with ExtensionManagerImpl */
   static readonly extensionNamespace = 'rancher-desktop-extensions';
+  protected readonly VERSION_FILE = 'version.txt';
   protected get extensionNamespace() {
     return ExtensionImpl.extensionNamespace;
+  }
+
+  get image() {
+    return `${ this.id }:${ this.version }`;
   }
 
   /** Extension metadata */
@@ -116,6 +124,7 @@ export class ExtensionImpl implements Extension {
       await this.installUI(this.dir, metadata);
       await this.installHostExecutables(this.dir, metadata);
       await this.installContainers(this.dir, metadata);
+      await this.markInstalled(this.dir);
     } catch (ex) {
       console.error(`Failed to install extension ${ this.id }, cleaning up:`, ex);
       await fs.promises.rm(this.dir, { recursive: true }).catch((e) => {
@@ -124,9 +133,8 @@ export class ExtensionImpl implements Extension {
       throw ex;
     }
 
-    mainEvents.emit('settings-write', { extensions: { [this.id]: true } });
+    mainEvents.emit('settings-write', { extensions: { [this.id]: this.version } });
 
-    // TODO: Do something so the extension is recognized by the UI.
     console.debug(`Install ${ this.id }: install complete.`);
 
     return true;
@@ -143,7 +151,7 @@ export class ExtensionImpl implements Extension {
       const origIconName = path.basename(metadata.icon);
 
       try {
-        await this.client.copyFile(this.id, metadata.icon, workDir, { namespace: this.extensionNamespace });
+        await this.client.copyFile(this.image, metadata.icon, workDir, { namespace: this.extensionNamespace });
       } catch (ex) {
         throw new ExtensionErrorImpl(ExtensionErrorCode.FILE_NOT_FOUND, `Could not copy icon file ${ metadata.icon }`, ex as Error);
       }
@@ -168,7 +176,7 @@ export class ExtensionImpl implements Extension {
       try {
         await fs.promises.mkdir(path.join(uiDir, name), { recursive: true });
         await this.client.copyFile(
-          this.id,
+          this.image,
           data.root,
           path.join(uiDir, name),
           { namespace: this.extensionNamespace });
@@ -198,7 +206,7 @@ export class ExtensionImpl implements Extension {
 
     await Promise.all(paths.map(async(p) => {
       try {
-        await this.client.copyFile(this.id, p, binDir, { namespace: this.extensionNamespace });
+        await this.client.copyFile(this.image, p, binDir, { namespace: this.extensionNamespace });
       } catch (ex: any) {
         throw new ExtensionErrorImpl(ExtensionErrorCode.FILE_NOT_FOUND, `Could not copy host binary ${ p }`, ex);
       }
@@ -231,7 +239,7 @@ export class ExtensionImpl implements Extension {
 
       await fs.promises.mkdir(composeDir, { recursive: true });
       await this.client.copyFile(
-        this.id,
+        this.image,
         imageComposeDir === '.' ? '/' : `${ imageComposeDir }/`,
         composeDir,
         { namespace: this.extensionNamespace });
@@ -290,14 +298,16 @@ export class ExtensionImpl implements Extension {
       {
         name:      this.containerName,
         namespace: this.extensionNamespace,
-        env:       { DESKTOP_PLUGIN_IMAGE: this.id },
+        env:       { DESKTOP_PLUGIN_IMAGE: this.image },
       },
     );
   }
 
-  async uninstall(): Promise<boolean> {
-    // TODO: Unregister the extension from the UI.
+  protected async markInstalled(workDir: string) {
+    await fs.promises.writeFile(path.join(workDir, this.VERSION_FILE), this.version, 'utf-8');
+  }
 
+  async uninstall(): Promise<boolean> {
     try {
       await this.uninstallContainers();
     } catch (ex) {
@@ -312,7 +322,7 @@ export class ExtensionImpl implements Extension {
       }
     }
 
-    mainEvents.emit('settings-write', { extensions: { [this.id]: false } });
+    mainEvents.emit('settings-write', { extensions: { [this.id]: undefined } });
 
     return true;
   }
@@ -324,9 +334,22 @@ export class ExtensionImpl implements Extension {
       {
         name:      this.containerName,
         namespace: this.extensionNamespace,
-        env:       { DESKTOP_PLUGIN_IMAGE: this.id },
+        env:       { DESKTOP_PLUGIN_IMAGE: this.image },
       },
     );
+  }
+
+  get isInstalled(): Promise<boolean> {
+    return (async() => {
+      try {
+        const filePath = path.join(this.dir, this.VERSION_FILE);
+        const installed = await fs.promises.readFile(filePath, 'utf-8');
+
+        return installed === this.version;
+      } catch (ex) {
+        return false;
+      }
+    })();
   }
 
   _composeFile: Promise<any> | undefined;
@@ -348,7 +371,7 @@ export class ExtensionImpl implements Extension {
       path.join(this.dir, 'compose'), {
         name:      this.containerName,
         namespace: this.extensionNamespace,
-        env:       { DESKTOP_PLUGIN_IMAGE: this.id },
+        env:       { DESKTOP_PLUGIN_IMAGE: this.image },
         service:   'r-d-x-port-forwarding',
         port:      80,
         protocol:  'tcp',
@@ -375,7 +398,7 @@ export class ExtensionImpl implements Extension {
     return this.client.composeExec(path.join(this.dir, 'compose'), {
       name:      this.containerName,
       namespace: this.extensionNamespace,
-      env:       { ...options.env, DESKTOP_PLUGIN_IMAGE: this.id },
+      env:       { ...options.env, DESKTOP_PLUGIN_IMAGE: this.image },
       service,
       command:   options.command,
       ...options.cwd ? { workdir: options.cwd } : {},
@@ -384,13 +407,13 @@ export class ExtensionImpl implements Extension {
 
   async extractFile(sourcePath: string, destinationPath: string): Promise<void> {
     await this.client.copyFile(
-      this.id,
+      this.image,
       sourcePath,
       destinationPath,
       { namespace: this.extensionNamespace });
   }
 
   async readFile(sourcePath: string): Promise<string> {
-    return await this.client.readFile(this.id, sourcePath, { namespace: this.extensionNamespace });
+    return await this.client.readFile(this.image, sourcePath, { namespace: this.extensionNamespace });
   }
 }

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -1,5 +1,4 @@
 import { ChildProcessByStdio, spawn } from 'child_process';
-import fs from 'fs';
 import path from 'path';
 import { Readable } from 'stream';
 
@@ -17,7 +16,9 @@ import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import type { RecursiveReadonly } from '@pkg/utils/typeUtils';
 
-import type { Extension, ExtensionManager, SpawnOptions, SpawnResult } from './types';
+import type {
+  Extension, ExtensionManager, ExtensionMetadata, SpawnOptions, SpawnResult,
+} from './types';
 
 const console = Logging.extensions;
 const ipcMain = getIpcMainProxy(console);
@@ -33,7 +34,12 @@ type IpcMainEventHandler<K extends keyof IpcMainInvokeEvents> =
 type ReadableChildProcess = ChildProcessByStdio<null, Readable, Readable>;
 
 class ExtensionManagerImpl implements ExtensionManager {
-  protected extensions: Record<string, ExtensionImpl> = {};
+  /**
+   * Known extensions.  Keyed by the image (excluding tag), then the tag.
+   * @note Items here are not necessarily installed, but all installed
+   * extensions are listed.
+   */
+  protected extensions: Record<string, Record<string, ExtensionImpl>> = {};
 
   constructor(client: ContainerEngineClient) {
     this.client = client;
@@ -112,9 +118,9 @@ class ExtensionManagerImpl implements ExtensionManager {
     this.setMainListener('extensions/spawn/streaming', async(event, options) => {
       switch (options.scope) {
       case 'host':
-        return this.execStreaming(event, options, this.spawnHost(event, options));
+        return this.execStreaming(event, options, await this.spawnHost(event, options));
       case 'docker-cli':
-        return this.execStreaming(event, options, this.spawnDockerCli(event, options));
+        return this.execStreaming(event, options, await this.spawnDockerCli(event, options));
       case 'container':
         return this.execStreaming(event, options, await this.spawnContainer(event, options));
       }
@@ -125,9 +131,9 @@ class ExtensionManagerImpl implements ExtensionManager {
     this.setMainHandler('extensions/spawn/blocking', async(event, options) => {
       switch (options.scope) {
       case 'host':
-        return this.execBlocking(this.spawnHost(event, options));
+        return this.execBlocking(await this.spawnHost(event, options));
       case 'docker-cli':
-        return this.execBlocking(this.spawnDockerCli(event, options));
+        return this.execBlocking(await this.spawnDockerCli(event, options));
       case 'container':
         return this.execBlocking(await this.spawnContainer(event, options));
       }
@@ -168,7 +174,7 @@ class ExtensionManagerImpl implements ExtensionManager {
 
     this.setMainHandler('extensions/vm/http-fetch', async(event, config) => {
       const extensionId = this.getExtensionIdFromEvent(event);
-      const extension = this.getExtension(extensionId) as ExtensionImpl;
+      const extension = await this.getExtension(extensionId) as ExtensionImpl;
       let url: URL;
 
       if (/^[^:/]*:/.test(config.url)) {
@@ -206,58 +212,79 @@ class ExtensionManagerImpl implements ExtensionManager {
       console, { namespace: ExtensionImpl.extensionNamespace });
 
     // Install / uninstall extensions as needed.
-    await Promise.all(Object.entries(config.extensions ?? {}).map(async([id, install]) => {
-      const op = install ? 'install' : 'uninstall';
+    const tasks: Promise<any>[] = [];
 
-      try {
-        await this.getExtension(id)[op]();
-      } catch (ex) {
-        console.error(`Failed to ${ op } extension "${ id }"`, ex);
+    for (const [repo, tag] of Object.entries(config.extensions)) {
+      if (!tag) {
+        // If the tag is unset / falsy, we wanted to uninstall the extension.
+        // There is no need to re-initialize it.
+        continue;
       }
-    }));
+
+      tasks.push((async(id: string) => {
+        try {
+          return (await this.getExtension(id)).install();
+        } catch (ex) {
+          console.error(`Failed to install extension ${ id }`, ex);
+        }
+      })(`${ repo }:${ tag }`));
+      await Promise.all(tasks);
+    }
   }
 
-  getExtension(id: string): Extension {
-    let ext = this.extensions[id];
+  async getExtension(image: string): Promise<Extension> {
+    let [, repo, tag] = /^(.*):(.*?)$/.exec(image) ?? ['', image, undefined];
+    const extGroup = this.extensions[image] ?? {};
 
-    if (!ext) {
-      ext = new ExtensionImpl(id, this.client);
-      this.extensions[id] = ext;
+    // The build process uses an older TypeScript that can't infer id correctly.
+    repo ??= image;
+    tag ??= undefined;
+
+    this.extensions[repo] = extGroup;
+
+    if (tag) {
+      // Requested a specific tag; create it if we don't have it.
+      extGroup[tag] ||= new ExtensionImpl(repo, tag, this.client);
+
+      return extGroup[tag];
     }
 
-    return ext;
+    // No tag specified; grab the installed version, if available
+    for (const ext of Object.values(extGroup)) {
+      if (await ext.isInstalled) {
+        return ext;
+      }
+    }
+
+    // If we get here, no tag is specified and nothing is installed.
+    // Return the latest version.
+    // TODO: Figure out something better than "latest" (#4362)
+    extGroup.latest ||= new ExtensionImpl(repo, 'latest', this.client);
+
+    return extGroup.latest;
   }
 
   async getInstalledExtensions() {
-    const extensions = Object.values(this.extensions);
-    let installedExtensions: string[] = [];
+    const exts = await Promise.all(Object.entries(this.extensions).map(async([id, group]) => {
+      const versions = Object.entries(group);
+      const states = await Promise.all(versions.map(async([version, ext]) => {
+        return [version, await ext.isInstalled, ext] as const;
+      }));
 
-    try {
-      installedExtensions = await fs.promises.readdir(paths.extensionRoot);
-    } catch (ex: any) {
-      if ((ex as NodeJS.ErrnoException)?.code === 'ENOENT') {
-        return [];
+      return [id, ...states.find(([, installed]) => installed) ?? ['', false]] as const;
+    }));
+
+    const result: { id: string, version: string, metadata: ExtensionMetadata }[] = [];
+
+    for (const [id, version, installed, ext] of exts) {
+      if (installed) {
+        result.push({
+          id, version, metadata: await ext!.metadata,
+        });
       }
-      throw ex;
     }
 
-    const transformedExtensions = extensions
-      .filter((extension) => {
-        const encodedExtension = Buffer.from(extension.id).toString('base64url');
-
-        return installedExtensions.includes(encodedExtension);
-      })
-      .map(async(current) => {
-        const { id } = current;
-        const metadata = await current.metadata;
-
-        return {
-          id,
-          metadata,
-        };
-      });
-
-    return await Promise.all(transformedExtensions);
+    return result;
   }
 
   /**
@@ -270,9 +297,9 @@ class ExtensionManagerImpl implements ExtensionManager {
   }
 
   /** Spawn a process in the host context. */
-  protected spawnHost(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): ReadableChildProcess {
+  protected async spawnHost(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): Promise<ReadableChildProcess> {
     const extensionId = this.getExtensionIdFromEvent(event);
-    const extension = this.getExtension(extensionId) as ExtensionImpl;
+    const extension = await this.getExtension(extensionId) as ExtensionImpl;
 
     if (!extension) {
       throw new Error(`Could not find calling extension ${ extensionId }`);
@@ -288,9 +315,9 @@ class ExtensionManagerImpl implements ExtensionManager {
   }
 
   /** Spawn a process in the docker-cli context. */
-  protected spawnDockerCli(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): ReadableChildProcess {
+  protected async spawnDockerCli(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): Promise<ReadableChildProcess> {
     const extensionId = this.getExtensionIdFromEvent(event);
-    const extension = this.getExtension(extensionId) as ExtensionImpl;
+    const extension = await this.getExtension(extensionId) as ExtensionImpl;
 
     if (!extension) {
       throw new Error(`Could not find calling extension ${ extensionId }`);
@@ -303,9 +330,9 @@ class ExtensionManagerImpl implements ExtensionManager {
   }
 
   /** Spawn a process in the container context. */
-  protected spawnContainer(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): Promise<ReadableChildProcess> {
+  protected async spawnContainer(event: IpcMainEvent | IpcMainInvokeEvent, options: SpawnOptions): Promise<ReadableChildProcess> {
     const extensionId = this.getExtensionIdFromEvent(event);
-    const extension = this.getExtension(extensionId) as ExtensionImpl;
+    const extension = await this.getExtension(extensionId) as ExtensionImpl;
 
     if (!extension) {
       return Promise.reject(new Error(`Could not find calling extension ${ extensionId }`));

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -236,7 +236,7 @@ class ExtensionManagerImpl implements ExtensionManager {
     let [, repo, tag] = /^(.*):(.*?)$/.exec(image) ?? ['', image, undefined];
     const extGroup = this.extensions[image] ?? {};
 
-    // The build process uses an older TypeScript that can't infer id correctly.
+    // The build process uses an older TypeScript that can't infer repo correctly.
     repo ??= image;
     tag ??= undefined;
 

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -251,7 +251,7 @@ class ExtensionManagerImpl implements ExtensionManager {
 
     // No tag specified; grab the installed version, if available
     for (const ext of Object.values(extGroup)) {
-      if (await ext.isInstalled) {
+      if (await ext.isInstalled()) {
         return ext;
       }
     }
@@ -268,7 +268,7 @@ class ExtensionManagerImpl implements ExtensionManager {
     const exts = await Promise.all(Object.entries(this.extensions).map(async([id, group]) => {
       const versions = Object.entries(group);
       const states = await Promise.all(versions.map(async([version, ext]) => {
-        return [version, await ext.isInstalled, ext] as const;
+        return [version, await ext.isInstalled(), ext] as const;
       }));
 
       return [id, ...states.find(([, installed]) => installed) ?? ['', false]] as const;

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -80,7 +80,7 @@ export interface Extension {
   /**
    * Check whether this extension is installed (at this version).
    */
-  readonly isInstalled: Promise<boolean>;
+  isInstalled(): Promise<boolean>;
 
   /**
    * Extract the given file from the image.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -45,9 +45,19 @@ export type ExtensionMetadata = {
  */
 export interface Extension {
   /**
-   * The image ID for this extension.
+   * The image ID for this extension, excluding the tag.
    */
   readonly id: string;
+
+  /**
+   * The image tag for this extension.
+   */
+  readonly version: string;
+
+  /**
+   * The full image tag for this image (a combination of idonly and version).
+   */
+  readonly image: string;
 
   /**
    * Metadata for this extension.
@@ -68,6 +78,11 @@ export interface Extension {
   uninstall(): Promise<boolean>;
 
   /**
+   * Check whether this extension is installed (at this version).
+   */
+  readonly isInstalled: Promise<boolean>;
+
+  /**
    * Extract the given file from the image.
    * @param sourcePath The name of the file (or directory) to extract, relative
    * to the root of the image; for example, `metadata.json`.
@@ -86,16 +101,18 @@ export interface ExtensionManager {
 
   /**
    * Get the given extension.
-   * @param id The image ID of the extension.
+   * @param id The image ID of the extension, possibly including the tag.
+   *        If the tag is not supplied, the currently-installed version is
+   *        used; if no version is installed, "latest" is assumed.
    * @note This may cause the given image to be downloaded.
    * @note The extension will not be automatically installed.
    */
-  getExtension(id: string): Extension;
+  getExtension(image: string): Promise<Extension>;
 
   /**
    * Get a collection of all installed extensions.
    */
-  getInstalledExtensions(): Promise<{ id: string; metadata: ExtensionMetadata; }[]>;
+  getInstalledExtensions(): Promise<{ id: string; version: string, metadata: ExtensionMetadata; }[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/pages/marketplace/details.vue
+++ b/pkg/rancher-desktop/pages/marketplace/details.vue
@@ -128,7 +128,7 @@ export default {
       }
 
       response.json().then((res) => {
-        this.isInstalled = Object.keys(res).includes(this.versionedExtension);
+        this.isInstalled = Object.keys(res).includes(this.extensionWithoutVersion);
       });
     });
   },

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -164,7 +164,7 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions/list': (extensions: { id: string; metadata: ExtensionMetadata; }[] | undefined) => void;
+  'extensions/list': (extensions: { id: string, version: string, metadata: ExtensionMetadata; }[]) => void;
   'extensions/open': (id: string, path: string) => void;
   'err:extensions/open': () => void;
   'extensions/close': () => void;

--- a/src/go/rdctl/cmd/extensionLS.go
+++ b/src/go/rdctl/cmd/extensionLS.go
@@ -29,9 +29,10 @@ import (
 
 // lsCmd represents the ls command
 var lsCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List currently installed images",
-	Long:  `List currently installed images.`,
+	Use:     "ls",
+	Aliases: []string{"list"},
+	Short:   "List currently installed images",
+	Long:    `List currently installed images.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			return fmt.Errorf("rdctl extension ls takes no additional arguments, got %s", args)
@@ -51,7 +52,7 @@ func listExtensions() error {
 	if errorPacket != nil || err != nil {
 		return displayAPICallResult([]byte{}, errorPacket, err)
 	}
-	extensionList := map[string]bool{}
+	extensionList := map[string]string{}
 	err = json.Unmarshal(result, &extensionList)
 	if err != nil {
 		return fmt.Errorf("failed to json-unmarshal results of `extensions ls`: %w", err)
@@ -61,8 +62,8 @@ func listExtensions() error {
 		return nil
 	}
 	extensionIDs := make([]string, 0, len(extensionList))
-	for id := range extensionList {
-		extensionIDs = append(extensionIDs, id)
+	for id, tag := range extensionList {
+		extensionIDs = append(extensionIDs, fmt.Sprintf("%s:%s", id, tag))
 	}
 	sort.Slice(extensionIDs, func(i, j int) bool { return strings.ToLower(extensionIDs[i]) < strings.ToLower(extensionIDs[j]) })
 


### PR DESCRIPTION
This splits out the extension tag from the extension ID, so that
- We only install one version of the extension at a time (instead of possibly installing multiple versions concurrently)
- This will let us later implement `rdctl extension upgrade`
- When we try to fetch an extension without a tag, we now get the currently-installed version rather than "latest".

Fixes #4416