### PR TITLE
Implement helper to get tags for an image name

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/__tests__/auth.spec.ts
+++ b/pkg/rancher-desktop/backend/containerClient/__tests__/auth.spec.ts
@@ -1,0 +1,59 @@
+import RegistryAuth from '@pkg/backend/containerClient/auth';
+
+describe('RegistryAuth', () => {
+  describe('parseAuthHeader', () => {
+    const testCases: {
+      input: string,
+      expected: { scheme: string, parameters?: Record<string, string>}[],
+    }[] = [
+      { input: '', expected: [] },
+      {
+        input:    'Basic',
+        expected: [{ scheme: 'basic' }],
+      },
+      {
+        input:    'Bearer realm="https://auth.docker.io/token",service="registry.docker.io"',
+        expected: [{ scheme: 'bearer', parameters: { realm: 'https://auth.docker.io/token', service: 'registry.docker.io' } }],
+      },
+      {
+        input:    'one,two,three',
+        expected: [{ scheme: 'one' }, { scheme: 'two' }, { scheme: 'three' }],
+      },
+      {
+        input:    'broken quotes="value starts but never ends',
+        expected: [{ scheme: 'broken', parameters: { quotes: 'value starts but never ends' } }],
+      },
+      {
+        input:    'Token one=1,two=2, Other three="3", four="4"',
+        expected: [{ scheme: 'token', parameters: { one: '1', two: '2' } }, { scheme: 'other', parameters: { three: '3', four: '4' } }],
+      },
+      {
+        input:    'parameter=unused, token',
+        expected: [{ scheme: 'token' }],
+      },
+      {
+        input:    'token parameter=, other',
+        expected: [{ scheme: 'token', parameters: { parameter: '' } }, { scheme: 'other' }],
+      },
+      {
+        // From RFC 9110, section 11.6.1
+        input:    'Basic realm="simple", Newauth realm="apps", type=1, title="Login to \\"apps\\""',
+        expected: [
+          { scheme: 'basic', parameters: { realm: 'simple' } },
+          {
+            scheme:     'newauth',
+            parameters: {
+              realm: 'apps', type: '1', title: 'Login to "apps"',
+            },
+          },
+        ],
+      },
+    ];
+
+    test.each(testCases)('$#: $input', ({ input, expected }) => {
+      const actual = RegistryAuth['parseAuthHeader'](input);
+
+      expect(actual).toEqual(expected.map(v => ({ parameters: {}, ...v })));
+    });
+  });
+});

--- a/pkg/rancher-desktop/backend/containerClient/__tests__/auth.spec.ts
+++ b/pkg/rancher-desktop/backend/containerClient/__tests__/auth.spec.ts
@@ -1,4 +1,5 @@
 import RegistryAuth from '@pkg/backend/containerClient/auth';
+import * as childProcess from '@pkg/utils/childProcess';
 
 describe('RegistryAuth', () => {
   describe('parseAuthHeader', () => {
@@ -54,6 +55,15 @@ describe('RegistryAuth', () => {
       const actual = RegistryAuth['parseAuthHeader'](input);
 
       expect(actual).toEqual(expected.map(v => ({ parameters: {}, ...v })));
+    });
+  });
+
+  describe('findAuth', () => {
+    it('should not fail when failing to list known credentials', async() => {
+      const exception = new Error('failed to spawn file');
+
+      jest.spyOn(childProcess, 'spawnFile').mockRejectedValue(exception);
+      await expect(RegistryAuth['findAuth']('example.test')).resolves.toBeUndefined();
     });
   });
 });

