### PR TITLE
Prevent mutex deadlock

### DIFF
--- a/src/go/privileged-service/pkg/port/portproxy.go
+++ b/src/go/privileged-service/pkg/port/portproxy.go
@@ -82,6 +82,13 @@ func (p *proxy) add(port portProxy) error {
 	if err != nil {
 		return err
 	}
+	// Ideally we would want to have the mutex lock around the entire add
+	// function to create an atomic operation for adding netsh and adding
+	// the portMappings cache. However, we don't want the netsh operation
+	// to be impacted by the lock contention and it is acceptable for cache
+	// to fall out of sync with netsh since the cost is cheap. When the cache
+	// attempts to remove an entry that does not exist or double remove an entry
+	// we would ignore the error and move on.
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	p.portMappings[hash] = port
@@ -97,6 +104,13 @@ func (p *proxy) delete(port portProxy) error {
 	if err != nil {
 		return err
 	}
+	// Ideally we would want to have the mutex lock around the entire delete
+	// function to create an atomic operation for deleting netsh and removing
+	// the portMappings cache. However, we don't want the netsh operation
+	// to be impacted by the lock contention and it is acceptable for cache
+	// to fall out of sync with netsh since the cost is cheap. When the cache
+	// attempts to remove an entry that does not exist or double remove an entry
+	// we would ignore the error and move on.
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	delete(p.portMappings, hash)

--- a/src/go/privileged-service/pkg/port/server.go
+++ b/src/go/privileged-service/pkg/port/server.go
@@ -96,14 +96,15 @@ func (s *Server) handleEvent(conn net.Conn) {
 		s.eventLogger.Error(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), fmt.Sprintf("port server decoding received payload error: %v", err))
 		return
 	}
-	s.eventLogger.Info(uint32(windows.NO_ERROR), fmt.Sprintf("%+v", pm))
+	s.eventLogger.Info(uint32(windows.NO_ERROR), fmt.Sprintf("handleEvent for %+v", pm))
 	if err = s.proxy.exec(pm); err != nil {
-		s.eventLogger.Error(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), fmt.Sprintf("port proxy failed: %v", err))
+		s.eventLogger.Error(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), fmt.Sprintf("port proxy [%+v] failed: %v", pm, err))
 	}
 }
 
 // Stop shuts down the server gracefully
 func (s *Server) Stop() {
+	s.eventLogger.Info(uint32(windows.NO_ERROR), fmt.Sprintf("remove all %+v", s.proxy.portMappings))
 	if err := s.proxy.removeAll(); err != nil {
 		s.eventLogger.Warning(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), err.Error())
 	}

--- a/src/go/privileged-service/pkg/port/server.go
+++ b/src/go/privileged-service/pkg/port/server.go
@@ -104,11 +104,11 @@ func (s *Server) handleEvent(conn net.Conn) {
 
 // Stop shuts down the server gracefully
 func (s *Server) Stop() {
+	close(s.quit)
+	s.listener.Close()
 	s.eventLogger.Info(uint32(windows.NO_ERROR), fmt.Sprintf("remove all %+v", s.proxy.portMappings))
 	if err := s.proxy.removeAll(); err != nil {
 		s.eventLogger.Warning(uint32(windows.ERROR_EXCEPTION_IN_SERVICE), err.Error())
 	}
-	close(s.quit)
-	s.listener.Close()
 	s.stopped = true
 }


### PR DESCRIPTION
Previously, the `removeAll` function was acquiring the mutex lock and while holding on to the lock it would call `delete` function which also required the mutex lock. Therefore, this was causing a deadlock in the service that became unresponsive.

- Also, adds additional event logging to help with the debugging process.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4571