### PR TITLE
Stop linter warning

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -61,6 +61,7 @@ EOF
     rdctl start "${args[@]}" "$@" &
 }
 
+# shellcheck disable=SC2120
 start_kubernetes() {
     start_container_engine \
         --kubernetes-enabled \


### PR DESCRIPTION
start_kubernetes is called by other bats tests with arguments, but it is ok to leave them off.