### PR TITLE
Add `RdRadioButton` component

### DIFF
--- a/pkg/rancher-desktop/assets/styles/themes/_dark.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_dark.scss
@@ -117,6 +117,8 @@
   --input-addon-bg             : #{$darker};
   --input-locked-text          : #{$lightest};
 
+  --radio-locked-bg-unchecked  : var(--body-bg);
+
   --progress-bg                : #{$medium};
   --progress-divider           : #{$lightest};
 

--- a/pkg/rancher-desktop/assets/styles/themes/_light.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_light.scss
@@ -387,6 +387,8 @@ BODY, .theme-light {
   --input-addon-bg             : #{$darker};
   --input-locked-text          : #{$darkest};
 
+  --radio-locked-bg-unchecked  : var(--body-bg);
+
   --progress-bg                : #{$medium};
   --progress-divider           : #{$medium};
 

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -1,13 +1,14 @@
 <script lang="ts">
 import os from 'os';
 
-import { RadioButton, RadioGroup } from '@rancher/components';
+import { RadioGroup } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
 import RdSelect from '@pkg/components/RdSelect.vue';
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
+import RdRadioButton from '@pkg/components/form/RdRadioButton.vue';
 import {
   CacheMode, MountType, ProtocolVersion, SecurityModel, Settings,
 } from '@pkg/config/settings';
@@ -20,7 +21,7 @@ export default Vue.extend({
     LabeledBadge,
     RadioGroup,
     RdFieldset,
-    RadioButton,
+    RdRadioButton,
     RdSelect,
   },
   props: {
@@ -127,20 +128,20 @@ export default Vue.extend({
             <radio-group
               :name="groupName"
               :options="options"
-              :disabled="isLocked"
             >
               <template
                 v-for="(option, index) in options"
-                #[index]="{ isDisabled }"
+                #[index]
               >
-                <radio-button
+                <rd-radio-button
                   :key="groupName+'-'+index"
                   :name="groupName"
                   :value="preferences.experimental.virtualMachine.mount.type"
                   :label="option.label"
                   :val="option.value"
                   :description="option.description"
-                  :disabled="option.disabled || isDisabled"
+                  :disabled="option.disabled"
+                  :is-locked="isLocked"
                   :data-test="option.label"
                   @input="updateValue('experimental.virtualMachine.mount.type', $event)"
                 >
@@ -155,7 +156,7 @@ export default Vue.extend({
                       />
                     </div>
                   </template>
-                </radio-button>
+                </rd-radio-button>
               </template>
             </radio-group>
           </template>

--- a/pkg/rancher-desktop/components/form/RdRadioButton.vue
+++ b/pkg/rancher-desktop/components/form/RdRadioButton.vue
@@ -1,0 +1,54 @@
+<script lang="ts">
+import { RadioButton } from '@rancher/components';
+import Vue from 'vue';
+
+export default Vue.extend({
+  name:         'rd-radio-button',
+  components:   { RadioButton },
+  inheritAttrs: false,
+  props:        {
+    isLocked: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+});
+</script>
+
+<template>
+  <div class="rd-radio-button-container">
+    <radio-button
+      :val="$attrs.val"
+      :value="$attrs.value"
+      :class="{ 'locked' : isLocked && !$attrs.disabled }"
+      :disabled="$attrs.disabled || isLocked"
+      v-bind="$attrs"
+      v-on="$listeners"
+    >
+      <template
+        v-for="(_, name) in $slots"
+        #[name]="slotData"
+      >
+        <slot
+          :name="name"
+          v-bind="slotData"
+        />
+      </template>
+    </radio-button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .rd-radio-button-container {
+    .locked::v-deep {
+      .radio-custom {
+        opacity: 1;
+
+        &:not([aria-checked="true"]) {
+          opacity: 1;
+          background-color: var(--radio-locked-bg-unchecked);
+        }
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
Add a `RdRadioButton` component to make it easier to differentiate between locked / disabled / locked + disabled radio buttons.

Example how the radio button does look like in all four situations:
![Screenshot_2023-05-30_16-13-43](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/52db699d-db23-4698-b2a7-4bcee5f9534b)
