### PR TITLE
Ensure k8s version is set on startup.

### DIFF
--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -127,7 +127,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   async install(config: BackendSettings, desiredVersion: semver.SemVer, allowSudo: boolean) {
     await this.progressTracker.action('Installing k3s', 50, async() => {
       await this.installK3s(desiredVersion);
-      await this.writeServiceScript(config, allowSudo);
+      await this.writeServiceScript(config, desiredVersion, allowSudo);
     });
 
     this.activeVersion = desiredVersion;
@@ -339,13 +339,13 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   /**
    * Write the openrc script for k3s.
    */
-  protected async writeServiceScript(cfg: BackendSettings, allowSudo: boolean) {
+  protected async writeServiceScript(cfg: BackendSettings, desiredVersion: semver.SemVer, allowSudo: boolean) {
     const config: Record<string, string> = {
       PORT:            this.desiredPort.toString(),
       ENGINE:          cfg.containerEngine.name ?? ContainerEngine.NONE,
       ADDITIONAL_ARGS: `--node-ip ${ await this.vm.ipAddress }`,
       LOG_DIR:         paths.logs,
-      USE_CRI_DOCKERD: BackendHelper.requiresCRIDockerd(cfg.containerEngine.name, cfg.kubernetes.version).toString(),
+      USE_CRI_DOCKERD: BackendHelper.requiresCRIDockerd(cfg.containerEngine.name, cfg.kubernetes.version || desiredVersion.version).toString(),
     };
 
     if (allowSudo && os.platform() === 'darwin') {

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -345,7 +345,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
       ENGINE:          cfg.containerEngine.name ?? ContainerEngine.NONE,
       ADDITIONAL_ARGS: `--node-ip ${ await this.vm.ipAddress }`,
       LOG_DIR:         paths.logs,
-      USE_CRI_DOCKERD: BackendHelper.requiresCRIDockerd(cfg.containerEngine.name, cfg.kubernetes.version || desiredVersion.version).toString(),
+      USE_CRI_DOCKERD: BackendHelper.requiresCRIDockerd(cfg.containerEngine.name, desiredVersion.version).toString(),
     };
 
     if (allowSudo && os.platform() === 'darwin') {


### PR DESCRIPTION
Fixes #4837

This will probably fix the CI/e2e failures for PR #4756

I have seen this error message for a long time but didn't bother working on it because the system always recovered and was working. Not sure why CI/e2e worked until the change in PR 4756