### PR TITLE
Protect rdx-proxy and installed RDX images from deletion

### DIFF
--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -101,6 +101,10 @@ export default {
       type:     Array,
       required: true,
     },
+    protectedImages: {
+      type:    Array,
+      default: () => [],
+    },
     imageNamespaces: {
       type:     Array,
       required: true,
@@ -342,7 +346,7 @@ export default {
       return row.imageName && row.imageName !== '<none>';
     },
     isDeletable(row) {
-      return row.imageName !== 'moby/buildkit' && !row.imageName.startsWith('rancher/');
+      return !this.protectedImages.includes(row.imageName);
     },
     isPushable(row) {
       // If it doesn't contain a '/', it's certainly not pushable,


### PR DESCRIPTION
This protects `ghcr.io/rancher-sandbox/rancher-desktop/rdx-proxy` and installed RDX images from deletion. 

Fetching a list of installed RDX images requires an IPC call, we shift the list of "protected images" into the Images page. This is done for two reasons:

1. Keeps pages as the boundary for interacting with backend and api calls
2. Ensures that the list of "protected images" is maintained in a single location

closes #4466 
 