### PR TITLE
fix: rewrites the user-agent opacity for select.disabled

### DIFF
--- a/pkg/rancher-desktop/assets/styles/global/_form.scss
+++ b/pkg/rancher-desktop/assets/styles/global/_form.scss
@@ -19,6 +19,7 @@ TEXTAREA,
   display: block;
   box-sizing: border-box;
   width: 100%;
+  opacity: 1;
   padding: $input-padding-sm;
   background-color: var(--input-bg);
   border-radius: var(--border-radius);


### PR DESCRIPTION
Fixes #4593

The issue seems to be that the `user-agent` adds some opacity to the type `select` element; this PR rewrites it by applying `opacity: 1` to all or form elements.

Issue:
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/548704fa-ea37-493a-96e5-0da2c251436f)

Resut:
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/ea7b4d1b-f304-48b5-91fc-6566e6ea7759)
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/68e7e483-f329-4d65-8c02-8d171c18d6c7)




Note: do we use some kind of `css-reset` ? 
