### PR TITLE
Add RD_USE_NETWORKING_TUNNEL option

### DIFF
--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -1,24 +1,47 @@
-validate_enum() {
-    local var=$1
-    shift
-    for value in "$@"; do
-        if [ "${!var}" = "$value" ]; then
-            return
-        fi
-    done
-    fatal "$var=${!var} is not a valid setting; select from [$*]"
-}
-
+########################################################################
 : "${RD_CONTAINER_ENGINE:=containerd}"
+
 validate_enum RD_CONTAINER_ENGINE containerd moby
 
+########################################################################
 : "${RD_KUBERNETES_VERSION:=1.23.6}"
+
+########################################################################
 : "${RD_KUBERNETES_PREV_VERSION:=1.22.7}"
+
+########################################################################
 : "${RD_RANCHER_IMAGE_TAG:=v2.7.0}"
 
+########################################################################
 : "${RD_USE_IMAGE_ALLOW_LIST:=false}"
+
+using_image_allow_list() {
+    is_true "$RD_USE_IMAGE_ALLOW_LIST"
+}
+
+########################################################################
 : "${RD_USE_WINDOWS_EXE:=false}"
 
+using_windows_exe() {
+    is_true "$RD_USE_WINDOWS_EXE"
+}
+
+if using_windows_exe && ! is_windows; then
+    fatal "RD_USE_WINDOWS_EXE only works on Windows"
+fi
+
+########################################################################
+: "${RD_USE_NETWORKING_TUNNEL:=false}"
+
+using_networking_tunnel() {
+    is_true "$RD_USE_NETWORKING_TUNNEL"
+}
+
+if using_networking_tunnel && ! is_windows; then
+    fatal "RD_USE_NETWORKING_TUNNEL only works on Windows"
+fi
+
+########################################################################
 # RD_LOCATION specifies the location where Rancher Desktop is installed
 #   system: default system-wide install location shared for all users
 #   user:   per-user install location
@@ -27,16 +50,9 @@ validate_enum RD_CONTAINER_ENGINE containerd moby
 #   "":     use first location from the list above that contains the app
 
 : "${RD_LOCATION:=}"
+
 validate_enum RD_LOCATION system user dist npm ""
 
 using_npm_run_dev() {
     [ "$RD_LOCATION" = "npm" ]
-}
-
-using_image_allow_list() {
-    is_true "$RD_USE_IMAGE_ALLOW_LIST"
-}
-
-using_windows_exe() {
-    is_true "$RD_USE_WINDOWS_EXE"
 }

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -20,14 +20,19 @@ source "$PATH_BATS_ROOT/bats-support/load.bash"
 source "$PATH_BATS_ROOT/bats-assert/load.bash"
 source "$PATH_BATS_ROOT/bats-file/load.bash"
 
-# "defaults.bash" *must* be sourced before the rest of the files
-source "$PATH_BATS_HELPERS/defaults.bash"
-source "$PATH_BATS_HELPERS/utils.bash"
 source "$PATH_BATS_HELPERS/os.bash"
+source "$PATH_BATS_HELPERS/utils.bash"
+
+# os.bash and utils.bash must be loaded before defaults.bash
+source "$PATH_BATS_HELPERS/defaults.bash"
+
+# defaults.bash must be loaded before paths.bash
 source "$PATH_BATS_HELPERS/paths.bash"
 
-# "vm.bash" must be loaded first to define `using_containerd` etc
+# paths.bash must be loaded before vm.bash
 source "$PATH_BATS_HELPERS/vm.bash"
+
+# vm.bash must be loaded before kubernetes.bash and commands.bash
 source "$PATH_BATS_HELPERS/kubernetes.bash"
 source "$PATH_BATS_HELPERS/commands.bash"
 

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -20,6 +20,19 @@ bool() {
     fi
 }
 
+# Ensure that the variable contains a valid value, e.g.
+# `validate_enum VAR value1 value2`
+validate_enum() {
+    local var=$1
+    shift
+    for value in "$@"; do
+        if [ "${!var}" = "$value" ]; then
+            return
+        fi
+    done
+    fatal "$var=${!var} is not a valid setting; select from [$*]"
+}
+
 assert_nothing() {
     # This is a no-op, used to show that run() has been used to continue the
     # test even when the command failed, but the failure itself is ignored.

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -66,6 +66,9 @@ start_container_engine() {
             --virtual-machine.memory-in-gb 6
         )
     fi
+    if using_networking_tunnel; then
+        args+=(--experimental.virtual-machine.networking-tunnel)
+    fi
 
     # TODO containerEngine.allowedImages.patterns and WSL.integrations
     # TODO cannot be set from the commandline yet


### PR DESCRIPTION
to run all tests with the new experimental networking stack on Windows.

Fixes #4596 

Tests with `RD_USE_NETWORKING_TUNNEL=true` are expected to fail until the rest of #4296 is implemented.