### PR TITLE
Automatically display BATS info as part of the first test

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -63,7 +63,6 @@ jobs:
         ./bats-core/bin/bats \
             --gather-test-outputs-in "$DEFAULT_DIR/logs" \
             --report-formatter tap \
-            tests/helpers/info.bash \
             ${{ inputs.tests }}
       env:
         RD_CONTAINER_ENGINE:     ${{ matrix.engine }}

--- a/bats/README.md
+++ b/bats/README.md
@@ -28,33 +28,45 @@ From the root directory of the Git repository, run the following commands to ins
 
 ## Running BATS
 
-1. To run the BATS test, specify the path to BATS executable from bats-core and run the following commands:
+To run the BATS test, specify the path to BATS executable from bats-core and run the following commands:
 
-    To run a specific test set from a bats file:
+To run a specific test set from a bats file:
 
-      ```sh
-      cd bats
-      ./bats-core/bin/bats tests/registry/creds.bats
-      ```
+```sh
+cd bats
+./bats-core/bin/bats tests/registry/creds.bats
+```
 
-    To run all BATS tests:
+To run all BATS tests:
 
-      ```sh
-      cd bats
-      ./bats-core/bin/bats tests/*/
-      ```
+```sh
+cd bats
+./bats-core/bin/bats tests/*/
+```
 
-    To run the BATS test, specifying some of Rancher Desktop's configuration, run the following commands:
+To run the BATS test, specifying some of Rancher Desktop's configuration, run the following commands:
 
-      ```sh
-      cd bats
-      RD_CONTAINER_RUNTIME=moby RD_USE_IMAGE_ALLOW_LIST=false ./bats-core/bin/bats tests/registry/creds.bats
-      ```
-    On Windows:
+```sh
+cd bats
+RD_CONTAINER_RUNTIME=moby RD_USE_IMAGE_ALLOW_LIST=false ./bats-core/bin/bats tests/registry/creds.bats
+```
 
-      BATS must be executed from within a WSL distibution. (You have to cd into `/mnt/c/REPOSITORY_LOCATION` from your unix shell.)
+### On Windows:
 
-      To test the Windows-based tools, set `RD_USE_WINDOWS_EXE` to `true` before running.
+BATS must be executed from within a WSL distibution. (You have to cd into `/mnt/c/REPOSITORY_LOCATION` from your unix shell.)
+
+To test the Windows-based tools, set `RD_USE_WINDOWS_EXE` to `true` before running.
+
+### RD_LOCATION
+
+By default bats will use Rancher Desktop installed in a "system" location. If that doesn't exists, it will try a "user" location, followed by the local "dist" directory inside the local git directory. The final option if is to use "npm". On Linux there is no "user" location.
+
+You can explicitly request a specific install location by setting `RD_LOCATION` to `system`, `user`, `dist`, or `npm`:
+
+```
+cd bats
+RD_LOCATION=dist ./bats-core/bin/bats ...
+```
 
 ## Writing BATS Tests
 

