### PR TITLE
RDX: force maximum length on compose name

### DIFF
--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -87,3 +87,14 @@ encoded_id() { # variant
     assert_success
     refute_line --partial "$(id vm-compose)"
 }
+
+@test 'compose - with a long name' {
+    local name="$(id vm-compose)-with-an-unsually-long-name-yes-it-is-very-long"
+
+    ctrctl tag "$(id vm-compose)" "$name"
+    rdctl extension install "$name"
+    run ctrctl container ls --all
+    assert_success
+    assert_line --partial "$(id vm-compose)"
+    rdctl extension uninstall "$name"
+}


### PR DESCRIPTION
This forces the compose project name to be something that should be acceptable.

This would hopefully handle #4510. Asking Adam to see if this makes a difference, as I couldn't reproduce the issue locally…