### PR TITLE
Add help button URLs for new preference pages

### DIFF
--- a/pkg/rancher-desktop/config/help.ts
+++ b/pkg/rancher-desktop/config/help.ts
@@ -26,14 +26,18 @@ class Url {
 
 class PreferencesHelp {
   private readonly url = new Url({
-    Application:                       'ui/preferences/application',
     'Application-behavior':            'ui/preferences/application#behavior',
     'Application-environment':         'ui/preferences/application#environment',
     'Application-general':             'ui/preferences/application#general',
-    'Virtual Machine':                 'ui/preferences/virtual-machine',
+    'Virtual Machine-hardware':        'ui/preferences/virtual-machine#hardware',
+    'Virtual Machine-volumes':         'ui/preferences/virtual-machine#volumes',
+    'Virtual Machine-network':         'ui/preferences/virtual-machine#network',
+    'Virtual Machine-emulation':       'ui/preferences/virtual-machine#emulation',
     'Container Engine-general':        'ui/preferences/container-engine#general',
     'Container Engine-allowed-images': 'ui/preferences/container-engine#allowed-images',
-    WSL:                               'ui/preferences/wsl',
+    'WSL-integrations':                'ui/preferences/wsl#integrations',
+    'WSL-network':                     'ui/preferences/wsl#network',
+    'WSL-proxy':                       'ui/preferences/wsl#proxy',
     Kubernetes:                        'ui/preferences/kubernetes',
   });
 


### PR DESCRIPTION
I've removed the URL for `Applications` without a tab; I don't think it was used for anything.

I've also only tested this on macOS; I made the WSL changes based on the preferences source code but haven't tested it.

Fixes #4691