### PR TITLE
RDX: Implement better fetching of image tags

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1097,7 +1097,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
 
   async installExtension(image: string, state: 'install' | 'uninstall'): Promise<{status: number, data?: any}> {
     const em = await getExtensionManager();
-    const extension = await em?.getExtension(image);
+    const extension = await em?.getExtension(image, { preferInstalled: state === 'uninstall' });
 
     if (!extension) {
       console.debug(`Failed to install extension ${ image }: could not get extension.`);

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -101,6 +101,14 @@ encoded_id() { # variant
     assert_line --partial "$(id basic):v0.0.2"
 }
 
+@test 'basic extension - uninstalling not installed version' {
+    rdctl extension uninstall "$(id basic):0.0.1"
+    run rdctl extension ls
+    assert_success
+    # Trying to uninstall a version that isn't installed should be a no-op
+    assert_line --partial "$(id basic):v0.0.2"
+}
+
 @test 'basic extension - uninstall' {
     ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):0.0.3"
     # Uninstall should remove whatever version is installed, not the newest.

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -85,7 +85,25 @@ encoded_id() { # variant
     assert_file_contents_equal "$PATH_EXTENSIONS/$(encoded_id basic)/icon.svg" "$TESTDATA_DIR/extension-icon.svg"
 }
 
+@test 'basic extension - upgrades' {
+    local tag
+    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):0.0.1"
+    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):v0.0.2"
+
+    run rdctl extension ls
+    assert_success
+    assert_line --partial "$(id basic):latest"
+
+    rdctl extension install "$(id basic)"
+    run rdctl extension ls
+    assert_success
+    # The highest semver tag should be installed, replacing the existing one.
+    assert_line --partial "$(id basic):v0.0.2"
+}
+
 @test 'basic extension - uninstall' {
+    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):0.0.3"
+    # Uninstall should remove whatever version is installed, not the newest.
     rdctl extension uninstall "$(id basic)"
 
     run rdctl extension ls
@@ -114,6 +132,12 @@ encoded_id() { # variant
     assert_dir_not_exist "$PATH_EXTENSIONS/$(encoded_id host-binaries)"
     run rdctl extension install "$(id host-binaries)"
     assert_success
+}
+
+@test 'host-binaries - check extension is installed' {
+    run rdctl extension ls
+    assert_success
+    assert_output --partial "rd/extension/host-binaries:latest"
 }
 
 @test 'host-binaries - check files' {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -102,7 +102,7 @@ EOF
     else
         # Detach `rdctl start` because on Windows the process may not exit until
         # Rancher Desktop itself quits.
-        rdctl start "${args[@]}" "$@" &
+        RD_TEST=bats rdctl start "${args[@]}" "$@" &
     fi
 }
 

