### PR TITLE
Change `Moproxy.name` to match its key in dependencies.yaml

### DIFF
--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -125,7 +125,7 @@ export class HostResolverHost implements Dependency, GithubDependency {
 }
 
 export class Moproxy implements Dependency, GithubDependency {
-  name = 'Moproxy';
+  name = 'moproxy';
   githubOwner = 'rancher-sandbox';
   githubRepo = 'moproxy';
 


### PR DESCRIPTION
There was a small typo in #4300. The `name` property of a `Dependency` must exactly match the key in dependencies.yaml that points to its current version.