### PR TITLE
Verify auto-start settings via BATS

### DIFF
--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -10,18 +10,23 @@ load '../helpers/load'
 
 @test 'Verify that initial Behavior is all set to false' {
     run get_setting '.application.autoStart'
+    assert_success
     assert_output false
     run get_setting '.application.startInBackground'
+    assert_success
     assert_output false
     run get_setting '.application.window.quitOnClose'
+    assert_success
     assert_output false
     run get_setting '.application.hideNotificationIcon'
+    assert_success
     assert_output false
 }
 
 @test 'Enable auto start' {
     rdctl set --application.auto-start=true
     run get_setting '.application.autoStart'
+    assert_success
     assert_output true
 }
 
@@ -45,6 +50,7 @@ load '../helpers/load'
 @test 'Disable auto start' {
     rdctl set --application.auto-start=false
     run get_setting '.application.autoStart'
+    assert_success
     assert_output false
 }
 
@@ -68,35 +74,41 @@ load '../helpers/load'
 @test 'Enable quit-on-close' {
     rdctl set --application.window.quit-on-close=true
     run get_setting '.application.window.quitOnClose'
+    assert_success
     assert_output true
 }
 
 @test 'Disable quit-on-close' {
     rdctl set --application.window.quit-on-close=false
     run get_setting '.application.window.quitOnClose'
+    assert_success
     assert_output false
 }
 
 @test 'Enable start-in-background' {
     rdctl set --application.start-in-background=true
     run get_setting '.application.startInBackground'
+    assert_success
     assert_output true
 }
 
 @test 'Disable start-in-background' {
     rdctl set --application.start-in-background=false
     run get_setting '.application.startInBackground'
+    assert_success
     assert_output false
 }
 
 @test 'Enable hide-notification-icon' {
     rdctl set --application.hide-notification-icon=true
     run get_setting '.application.hideNotificationIcon'
+    assert_success
     assert_output true
 }
 
 @test 'Disable hide-notification-icon' {
     rdctl set --application.hide-notification-icon=false
     run get_setting '.application.hideNotificationIcon'
+    assert_success
     assert_output false
 }

