### PR TITLE
Get rid of PathManagementStrategy.NotSet

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -126,9 +126,11 @@ mainEvents.on('settings-update', async(newSettings) => {
   }
   k8smanager.debug = runInDebugMode;
 
-  if (pathManager.strategy !== newSettings.application.pathManagementStrategy) {
-    await pathManager.remove();
-    pathManager = getPathManagerFor(newSettings.application.pathManagementStrategy);
+  if (process.platform !== 'win32') {
+    if (pathManager.strategy !== newSettings.application.pathManagementStrategy) {
+      await pathManager.remove();
+      pathManager = getPathManagerFor(newSettings.application.pathManagementStrategy);
+    }
     await pathManager.enforce();
   }
 

--- a/background.ts
+++ b/background.ts
@@ -20,7 +20,7 @@ import * as settings from '@pkg/config/settings';
 import { TransientSettings } from '@pkg/config/transientSettings';
 import { IntegrationManager, getIntegrationManager } from '@pkg/integrations/integrationManager';
 import { removeLegacySymlinks, PermissionError } from '@pkg/integrations/legacy';
-import { getPathManagerFor, PathManagementStrategy, PathManager } from '@pkg/integrations/pathManager';
+import { getPathManagerFor, PathManager } from '@pkg/integrations/pathManager';
 import { CommandWorkerInterface, HttpCommandServer } from '@pkg/main/commandServer/httpCommandServer';
 import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
 import { HttpCredentialHelperServer } from '@pkg/main/credentialServer/httpCredentialHelperServer';
@@ -269,16 +269,6 @@ Electron.app.whenReady().then(async() => {
     }
 
     await dockerDirManager.ensureCredHelperConfigured();
-
-    // Path management strategy will need to be selected after an update
-    if (!os.platform().startsWith('win') && cfg.application.pathManagementStrategy === PathManagementStrategy.NotSet) {
-      if (!noModalDialogs) {
-        await window.openFirstRunDialog();
-      } else {
-        cfg.application.pathManagementStrategy = PathManagementStrategy.RcFiles;
-        mainEvents.emit('settings-write', { application: { pathManagementStrategy: cfg.application.pathManagementStrategy } });
-      }
-    }
 
     if (os.platform() === 'linux' || os.platform() === 'darwin') {
       try {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -22,7 +22,7 @@ const console = Logging.settings;
 // it will be picked up from the default settings object.
 // Version incrementing is for when a breaking change is introduced in the settings object.
 
-export const CURRENT_SETTINGS_VERSION = 7 as const;
+export const CURRENT_SETTINGS_VERSION = 8 as const;
 
 export enum VMType {
   QEMU = 'qemu',
@@ -77,7 +77,7 @@ export const defaultSettings = {
         list:    [] as Array<string>,
       },
     },
-    pathManagementStrategy: PathManagementStrategy.NotSet,
+    pathManagementStrategy: PathManagementStrategy.RcFiles,
     telemetry:              { enabled: true },
     /** Whether we should check for updates and apply them. */
     updater:                { enabled: true },
@@ -496,6 +496,11 @@ const updateTable: Record<number, (settings: any) => void> = {
     });
 
     settings.extensions = Object.fromEntries(extensions);
+  },
+  7: (settings) => {
+    if (settings.application.pathManagementStrategy === 'notset') {
+      settings.application.pathManagementStrategy = PathManagementStrategy.RcFiles;
+    }
   },
 };
 

--- a/pkg/rancher-desktop/integrations/pathManager.ts
+++ b/pkg/rancher-desktop/integrations/pathManager.ts
@@ -30,16 +30,6 @@ export class ManualPathManager implements PathManager {
 }
 
 /**
- * NotSetPathManager is used when a choice hasn't been made. This is reserved
- * for scenarios like first run, where a decision needs to be made.
- */
-export class NotSetPathManager implements PathManager {
-  readonly strategy = PathManagementStrategy.NotSet;
-  async enforce(): Promise<void> {}
-  async remove(): Promise<void> {}
-}
-
-/**
  * RcFilePathManager is for when the user wants Rancher Desktop to
  * make changes to their PATH by putting lines that change it in their
  * shell .rc files.
@@ -152,7 +142,6 @@ export class RcFilePathManager implements PathManager {
 export enum PathManagementStrategy {
   Manual = 'manual',
   RcFiles = 'rcfiles',
-  NotSet = 'notset'
 }
 
 /**
@@ -165,8 +154,6 @@ export function getPathManagerFor(strategy: PathManagementStrategy): PathManager
     return new ManualPathManager();
   case PathManagementStrategy.RcFiles:
     return new RcFilePathManager();
-  case PathManagementStrategy.NotSet:
-    return new NotSetPathManager();
   default:
     throw new Error(`Invalid strategy "${ strategy }"`);
   }

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -383,20 +383,18 @@ describe(SettingsValidator, () => {
       spyPlatform.mockReturnValue('linux');
     });
     describe('should accept valid settings', () => {
-      const validStrategies = Object.keys(PathManagementStrategy).filter(x => x !== 'NotSet');
-
-      test.each(validStrategies)('%s', (strategy) => {
+      test.each(Object.keys(PathManagementStrategy))('%s', (strategy) => {
         const value = PathManagementStrategy[strategy as keyof typeof PathManagementStrategy];
         const [needToUpdate, errors] = subject.validateSettings({
           ...cfg,
           application: {
             ...cfg.application,
-            pathManagementStrategy: PathManagementStrategy.NotSet,
+            pathManagementStrategy: PathManagementStrategy.Manual,
           },
         }, { application: { pathManagementStrategy: value } });
 
         expect({ needToUpdate, errors }).toEqual({
-          needToUpdate: true,
+          needToUpdate: value !== PathManagementStrategy.Manual,
           errors:       [],
         });
       });
@@ -408,17 +406,7 @@ describe(SettingsValidator, () => {
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: false,
-        errors:       [`application.pathManagementStrategy: "invalid value" is not a valid strategy`],
-      });
-    });
-
-    it('should reject setting as NotSet', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg,
-        { application: { pathManagementStrategy: PathManagementStrategy.NotSet } });
-
-      expect({ needToUpdate, errors }).toEqual({
-        needToUpdate: false,
-        errors:       [`application.pathManagementStrategy: "notset" is not a valid strategy`],
+        errors:       [`Invalid value for application.pathManagementStrategy: <"invalid value">; must be one of ["manual","rcfiles"]`],
       });
     });
   });

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -83,7 +83,7 @@ export default class SettingsValidator {
             list:    this.checkExtensionAllowList,
           },
         },
-        pathManagementStrategy: this.checkLima(this.checkPathManagementStrategy),
+        pathManagementStrategy: this.checkLima(this.checkEnum(...Object.values(PathManagementStrategy))),
         telemetry:              { enabled: this.checkBoolean },
         /** Whether we should check for updates and apply them. */
         updater:                { enabled: this.checkBoolean },
@@ -514,27 +514,6 @@ export default class SettingsValidator {
     }
 
     return Array.from(duplicates);
-  }
-
-  protected checkPathManagementStrategy(mergedSettings: Settings, currentValue: PathManagementStrategy,
-    desiredValue: any, errors: string[], fqname: string): boolean {
-    if (!(Object.values(PathManagementStrategy).includes(desiredValue))) {
-      errors.push(`${ fqname }: "${ desiredValue }" is not a valid strategy`);
-
-      return false;
-    }
-
-    if (desiredValue !== currentValue) {
-      if (desiredValue === PathManagementStrategy.NotSet) {
-        errors.push(`${ fqname }: "${ desiredValue }" is not a valid strategy`);
-
-        return false;
-      }
-
-      return true;
-    }
-
-    return false;
   }
 
   protected checkExtensions(

--- a/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
+++ b/pkg/rancher-desktop/main/diagnostics/rdBinInShell.ts
@@ -13,7 +13,7 @@ import paths from '@pkg/utils/paths';
 
 const console = Logging.diagnostics;
 const pathOutputDelimiter = 'Rancher Desktop Diagnostics PATH:';
-let pathStrategy = PathManagementStrategy.NotSet;
+let pathStrategy = PathManagementStrategy.RcFiles;
 
 mainEvents.on('settings-update', (cfg) => {
   pathStrategy = cfg.application.pathManagementStrategy;


### PR DESCRIPTION
It was introduced to help users upgrading from 1.3 to 1.4 (I think), which added the path management strategy setting as a replacement for putting symlinks into /usr/local/bin. Instead of the full first-run dialog we would display a simpler version that only asks about the value for the path management strategy.

This dialog has since been removed. If somebody will upgrade from 1.3 or earlier to 1.9 or later, then we'll default the strategy to RcFiles. This can still be changed in the preferences dialog later.

Fixes #4918
Fixes #4923