### PR TITLE
Replace Selects by RdSelects

### DIFF
--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -5,6 +5,7 @@ import { RadioButton, RadioGroup } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
+import RdSelect from '@pkg/components/RdSelect.vue';
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import {
@@ -20,6 +21,7 @@ export default Vue.extend({
     RadioGroup,
     RdFieldset,
     RadioButton,
+    RdSelect,
   },
   props: {
     preferences: {
@@ -168,8 +170,10 @@ export default Vue.extend({
           :legend-text="t('virtualMachine.mount.type.options.9p.options.cacheMode.legend')"
           :legend-tooltip="t('virtualMachine.mount.type.options.9p.options.cacheMode.tooltip')"
         >
-          <select
-            @input="updateValue('experimental.virtualMachine.mount.9p.cacheMode', $event.target.value)"
+          <rd-select
+            :value="preferences.experimental.virtualMachine.mount['9p'].cacheMode"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.mount.9p.cacheMode')"
+            @change="updateValue('experimental.virtualMachine.mount.9p.cacheMode', $event.target.value)"
           >
             <option
               v-for="item in ninePOptions('cacheMode')"
@@ -179,7 +183,7 @@ export default Vue.extend({
             >
               {{ item.label }}
             </option>
-          </select>
+          </rd-select>
         </rd-fieldset>
         <rd-fieldset
           data-test="msizeInKib"
@@ -198,8 +202,10 @@ export default Vue.extend({
           :legend-text="t('virtualMachine.mount.type.options.9p.options.protocolVersion.legend')"
           :legend-tooltip="t('virtualMachine.mount.type.options.9p.options.protocolVersion.tooltip')"
         >
-          <select
-            @input="updateValue('experimental.virtualMachine.mount.9p.protocolVersion', $event.target.value)"
+          <rd-select
+            :value="preferences.experimental.virtualMachine.mount['9p'].protocolVersion"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.mount.9p.protocolVersion')"
+            @change="updateValue('experimental.virtualMachine.mount.9p.protocolVersion', $event.target.value)"
           >
             <option
               v-for="item in ninePOptions('protocolVersion')"
@@ -209,15 +215,17 @@ export default Vue.extend({
             >
               {{ item.label }}
             </option>
-          </select>
+          </rd-select>
         </rd-fieldset>
         <rd-fieldset
           data-test="securityModel"
           :legend-text="t('virtualMachine.mount.type.options.9p.options.securityModel.legend')"
           :legend-tooltip="t('virtualMachine.mount.type.options.9p.options.securityModel.tooltip')"
         >
-          <select
-            @input="updateValue('experimental.virtualMachine.mount.9p.securityModel', $event.target.value)"
+          <rd-select
+            :value="preferences.experimental.virtualMachine.mount['9p'].securityModel"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.mount.9p.securityModel')"
+            @change="updateValue('experimental.virtualMachine.mount.9p.securityModel', $event.target.value)"
           >
             <option
               v-for="item in ninePOptions('securityModel')"
@@ -227,7 +235,7 @@ export default Vue.extend({
             >
               {{ item.label }}
             </option>
-          </select>
+          </rd-select>
         </rd-fieldset>
       </div>
     </div>

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -11,7 +11,12 @@
     />
     <label>
       Please select a Kubernetes version{{ offlineCheck() }}:
-      <select v-model="settings.kubernetes.version" class="select-k8s-version" @change="onChange">
+      <rd-select
+        v-model="settings.kubernetes.version"
+        :is-locked="kubernetesVersionLocked"
+        class="select-k8s-version"
+        @change="onChange"
+      >
         <!--
             - On macOS Chrome / Electron can't style the <option> elements.
             - We do the best we can by instead using <optgroup> for a recommended section.
@@ -36,7 +41,7 @@
             v{{ item.version.version }}
           </option>
         </optgroup>
-      </select>
+      </rd-select>
     </label>
     <engine-selector
       :container-engine="settings.containerEngine.name"
@@ -69,6 +74,7 @@ import { mapGetters } from 'vuex';
 import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
+import RdSelect from '@pkg/components/RdSelect.vue';
 import RdCheckbox from '@pkg/components/form/RdCheckbox.vue';
 import { defaultSettings } from '@pkg/config/settings';
 import type { ContainerEngine } from '@pkg/config/settings';
@@ -77,14 +83,15 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   components: {
-    RdCheckbox, EngineSelector, PathManagementSelector,
+    RdCheckbox, EngineSelector, PathManagementSelector, RdSelect,
   },
   layout: 'dialog',
   data() {
     return {
-      settings:         defaultSettings,
-      kubernetesLocked: false,
-      versions:         [] as VersionEntry[],
+      settings:                defaultSettings,
+      kubernetesLocked:        false,
+      kubernetesVersionLocked: false,
+      versions:                [] as VersionEntry[],
 
       // If cachedVersionsOnly is true, it means we're offline and showing only the versions in the cache,
       // not all the versions listed in <cache>/rancher-desktop/k3s-versions.json
@@ -144,6 +151,7 @@ export default Vue.extend({
     }
     ipcRenderer.invoke('get-locked-fields').then((lockedFields) => {
       this.$data.kubernetesLocked = _.get(lockedFields, 'kubernetes.enabled');
+      this.$data.kubernetesVersionLocked = _.get(lockedFields, 'kubernetes.version');
     });
   },
   beforeDestroy() {


### PR DESCRIPTION
Based on https://github.com/rancher-sandbox/rancher-desktop/pull/4706 replace all preference Selects by lockable RdSelects.

![Screenshot_2023-05-31_14-24-46](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/e3218ecb-fcc2-4bad-b93b-81c693a99507)
![Screenshot_2023-05-31_14-27-11](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/e11e2154-80dd-4f91-91a4-8173b4a8c830)

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4723