### PR TITLE
Change defaults for adminAccess and containerEngine

### DIFF
--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -69,7 +69,7 @@ export enum CacheMode {
 export const defaultSettings = {
   version:     CURRENT_SETTINGS_VERSION,
   application: {
-    adminAccess: true,
+    adminAccess: false,
     debug:       false,
     extensions:  {
       allowed: {
@@ -91,7 +91,7 @@ export const defaultSettings = {
       enabled:  false,
       patterns: [] as Array<string>,
     },
-    name: ContainerEngine.CONTAINERD,
+    name: ContainerEngine.MOBY,
   },
   virtualMachine: {
     memoryInGB:   2,


### PR DESCRIPTION
Pick defaults that work best for new users who cannot make an informed decision themselves. This affects only the first-run experience for new users (or after a factory-reset).

Fixes #4546 
Fixes #4547 
