### PR TITLE
Target margin/padding/border when resetting fieldset styles

### DIFF
--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -31,13 +31,14 @@ export default Vue.extend({
 </template>
 
 <style lang="scss" scoped>
-  fieldset {
-    all: unset;
-  }
-
   .rd-fieldset {
+    margin: 0;
+    padding: 0;
+    border: none;
+
     legend {
       font-size: 1rem;
+      color: inherit;
       line-height: 1.5rem;
       padding-bottom: 0.5rem;
     }


### PR DESCRIPTION
This brings the radio button styles to be more in line with how radio buttons look in Rancher Dashboard by being more targeted in the style reset used in the `RdFieldset` component. The previous usage of `all: unset;` was inadvertently resetting styles of children contained within.

## 🔎 Comparisons

### Previous

![image](https://user-images.githubusercontent.com/835961/234429414-3502155f-39a6-49e0-b12e-7c5814479794.png)

### Current

![image](https://user-images.githubusercontent.com/835961/234430523-6aaefc19-4d1f-455f-87c8-cc0ae4ea247a.png)

### Rancher Dashboard

![image](https://user-images.githubusercontent.com/835961/234429167-0c4d717b-237a-4873-9d9f-8b91462fbc6a.png)

closes #4552 