### PR TITLE
Add needs_port() function to BATS

### DIFF
--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -29,6 +29,7 @@ is_linux() {
         test "$OS" = linux -a "$ARCH" = "$1"
     fi
 }
+
 is_macos() {
     if [ -z "${1-}" ]; then
         test "$OS" = darwin
@@ -36,6 +37,7 @@ is_macos() {
         test "$OS" = darwin -a "$ARCH" = "$1"
     fi
 }
+
 is_windows() {
     if [ -z "${1-}" ]; then
         test "$OS" = windows
@@ -43,16 +45,32 @@ is_windows() {
         test "$OS" = windows -a "$ARCH" = "$1"
     fi
 }
+
 is_unix() {
     ! is_windows "$@"
 }
+
 skip_on_windows() {
     if is_windows; then
         skip "This test is not applicable on Windows."
     fi
 }
+
 skip_on_unix() {
     if is_unix; then
         skip "This test is not applicable on MacOS/Linux."
+    fi
+}
+
+needs_port() {
+    local port=$1
+    if is_linux; then
+        if [ "$(sysctl -n net.ipv4.ip_unprivileged_port_start)" -gt "$port" ]; then
+            # Run sudo non-interactive, so don't prompt for password
+            run sudo -n sysctl -w "net.ipv4.ip_unprivileged_port_start=$port"
+            if [ "$status" -ne 0 ]; then
+                skip "net.ipv4.ip_unprivileged_port_start must be $port or less"
+            fi
+        fi
     fi
 }

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -3,12 +3,7 @@
 load '../helpers/load'
 
 setup() {
-    # TODO - Consider implementing a function to check for sudo permissions before running tests that require them.
-    # If sudo permissions are not present, these tests should be skipped.
-    if is_linux; then
-        run sudo sysctl -w net.ipv4.ip_unprivileged_port_start=443
-        assert_nothing
-    fi
+    needs_port 443
 }
 
 @test 'factory reset' {

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -8,11 +8,7 @@
 load '../helpers/load'
 
 setup() {
-    if is_linux; then
-        if [ "$(sysctl -n net.ipv4.ip_unprivileged_port_start)" -gt 80 ]; then
-            skip "net.ipv4.ip_unprivileged_port_start must be 80 or less"
-        fi
-    fi
+    needs_port 80
 }
 
 @test 'factory reset' {


### PR DESCRIPTION
Use it to request binding to a privileged port. It will succeed if the port is greater equal to net.ipv4.ip_unprivileged_port_start. If it isn't, then try to change the starting port using sudo. If that fails (e.g. because sudo requires a password), then skip the test.

Fixes #4513