### PR TITLE
guest agent service: quote log file name

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
+++ b/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
@@ -21,8 +21,8 @@ command_args="
   ${GUESTAGENT_DEBUG:+-debug}
   "
 command_args="${command_args//$'\n'/ }"
-output_log="${GUESTAGENT_LOGFILE}"
-error_log="${GUESTAGENT_LOGFILE}"
+output_log="'${GUESTAGENT_LOGFILE}'"
+error_log="'${GUESTAGENT_LOGFILE}'"
 
 respawn_delay=5
 respawn_max=0


### PR DESCRIPTION
Due to issues with openrc-run, we need to quote the file names we pass to supervise-daemon as it could contain spaces.

All the other files that mention output_log / error_log already do this quoting; this is the only file that doesn't.