### PR TITLE
Enable locking of Radio Buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@docker/extension-api-client-types": "0.3.4",
         "@kubernetes/client-node": "0.18.1",
         "@nuxtjs/eslint-module": "3.1.0",
-        "@rancher/components": "0.1.1",
+        "@rancher/components": "0.1.3",
         "@rancher/shell": "0.1.3",
         "agent-base": "6.0.2",
         "bufferutil": "4.0.7",
@@ -6195,9 +6195,9 @@
       }
     },
     "node_modules/@rancher/components": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.1.tgz",
-      "integrity": "sha512-jR/8ce1JWjtKMrVnSSDkvtqfZAMGFVra61RJh3GN39jtRREipEoyQxEHsM9BPfw7Va83BhZkdBkkKupJ1Vs0dA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.3.tgz",
+      "integrity": "sha512-SgWewaUDW5RjPhDZsn9O3nPivKlQ7dcy//QbbWhZ77l27k9wk5KtJpTgCJIvsRFmCaR+EjKz67MV3+HE5eyzGQ==",
       "dependencies": {
         "lodash.debounce": "4.0.8"
       },
@@ -6206,7 +6206,7 @@
       },
       "peerDependencies": {
         "core-js": "3.25.3",
-        "vue": "2.6.14"
+        "vue": "^2.6.14"
       }
     },
     "node_modules/@rancher/shell": {
@@ -39080,9 +39080,9 @@
       "version": "2.11.6"
     },
     "@rancher/components": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.1.tgz",
