### PR TITLE
RDX: Use image labels for the installed extensions list

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1082,8 +1082,14 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     })());
   }
 
-  listExtensions(): Promise<Record<string, string>> {
-    const entries = Object.entries(cfg.extensions).filter(([k, v]) => v);
+  async listExtensions() {
+    const extensionManager = await getExtensionManager();
+    const extensions = await extensionManager?.getInstalledExtensions() ?? [];
+    const entries = await Promise.all(extensions.map(async x => [x.id, {
+      version:  x.version,
+      metadata: await x.metadata,
+      labels:   await x.labels,
+    }] as const));
 
     return Promise.resolve(Object.fromEntries(entries));
   }

--- a/background.ts
+++ b/background.ts
@@ -279,7 +279,7 @@ Electron.app.whenReady().then(async() => {
     diagnostics.runChecks().catch(console.error);
 
     await startBackend(cfg);
-    await listExtensionsMetadata();
+    window.send('extensions/changed');
   } catch (ex) {
     console.error('Error starting up:', ex);
     gone = true;
@@ -530,8 +530,6 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 });
 
 mainEvents.on('settings-write', writeSettings);
-
-ipcMainProxy.on('extensions/list', listExtensionsMetadata);
 
 ipcMainProxy.on('extensions/open', (_event, id, path) => {
   window.openExtension(id, path);
@@ -853,13 +851,6 @@ async function getExtensionManager() {
   return await getEM();
 }
 
-async function listExtensionsMetadata() {
-  const extensionManager = await getExtensionManager();
-  const extensions = await extensionManager?.getInstalledExtensions() ?? [];
-
-  window.send('extensions/list', extensions);
-}
-
 function newK8sManager() {
   const arch = (Electron.app.runningUnderARM64Translation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';
   const mgr = K8sFactory(arch, dockerDirManager);
@@ -1122,7 +1113,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
         }
         throw ex;
       } finally {
-        listExtensionsMetadata();
+        window.send('extensions/changed');
       }
     } else {
       console.debug(`Uninstalling extension ${ image }...`);
@@ -1143,7 +1134,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
         }
         throw ex;
       } finally {
-        listExtensionsMetadata();
+        window.send('extensions/changed');
       }
     }
   }

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -58,7 +58,7 @@ encoded_id() { # variant
 
     run rdctl api /v1/extensions
     assert_success
-    output="$(jq ".[\"$(id vm-image)\"]" <<<"${output}")"
+    output="$(jq ".[\"$(id vm-image)\"].version" <<<"${output}")"
     assert_output '"latest"'
 }
 
@@ -81,7 +81,7 @@ encoded_id() { # variant
 
     run rdctl api /v1/extensions
     assert_success
-    output="$(jq ".[\"$(id vm-compose)\"]" <<<"${output}")"
+    output="$(jq ".[\"$(id vm-compose)\"].version" <<<"${output}")"
     assert_output '"latest"'
 }
 

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -131,7 +131,16 @@ paths:
               schema:
                 type: object
                 additionalProperties:
-                  type: string
+                  type: object
+                  properties:
+                    version:
+                      type: string
+                    metadata:
+                      type: object
+                    labels:
+                      type: object
+                      additionalProperties:
+                        type: string
 
   /v1/extensions/install:
     post:

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -15,7 +15,7 @@
     </ul>
     <template v-if="featureExtensions">
       <hr>
-      <template v-for="extension in extensions">
+      <template v-for="extension in extensionsWithUI">
         <nuxt-link
           :key="extension.id"
           :data-test="`extension-nav-${ extension.metadata.ui['dashboard-tab'].title.toLowerCase() }`"
@@ -44,11 +44,17 @@ import os from 'os';
 
 import { NuxtApp } from '@nuxt/types/app';
 import { BadgeState } from '@rancher/components';
+import { PropType } from 'vue';
 import { RouteRecordPublic } from 'vue-router';
 
 import NavItem from './NavItem.vue';
 
+import type { ExtensionMetadata } from '@pkg/main/extensions/types';
 import { hexEncode } from '@pkg/utils/string-encode';