--- a/pkg/rancher-desktop/backend/containerClient/__tests__/registry.spec.ts
+++ b/pkg/rancher-desktop/backend/containerClient/__tests__/registry.spec.ts
@@ -1,0 +1,43 @@
+import { FetchError } from 'node-fetch';
+
+import dockerRegistry, { getAsList } from '@pkg/backend/containerClient/registry';
+import { Headers } from '@pkg/utils/fetch';
+
+describe('Headers', () => {
+  test('getAsList', () => {
+    const headers = new Headers();
+
+    headers.append('a', '1');
+    headers.append('A', '2');
+    headers.append('b', '3');
+
+    expect(headers.get('a')).toEqual('1, 2');
+    expect(headers[getAsList]('a')).toEqual(['1', '2']);
+    expect(headers[getAsList]('B')).toEqual(['3']);
+    expect(headers[getAsList]('c')).toBeNull();
+  });
+});
+
+describe('DockerRegistry', () => {
+  describe('getTags', () => {
+    it('should get tags from unauthenticated registry', async() => {
+      const reference = 'registry.opensuse.org/opensuse/leap';
+
+      await expect(dockerRegistry.getTags(reference))
+        .resolves
+        .toEqual(expect.arrayContaining(['15.4']));
+    });
+
+    it('should get tags from docker hub', async() => {
+      await expect(dockerRegistry.getTags('hello-world'))
+        .resolves
+        .toEqual(expect.arrayContaining(['linux']));
+    });
+
+    it('should fail trying to get tags from invalid registry', async() => {
+      await expect(dockerRegistry.getTags('host.invalid/name'))
+        .rejects
+        .toThrow(FetchError);
+    });
+  });
+});

