### PR TITLE
Remove unnecessary padding on tabs

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/WslIntegrations.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslIntegrations.vue
@@ -43,9 +43,3 @@ export default Vue.extend({
     </rd-fieldset>
   </div>
 </template>
-
-<style scoped>
-  .wsl-integrations {
-    padding: var(--preferences-content-padding);
-  }
-</style>

--- a/pkg/rancher-desktop/components/Preferences/WslNetwork.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslNetwork.vue
@@ -40,9 +40,3 @@ export default Vue.extend({
     </rd-fieldset>
   </div>
 </template>
-
-<style scoped>
-  .wsl-network {
-    padding: var(--preferences-content-padding);
-  }
-</style>


### PR DESCRIPTION
The `BodyWsl` page already includes the needed padding. It is unnecessary on the tabs.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4578