### PR TITLE
Add `global_teardown()` function to BATS

### DIFF
--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -44,9 +44,12 @@ source "$PATH_BATS_HELPERS/kubernetes.bash"
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
-# On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
-teardown_file() {
+global_teardown() {
+    # On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
     run rdctl shutdown
+}
+teardown_file() {
+    global_teardown
 }
 
 # Bug workarounds go here. The goal is to make this an empty file

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -62,4 +62,5 @@ teardown_file() {
     assert_nothing
     run helm uninstall cert-manager --namespace cert-manager --wait
     assert_nothing
+    global_teardown
 }

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -165,4 +165,5 @@ teardown_file() {
     assert_nothing
     run kubectl delete --selector="app=busybox"
     assert_nothing
+    global_teardown
 }

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -55,4 +55,5 @@ teardown_file() {
     # The database PVC doesn't get deleted by `helm uninstall`.
     run kubectl delete pvc data-wordpress-mariadb-0
     assert_nothing
+    global_teardown
 }


### PR DESCRIPTION
That way even tests that override `teardown_file()` can still call it at the end of their custom teardown function.

Ideally we would be using `teardown_suite()`, but that function must be defined in a `setup_suite.bash` file in the same directory as the first `*.bats` file passed to the bats command. That doesn't work for us, so you would have to specify `--setup-suite-file tests/helpers/setup-suite.bash` which is too cumbersome unless/until we use wrapper scripts to run tests.

Fixes #4509