### PR TITLE
Add locked styling for radio buttons

### DIFF
--- a/pkg/rancher-desktop/assets/styles/rancher-desktop.scss
+++ b/pkg/rancher-desktop/assets/styles/rancher-desktop.scss
@@ -12,6 +12,18 @@ label > button:first-child:not(.btn-sm) {
     margin-right: 1em;
 }
 
+.locked-radio .radio-container span.radio-custom {
+  &[aria-checked="true"] {
+    opacity: 1;
+  }
+
+  &:not([aria-checked="true"]) {
+    opacity: 1;
+    background-color: var(--radio-locked-bg);
+    box-shadow: var(--radio-locked-shadow);
+  }
+}
+
 @media screen and (prefers-color-scheme: dark) {
     option {
         background-color: var(--input-bg);

--- a/pkg/rancher-desktop/assets/styles/themes/_dark.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_dark.scss
@@ -117,6 +117,9 @@
   --input-addon-bg             : #{$darker};
   --input-locked-text          : #{$lightest};
 
+  --radio-locked-bg            : var(--body-bg);
+  --radio-locked-shadow        : var(--body-bg);
+
   --progress-bg                : #{$medium};
   --progress-divider           : #{$lightest};
 

--- a/pkg/rancher-desktop/assets/styles/themes/_light.scss
+++ b/pkg/rancher-desktop/assets/styles/themes/_light.scss
@@ -387,6 +387,9 @@ BODY, .theme-light {
   --input-addon-bg             : #{$darker};
   --input-locked-text          : #{$darkest};
 
+  --radio-locked-bg            : var(--body-bg);
+  --radio-locked-shadow        : var(--body-bg);
+
   --progress-bg                : #{$medium};
   --progress-divider           : #{$medium};
 

--- a/pkg/rancher-desktop/components/EngineSelector.vue
+++ b/pkg/rancher-desktop/components/EngineSelector.vue
@@ -45,6 +45,7 @@ export default {
     <radio-group
       name="containerEngine"
       class="container-engine"
+      :class="{ 'locked-radio' : isLocked }"
       :value="containerEngine"
       :options="options"
       :row="row"

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -128,6 +128,7 @@ export default Vue.extend({
               :name="groupName"
               :options="options"
               :disabled="isLocked"
+              :class="{ 'locked-radio' : isLocked }"
             >
               <template
                 v-for="(option, index) in options"

--- a/pkg/rancher-desktop/components/PathManagementSelector.vue
+++ b/pkg/rancher-desktop/components/PathManagementSelector.vue
@@ -75,6 +75,7 @@ export default Vue.extend({
     :options="options"
     :row="row"
     :disabled="isLocked"
+    :class="{ 'locked-radio' : isLocked }"
     class="path-management"
     @input="updateVal"
   >

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -88,6 +88,7 @@ export default Vue.extend({
               :options="options"
               :name="groupName"
               :disabled="isLocked"
+              :class="{ 'locked-radio' : isLocked }"
             >
               <template
                 v-for="(option, index) in options"

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -43,15 +43,29 @@
         </optgroup>
       </rd-select>
     </label>
-    <engine-selector
-      :container-engine="settings.containerEngine.name"
-      @change="onChangeEngine"
-    />
-    <path-management-selector
+    <rd-fieldset
+      :legend-text="t('containerEngine.label')"
+      :is-locked="engineSelectorLocked"
+    >
+      <engine-selector
+        :container-engine="settings.containerEngine.name"
+        :is-locked="engineSelectorLocked"
+        @change="onChangeEngine"
+      />
+    </rd-fieldset>
+    <rd-fieldset
       v-if="pathManagementRelevant"
-      :value="pathManagementStrategy"
-      @input="setPathManagementStrategy"
-    />
+      :legend-text="t('pathManagement.label')"
+      :legend-tooltip="t('pathManagement.tooltip', { }, true)"
+      :is-locked="pathManagementSelectorLocked"
+    >
+      <path-management-selector
+        :value="pathManagementStrategy"
+        :is-locked="pathManagementSelectorLocked"
+        :show-label="false"
+        @input="setPathManagementStrategy"
+      />
+    </rd-fieldset>
     <div class="button-area">
       <button
         data-test="accept-btn"
@@ -80,18 +94,25 @@ import { defaultSettings } from '@pkg/config/settings';
 import type { ContainerEngine } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import RdFieldset from '~/components/form/RdFieldset.vue';
 
 export default Vue.extend({
   components: {
-    RdCheckbox, EngineSelector, PathManagementSelector, RdSelect,
+    RdFieldset,
+    RdCheckbox,
+    EngineSelector,
+    PathManagementSelector,
+    RdSelect,
   },
   layout: 'dialog',
   data() {
     return {
-      settings:                defaultSettings,
-      kubernetesLocked:        false,
-      kubernetesVersionLocked: false,
-      versions:                [] as VersionEntry[],
+      settings:                     defaultSettings,
+      kubernetesLocked:             false,
+      kubernetesVersionLocked:      false,
+      engineSelectorLocked:         false,
+      pathManagementSelectorLocked: false,
+      versions:                     [] as VersionEntry[],
 
       // If cachedVersionsOnly is true, it means we're offline and showing only the versions in the cache,
       // not all the versions listed in <cache>/rancher-desktop/k3s-versions.json
@@ -152,6 +173,8 @@ export default Vue.extend({
     ipcRenderer.invoke('get-locked-fields').then((lockedFields) => {
       this.$data.kubernetesLocked = _.get(lockedFields, 'kubernetes.enabled');
       this.$data.kubernetesVersionLocked = _.get(lockedFields, 'kubernetes.version');
+      this.$data.engineSelectorLocked = _.get(lockedFields, 'containerEngine.name');
+      this.$data.pathManagementSelectorLocked = _.get(lockedFields, 'application.pathManagementStrategy');
     });
   },
   beforeDestroy() {


### PR DESCRIPTION
Add the locked styling for preference radio buttons and update all existing elements.
On the FirstRun dialog add `rd-fieldset`s as well because otherwise the locked icon won't be shown.

This PR is an alternative for https://github.com/rancher-sandbox/rancher-desktop/pull/4797.

![Screenshot_2023-06-01_16-25-18](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/a142ceec-198e-4b7a-9693-1a1d62ff5134)

![Screenshot_2023-06-01_16-35-08](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/0fe49637-f772-4b37-b121-51de349e04a0)



Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4816