--- a/pkg/rancher-desktop/backend/containerClient/__tests__/client.spec.ts
+++ b/pkg/rancher-desktop/backend/containerClient/__tests__/client.spec.ts
@@ -1,0 +1,101 @@
+import { MobyClient } from '@pkg/backend/containerClient/mobyClient';
+import { NerdctlClient } from '@pkg/backend/containerClient/nerdctlClient';
+import dockerRegistry from '@pkg/backend/containerClient/registry';
+import { ContainerEngineClient } from '@pkg/backend/containerClient/types';
+import MockBackend from '@pkg/backend/mock';
+
+jest.mock('@pkg/backend/mock');
+jest.mock('@pkg/backend/containerClient/registry');
+
+describe.each(['nerdctl', 'moby'] as const)('%s', (clientName) => {
+  let subject: ContainerEngineClient;
+
+  beforeEach(() => {
+    const executor = new MockBackend() as jest.Mocked<MockBackend>;
+
+    switch (clientName) {
+    case 'nerdctl':
+      subject = new NerdctlClient(executor);
+      break;
+    case 'moby':
+      subject = new MobyClient(executor, '');
+      break;
+    default:
+      throw new Error(`Unexpected client name ${ clientName }`);
+    }
+  });
+
+  describe('getTags', () => {
+    const repository = 'registry.test/name';
+    let registryTags: string[];
+    let localTags: string[];
+    let localExtras: string[];
+
+    beforeEach(() => {
+      registryTags = [];
+      localTags = [];
+      localExtras = [];
+
+      jest.mocked(dockerRegistry).getTags.mockImplementation((name) => {
+        expect(name).toEqual(repository);
+
+        if (registryTags.length) {
+          return Promise.resolve(registryTags);
+        }
+
+        return Promise.reject('Could not get tags from registry');
+      });
+
+      jest.spyOn(subject, 'runClient').mockImplementation((args, stdio) => {
+        expect(args).toEqual(expect.arrayContaining(['image', 'list']));
+        expect(stdio).toEqual('pipe');
+
+        const results: string[] = [];
+
+        if (localTags.length) {
+          results.push(...localTags.map(t => `${ repository }:${ t }`));
+        }
+        if (localExtras.length) {
+          results.push(...localExtras);
+        }
+
+        if (results.length) {
+          return Promise.resolve({ stdout: results.join('\n') });
+        }
+
+        // We need the cast to any because `runClient()` is overloaded and
+        // it's hard to convince TypeScript that the return value is fine.
+        return Promise.reject('Could not get tags locally') as any;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.resetAllMocks();
+    });
+
+    it('should list tags from the registry', async() => {
+      registryTags = ['apple', 'banana'];
+
+      await expect(subject.getTags(repository)).resolves.toEqual(new Set(registryTags));
+    });
+
+    it('should list local tags', async() => {
+      localTags = ['carrot', 'durian'];
+      localExtras = ['irrelevant:grape', 'registry.invalid/other:honeydew'];
+
+      await expect(subject.getTags(repository)).resolves.toEqual(new Set(localTags));
+    });
+
+    it('should merge tags', async() => {
+      registryTags = ['jackfruit', 'kiwi'];
+      localTags = ['kiwi', 'lemon'];
+
+      await expect(subject.getTags(repository)).resolves.toEqual(new Set([...registryTags, ...localTags]));
+    });
+
+    it('should ignore errors', async() => {
+      await expect(subject.getTags(repository)).resolves.toEqual(new Set());
+    });
+  });
+});

--- a/pkg/rancher-desktop/backend/containerClient/types.ts
+++ b/pkg/rancher-desktop/backend/containerClient/types.ts
@@ -3,7 +3,7 @@ import type { Log } from '@pkg/utils/logging';
 import type { ChildProcessByStdio, SpawnOptions } from 'child_process';
 import type { Readable } from 'stream';
 
-type ContainerBasicOptions = {
+export type ContainerBasicOptions = {
   /**
    * Namespace the container should be created in.
    * @note Silently ignored when using moby.
@@ -112,6 +112,13 @@ export interface ContainerEngineClient {
    */
   copyFile(imageID: string, sourcePath: string, destinationDir: string): Promise<void>;
   copyFile(imageID: string, sourcePath: string, destinationDir: string, options: { namespace?: string }): Promise<void>;
+
+  /**
+   * Get all tags available for the given image name.
+   * @param imageName the image name, possibly including the registry, but
+   *        excluding the tag.
+   */
+  getTags(imageName: string, options?: ContainerBasicOptions): Promise<Set<string>>;
 
   /**
    * Start a container.

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -19,7 +19,7 @@ import { defined } from '@pkg/utils/typeUtils';
 
 const console = Logging.extensions;
 
-class ExtensionErrorImpl extends Error implements ExtensionError {
+export class ExtensionErrorImpl extends Error implements ExtensionError {
   [ExtensionErrorMarker] = 0;
   code: ExtensionErrorCode;
 

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -383,6 +383,17 @@ export class ExtensionImpl implements Extension {
   }
 
   async uninstall(): Promise<boolean> {
+    const installedVersion = await this.getInstalledVersion();
+
+    if (installedVersion !== undefined && installedVersion !== this.version) {
+      // A _different_ version is installed; nothing to do here.
+      // Note that we continue if no version is installed, in case there was a
+      // partial install (so we can clean up leftover files).
+      console.debug(`Extension ${ this.id }:${ installedVersion } is installed, skipping uninstall of ${ this.image }.`);
+
+      return false;
+    }
+
     try {
       await this.uninstallContainers();
     } catch (ex) {
@@ -412,15 +423,19 @@ export class ExtensionImpl implements Extension {
     });
   }
 
-  async isInstalled(): Promise<boolean> {
+  protected async getInstalledVersion(): Promise<string | undefined> {
     try {
       const filePath = path.join(this.dir, this.VERSION_FILE);
       const installed = await fs.promises.readFile(filePath, 'utf-8');
 
-      return installed === this.version;
+      return installed.trim();
     } catch (ex) {
-      return false;
+      return undefined;
     }
+  }
+
+  async isInstalled(): Promise<boolean> {
+    return this.version === await this.getInstalledVersion();
   }
 
   _composeFile: Promise<any> | undefined;

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -111,11 +111,15 @@ export interface ExtensionManager {
    * Get the given extension.
    * @param image The image reference of the extension, possibly including the
    *        tag.  If the tag is not supplied, the currently-installed version is
-   *        used; if no version is installed, "latest" is assumed.
+   *        used (see options.preferInstalled); if no version is installed,
+   *        "latest" is assumed.
+   * @param [options.preferInstalled=true] If the given image reference does not
+   *        include tags and the extension is already installed, return the
+   *        currently installed version.
    * @note This may cause the given image to be downloaded.
    * @note The extension will not be automatically installed.
    */
-  getExtension(image: string): Promise<Extension>;
+  getExtension(image: string, options?: { preferInstalled?: boolean }): Promise<Extension>;
 
   /**
    * Get a collection of all installed extensions.

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -55,7 +55,7 @@ export interface Extension {
   readonly version: string;
 
   /**
-   * The full image tag for this image (a combination of idonly and version).
+   * The full image tag for this image (a combination of id and version).
    */
   readonly image: string;
 

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -173,7 +173,7 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
     return (async() => {
       const response = await ipcRenderer.invoke('extensions/spawn/blocking', safeOptions);
 
-      console.debug(`spawn/blocking got result:`, process.env.RD_E2E_TEST ? JSON.stringify(response) : response);
+      console.debug(`spawn/blocking got result:`, process.env.RD_TEST === 'e2e' ? JSON.stringify(response) : response);
 
       return {
         cmd:    response.cmd,

--- a/pkg/rancher-desktop/utils/logging.ts
+++ b/pkg/rancher-desktop/utils/logging.ts
@@ -45,7 +45,7 @@ export class Log {
     // If we're running unit tests, output to the console rather than file.
     // However, _don't_ do so for end-to-end tests in Playwright.
     // We detect Playwright via an environment variable we set in scripts/e2e.ts
-    if (process.env.NODE_ENV === 'test' && !process.env.RD_E2E_TEST) {
+    if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {
       this.console = globalThis.console;
     } else {
       this.console = new Console(this.stream);
@@ -105,10 +105,6 @@ export class Log {
     this.logWithDate('warn', message, optionalParameters);
   }
 
-  protected logWithDate(method: consoleKey, message: any, optionalParameters: any[]) {
-    this.console[method](`%s: ${ message }`, new Date(), ...optionalParameters);
-  }
-
   /**
    * Log with the given arguments, but only if debug logging is enabled.
    */
@@ -116,6 +112,23 @@ export class Log {
     if (LOG_LEVEL === 'debug') {
       this.log(data, ...args);
     }
+  }
+
+  /**
+   * Log a description and an exception.  If running in development or in test,
+   * include the exception logs.  This is useful for exceptions that are
+   * somewhat expected, but can occasionally be relevant.
+   */
+  debugE(message: string, exception: any) {
+    if (process.env.RD_TEST || process.env.NODE_ENV !== 'production') {
+      this.debug(message, exception);
+    } else {
+      this.debug(`${ message } ${ exception }`);
+    }
+  }
+
+  protected logWithDate(method: consoleKey, message: any, optionalParameters: any[]) {
+    this.console[method](`%s: ${ message }`, new Date(), ...optionalParameters);
   }
 
   async sync() {

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -98,7 +98,7 @@ class E2ETestRunner extends events.EventEmitter {
   async run() {
     try {
       process.env.NODE_ENV = 'test';
-      process.env.RD_E2E_TEST = '1';
+      process.env.RD_TEST = 'e2e';
 
       // Set feature flags
       process.env.RD_ENV_EXTENSIONS = '1';


### PR DESCRIPTION
This implements the behaviour specified in #4362 on how to determine which tag to use when installing/uninstalling an extension:
    
- If a tag was supplied, use it.
- Optionally, use the installed version.
- Use the semver-largest tag
- Use "latest"
    
When we attempt to install an extension, we skip looking at the currently installed version.  When we uninstall it, we prefer to select the currently installed version for uninstall.

The commits should be reasonably set up so that reviewing commit-by-commit is doable.
