### PR TITLE
Allow all default settings to be locked

### DIFF
--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -134,8 +134,8 @@ describe('settings', () => {
   const plistProfile = plist.build(fullDefaults);
   const unlockedProfile = {
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
-    containerEngine: { name: 'should be ignored' },
-    kubernetes:      { version: "Shouldn't see this" },
+    containerEngine: { name: 'moby' },
+    kubernetes:      { version: '1.25.9' },
   };
   const lockedProfile = {
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
@@ -145,7 +145,7 @@ describe('settings', () => {
         patterns: ['nginx', 'alpine'],
       },
     },
-    kubernetes: { version: "Shouldn't see this" },
+    kubernetes: { version: '1.25.9' },
   };
   const unlockedJSONProfile = JSON.stringify(unlockedProfile);
   const lockedJSONProfile = JSON.stringify(lockedProfile);
@@ -336,8 +336,16 @@ describe('settings', () => {
               .mockImplementation(createMocker(ProfileTypes.None, ProfileTypes.Unlocked));
             const profiles = await readDeploymentProfiles();
             const expectedDefaults = _.omit(fullDefaults, ['debug', 'ignorableTestSettings', 'diagnostics.locked']);
+            const expected = {
+              containerEngine: {
+                name: 'moby',
+              },
+              kubernetes: {
+                version: '1.25.9',
+              },
+            };
 
-            expect(profiles.locked).toEqual({ containerEngine: {} });
+            expect(profiles.locked).toEqual(expected);
             expect(profiles.defaults).toEqual(expectedDefaults);
           });
         });

--- a/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
@@ -5,10 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import * as settings from '@pkg/config/settings';
-import {
-  readDeploymentProfiles,
-  lockableDefaultSettings, validateDeploymentProfile,
-} from '@pkg/main/deploymentProfiles';
+import { readDeploymentProfiles, validateDeploymentProfile } from '@pkg/main/deploymentProfiles';
 import { spawnFile } from '@pkg/utils/childProcess';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
@@ -395,7 +392,7 @@ describe('deployment profiles', () => {
       let error: Error | undefined;
 
       try {
-        validateDeploymentProfile('fake locked profile', invalidDefaultProfile, lockableDefaultSettings, []);
+        validateDeploymentProfile('fake locked profile', invalidDefaultProfile, settings.defaultSettings, []);
       } catch (ex: any) {
         error = ex;
       }

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -17,19 +17,6 @@ const console = Logging.deploymentProfile;
 export class DeploymentProfileError extends Error {
 }
 
-/**
- * Lockable default settings used for validating deployment profiles.
- * Data values are ignored, but types are used for validation.
- */
-export const lockableDefaultSettings = {
-  containerEngine: {
-    allowedImages: {
-      enabled:  true,
-      patterns: [] as Array<string>,
-    },
-  },
-};
-
 const REGISTRY_PATH_PROFILE = ['SOFTWARE', 'Rancher Desktop', 'Profile'];
 
 /**
@@ -91,7 +78,7 @@ export async function readDeploymentProfiles(registryProfilePath = REGISTRY_PATH
   }
 
   profiles.defaults = validateDeploymentProfile(fullDefaultPath, defaults, settings.defaultSettings, []) ?? {};
-  profiles.locked = validateDeploymentProfile(fullLockedPath, locked, lockableDefaultSettings, []) ?? {};
+  profiles.locked = validateDeploymentProfile(fullLockedPath, locked, settings.defaultSettings, []) ?? {};
 
   return profiles;
 }


### PR DESCRIPTION
This allows all of our default settings to be lockable by setting `lockableDefaultSettings` to `settings.default`. 