### PR TITLE
RDX: Fix installation on Windows

### DIFF
--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -7,6 +7,10 @@ setup() {
 
     TESTDATA_DIR="${PATH_TEST_ROOT}/extensions/testdata/"
 
+    if using_windows_exe; then
+        TESTDATA_DIR="$(wslpath -m "${TESTDATA_DIR}")"
+    fi
+
     if using_containerd; then
         namespace_arg=('--namespace=rancher-desktop-extensions')
     else

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -7,6 +7,12 @@ setup() {
 
     TESTDATA_DIR="${PATH_TEST_ROOT}/extensions/testdata/"
 
+    if using_windows_exe; then
+        TESTDATA_DIR_CLI="$(wslpath -m "${TESTDATA_DIR}")"
+    else
+        TESTDATA_DIR_CLI="${TESTDATA_DIR}"
+    fi
+
     if using_containerd; then
         namespace_arg=('--namespace=rancher-desktop-extensions')
     else
@@ -64,7 +70,10 @@ encoded_id() { # variant
         basic host-binaries missing-icon missing-icon-file ui
     )
     for extension in "${variants[@]}"; do
-        ctrctl "${namespace_arg[@]}" build --tag "rd/extension/$extension" --build-arg "variant=$extension" "$TESTDATA_DIR"
+        ctrctl "${namespace_arg[@]}" build \
+            --tag "rd/extension/$extension" \
+            --build-arg "variant=$extension" \
+            "$TESTDATA_DIR_CLI"
     done
     run ctrctl "${namespace_arg[@]}" image list --format '{{ .Repository }}'
     assert_success

--- a/pkg/rancher-desktop/backend/backend.ts
+++ b/pkg/rancher-desktop/backend/backend.ts
@@ -199,6 +199,11 @@ export type execOptions = childProcess.CommonOptions & {
  */
 export interface VMExecutor {
   /**
+   * The backend in use.
+   */
+  readonly backend: VMBackend['backend'];
+
+  /**
    * execCommand runs the given command in the virtual machine.
    * @param execOptions Execution options.  If capture is set, standard output is
    *    returned.

--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -169,33 +169,33 @@ export class MobyClient implements ContainerEngineClient {
     }
   }
 
-  async composeUp(composeDir: string, options?: ContainerComposeOptions): Promise<void> {
-    const args = ['--project-directory', composeDir];
+  async composeUp(options: ContainerComposeOptions): Promise<void> {
+    const args = ['--project-directory', options.composeDir];
 
-    if (options?.name) {
+    if (options.name) {
       args.push('--project-name', options.name);
     }
     args.push('up', '--quiet-pull', '--wait', '--remove-orphans');
 
-    const result = await this.runTool({ env: options?.env ?? {} }, 'docker-compose', ...args);
+    const result = await this.runTool({ env: options.env ?? {} }, 'docker-compose', ...args);
 
     console.debug('ran docker compose up', result);
   }
 
-  async composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void> {
+  async composeDown(options: ContainerComposeOptions): Promise<void> {
     const args = [
-      options?.name ? ['--project-name', options.name] : [],
-      ['--project-directory', composeDir, 'down'],
+      options.name ? ['--project-name', options.name] : [],
+      ['--project-directory', options.composeDir, 'down'],
     ].flat();
-    const result = await this.runTool('docker-compose', ...args);
+    const result = await this.runTool({ env: options.env ?? {} }, 'docker-compose', ...args);
 
     console.debug('ran docker compose down', result);
   }
 
-  composeExec(composeDir: string, options: ContainerComposeExecOptions): Promise<ReadableProcess> {
+  composeExec(options: ContainerComposeExecOptions): Promise<ReadableProcess> {
     const args = [
       options.name ? ['--project-name', options.name] : [],
-      ['--project-directory', composeDir, 'exec'],
+      ['--project-directory', options.composeDir, 'exec'],
       options.user ? ['--user', options.user] : [],
       options.workdir ? ['--workdir', options.workdir] : [],
       [options.service, ...options.command],
@@ -210,10 +210,10 @@ export class MobyClient implements ContainerEngineClient {
     }));
   }
 
-  async composePort(composeDir: string, options: ContainerComposePortOptions): Promise<string> {
+  async composePort(options: ContainerComposePortOptions): Promise<string> {
     const args = [
       options.name ? ['--project-name', options.name] : [],
-      ['--project-directory', composeDir, 'port'],
+      ['--project-directory', options.composeDir, 'port'],
       options.protocol ? ['--protocol', options.protocol] : [],
       [options.service, options.port.toString()],
     ].flat();

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -150,9 +150,8 @@ export class NerdctlClient implements ContainerEngineClient {
   }
 
   copyFile(imageID: string, sourcePath: string, destinationDir: string): Promise<void>;
-  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { resolveSymlinks: false, namespace?: string }): Promise<void>;
-  async copyFile(imageID: string, sourcePath: string, destinationDir: string, options?: { resolveSymlinks?: boolean, namespace?: string }): Promise<void> {
-    const resolveSymlinks = options?.resolveSymlinks !== false;
+  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { namespace?: string }): Promise<void>;
+  async copyFile(imageID: string, sourcePath: string, destinationDir: string, options?: { namespace?: string }): Promise<void> {
     const [imageDir, cleanups] = await this.mountImage(imageID, options?.namespace);
 
     try {
@@ -161,7 +160,7 @@ export class NerdctlClient implements ContainerEngineClient {
       const archive = path.posix.join(workDir, 'archive.tgz');
       const fileList = path.posix.join(workDir, 'files.txt');
 
-      cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', archive));
+      cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', workDir));
       let sourceName: string, sourceDir: string;
 
       if (sourcePath.endsWith('/')) {
@@ -186,8 +185,7 @@ export class NerdctlClient implements ContainerEngineClient {
 
       const args = [
         '--create', '--gzip', '--file', archive, '--directory', sourceDir,
-        resolveSymlinks ? '--dereference' : undefined,
-        '--one-file-system', '--sparse', '--files-from', fileList,
+        '--dereference', '--one-file-system', '--sparse', '--files-from', fileList,
       ].filter(defined);
 
       await this.vm.execCommand({ root: true }, '/usr/bin/tar', ...args);

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -180,7 +180,7 @@ export class NerdctlClient implements ContainerEngineClient {
       const archive = path.posix.join(workDir, 'archive.tgz');
       const fileList = path.posix.join(workDir, 'files.txt');
 
-      cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', workDir));
+      cleanups.push(() => this.vm.execCommand('/bin/rm', '-rf', workDir));
       let sourceName: string, sourceDir: string;
 
       if (sourcePath.endsWith('/')) {

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -101,12 +101,12 @@ export interface ContainerEngineClient {
    * an extra directory.  Otherwise, this is the parent directory, and the
    * named file will be created within this directory with the same base name as
    * in the VM.
-   * @param [options.resolveSymlinks] Follow symlinks in the source; default true.
    * @param [options.namespace] Namespace the image is in, if supported.
-   * @note Symbolic links might not be copied correctly (for example, the host might be Windows).
+   * @note Symbolic links are always resolved, as some hosts might not support
+   * them.
    */
   copyFile(imageID: string, sourcePath: string, destinationDir: string): Promise<void>;
-  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { resolveSymlinks?: false, namespace?: string }): Promise<void>;
+  copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { namespace?: string }): Promise<void>;
 
   /**
    * Start a container.

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -39,6 +39,8 @@ export type ContainerStopOptions = ContainerBasicOptions & {
  * optional.
  */
 export type ContainerComposeOptions = ContainerBasicOptions & {
+  /** The directory holding the compose files. */
+  composeDir: string;
   /** The name of the project */
   name?: string;
   /** Environment variables to set on build */
@@ -121,29 +123,25 @@ export interface ContainerEngineClient {
 
   /**
    * Start containers via `docker compose` / `nerdctl compose`.
-   * @param composeDir The path containing the compose file.
    */
-  composeUp(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
+  composeUp(options: ContainerComposeOptions): Promise<void>;
 
   /**
    * Stop containers via `docker compose` / `nerdctl compose`.
-   * @param composeDir The path containing the compose file.
    */
-  composeDown(composeDir: string, options?: ContainerComposeOptions): Promise<void>;
+  composeDown(options?: ContainerComposeOptions): Promise<void>;
 
   /**
    * Spawn a process using `docker compose exec` / `nerdctl ...`, returning a
    * raw process that has stdout and stderr set to pipe (but nothing for stdin).
-   * @param composeDir The host path containing the compose file.
    */
-  composeExec(composeDir: string, options: ContainerComposeExecOptions): Promise<ReadableProcess>;
+  composeExec(options: ContainerComposeExecOptions): Promise<ReadableProcess>;
 
   /**
    * Get port information for a compose service.
-   * @param composeDir The host path containing the compose file.
    * @returns The port information, looking like `0.0.0.0:12345`.
    */
-  composePort(composeDir: string, options: ContainerComposePortOptions): Promise<string>;
+  composePort(options: ContainerComposePortOptions): Promise<string>;
 
   /**
    * Run the client directly, using the given arguments.  The 'stdio' argument

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -81,6 +81,11 @@ export type ContainerRunClientOptions = SpawnOptions & { namespace?: string };
  */
 export interface ContainerEngineClient {
   /**
+   * Block until the container engine is ready.
+   */
+  waitForReady(): Promise<void>;
+
+  /**
    * Read the file from the given container image.
    * @param imageID The ID of the image to read.
    * @param filePath The file to read, relative to the root of the container.

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -927,11 +927,17 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   async execCommand(options: wslExecOptions & { capture: true }, ...command: string[]): Promise<string>;
   async execCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<void | string> {
     let options: wslExecOptions = {};
+    const cwdOptions: string[] = [];
 
     if (typeof optionsOrArg === 'string') {
       command = [optionsOrArg].concat(command);
     } else {
       options = optionsOrArg;
+    }
+
+    if (options.cwd) {
+      cwdOptions.push('--cd', options.cwd.toString());
+      delete options.cwd;
     }
 
     const expectFailure = options.expectFailure ?? false;
@@ -940,7 +946,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       // Print a slightly different message if execution fails.
       return await this.execWSL({
         encoding: 'utf-8', ...options, expectFailure: true,
-      }, '--distribution', options.distro ?? INSTANCE_NAME, '--exec', ...command);
+      }, '--distribution', options.distro ?? INSTANCE_NAME, ...cwdOptions, '--exec', ...command);
     } catch (ex) {
       if (!expectFailure) {
         console.log(`WSL: executing: ${ command.join(' ') }: ${ ex }`);

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -694,15 +694,15 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   }
 
   async copyFileIn(hostPath: string, vmPath: string): Promise<void> {
-    const windowsPath = (await this.execCommand({ capture: true }, '/bin/wslpath', '-w', vmPath)).trim();
-
-    await fs.promises.copyFile(windowsPath, hostPath);
+    // Sometimes WSL has issues copying _from_ the VM.  So we instead do the
+    // copying from inside the VM.
+    await this.execCommand('/bin/cp', '-f', '-T', await this.wslify(hostPath), vmPath);
   }
 
   async copyFileOut(vmPath: string, hostPath: string): Promise<void> {
-    const windowsPath = (await this.execCommand({ capture: true }, '/bin/wslpath', '-w', vmPath)).trim();
-
-    await fs.promises.copyFile(windowsPath, hostPath);
+    // Sometimes WSL has issues copying _from_ the VM.  So we instead do the
+    // copying from inside the VM.
+    await this.execCommand('/bin/cp', '-f', '-T', vmPath, await this.wslify(hostPath));
   }
 
   /**

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1384,9 +1384,10 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           break;
         case ContainerEngine.MOBY:
           this.#containerEngineClient = new MobyClient(this, 'npipe:////./pipe/docker_engine');
-          await this.progressTracker.action('Waiting for socket to stabilize', 0, this.waitForDockerSocket());
           break;
         }
+
+        await this.progressTracker.action('Waiting for container engine to be ready', 0, this.containerEngineClient.waitForReady());
 
         // If it's not a privileged installation preset guestAgent
         // port binding address to localhost only.
@@ -1497,29 +1498,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         await this.execCommand('/usr/local/bin/wsl-service', 'local', 'start');
       })(),
     ]);
-  }
-
-  /**
-   * The docker proxy process flaps a bit at the start while things are starting
-   * up.  We need to wait for it to stabilize before declaring it ready.
-   */
-  async waitForDockerSocket(): Promise<void> {
-    let successCount = 0;
-
-    // Wait for ten consecutive successes, clearing out successCount whenever we
-    // hit an error.  In the ideal case this is a ten-second delay in startup
-    // time.  We use `docker system info` because that needs to talk to the
-    // socket to fetch data about the engine (and it returns an error if it
-    // fails to do so).
-    while (successCount < 10) {
-      try {
-        await this.containerEngineClient.runClient(['system', 'info'], 'ignore');
-        successCount++;
-      } catch (ex) {
-        successCount = 0;
-      }
-      await util.promisify(setTimeout)(1_000);
-    }
   }
 
   async stop(): Promise<void> {

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -244,16 +244,7 @@ export class ExtensionImpl implements Extension {
         composeDir,
         { namespace: this.extensionNamespace });
 
-      const composeNames = ['compose.yaml', 'compose.yml', 'docker-compose.yaml', 'docker-compose.yml'];
-
-      for (const composeName of composeNames) {
-        try {
-          contents = yaml.parse(await fs.promises.readFile(path.join(composeDir, composeName), 'utf-8'));
-          break;
-        } catch (ex) {
-          /* Try the next file, or fall back to nothing */
-        }
-      }
+      contents = yaml.parse(await fs.promises.readFile(path.join(composeDir, path.posix.basename(metadata.vm.composefile)), 'utf-8'));
     } else {
       console.debug(`Extension ${ this.id } does not have containers to run.`);
 

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -294,8 +294,8 @@ export class ExtensionImpl implements Extension {
     // Run `ctrctl compose up`
     console.debug(`Running ${ this.id } compose up`);
     await this.client.composeUp(
-      composeDir,
       {
+        composeDir,
         name:      this.containerName,
         namespace: this.extensionNamespace,
         env:       { DESKTOP_PLUGIN_IMAGE: this.image },
@@ -329,14 +329,12 @@ export class ExtensionImpl implements Extension {
 
   protected async uninstallContainers() {
     console.debug(`Running ${ this.id } compose down`);
-    await this.client.composeDown(
-      path.join(this.dir, 'compose'),
-      {
-        name:      this.containerName,
-        namespace: this.extensionNamespace,
-        env:       { DESKTOP_PLUGIN_IMAGE: this.image },
-      },
-    );
+    await this.client.composeDown({
+      composeDir: path.join(this.dir, 'compose'),
+      name:       this.containerName,
+      namespace:  this.extensionNamespace,
+      env:        { DESKTOP_PLUGIN_IMAGE: this.image },
+    });
   }
 
   async isInstalled(): Promise<boolean> {
@@ -365,15 +363,15 @@ export class ExtensionImpl implements Extension {
   }
 
   async getBackendPort() {
-    const portInfo = await this.client.composePort(
-      path.join(this.dir, 'compose'), {
-        name:      this.containerName,
-        namespace: this.extensionNamespace,
-        env:       { DESKTOP_PLUGIN_IMAGE: this.image },
-        service:   'r-d-x-port-forwarding',
-        port:      80,
-        protocol:  'tcp',
-      });
+    const portInfo = await this.client.composePort({
+      composeDir: path.join(this.dir, 'compose'),
+      name:       this.containerName,
+      namespace:  this.extensionNamespace,
+      env:        { DESKTOP_PLUGIN_IMAGE: this.image },
+      service:    'r-d-x-port-forwarding',
+      port:       80,
+      protocol:   'tcp',
+    });
 
     // The port info looks like "0.0.0.0:1234", return only the port number.
     return /:(\d+)$/.exec(portInfo)?.[1];
@@ -393,12 +391,13 @@ export class ExtensionImpl implements Extension {
       throw new Error('No services found, cannot run exec');
     }
 
-    return this.client.composeExec(path.join(this.dir, 'compose'), {
-      name:      this.containerName,
-      namespace: this.extensionNamespace,
-      env:       { ...options.env, DESKTOP_PLUGIN_IMAGE: this.image },
+    return this.client.composeExec({
+      composeDir: path.join(this.dir, 'compose'),
+      name:       this.containerName,
+      namespace:  this.extensionNamespace,
+      env:        { ...options.env, DESKTOP_PLUGIN_IMAGE: this.image },
       service,
-      command:   options.command,
+      command:    options.command,
       ...options.cwd ? { workdir: options.cwd } : {},
     });
   }

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -87,17 +87,18 @@ export class ExtensionImpl implements Extension {
         const raw = await this.readFile('metadata.json');
         const result = _.merge({}, fallback, JSON.parse(raw));
 
-        if (!result.icon) {
-          throw new ExtensionErrorImpl(ExtensionErrorCode.INVALID_METADATA, 'Invalid extension: missing icon');
+        if (result.icon) {
+          return result;
         }
-
-        return result;
       } catch (ex: any) {
         console.error(`Failed to read metadata for ${ this.id }: ${ ex }`);
         // Unset metadata so we can try again later
         this._metadata = undefined;
         throw new ExtensionErrorImpl(ExtensionErrorCode.INVALID_METADATA, 'Could not read extension metadata', ex);
       }
+      // If we reach here, we got the metadata but there was no icon set.
+      // There's no point in retrying in that case.
+      throw new ExtensionErrorImpl(ExtensionErrorCode.INVALID_METADATA, 'Invalid extension: missing icon');
     })();
 
     return this._metadata as Promise<ExtensionMetadata>;

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -130,7 +130,9 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
     // Build options to pass to the main process, while not trusting the input
     // too much.
     const safeOptions: SpawnOptions = {
-      command: [`${ cmd }`].concat(Array.from(args).map(arg => `${ arg }`)),
+      command: [`${ cmd }`].concat(Array.from(args).map((arg) => {
+        return `${ arg }`.replace(/^(["'])(.*)\1$/, '\\2');
+      })),
       execId,
       scope,
       ...options?.cwd ? { cwd: options.cwd } : {},


### PR DESCRIPTION
This fixes issues with installing extensions on Windows.

- There's some differences with how `nerdctl compose up` needs to be handled (because we use `nerdctl-stub` there)
- There's also differences when copying files out on Windows (while Windows `tar.exe` supports symlinks, it requires administrator privileges).
- Fixes running commands in WSL at a specific (Linux) directory.
- When starting, wait for the containerd backend to finish starting, like we do for the moby socket.

This should fix #4349 — needs to re-check after.