--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -10,7 +10,9 @@ load '../helpers/load'
 
 get_json_key() {
     local json_key=$1
-    rdctl list-settings | jq -r "${json_key}" 3>&-
+    run rdctl list-settings
+    assert_success
+    jq -r "${json_key}" <<<"${output}"
 }
 
 @test 'Verify that initial Behavior is all set to false' {
@@ -25,8 +27,7 @@ get_json_key() {
 }
 
 @test 'Enable auto start' {
-    run rdctl set --application.auto-start=true
-    assert_success
+    rdctl set --application.auto-start=true
     run get_json_key '.application.autoStart'
     assert_output true
 }
@@ -43,13 +44,13 @@ get_json_key() {
 
     if is_windows; then
         run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
+        assert_success
         assert_line --index 2 --partial "\Rancher Desktop\Rancher Desktop.exe"
     fi
 }
 
 @test 'Disable auto start' {
-    run rdctl set --application.auto-start=false
-    assert_success
+    rdctl set --application.auto-start=false
     run get_json_key '.application.autoStart'
     assert_output false
 }
@@ -66,48 +67,43 @@ get_json_key() {
 
     if is_windows; then
         run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
+        assert_success
         assert_output --partial "The system was unable to find the specified registry"
     fi
 }
 
 @test 'Enable quit-on-close' {
-    run rdctl set --application.window.quit-on-close=true
-    assert_success
+    rdctl set --application.window.quit-on-close=true
     run get_json_key '.application.window.quitOnClose'
     assert_output true
 }
 
 @test 'Disable quit-on-close' {
-    run rdctl set --application.window.quit-on-close=false
-    assert_success
+    rdctl set --application.window.quit-on-close=false
     run get_json_key '.application.window.quitOnClose'
     assert_output false
 }
 
 @test 'Enable start-in-background' {
-    run rdctl set --application.start-in-background=true
-    assert_success
+    rdctl set --application.start-in-background=true
     run get_json_key '.application.startInBackground'
     assert_output true
 }
 
 @test 'Disable start-in-background' {
-    run rdctl set --application.start-in-background=false
-    assert_success
+    rdctl set --application.start-in-background=false
     run get_json_key '.application.startInBackground'
     assert_output false
 }
 
 @test 'Enable hide-notification-icon' {
-    run rdctl set --application.hide-notification-icon=true
-    assert_success
+    rdctl set --application.hide-notification-icon=true
     run get_json_key '.application.hideNotificationIcon'
     assert_output true
 }
 
 @test 'Disable hide-notification-icon' {
-    run rdctl set --application.hide-notification-icon=false
-    assert_success
+    rdctl set --application.hide-notification-icon=false
     run get_json_key '.application.hideNotificationIcon'
     assert_output false
 }

--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -1,0 +1,113 @@
+load '../helpers/load'
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'Start up Rancher Desktop' {
+    start_application
+}
+
+get_json_key() {
+    local json_key=$1
+    rdctl list-settings | jq -r "${json_key}" 3>&-
+}
+
+@test 'Verify that initial Behavior is all set to false' {
+    run get_json_key '.application.autoStart'
+    assert_output false
+    run get_json_key '.application.startInBackground'
+    assert_output false
+    run get_json_key '.application.window.quitOnClose'
+    assert_output false
+    run get_json_key '.application.hideNotificationIcon'
+    assert_output false
+}
+
+@test 'Enable auto start' {
+    run rdctl set --application.auto-start=true
+    assert_success
+    run get_json_key '.application.autoStart'
+    assert_output true
+}
+
+@test 'Verify that the auto-start config is created' {
+
+    if is_linux; then
+        assert_file_exists "${XDG_CONFIG_HOME:-$HOME/.config}/autostart/rancher-desktop.desktop"
+    fi
+
+    if is_macos; then
+        assert_file_exists "$HOME/Library/LaunchAgents/io.rancherdesktop.autostart.plist"
+    fi
+
+    if is_windows; then
+        run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
+        assert_line --index 2 --partial "\Rancher Desktop\Rancher Desktop.exe"
+    fi
+}
+
+@test 'Disable auto start' {
+    run rdctl set --application.auto-start=false
+    assert_success
+    run get_json_key '.application.autoStart'
+    assert_output false
+}
+
+@test 'Verify that the auto-start config is removed' {
+
+    if is_linux; then
+        assert_file_not_exists "${XDG_CONFIG_HOME:-$HOME/.config}/autostart/rancher-desktop.desktop"
+    fi
+
+    if is_macos; then
+        assert_file_not_exists "$HOME/Library/LaunchAgents/io.rancherdesktop.autostart.plist"
+    fi
+
+    if is_windows; then
+        run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
+        assert_output --partial "The system was unable to find the specified registry"
+    fi
+}
+
+@test 'Enable quit-on-close' {
+    run rdctl set --application.window.quit-on-close=true
+    assert_success
+    run get_json_key '.application.window.quitOnClose'
+    assert_output true
+}
+
+@test 'Disable quit-on-close' {
+    run rdctl set --application.window.quit-on-close=false
+    assert_success
+    run get_json_key '.application.window.quitOnClose'
+    assert_output false
+}
+
+@test 'Enable start-in-background' {
+    run rdctl set --application.start-in-background=true
+    assert_success
+    run get_json_key '.application.startInBackground'
+    assert_output true
+}
+
+@test 'Disable start-in-background' {
+    run rdctl set --application.start-in-background=false
+    assert_success
+    run get_json_key '.application.startInBackground'
+    assert_output false
+}
+
+@test 'Enable hide-notification-icon' {
+    run rdctl set --application.hide-notification-icon=true
+    assert_success
+    run get_json_key '.application.hideNotificationIcon'
+    assert_output true
+}
+
+@test 'Disable hide-notification-icon' {
+    run rdctl set --application.hide-notification-icon=false
+    assert_success
+    run get_json_key '.application.hideNotificationIcon'
+    assert_output false
+}

--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -8,27 +8,20 @@ load '../helpers/load'
     start_application
 }
 
