### PR TITLE
Ensure single instance of Vue is used with `npm link`

### DIFF
--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import path from 'path';
+
 import _ from 'lodash';
 
 import babelConfig from '../../babel.config';
@@ -22,6 +24,7 @@ export default {
       webpackConfig.target = 'electron-renderer';
       // Set a resolver alias for `./@pkg` so that we can load things from @ in CSS
       webpackConfig.resolve.alias['./@pkg'] = __dirname;
+      webpackConfig.resolve.alias['vue$'] = isDevelopment ? path.resolve(process.cwd(), 'node_modules', 'vue') : 'vue';
 
       // Add necessary loaders
       webpackConfig.module.rules.push({


### PR DESCRIPTION
This configuration sets up an alias for the vue package that points to the version of Vue installed in Rancher Desktop's `node_modules` directory. This ensures that only one instance of Vue is used during development.

After Rancher Dashboard upgraded to Vue 2.7, we started getting several errors in Rancher Desktop when using `npm link` with `@rancher/components`. Some of these errors include 

- `[Vue warn]: $attrs is readonly.`
- `[Vue warn]: $listeners is readonly.`

Setting up this alias helps to resolve issues involved in linking a library that targets Vue 2.7 in our project that targets Vue 2.6.