### PR TITLE
Make navigation in main & preferences window keyboard-navigable

### DIFF
--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -1,9 +1,20 @@
 <template>
-  <nav>
-    <ul>
-      <li v-for="item in items" :key="item.route" :item="item.route">
-        <NuxtLink :to="item.route">
-          {{ routes[item.route].name }}
+  <nav aria-label="Primary navigation">
+    <ul role="menu">
+      <li
+        v-for="item in items"
+        :key="item.route"
+        :item="item.route"
+        :aria-describedby="'menu-item-description-' + item.route"
+        tabindex="0"
+        role="menuitem"
+        @keydown.enter="activateLink(item.route)"
+      >
+        <NuxtLink
+          :to="item.route"
+          tabindex="-1"
+        >
+          <span :id="'menu-item-description-' + item.route">{{ routes[item.route].name }}</span>
           <badge-state
             v-if="item.error"
             color="bg-error"
@@ -21,12 +32,19 @@
             :key="extension.id"
             :data-test="`extension-nav-${ extension.metadata.ui['dashboard-tab'].title.toLowerCase() }`"
             :to="extensionRoute(extension)"
+            tabindex="-1"
           >
-            <nav-item :id="`extension:${extension.id}`">
+            <nav-item
+              :id="`extension:${extension.id}`"
+              :aria-describedby="'menu-item-description-' + extension.metadata.ui['dashboard-tab'].title"
+              role="menuitem"
+              tabindex="0"
+              @keydown.enter="activateLink(extensionRoute(extension))"
+            >
               <template #before>
                 <nav-icon-extension :extension-id="extension.id" />
               </template>
-              {{ extension.metadata.ui['dashboard-tab'].title }}
+              <span :id="'menu-item-description-' + extension.metadata.ui['dashboard-tab'].title">{{ extension.metadata.ui['dashboard-tab'].title }}</span>
             </nav-item>
           </nuxt-link>
         </template>
@@ -41,7 +59,7 @@ import os from 'os';
 import { NuxtApp } from '@nuxt/types/app';
 import { BadgeState } from '@rancher/components';
 import { PropType } from 'vue';
-import { RouteRecordPublic } from 'vue-router';
+import { RawLocation, RouteRecordPublic } from 'vue-router';
 
 import NavIconExtension from './NavIconExtension.vue';
 import NavItem from './NavItem.vue';
@@ -128,6 +146,11 @@ export default {
         },
       };
     },
+    activateLink(route: RawLocation) {
+      const nuxt: NuxtApp = (this as any).$nuxt;
+
+      nuxt.$router.push(route);
+    },
   },
 };
 </script>
@@ -172,6 +195,12 @@ ul {
 
         a.nuxt-link-active {
             background-color: var(--nav-active);
+        }
+
+        &:focus {
+          border: none;
+          outline: none;
+          background-color: var(--primary-banner-bg);
         }
     }
 }

--- a/pkg/rancher-desktop/components/NavItem.vue
+++ b/pkg/rancher-desktop/components/NavItem.vue
@@ -37,6 +37,12 @@ export default Vue.extend({ props: { id: { type: String, default: '' } } });
     &:hover {
       cursor: pointer;
     }
+
+    &:focus {
+      border: none;
+      outline: none;
+      background-color: var(--primary-banner-bg);
+    }
   }
 
   .before {

--- a/pkg/rancher-desktop/components/Preferences/ModalNav.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalNav.vue
@@ -32,17 +32,23 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div class="preferences-nav">
+  <div
+    class="preferences-nav"
+    aria-label="Preferences navigation"
+    role="menu"
+  >
     <nav-item
       v-for="navItem in navItems"
       :key="navItem"
       :data-test="navToKebab(navItem)"
       :name="navItem"
       :active="currentNavItem === navItem"
+      :aria-describedby="'menu-item-description-' + navItem"
       tabindex="0"
+      role="menuitem"
       @click="navClicked"
     >
-      {{ navItem }}
+      <span :id="'menu-item-description-' + navItem">{{ navItem }}</span>
     </nav-item>
   </div>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/ModalNav.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalNav.vue
@@ -19,6 +19,7 @@ export default Vue.extend({
 
   methods: {
     navClicked(tabName: string) {
+      console.log('NOT FAIL');
       if (tabName !== this.$props.currentNavItem) {
         this.$emit('nav-changed', tabName);
       }
@@ -38,6 +39,7 @@ export default Vue.extend({
       :data-test="navToKebab(navItem)"
       :name="navItem"
       :active="currentNavItem === navItem"
+      tabindex="0"
       @click="navClicked"
     >
       {{ navItem }}

--- a/pkg/rancher-desktop/components/Preferences/ModalNavItem.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalNavItem.vue
@@ -27,7 +27,12 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div class="preferences-nav-item" :class="{ active }" @click="navClicked">
+  <div
+    class="preferences-nav-item"
+    :class="{ active }"
+    @click="navClicked"
+    @keydown.enter="navClicked"
+  >
     <slot>Menu Item</slot>
   </div>
 </template>
@@ -39,9 +44,19 @@ export default Vue.extend({
     padding: 0.5rem 0.75rem;
     cursor: pointer;
     user-select: none;
-  }
 
-  .active {
-    background-color: var(--nav-active);
+    &.active {
+      background-color: var(--nav-active);
+
+      &:focus {
+        background-color: var(--nav-active);
+      }
+    }
+
+    &:focus {
+      border: none;
+      outline: none;
+      background-color: var(--primary-banner-bg);
+    }
   }
 </style>


### PR DESCRIPTION
This is still a draft, but I often find that I would like to be able to tab through our navigation. This PR resolves that. 

Please give this a look, I would especially like some feedback on the focus styles and behavior.