### PR TITLE
Bats updates

### DIFF
--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -87,8 +87,8 @@ encoded_id() { # variant
 
 @test 'basic extension - upgrades' {
     local tag
-    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):0.0.1"
-    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):v0.0.2"
+    ctrctl image tag "$(id basic)" "$(id basic):0.0.1"
+    ctrctl image tag "$(id basic)" "$(id basic):v0.0.2"
 
     run rdctl extension ls
     assert_success
@@ -110,7 +110,7 @@ encoded_id() { # variant
 }
 
 @test 'basic extension - uninstall' {
-    ctrctl "${namespace_arg[@]}" image tag "$(id basic)" "$(id basic):0.0.3"
+    ctrctl image tag "$(id basic)" "$(id basic):0.0.3"
     # Uninstall should remove whatever version is installed, not the newest.
     rdctl extension uninstall "$(id basic)"
 

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -42,6 +42,17 @@ using_image_allow_list() {
 }
 
 ########################################################################
+: "${RD_USE_VZ_EMULATION:=false}"
+
+using_vz_emulation() {
+    is_true "$RD_USE_VZ_EMULATION"
+}
+
+if using_vz_emulation && ! is_macos; then
+    fatal "RD_USE_VZ_EMULATION only works on macOS"
+fi
+
+########################################################################
 : "${RD_USE_WINDOWS_EXE:=false}"
 
 using_windows_exe() {

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2059
+# https://www.shellcheck.net/wiki/SC2059 -- Don't use variables in the printf format string. Use printf '..%s..' "$foo".
 load load.bash
 
 # This file exists to print information about the configuration just once, e.g.
@@ -14,11 +16,37 @@ load load.bash
 # uses a `.bash` extension so it is not matched by `tests/*` when running all
 # tests; you'll want to run it before all the other tests.
 
+predicate() {
+    if eval "$1"; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
 info() { # @test
     if capturing_logs || taking_screenshots; then
         rm -rf "$PATH_BATS_LOGS"
     fi
-    echo "Using '$RD_LOCATION' install; resources '$PATH_RESOURCES'" >&3
+    (
+        local format="# %-25s %s\n"
+
+        printf "$format" "Install location:" "$RD_LOCATION"
+        printf "$format" "Resources path:" "$PATH_RESOURCES"
+        echo "#"
+        printf "$format" "Container engine:" "$RD_CONTAINER_ENGINE"
+        printf "$format" "Using image allow list:" "$(predicate using_image_allow_list)"
+        if is_macos; then
+            printf "$format" "Using VZ emulation:" "$(predicate using_vz_emulation)"
+        fi
+        if is_windows; then
+            printf "$format" "Using Windows executables:" "$(predicate using_windows_exe)"
+            printf "$format" "Using networking tunnel:" "$(predicate using_networking_tunnel)"
+        fi
+        echo "#"
+        printf "$format" "Capturing logs:" "$(predicate capturing_logs)"
+        printf "$format" "Taking screenshots:" "$(predicate taking_screenshots)"
+    ) >&3
 }
 
 # Disable global setup/teardown functions because we are not running Rancher Desktop.

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -61,7 +61,9 @@ setup_file() {
 global_teardown() {
     capture_logs
     # On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
-    run rdctl shutdown
+    if is_linux; then
+        run rdctl shutdown
+    fi
 }
 teardown_file() {
     global_teardown

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -80,6 +80,7 @@ try() {
         sleep "$delay"
         count=$((count + 1))
     done
+    echo "$output"
     return "$status"
 }
 

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -73,6 +73,12 @@ start_container_engine() {
     if using_networking_tunnel; then
         args+=(--experimental.virtual-machine.networking-tunnel)
     fi
+    if using_vz_emulation; then
+        args+=(--experimental.virtual-machine.type vz)
+        if is_macos arm64; then
+            args+=(--experimental.virtual-machine.use-rosetta)
+        fi
+    fi
 
     # TODO containerEngine.allowedImages.patterns and WSL.integrations
     # TODO cannot be set from the commandline yet

--- a/scripts/install-latest-ci.sh
+++ b/scripts/install-latest-ci.sh
@@ -9,6 +9,13 @@ set -o xtrace
 : ${WORKFLOW:=Package}
 : ${RESULTS:=30}
 
+: ${RD_LOCATION:=user}
+
+if ! [[ $RD_LOCATION =~ ^(system|user)$ ]]; then
+    echo "RD_LOCATION must be either 'system' or 'user'"
+    exit 1
+fi
+
 # Get a list of all successful workflow runs for this repo.
 # I couldn't find a way to filter by workflow name, so get the last $RESULTS
 # runs and hope that at least one of them was for $WORKFLOW.
@@ -67,9 +74,14 @@ fi
 unzip -o "$TMPDIR/$FILENAME" "$ZIP" -d "$TMPDIR"
 
 # Extract from inner archive into ~/Applications
+DEST="/Applications"
+if [ "$RD_LOCATION" = "user" ]; then
+    DEST="$HOME/$DEST"
+fi
+
 APP="Rancher Desktop.app"
-rm -rf "$HOME/Applications/$APP"
-unzip -o "$TMPDIR/$ZIP" "$APP/*" -d "$HOME/Applications" >/dev/null
+rm -rf "$DEST/$APP"
+unzip -o "$TMPDIR/$ZIP" "$APP/*" -d "$DEST" >/dev/null
 
 download_artifact "bats.tar.gz"
 

--- a/scripts/install-latest-ci.sh
+++ b/scripts/install-latest-ci.sh
@@ -39,7 +39,11 @@ download_artifact() {
     gh api "$API" > "$TMPDIR/$FILENAME"
 }
 
-download_artifact "Rancher Desktop-mac.x86_64.zip"
+ARCH=x86_64
+if [ "$(uname -m)" = "arm64" ]; then
+    ARCH=aarch64
+fi
+download_artifact "Rancher Desktop-mac.$ARCH.zip"
 
 # Artifacts are zipped, so extract inner ZIP file from outer wrapper.
 # The outer ZIP has a predictable name like "Rancher Desktop-mac.x86_64.zip"


### PR DESCRIPTION
* Add more useful info to `tests/helpers/info.bash` output

* Remove left-over `namespace_args` references

* Only shutdown RD in `teardown_file()` on Linux

* Support installation of CI build into system location

* Add support to install macOS CI build for aarch64

* Add `RD_USE_VZ_EMULATION`

* Report output of failed try commands
