### PR TITLE
Fixes the iptables option for older k8s

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -852,14 +852,15 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
   protected async installGuestAgent(kubeVersion: semver.SemVer | undefined, cfg: BackendSettings | undefined) {
     let guestAgentConfig: Record<string, any>;
-    const enableKubernetes = K3sHelper.requiresPortForwardingFix(kubeVersion);
+    const requireK8sPortForwardingFix = K3sHelper.requiresPortForwardingFix(kubeVersion);
+    const enableKubernetes = cfg?.kubernetes.enabled;
     const rdNetworking = !!cfg?.experimental.virtualMachine.networkingTunnel;
 
     if (rdNetworking || this.privilegedServiceEnabled) {
       guestAgentConfig = {
         LOG_DIR:                       await this.wslify(paths.logs),
         GUESTAGENT_KUBERNETES:         enableKubernetes ? 'true' : 'false',
-        GUESTAGENT_IPTABLES:           enableKubernetes ? 'false' : 'true', // only enable IPTABLES for older K8s
+        GUESTAGENT_IPTABLES:           requireK8sPortForwardingFix ? 'false' : 'true', // only enable IPTABLES for older K8s
         GUESTAGENT_PRIVILEGED_SERVICE: rdNetworking ? 'false' : 'true',
         GUESTAGENT_CONTAINERD:         cfg?.containerEngine.name === ContainerEngine.CONTAINERD ? 'true' : 'false',
         GUESTAGENT_DOCKER:             cfg?.containerEngine.name === ContainerEngine.MOBY ? 'true' : 'false',


### PR DESCRIPTION
- The previous logic to enable k8s and iptables didn't seem to be correct. The new changes relies on the actual config to determine enabling k8s.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4730
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4682