--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -14,6 +14,14 @@ my $problems = 0;
 my $run;
 
 while (<>) {
+    # bats files should not override the global setup and teardown functions.
+    # They should define local_* variants instead, which will be called from
+    # the global versions.
+    if (/^((setup|teardown)\w*)\(/) {
+        print "$ARGV:$.: Don't define $1(); define local_$1() instead\n";
+        $problems++;
+    }
+
     # Matches:
     # - assert_success
     # - $assert_success

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -1,7 +1,6 @@
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"
 

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -1,6 +1,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"
 

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -1,6 +1,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
 
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -1,7 +1,6 @@
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
 
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -1,6 +1,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
 
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -1,7 +1,6 @@
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     CONTAINERD_NAMESPACE=rancher-desktop-extensions
 
     TESTDATA_DIR="${PATH_BATS_ROOT}/tests/extensions/testdata/"

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -1,33 +1,17 @@
 # shellcheck disable=SC2059
 # https://www.shellcheck.net/wiki/SC2059 -- Don't use variables in the printf format string. Use printf '..%s..' "$foo".
-load load.bash
+# This file exists to print information about the configuration.
 
-# This file exists to print information about the configuration just once, e.g.
-#
-#   bats test/helpers/info.bash tests/*
-#
-# This can't be done during normal `load` operation because then it would be
-# printed for every single test run.
-
-# The info output is wrapped in a dummy test because bats doesn't execute files
-# that don't contain at least a single test case.
-#
-# Also use bash-compatible @test syntax so shellcheck doesn't complain. The file
-# uses a `.bash` extension so it is not matched by `tests/*` when running all
-# tests; you'll want to run it before all the other tests.
-
-predicate() {
-    if eval "$1"; then
-        echo "true"
-    else
-        echo "false"
+show_info() { # @test
+    # In case the file is loaded as a test: bats tests/helpers/info.bash
+    if [ -z "$RD_LOCATION" ]; then
+        load load.bash
     fi
-}
 
-info() { # @test
     if capturing_logs || taking_screenshots; then
         rm -rf "$PATH_BATS_LOGS"
     fi
+
     (
         local format="# %-25s %s\n"
 
@@ -35,20 +19,16 @@ info() { # @test
         printf "$format" "Resources path:" "$PATH_RESOURCES"
         echo "#"
         printf "$format" "Container engine:" "$RD_CONTAINER_ENGINE"
-        printf "$format" "Using image allow list:" "$(predicate using_image_allow_list)"
+        printf "$format" "Using image allow list:" "$(bool using_image_allow_list)"
         if is_macos; then
-            printf "$format" "Using VZ emulation:" "$(predicate using_vz_emulation)"
+            printf "$format" "Using VZ emulation:" "$(bool using_vz_emulation)"
         fi
         if is_windows; then
-            printf "$format" "Using Windows executables:" "$(predicate using_windows_exe)"
-            printf "$format" "Using networking tunnel:" "$(predicate using_networking_tunnel)"
+            printf "$format" "Using Windows executables:" "$(bool using_windows_exe)"
+            printf "$format" "Using networking tunnel:" "$(bool using_networking_tunnel)"
         fi
         echo "#"
-        printf "$format" "Capturing logs:" "$(predicate capturing_logs)"
-        printf "$format" "Taking screenshots:" "$(predicate taking_screenshots)"
+        printf "$format" "Capturing logs:" "$(bool capturing_logs)"
+        printf "$format" "Taking screenshots:" "$(bool taking_screenshots)"
     ) >&3
 }
-
-# Disable global setup/teardown functions because we are not running Rancher Desktop.
-setup_file() { true; }
-teardown_file() { true; }

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -50,15 +50,15 @@ source "$PATH_BATS_HELPERS/kubernetes.bash"
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
-global_setup() {
+shared_setup_file() {
     # Ideally this should be printed only when using the tap formatter,
     # but I don't see a way to check for this.
     echo "# ===== $RD_TEST_FILENAME =====" >&3
 }
 setup_file() {
-    global_setup
+    shared_setup_file
 }
-global_teardown() {
+shared_teardown_file() {
     capture_logs
     # On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
     if is_linux; then
@@ -66,12 +66,25 @@ global_teardown() {
     fi
 }
 teardown_file() {
-    global_teardown
+    shared_teardown_file
 }
-teardown() {
+shared_setup() {
+    if [ "${BATS_SUITE_TEST_NUMBER}" -eq 1 ] && [ "$RD_TEST_FILENAME" != "helpers/info.bash" ]; then
+        source "$PATH_BATS_HELPERS/info.bash"
+        show_info
+        echo "#"
+    fi
+}
+setup() {
+    shared_setup
+}
+shared_teardown() {
     if [ -z "$BATS_TEST_SKIPPED" ] && [ -z "$BATS_TEST_COMPLETED" ]; then
         take_screenshot
     fi
+}
+teardown() {
+    shared_teardown
 }
 
 # Bug workarounds go here. The goal is to make this an empty file

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -13,7 +13,7 @@ is_false() {
 }
 
 bool() {
-    if is_true "$1"; then
+    if eval "$1"; then
         echo "true"
     else
         echo "false"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -82,7 +82,7 @@ start_container_engine() {
 
     # TODO containerEngine.allowedImages.patterns and WSL.integrations
     # TODO cannot be set from the commandline yet
-    image_allow_list="$(bool "$RD_USE_IMAGE_ALLOW_LIST")"
+    image_allow_list="$(bool using_image_allow_list)"
     wsl_integrations="{}"
     if is_windows; then
         wsl_integrations="{\"$WSL_DISTRO_NAME\":true}"

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -2,8 +2,7 @@
 
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     needs_port 443
 }
 
@@ -56,12 +55,9 @@ get_host() {
     assert_output --partial "bootstrapPassword"
 }
 
-teardown_file() {
-    load '../helpers/load'
-
+local_teardown_file() {
     run helm uninstall rancher --namespace cattle-system --wait
     assert_nothing
     run helm uninstall cert-manager --namespace cert-manager --wait
     assert_nothing
-    shared_teardown_file
 }

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -3,6 +3,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     needs_port 443
 }
 
@@ -62,5 +63,5 @@ teardown_file() {
     assert_nothing
     run helm uninstall cert-manager --namespace cert-manager --wait
     assert_nothing
-    global_teardown
+    shared_teardown_file
 }

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -7,8 +7,7 @@
 
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     needs_port 80
 }
 

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -8,6 +8,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     needs_port 80
 }
 

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -158,12 +158,9 @@ verify_nginx_after_change_k8s() {
     verify_images
 }
 
-teardown_file() {
-    load '../helpers/load'
-
+local_teardown_file() {
     run ctrctl rm -f nginx-restart nginx-no-restart
     assert_nothing
     run kubectl delete --selector="app=busybox"
     assert_nothing
-    shared_teardown_file
 }

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -165,5 +165,5 @@ teardown_file() {
     assert_nothing
     run kubectl delete --selector="app=busybox"
     assert_nothing
-    global_teardown
+    shared_teardown_file
 }

--- a/bats/tests/k8s/verify-cached-images.bats
+++ b/bats/tests/k8s/verify-cached-images.bats
@@ -36,10 +36,3 @@ test_k8s_version_has_correct_cached_extension() {
 @test 'verify k8s 1.26.3 uses .tar.zst in the cache' {
     test_k8s_version_has_correct_cached_extension "1.26.3" "tar.zst"
 }
-
-# Linux bats doesn't shutdown if Rancher Desktop is still running
-teardown_file() {
-    load '../helpers/load'
-    run rdctl shutdown
-    assert_success
-}

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -1,7 +1,6 @@
 load '../helpers/load'
 
-setup() {
-    shared_setup
+local_setup() {
     if is_macos arm64; then
         skip "The bitnami wordpress image is not available for arm64 architecture. Skipping..."
     fi
@@ -48,13 +47,11 @@ setup() {
     assert_output --regexp "(Just another WordPress site|<title>User&#039;s Blog!</title>)"
 }
 
-teardown_file() {
-    load '../helpers/load'
+local_teardown_file() {
     run helm uninstall wordpress --wait
     assert_nothing
 
     # The database PVC doesn't get deleted by `helm uninstall`.
     run kubectl delete pvc data-wordpress-mariadb-0
     assert_nothing
-    shared_teardown_file
 }

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -1,6 +1,7 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
     if is_macos arm64; then
         skip "The bitnami wordpress image is not available for arm64 architecture. Skipping..."
     fi
@@ -55,5 +56,5 @@ teardown_file() {
     # The database PVC doesn't get deleted by `helm uninstall`.
     run kubectl delete pvc data-wordpress-mariadb-0
     assert_nothing
-    global_teardown
+    shared_teardown_file
 }

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -4,8 +4,7 @@ load '../helpers/load'
 # Ensure subshells don't inherit a path that includes ~/.rd/bin
 export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
 
-setup() {
-    shared_setup
+local_setup() {
     if is_windows; then
         skip "test not applicable on Windows"
     fi

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -5,6 +5,7 @@ load '../helpers/load'
 export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
 
 setup() {
+    shared_setup
     if is_windows; then
         skip "test not applicable on Windows"
     fi

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -1,8 +1,6 @@
 load '../helpers/load'
 
-setup() {
-    shared_setup
-
+local_setup() {
     REGISTRY_IMAGE="registry:2.8.1"
     REGISTRY_PORT="5050"
     DOCKER_CONFIG_FILE="$HOME/.docker/config.json"

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -1,6 +1,8 @@
 load '../helpers/load'
 
 setup() {
+    shared_setup
+
     REGISTRY_IMAGE="registry:2.8.1"
     REGISTRY_PORT="5050"
     DOCKER_CONFIG_FILE="$HOME/.docker/config.json"


### PR DESCRIPTION
Still keeps `tests/helpers/info.bats` executable as a stand-alone test.

Also:
* Rename `setup` to `local_setup` etc. and invoke them from the global version
* Document `RD_LOCATION` setting for BATS