### PR TITLE
Don't throw an error that Rosetta is still selected when switching back to QEMU

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -288,7 +288,7 @@ export default class SettingsValidator {
   }
 
   protected checkRosetta(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
-    if (desiredValue) {
+    if (desiredValue && !currentValue) {
       if (mergedSettings.experimental.virtualMachine.type !== VMType.VZ) {
         errors.push(`Setting ${ fqname } can only be enabled when experimental.virtual-machine.type is "${ VMType.VZ }".`);
 


### PR DESCRIPTION
It should be silently ignored. It is only an error when Rosetta was not selected while using VZ; you can't enable it, and switch to QEMU in one step, as it makes no sense.

Unfortunately we can't do the same thing for VIRTIOFS; the user **must** select an alternative mounting mechanism before switching back to QEMU as there are multiple choices.

Fixes #4882