### PR TITLE
Package bats.tar.gz as a build artifact

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -60,6 +60,16 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm run package -- --${{ matrix.platform }} --publish=never
+    - name: Build bats.tar.gz
+      if: matrix.platform == 'linux'
+      run: make -C bats bats.tar.gz
+    - name: Upload bats.tar.gz
+      uses: actions/upload-artifact@v3
+      if: matrix.platform == 'linux'
+      with:
+        name: bats.tar.gz
+        path: bats/bats.tar.gz
+        if-no-files-found: error
     - name: Upload mac disk image
       uses: actions/upload-artifact@v3
       if: matrix.platform == 'mac'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 /e2e/reports/*
 *.exe
 /screenshots/output/
+/bats/bin/
+/bats/bats.tar.gz

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -1,6 +1,8 @@
+.PHONY: all
 all:
 	bats --show-output-of-passing-tests ./tests/*/
 
+.PHONY: containers
 containers:
 	bats --show-output-of-passing-tests ./tests/containers/
 
@@ -11,9 +13,35 @@ containers:
 
 SC_EXCLUDES ?= SC1091,SC2034,SC2154,SC2155
 
+.PHONY: lint
 lint:
 	@./scripts/bats-lint.pl $(shell find tests -name '*.bats')
 	find tests -name '*.bash' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find tests -name '*.bats' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find tests -name '*.bash' | xargs shfmt -s -d
 	find tests -name '*.bats' | xargs shfmt -s -d
+
+DEPS = bin/darwin/jq bin/linux/jq
+
+# Package bats tests with bats itself and dependencies into a single tarball for distribution
+bats.tar.gz: $(DEPS)
+	git submodule update --init --recursive
+	tar cvfz "$@" --exclude-vcs --exclude "*/test/*" --exclude "*/docs/*" -- *
+
+JQ_VERSION ?= 1.6
+JQ_URL=https://github.com/stedolan/jq/releases/download/jq-$(JQ_VERSION)
+
+bin/darwin/jq:
+	mkdir -p bin/darwin
+	wget --no-verbose $(JQ_URL)/jq-osx-amd64 -O $@
+	chmod +x $@
+
+bin/linux/jq:
+	mkdir -p bin/linux
+	wget --no-verbose $(JQ_URL)/jq-linux64 -O $@
+	chmod +x $@
+
+.PHONY: clean
+clean:
+	rm -f $(DEPS)
+	rm -f bats.tar.gz

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -1,19 +1,29 @@
-helpers="$(dirname "${BASH_SOURCE[0]}")"
-topdir="$helpers/../.."
-
 set -o errexit -o nounset -o pipefail
 
-source "$topdir/bats-support/load.bash"
-source "$topdir/bats-assert/load.bash"
-source "$topdir/bats-file/load.bash"
+# Get absolute path names for current and top directories
+PATH_BATS_HELPERS=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd
+)
+PATH_BATS_ROOT=$(
+    cd "$PATH_BATS_HELPERS/../.."
+    pwd
+)
+
+source "$PATH_BATS_ROOT/bats-support/load.bash"
+source "$PATH_BATS_ROOT/bats-assert/load.bash"
+source "$PATH_BATS_ROOT/bats-file/load.bash"
 
 # "defaults.bash" *must* be sourced before the rest of the files
-source "$helpers/defaults.bash"
-source "$helpers/utils.bash"
-source "$helpers/os.bash"
-source "$helpers/paths.bash"
+source "$PATH_BATS_HELPERS/defaults.bash"
+source "$PATH_BATS_HELPERS/utils.bash"
+source "$PATH_BATS_HELPERS/os.bash"
+source "$PATH_BATS_HELPERS/paths.bash"
 
 # "vm.bash" must be loaded first to define `using_containerd` etc
-source "$helpers/vm.bash"
-source "$helpers/kubernetes.bash"
-source "$helpers/commands.bash"
+source "$PATH_BATS_HELPERS/vm.bash"
+source "$PATH_BATS_HELPERS/kubernetes.bash"
+source "$PATH_BATS_HELPERS/commands.bash"
+
+# Use Linux utilities (like jq) on WSL
+export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"


### PR DESCRIPTION
Includes `jq` for Linux and macOS

This allows the bats tests corresponding to the PR to be downloaded to and executed on any machine that we want to test on. E.g. get a fresh VM, install Rancher Desktop and the untar the bats tarball, and you should be ready to run the tests.

This will also be used by CI to test the latest successful build from `main` with the corresponding tests.