### PR TITLE
RDX: Suppress errors reinstalling extensions on startup

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -223,7 +223,7 @@ class ExtensionManagerImpl implements ExtensionManager {
 
       tasks.push((async(id: string) => {
         try {
-          return (await this.getExtension(id)).install(allowList);
+          return await (await this.getExtension(id)).install(allowList);
         } catch (ex) {
           console.error(`Failed to install extension ${ id }`, ex);
         }


### PR DESCRIPTION
We were failing to await the install, which means we were not catching any errors from the actual install itself (just any errors when getting the extension).

See #4788 for the dialog that shows up. (That issue actually asks for something else, though.)