### PR TITLE
Bats fixes

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -130,6 +130,7 @@ refute=refute
 }
 
 rdctl_factory_reset() {
+    capture_logs
     rdctl factory-reset "$@"
 
     if [[ $1 == "--remove-kubernetes-cache=true" ]]; then

--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -66,8 +66,8 @@ kubectl_exe() {
     "$PATH_RESOURCES/$PLATFORM/bin/kubectl$EXE" "$@" | no_cr
 }
 limactl() {
-    # LIMA_HOME is set by paths.bash
-    "$PATH_RESOURCES/$PLATFORM/lima/bin/limactl" "$@"
+    # LIMA_HOME is set by paths.bash but not exported
+    LIMA_HOME="$LIMA_HOME" "$PATH_RESOURCES/$PLATFORM/lima/bin/limactl" "$@"
 }
 nerdctl() {
     "$PATH_RESOURCES/$PLATFORM/bin/nerdctl$EXE" --namespace "$CONTAINERD_NAMESPACE" "$@" | no_cr

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -68,7 +68,7 @@ teardown_file() {
 }
 teardown() {
     if [ -z "$BATS_TEST_SKIPPED" ] && [ -z "$BATS_TEST_COMPLETED" ]; then
-        screenshot
+        take_screenshot
     fi
 }
 

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -127,7 +127,7 @@ capture_logs() {
     fi
 }
 
-screenshot() {
+take_screenshot() {
     if taking_screenshots; then
         if is_macos; then
             local file=$(unique_filename "${PATH_BATS_LOGS}/${BATS_SUITE_TEST_NUMBER}-${BATS_TEST_DESCRIPTION}" .png)

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -119,7 +119,7 @@ unique_filename() {
 }
 
 capture_logs() {
-    if capturing_logs; then
+    if capturing_logs && [ -d "$PATH_LOGS" ]; then
         local logdir=$(unique_filename "${PATH_BATS_LOGS}/${RD_TEST_FILENAME}")
         mkdir -p "$logdir"
         cp -LR "$PATH_LOGS/" "$logdir"


### PR DESCRIPTION
These fixes are needed to get `containers/factory-reset.bats` to pass on macOS.