### PR TITLE
Override default input event in `RdSelect`

### DIFF
--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -27,6 +27,18 @@ export default Vue.extend({
         this.$emit('input', newValue);
       },
     },
+    /**
+     * Ensure that the correct value is emitted by overriding the default
+     * listeners to supply a custom input event. Resolves an issue where the
+     * entire vnode emits when using v-model.
+     */
+    computedListeners(): Record<string, Function | Function[]> & { input: (e: any) => any; } {
+      return Object.assign(
+        {},
+        this.$listeners,
+        { input: (e: any) => this.$emit('input', e.target.value) },
+      );
+    },
   },
 });
 </script>
@@ -38,7 +50,7 @@ export default Vue.extend({
       v-bind="$attrs"
       :class="{ 'locked' : isLocked && !$attrs.disabled }"
       :disabled="$attrs.disabled || isLocked"
-      v-on="$listeners"
+      v-on="computedListeners"
     >
       <slot name="default">
         <!-- Slot contents -->


### PR DESCRIPTION
The problem described in issue #4916 appears to be related to using arrow keys to select options within the `RdSelect` component when used with `v-model`. In this scenario, the entire `vnode` was emitted instead of just the selected value. 

To resolve this issue, we override the default listeners for `RdSelect` by adding a custom `input` event that emits `e.target.value` to ensure that the correct value is emitted when selecting values.

This issue was specific to the first run dialog, as other usages of `RdSelect` throughout Rancher Desktop utilize `:val` and `@change`.

While investigating this bug, I observed that other frameworks avoid wrapping selects and re-implement select behavior from scratch. There may be a reason behind this approach and we might want to take this into consideration in the future.

closes #4916