### PR TITLE
Fix the redirection to localhost within the WSL VM

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/moproxy.initd
+++ b/pkg/rancher-desktop/assets/scripts/moproxy.initd
@@ -19,6 +19,8 @@ description_reload="Reload the proxy list."
 : ${moproxy_args:=${MOPROXY_ARGS:-""}}
 # Comma-seperated list of port traffic to redirect to moproxy
 : ${ports_redirected:=${MOPROXY_REDIRECTED_PORT:-"80,443"}}
+# Comma-seperated list of hostname to not redirect to the proxy
+: ${noproxy_rules:=${MOPROXY_NOPROXY:-"0.0.0.0/8,10.0.0.0/8,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.168.0.0/16,224.0.0.0/4,240.0.0.0/4"}}
 
 command="'${MOPROXY_BINARY:-/usr/sbin/moproxy}'"
 command_args="--host ${host} --port ${port} --list ${proxy_list} ${moproxy_args}"
@@ -29,23 +31,41 @@ MOPROXY_LOGFILE="${MOPROXY_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
 output_log="'${MOPROXY_LOGFILE}'"
 error_log="'${MOPROXY_LOGFILE}'"
 
-iptables_cmd() {
+iptables_redirect() {
 	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --jump REDIRECT --to-port "${port}"
 }
 
+iptables_accept() {
+	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --destination $3 --jump ACCEPT
+}
+
 add_rule_to_chain() {
-	if ! iptables_cmd check $1 &> /dev/null
+	if ! iptables_$1 check $2 $3 &> /dev/null
 	then
-		iptables_cmd append $1
+		iptables_$1 append $2 $3
 	else
 		einfo "Rule already in table"
 	fi
 }
 
 remove_rule_from_chain() {
-	while iptables_cmd check $1 &> /dev/null
+	while iptables_$1 check $2 $3 &> /dev/null
 	do
-		iptables_cmd delete $1
+		iptables_$1 delete $2 $3
+	done
+}
+
+add_noproxy_rules() {
+	for i in ${noproxy_rules//,/ }
+	do
+		add_rule_to_chain accept OUTPUT $i
+	done
+}
+
+remove_noproxy_rules() {
+	for i in ${noproxy_rules//,/ }
+	do
+		remove_rule_from_chain accept OUTPUT $i
 	done
 }
 
@@ -55,14 +75,16 @@ depend() {
 
 enable() {
 	einfo "Starting the iptables rules to start redirection of ports ${ports_redirected} to ${name}"
-	add_rule_to_chain OUTPUT
-	add_rule_to_chain PREROUTING
+	add_noproxy_rules
+	add_rule_to_chain redirect OUTPUT
+	add_rule_to_chain redirect PREROUTING
 }
 
 disable() {
 	einfo "Removing all the iptables rules to stop redirection to ${name}"
-	remove_rule_from_chain OUTPUT
-	remove_rule_from_chain PREROUTING
+	remove_noproxy_rules
+	remove_rule_from_chain redirect OUTPUT
+	remove_rule_from_chain redirect PREROUTING
 }
 
 start_post() {

--- a/pkg/rancher-desktop/assets/scripts/moproxy.initd
+++ b/pkg/rancher-desktop/assets/scripts/moproxy.initd
@@ -31,60 +31,68 @@ MOPROXY_LOGFILE="${MOPROXY_LOGFILE:-${LOG_DIR:-/var/log}/${RC_SVCNAME}.log}"
 output_log="'${MOPROXY_LOGFILE}'"
 error_log="'${MOPROXY_LOGFILE}'"
 
+iptables_redirect_to_moproxy_chain() {
+	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --jump MOPROXY
+}
+
 iptables_redirect() {
-	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --jump REDIRECT --to-port "${port}"
+	iptables --table nat --append MOPROXY --protocol tcp --jump REDIRECT --to-port "${port}"
 }
 
 iptables_accept() {
-	iptables --table nat --$1 $2 --protocol tcp --match multiport --dports "${ports_redirected}" --destination $3 --jump ACCEPT
-}
-
-add_rule_to_chain() {
-	if ! iptables_$1 check $2 $3 &> /dev/null
-	then
-		iptables_$1 append $2 $3
-	else
-		einfo "Rule already in table"
-	fi
-}
-
-remove_rule_from_chain() {
-	while iptables_$1 check $2 $3 &> /dev/null
-	do
-		iptables_$1 delete $2 $3
-	done
+	iptables --table nat --append MOPROXY --protocol tcp --destination "$1" --jump ACCEPT
 }
 
 add_noproxy_rules() {
 	for i in ${noproxy_rules//,/ }
 	do
-		add_rule_to_chain accept OUTPUT $i
+		iptables_accept "$i"
 	done
 }
 
-remove_noproxy_rules() {
-	for i in ${noproxy_rules//,/ }
+enable_redirection_to_moproxy_chain() {
+	if ! iptables_redirect_to_moproxy_chain check $1 &> /dev/null
+	then
+		iptables_redirect_to_moproxy_chain append $1
+	else
+		einfo "Rule already in table"
+	fi
+}
+
+disable_redirection_to_moproxy_chain() {
+	while iptables_redirect_to_moproxy_chain check $1  &> /dev/null
 	do
-		remove_rule_from_chain accept OUTPUT $i
+		iptables_redirect_to_moproxy_chain delete $1
 	done
+}
+
+create_moproxy_chain() {
+	iptables --table nat --new MOPROXY
+}
+
+delete_moproxy_chain() {
+	iptables --table nat --flush MOPROXY
+	iptables --table nat --delete-chain MOPROXY
 }
 
 depend() {
-    after iptables ip6tables
+	after iptables ip6tables
 }
 
 enable() {
 	einfo "Starting the iptables rules to start redirection of ports ${ports_redirected} to ${name}"
+	create_moproxy_chain
 	add_noproxy_rules
-	add_rule_to_chain redirect OUTPUT
-	add_rule_to_chain redirect PREROUTING
+	iptables_redirect
+	enable_redirection_to_moproxy_chain OUTPUT
+	enable_redirection_to_moproxy_chain PREROUTING
 }
 
 disable() {
 	einfo "Removing all the iptables rules to stop redirection to ${name}"
-	remove_noproxy_rules
-	remove_rule_from_chain redirect OUTPUT
-	remove_rule_from_chain redirect PREROUTING
+	disable_redirection_to_moproxy_chain PREROUTING
+	disable_redirection_to_moproxy_chain OUTPUT
+	delete_moproxy_chain
 }
 
 start_post() {
@@ -98,4 +106,7 @@ stop_pre() {
 reload() {
 	ebegin "Reloading ${name}"
 	start-stop-daemon --signal HUP --pidfile "$pidfile"
+	iptables --table nat --flush MOPROXY
+	add_noproxy_rules
+	iptables_redirect
 }


### PR DESCRIPTION
If you are connected to an http proxy and spawn a container that uses the port 80, for instance with:  `docker run -d -p  8000:80 nginx`.
In your WSL VM if you run a `curl` command on the port 8000 the translation to port 80 will redirect the traffic to your configured proxy.

This fix this issue by adding an `iptables` rule to not redirect any of the traffic to `127.0.0.1`.