-      "integrity": "sha512-jR/8ce1JWjtKMrVnSSDkvtqfZAMGFVra61RJh3GN39jtRREipEoyQxEHsM9BPfw7Va83BhZkdBkkKupJ1Vs0dA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@rancher/components/-/components-0.1.3.tgz",
+      "integrity": "sha512-SgWewaUDW5RjPhDZsn9O3nPivKlQ7dcy//QbbWhZ77l27k9wk5KtJpTgCJIvsRFmCaR+EjKz67MV3+HE5eyzGQ==",
       "requires": {
         "lodash.debounce": "4.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@docker/extension-api-client-types": "0.3.4",
     "@kubernetes/client-node": "0.18.1",
     "@nuxtjs/eslint-module": "3.1.0",
-    "@rancher/components": "0.1.1",
+    "@rancher/components": "0.1.3",
     "@rancher/shell": "0.1.3",
     "agent-base": "6.0.2",
     "bufferutil": "4.0.7",

--- a/pkg/rancher-desktop/components/EngineSelector.vue
+++ b/pkg/rancher-desktop/components/EngineSelector.vue
@@ -14,6 +14,10 @@ export default {
       type:    Boolean,
       default: false,
     },
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
   },
   computed: {
     options() {
@@ -44,6 +48,7 @@ export default {
       :value="containerEngine"
       :options="options"
       :row="row"
+      :disabled="isLocked"
       @input="updateEngine"
     >
       <template #label>

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -3,6 +3,7 @@ import os from 'os';
 
 import { RadioButton, RadioGroup } from '@rancher/components';
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
@@ -27,6 +28,7 @@ export default Vue.extend({
     },
   },
   computed: {
+    ...mapGetters('preferences', ['isPreferenceLocked']),
     options(): { label: string, value: MountType, description: string, experimental: boolean, disabled: boolean }[] {
       const defaultOption = MountType.REVERSE_SSHFS;
 
@@ -117,6 +119,7 @@ export default Vue.extend({
         <rd-fieldset
           data-test="mountType"
           :legend-text="t('virtualMachine.mount.type.legend')"
+          :is-locked="isPreferenceLocked('experimental.virtualMachine.mount.type')"
         >
           <template #default="{ isLocked }">
             <radio-group

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -118,39 +118,42 @@ export default Vue.extend({
           data-test="mountType"
           :legend-text="t('virtualMachine.mount.type.legend')"
         >
-          <radio-group
-            :name="groupName"
-            :options="options"
-          >
-            <template
-              v-for="(option, index) in options"
-              #[index]
+          <template #default="{ isLocked }">
+            <radio-group
+              :name="groupName"
+              :options="options"
+              :disabled="isLocked"
             >
-              <radio-button
-                :key="groupName+'-'+index"
-                :name="groupName"
-                :value="preferences.experimental.virtualMachine.mount.type"
-                :label="option.label"
-                :val="option.value"
-                :description="option.description"
-                :disabled="option.disabled"
-                :data-test="option.label"
-                @input="updateValue('experimental.virtualMachine.mount.type', $event)"
+              <template
+                v-for="(option, index) in options"
+                #[index]="{ isDisabled }"
               >
-                <template #label>
-                  <div
-                    v-tooltip="disabledVirtIoFsTooltip(option.disabled)"
-                  >
-                    {{ option.label }}
-                    <labeled-badge
-                      v-if="option.experimental"
-                      :text="t('prefs.experimental')"
-                    />
-                  </div>
-                </template>
-              </radio-button>
-            </template>
-          </radio-group>
+                <radio-button
+                  :key="groupName+'-'+index"
+                  :name="groupName"
+                  :value="preferences.experimental.virtualMachine.mount.type"
+                  :label="option.label"
+                  :val="option.value"
+                  :description="option.description"
+                  :disabled="option.disabled || isDisabled"
+                  :data-test="option.label"
+                  @input="updateValue('experimental.virtualMachine.mount.type', $event)"
+                >
+                  <template #label>
+                    <div
+                      v-tooltip="disabledVirtIoFsTooltip(option.disabled)"
+                    >
+                      {{ option.label }}
+                      <labeled-badge
+                        v-if="option.experimental"
+                        :text="t('prefs.experimental')"
+                      />
+                    </div>
+                  </template>
+                </radio-button>
+              </template>
+            </radio-group>
+          </template>
         </rd-fieldset>
       </div>
       <div

--- a/pkg/rancher-desktop/components/PathManagementSelector.vue
+++ b/pkg/rancher-desktop/components/PathManagementSelector.vue
@@ -28,6 +28,10 @@ export default Vue.extend({
       type:    Boolean,
       default: true,
     },
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
   },
   computed: {
     options(): pathManagementOptions[] {
@@ -70,6 +74,7 @@ export default Vue.extend({
     :value="value"
     :options="options"
     :row="row"
+    :disabled="isLocked"
     class="path-management"
     @input="updateVal"
   >

--- a/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
@@ -34,10 +34,13 @@ export default Vue.extend({
     :legend-text="t('pathManagement.label')"
     :legend-tooltip="t('pathManagement.tooltip', { }, true)"
   >
-    <path-management-selector
-      :show-label="false"
-      :value="preferences.application.pathManagementStrategy"
-      @input="onChange('application.pathManagementStrategy', $event)"
-    />
+    <template #default="{ isLocked }">
+      <path-management-selector
+        :show-label="false"
+        :value="preferences.application.pathManagementStrategy"
+        :is-locked="isLocked"
+        @input="onChange('application.pathManagementStrategy', $event)"
+      />
+    </template>
   </rd-fieldset>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
@@ -19,8 +19,11 @@ export default Vue.extend({
       required: true,
     },
   },
-  computed: { ...mapGetters('applicationSettings', ['pathManagementStrategy']) },
-  methods:  {
+  computed: {
+    ...mapGetters('applicationSettings', ['pathManagementStrategy']),
+    ...mapGetters('preferences', ['isPreferenceLocked']),
+  },
+  methods: {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
     },
@@ -33,6 +36,7 @@ export default Vue.extend({
     data-test="pathManagement"
     :legend-text="t('pathManagement.label')"
     :legend-tooltip="t('pathManagement.tooltip', { }, true)"
+    :is-locked="isPreferenceLocked('application.pathManagementStrategy')"
   >
     <template #default="{ isLocked }">
       <path-management-selector

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
@@ -20,7 +21,8 @@ export default Vue.extend({
   data() {
     return { containerEngine: ContainerEngine.CONTAINERD };
   },
-  methods: {
+  computed: { ...mapGetters('preferences', ['isPreferenceLocked']) },
+  methods:  {
     onChangeEngine(desiredEngine: ContainerEngine) {
       this.containerEngine = desiredEngine;
       this.$emit('container-engine-change', desiredEngine);
@@ -37,6 +39,7 @@ export default Vue.extend({
     <rd-fieldset
       data-test="containerEngine"
       :legend-text="t('containerEngine.label')"
+      :is-locked="isPreferenceLocked('containerEngine.name')"
     >
       <template #default="{ isLocked }">
         <engine-selector

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
@@ -38,10 +38,13 @@ export default Vue.extend({
       data-test="containerEngine"
       :legend-text="t('containerEngine.label')"
     >
-      <engine-selector
-        :container-engine="preferences.containerEngine.name"
-        @change="onChange('containerEngine.name', $event)"
-      />
+      <template #default="{ isLocked }">
+        <engine-selector
+          :container-engine="preferences.containerEngine.name"
+          :is-locked="isLocked"
+          @change="onChange('containerEngine.name', $event)"
+        />
+      </template>
     </rd-fieldset>
   </div>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -3,6 +3,7 @@ import os from 'os';
 
 import { Checkbox, RadioButton, RadioGroup } from '@rancher/components';
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
@@ -27,6 +28,7 @@ export default Vue.extend({
     },
   },
   computed: {
+    ...mapGetters('preferences', ['isPreferenceLocked']),
     options(): { label: string, value: VMType, description: string, experimental: boolean, disabled: boolean }[] {
       const defaultOption = VMType.QEMU;
 
@@ -78,40 +80,44 @@ export default Vue.extend({
         <rd-fieldset
           data-test="vmType"
           :legend-text="t('virtualMachine.type.legend')"
+          :is-locked="isPreferenceLocked('experimental.virtualMachine.type')"
         >
-          <radio-group
-            :options="options"
-            :name="groupName"
-          >
-            <template
-              v-for="(option, index) in options"
-              #[index]
+          <template #default="{ isLocked }">
+            <radio-group
+              :options="options"
+              :name="groupName"
+              :disabled="isLocked"
             >
-              <radio-button
-                :key="groupName+'-'+index"
-                :name="groupName"
-                :value="preferences.experimental.virtualMachine.type"
-                :label="option.label"
-                :val="option.value"
-                :description="option.description"
-                :disabled="option.disabled"
-                :data-test="option.label"
-                @input="onChange('experimental.virtualMachine.type', $event)"
+              <template
+                v-for="(option, index) in options"
+                #[index]="{ isDisabled }"
               >
-                <template #label>
-                  <div
-                    v-tooltip="disabledVmTypeTooltip(option.disabled)"
-                  >
-                    {{ option.label }}
-                    <labeled-badge
-                      v-if="option.experimental"
-                      :text="t('prefs.experimental')"
-                    />
-                  </div>
-                </template>
-              </radio-button>
-            </template>
-          </radio-group>
+                <radio-button
+                  :key="groupName+'-'+index"
+                  :name="groupName"
+                  :value="preferences.experimental.virtualMachine.type"
+                  :label="option.label"
+                  :val="option.value"
+                  :description="option.description"
+                  :disabled="option.disabled || isDisabled"
+                  :data-test="option.label"
+                  @input="onChange('experimental.virtualMachine.type', $event)"
+                >
+                  <template #label>
+                    <div
+                      v-tooltip="disabledVmTypeTooltip(option.disabled)"
+                    >
+                      {{ option.label }}
+                      <labeled-badge
+                        v-if="option.experimental"
+                        :text="t('prefs.experimental')"
+                      />
+                    </div>
+                  </template>
+                </radio-button>
+              </template>
+            </radio-group>
+          </template>
         </rd-fieldset>
       </div>
       <div

--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -21,6 +21,17 @@ export default Vue.extend({
       type:    String,
       default: '',
     },
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    lockedTooltip() {
+      const legendTooltip = this.legendTooltip ? ` <br><br> ${ this.legendTooltip }` : '';
+
+      return `${ this.t('preferences.locked.tooltip') }${ legendTooltip }`;
+    },
   },
 });
 </script>
@@ -30,14 +41,31 @@ export default Vue.extend({
     <legend>
       <slot name="legend">
         {{ legendText }}
-        <i v-if="legendTooltip" v-tooltip="legendTooltip" class="icon icon-info icon-lg" />
+        <i
+          v-if="isLocked"
+          v-tooltip="{
+            content: lockedTooltip,
+            placement: 'right'
+          }"
+          class="icon icon-lock icon-lg"
+        />
+        <i
+          v-else-if="legendTooltip"
+          v-tooltip="legendTooltip"
+          class="icon icon-info icon-lg"
+        />
         <labeled-badge
           v-if="badgeText"
           :text="badgeText"
         />
       </slot>
     </legend>
-    <slot></slot>
+    <slot
+      name="default"
+      :is-locked="isLocked"
+    >
+      <!-- Slot content -->
+    </slot>
   </fieldset>
 </template>
 

--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -40,7 +40,11 @@ export default Vue.extend({
   <fieldset class="rd-fieldset">
     <legend>
       <slot name="legend">
-        {{ legendText }}
+        <span>{{ legendText }}</span>
+        <labeled-badge
+          v-if="badgeText"
+          :text="badgeText"
+        />
         <i
           v-if="isLocked"
           v-tooltip="{
@@ -53,10 +57,6 @@ export default Vue.extend({
           v-else-if="legendTooltip"
           v-tooltip="legendTooltip"
           class="icon icon-info icon-lg"
-        />
-        <labeled-badge
-          v-if="badgeText"
-          :text="badgeText"
         />
       </slot>
     </legend>
@@ -80,6 +80,10 @@ export default Vue.extend({
       color: inherit;
       line-height: 1.5rem;
       padding-bottom: 0.5rem;
+
+      > * {
+        margin-right: 0.25rem;
+      }
     }
   }
 </style>


### PR DESCRIPTION
This pull request enables the ability to lock radio buttons in the preferences modal.

To implement this feature, I introduced a new `isLocked` prop to the `RdFieldset` component. This prop allows us to display a lock icon next to the label. I chose this approach because our locked profiles are represented as boolean values, and placing the lock button directly next to each radio button would complicate the logic. 

This is an example of a locked profile for `containerEngine`:

```
"containerEngine": {
  "allowedImages": {
    "enabled": true,
    "patterns": true
  },
  "name": true
},
```

In this example, `"name": "moby"` is translated to `"name": true` for the locked profile. 

## 📷 Screenshots

### Application: Environment 

<img width="880" alt="Screenshot 2023-05-25 at 2 55 49 PM" src="https://github.com/rancher-sandbox/rancher-desktop/assets/835961/62e0c43a-cccc-4370-bc1e-13c41217748a">

### Virtual Machine: Volumes
<img width="880" alt="Screenshot 2023-05-25 at 2 55 55 PM" src="https://github.com/rancher-sandbox/rancher-desktop/assets/835961/919ff97a-d899-4cd5-af5c-381a5d9be2ba">

### Virtual Machine: Emulation

<img width="880" alt="Screenshot 2023-05-25 at 2 55 59 PM" src="https://github.com/rancher-sandbox/rancher-desktop/assets/835961/9c785ad7-4958-4ba6-a88b-a0d6047be7a3">

### Container Engine: General

<img width="880" alt="Screenshot 2023-05-25 at 2 56 02 PM" src="https://github.com/rancher-sandbox/rancher-desktop/assets/835961/c2d3b562-f5f6-4558-a1a9-3aae0d4f74c4">

