### PR TITLE
Add BATS test filename in front of each file's output

### DIFF
--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -44,6 +44,14 @@ source "$PATH_BATS_HELPERS/kubernetes.bash"
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
+global_setup() {
+    # Ideally this should be printed only when using the tap formatter,
+    # but I don't see a way to check for this.
+    echo "# --- ${BATS_TEST_FILENAME#"$PATH_BATS_ROOT/tests/"}" >&3
+}
+setup_file() {
+    global_setup
+}
 global_teardown() {
     # On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
     run rdctl shutdown


### PR DESCRIPTION
This is needed for running bats in CI, in which case it will produce TAP output covering all input files, so it is no longer easy to connect the test output back to the test file.

This info is redundant when running bats from a terminal, but I haven't found a way to tell the difference from inside the test helpers.