### PR TITLE
Update image rows when `protectedImages` changes

### DIFF
--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -80,9 +80,10 @@
 </template>
 
 <script>
-
 import SortableTable from '@pkg/components/SortableTable';
 import { Card, Checkbox } from '@rancher/components';
+import _ from 'lodash';
+import { mapState, mapMutations } from 'vuex';
 
 import ImagesOutputWindow from '@pkg/components/ImagesOutputWindow.vue';
 import getImageOutputCuller from '@pkg/utils/imageOutputCuller';
@@ -161,6 +162,7 @@ export default {
     };
   },
   computed: {
+    ...mapState('action-menu', { menuImages: state => state.resources?.map(i => i.imageName) ?? [] }),
     keyedImages() {
       return this.images
         .map((image, index) => {
@@ -190,7 +192,9 @@ export default {
         .map(this.getTaggedImage);
     },
     rows() {
-      return this.filteredImages
+      const filteredImages = _.cloneDeep(this.filteredImages);
+
+      return filteredImages
         .map((image) => {
           // The `availableActions` property is used by the ActionMenu to fill
           // out the menu entries.  Note that we need to modify the items
@@ -244,11 +248,22 @@ export default {
     },
   },
 
+  watch: {
+    rows: {
+      handler(newRows) {
+        if (this.menuImages.some(name => newRows.map(r => r.imageName).includes(name))) {
+          this.hideMenu();
+        }
+      },
+    },
+  },
+
   mounted() {
     this.main = document.getElementsByTagName('main')[0];
   },
 
   methods: {
+    ...mapMutations('action-menu', { hideMenu: 'hide' }),
     updateSelection(val) {
       this.selected = val;
     },

--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -192,34 +192,32 @@ export default {
     rows() {
       return this.filteredImages
         .map((image) => {
-          if (!image.availableActions) {
           // The `availableActions` property is used by the ActionMenu to fill
           // out the menu entries.  Note that we need to modify the items
           // in-place, as SortableTable depends on object identity to manage its
           // selection state.
-            image.availableActions = [
-              {
-                label:   this.t('images.manager.table.action.push'),
-                action:  'doPush',
-                enabled: this.isPushable(image),
-                icon:    'icon icon-upload',
-              },
-              {
-                label:      this.t('images.manager.table.action.delete'),
-                action:     'deleteImage',
-                enabled:    this.isDeletable(image),
-                icon:       'icon icon-delete',
-                bulkable:   true,
-                bulkAction: 'deleteImages',
-              },
-              {
-                label:   this.t('images.manager.table.action.scan'),
-                action:  'scanImage',
-                enabled: true,
-                icon:    'icon icon-info',
-              },
-            ].filter(x => x.enabled);
-          }
+          image.availableActions = [
+            {
+              label:   this.t('images.manager.table.action.push'),
+              action:  'doPush',
+              enabled: this.isPushable(image),
+              icon:    'icon icon-upload',
+            },
+            {
+              label:      this.t('images.manager.table.action.delete'),
+              action:     'deleteImage',
+              enabled:    this.isDeletable(image),
+              icon:       'icon icon-delete',
+              bulkable:   true,
+              bulkAction: 'deleteImages',
+            },
+            {
+              label:   this.t('images.manager.table.action.scan'),
+              action:  'scanImage',
+              enabled: true,
+              icon:    'icon icon-info',
+            },
+          ].filter(x => x.enabled);
           // ActionMenu callbacks - SortableTable assumes that these methods live
           // on the rows directly.
           if (!image.doPush) {


### PR DESCRIPTION
This ensures that we always update the actions in our Images table when the collection of protected images updates through:

- Utilizing `const protectedImages = this.protectedImages;` to ensure that the `rows` computed prop triggers when we receive an update to `protectedImages`.
- Adding `protectedImages` as a parameter to `isDeletable` and `isPushable` methods to ensure that we are using our updated list when evaluating available actions
- Removing the condition `if (!image.availableActions)` so that we always evaluate whether or not image actions are applicable to our collection. 

Previous use cases for protecting images from deletion relied on the collection of protected images being known at the same time we received our collection of images to display in the table. This assumption is not always true when working with RDX images, as we can potentially have an image that exists in our table that will later become lockable when the extension is installed.

issue identified during review of PR #4657

closes #4663 