### PR TITLE
Create lockable `rd-select` wrapper component

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4773,6 +4773,8 @@ preferences:
       reset: Kubernetes will reset after applying changes.
       restart: Kubernetes will restart after applying changes.
       error: "There's a problem with the preferences selection."
+  locked:
+    tooltip: Locked due to organization's policy
 
 ##############################
 ### Integrations Page

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -4,6 +4,7 @@ import { Checkbox } from '@rancher/components';
 import Vue from 'vue';
 
 import { VersionEntry } from '@pkg/backend/k8s';
+import RdSelect from '@pkg/components/RdSelect.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
@@ -13,8 +14,10 @@ import type { PropType } from 'vue';
 
 export default Vue.extend({
   name:       'preferences-body-kubernetes',
-  components: { Checkbox, RdFieldset },
-  props:      {
+  components: {
+    Checkbox, RdFieldset, RdSelect,
+  },
+  props: {
     preferences: {
       type:     Object as PropType<Settings>,
       required: true,
@@ -27,7 +30,6 @@ export default Vue.extend({
       kubernetesPort:     6443,
       versions:           [] as VersionEntry[],
       cachedVersionsOnly: false,
-      kubernetesVersion:  this.preferences.kubernetes.version,
     };
   },
   computed: {
@@ -46,6 +48,9 @@ export default Vue.extend({
     },
     isKubernetesDisabled(): boolean {
       return !this.preferences.kubernetes.enabled;
+    },
+    kubernetesVersion(): string {
+      return this.preferences.kubernetes.version;
     },
     kubernetesVersionLabel(): string {
       return `Kubernetes version${ this.cachedVersionsOnly ? ' (cached versions only)' : '' }`;
@@ -100,9 +105,9 @@ export default Vue.extend({
       class="width-xs"
       :legend-text="kubernetesVersionLabel"
     >
-      <select
-        v-model="kubernetesVersion"
+      <rd-select
         class="select-k8s-version"
+        :value="kubernetesVersion"
         :disabled="isKubernetesDisabled"
         @change="onChange('kubernetes.version', $event.target.value)"
       >
@@ -130,7 +135,7 @@ export default Vue.extend({
             v{{ item.version.version }}
           </option>
         </optgroup>
-      </select>
+      </rd-select>
     </rd-fieldset>
     <rd-fieldset
       data-test="kubernetesPort"

--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -18,15 +18,25 @@ export default Vue.extend({
       default: null,
     },
   },
+  computed: {
+    selectedValue: {
+      get(): string {
+        return this.value;
+      },
+      set(newValue: string): void {
+        this.$emit('input', newValue);
+      },
+    },
+  },
 });
 </script>
 
 <template>
   <div class="rd-select-container">
     <select
-      :value="value"
-      :disabled="$attrs.disabled || isLocked"
+      v-model="selectedValue"
       v-bind="$attrs"
+      :disabled="$attrs.disabled || isLocked"
       v-on="$listeners"
     >
       <slot name="default">

--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -1,0 +1,55 @@
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name:         'rd-select',
+  inheritAttrs: false,
+  props:        {
+    value: {
+      type:    String,
+      default: '',
+    },
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
+    tooltip: {
+      type:    String,
+      default: null,
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="rd-select-container">
+    <select
+      :value="value"
+      :disabled="$attrs.disabled || isLocked"
+      v-bind="$attrs"
+      v-on="$listeners"
+    >
+      <slot name="default">
+        <!-- Slot contents -->
+      </slot>
+    </select>
+    <slot name="after">
+      <i
+        v-if="isLocked"
+        v-tooltip="{
+          content: tooltip || t('preferences.locked.tooltip'),
+          placement: 'right'
+        }"
+        class="icon icon-lock icon-lg"
+      />
+    </slot>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .rd-select-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
This creates an `rd-select` wrapper component that adds a locked state for `select` elements in the Preferences modal. 

This new component contributes to the addition of locked fields throughout Rancher Desktop via #4662

## 🗒️ Testing Notes

This PR covers the creation of the wrapper component and we don't currently have the ability apply a locked state via deployment profiles. Basic functionality can be confirmed by supplying the `:is-locked` prop to `rd-select`. Additional acceptance criteria detailed in associated issue. 

## 📷 Screenshots

### Locked

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/aa865b82-fef8-43ab-93f6-2d9d73d49aa3)

### Disabled

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/90b3b060-0569-48a5-ab19-846e04874f65)

### Default

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/d5f64b80-8ab0-4d18-96f2-0e82b36840cc)

closes #4700