+
+type ExtensionWithUI = ExtensionMetadata & {
+  ui: { 'dashboard-tab': { title: string } };
+};
 
 export default {
   components: {
@@ -79,7 +85,7 @@ export default {
       },
     },
     extensions: {
-      type:     Array,
+      type:     Array as PropType<{ id: string, metadata: ExtensionMetadata }[]>,
       required: true,
     },
   },
@@ -104,6 +110,11 @@ export default {
       const nuxt: NuxtApp = (this as any).$nuxt;
 
       return !!nuxt.$config.featureExtensions;
+    },
+    extensionsWithUI(): { id: string, metadata: ExtensionWithUI }[] {
+      const allExtensions: { id: string, metadata: ExtensionMetadata }[] = (this as any).extensions;
+
+      return allExtensions.filter(ext => ext.metadata?.ui?.['dashboard-tab']) as any;
     },
   },
   methods: {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -38,9 +38,6 @@ export default {
     TheTitle,
   },
 
-  data() {
-    return { extensions: [] };
-  },
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
     if (!this.credentials.port || !this.credentials.user || !this.credentials.password) {
@@ -73,6 +70,7 @@ export default {
     },
     ...mapState('credentials', ['credentials']),
     ...mapGetters('diagnostics', ['diagnostics']),
+    ...mapGetters('extensions', { extensions: 'list' }),
   },
 
   beforeMount() {
@@ -82,12 +80,10 @@ export default {
     ipcRenderer.on('route', (event, args) => {
       this.goToRoute(args);
     });
-    ipcRenderer.on('extensions/list', (_event, extensions) => {
-      this.extensions = (extensions || []).filter((e) => {
-        return !!e.metadata.ui?.['dashboard-tab'];
-      });
+    ipcRenderer.on('extensions/changed', () => {
+      this.$store.dispatch('extensions/fetch');
     });
-    ipcRenderer.send('extensions/list');
+    this.$store.dispatch('extensions/fetch');
 
     ipcRenderer.on('extensions/getContentArea', () => {
       const rect = this.$refs['rdx-title'].$el.getBoundingClientRect();

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import type { Settings } from '@pkg/config/settings';
 import type { TransientSettings } from '@pkg/config/transientSettings';
 import type { DiagnosticsResultCollection } from '@pkg/main/diagnostics/diagnostics';
+import { ExtensionMetadata } from '@pkg/main/extensions/types';
 import mainEvents from '@pkg/main/mainEvents';
 import { getVtunnelInstance } from '@pkg/main/networking/vtunnel';
 import * as serverHelper from '@pkg/main/serverHelper';
@@ -641,7 +642,7 @@ export interface CommandWorkerInterface {
 
   // #region extensions
   /** List the installed extensions with their versions */
-  listExtensions(): Promise<Record<string, string>>;
+  listExtensions(): Promise<Record<string, {version: string, metadata: ExtensionMetadata, labels: Record<string, string>}>>;
   /**
    * Install or uninstall the given extension, returning an appropriate HTTP status code.
    * @param state Whether to install or uninstall the extension.

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -67,6 +67,7 @@ export class ExtensionImpl implements Extension {
   readonly dir: string;
   protected readonly client: ContainerEngineClient;
   protected _metadata: Promise<ExtensionMetadata> | undefined;
+  protected _labels: Promise<Record<string, string>> | undefined;
   /** The (nerdctl) namespace to use; shared with ExtensionManagerImpl */
   static readonly extensionNamespace = 'rancher-desktop-extensions';
   protected readonly VERSION_FILE = 'version.txt';
@@ -101,6 +102,26 @@ export class ExtensionImpl implements Extension {
     })();
 
     return this._metadata as Promise<ExtensionMetadata>;
+  }
+
+  /** Extension image labels */
+  get labels(): Promise<Record<string, string>> {
+    this._labels ??= (async() => {
+      if (await this.isInstalled()) {
+        const labelPath = path.join(this.dir, 'labels.json');
+
+        return JSON.parse(await fs.promises.readFile(labelPath, 'utf-8'));
+      }
+
+      const info = await this.client.runClient(
+        ['image', 'inspect', '--format={{ json .Config.Labels }}', this.image],
+        'pipe',
+        { namespace: ExtensionImpl.extensionNamespace });
+
+      return JSON.parse(info.stdout);
+    })();
+
+    return this._labels as Promise<Record<string, string>>;
   }
 
   protected _iconName: Promise<string> | undefined;
@@ -140,10 +161,15 @@ export class ExtensionImpl implements Extension {
     return true;
   }
 
-  protected installMetadata(workDir: string, metadata: ExtensionMetadata): Promise<void> {
-    return fs.promises.writeFile(
-      path.join(workDir, 'metadata.json'),
-      JSON.stringify(metadata, undefined, 2));
+  protected async installMetadata(workDir: string, metadata: ExtensionMetadata): Promise<void> {
+    await Promise.all([
+      fs.promises.writeFile(
+        path.join(workDir, 'metadata.json'),
+        JSON.stringify(metadata, undefined, 2)),
+      fs.promises.writeFile(
+        path.join(workDir, 'labels.json'),
+        JSON.stringify(await this.labels, undefined, 2)),
+    ]);
   }
 
   protected async installIcon(workDir: string, metadata: ExtensionMetadata): Promise<void> {

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -117,7 +117,7 @@ export interface ExtensionManager {
   /**
    * Get a collection of all installed extensions.
    */
-  getInstalledExtensions(): Promise<{ id: string; version: string, metadata: ExtensionMetadata; }[]>;
+  getInstalledExtensions(): Promise<Extension[]>;
 
   /**
    * Shut down the extension manager, doing any clean up necessary.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -65,6 +65,11 @@ export interface Extension {
   readonly metadata: Promise<ExtensionMetadata>;
 
   /**
+   * Image labels associated with this extension.
+   */
+  readonly labels: Promise<Record<string, string>>;
+
+  /**
    * Install this extension.
    * @note If the extension is already installed, this is a no-op.
    * @return Whether the extension was installed.

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -55,6 +55,9 @@ export default Vue.extend({
     browseExtensions() {
       this.$emit('click:browse');
     },
+    extensionTitle(ext: {id: string, labels: Record<string, string>}): string {
+      return ext.labels?.['org.opencontainers.image.title'] ?? ext.id;
+    },
     uninstall(id: string) {
       fetch(
         `http://localhost:${ this.credentials?.port }/v1/extensions/uninstall?id=${ id }`,
@@ -113,7 +116,7 @@ export default Vue.extend({
               }
             }"
           >
-            {{ (row.labels || {})['org.opencontainers.image.title'] || row.id }}
+            {{ extensionTitle(row) }}
           </nuxt-link>
         </td>
       </template>

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -124,7 +124,7 @@ export default Vue.extend({
         <td>
           <button
             class="btn btn-sm role-primary"
-            @click="uninstall(row.id)"
+            @click="uninstall(`${ row.id }:${ row.version }`)"
           >
             {{ t('extensions.installed.list.uninstall') }}
           </button>

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
               }
             }"
           >
-            {{ row.metadata.ui['dashboard-tab'].title }}
+            {{ (row.labels || {})['org.opencontainers.image.title'] || row.id }}
           </nuxt-link>
         </td>
       </template>

--- a/pkg/rancher-desktop/store/credentials.ts
+++ b/pkg/rancher-desktop/store/credentials.ts
@@ -3,9 +3,33 @@ import { ActionContext, MutationsType } from './ts-helpers';
 
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import Latch from '@pkg/utils/latch';
+
+export type Credentials = Omit<ServerState, 'pid'>;
 
 interface CredentialsState {
-  credentials: Omit<ServerState, 'pid'>;
+  credentials: Credentials;
+}
+
+const hasCredentials = Latch();
+
+export async function fetchAPI(api: string, rootState: any, init?: RequestInit) {
+  // Any fetches will block until we have credentials.
+  await hasCredentials;
+
+  const { port, user, password } = rootState.credentials.credentials as Credentials;
+  const url = new URL(api, `http://localhost:${ port }/`);
+  const headers = new Headers(init?.headers);
+
+  headers.set('Authorization', `Basic ${ window.btoa(`${ user }:${ password }`) }`);
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/x-www-form-urlencoded');
+  }
+
+  init ??= {};
+  init.headers = headers;
+
+  return fetch(url.toString(), init);
 }
 
 export const state: () => CredentialsState = () => (
@@ -21,13 +45,14 @@ export const state: () => CredentialsState = () => (
 export const mutations: MutationsType<CredentialsState> = {
   SET_CREDENTIALS(state, credentials) {
     state.credentials = credentials;
+    hasCredentials.resolve();
   },
 };
 
 type CredActionContext = ActionContext<CredentialsState>;
 
 export const actions = {
-  async fetchCredentials({ commit }: CredActionContext): Promise<Omit<ServerState, 'pid'>> {
+  async fetchCredentials({ commit }: CredActionContext): Promise<Credentials> {
     const result = await ipcRenderer.invoke('api-get-credentials');
 
     commit('SET_CREDENTIALS', result);

--- a/pkg/rancher-desktop/store/extensions.ts
+++ b/pkg/rancher-desktop/store/extensions.ts
@@ -1,0 +1,55 @@
+import { GetterTree } from 'vuex';
+
+import { fetchAPI } from './credentials';
+import { ActionContext, MutationsType } from './ts-helpers';
+
+import type { ExtensionMetadata } from '@pkg/main/extensions/types';
+
+interface ExtensionState {
+  version: string;
+  metadata: ExtensionMetadata;
+  labels: Record<string, string>;
+}
+
+interface ExtensionsState {
+  extensions: Record<string, ExtensionState>;
+  inError: boolean;
+}
+
+export const state: () => ExtensionsState = () => ({
+  extensions: {},
+  inError:    false,
+});
+
+export const mutations: MutationsType<ExtensionsState> = {
+  SET_EXTENSIONS(state: ExtensionsState, extensions: Record<string, ExtensionState>) {
+    state.extensions = extensions;
+  },
+  SET_IN_ERROR(state: ExtensionsState, status: boolean) {
+    state.inError = status;
+  },
+};
+
+type ExtensionsActionContext = ActionContext<ExtensionsState>;
+
+export const actions = {
+  async fetch({ commit, rootState }: ExtensionsActionContext) {
+    const response = await fetchAPI('/v1/extensions', rootState);
+
+    if (!response.ok) {
+      console.log(`fetchExtensions: failed: status: ${ response.status }:${ response.statusText }`);
+      commit('SET_IN_ERROR', true);
+
+      return;
+    }
+    const result: Record<string, ExtensionState> = await response.json();
+
+    commit('SET_EXTENSIONS', result);
+  },
+};
+
+export const getters: GetterTree<ExtensionsState, ExtensionsState> = {
+  list(state: ExtensionsState): ({ id: string } & ExtensionState )[] {
+    return Object.entries(state.extensions).map(([id, info]) => ({ id, ...info }));
+  },
+};

--- a/pkg/rancher-desktop/store/extensions.ts
+++ b/pkg/rancher-desktop/store/extensions.ts
@@ -13,20 +13,13 @@ interface ExtensionState {
 
 interface ExtensionsState {
   extensions: Record<string, ExtensionState>;
-  inError: boolean;
 }
 
-export const state: () => ExtensionsState = () => ({
-  extensions: {},
-  inError:    false,
-});
+export const state: () => ExtensionsState = () => ({ extensions: {} });
 
 export const mutations: MutationsType<ExtensionsState> = {
   SET_EXTENSIONS(state: ExtensionsState, extensions: Record<string, ExtensionState>) {
     state.extensions = extensions;
-  },
-  SET_IN_ERROR(state: ExtensionsState, status: boolean) {
-    state.inError = status;
   },
 };
 
@@ -38,7 +31,6 @@ export const actions = {
 
     if (!response.ok) {
       console.log(`fetchExtensions: failed: status: ${ response.status }:${ response.statusText }`);
-      commit('SET_IN_ERROR', true);
 
       return;
     }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -6,7 +6,6 @@ import Electron from 'electron';
 
 import type { ServiceEntry } from '@pkg/backend/k8s';
 import type { RecursivePartial, Direction } from '@pkg/utils/typeUtils';
-import type { ExtensionMetadata } from '@pkg/main/extensions/types'
 /**
  * IpcMainEvents describes events the renderer can send to the main process,
  * i.e. ipcRenderer.send() -> ipcMain.on().
@@ -78,7 +77,6 @@ export interface IpcMainEvents {
   'help/preferences/open-url': () => void;
 
   // #region Extensions
-  'extensions/list': () => void;
   'extensions/open': (id: string, path: string) => void;
   'extensions/close': () => void;
   'extensions/open-external': (url: string) => void;
@@ -164,7 +162,8 @@ export interface IpcRendererEvents {
   // #endregion
 
   // #region extensions
-  'extensions/list': (extensions: { id: string, version: string, metadata: ExtensionMetadata; }[]) => void;
+  // The list of installed extensions may have changed.
+  'extensions/changed': () => void;
   'extensions/open': (id: string, path: string) => void;
   'err:extensions/open': () => void;
   'extensions/close': () => void;

--- a/pkg/rancher-desktop/typings/store.d.ts
+++ b/pkg/rancher-desktop/typings/store.d.ts
@@ -1,6 +1,7 @@
 import type { actions as ApplicationSettingsActions } from '@pkg/store/applicationSettings';
 import type { actions as CredentialsActions } from '@pkg/store/credentials';
 import type { actions as DiagnosticsActions } from '@pkg/store/diagnostics';
+import type { actions as ExtensionsActions } from '@pkg/store/extensions';
 import type { actions as PageActions } from '@pkg/store/page';
 import type { actions as PreferencesActions } from '@pkg/store/preferences';
 import type { actions as TransientSettingsActions } from '@pkg/store/transientSettings';
@@ -19,6 +20,7 @@ type storeActions = Record<string, never>
   & Actions<'preferences', typeof PreferencesActions>
   & Actions<'diagnostics', typeof DiagnosticsActions>
   & Actions<'credentials', typeof CredentialsActions>
+  & Actions<'extensions', typeof ExtensionsActions>
   & Actions<'transientSettings', typeof TransientSettingsActions>
 
 declare module 'vuex/types' {

--- a/src/go/rdctl/cmd/extensionLS.go
+++ b/src/go/rdctl/cmd/extensionLS.go
@@ -52,7 +52,9 @@ func listExtensions() error {
 	if errorPacket != nil || err != nil {
 		return displayAPICallResult([]byte{}, errorPacket, err)
 	}
-	extensionList := map[string]string{}
+	extensionList := map[string]struct {
+		Version string `json:"version"`
+	}{}
 	err = json.Unmarshal(result, &extensionList)
 	if err != nil {
 		return fmt.Errorf("failed to json-unmarshal results of `extensions ls`: %w", err)
@@ -62,8 +64,8 @@ func listExtensions() error {
 		return nil
 	}
 	extensionIDs := make([]string, 0, len(extensionList))
-	for id, tag := range extensionList {
-		extensionIDs = append(extensionIDs, fmt.Sprintf("%s:%s", id, tag))
+	for id, info := range extensionList {
+		extensionIDs = append(extensionIDs, fmt.Sprintf("%s:%s", id, info.Version))
 	}
 	sort.Slice(extensionIDs, func(i, j int) bool { return strings.ToLower(extensionIDs[i]) < strings.ToLower(extensionIDs[j]) })
 


### PR DESCRIPTION
- Expose the image labels on extensions
- Convert the front end to use API calls to get extension information, rather than IPC calls. (This involves changing the API to return information about the extensions beyond just the version.)
- In the UI in the installed extensions list, use the new labels (falling back to the extension ID) instead of the UI title.

This is meant to help with #4543 but we should double-check after merging if this solves all parts of it.