### PR TITLE
Dynamically import actions in `TheTitle`

### DIFF
--- a/pkg/rancher-desktop/components/TheTitle.vue
+++ b/pkg/rancher-desktop/components/TheTitle.vue
@@ -2,17 +2,14 @@
 import Vue from 'vue';
 import { mapState } from 'vuex';
 
-import DiagnosticsButtonRun from '@pkg/components/DiagnosticsButtonRun.vue';
-import ImagesButtonAdd from '@pkg/components/ImagesButtonAdd.vue';
+const componentCache: { [key: string]: any } = {};
 
 export default Vue.extend({
-  name:       'the-title',
-  components: { ImagesButtonAdd, DiagnosticsButtonRun },
+  name: 'the-title',
   data() {
     return {
-      data() {
-        return { isChild: false };
-      },
+      isChild:          false,
+      dynamicComponent: null,
     };
   },
   computed: {
@@ -30,6 +27,15 @@ export default Vue.extend({
       handler(current) {
         this.isChild = current.path.lastIndexOf('/') > 0;
       },
+    },
+    action: {
+      async handler(componentName) {
+        if (componentName) {
+          componentCache[componentName] ||= (await import(`@pkg/components/${ componentName }.vue`)).default;
+          this.dynamicComponent = componentCache[componentName];
+        }
+      },
+      immediate: true,
     },
   },
   methods: {
@@ -76,7 +82,7 @@ export default Vue.extend({
           key="actions"
           class="actions fade-actions"
         >
-          <component :is="action" />
+          <component :is="dynamicComponent" />
         </div>
       </transition>
     </div>

--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -62,7 +62,7 @@ export default {
 
         this.$store.dispatch(
           'page/setAction',
-          { action: 'images-button-add' },
+          { action: 'ImagesButtonAdd' },
         );
       },
       immediate: true,


### PR DESCRIPTION
This dynamically imports any actions we might have for `TheTitle` without the need to register each component we expect to use. The only action we have available at this time is the "Add Image" button on the Images page. 

This change was originally developed as a part of #4440 but I think it'll be easier to evaluate and review this on its own. 

This change supports efforts for #4440. 