### PR TITLE
RDX: preload: fix regexp backref

### DIFF
--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -131,7 +131,7 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
     // too much.
     const safeOptions: SpawnOptions = {
       command: [`${ cmd }`].concat(Array.from(args).map((arg) => {
-        return `${ arg }`.replace(/^(["'])(.*)\1$/, '\\2');
+        return `${ arg }`.replace(/^(["'])(.*)\1$/, '$2');
       })),
       execId,
       scope,


### PR DESCRIPTION
Fixes #4634

In JavaScript, the backref for [`String.replace()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement) uses `$` instead of `\` for marking a backref.