-get_json_key() {
-    local json_key=$1
-    run rdctl list-settings
-    assert_success
-    jq -r "${json_key}" <<<"${output}"
-}
-
 @test 'Verify that initial Behavior is all set to false' {
-    run get_json_key '.application.autoStart'
+    run get_setting '.application.autoStart'
     assert_output false
-    run get_json_key '.application.startInBackground'
+    run get_setting '.application.startInBackground'
     assert_output false
-    run get_json_key '.application.window.quitOnClose'
+    run get_setting '.application.window.quitOnClose'
     assert_output false
-    run get_json_key '.application.hideNotificationIcon'
+    run get_setting '.application.hideNotificationIcon'
     assert_output false
 }
 
 @test 'Enable auto start' {
     rdctl set --application.auto-start=true
-    run get_json_key '.application.autoStart'
+    run get_setting '.application.autoStart'
     assert_output true
 }
 
@@ -51,7 +44,7 @@ get_json_key() {
 
 @test 'Disable auto start' {
     rdctl set --application.auto-start=false
-    run get_json_key '.application.autoStart'
+    run get_setting '.application.autoStart'
     assert_output false
 }
 
@@ -74,36 +67,36 @@ get_json_key() {
 
 @test 'Enable quit-on-close' {
     rdctl set --application.window.quit-on-close=true
-    run get_json_key '.application.window.quitOnClose'
+    run get_setting '.application.window.quitOnClose'
     assert_output true
 }
 
 @test 'Disable quit-on-close' {
     rdctl set --application.window.quit-on-close=false
-    run get_json_key '.application.window.quitOnClose'
+    run get_setting '.application.window.quitOnClose'
     assert_output false
 }
 
 @test 'Enable start-in-background' {
     rdctl set --application.start-in-background=true
-    run get_json_key '.application.startInBackground'
+    run get_setting '.application.startInBackground'
     assert_output true
 }
 
 @test 'Disable start-in-background' {
     rdctl set --application.start-in-background=false
-    run get_json_key '.application.startInBackground'
+    run get_setting '.application.startInBackground'
     assert_output false
 }
 
 @test 'Enable hide-notification-icon' {
     rdctl set --application.hide-notification-icon=true
-    run get_json_key '.application.hideNotificationIcon'
+    run get_setting '.application.hideNotificationIcon'
     assert_output true
 }
 
 @test 'Disable hide-notification-icon' {
     rdctl set --application.hide-notification-icon=false
-    run get_json_key '.application.hideNotificationIcon'
+    run get_setting '.application.hideNotificationIcon'
     assert_output false
 }

--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -60,7 +60,7 @@ load '../helpers/load'
 
     if is_windows; then
         run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
-        assert_success
+        assert_failure
         assert_output --partial "The system was unable to find the specified registry"
     fi
 }

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -26,6 +26,17 @@ assert_nothing() {
     true
 }
 
+jq_output() {
+    jq -r "$@" <<<"${output}"
+}
+
+get_setting() {
+    local json_key=$1
+    run rdctl api /settings
+    assert_success
+    jq_output "${json_key}"
+}
+
 try() {
     local max=24
     local delay=5

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -31,10 +31,9 @@ jq_output() {
 }
 
 get_setting() {
-    local json_key=$1
     run rdctl api /settings
     assert_success
-    jq_output "${json_key}"
+    jq_output "$@"
 }
 
 try() {


### PR DESCRIPTION
This test is to verify all the features included in `Preferences >Application>Behavior` and includes enabling and disabling via `rdctl set` the `hide-notification-icon`, `start-in-background`, `auto-start` and `quit-on-close`. It also verifies if the configuration for the `auto-start` is created/removed in all platforms. 
