### PR TITLE
RDX: Work with deployment profiles

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1097,7 +1097,9 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     if (state === 'install') {
       console.debug(`Installing extension ${ image }...`);
       try {
-        if (await extension.install()) {
+        const { enabled, list } = cfg.application.extensions.allowed;
+
+        if (await extension.install(enabled ? list : undefined)) {
           return { status: 201 };
         } else {
           return { status: 204 };
@@ -1109,6 +1111,8 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
             return { status: 422, data: `The image ${ image } has invalid extension metadata` };
           case ExtensionErrorCode.FILE_NOT_FOUND:
             return { status: 422, data: `The image ${ image } failed to install: ${ ex.message }` };
+          case ExtensionErrorCode.INSTALL_DENIED:
+            return { status: 403, data: `The image ${ image } is not an allowed extension` };
           }
         }
         throw ex;

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -40,6 +40,12 @@ write_allow_list() { # list
     }'
 }
 
+check_extension_installed() { # refute, name
+    run rdctl extension ls
+    assert_success
+    ${1:-assert}_output --partial ${2:-rd/extension/basic}
+}
+
 @test 'factory reset' {
     factory_reset
 }
@@ -63,26 +69,39 @@ write_allow_list() { # list
 @test 'when no extension allow list is set up, all extensions can install' {
     write_allow_list ''
     rdctl extension install rd/extension/basic
+    check_extension_installed
     rdctl extension uninstall rd/extension/basic
+}
+
+@test 'empty allow list disables extension installs' {
+    write_allow_list '[]'
+    run rdctl extension install rd/extension/basic
+    assert_failure
+    check_extension_installed refute
 }
 
 @test 'when an extension is explicitly allowed, it can be installed' {
-    write_allow_list '["rd/extension/basic:latest"]'
+    write_allow_list '["irrelevant/image","rd/extension/basic:latest"]'
     rdctl extension install rd/extension/basic:latest
+    check_extension_installed
     rdctl extension uninstall rd/extension/basic
+    check_extension_installed refute
 }
 
-@test 'when an extension is not in the allowe list, it cannot be installed' {
-    write_allow_list '["rd/extension/other"]'
+@test 'when an extension is not in the allowed list, it cannot be installed' {
+    write_allow_list '["rd/extension/other","registry.test/image"]'
     run rdctl extension install rd/extension/basic
     assert_failure
+    check_extension_installed refute
 }
 
 @test 'when no tags given, any tag is allowed' {
     write_allow_list '["rd/extension/basic"]'
     ctrctl "${namespace_arg[@]}" tag rd/extension/basic rd/extension/basic:0.0.3
     rdctl extension install rd/extension/basic:0.0.3
+    check_extension_installed
     rdctl extension uninstall rd/extension/basic
+    check_extension_installed refute
 }
 
 @test 'when tags are given, only the specified tag is allowed' {
@@ -91,17 +110,22 @@ write_allow_list() { # list
     ctrctl "${namespace_arg[@]}" tag rd/extension/basic rd/extension/basic:0.0.3
     run rdctl extension install rd/extension/basic:0.0.3
     assert_failure
+    check_extension_installed refute
 }
 
 @test 'extensions can be allowed by organization' {
     write_allow_list '["rd/extension/"]'
     rdctl extension install rd/extension/basic
+    check_extension_installed
     rdctl extension uninstall rd/extension/basic
+    check_extension_installed refute
 }
 
 @test 'extensions can be allowed by repository host' {
     write_allow_list '["registry.test/"]'
     ctrctl "${namespace_arg[@]}" tag rd/extension/basic registry.test/basic:0.0.3
     rdctl extension install registry.test/basic:0.0.3
+    check_extension_installed '' registry.test/basic
     rdctl extension uninstall registry.test/basic
+    check_extension_installed refute registry.test/basic
 }

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -17,7 +17,7 @@ setup() {
 }
 
 write_allow_list() { # list
-    local list=${1:-}
+    local list=${1-}
     local allowed=true
 
     if [ -z "$list" ]; then
@@ -27,8 +27,8 @@ write_allow_list() { # list
     # Note that the list preference is not writable using `rdctl set`, and we
     # need to do a direct API call instead.
 
-    rdctl api /v1/settings --input - <<< '{
-        "version": 7,
+    rdctl api /v1/settings --input - <<<'{
+        "version": '"$(get_setting .version)"',
         "application": {
             "extensions": {
                 "allowed": {

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -43,7 +43,7 @@ write_allow_list() { # list
 check_extension_installed() { # refute, name
     run rdctl extension ls
     assert_success
-    ${1:-assert}_output --partial ${2:-rd/extension/basic}
+    "${1:-assert}_output" --partial "${2:-rd/extension/basic}"
 }
 
 @test 'factory reset' {

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -1,0 +1,107 @@
+load '../helpers/load'
+
+setup() {
+    TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"
+
+    if using_windows_exe; then
+        TESTDATA_DIR_CLI="$(wslpath -m "${TESTDATA_DIR}")"
+    else
+        TESTDATA_DIR_CLI="${TESTDATA_DIR}"
+    fi
+
+    if using_containerd; then
+        namespace_arg=('--namespace=rancher-desktop-extensions')
+    else
+        namespace_arg=()
+    fi
+}
+
+write_allow_list() { # list
+    local list=${1:-}
+    local allowed=true
+
+    if [ -z "$list" ]; then
+        allowed=false
+    fi
+
+    # Note that the list preference is not writable using `rdctl set`, and we
+    # need to do a direct API call instead.
+
+    rdctl api /v1/settings --input - <<< '{
+        "version": 7,
+        "application": {
+            "extensions": {
+                "allowed": {
+                    "enabled": '"${allowed}"',
+                    "list": '"${list:-[]}"'
+                }
+            }
+        }
+    }'
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start container engine' {
+    RD_ENV_EXTENSIONS=1 start_container_engine
+    wait_for_container_engine
+}
+
+@test 'build extension testing image' {
+    ctrctl "${namespace_arg[@]}" build \
+        --tag "rd/extension/basic" \
+        --build-arg "variant=basic" \
+        "$TESTDATA_DIR_CLI"
+
+    run ctrctl "${namespace_arg[@]}" image list --format '{{ .Repository }}'
+    assert_success
+    assert_line "rd/extension/basic"
+}
+
+@test 'when no extension allow list is set up, all extensions can install' {
+    write_allow_list ''
+    rdctl extension install rd/extension/basic
+    rdctl extension uninstall rd/extension/basic
+}
+
+@test 'when an extension is explicitly allowed, it can be installed' {
+    write_allow_list '["rd/extension/basic:latest"]'
+    rdctl extension install rd/extension/basic:latest
+    rdctl extension uninstall rd/extension/basic
+}
+
+@test 'when an extension is not in the allowe list, it cannot be installed' {
+    write_allow_list '["rd/extension/other"]'
+    run rdctl extension install rd/extension/basic
+    assert_failure
+}
+
+@test 'when no tags given, any tag is allowed' {
+    write_allow_list '["rd/extension/basic"]'
+    ctrctl "${namespace_arg[@]}" tag rd/extension/basic rd/extension/basic:0.0.3
+    rdctl extension install rd/extension/basic:0.0.3
+    rdctl extension uninstall rd/extension/basic
+}
+
+@test 'when tags are given, only the specified tag is allowed' {
+    sleep 20
+    write_allow_list '["rd/extension/basic:0.0.2"]'
+    ctrctl "${namespace_arg[@]}" tag rd/extension/basic rd/extension/basic:0.0.3
+    run rdctl extension install rd/extension/basic:0.0.3
+    assert_failure
+}
+
+@test 'extensions can be allowed by organization' {
+    write_allow_list '["rd/extension/"]'
+    rdctl extension install rd/extension/basic
+    rdctl extension uninstall rd/extension/basic
+}
+
+@test 'extensions can be allowed by repository host' {
+    write_allow_list '["registry.test/"]'
+    ctrctl "${namespace_arg[@]}" tag rd/extension/basic registry.test/basic:0.0.3
+    rdctl extension install registry.test/basic:0.0.3
+    rdctl extension uninstall registry.test/basic
+}

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -345,6 +345,20 @@ components:
             debug:
               type: boolean
               x-rd-usage: generate more verbose logging
+            extensions:
+              type: object
+              properties:
+                allowed:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      x-rd-hidden: true
+                    list:
+                      type: array
+                      items:
+                        type: string
+                        x-rd-hidden: true
             pathManagementStrategy:
               type: string
               enum: [manual, rcfiles]

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -74,7 +74,7 @@ export const defaultSettings = {
     extensions:  {
       allowed: {
         enabled: false,
-        list:    [],
+        list:    [] as Array<string>,
       },
     },
     pathManagementStrategy: PathManagementStrategy.NotSet,

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -69,8 +69,14 @@ export enum CacheMode {
 export const defaultSettings = {
   version:     CURRENT_SETTINGS_VERSION,
   application: {
-    adminAccess:            true,
-    debug:                  false,
+    adminAccess: true,
+    debug:       false,
+    extensions:  {
+      allowed: {
+        enabled: false,
+        list:    [],
+      },
+    },
     pathManagementStrategy: PathManagementStrategy.NotSet,
     telemetry:              { enabled: true },
     /** Whether we should check for updates and apply them. */

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -573,7 +573,7 @@ export default class SettingsValidator {
     }
 
     for (const pattern of desiredValue as string[]) {
-      if (!parseImageReference(pattern)) {
+      if (!parseImageReference(pattern, true)) {
         errors.push(`${ fqname }: "${ pattern }" does not describe an image reference`);
       }
     }

--- a/pkg/rancher-desktop/main/extensions/__tests__/extensions.spec.ts
+++ b/pkg/rancher-desktop/main/extensions/__tests__/extensions.spec.ts
@@ -1,0 +1,49 @@
+import { ExtensionImpl } from '@pkg/main/extensions/extensions';
+
+describe('ExtensionImpl', () => {
+  describe('checkInstallAllowed', () => {
+    const subject = ExtensionImpl['checkInstallAllowed'];
+
+    it('should reject invalid image references', () => {
+      expect(() => subject(undefined, '/')).toThrow();
+    });
+
+    it('should allow images if the allow list is not enabled', () => {
+      expect(() => subject(undefined, 'image')).not.toThrow();
+    });
+
+    it('should disallow any images given an empty list', () => {
+      expect(() => subject([], 'image')).toThrow();
+    });
+
+    it('should allow specified image', () => {
+      expect(() => subject(['other', 'image'], 'image')).not.toThrow();
+    });
+
+    it('should reject unknown image', () => {
+      expect(() => subject(['allowed'], 'image')).toThrow();
+    });
+
+    it('should support missing tags', () => {
+      expect(() => subject(['image'], 'image:1.0.0')).not.toThrow();
+    });
+
+    it('should reject images with the wrong tag', () => {
+      expect(() => subject(['image:0.1'], 'image:0.2')).toThrow();
+    });
+
+    it('should support image references with registries', () => {
+      const ref = 'r.example.test:1234/org/name:tag';
+
+      expect(() => subject([ref], ref)).not.toThrow();
+    });
+
+    it('should support org-level references', () => {
+      expect(() => subject(['test.invalid/org/'], 'test.invalid/org/image:tag')).not.toThrow();
+    });
+
+    it('should support registry-level references', () => {
+      expect(() => subject(['registry.test/'], 'registry.test/image:tag')).not.toThrow();
+    });
+  });
+});

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -25,9 +25,9 @@ class ExtensionErrorImpl extends Error implements ExtensionError {
 
   constructor(code: ExtensionErrorCode, message: string, cause?: Error) {
     // XXX We're currently using a version of TypeScript that doesn't have the
-    // ES2022.Error lib, so it does't understand the "cause" option to the Error
-    // constructor.  Work around this by explicitly calling setting the cause.
-    // It appears to still be printed in that case.
+    // ES2022.Error lib, so it doesn't understand the "cause" option to the
+    // Error constructor.  Work around this by explicitly calling setting the
+    // cause.  It appears to still be printed in that case.
     super(message);
     if (cause) {
       (this as any).cause = cause;

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -228,17 +228,17 @@ class ExtensionManagerImpl implements ExtensionManager {
           console.error(`Failed to install extension ${ id }`, ex);
         }
       })(`${ repo }:${ tag }`));
-      await Promise.all(tasks);
     }
+    await Promise.all(tasks);
   }
 
   async getExtension(image: string): Promise<Extension> {
+    // eslint-disable-next-line prefer-const
     let [, repo, tag] = /^(.*):(.*?)$/.exec(image) ?? ['', image, undefined];
     const extGroup = this.extensions[image] ?? {};
 
     // The build process uses an older TypeScript that can't infer repo correctly.
     repo ??= image;
-    tag ??= undefined;
 
     this.extensions[repo] = extGroup;
 

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -211,6 +211,8 @@ class ExtensionManagerImpl implements ExtensionManager {
 
     // Install / uninstall extensions as needed.
     const tasks: Promise<any>[] = [];
+    const { enabled: allowEnabled, list: allowListRaw } = config.application.extensions.allowed;
+    const allowList = allowEnabled ? allowListRaw : undefined;
 
     for (const [repo, tag] of Object.entries(config.extensions)) {
       if (!tag) {
@@ -221,7 +223,7 @@ class ExtensionManagerImpl implements ExtensionManager {
 
       tasks.push((async(id: string) => {
         try {
-          return (await this.getExtension(id)).install();
+          return (await this.getExtension(id)).install(allowList);
         } catch (ex) {
           console.error(`Failed to install extension ${ id }`, ex);
         }

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -71,10 +71,13 @@ export interface Extension {
 
   /**
    * Install this extension.
+   * @param allowedImages The list of extension images that are allowed to be
+   *        used; if all images are allowed, pass in undefined.
    * @note If the extension is already installed, this is a no-op.
+   * @throws If the settings specify an allow list and this is not in it.
    * @return Whether the extension was installed.
    */
-  install(): Promise<boolean>;
+  install(allowedImages: readonly string[] | undefined): Promise<boolean>;
   /**
    * Uninstall this extension.
    * @note If the extension was not installed, this is a no-op.
@@ -169,6 +172,7 @@ export const ExtensionErrorMarker = Symbol('extension-error');
 export enum ExtensionErrorCode {
   INVALID_METADATA,
   FILE_NOT_FOUND,
+  INSTALL_DENIED,
 }
 
 export interface ExtensionError extends Error {

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -109,8 +109,8 @@ export interface ExtensionManager {
 
   /**
    * Get the given extension.
-   * @param id The image ID of the extension, possibly including the tag.
-   *        If the tag is not supplied, the currently-installed version is
+   * @param image The image reference of the extension, possibly including the
+   *        tag.  If the tag is not supplied, the currently-installed version is
    *        used; if no version is installed, "latest" is assumed.
    * @note This may cause the given image to be downloaded.
    * @note The extension will not be automatically installed.

--- a/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
@@ -12,9 +12,26 @@ describe('parseImageReference', () => {
     ':10/tag':                          null,
     [`xxx:${ Array(130).join('x') }`]:  null,
     'name:':                            null,
+    'dir/':                             null,
+    '':                                 null,
   };
 
   test.each(Object.entries(testCases))('%s', (input, expected) => {
     expect(parseImageReference(input)).toEqual(expected);
+  });
+
+  describe('when parsing for prefix', () => {
+    const testCases: Record<string, ReturnType<typeof parseImageReference>> = {
+      component:            new imageInfo(dockerHub, 'library/component'),
+      'name:tag':           new imageInfo(dockerHub, 'library/name', 'tag'),
+      'dir/':               new imageInfo(dockerHub, 'dir/'),
+      'registry.test/':     new imageInfo(new URL('https://registry.test/'), ''),
+      'registry.test/dir/': new imageInfo(new URL('https://registry.test/'), 'dir/'),
+      '':                   null,
+    };
+
+    test.each(Object.entries(testCases))('%s', (input, expected) => {
+      expect(parseImageReference(input, true)).toEqual(expected);
+    });
   });
 });

--- a/scripts/generateCliCode.ts
+++ b/scripts/generateCliCode.ts
@@ -275,6 +275,7 @@ class Generator {
     settingsTree: settingsTreeType): void {
     const platforms = preference['x-rd-platforms'] ?? [];
 
+    notAvailable ||= preference['x-rd-hidden'];
     notAvailable ||= platforms.length > 0 && !platforms.includes(process.platform);
     switch (preference.type) {
     case 'object':


### PR DESCRIPTION
This handles #4341 — we now have a preference that can be used to limit the extensions that can be installed.
See attached BATS test case to see how it works.

`rdctl set` intentionally doesn't support this, as it's more meant for use with locked profiles. But (as seen in the tests) it's possible to set it via the API.