### PR TITLE
RdSelect: differentiate between locked / disabled + locked

### DIFF
--- a/pkg/rancher-desktop/assets/styles/themes/_dark.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_dark.scss
@@ -95,6 +95,7 @@
   --dropdown-hover-bg          : #{$link};
   --dropdown-disabled-bg       : #{$disabled};
   --dropdown-disabled-text     : #{$disabled};
+  --dropdown-locked-text       : #{$lightest};
 
   --input-text                 : #{$lightest};
   --input-label                : #{$lighter};

--- a/pkg/rancher-desktop/assets/styles/themes/_light.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_light.scss
@@ -362,6 +362,7 @@ BODY, .theme-light {
   --dropdown-hover-bg          : var(--primary);
   --dropdown-disabled-text     : var(--muted);
   --dropdown-disabled-bg       : #{$disabled};
+  --dropdown-locked-text       : #{$darkest};
 
   // UNUSED?
   --card-header                : var(--primary-banner-bg);

--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -36,6 +36,7 @@ export default Vue.extend({
     <select
       v-model="selectedValue"
       v-bind="$attrs"
+      :class="{ 'locked' : isLocked && !$attrs.disabled }"
       :disabled="$attrs.disabled || isLocked"
       v-on="$listeners"
     >
@@ -61,5 +62,13 @@ export default Vue.extend({
     display: flex;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  .locked {
+    color: var(--dropdown-locked-text);
+
+    &:hover {
+      color: var(--dropdown-locked-text);
+    }
   }
 </style>


### PR DESCRIPTION
Change the text color to differentiate between a locked and a disabled and locked `RdSelect`.

Light theme (active, disabled, locked, disabled + locked):
![Screenshot_2023-05-26_14-11-18](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/bbcac963-0186-405c-9261-98a0d5b2694a)

Dark theme (active, disabled, locked, disabled + locked):
![Screenshot_2023-05-26_14-10-37](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/f46e4bf9-35fc-461d-9288-85757974c221)
