### PR TITLE
Moproxy support for noproxy policies modification from graphical interface

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -543,6 +543,9 @@ components:
                     username:
                       type: string
                       x-rd-usage: if needed the username to connect to the proxy
+                    noproxy:
+                      type: string
+                      x-rd-usage: comma-separated list of addresses not redicrected to the proxy
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -544,8 +544,9 @@ components:
                       type: string
                       x-rd-usage: if needed the username to connect to the proxy
                     noproxy:
-                      type: string
-                      x-rd-usage: comma-separated list of addresses not redicrected to the proxy
+                      type: array
+                      x-rd-usage: list of hostname to exclude from using the proxy
+                      items: { type: string }
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -353,7 +353,7 @@ virtualMachine:
     username: Username
     password: Password
     noproxyTitle: No proxy hostname list
-    noproxy: Comma-seperated list of hostname to not redirect to the proxy
+    noproxy: List of hostname to not redirect to the proxy
   socketVmNet:
     legend: Enable socket-vmnet
     label: Use socket-vmnet instead of vde-vmnet

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -352,6 +352,8 @@ virtualMachine:
     authTitle: Authentication information
     username: Username
     password: Password
+    noproxyTitle: No proxy hostname list
+    noproxy: Comma-seperated list of hostname to not redirect to the proxy
   socketVmNet:
     legend: Enable socket-vmnet
     label: Use socket-vmnet instead of vde-vmnet

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -852,7 +852,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       await this.writeFile(`/etc/moproxy/proxy.ini`, '; no proxy defined');
     }
 