--- a/pkg/rancher-desktop/backend/containerClient/auth.ts
+++ b/pkg/rancher-desktop/backend/containerClient/auth.ts
@@ -22,7 +22,7 @@ class RegistryAuth {
 
   /**
    * Ask the credential helpers for authentication for the given host.
-   * @param host The host to find auth for; possibly a URL instead.
+   * @param hosts The hosts to find auth for; possibly a URL instead.
    * @returns The value of the `Authorization` header to use.
    */
   protected async findAuth(...hosts: string[]): Promise<string | undefined> {
@@ -155,7 +155,7 @@ class RegistryAuth {
     try {
       issuedDate = Date.parse(parsed.issued_at);
     } catch (ex) {
-      const error = new Error(`Failed to parse authroization response issued_at ${ parsed.issued_at }`);
+      const error = new Error(`Failed to parse authorization response issued_at ${ parsed.issued_at }`);
 
       (error as any).cause = ex;
       throw error;
@@ -226,7 +226,7 @@ class RegistryAuth {
 
             switch (quoteType) {
             case 'backslash': {
-              // We can get away with just treating the next character as a
+              // We can get away with just treating the next character as
               // a literal (no `\n` for newline, etc.).
               value += header.substring(0, quotePos);
               header = header.substring(quotePos + 1);

--- a/pkg/rancher-desktop/backend/containerClient/auth.ts
+++ b/pkg/rancher-desktop/backend/containerClient/auth.ts
@@ -1,0 +1,354 @@
+import runCredentialCommand from '@pkg/main/credentialServer/credentialUtils';
+import fetch, { Headers } from '@pkg/utils/fetch';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.background;
+
+type tokenCacheEntry = {
+  /** The expiry of this token, as milliseconds since Unix epoch. */
+  expiry: number;
+  /** The raw token. */
+  token: string;
+};
+
+/**
+ * RegistryAuth handles HTTP authentication for the registries
+ */
+class RegistryAuth {
+  /**
+   * A cache of still-valid tokens, keyed by (registry) host.
+   */
+  protected tokenCache: Record<string, tokenCacheEntry> = {};
+
+  /**
+   * Ask the credential helpers for authentication for the given host.
+   * @param host The host to find auth for; possibly a URL instead.
+   * @returns The value of the `Authorization` header to use.
+   */
+  protected async findAuth(...hosts: string[]): Promise<string | undefined> {
+    const candidates: string[] = [];
+    const hostCandidates: string[] = [];
+    const suffixes = ['/', ''];
+
+    for (const host of hosts) {
+      if (!host) {
+        continue;
+      }
+      if (host.includes('://')) {
+        // This is a full URL, parse it.
+        const url = new URL(host);
+
+        candidates.push(host);
+        hostCandidates.push(url.host, url.hostname);
+        suffixes.push(url.pathname);
+      } else {
+        hostCandidates.push(host);
+      }
+    }
+
+    if (hostCandidates.some(h => h === 'docker.io' || h.endsWith('.docker.io'))) {
+      // Special handling for docker (typically, `https://auth.docker.io/token`).
+      hostCandidates.push('index.docker.io');
+      suffixes.push('/v1/');
+    }
+
+    for (const protocol of ['http', 'https']) {
+      for (const hostPart of hostCandidates) {
+        for (const suffix of suffixes) {
+          candidates.push(`${ protocol }://${ hostPart }${ suffix }`);
+        }
+      }
+    }
+
+    const knownAuths = JSON.parse(await runCredentialCommand('list'));
+
+    for (const candidate of candidates) {
+      if (candidate in knownAuths) {
+        const auth = JSON.parse(await runCredentialCommand('get', candidate));
+        const login = Buffer.from(`${ auth.Username }:${ auth.Secret }`, 'utf-8');
+
+        return `Basic ${ login.toString('base64') }`;
+      }
+    }
+  }
+
+  /**
+   * HTTP Basic Authentication
+   */
+  protected async basicAuth(host: string): Promise<Record<string, string>> {
+    const auth = await this.findAuth(host);
+
+    if (auth) {
+      return { Authorization: auth };
+    }
+
+    throw new Error(`Could not find auth for ${ host }`);
+  }
+
+  /**
+   * HTTP Bearer Authentication
+   * @param host The host we're trying to authenticate against
+   * @param parameters The WWW-Authenticate header parameters.
+   */
+  protected async bearerAuth(host: string, parameters: Record<string, string>): Promise<Record<string, string>> {
+    // If we have a token in the cache, return it.
+    if (host in this.tokenCache) {
+      const cachedToken = this.tokenCache[host];
+
+      if (cachedToken.expiry > Date.now()) {
+        return { Authorization: `Bearer ${ cachedToken.token }` };
+      }
+      delete this.tokenCache[host];
+    }
+
+    const url = new URL(parameters.realm ?? (host.includes('://') ? host : `https://${ host }`));
+    const auth = await this.findAuth(parameters.realm, host);
+    const headers: Record<string, string> = auth ? { Authorization: auth } : {};
+
+    if (parameters.service) {
+      url.searchParams.set('service', parameters.service);
+    }
+    if (parameters.scope) {
+      for (const scope of parameters.scope.split(/\s+/)) {
+        url.searchParams.append('scope', scope);
+      }
+    }
+
+    const resp = await fetch(url.toString(), { headers });
+
+    if (!resp.ok) {
+      throw new Error(`Could not get authorization token from ${ url } (for ${ url }): ${ JSON.stringify(resp) }`);
+    }
+
+    let result: any;
+
+    try {
+      result = await resp.json();
+    } catch (ex) {
+      const error = new Error(`Failed to parse authorization response`);
+
+      (error as any).cause = ex;
+      throw error;
+    }
+
+    const parsed = {
+      token:      result.token || result.access_token,
+      issued_at:  result.issued_at,
+      expires_in: result.expires_in ?? 300,
+    };
+
+    type parsedKey = keyof typeof parsed;
+    const types: Record<parsedKey, 'string' | 'number'> = {
+      token:      'string',
+      issued_at:  'string',
+      expires_in: 'number',
+    };
+    let issuedDate: number;
+
+    for (const [k, type] of Object.entries(types) as [parsedKey, typeof types[parsedKey]][]) {
+      // eslint-disable-next-line valid-typeof -- The set is hard-coded.
+      if (typeof parsed[k] !== type) {
+        throw new TypeError(`Failed to read authorization response: ${ k } is not a ${ type } (${ typeof parsed[k] })`);
+      }
+    }
+
+    try {
+      issuedDate = Date.parse(parsed.issued_at);
+    } catch (ex) {
+      const error = new Error(`Failed to parse authroization response issued_at ${ parsed.issued_at }`);
+
+      (error as any).cause = ex;
+      throw error;
+    }
+
+    this.tokenCache[host] = {
+      expiry: issuedDate + parsed.expires_in * 1_000,
+      token:  parsed.token,
+    };
+
+    return { Authorization: `Bearer ${ parsed.token }` };
+  }
+
+  protected parseAuthHeader(header: string): { scheme: string, parameters: Record<string, string> }[] {
+    // This header is a bit tricky (hence a separate method for testing):
+    // The header may contain multiple comma-separated challenge specifications,
+    // each of which consists of one word ("scheme") plus zero or more comma-
+    // separated parameters for that scheme.  Parameters may have quoted values
+    // which may internally contain commas.
+
+    const results: { scheme: string, parameters: Record<string, string>}[] = [];
+    let scheme = '';
+    let parameters: Record<string, string> = {};
+
+    function push() {
+      if (scheme) {
+        results.push({ scheme, parameters });
+        parameters = {};
+      }
+    }
+
+    header = header.trim();
+    // From now on, `header` should never have leading/trailing whitespace.
+    while (header) {
+      const posMapping = {
+        space: /\s/.exec(header)?.index ?? -1,
+        equal: header.indexOf('='),
+        comma: header.indexOf(','),
+        end:   header.length,
+      } as const;
+      const posList = (Object.entries(posMapping) as [keyof typeof posMapping, number][])
+        .filter(([, v]) => v >= 0)
+        .sort(([, l], [, r]) => l - r);
+      const [type, pos] = posList[0];
+
+      switch (type) {
+      case 'equal': {
+        // An equals sign precedes any spaces etc.; this is a parameter.
+        const key = header.substring(0, pos);
+        let value = '';
+
+        header = header.substring(pos + 1).trimStart();
+        if (header.startsWith('"')) {
+          let quoteEnded = false;
+
+          header = header.substring(1);
+
+          while (!quoteEnded) {
+            const quotePosMapping = {
+              backslash: header.indexOf('\\'),
+              quote:     header.indexOf('"'),
+              end:       header.length,
+            } as const;
+            const quotePosList = (Object.entries(quotePosMapping) as [keyof typeof quotePosMapping, number][])
+              .filter(([, v]) => v >= 0)
+              .sort(([, l], [, r]) => l - r);
+            const [quoteType, quotePos] = quotePosList[0];
+
+            switch (quoteType) {
+            case 'backslash': {
+              // We can get away with just treating the next character as a
+              // a literal (no `\n` for newline, etc.).
+              value += header.substring(0, quotePos);
+              header = header.substring(quotePos + 1);
+              if (header) {
+                value += header.substring(0, 1);
+                header = header.substring(1);
+              }
+              break;
+            }
+            case 'quote': {
+              value += header.substring(0, quotePos);
+              header = header.substring(quotePos + 1).replace(/^[,\s]*/, '');
+              quoteEnded = true;
+              break;
+            }
+            case 'end': {
+              // Could not find end of quote
+              value += header;
+              header = '';
+              quoteEnded = true;
+              break;
+            }
+            }
+          }
+        } else {
+          // This value is not quoted
+          const commaPos = header.indexOf(',');
+
+          if (commaPos < 0) {
+            // No comma, the parameter runs to the end of the header.
+            value = header;
+            header = '';
+          } else {
+            value = header.substring(0, commaPos);
+            header = header.substring(commaPos).replace(/^[,\s]*/, '');
+          }
+        }
+
+        if (scheme) {
+          // Only allow adding parameters if we already found a scheme.
+          parameters[key] = value;
+        }
+        break;
+      }
+      case 'space': {
+        // A space precedes any equals signs; this is a scheme.
+        push();
+        scheme = header.substring(0, pos).toLowerCase();
+        header = header.substring(pos).replace(/^[,\s]*/, '');
+        break;
+      }
+      case 'end': {
+        // Neither space nor equal found.
+        // This is a bare scheme.
+        push();
+        scheme = header.trim().toLowerCase();
+        header = header.substring(scheme.length).trim();
+        break;
+      }
+      case 'comma': {
+        // This is a bare scheme.
+        push();
+        scheme = header.substring(0, pos);
+        header = header.substring(pos + 1).replace(/^[,\s]*/, '');
+      }
+      }
+    }
+
+    push();
+
+    return results;
+  }
+
+  /**
+   * Determine authentication required.
+   * @param endpoint The endpoint to use to test for authentication requirements.
+   * @returns The headers needed for authentication.
+   */
+  async authenticate(endpoint: URL): Promise<Headers> {
+    if (endpoint.host in this.tokenCache) {
+      // If we have a valid cached token, use it directly.
+      const cachedToken = this.tokenCache[endpoint.host];
+
+      if (cachedToken.expiry > Date.now()) {
+        return new Headers({ Authorization: `Bearer ${ cachedToken.token }` });
+      }
+    }
+
+    const resp = await fetch(endpoint.toString());
+
+    if (resp.status !== 401) {
+      console.debug(`${ endpoint } does not require authentication`);
+
+      return new Headers();
+    }
+
+    const authenticateHeader = resp.headers.get('WWW-Authenticate') ?? '';
+
+    for (const challenge of this.parseAuthHeader(authenticateHeader)) {
+      if (challenge.scheme === 'basic') {
+        try {
+          return new Headers(await this.basicAuth(endpoint.toString()));
+        } catch (ex) {
+          console.debug(`Could not do Basic authentication for ${ endpoint }`, ex);
+        }
+      } else if (challenge.scheme === 'bearer') {
+        try {
+          return new Headers(await this.bearerAuth(endpoint.toString(), challenge.parameters));
+        } catch (ex) {
+          console.debug(`Could not do Bearer authentication for ${ endpoint }:`, ex);
+        }
+      } else {
+        console.debug(`Don't know how to do ${ challenge.scheme } authentication for ${ endpoint }, skipping`);
+      }
+    }
+
+    // If we reach here, we got a HTTP 401, but couldn't figure out how to do
+    // authentication.
+    throw new Error(`Failed to find compatible authentication scheme for ${ endpoint }`);
+  }
+}
+
+const auth = new RegistryAuth();
+
+export default auth;

--- a/pkg/rancher-desktop/backend/containerClient/registry.ts
+++ b/pkg/rancher-desktop/backend/containerClient/registry.ts
@@ -50,9 +50,12 @@ class DockerRegistry {
       for (const link of resp.headers[getAsList]('Link') ?? []) {
         const fields = link.split(/;\s*/);
 
-        if (!fields.includes('rel="next"')) {
+        if (!fields.some(field => /^rel=("?)next\1$/i.test(field))) {
           continue;
         }
+        // The `Link` header defined in RFC 8288 always has angle brackets
+        // around the (possibly relative) URL:
+        // https://www.rfc-editor.org/rfc/rfc8288#section-3
         endpoint = new URL(fields[0].replace(/^<(.+)>$/, '$1'), endpoint);
         hasMore = true;
       }

--- a/pkg/rancher-desktop/backend/containerClient/registry.ts
+++ b/pkg/rancher-desktop/backend/containerClient/registry.ts
@@ -1,0 +1,97 @@
+import registryAuth from '@pkg/backend/containerClient/auth';
+import { parseImageReference } from '@pkg/utils/dockerUtils';
+import fetch, { Headers } from '@pkg/utils/fetch';
+
+/**
+ * Registry interaction, with both Docker Hub and Docker Registry V2 APIs.
+ */
+class DockerRegistry {
+  /**
+   * Fetch some API endpoint from the registry
+   * @param endpoint The API endpoint, including the registry host.
+   */
+  async get(endpoint: URL): ReturnType<typeof fetch> {
+    const headers = await this.authenticate(endpoint);
+
+    return await fetch(endpoint.toString(), { headers });
+  }
+
+  /**
+   * List all tags for the given image name.
+   * @param name An image name, including registry as needed.
+   */
+  async getTags(name: string): Promise<string[]> {
+    const info = parseImageReference(name);
+    const tags: string[] = [];
+
+    if (!info) {
+      throw new Error(`Invalid image name: "${ name }"`);
+    }
+
+    let endpoint = new URL(`/v2/${ info.name }/tags/list?n=65536`, info.registry);
+    let hasMore = true;
+
+    while (hasMore) {
+      const resp = await this.get(endpoint);
+
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch ${ endpoint }: ${ resp.status } ${ resp.statusText }`);
+      }
+
+      const result: { name: string, tags: string[] } = await resp.json();
+
+      if (result.name !== info.name) {
+        throw new Error(`Invalid tags: incorrect response name ${ result.name } from ${ endpoint }`);
+      }
+
+      tags.push(...result.tags);
+      hasMore = false;
+
+      for (const link of resp.headers[getAsList]('Link') ?? []) {
+        const fields = link.split(/;\s*/);
+
+        if (!fields.includes('rel="next"')) {
+          continue;
+        }
+        endpoint = new URL(fields[0].replace(/^<(.+)>$/, '$1'), endpoint);
+        hasMore = true;
+      }
+    }
+
+    return tags;
+  }
+
+  protected authenticate(endpoint: URL): Promise<Headers> {
+    return registryAuth.authenticate(endpoint);
+  }
+}
+
+const registry = new DockerRegistry();
+
+export default registry;
+
+// Extend Headers with a helper to get the header values as a list.
+// This is only exported for testing.
+export const getAsList = Symbol('get-as-list');
+
+declare module '@pkg/utils/fetch' {
+  interface Headers {
+    [getAsList](key: string): string[] | null;
+  }
+}
+
+Object.defineProperties(Headers.prototype, {
+  [getAsList]: {
+    value: function(this: Headers, key: string): string[] | null {
+      const collator = Intl.Collator(undefined, { usage: 'search', sensitivity: 'accent' });
+
+      for (const [k, v] of Object.entries(this.raw())) {
+        if (collator.compare(k, key) === 0) {
+          return v;
+        }
+      }
+
+      return null;
+    },
+  },
+});

--- a/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
@@ -1,0 +1,20 @@
+import { imageInfo, parseImageReference } from '../dockerUtils';
+
+describe('parseImageReference', () => {
+  const dockerHub = new URL('https://index.docker.io');
+  const testCases: Record<string, ReturnType<typeof parseImageReference>> = {
+    component:                          new imageInfo(dockerHub, 'library/component'),
+    'name:tag':                         new imageInfo(dockerHub, 'library/name', 'tag'),
+    'dir/name':                         new imageInfo(dockerHub, 'dir/name'),
+    'registry.test/thing':              new imageInfo(new URL('https://registry.test/'), 'thing' ),
+    'registry.test:5000/org/thing:tag': new imageInfo(new URL('https://registry.test:5000/'), 'org/thing', 'tag'),
+    _:                                  null,
+    ':10/tag':                          null,
+    [`xxx:${ Array(130).join('x') }`]:  null,
+    'name:':                            null,
+  };
+
+  test.each(Object.entries(testCases))('%s', (input, expected) => {
+    expect(parseImageReference(input)).toEqual(expected);
+  });
+});

--- a/pkg/rancher-desktop/utils/dockerUtils.ts
+++ b/pkg/rancher-desktop/utils/dockerUtils.ts
@@ -51,31 +51,26 @@ function makeRE(strings: TemplateStringsArray, ...substitutions: any[]) {
  * (including optional registry and one or more name components).
  */
 const ImageNameRegExp = (function() {
-  const domainComponent = makeRE`
-    # a domain component is alpha-numeric-or-dash, but the start and end
-    # characters may not be a dash.
-    [a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
-    `;
+  // a domain component is alpha-numeric-or-dash, but the start and end
+  // characters may not be a dash.
+  const domainComponent = /[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?/;
+  // a domain is two or more domain components joined by dot, and optionally
+  // with a colon followed by a port number.
   const domain = makeRE`
-    # a domain is two or more domain components joined by dot, and optionally
-    # with a colon followed by a port number.
     ${ domainComponent }(?:\.${ domainComponent })+
     (?::[0-9]+)?
     `;
-  const nameComponent = makeRE`
-    # a name component is lower-alpha-numeric things, separated by any one of
-    # a set of separators.
-    [a-z0-9]+(?:(?:\.|_|__|-*)[a-z0-9]+)*
-    `;
-  const nameRE = makeRE`
+  // a name component is lower-alpha-numeric things, separated by any one of
+  // a set of separators.
+  const nameComponent = /[a-z0-9]+(?:(?:\.|_|__|-*)[a-z0-9]+)*/;
+
+  return makeRE`
     (?:(?<domain>${ domain })/)?
     (?<name>
       ${ nameComponent }
       (?:/${ nameComponent })*
     )
     `;
-
-  return nameRE;
 })();
 
 /**

--- a/pkg/rancher-desktop/utils/dockerUtils.ts
+++ b/pkg/rancher-desktop/utils/dockerUtils.ts
@@ -1,0 +1,135 @@
+/**
+ * The return result of parseImageReference().
+ *
+ * @note This is only exported for the test.
+ */
+export class imageInfo {
+  /**
+   * The registry, as a URL (e.g. `https://registry.opensuse.org/`);
+   * defaults to Docker Hub, i.e. `https://index.docker.io/`.
+   */
+  registry: URL;
+  /**
+   * The image name (e.g. `opensuse/leap`).
+   * For Docker Hub images, `library/` will be added if there is no org.
+   */
+  name: string;
+  /** Any tags (e.g. `latest`, `15.4`) */
+  tag?: string;
+
+  constructor(registry: URL, name: string, tag?: string) {
+    this.registry = registry;
+    this.name = name;
+    this.tag = tag;
+  }
+
+  /**
+   * Check if this image (excluding the tag) is the same as another one.
+   */
+  equalName(other?: imageInfo | null): boolean {
+    return this.registry.href === other?.registry.href && this.name === other?.name;
+  }
+}
+
+/**
+ * makeRE is a tagged template for making regular expressions with /x (i.e.
+ * ignoring any whitespace within the regular expression itself).
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
+ */
+function makeRE(strings: TemplateStringsArray, ...substitutions: any[]) {
+  const substitutionSources = substitutions.map(s => s instanceof RegExp ? s.source : s);
+  const raw = String.raw(strings, ...substitutionSources);
+  const lines = raw.split(/\r?\n/);
+  // Drop comments at end of line
+  const uncommentedLines = lines.map(line => line.replace(/\s#.*$/, ''));
+
+  return new RegExp(uncommentedLines.join('').replace(/\s+/g, ''));
+}
+
+/**
+ * ImageNameRegExp is a regular expression that matches a docker image name
+ * (including optional registry and one or more name components).
+ */
+const ImageNameRegExp = (function() {
+  const domainComponent = makeRE`
+    # a domain component is alpha-numeric-or-dash, but the start and end
+    # characters may not be a dash.
+    [a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
+    `;
+  const domain = makeRE`
+    # a domain is two or more domain components joined by dot, and optionally
+    # with a colon followed by a port number.
+    ${ domainComponent }(?:\.${ domainComponent })+
+    (?::[0-9]+)?
+    `;
+  const nameComponent = makeRE`
+    # a name component is lower-alpha-numeric things, separated by any one of
+    # a set of separators.
+    [a-z0-9]+(?:(?:\.|_|__|-*)[a-z0-9]+)*
+    `;
+  const nameRE = makeRE`
+    (?:(?<domain>${ domain })/)?
+    (?<name>
+      ${ nameComponent }
+      (?:/${ nameComponent })*
+    )
+    `;
+
+  return nameRE;
+})();
+
+/**
+ * ImageTagRegExp is a regular expression that matches a docker image tag (that
+ * is, only the bit after the colon).
+ */
+const ImageTagRegExp = /[\w][\w.-]{0,127}/;
+
+const ImageRefRegExp = makeRE`
+  ^
+  ${ ImageNameRegExp }
+  (?::(?<tag>${ ImageTagRegExp }))?
+  $
+  `;
+
+/**
+ * Given an image reference, parse it into (possibly) registry, name, and
+ * (possibly) tag components.
+ */
+export function parseImageReference(reference: string): imageInfo | null {
+  const result = ImageRefRegExp.exec(reference);
+
+  if (!result?.groups) {
+    return null;
+  }
+
+  let registry = result.groups['domain'] ?? 'index.docker.io';
+  let name = result.groups['name'];
+
+  if (registry === 'docker.io') {
+    registry = 'index.docker.io';
+  }
+  if (!registry.includes('://')) {
+    registry = `https://${ registry }`;
+  }
+
+  if (registry.endsWith('.docker.io') && !name.includes('/')) {
+    name = `library/${ name }`;
+  }
+
+  return new imageInfo(new URL(registry), name, result.groups['tag']);
+}
+
+/**
+ * Check if a given string is a valid docker image name component (excluding any
+ * tags).
+ */
+export function validateImageName(name: string): boolean {
+  return makeRE`^${ ImageNameRegExp }$`.test(name);
+}
+
+/**
+ * Check if a given string is a valid docker image tag.
+ */
+export function validateImageTag(tag: string): boolean {
+  return makeRE`^${ ImageTagRegExp }$`.test(tag);
+}

--- a/pkg/rancher-desktop/utils/fetch.ts
+++ b/pkg/rancher-desktop/utils/fetch.ts
@@ -6,7 +6,7 @@ import util from 'util';
 
 import _fetch, { RequestInit } from 'node-fetch';
 
-export { RequestInit } from 'node-fetch';
+export { Headers, RequestInit } from 'node-fetch';
 
 /**
  * CertificateVerificationError is a custom Error class that describes a TLS


### PR DESCRIPTION
This implements a bare-bones client to talk to docker registries (either generic v2 registries, or Docker Hub) to fetch lists of tags for a given image name.

This is probably easier reviewed per-commit.

This is part of #4362 (but does not complete it).