### PR TITLE
Implement card design for Troubleshooting page

### DIFF
--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -78,7 +78,7 @@ test.describe.serial('Main App Test', () => {
     const troubleshootingPage = await navPage.navigateTo('Troubleshooting');
 
     await expect(navPage.mainTitle).toHaveText('Troubleshooting');
-    await expect(troubleshootingPage.dashboard).toBeVisible();
+    await expect(troubleshootingPage.troubleshooting).toBeVisible();
     await expect(troubleshootingPage.logsButton).toBeVisible();
     await expect(troubleshootingPage.factoryResetButton).toBeVisible();
   });

--- a/e2e/pages/troubleshooting-page.ts
+++ b/e2e/pages/troubleshooting-page.ts
@@ -4,12 +4,12 @@ export class TroubleshootingPage {
   readonly page: Page;
   readonly factoryResetButton: Locator;
   readonly logsButton: Locator;
-  readonly dashboard: Locator;
+  readonly troubleshooting: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.factoryResetButton = page.locator('[data-test="factoryResetButton"]');
     this.logsButton = page.locator('[data-test="logsButton"]');
-    this.dashboard = page.locator('.dashboard');
+    this.troubleshooting = page.locator('.troubleshooting');
   }
 }

--- a/pkg/rancher-desktop/components/TroubleshootingLineItem.vue
+++ b/pkg/rancher-desktop/components/TroubleshootingLineItem.vue
@@ -1,37 +1,33 @@
+<script lang="ts">
+import { Card } from '@rancher/components';
+import Vue from 'vue';
+
+export default Vue.extend({
+  name:       'troubleshooting-line-item',
+  components: { Card },
+});
+</script>
 <template>
-  <div class="troubleshooting-line-item">
-    <div class="description">
-      <h3>
-        <slot name="title">
-        </slot>
-      </h3>
-      <span>
-        <slot name="description">
-        </slot>
+  <card
+    class="troubleshooting-line-item"
+    :show-highlight-border="false"
+  >
+    <template #title>
+      <slot name="title"></slot>
+    </template>
+    <template #body>
+      <slot name="description"></slot>
+      <span class="options">
+        <slot name="options"></slot>
       </span>
-      <div class="options">
-        <slot name="options">
-        </slot>
-      </div>
-    </div>
-    <slot>
-    </slot>
-  </div>
+    </template>
+    <template #actions>
+      <slot name="actions"></slot>
+    </template>
+  </card>
 </template>
 
 <style lang="scss" scoped>
-  .troubleshooting-line-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-top: 1.25rem;
-    margin-bottom: 1.25rem;
-  }
-
-  .description {
-    margin-right: 1.5rem;
-  }
-
   .options {
     margin-top: 0.5rem;
   }

--- a/pkg/rancher-desktop/pages/Troubleshooting.vue
+++ b/pkg/rancher-desktop/pages/Troubleshooting.vue
@@ -1,14 +1,17 @@
 <template>
-  <section class="dashboard">
-    <section class="troubleshooting">
-      <section class="general">
-        <troubleshooting-line-item>
-          <template #title>
+  <div class="troubleshooting">
+    <div class="troubleshooting-items">
+      <troubleshooting-line-item>
+        <template #title>
+          <span class="text-xl">
             {{ t('troubleshooting.general.logs.title') }}
-          </template>
-          <template #description>
-            {{ t('troubleshooting.general.logs.description') }}
-          </template>
+            </h3>
+          </span>
+        </template>
+        <template #description>
+          {{ t('troubleshooting.general.logs.description') }}
+        </template>
+        <template #actions>
           <button
             data-test="logsButton"
             type="button"
@@ -17,24 +20,27 @@
           >
             {{ t('troubleshooting.general.logs.buttonText') }}
           </button>
-          <template #options>
-            <Checkbox
-              :value="isDebugging"
-              :disabled="alwaysDebugging"
-              :tooltip="debugModeTooltip"
-              label="Enable debug mode"
-              @input="updateDebug"
-            />
-          </template>
-        </troubleshooting-line-item>
-        <hr>
-        <troubleshooting-line-item>
-          <template #title>
+        </template>
+        <template #options>
+          <Checkbox
+            :value="isDebugging"
+            :disabled="alwaysDebugging"
+            :tooltip="debugModeTooltip"
+            label="Enable debug mode"
+            @input="updateDebug"
+          />
+        </template>
+      </troubleshooting-line-item>
+      <troubleshooting-line-item>
+        <template #title>
+          <span class="text-xl">
             {{ t('troubleshooting.kubernetes.resetKubernetes.title') }}
-          </template>
-          <template #description>
-            {{ t('troubleshooting.kubernetes.resetKubernetes.description') }}
-          </template>
+          </span>
+        </template>
+        <template #description>
+          {{ t('troubleshooting.kubernetes.resetKubernetes.description') }}
+        </template>
+        <template #actions>
           <button
             data-test="k8sResetBtn"
             type="button"
@@ -43,15 +49,18 @@
           >
             {{ t('troubleshooting.kubernetes.resetKubernetes.buttonText') }}
           </button>
-        </troubleshooting-line-item>
-        <hr>
-        <troubleshooting-line-item>
-          <template #title>
+        </template>
+      </troubleshooting-line-item>
+      <troubleshooting-line-item>
+        <template #title>
+          <span class="text-xl">
             {{ t('troubleshooting.general.factoryReset.title') }}
-          </template>
-          <template #description>
-            {{ t('troubleshooting.general.factoryReset.description') }}
-          </template>
+          </span>
+        </template>
+        <template #description>
+          {{ t('troubleshooting.general.factoryReset.description') }}
+        </template>
+        <template #actions>
           <button
             data-test="factoryResetButton"
             type="button"
@@ -60,17 +69,17 @@
           >
             {{ t('troubleshooting.general.factoryReset.buttonText') }}
           </button>
-        </troubleshooting-line-item>
-        <section class="need-help">
-          <hr>
-          <span
-            class="description"
-            v-html="t('troubleshooting.needHelp', { }, true)"
-          />
-        </section>
-      </section>
-    </section>
-  </section>
+        </template>
+      </troubleshooting-line-item>
+    </div>
+    <div class="need-help">
+      <hr>
+      <span
+        class="description"
+        v-html="t('troubleshooting.needHelp', { }, true)"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
@@ -188,17 +197,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .troubleshooting {
-    max-width: 56rem;
+  .troubleshooting-items {
+    display: flex;
+    flex-direction: column;
   }
 
-  .general,
-  .kubernetes {
-    margin-top: 2rem;
-  }
-
-  .title {
-    padding-bottom: 0.25rem;
+  .text-xl {
+    font-size: 1.25rem;
+    line-height: 1.75rem;
   }
 
   .btn-xs {


### PR DESCRIPTION
This implements a card design for the Troubleshooting page to better accommodate  different window dimensions. 

## Examples

### Default

![rancher-desktop-troubleshooting-01](https://user-images.githubusercontent.com/835961/236310060-81d83b90-7f2f-45b3-812e-2db2eb9aa655.png)

### Large

![rancher-desktop-troubleshooting-03](https://user-images.githubusercontent.com/835961/236310057-bd4dcb92-9c8c-4074-89a0-ea04c4fefd79.png)

### Small

![rancher-desktop-troubleshooting-02](https://user-images.githubusercontent.com/835961/236310059-e0ab71bb-c419-4442-a3ec-140e98c741ac.png)

closes #4467 