### PR TITLE
Create lockable `rd-input` wrapper component

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -4,6 +4,7 @@ import { Checkbox } from '@rancher/components';
 import Vue from 'vue';
 
 import { VersionEntry } from '@pkg/backend/k8s';
+import RdInput from '@pkg/components/RdInput.vue';
 import RdSelect from '@pkg/components/RdSelect.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
@@ -15,7 +16,7 @@ import type { PropType } from 'vue';
 export default Vue.extend({
   name:       'preferences-body-kubernetes',
   components: {
-    Checkbox, RdFieldset, RdSelect,
+    Checkbox, RdFieldset, RdSelect, RdInput,
   },
   props: {
     preferences: {
@@ -142,7 +143,7 @@ export default Vue.extend({
       class="width-xs"
       legend-text="Kubernetes Port"
     >
-      <input
+      <rd-input
         type="number"
         :disabled="isKubernetesDisabled"
         :value="preferences.kubernetes.port"

--- a/pkg/rancher-desktop/components/RdInput.vue
+++ b/pkg/rancher-desktop/components/RdInput.vue
@@ -1,0 +1,51 @@
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name:         'rd-input',
+  inheritAttrs: false,
+  props:        {
+    value: {
+      type:    [String, Number],
+      default: null,
+    },
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
+    tooltip: {
+      type:    String,
+      default: null,
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="rd-input-container">
+    <input
+      :value="value"
+      :disabled="$attrs.disabled || isLocked"
+      v-bind="$attrs"
+      v-on="$listeners"
+    />
+    <slot name="after">
+      <i
+        v-if="isLocked"
+        v-tooltip="{
+          content: tooltip || t('preferences.locked.tooltip'),
+          placement: 'right'
+        }"
+        class="icon icon-lock icon-lg"
+      />
+    </slot>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .rd-input-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
This creates an `rd-input` wrapper component that adds a locked state for `input` elements in the Preferences modal. 

This new component contributes to the addition of locked fields throughout Rancher Desktop via #4662

## 🗒️ Testing Notes

This PR covers the creation of the wrapper component and we don't currently have the ability apply a locked state via deployment profiles. Basic functionality can be confirmed by supplying the `:is-locked` prop to `rd-select`. Additional acceptance criteria detailed in associated issue. 

## 📷 Screenshots

### Locked

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/ac615b63-c813-4228-9bff-a7b6b35d3390)

### Disabled

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/797401d4-eb9e-4309-86bb-579ef8b2aa70)

### Default

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/76f7f090-cdd4-4964-91cc-1ebf93a79289)

closes #4707 