-    await this.modifyConf('moproxy', { MOPROXY_NOPROXY: proxy.noproxy });
+    await this.modifyConf('moproxy', { MOPROXY_NOPROXY: proxy.noproxy.join(',') });
   }
 
   /**

--- a/pkg/rancher-desktop/components/Preferences/WslProxy.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslProxy.vue
@@ -26,6 +26,14 @@ export default Vue.extend({
     isFieldDisabled() {
       return !(this.preferences.experimental.virtualMachine.proxy.enabled);
     },
+    noProxyText: {
+      get() {
+        return this.preferences.experimental.virtualMachine.proxy.noproxy.join('\n');
+      },
+      set(value: String) {
+        this.$store.dispatch('preferences/updatePreferencesData', { property: 'experimental.virtualMachine.proxy.noproxy', value: value.trim().split('\n') });
+      },
+    },
   },
   methods: {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
@@ -49,67 +57,83 @@ export default Vue.extend({
       />
     </rd-fieldset>
     <hr>
-    <rd-fieldset
-      data-test="addressTitle"
-      class="wsl-proxy-fieldset"
-      :legend-text="t('virtualMachine.proxy.addressTitle', { }, true)"
-    >
-      <rd-input
-        :placeholder="t('virtualMachine.proxy.address', { }, true)"
-        :disabled="isFieldDisabled"
-        :value="preferences.experimental.virtualMachine.proxy.address"
-        :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.address')"
-        class="wsl-proxy-field"
-        @input="onChange('experimental.virtualMachine.proxy.address', $event.target.value)"
-      />
-      <rd-input
-        type="number"
-        :placeholder="t('virtualMachine.proxy.port', { }, true)"
-        :disabled="isFieldDisabled"
-        :value="preferences.experimental.virtualMachine.proxy.port"
-        :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.port')"
-        class="wsl-proxy-field"
-        @input="onChange('experimental.virtualMachine.proxy.port', $event.target.value)"
-      />
-    </rd-fieldset>
-    <rd-fieldset
-      class="wsl-proxy-fieldset"
-      :legend-text="t('virtualMachine.proxy.authTitle', { }, true)"
-    >
-      <rd-input
-        :placeholder="t('virtualMachine.proxy.username', { }, true)"
-        :disabled="isFieldDisabled"
-        :value="preferences.experimental.virtualMachine.proxy.username"
-        :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.username')"
-        class="wsl-proxy-field"
-        @input="onChange('experimental.virtualMachine.proxy.username', $event.target.value)"
-      />
-      <rd-input
-        type="password"
-        :placeholder="t('virtualMachine.proxy.password', { }, true)"
-        :disabled="isFieldDisabled"
-        :value="preferences.experimental.virtualMachine.proxy.password"
-        :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.password')"
-        class="wsl-proxy-field"
-        @input="onChange('experimental.virtualMachine.proxy.password', $event.target.value)"
-      />
-    </rd-fieldset>
-    <rd-fieldset
-      class="wsl-proxy-fieldset"
-      :legend-text="t('virtualMachine.proxy.noproxyTitle', { }, true)"
-    >
-      <input
-        :placeholder="t('virtualMachine.proxy.noproxy', { }, true)"
-        :disabled="isFieldDisabled"
-        :value="preferences.experimental.virtualMachine.proxy.noproxy"
-        class="wsl-proxy-field"
-        @input="onChange('experimental.virtualMachine.proxy.noproxy', $event.target.value)"
-      />
-    </rd-fieldset>
+    <div class="proxy-row">
+      <div class="proxy-col">
+        <rd-fieldset
+          data-test="addressTitle"
+          class="wsl-proxy-fieldset"
+          :legend-text="t('virtualMachine.proxy.addressTitle', { }, true)"
+        >
+          <rd-input
+            :placeholder="t('virtualMachine.proxy.address', { }, true)"
+            :disabled="isFieldDisabled"
+            :value="preferences.experimental.virtualMachine.proxy.address"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.address')"
+            class="wsl-proxy-field"
+            @input="onChange('experimental.virtualMachine.proxy.address', $event.target.value)"
+          />
+          <rd-input
+            type="number"
+            :placeholder="t('virtualMachine.proxy.port', { }, true)"
+            :disabled="isFieldDisabled"
+            :value="preferences.experimental.virtualMachine.proxy.port"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.port')"
+            class="wsl-proxy-field"
+            @input="onChange('experimental.virtualMachine.proxy.port', $event.target.value)"
+          />
+        </rd-fieldset>
+        <rd-fieldset
+          class="wsl-proxy-fieldset"
+          :legend-text="t('virtualMachine.proxy.authTitle', { }, true)"
+        >
+          <rd-input
+            :placeholder="t('virtualMachine.proxy.username', { }, true)"
+            :disabled="isFieldDisabled"
+            :value="preferences.experimental.virtualMachine.proxy.username"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.username')"
+            class="wsl-proxy-field"
+            @input="onChange('experimental.virtualMachine.proxy.username', $event.target.value)"
+          />
+          <rd-input
+            type="password"
+            :placeholder="t('virtualMachine.proxy.password', { }, true)"
+            :disabled="isFieldDisabled"
+            :value="preferences.experimental.virtualMachine.proxy.password"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.password')"
+            class="wsl-proxy-field"
+            @input="onChange('experimental.virtualMachine.proxy.password', $event.target.value)"
+          />
+        </rd-fieldset>
+      </div>
+      <div class="proxy-col">
+        <rd-fieldset
+          :legend-text="t('virtualMachine.proxy.noproxyTitle', { }, true)"
+          :style="{ height: '100%' }"
+        >
+          <textarea
+            :placeholder="t('virtualMachine.proxy.noproxy', { }, true)"
+            :disabled="isFieldDisabled"
+            :value="preferences.experimental.virtualMachine.proxy.noproxy.join('\n')"
+            class="wsl-proxy-textarea"
+            @input="onChange('experimental.virtualMachine.proxy.noproxy', $event.target.value.split('\n'))"
+          />
+        </rd-fieldset>
+      </div>
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
+  .proxy-row {
+    display: flex;
+    flex-direction: row;
+  }
+  .proxy-col {
+    padding: 0rem .5rem;
+    width: 50%;
+    display: flex;
+    flex-direction: column;
+  }
   .wsl-proxy {
     display: flex;
     flex-direction: column;
@@ -122,5 +146,10 @@ export default Vue.extend({
   }
   .wsl-proxy-field {
     width: 100%;
+  }
+  .wsl-proxy-textarea{
+    width: 100%;
+    height: 100%;
+    padding: 2px;
   }
 </style>

--- a/pkg/rancher-desktop/components/Preferences/WslProxy.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslProxy.vue
@@ -94,6 +94,18 @@ export default Vue.extend({
         @input="onChange('experimental.virtualMachine.proxy.password', $event.target.value)"
       />
     </rd-fieldset>
+    <rd-fieldset
+      class="wsl-proxy-fieldset"
+      :legend-text="t('virtualMachine.proxy.noproxyTitle', { }, true)"
+    >
+      <input
+        :placeholder="t('virtualMachine.proxy.noproxy', { }, true)"
+        :disabled="isFieldDisabled"
+        :value="preferences.experimental.virtualMachine.proxy.noproxy"
+        class="wsl-proxy-field"
+        @input="onChange('experimental.virtualMachine.proxy.noproxy', $event.target.value)"
+      />
+    </rd-fieldset>
   </div>
 </template>
 

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -127,7 +127,7 @@ export const defaultSettings = {
       /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
       networkingTunnel: false,
       proxy:            {
-        enabled: false, address: '', password: '', port: 3128, username: '',
+        enabled: false, address: '', password: '', port: 3128, username: '', noproxy: '0.0.0.0/8,10.0.0.0/8,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.168.0.0/16,224.0.0.0/4,240.0.0.0/4',
       },
     },
   },

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -127,7 +127,7 @@ export const defaultSettings = {
       /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
       networkingTunnel: false,
       proxy:            {
-        enabled: false, address: '', password: '', port: 3128, username: '', noproxy: '0.0.0.0/8,10.0.0.0/8,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.168.0.0/16,224.0.0.0/4,240.0.0.0/4',
+        enabled: false, address: '', password: '', port: 3128, username: '', noproxy: ['0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16', '224.0.0.0/4', '240.0.0.0/4'],
       },
     },
   },

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -127,7 +127,13 @@ export const defaultSettings = {
       /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
       networkingTunnel: false,
       proxy:            {
-        enabled: false, address: '', password: '', port: 3128, username: '', noproxy: ['0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16', '224.0.0.0/4', '240.0.0.0/4'],
+        enabled:  false,
+        address:  '',
+        password: '',
+        port:     3128,
+        username: '',
+        noproxy:  ['0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16',
+          '224.0.0.0/4', '240.0.0.0/4'],
       },
     },
   },

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -76,6 +76,7 @@ describe(SettingsValidator, () => {
       ['experimental', 'virtualMachine', 'mount', 'type'],
       ['experimental', 'virtualMachine', 'type'],
       ['experimental', 'virtualMachine', 'useRosetta'],
+      ['experimental', 'virtualMachine', 'proxy', 'noproxy'],
       ['kubernetes', 'version'],
       ['version'],
       ['WSL', 'integrations'],

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -133,7 +133,7 @@ export default class SettingsValidator {
             password: this.checkString,
             port:     this.checkNumber(1, 65535),
             username: this.checkString,
-            noproxy:  this.checkString,
+            noproxy:  this.checkUniqueStringArray,
           },
         },
       },

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -133,6 +133,7 @@ export default class SettingsValidator {
             password: this.checkString,
             port:     this.checkNumber(1, 65535),
             username: this.checkString,
+            noproxy:  this.checkString,
           },
         },
       },


### PR DESCRIPTION
Add support for noproxy policies from the rancher-desktop settings window.

![Screenshot_win10_2023-06-07_14:59:47](https://github.com/rancher-sandbox/rancher-desktop/assets/4118134/e6934710-1b1e-41ee-9ab1-587b175a21ae)

The input box is already full with the default addresses. I'm open to any proposition to make this more clear.

Next step of the PR https://github.com/rancher-sandbox/rancher-desktop/pull/4697 

https://github.com/rancher-sandbox/rancher-desktop/issues/4603


Fixes #5100