### PR TITLE
Wait for docker context being written after changing allowed images filtering

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -4,12 +4,13 @@ RD_USE_IMAGE_ALLOW_LIST=true
 @test 'start' {
     factory_reset
     start_kubernetes
-    wait_for_apiserver
     wait_for_container_engine
+    wait_for_apiserver
 }
 
 @test 'update the list of patterns first time' {
     update_allowed_patterns true '"nginx", "busybox", "python"'
+    wait_for_container_engine
 }
 
 @test 'verify pull nginx succeeds' {
@@ -71,6 +72,7 @@ verify_no_nginx() {
 @test 'set patterns with the allowed list disabled' {
     update_allowed_patterns false '"nginx", "busybox", "ruby"'
     # containerEngine.allowedImages.enabled changed, so wait for a restart
+    wait_for_container_engine
     wait_for_apiserver "$RD_KUBERNETES_PREV_VERSION"
 }
 


### PR DESCRIPTION
Changing the filter status will restart the container engine, which may delete and recreate the docker context when the engine is moby.