### PR TITLE
Load user-defined deployment settings

### DIFF
--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -113,8 +113,8 @@ export async function readDeploymentProfiles(): Promise<settings.DeploymentProfi
     break;
   }
 
-  profiles.defaults = validateDeploymentProfile(defaults, settings.defaultSettings) ?? {};
-  profiles.locked = validateDeploymentProfile(locked, lockableDefaultSettings) ?? {};
+  profiles.defaults = validateDeploymentProfile(defaults, settings.defaultSettings, []) ?? {};
+  profiles.locked = validateDeploymentProfile(locked, lockableDefaultSettings, []) ?? {};
 
   return profiles;
 }
@@ -154,6 +154,7 @@ async function convertAndParsePlist(inputPath: string): Promise<undefined|Recurs
     throw new DeploymentProfileError(`Error parsing deployment profile JSON object from ${ inputPath }: ${ getErrorString(error) }`);
   }
 }
+
 /**
  * Read and parse plutil deployment profile files.
  * @param rootPath the system or user directory containing profiles.
@@ -260,31 +261,46 @@ function readRegistryUsingSchema(schemaObj: any, regKey: nativeReg.HKEY): Recurs
  * Do simple type validation of a deployment profile
  * @param profile The profile to be validated
  * @param schema The structure (usually defaultSettings) used as a template
+ * @param parentPathParts The parent path for the current schema key.
  * @returns The original profile, less any invalid fields
  */
-function validateDeploymentProfile(profile: any, schema: any) {
+function validateDeploymentProfile(profile: any, schema: any, parentPathParts: string[]) {
   if (typeof profile === 'object') {
     for (const key in profile) {
       if (key in schema) {
-        if (typeof profile[key] === typeof schema[key]) {
-          if (typeof profile[key] === 'object') {
-            if (Array.isArray(profile[key] !== Array.isArray(schema[key]))) {
-              console.log(`Deployment Profile ignoring '${ key }'. Array type mismatch.`);
+        if (typeof profile[key] === 'object') {
+          if (Array.isArray(profile[key])) {
+            if (!Array.isArray(schema[key])) {
+              console.log(`Deployment Profile ignoring '${ parentPathParts.join('.') }.${ key }': got an array, expecting type ${ typeof schema[key] }.`);
               delete profile[key];
-            } else if (!Array.isArray(profile[key])) {
-              validateDeploymentProfile(profile[key], schema[key]);
             }
+          } else if (parentPathParts.length <= 2 && isSpecialObject(parentPathParts, key)) {
+            // Keep this part of the profile
+          } else {
+            validateDeploymentProfile(profile[key], schema[key], parentPathParts.concat(key));
           }
-        } else {
-          console.log(`Deployment Profile ignoring '${ key }'. Wrong type.`);
+        } else if (typeof profile[key] !== typeof schema[key]) {
+          console.log(`Deployment Profile ignoring '${ parentPathParts.join('.') }.${ key }': expecting value of type ${ typeof schema[key] }, got ${ typeof profile[key] }.`);
           delete profile[key];
         }
       } else {
-        console.log(`Deployment Profile ignoring '${ key }'. Not in schema.`);
+        console.log(`Deployment Profile ignoring '${ parentPathParts.join('.') }.${ key }': not in schema.`);
         delete profile[key];
       }
     }
   }
 
   return profile;
+}
+
+function isSpecialObject(pathParts: string[], key: string): boolean {
+  switch (pathParts.length) {
+  case 0:
+    return key === 'extensions';
+  case 1:
+    return ((key === 'integrations' && pathParts[0] === 'WSL') ||
+      (key === 'mutedChecks' && pathParts[0] === 'diagnostics'));
+  }
+
+  return false;
 }

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -141,6 +141,7 @@ async function convertAndParsePlist(inputPath: string): Promise<undefined|Recurs
   try {
     plutilResult = await spawnFile('plutil', args, { stdio: [body, 'pipe', 'pipe'] });
   } catch (error: any) {
+    // throw error if plutil fails to parse the 'locked' profile
     console.log(`Error parsing deployment profile plist file ${ inputPath }\n${ error }`);
     throw new DeploymentProfileError(`Error loading plist file ${ inputPath }: ${ getErrorString(error) }`);
   }
@@ -148,6 +149,7 @@ async function convertAndParsePlist(inputPath: string): Promise<undefined|Recurs
   try {
     return JSON.parse(plutilResult.stdout ?? '');
   } catch (error: any) {
+    // throw error if we fail to parse the 'locked' profile
     console.log(`Error parsing deployment profile JSON object ${ inputPath }\n${ error }`);
     throw new DeploymentProfileError(`Error parsing deployment profile JSON object from ${ inputPath }: ${ getErrorString(error) }`);
   }


### PR DESCRIPTION
Fixes #4579

Don't filter out default settings for values like `WSL.integrations`, `diagnostics.mutedChecks`, or `extensions`.