### PR TITLE
Filter incompatible containerd extensions from catalog

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1046,6 +1046,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       writeSettings(newSettings);
       // cfg is a global, and at this point newConfig has been merged into it :(
       window.send('settings-update', cfg);
+      window.send('preferences/changed');
     } else {
       // Obviously if there are no settings to update, there's no need to restart.
       return ['no changes necessary', ''];

--- a/pkg/rancher-desktop/components/MarketplaceCatalog.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCatalog.vue
@@ -1,13 +1,19 @@
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { VueConstructor } from 'vue';
+import { mapGetters } from 'vuex';
 
 import { demoMarketplace } from '../utils/_demo_marketplace_items.js';
 
 import MarketplaceCard from '@pkg/components/MarketplaceCard.vue';
+import { Settings } from '@pkg/config/settings';
 
 type FilteredExtensions = typeof demoMarketplace.summaries;
 
-export default Vue.extend({
+interface VuexBindings {
+  getPreferences: Settings;
+}
+
+export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
   name:       'marketplace-catalog',
   components: { MarketplaceCard },
   data() {
@@ -51,6 +57,13 @@ export default Vue.extend({
     });
   },
   computed: {
+    ...mapGetters('preferences', ['getPreferences']),
+    containerEngine(): string {
+      return this.getPreferences.containerEngine.name;
+    },
+    isMobyActive(): boolean {
+      return this.containerEngine === 'moby';
+    },
     filteredExtensions(): FilteredExtensions {
       let tempExtensions = this.extensions;
 
@@ -62,7 +75,7 @@ export default Vue.extend({
         });
       }
 
-      return tempExtensions;
+      return tempExtensions.filter(item => this.isMobyActive || item.containerd_compatible);
     },
   },
   methods: {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -85,6 +85,10 @@ export default {
     });
     this.$store.dispatch('extensions/fetch');
 
+    ipcRenderer.on('preferences/changed', () => {
+      this.$store.dispatch('preferences/fetchPreferences', this.credentials);
+    });
+
     ipcRenderer.on('extensions/getContentArea', () => {
       const rect = this.$refs['rdx-title'].$el.getBoundingClientRect();
 

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -172,4 +172,8 @@ export interface IpcRendererEvents {
   'extensions/spawn/output': (id: string, data: { stdout: string } | { stderr: string }) => void;
   'ok:extensions/uninstall': (id: string) => void;
   // #endregion
+
+  // #region preferences
+  'preferences/changed': () => void;
+  // #endregion
 }


### PR DESCRIPTION
This filters extensions that have been flagged as incompatible out of the extension catalog and makes sure that preferences are updated in the main window when new preferences are committed. 

Previously, changes made in the preferences modal were not immediately reflected in the main window. This is fixed by emitting a `preferences/changed` ipc event when new preferences are committed. When `default.vue` receives this event, new preferences are fetched for the main window. 

## 📷 Screenshots

### Container Engine: moby

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/a9b73c37-b1f5-4053-856d-1876ad522ded)

### Container Engine: containerd

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/7ff91ba5-5ab6-44cb-af61-0f27c9449fcf)

closes #4801
