### PR TITLE
Add locked settings API endpoint and persist locked settings in preferences store

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -959,6 +959,10 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     return jsonStringifyWithWhiteSpace(cfg);
   }
 
+  getLockedSettings() {
+    return jsonStringifyWithWhiteSpace(settings.getLockedSettings());
+  }
+
   getDiagnosticCategories(): string[]|undefined {
     return diagnostics.getCategoryNames();
   }

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -282,6 +282,18 @@ paths:
               schema:
                 type: string
 
+  /v1/settings/locked:
+    get:
+      operationId: listLockedSettings
+      summary:  List the current locked settings
+      responses:
+        '200':
+          description: The locked preferences in JSON format
+          content:
+            application/json:
+              schema:
+                "$ref" : "#/components/schemas/preferences"
+
   /v1/shutdown:
     put:
       operationId: shutdownApp

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -2,6 +2,7 @@
 
 import { Checkbox } from '@rancher/components';
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import { VersionEntry } from '@pkg/backend/k8s';
 import RdInput from '@pkg/components/RdInput.vue';
@@ -34,6 +35,7 @@ export default Vue.extend({
     };
   },
   computed: {
+    ...mapGetters('preferences', ['isPreferenceLocked']),
     defaultVersion(): VersionEntry {
       const version = this.recommendedVersions.find(v => (v.channels ?? []).includes('stable'));
 
@@ -110,6 +112,7 @@ export default Vue.extend({
         class="select-k8s-version"
         :value="kubernetesVersion"
         :disabled="isKubernetesDisabled"
+        :is-locked="isPreferenceLocked('kubernetes.version')"
         @change="onChange('kubernetes.version', $event.target.value)"
       >
         <!--
@@ -147,6 +150,7 @@ export default Vue.extend({
         type="number"
         :disabled="isKubernetesDisabled"
         :value="preferences.kubernetes.port"
+        :is-locked="isPreferenceLocked('kubernetes.port')"
         @input="onChange('kubernetes.port', castToNumber($event.target.value))"
       />
     </rd-fieldset>

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
@@ -28,7 +28,7 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
   },
   computed: {
     ...mapGetters('preferences', ['isPreferenceLocked']),
-    patterns() {
+    patterns(): string[] {
       return this.preferences.containerEngine.allowedImages.patterns;
     },
     isAllowedImagesEnabled(): boolean {
@@ -40,10 +40,10 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
     isPatternsFieldLocked(): boolean {
       return this.isPreferenceLocked('containerEngine.allowedImages.patterns') || !this.isAllowedImagesEnabled;
     },
-    allowedImagesLockedTooltip() {
+    allowedImagesLockedTooltip(): string {
       return this.t('allowedImages.locked.tooltip');
     },
-    patternsErrorMessages() {
+    patternsErrorMessages(): { duplicate: string } {
       return { duplicate: this.t('allowedImages.errors.duplicate') };
     },
   },

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
@@ -1,15 +1,19 @@
 <script lang="ts">
 import { Checkbox, StringList } from '@rancher/components';
-import Vue from 'vue';
+import Vue, { VueConstructor } from 'vue';
+import { mapGetters } from 'vuex';
 
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
-import { LockedSettingsType, Settings } from '@pkg/config/settings';
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { Settings } from '@pkg/config/settings';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
 import type { PropType } from 'vue';
 
-export default Vue.extend({
+interface VuexBindings {
+  isPreferenceLocked(path: string): boolean;
+}
+
+export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
   name:       'preferences-container-engine-allowed-images',
   components: {
     Checkbox,
@@ -22,10 +26,8 @@ export default Vue.extend({
       required: true,
     },
   },
-  data() {
-    return { lockedFields: {} as LockedSettingsType };
-  },
   computed: {
+    ...mapGetters('preferences', ['isPreferenceLocked']),
     patterns() {
       return this.preferences.containerEngine.allowedImages.patterns;
     },
@@ -33,10 +35,10 @@ export default Vue.extend({
       return this.preferences.containerEngine.allowedImages.enabled;
     },
     isEnabledFieldLocked(): boolean {
-      return this.lockedFields.containerEngine?.allowedImages?.enabled ?? false;
+      return this.isPreferenceLocked('containerEngine.allowedImages.enabled');
     },
     isPatternsFieldLocked(): boolean {
-      return this.lockedFields.containerEngine?.allowedImages?.patterns || !this.isAllowedImagesEnabled;
+      return this.isPreferenceLocked('containerEngine.allowedImages.patterns') || !this.isAllowedImagesEnabled;
     },
     allowedImagesLockedTooltip() {
       return this.t('allowedImages.locked.tooltip');
@@ -44,11 +46,6 @@ export default Vue.extend({
     patternsErrorMessages() {
       return { duplicate: this.t('allowedImages.errors.duplicate') };
     },
-  },
-  mounted() {
-    ipcRenderer.invoke('get-locked-fields').then((lockedFields: LockedSettingsType) => {
-      this.lockedFields = lockedFields;
-    });
   },
   methods: {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
@@ -129,7 +129,6 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
 
   .icon-lock {
     vertical-align: 2%;
-    color: var(--warning);
   }
 
 </style>

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -61,6 +61,7 @@ export class HttpCommandServer {
         '/v1/diagnostic_ids':        [0, this.diagnosticIDsForCategory],
         '/v1/diagnostic_checks':     [0, this.diagnosticChecks],
         '/v1/settings':              [0, this.listSettings],
+        '/v1/settings/locked':       [0, this.listLockedSettings],
         '/v1/transient_settings':    [0, this.listTransientSettings],
       },
       post: { '/v1/diagnostic_checks': [0, this.diagnosticRunChecks] },
@@ -325,6 +326,20 @@ export class HttpCommandServer {
     } else {
       console.debug('listSettings: failed 200');
       response.status(404).type('txt').send('No settings found');
+    }
+
+    return Promise.resolve();
+  }
+
+  protected listLockedSettings(request: express.Request, response: express.Response, context: commandContext): Promise<void> {
+    const settings = this.commandWorker.getLockedSettings(context);
+
+    if (settings) {
+      console.debug('listLockedSettings: succeeded 200');
+      response.status(200).type('txt').send(settings);
+    } else {
+      console.debug('listLockedSettings: failed 200');
+      response.status(404).type('txt').send('No locked settings found');
     }
 
     return Promise.resolve();
@@ -630,6 +645,7 @@ interface commandContext {
 export interface CommandWorkerInterface {
   factoryReset: (keepSystemImages: boolean) => void;
   getSettings: (context: commandContext) => string;
+  getLockedSettings: (context: commandContext) => string;
   updateSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
   proposeSettings: (context: commandContext, newSettings: RecursivePartial<Settings>) => Promise<[string, string]>;
   requestShutdown: (context: commandContext) => void;

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -338,7 +338,7 @@ export class HttpCommandServer {
       console.debug('listLockedSettings: succeeded 200');
       response.status(200).type('txt').send(settings);
     } else {
-      console.debug('listLockedSettings: failed 200');
+      console.debug('listLockedSettings: failed 404');
       response.status(404).type('txt').send('No locked settings found');
     }
 

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import os from 'os';
 
-import Vue from 'vue';
+import Vue, { VueConstructor } from 'vue';
 import { mapGetters, mapState } from 'vuex';
 
 import EmptyState from '@pkg/components/EmptyState.vue';
@@ -15,7 +15,12 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { Direction, RecursivePartial } from '@pkg/utils/typeUtils';
 import { preferencesNavItems } from '@pkg/window/preferences';
 
-export default Vue.extend({
+interface VuexBindings {
+  credentials: Omit<ServerState, 'pid'>;
+  getCurrentNavItem: 'WSL' | 'Application' | 'Virtual Machine' | 'Container Engine' | 'Kubernetes';
+}
+
+export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
   name:       'preferences-modal',
   components: {
     PreferencesHeader, PreferencesNav, PreferencesBody, PreferencesFooter, EmptyState,
@@ -27,6 +32,7 @@ export default Vue.extend({
   async fetch() {
     await this.$store.dispatch('credentials/fetchCredentials');
     await this.$store.dispatch('preferences/fetchPreferences', this.credentials as ServerState);
+    await this.$store.dispatch('preferences/fetchLocked', this.credentials as ServerState);
     await this.$store.dispatch('transientSettings/fetchTransientSettings', this.credentials as ServerState);
     this.preferencesLoaded = true;
 

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -9,7 +9,7 @@ import PreferencesBody from '@pkg/components/Preferences/ModalBody.vue';
 import PreferencesFooter from '@pkg/components/Preferences/ModalFooter.vue';
 import PreferencesHeader from '@pkg/components/Preferences/ModalHeader.vue';
 import PreferencesNav from '@pkg/components/Preferences/ModalNav.vue';
-import type { TransientSettings } from '@pkg/config/transientSettings';
+import type { NavItemName, TransientSettings } from '@pkg/config/transientSettings';
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { Direction, RecursivePartial } from '@pkg/utils/typeUtils';
@@ -17,7 +17,7 @@ import { preferencesNavItems } from '@pkg/window/preferences';
 
 interface VuexBindings {
   credentials: Omit<ServerState, 'pid'>;
-  getCurrentNavItem: 'WSL' | 'Application' | 'Virtual Machine' | 'Container Engine' | 'Kubernetes';
+  getCurrentNavItem: NavItemName;
 }
 
 export default (Vue as VueConstructor<Vue & VuexBindings>).extend({

--- a/pkg/rancher-desktop/store/preferences.ts
+++ b/pkg/rancher-desktop/store/preferences.ts
@@ -337,4 +337,7 @@ export const getters: GetterTree<PreferencesState, PreferencesState> = {
   getPreferencesNormalized(state: PreferencesState) {
     return normalizePreferences(state.preferences);
   },
+  isPreferenceLocked: (state: PreferencesState) => (value: string) => {
+    return _.get(state.lockedPreferences, value);
+  },
 };


### PR DESCRIPTION
This adds an API endpoint for fetching locked settings and and updates the preferences store to persist locked settings whenever the Preferences modal is rendered.

Locked settings for any given field can be accessed via the `isPreferenceLocked` getter. We make use of the new getter for Kubernetes Version & Port on the Kubernetes page. We also replace the existing method for fetching locked settings with the new getter on the Allowed Images tab in Container Engine.