### PR TITLE
RDX: Image for testing host APIs

### DIFF
--- a/.github/workflows/rdx-host-api-tests.yaml
+++ b/.github/workflows/rdx-host-api-tests.yaml
@@ -1,0 +1,41 @@
+# This workflow builds the Rancher Desktop Extensions Host APIs testing image
+# and publishes it.
+
+name: RDX Host APIs Testing image
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'bats/tests/extensions/testdata/**' ]
+  workflow_dispatch: {}
+permissions:
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/metadata-action@v4
+      id: meta
+      with:
+        images: |
+          ghcr.io/${{ github.repository }}/rdx-host-api-test
+        tags: type=raw,value=latest,enable={{ is_default_branch }}
+    - uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+    - uses: docker/build-push-action@v4
+      with:
+        build-args: variant=host-apis
+        context: bats/tests/extensions/testdata
+        platforms: |
+          linux/amd64
+          linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/bats/tests/extensions/testdata/Makefile
+++ b/bats/tests/extensions/testdata/Makefile
@@ -1,8 +1,10 @@
 all: \
   image-basic image-missing-icon image-ui \
-  image-vm-image image-vm-compose image-host-binaries
+  image-vm-image image-vm-compose image-host-binaries image-host-apis
 
 TOOL ?= docker
 
+NAMESPACE = $(if $(filter %nerdctl,${TOOL}),--namespace=rancher-desktop-extensions)
+
 image-%:
-	${TOOL} build -t rd/extension/$(@:image-%=%) --build-arg variant=$(@:image-%=%) .
+	${TOOL} ${NAMESPACE} build -t rd/extension/$(@:image-%=%) --build-arg variant=$(@:image-%=%) .

--- a/bats/tests/extensions/testdata/host-apis.json
+++ b/bats/tests/extensions/testdata/host-apis.json
@@ -1,0 +1,11 @@
+{
+  "info": "This is used to do manual testing of various host APIs",
+  "icon": "extension-icon.svg",
+  "ui": {
+    "dashboard-tab": {
+      "title": "RDX Host-APIs Test",
+      "root": "/ui",
+      "src": "host-apis.html"
+    }
+  }
+}

--- a/bats/tests/extensions/testdata/ui/host-apis.html
+++ b/bats/tests/extensions/testdata/ui/host-apis.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script type="application/javascript">
+
+    function openExternal() {
+      ddClient.host.openExternal("https://rancherdesktop.io");
+    }
+
+    function openDialog() {
+      const properties=Array.from(document.getElementById('dialogOptions').selectedOptions).map(v => v.value);
+      const options=properties.length>0? {properties}:undefined;
+      ddClient.desktopUI.dialog.showOpenDialog(options).then(result => {
+        console.log('openDialog result:',result);
+        document.getElementById('dialogCancelled').checked=result.canceled;
+        document.getElementById('dialogFilePaths').innerHTML=
+          result.filePaths.map(p => `<option>${p}</option>`).join('');
+        document.getElementById('dialogBookmarks').innerHTML=
+          (result.bookmarks??[]).map(p => `<option>${p}</option>`).join('');
+      });
+    }
+
+    /**
+     * Open a toast notification
+     * @param type ['success' | 'warning' | 'error'] The type of toast to invoke.
+     */
+    function toast(type) {
+      ddClient.desktopUI.toast[type](`This is a ${type} toast`);
+    }
+
+    let platform='unknown';
+    if(/^mac/i.test(navigator.platform)) {
+      platform='darwin';
+    } else if(/^win/i.test(navigator.platform)) {
+      platform='win32';
+    } else if(/^linunx/i.test(navigator.platform)) {
+      platform='linux';
+    }
+    document.documentElement.setAttribute('platform',platform);
+  </script>
+
+  <style>
+    #dialog {
+      display: flex;
+    }
+
+    #dialog>* {
+      flex: 1;
+    }
+
+    :root:not([platform="darwin"]) #dialogOptions>option[darwin],
+    :root:not([platform="win32"]) #dialogOptions>option[win32],
+    :root:not([platform="linux"]) #dialogOptions>option[linux] {
+      display: none;
+    }
+
+    #dialog table {
+      border: 1px solid;
+    }
+
+    #dialog table td,
+    #dialog table td>select {
+      width: 100%;
+    }
+
+  </style>
+</head>
+
+<body>
+  <h1>Rancher Desktop Extensions Host API Testing</h1>
+
+  <h2>Open external</h2>
+  <p>Clicking the button should open the Rancher Desktop home page in a browser.</p>
+  <button onclick="openExternal()">Open in web page</button>
+  <hr>
+
+  <h2>Select file</h2>
+  <section id="dialog">
+    <div>
+      <p>Clicking on the button should show a file open dialog.</p>
+      <select id="dialogOptions" multiple>
+        <option value="openFile">Open File</option>
+        <option value="openDirectory">Open Directory</option>
+        <option value="multiSelections">Multiple Selection</option>
+        <option value="showHiddenFiles">Show Hidden Files</option>
+        <option value="createDirectory" darwin>Create Directory</option>
+        <option value="promptToCreate" win32>Prompt to Create</option>
+        <option value="noResolveAliases" darwin>No Resolve Symlinks</option>
+        <option value="treatPackageAsDirectory" darwin>Treat Package as Directory</option>
+        <option value="dontAddToRecent" win32>Don't Add to Recent</option>
+      </select>
+      <button onclick="openDialog()">Choose File</button>
+    </div>
+    <div>
+      <table>
+        <th>
+        <td colspan="2">Dialog Output</td>
+        </th>
+        <tr>
+          <th>cancelled</th>
+          <td><input type="checkbox" id="dialogCancelled"></td>
+        </tr>
+        <tr>
+          <th>file paths</th>
+          <td><select multiple id="dialogFilePaths"></select></td>
+        </tr>
+      </table>
+    </div>
+  </section>
+  <hr>
+
+  <h2>Toast</h2>
+  <p>
+    Clicking on each of the buttons should pop up a notification where the
+    notification title matches the type clicked on.
+  </p>
+  <button onclick="toast('success')">Success</button>
+  <button onclick="toast('warning')">Warning</button>
+  <button onclick="toast('error')">Error</button>
+</body>
+
+</html>

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -305,7 +305,7 @@ class Client implements v1.DockerDesktopClient {
       showOpenDialog(options: any): Promise<v1.OpenDialogResult> {
         // Use the clone() here to ensure we only pass plain data structures to
         // the main process.
-        return ipcRenderer.invoke('extensions/ui/show-open', clone(options));
+        return ipcRenderer.invoke('extensions/ui/show-open', clone(options ?? {}));
       },
     },
     navigate: {} as v1.NavigationIntents,


### PR DESCRIPTION
This image is to be used for testing #4312

The test procedure would be something like:

1. Run `rdctl extension install ghcr.io/mook-as/rd/rdx-host-api-test`
2. Open the new extension
3. Click on "Open in web page" in the first section; it should open a browser.
4. (… other instructions dealing with clicking buttons)

This actually includes GitHub Actions to build the image in CI, publishing it into the repository's packages list (filtered on only when the image sources change).  This way we won't need the tester to build the image manually.  I believe we _shouldn't_ do this for the other variants (used in automated tests), because ensuring we test against the images in-tree (at the same commit we're testing) should be useful.