### PR TITLE
Create BATS workflow for macOS

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -1,0 +1,86 @@
+name: BATS on macOS on latest CI build
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: Override owner (e.g. rancher-sandbox)
+        type: string
+      repo:
+        description: Override repository (e.g. rancher-desktop)
+        type: string
+      branch:
+        description: Override branch (e.g. main)
+        type: string
+      tests:
+        description: 'Tests (e.g. tests/containers/*)'
+        default: 'tests/*'
+        type: string
+      results:
+        description: Number of runs to search for Package workflow
+        default: 30
+        type: number
+
+env:
+  SCRIPT:        install-latest-ci.sh
+  RD_LOCATION:   user
+  GH_OWNER:      ${{ github.repository_owner }}
+  GH_REPOSITORY: ${{ github.repository }}
+  GH_REF_NAME:   ${{ github.ref_name }}
+
+jobs:
+  bats:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        engine:
+        - containerd
+        - moby
+    steps:
+    - name: Fetch install script
+      run: |
+        URL="https://raw.githubusercontent.com/$GH_REPOSITORY/$GH_REF_NAME/scripts/$SCRIPT"
+        curl --output-dir "$TMPDIR" -O "$URL"
+        chmod +x "$TMPDIR/$SCRIPT"
+
+    - name: Install latest CI build
+      run: |
+        : ${OWNER:=$GH_OWNER}
+        : ${REPO:=${GH_REPOSITORY#$GH_OWNER/}}
+        : ${BRANCH:=$GH_REF_NAME}
+        "$TMPDIR/$SCRIPT"
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OWNER:    ${{ inputs.owner }}
+        REPO:     ${{ inputs.repo }}
+        BRANCH:   ${{ inputs.branch }}
+        RESULTS:  ${{ inputs.results }}
+
+    - name: Run BATS
+      run: |
+        DEFAULT_DIR=$PWD
+        cd "$TMPDIR/bats"
+        ./bats-core/bin/bats \
+            --gather-test-outputs-in "$DEFAULT_DIR/logs" \
+            --report-formatter tap \
+            tests/helpers/info.bash \
+            ${{ inputs.tests }}
+      env:
+        RD_CONTAINER_ENGINE:     ${{ matrix.engine }}
+        RD_CAPTURE_LOGS:         "true"
+        RD_TAKE_SCREENSHOTS:     "true"
+        RD_USE_IMAGE_ALLOW_LIST: "true"
+
+    - name: Consolidate logs
+      if: ${{ success() || failure() }}
+      run: |
+        cp -R "$TMPDIR/bats/logs/" logs
+        cp "$TMPDIR/bats/report.tap" logs
+
+    - name: Upload logs
+      if: ${{ success() || failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.engine }}.logs
+        path: logs/
+        if-no-files-found: error

--- a/scripts/install-latest-ci.sh
+++ b/scripts/install-latest-ci.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+set -o xtrace
+
+: ${OWNER:=rancher-sandbox}
+: ${REPO:=rancher-desktop}
+: ${BRANCH:=main}
+: ${WORKFLOW:=Package}
+: ${RESULTS:=30}
+
+# Get a list of all successful workflow runs for this repo.
+# I couldn't find a way to filter by workflow name, so get the last $RESULTS
+# runs and hope that at least one of them was for $WORKFLOW.
+API="repos/$OWNER/$REPO/actions/runs?branch=$BRANCH&status=success&per_page=$RESULTS"
+FILTER="[.workflow_runs[] | select(.name == \"$WORKFLOW\")] | .[0].id"
+
+ID=$(gh api "$API" --jq "$FILTER")
+if [ -z "$ID" ]; then
+    echo "No successful $WORKFLOW run found for branch $BRANCH"
+    exit 1
+fi
+
+download_artifact() {
+    FILENAME=$1
+
+    # Get the artifact id for the package
+    API="repos/$OWNER/$REPO/actions/runs/$ID/artifacts"
+    FILTER=".artifacts[] | select(.name == \"$FILENAME\").id"
+
+    ARTIFACT_ID=$(gh api "$API" --jq "$FILTER")
+    if [ -z "$ARTIFACT_ID" ]; then
+        echo "No download url for '$FILENAME' from $WORKFLOW run $ID"
+        exit 1
+    fi
+
+    # Download the package. It requires authentication, so use gh instead of curl.
+    API=repos/$OWNER/$REPO/actions/artifacts/$ARTIFACT_ID/zip
+    gh api "$API" > "$TMPDIR/$FILENAME"
+}
+
+download_artifact "Rancher Desktop-mac.x86_64.zip"
+
+# Artifacts are zipped, so extract inner ZIP file from outer wrapper.
+# The outer ZIP has a predictable name like "Rancher Desktop-mac.x86_64.zip"
+# but the inner one has version string: "Rancher Desktop-1.7.0-1061-g91ab3831-mac.zip"
+# Extract filename from:
+# ---------------------------------------------------------------------------
+# $ unzip -l Rancher\ Desktop-mac.x86_64.zip
+# Archive:  Rancher Desktop-mac.x86_64.zip
+#   Length      Date    Time    Name
+# ---------  ---------- -----   ----
+# 617701842  04-18-2023 23:56   Rancher Desktop-1.7.0-1061-g91ab3831-mac.zip
+# ---------                     -------
+# 617701842                     1 file
+# ---------------------------------------------------------------------------
+ZIP=$(unzip -l "$TMPDIR/$FILENAME" | perl -ne 'print if s/^\d.*Rancher/Rancher/')
+if [ -z "$ZIP" ]; then
+    echo "Cannot find inner archive in $TMPDIR/$FILENAME"
+    exit 1
+fi
+
+unzip -o "$TMPDIR/$FILENAME" "$ZIP" -d "$TMPDIR"
+
+# Extract from inner archive into ~/Applications
+APP="Rancher Desktop.app"
+rm -rf "$HOME/Applications/$APP"
+unzip -o "$TMPDIR/$ZIP" "$APP/*" -d "$HOME/Applications" >/dev/null
+
+download_artifact "bats.tar.gz"
+
+# Despite the name the downloaded bats.tar.gz is actually a ZIP file; extract in place
+unzip -o "$TMPDIR/bats.tar.gz" bats.tar.gz -d "$TMPDIR"
+
+# Unpack bats into $TMPDIR/bats
+rm -rf "$TMPDIR/bats"
+mkdir "$TMPDIR/bats"
+tar xfz "$TMPDIR/bats.tar.gz" -C "$TMPDIR/bats"

--- a/scripts/install-latest-ci.sh
+++ b/scripts/install-latest-ci.sh
@@ -35,7 +35,7 @@ download_artifact() {
     fi
 
     # Download the package. It requires authentication, so use gh instead of curl.
-    API=repos/$OWNER/$REPO/actions/artifacts/$ARTIFACT_ID/zip
+    API="repos/$OWNER/$REPO/actions/artifacts/$ARTIFACT_ID/zip"
     gh api "$API" > "$TMPDIR/$FILENAME"
 }
 
@@ -43,7 +43,7 @@ download_artifact "Rancher Desktop-mac.x86_64.zip"
 
 # Artifacts are zipped, so extract inner ZIP file from outer wrapper.
 # The outer ZIP has a predictable name like "Rancher Desktop-mac.x86_64.zip"
-# but the inner one has version string: "Rancher Desktop-1.7.0-1061-g91ab3831-mac.zip"
+# but the inner one has a version string: "Rancher Desktop-1.7.0-1061-g91ab3831-mac.zip"
 # Extract filename from:
 # ---------------------------------------------------------------------------
 # $ unzip -l Rancher\ Desktop-mac.x86_64.zip


### PR DESCRIPTION
Runs BATS against the latest successful CI build from `main` (or user-selected branch) with both `containerd` and `moby`.

Example run at https://github.com/jandubois/rancher-desktop/actions/runs/5117315291

Overriden parameters: branch `bats-logs` and tests `tests/containers/platform.bats tests/registry/creds.bats`:

<img width="320" alt="CleanShot 2023-05-29 at 20 38 51@2x" src="https://github.com/rancher-sandbox/rancher-desktop/assets/78947/7e5d94c8-0606-43a3-af1b-e0f2ade1c491">

Overriding parameters is not necessary for regular operation once the PR is merged to `main`.

Each log archive contains:

* `report.tap` (a copy of the BATS output)
* `*.log` files (output from each test step)
* `*.png` files (screenshots for each test step that failed)
* subdirectories with Rancher Desktop logs files collected before `factor_reset` and from `teardown_file`
* each subdirectory contains a `test_description` file containing the name of the test capturing the logs

Tests are failing under CI, and screenshots show a white Rancher Desktop window; those need to be investigated, but are outside the scope of this PR.

Fixes #4790