### PR TITLE
Update VZ settings checks

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -746,6 +746,10 @@ ipcMainProxy.on('get-app-version', async(event) => {
   event.reply('get-app-version', await getVersion());
 });
 
+ipcMainProxy.handle('versions/macOs', () => {
+  return getMacOsVersion();
+});
+
 ipcMainProxy.on('help/preferences/open-url', async() => {
   Help.preferences.openUrl(await getVersion());
 });

--- a/background.ts
+++ b/background.ts
@@ -40,7 +40,7 @@ import getCommandLineArgs from '@pkg/utils/commandLine';
 import DockerDirManager from '@pkg/utils/dockerDirManager';
 import { isDevEnv } from '@pkg/utils/environment';
 import Logging, { setLogLevel, clearLoggingDirectory } from '@pkg/utils/logging';
-import { getMacOsVersion } from '@pkg/utils/osVersion';
+import { fetchMacOsVersion, getMacOsVersion } from '@pkg/utils/osVersion';
 import paths from '@pkg/utils/paths';
 import { setupProtocolHandlers, protocolsRegistered } from '@pkg/utils/protocols';
 import { executable } from '@pkg/utils/resources';
@@ -161,6 +161,11 @@ Electron.app.whenReady().then(async() => {
     const commandLineArgs = getCommandLineArgs();
 
     setupProtocolHandlers();
+
+    // make sure we have the macOS version cached before calling getMacOsVersion()
+    if (os.platform() === 'darwin') {
+      await fetchMacOsVersion(console);
+    }
 
     // Needs to happen before any file is written, otherwise that file
     // could be owned by root, which will lead to future problems.
@@ -347,13 +352,7 @@ async function checkPrerequisites() {
   }
   case 'darwin': {
     // Required: MacOS-10.15(Darwin-19) or newer
-    const macOsVersion = await getMacOsVersion(console);
-
-    if (macOsVersion === null) {
-      console.warn('failed to get macOS version');
-      break;
-    }
-    if (semver.gt('10.15.0', macOsVersion)) {
+    if (semver.gt('10.15.0', getMacOsVersion())) {
       messageId = 'macOS-release';
     }
     break;

--- a/docs/development/env.md
+++ b/docs/development/env.md
@@ -1,0 +1,21 @@
+# Internal Rancher Desktop environment variables
+
+These variables are used for build and development purposes; they are not meant to be set by users.
+
+They do not form an API and may be changed or removed at any time without prior notice.
+
+## RD_DEBUG_ENABLED=anything
+
+Forces debug logging to always be enabled. Useful to debug first-run issues when there is no `settings.yaml` yet to set debug mode.
+
+## RD_FORCE_UPDATES_ENABLED=anything
+
+When set, it will force auto-update to be enabled even in `npm run dev` mode. Updates will be checked and downloaded, but **not** installed.
+
+## RD_MOCK_MACOS_VERSION=semver
+
+Used for testing compatibility of the app with the OS version, for upgrade responder tests, and for enabling/disabling certain parts of the preferences (related to VZ emulation mode).
+
+## RD_UPGRADE_RESPONDER_URL=http://localhost:8314/v1/checkupgrade
+
+Set an alternate upgrade responder endpoint for testing.

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -2628,7 +2628,8 @@ prefs:
     'false': Show Releases Only
     label: Helm Charts
   experimental: Experimental
-  onlyFromVentura: The setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_arm64: This setting requires macOS 13.3 (Ventura) or later.
 
 principal:
   loading: Loading&hellip;

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -2630,6 +2630,7 @@ prefs:
   experimental: Experimental
   onlyFromVentura_x64: This setting requires macOS 13.0 (Ventura) or later.
   onlyFromVentura_arm64: This setting requires macOS 13.3 (Ventura) or later.
+  onlyWithVZ: This setting requires using the VZ emulation mode.
 
 principal:
   loading: Loading&hellip;

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -10,7 +10,7 @@ import RdSelect from '@pkg/components/RdSelect.vue';
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import {
-  CacheMode, MountType, ProtocolVersion, SecurityModel, Settings,
+  CacheMode, MountType, ProtocolVersion, SecurityModel, Settings, VMType,
 } from '@pkg/config/settings';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
@@ -68,7 +68,7 @@ export default Vue.extend({
       return os.platform() === 'darwin';
     },
     virtIoFsDisabled(): boolean {
-      return parseInt(os.release()) < 22;
+      return this.preferences.experimental.virtualMachine.type !== VMType.VZ;
     },
   },
   methods: {
@@ -107,7 +107,7 @@ export default Vue.extend({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t('prefs.onlyFromVentura') };
+        tooltip = { content: this.t('prefs.onlyWithVZ') };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -2,6 +2,7 @@
 import os from 'os';
 
 import { RadioButton, RadioGroup } from '@rancher/components';
+import semver from 'semver';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
@@ -9,6 +10,7 @@ import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdCheckbox from '@pkg/components/form/RdCheckbox.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings, VMType } from '@pkg/config/settings';
+import { getMacOsVersion } from '@pkg/utils/osVersion';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
 import type { PropType } from 'vue';
@@ -51,7 +53,7 @@ export default Vue.extend({
       return this.preferences.experimental.virtualMachine.type === VMType.VZ;
     },
     vzDisabled(): boolean {
-      return parseInt(os.release()) < 22;
+      return semver.gt('13.0.0', getMacOsVersion()) || (os.arch() === 'arm64' && semver.gt('13.3.0', getMacOsVersion()));
     },
     rosettaDisabled(): boolean {
       return os.arch() !== 'arm64';
@@ -65,7 +67,7 @@ export default Vue.extend({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t('prefs.onlyFromVentura') };
+        tooltip = { content: this.t(`prefs.onlyFromVentura_${ os.arch() }`) };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
+++ b/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
@@ -30,13 +30,13 @@ const CheckLimaDarwin: DiagnosticsChecker = {
 
     return Promise.resolve(isDarwin && isArm);
   },
-  async check() {
+  check() {
     const result = {
       description: '',
       passed:      false,
       fixes:       [] as { description: string }[],
     };
-    const currentVersion = await getMacOsVersion(console);
+    const currentVersion = getMacOsVersion();
 
     result.passed = !!currentVersion && semver.gte(currentVersion, '12.4.0', { loose: true });
     result.description = `This machine is running macOS ${ currentVersion }.`;
@@ -54,7 +54,7 @@ const CheckLimaDarwin: DiagnosticsChecker = {
     }
     console.debug(`${ this.id }: version=${ currentVersion } result=${ JSON.stringify(result) }`);
 
-    return result;
+    return Promise.resolve(result);
   },
 };
 

--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -222,18 +222,12 @@ export async function setHasQueuedUpdate(isQueued: boolean): Promise<void> {
  * i.e. the version of the entire package, including kernel,
  * userspace programs, base configuration, etc.
  */
-async function getPlatformVersion(): Promise<string> {
+function getPlatformVersion(): string {
   switch (process.platform) {
   case 'win32':
     return os.release();
   case 'darwin': {
-    const macOsVersion = await getMacOsVersion(console);
-
-    if (macOsVersion === null) {
-      throw new Error('failed to get macOS version');
-    }
-
-    return macOsVersion.toString();
+    return getMacOsVersion().toString();
   }
   case 'linux':
     // OS version is hard to get on Linux and could be in many different
@@ -300,7 +294,7 @@ export async function queryUpgradeResponder(url: string, currentVersion: semver.
     appVersion: currentVersion.toString(),
     extraInfo:  {
       platform:        `${ process.platform }-${ os.arch() }`,
-      platformVersion: await getPlatformVersion(),
+      platformVersion: getPlatformVersion(),
     },
   };
 

--- a/pkg/rancher-desktop/pages/Preferences.vue
+++ b/pkg/rancher-desktop/pages/Preferences.vue
@@ -56,6 +56,10 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
     ipcRenderer.on('route', async(event, args) => {
       await this.navigateToTab(args);
     });
+
+    ipcRenderer.invoke('versions/macOs').then((macOsVersion) => {
+      this.$store.dispatch('transientSettings/setMacOsVersion', macOsVersion);
+    });
   },
   beforeDestroy() {
     /**

--- a/pkg/rancher-desktop/store/transientSettings.ts
+++ b/pkg/rancher-desktop/store/transientSettings.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import semver from 'semver';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
@@ -14,20 +15,27 @@ interface CommitArgs extends ServerState {
   payload?: RecursivePartial<TransientSettings>;
 }
 
+type ExtendedTransientSettings = TransientSettings & {
+  macOsVersion?: semver.SemVer;
+};
+
 const uri = (port: number) => `http://localhost:${ port }/v1/transient_settings`;
 
-export const state: () => TransientSettings = () => _.cloneDeep(defaultTransientSettings);
+export const state: () => ExtendedTransientSettings = () => _.cloneDeep(defaultTransientSettings);
 
-export const mutations: MutationsType<TransientSettings> = {
+export const mutations: MutationsType<ExtendedTransientSettings> = {
   SET_PREFERENCES(state, preferences) {
     state.preferences = preferences;
   },
   SET_NO_MODAL_DIALOGS(state, noModalDialogs) {
     state.noModalDialogs = noModalDialogs;
   },
+  SET_MAC_OS_VERSION(state, macOsVersion) {
+    state.macOsVersion = macOsVersion;
+  },
 };
 
-type TransientSettingsContext = ActionContext<TransientSettings>;
+type TransientSettingsContext = ActionContext<ExtendedTransientSettings>;
 
 export const actions = {
   setPreferences({ commit }: TransientSettingsContext, preferences: Preferences) {
@@ -68,6 +76,9 @@ export const actions = {
       'transientSettings/fetchTransientSettings',
       args,
       { root: true });
+  },
+  setMacOsVersion({ commit }: TransientSettingsContext, macOsVersion: semver.SemVer) {
+    commit('SET_MAC_OS_VERSION', macOsVersion);
   },
 };
 

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -6,6 +6,7 @@ import Electron from 'electron';
 
 import type { ServiceEntry } from '@pkg/backend/k8s';
 import type { RecursivePartial, Direction } from '@pkg/utils/typeUtils';
+import semver from 'semver';
 /**
  * IpcMainEvents describes events the renderer can send to the main process,
  * i.e. ipcRenderer.send() -> ipcMain.on().
@@ -118,6 +119,10 @@ export interface IpcMainInvokeEvents {
   /** Fetch data from the backend, or arbitrary host ignoring CORS. */
   'extensions/vm/http-fetch': (config: import('@docker/extension-api-client-types').v1.RequestConfig) => any;
   // #endregion
+
+  // #region Versions
+  'versions/macOs': () => semver.SemVer;
+  // #endregion
 }
 
 /**
@@ -175,5 +180,9 @@ export interface IpcRendererEvents {
 
   // #region preferences
   'preferences/changed': () => void;
+  // #endregion
+
+  // #region Versions
+  'versions/macOs': (macOsVersion: semver.SemVer) => void;
   // #endregion
 }

--- a/pkg/rancher-desktop/utils/osVersion.ts
+++ b/pkg/rancher-desktop/utils/osVersion.ts
@@ -1,3 +1,5 @@
+import * as process from 'process';
+
 import semver from 'semver';
 
 import { spawnFile } from '@pkg/utils/childProcess';
@@ -6,13 +8,19 @@ import { Log } from '@pkg/utils/logging';
 let macOsVersion: semver.SemVer;
 
 export async function fetchMacOsVersion(console: Log) {
-  const { stdout } = await spawnFile('/usr/bin/sw_vers', ['-productVersion'], { stdio: ['ignore', 'pipe', console] });
-  const currentVersion = semver.coerce(stdout);
+  let versionString = process.env.RD_MOCK_MACOS_VERSION;
+
+  if (!versionString) {
+    const { stdout } = await spawnFile('/usr/bin/sw_vers', ['-productVersion'], { stdio: ['ignore', 'pipe', console] });
+
+    versionString = stdout.trimEnd();
+  }
+  const currentVersion = semver.coerce(versionString);
 
   if (currentVersion) {
     macOsVersion = currentVersion;
   } else {
-    throw new Error(`Cannot convert "${ stdout.trimEnd() }" to macOS semver`);
+    throw new Error(`Cannot convert "${ versionString }" to macOS semver`);
   }
 }
 

--- a/pkg/rancher-desktop/utils/osVersion.ts
+++ b/pkg/rancher-desktop/utils/osVersion.ts
@@ -3,9 +3,19 @@ import semver from 'semver';
 import { spawnFile } from '@pkg/utils/childProcess';
 import { Log } from '@pkg/utils/logging';
 
-export async function getMacOsVersion(console: Log): Promise<semver.SemVer | null> {
+let macOsVersion: semver.SemVer;
+
+export async function fetchMacOsVersion(console: Log) {
   const { stdout } = await spawnFile('/usr/bin/sw_vers', ['-productVersion'], { stdio: ['ignore', 'pipe', console] });
   const currentVersion = semver.coerce(stdout);
 
-  return currentVersion;
+  if (currentVersion) {
+    macOsVersion = currentVersion;
+  } else {
+    throw new Error(`Cannot convert "${ stdout.trimEnd() }" to macOS semver`);
+  }
+}
+
+export function getMacOsVersion(): semver.SemVer {
+  return macOsVersion;
 }


### PR DESCRIPTION
VZ now requires 13.0 on Intel and 13.3 on ARM.

Also VIRTIOFS requires that the emulation mode is VZ; just running on Ventura is not enough. It does not work with QEMU.

Fixes #4792