### PR TITLE
BATS: various extension fixes

### DIFF
--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -59,7 +59,7 @@ namespace_arg() {
     run rdctl api /v1/extensions
     assert_success
     output="$(jq ".[\"$(id vm-image)\"]" <<<"${output}")"
-    assert_output true
+    assert_output '"latest"'
 }
 
 @test 'image - check for running container' {
@@ -82,7 +82,7 @@ namespace_arg() {
     run rdctl api /v1/extensions
     assert_success
     output="$(jq ".[\"$(id vm-compose)\"]" <<<"${output}")"
-    assert_output true
+    assert_output '"latest"'
 }
 
 @test 'compose - check for running container' {

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -6,6 +6,12 @@ setup() {
     load '../helpers/load'
 
     TESTDATA_DIR="${PATH_TEST_ROOT}/extensions/testdata/"
+
+    if using_containerd; then
+        namespace_arg=('--namespace=rancher-desktop-extensions')
+    else
+        namespace_arg=()
+    fi
 }
 
 teardown_file() {
@@ -36,12 +42,6 @@ encoded_id() { # variant
     id "$1" | tr -d '\r\n' | base64 | tr '+/' '-_' | tr -d '='
 }
 
-namespace_arg() {
-    if using_containerd; then
-        echo '--namespace=rancher-desktop-extensions'
-    fi
-}
-
 @test 'factory reset' {
     factory_reset
 }
@@ -64,9 +64,9 @@ namespace_arg() {
         basic host-binaries missing-icon missing-icon-file ui
     )
     for extension in "${variants[@]}"; do
-        ctrctl "$(namespace_arg)" build --tag "rd/extension/$extension" --build-arg "variant=$extension" "$TESTDATA_DIR"
+        ctrctl "${namespace_arg[@]}" build --tag "rd/extension/$extension" --build-arg "variant=$extension" "$TESTDATA_DIR"
     done
-    run ctrctl "$(namespace_arg)" image list --format '{{ .Repository }}'
+    run ctrctl "${namespace_arg[@]}" image list --format '{{ .Repository }}'
     assert_success
     for extension in "${variants[@]}"; do
         assert_line "rd/extension/$extension"

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -81,7 +81,7 @@ namespace_arg() {
 @test 'basic extension - check extension is installed' {
     run rdctl extension ls
     assert_success
-    assert_line "rd/extension/basic"
+    assert_line --partial "rd/extension/basic"
 }
 
 @test 'basic extension - check extension contents' {

--- a/bats/tests/extensions/testdata/Makefile
+++ b/bats/tests/extensions/testdata/Makefile
@@ -3,6 +3,7 @@ all: \
   image-vm-image image-vm-compose image-host-binaries image-host-apis
 
 TOOL ?= docker
+NAMESPACE := $(if $(filter %nerdctl,${TOOL}),--namespace=rancher-desktop-extensions)
 
 NAMESPACE = $(if $(filter %nerdctl,${TOOL}),--namespace=rancher-desktop-extensions)
 

--- a/bats/tests/extensions/testdata/bin/server.py
+++ b/bats/tests/extensions/testdata/bin/server.py
@@ -4,35 +4,56 @@
 # `/run/guest-services/hello.sock` (see `everything.json`) to exercise the
 # ability for the front end to talk to the back end.
 
+from functools import partial
 from http import server
 import os
+import signal
 import socketserver
+import sys
 
 
 class RequestHandler(server.SimpleHTTPRequestHandler):
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs, directory="/")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, directory="/")
 
-  def address_string(self):
-    # SimpleHTTPRequestHandler assumes TCP; fix up the client address if it's
-    # just a string (because Unix socket).
-    if isinstance(self.client_address, str):
-      self.client_address = [self.client_address, 0]
-    return super().address_string()
+    def address_string(self):
+        # SimpleHTTPRequestHandler assumes TCP; fix up the client address if it's
+        # just a string (because Unix socket).
+        if isinstance(self.client_address, str):
+            self.client_address = [self.client_address, 0]
+        return super().address_string()
+
+
+def make_unix_socket_server():
+    addr = '/run/guest-services/hello.sock'
+    try:
+        os.unlink(addr)
+    except Exception as ex:
+        print(ex)
+    httpd = socketserver.ThreadingUnixStreamServer(addr, RequestHandler)
+    return (addr, httpd)
+
+
+def make_tcp_server():
+    handler_class = partial(server.SimpleHTTPRequestHandler,
+                            directory="/")
+    httpd = server.ThreadingHTTPServer(("", 0), handler_class)
+    host, port = httpd.socket.getsockname()[:2]
+    addr = f"http://{host}:{port}"
+    return (addr, httpd)
 
 
 if __name__ == '__main__':
-  addr = '/run/guest-services/hello.sock'
-  try:
-    os.unlink(addr)
-  except Exception as ex:
-    print(ex)
-
-  print("Starting HTTP server...")
-  with socketserver.ThreadingUnixStreamServer(addr, RequestHandler) as httpd:
-    print(f"Serving HTTP on {addr}")
+    signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
+    signal.signal(signal.SIGINT, lambda *args: sys.exit(0))
     try:
-      httpd.serve_forever()
-    except KeyboardInterrupt:
-      print("\nexiting...")
-      pass
+        print("Starting HTTP server...")
+        try:
+            addr, httpd = make_unix_socket_server()
+        except FileNotFoundError:
+            addr, httpd = make_tcp_server()
+        print(f"Serving HTTP on {addr}")
+        httpd.serve_forever()
+
+    except SystemExit:
+        print("\nexiting...")

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -1,8 +1,12 @@
 wait_for_apiserver() {
     local desired_version="${1:-$RD_KUBERNETES_PREV_VERSION}"
+    local timeout="$(($(date +%s) + 10 * 60))"
     while true; do
-        until kubectl get --raw /readyz &>/dev/null; do sleep 1; done
-        sleep 1
+        until kubectl get --raw /readyz &>/dev/null; do
+            assert [ "$(date +%s)" -lt "${timeout}" ]
+            sleep 1
+        done
+        assert [ "$(date +%s)" -lt "${timeout}" ]
         run kubectl get node -o jsonpath="{.items[0].status.nodeInfo.kubeletVersion}"
         if [ "$status" -eq 0 ]; then
             # Turn "v1.23.4+k3s1" into "1.23.4"

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -76,8 +76,10 @@ assert_traefik_pods_are_up() {
     # Check if the traefik pods come up
     try --max 30 --delay 10 assert_traefik_pods_are_up
     assert_success
-    run curl "http://$(get_host):80"
-    [ "$status" -ne 0 ]
-    run curl -k "https://$(get_host):443"
-    [ "$status" -ne 0 ]
+    try --max 30 --delay 10 curl --head "http://$(get_host):80"
+    assert_success
+    assert_output --regexp 'HTTP/[0-9.]* 404'
+    try --max 30 --delay 10 curl --head --insecure "https://$(get_host):443"
+    assert_success
+    assert_output --regexp 'HTTP/[0-9.]* 404'
 }

--- a/bats/tests/k8s/verify-cached-images.bats
+++ b/bats/tests/k8s/verify-cached-images.bats
@@ -19,7 +19,7 @@ test_k8s_version_has_correct_cached_extension() {
     local EXTENSION=$2
     rdctl set --kubernetes-version "$K8S_VERSION"
     wait_for_apiserver "$K8S_VERSION"
-    run ls "$PATH_CACHE/k3s/v${K8S_VERSION}"*k3s*/k3s-airgap-images-amd64."${EXTENSION}"
+    run ls "$PATH_CACHE/k3s/v${K8S_VERSION}"*k3s*/k3s-airgap-images-*."${EXTENSION}"
     assert_success
 }
 

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -226,7 +226,7 @@ export class ExtensionImpl implements Extension {
     // Extract compose file and place it in composeDir
     if (isVMTypeImage(metadata.vm)) {
       contents = {
-        name:     this.id,
+        name:     this.id.replace(/[^a-z0-9_-]/g, '_'),
         // Disable lint because it's a literal ${DESKTOP_PLUGIN_IMAGE} string.
         // eslint-disable-next-line no-template-curly-in-string
         services: { web: { image: '${DESKTOP_PLUGIN_IMAGE}' } },


### PR DESCRIPTION
Found a few issues running BATS locally:

- c087f2b2b48bee3a9b11099ddc29fe852181e42d (#4403) broke all the non-`everything` test extension images (because they don't have the backend socket mount, they no longer started properly).
- nerdctl limits the compose project names to match something like `[a-z0-9_-]+` (in particular, slashes are not allowed).  We were using the image name (including slashes), which got it rejected.
- When building test extension images, if we're using `nerdctl`, put them in the namespace that the extension code expects (so we can just build locally and install them).