### PR TITLE
BATS: fix extensions/containers output

### DIFF
--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -59,7 +59,7 @@ namespace_arg() {
     run rdctl api /v1/extensions
     assert_success
     output="$(jq ".[\"$(id vm-image)\"]" <<<"${output}")"
-    assert_output true
+    assert_output '"latest"'
 }
 
 @test 'image - check for running container' {
@@ -82,7 +82,7 @@ namespace_arg() {
     run rdctl api /v1/extensions
     assert_success
     output="$(jq ".[\"$(id vm-compose)\"]" <<<"${output}")"
-    assert_output true
+    assert_output '"latest"'
 }
 
 @test 'compose - check for running container' {


### PR DESCRIPTION
In #4514, we now put the tag as the JSON body, rather than a literal `true`.  But the BATS test wasn't updated to match that.

Fixes an error from 1de9254eb5c5f40e9b595ca8e020569c4e700efa.

