### PR TITLE
Close active extension view if it's uninstalled

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1104,6 +1104,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       console.debug(`Uninstalling extension ${ image }...`);
       try {
         if (await extension.uninstall()) {
+          window.send('ok:extensions/uninstall', image);
+
           return { status: 201 };
         } else {
           return { status: 204 };

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4682,6 +4682,7 @@ diagnostics:
 ### Extensions Page
 ##############################
 extensions:
+  icon: icon-extension
   installed:
     list:
       uninstall: Uninstall
@@ -4691,6 +4692,10 @@ extensions:
       body: It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
       button: 
         text: Browse Extensions
+  view:
+    emptyState:
+      heading: Extension uninstalled
+      body: 'was uninstalled. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.'
 
 ##############################
 ### Preferences Page

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4695,7 +4695,7 @@ extensions:
   view:
     emptyState:
       heading: Extension uninstalled
-      body: 'was uninstalled. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.'
+      body: '{extensionId} was uninstalled. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.'
 
 ##############################
 ### Preferences Page

--- a/pkg/rancher-desktop/components/EmptyState.vue
+++ b/pkg/rancher-desktop/components/EmptyState.vue
@@ -68,6 +68,7 @@ export default Vue.extend({
   .empty-state-body {
     font-size: 1rem;
     line-height: 1.5rem;
+    text-align: center;
   }
 
   .empty-state-primary-action {

--- a/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
+++ b/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
@@ -1,0 +1,51 @@
+<script lang="ts">
+import Vue from 'vue';
+
+import EmptyState from '@pkg/components/EmptyState.vue';
+
+export default Vue.extend({
+  name:       'extensions-uninstalled',
+  components: { EmptyState },
+  props:      {
+    extensionId: {
+      required: true,
+      type:     String,
+    },
+  },
+  computed: {
+    emptyStateIcon(): string {
+      return this.t('extensions.icon');
+    },
+    emptyStateHeading(): string {
+      return this.t('extensions.view.emptyState.heading');
+    },
+    emptyStateBody(): string {
+      return this.t('extensions.view.emptyState.body');
+    },
+  },
+  methods: {
+    browseExtensions() {
+      this.$emit('click:browse');
+    },
+  },
+});
+</script>
+
+<template>
+  <empty-state
+    :icon="emptyStateIcon"
+    :heading="emptyStateHeading"
+  >
+    <template #body>
+      <code>{{ extensionId }}</code> {{ emptyStateBody }}
+    </template>
+    <template #primary-action>
+      <button
+        class="btn role-primary"
+        @click="browseExtensions"
+      >
+        {{ t('extensions.installed.emptyState.button.text') }}
+      </button>
+    </template>
+  </empty-state>
+</template>

--- a/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
+++ b/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
@@ -20,7 +20,11 @@ export default Vue.extend({
       return this.t('extensions.view.emptyState.heading');
     },
     emptyStateBody(): string {
-      return this.t('extensions.view.emptyState.body');
+      return this.t(
+        'extensions.view.emptyState.body',
+        { extensionId: `<code>${ this.extensionId }</code>` },
+        true,
+      );
     },
   },
   methods: {
@@ -37,7 +41,7 @@ export default Vue.extend({
     :heading="emptyStateHeading"
   >
     <template #body>
-      <code>{{ extensionId }}</code> {{ emptyStateBody }}
+      <span v-html="emptyStateBody"></span>
     </template>
     <template #primary-action>
       <button

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -30,7 +30,10 @@ export default Vue.extend({
     next();
   },
   data(): ExtensionsData {
-    return { error: undefined };
+    return {
+      error:           undefined,
+      isExtensionGone: false,
+    };
   },
   computed: {
     extensionId(): string | undefined {
@@ -44,6 +47,7 @@ export default Vue.extend({
     );
 
     ipcRenderer.on('err:extensions/open', this.extensionError);
+    ipcRenderer.on('ok:extensions/uninstall', this.extensionUninstalled);
   },
   beforeDestroy() {
     ipcRenderer.off('err:extensions/open', this.extensionError);
@@ -57,6 +61,16 @@ export default Vue.extend({
     },
     extensionError(_event: any, err: Error): void {
       this.error = err;
+    },
+    extensionUninstalled(_event: any, extensionId: string): void {
+      if (!this.extensionId) {
+        return;
+      }
+
+      if (extensionId.startsWith(this.extensionId)) {
+        this.isExtensionGone = true;
+        this.closeExtensionView();
+      }
     },
   },
 });

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -82,7 +82,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
+  <div class="extensions-container">
     <extensions-uninstalled
       v-if="isExtensionGone"
       :extension-id="extensionId"
@@ -95,3 +95,11 @@ export default Vue.extend({
     />
   </div>
 </template>
+
+<style lang="scss" scoped>
+  .extensions-container {
+    padding: 0 6rem;
+    max-width: 64rem;
+    justify-self: center;
+  }
+</style>

--- a/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
+++ b/pkg/rancher-desktop/pages/extensions/_root/_src/_id.vue
@@ -3,14 +3,16 @@ import { ipcRenderer } from 'electron';
 import Vue from 'vue';
 
 import ExtensionsError from '@pkg/components/ExtensionsError.vue';
+import ExtensionsUninstalled from '@pkg/components/ExtensionsUninstalled.vue';
 import { hexDecode } from '@pkg/utils/string-encode';
 
 interface ExtensionsData {
   error: Error | undefined;
+  isExtensionGone: boolean;
 }
 
 export default Vue.extend({
-  components: { ExtensionsError },
+  components: { ExtensionsError, ExtensionsUninstalled },
   beforeRouteEnter(to, _from, next) {
     const { params: { root, src, id } } = to;
 
@@ -72,14 +74,24 @@ export default Vue.extend({
         this.closeExtensionView();
       }
     },
+    browseCatalog() {
+      this.$router.push({ name: 'Extensions' });
+    },
   },
 });
 </script>
 
 <template>
-  <extensions-error
-    v-if="error"
-    :error="error"
-    :extension-id="extensionId"
-  />
+  <div>
+    <extensions-uninstalled
+      v-if="isExtensionGone"
+      :extension-id="extensionId"
+      @click:browse="browseCatalog"
+    />
+    <extensions-error
+      v-if="error"
+      :error="error"
+      :extension-id="extensionId"
+    />
+  </div>
 </template>

--- a/pkg/rancher-desktop/pages/marketplace/details.vue
+++ b/pkg/rancher-desktop/pages/marketplace/details.vue
@@ -96,6 +96,18 @@ import demoMetadata from '@pkg/utils/_demo_metadata.js';
 export default {
   name:       'marketplace-details',
   components: { LoadingIndicator, Banner },
+
+  beforeRouteEnter(to, _from, next) {
+    const { params: { slug } } = to;
+
+    if (!slug) {
+      next({ name: 'Extensions' });
+
+      return;
+    }
+
+    next();
+  },
   data() {
     return {
       extension:        this.$route.params.slug,

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -171,5 +171,6 @@ export interface IpcRendererEvents {
   'extensions/spawn/close': (id: string, code: number) => void;
   'extensions/spawn/error': (id: string, error: Error | NodeJS.Signals) => void;
   'extensions/spawn/output': (id: string, data: { stdout: string } | { stderr: string }) => void;
+  'ok:extensions/uninstall': (id: string) => void;
   // #endregion
 }


### PR DESCRIPTION
This closes the extension's browser view if it is uninstalled while active. We display a message with a CTA to return to the extension catalog after the browser view is closed.

### 🗒️ Notes

- To trigger this behavior

   1. Install the Epinio extension
   2. Navigate to the Epinio extension and ensure that it renders properly
   3. With the Epinio extension active in the UI, uninstall it via `rdctl extension uninstall ghcr.io/rancher-sandbox/epinio-desktop-extension:0.0.23.4`
   4. The Epinio extension view should close and display the message that the extension was uninstalled

- The extension view should not close if a different extension is uninstalled. For example, the Tachometer extension will remain visible when the Epinio extension is uninstalled.

### 📷 Screenshots

![image](https://user-images.githubusercontent.com/835961/234969064-842d66a2-548b-46e5-a87c-198ac29fb8b5.png)
