### PR TITLE
Display a default icon in the primary nav when an installed extension doesn't provide a valid icon.

### DIFF
--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -24,13 +24,7 @@
           >
             <nav-item :id="`extension:${extension.id}`">
               <template #before>
-                <img
-                  class="extension-icon"
-                  :class="{
-                    'known-monochrome': isKnownMonochrome(extension.id),
-                  }"
-                  :src="imageUri(extension.id)"
-                >
+                <nav-icon-extension :extension-id="extension.id" />
               </template>
               {{ extension.metadata.ui['dashboard-tab'].title }}
             </nav-item>
@@ -49,6 +43,7 @@ import { BadgeState } from '@rancher/components';
 import { PropType } from 'vue';
 import { RouteRecordPublic } from 'vue-router';
 
+import NavIconExtension from './NavIconExtension.vue';
 import NavItem from './NavItem.vue';
 
 import type { ExtensionMetadata } from '@pkg/main/extensions/types';
@@ -62,6 +57,7 @@ export default {
   components: {
     BadgeState,
     NavItem,
+    NavIconExtension,
   },
   props: {
     items: {
@@ -120,9 +116,6 @@ export default {
     },
   },
   methods: {
-    imageUri(id: string): string {
-      return `x-rd-extension://${ hexEncode(id) }/icon.svg`;
-    },
     extensionRoute({ id, metadata }: { id: string, metadata: any }) {
       const { ui: { 'dashboard-tab': { root, src } } } = metadata;
 
@@ -134,14 +127,6 @@ export default {
           id: hexEncode(id),
         },
       };
-    },
-    isKnownMonochrome(id: string): boolean {
-      return !!id && [
-        'ghcr.io/rancher-sandbox/epinio-desktop-extension',
-        'julianb90/tachometer',
-        'prakhar1989/dive-in',
-        'joycelin79/newman-extension',
-      ].includes(id.split(':')[0]);
     },
   },
 };
@@ -204,24 +189,6 @@ a {
   line-height: initial;
   letter-spacing: initial;
   font-size: 0.75rem;
-}
-
-/**
-  * Change the icon colors by setting a class 'known-monochrome' containing dark theme properties.
-  */
-@media (prefers-color-scheme: dark) {
-  .known-monochrome {
-    filter: brightness(0) invert(100%) grayscale(1) brightness(2);
-  }
-}
-
-/**
-  * Change the icon colors by setting a class 'known-monochrome' containing light theme properties.
-  */
-@media (prefers-color-scheme: light) {
-  .known-monochrome {
-    filter: brightness(0) grayscale(1) brightness(4);
-  }
 }
 
 </style>

--- a/pkg/rancher-desktop/components/NavIconExtension.vue
+++ b/pkg/rancher-desktop/components/NavIconExtension.vue
@@ -1,0 +1,60 @@
+<script lang="ts">
+import Vue from 'vue';
+
+import { hexEncode } from '@pkg/utils/string-encode';
+
+const knownMonochromeIcons = [
+  'ghcr.io/rancher-sandbox/epinio-desktop-extension',
+  'julianb90/tachometer',
+  'prakhar1989/dive-in',
+  'joycelin79/newman-extension',
+];
+
+export default Vue.extend({
+  name:  'nav-icon-extension',
+  props: {
+    extensionId: {
+      type:     String,
+      required: true,
+    },
+  },
+  computed: {
+    imageUri(): string {
+      return `x-rd-extension://${ hexEncode(this.extensionId) }/icon.svg`;
+    },
+    isKnownMonochrome(): boolean {
+      return !!this.extensionId && knownMonochromeIcons.includes(this.extensionId.split(':')[0]);
+    },
+  },
+});
+</script>
+
+<template>
+  <img
+    class="extension-icon"
+    :class="{
+      'known-monochrome': isKnownMonochrome,
+    }"
+    :src="imageUri"
+  >
+</template>
+
+<style lang="scss" scoped>
+  /**
+    * Change the icon colors by setting a class 'known-monochrome' containing dark theme properties.
+    */
+  @media (prefers-color-scheme: dark) {
+    .known-monochrome {
+      filter: brightness(0) invert(100%) grayscale(1) brightness(2);
+    }
+  }
+
+  /**
+    * Change the icon colors by setting a class 'known-monochrome' containing light theme properties.
+    */
+  @media (prefers-color-scheme: light) {
+    .known-monochrome {
+      filter: brightness(0) grayscale(1) brightness(4);
+    }
+  }
+</style>

--- a/pkg/rancher-desktop/components/NavIconExtension.vue
+++ b/pkg/rancher-desktop/components/NavIconExtension.vue
@@ -18,6 +18,9 @@ export default Vue.extend({
       required: true,
     },
   },
+  data() {
+    return { imageError: false };
+  },
   computed: {
     imageUri(): string {
       return `x-rd-extension://${ hexEncode(this.extensionId) }/icon.svg`;
@@ -26,17 +29,28 @@ export default Vue.extend({
       return !!this.extensionId && knownMonochromeIcons.includes(this.extensionId.split(':')[0]);
     },
   },
+  methods: {
+    handleImageError(): void {
+      this.imageError = true;
+    },
+  },
 });
 </script>
 
 <template>
   <img
+    v-if="!imageError"
     class="extension-icon"
     :class="{
       'known-monochrome': isKnownMonochrome,
     }"
     :src="imageUri"
+    @error="handleImageError"
   >
+  <i
+    v-else
+    class="icon icon-extension icon-lg"
+  />
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
This PR introduces a fallback icon to handle cases when an extension doesn't supply a valid icon.

Some extensions, like BlocklyAutomation, may not expose a valid icon in their metadata, resulting in a broken image. To provide consistent user experience, we display a placeholder icon instead of displaying an error when a valid icon is not available.

## 📷 Screenshots

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/af571801-a87e-4875-b3cd-ac6b618514fd)
