### PR TITLE
Fix the path of local.d for provisioning script

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1490,7 +1490,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         // Ensure all scripts are executable; Windows mounts are unlikely to
         // have it set by default.
         await this.execCommand('/usr/bin/find',
-          '/etc/local.d',
+          '/etc/local.d/',
           '(', '-name', '*.start', '-o', '-name', '*.stop', ')',
           '-print', '-exec', 'chmod', 'a+x', '{}', ';');
 


### PR DESCRIPTION
This is a potential fix for https://github.com/rancher-sandbox/rancher-desktop/issues/4595. This simply make it so that when the find command is issued against local.d it browses the folder rather than the link (`local.d/` vs `local.d`). 

Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/4595