### PR TITLE
RDX: Fix auth against `ghcr.io`

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/auth.ts
+++ b/pkg/rancher-desktop/backend/containerClient/auth.ts
@@ -148,7 +148,7 @@ class RegistryAuth {
 
     const parsed = {
       token:      result.token || result.access_token,
-      issued_at:  result.issued_at,
+      issued_at:  result.issued_at ?? (new Date()).toISOString(),
       expires_in: result.expires_in ?? 300,
     };
 

--- a/pkg/rancher-desktop/main/extensions/__tests__/manager.spec.ts
+++ b/pkg/rancher-desktop/main/extensions/__tests__/manager.spec.ts
@@ -1,0 +1,39 @@
+import { ExtensionManagerImpl } from '../manager';
+
+describe('ExtensionManagerImpl', () => {
+  describe('findBestVersion', () => {
+    let subject: ExtensionManagerImpl;
+
+    beforeEach(() => {
+      subject = new ExtensionManagerImpl({ getTags: jest.fn() } as any, false);
+    });
+
+    test.each<[string[], string | RegExp | undefined]>([
+      // Highest semver
+      [['0.0.1', '0.0.3', '0.0.2'], '0.0.3'],
+      // Use latest
+      [['foo', 'latest', 'bar', 'xyzzy'], 'latest'],
+      // No tags available
+      [[], undefined],
+      // Prefer proper semver over random numbers embedded in strings
+      [['foo', 'chore23', '0.0.1'], '0.0.1'],
+      // ... including with "v" prefix
+      [['foo', 'chore23', 'v0.0.1'], 'v0.0.1'],
+      // ... or "v." prefix
+      [['foo', 'chore23', 'v.0.0.1'], 'v.0.0.1'],
+      // If no semver, grab anything with numbers
+      [['foo1', 'foo3', 'foo2'], 'foo3'],
+    ])('%s => %s', async(versions, expected) => {
+      jest.spyOn(subject.client, 'getTags').mockImplementation(() => {
+        return Promise.resolve(new Set(versions));
+      });
+      if (expected === undefined) {
+        await expect(subject['findBestVersion']('')).rejects.toThrow();
+      } else if (typeof expected === 'string') {
+        await expect(subject['findBestVersion']('')).resolves.toEqual(expected);
+      } else {
+        await expect(subject['findBestVersion']('')).resolves.toMatch(expected);
+      }
+    });
+  });
+});

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -30,6 +30,15 @@ jest.mock('@pkg/utils/childProcess', () => {
   };
 });
 
+jest.mock('@pkg/utils/osVersion', () => {
+  return {
+    __esModule:      true,
+    getMacOsVersion: jest.fn(() => {
+      return new semver.SemVer('12.0.0');
+    }),
+  };
+});
+
 describe('queryUpgradeResponder', () => {
   afterEach(() => {
     (spawnFile as jest.Mock).mockReset();

--- a/pkg/rancher-desktop/utils/testUtils/setupElectron.ts
+++ b/pkg/rancher-desktop/utils/testUtils/setupElectron.ts
@@ -14,6 +14,7 @@ jest.mock('electron', () => {
         isPackaged: false,
         getAppPath: () => path.resolve('.'),
       },
+      ipcMain: {},
     },
   };
 });


### PR DESCRIPTION
Fixes #4362 (it's really a separate issue…)

`ghcr.io` auth doesn't return `issued_at` in their bearer token, so we default it to the current time.

Also adds a fix for determining the latest version of a tag (we grabbed anything with numbers, including things that don't look semver).

Lastly, fixes running unit tests on macOS.