### PR TITLE
Layout: filter out extensions without UI

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -83,7 +83,9 @@ export default {
       this.goToRoute(args);
     });
     ipcRenderer.on('extensions/list', (_event, extensions) => {
-      this.extensions = extensions || [];
+      this.extensions = (extensions || []).filter((e) => {
+        return !!e.metadata.ui?.['dashboard-tab'];
+      });
     });
     ipcRenderer.send('extensions/list');
 


### PR DESCRIPTION
When we list extensions in the UI, filter out the ones without UI. Otherwise we will fail to render the front end.

To test: install the `rd/extensions/vm-compose` extension (the source lives in `bats/tests/extensions/testdata/`)