### PR TITLE
Don't enforce path management strategy on Windows

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -226,8 +226,12 @@ Electron.app.whenReady().then(async() => {
       }
       console.log(`Failed to update command from argument ${ commandLineArgs.join(', ') }`, err);
     }
-    pathManager = getPathManagerFor(cfg.application.pathManagementStrategy);
-    await integrationManager.enforce();
+
+    if (process.platform !== 'win32') {
+      pathManager = getPathManagerFor(cfg.application.pathManagementStrategy);
+      await integrationManager.enforce();
+    }
+
     mainEvents.emit('settings-update', cfg);
 
     // Set up the updater; we may need to quit the app if an update is already


### PR DESCRIPTION
This PR adds an additional check for the platform before enforcing a path management strategy.

After merging  #4928 [^1], it appears that we don't want to enforce a path management strategy if the platform is `win32`. Otherwise, Rancher Desktop fails to launch with an error `Error starting up: Error: Platform "win32" is not supported by RcFilePathManager`.

closes #4937

[^1]: https://github.com/rancher-sandbox/rancher-desktop/pull/4928/commits/d78d1ca455e6a02d0ea0fa0f27cebcf27f6cf787