### PR TITLE
nerdctl: Try harder to ignore dangling symlinks when copying out

### DIFF
--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -80,6 +80,14 @@ encoded_id() { # variant
     assert_line --regexp "$(id vm-compose).*[[:space:]]Up[[:space:]]"
 }
 
+@test 'compose - check for dangling symlinks' {
+    if ! using_containerd; then
+        skip 'This test only applies to containerd'
+    fi
+    assert_exists "$PATH_EXTENSIONS/$(encoded_id vm-compose)/compose/link"
+    assert_not_exists "$PATH_EXTENSIONS/$(encoded_id vm-compose)/compose/dangling-link"
+}
+
 @test 'compose - uninstall' {
     rdctl api --method=POST "/v1/extensions/uninstall?id=$(id vm-compose)"
 

--- a/bats/tests/extensions/testdata/Dockerfile
+++ b/bats/tests/extensions/testdata/Dockerfile
@@ -6,5 +6,7 @@ ADD extension-icon.svg /extension-icon.svg
 ADD ui /ui/
 ADD bin /bin/
 ADD compose.yaml /compose/
+RUN ln -s does/not/exist /compose/dangling-link
+RUN ln -s compose.yaml /compose/link
 
 ENTRYPOINT ["/usr/local/bin/python3", "/bin/server.py"]


### PR DESCRIPTION
This should fix #4676.

Note that `docker/volumes-backup-extension:1.1.2` will still not install, because that runs a container that wants to mount `/var/run/docker.sock` (so it'll fail there when using the containerd backend and get uninstalled).

Also, this still doesn't match the behaviour of what `docker cp` actually does; I'll be working on a follow up (with tests) later.