### PR TITLE
RdInput: differentiate between locked / disabled + locked

### DIFF
--- a/pkg/rancher-desktop/assets/styles/themes/_dark.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_dark.scss
@@ -110,6 +110,7 @@
   --input-disabled-border      : #{darken($medium, 30%)};
   --input-disabled-placeholder : #{darken($disabled, 10%)};
   --input-addon-bg             : #{$darker};
+  --input-locked-text          : #{$lightest};
 
   --progress-bg                : #{$medium};
   --progress-divider           : #{$lightest};

--- a/pkg/rancher-desktop/assets/styles/themes/_light.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_light.scss
@@ -380,6 +380,7 @@ BODY, .theme-light {
   --input-disabled-border      : #{darken($medium, 10%)};
   --input-disabled-placeholder : #{darken($medium, 15%)};
   --input-addon-bg             : #{$darker};
+  --input-locked-text          : #{$darkest};
 
   --progress-bg                : #{$medium};
   --progress-divider           : #{$medium};

--- a/pkg/rancher-desktop/components/RdInput.vue
+++ b/pkg/rancher-desktop/components/RdInput.vue
@@ -25,6 +25,7 @@ export default Vue.extend({
   <div class="rd-input-container">
     <input
       :value="value"
+      :class="{ 'locked' : isLocked && !$attrs.disabled }"
       :disabled="$attrs.disabled || isLocked"
       v-bind="$attrs"
       v-on="$listeners"
@@ -47,5 +48,13 @@ export default Vue.extend({
     display: flex;
     align-items: center;
     gap: 0.5rem;
+
+    .locked {
+      color: var(--input-locked-text);
+
+      &:hover {
+        color: var(--input-locked-text);
+      }
+    }
   }
 </style>


### PR DESCRIPTION
Change the text color to differentiate between a locked and a disabled and locked `RdInput`.

Light theme (active, disabled, locked, disabled + locked):
![Screenshot_2023-05-26_15-09-46](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/2d8e4293-60c6-4f84-853e-8506502f536b)

Dark theme (active, disabled, locked, disabled + locked):
![Screenshot_2023-05-26_15-12-44](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/c4933753-5acf-40b6-9e7d-9de1e03d3e80)
