### PR TITLE
Default to `manual` on windows

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -126,13 +126,11 @@ mainEvents.on('settings-update', async(newSettings) => {
   }
   k8smanager.debug = runInDebugMode;
 
-  if (process.platform !== 'win32') {
-    if (pathManager.strategy !== newSettings.application.pathManagementStrategy) {
-      await pathManager.remove();
-      pathManager = getPathManagerFor(newSettings.application.pathManagementStrategy);
-    }
-    await pathManager.enforce();
+  if (pathManager.strategy !== newSettings.application.pathManagementStrategy) {
+    await pathManager.remove();
+    pathManager = getPathManagerFor(newSettings.application.pathManagementStrategy);
   }
+  await pathManager.enforce();
 
   if (newSettings.application.hideNotificationIcon) {
     Tray.getInstance(cfg).hide();
@@ -229,10 +227,8 @@ Electron.app.whenReady().then(async() => {
       console.log(`Failed to update command from argument ${ commandLineArgs.join(', ') }`, err);
     }
 
-    if (process.platform !== 'win32') {
-      pathManager = getPathManagerFor(cfg.application.pathManagementStrategy);
-      await integrationManager.enforce();
-    }
+    pathManager = getPathManagerFor(cfg.application.pathManagementStrategy);
+    await integrationManager.enforce();
 
     mainEvents.emit('settings-update', cfg);
 

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -77,7 +77,7 @@ export const defaultSettings = {
         list:    [] as Array<string>,
       },
     },
-    pathManagementStrategy: PathManagementStrategy.RcFiles,
+    pathManagementStrategy: process.platform === 'win32' ? PathManagementStrategy.Manual : PathManagementStrategy.RcFiles,
     telemetry:              { enabled: true },
     /** Whether we should check for updates and apply them. */
     updater:                { enabled: true },
@@ -499,7 +499,11 @@ const updateTable: Record<number, (settings: any) => void> = {
   },
   7: (settings) => {
     if (settings.application.pathManagementStrategy === 'notset') {
-      settings.application.pathManagementStrategy = PathManagementStrategy.RcFiles;
+      if (process.platform === 'win32') {
+        settings.application.pathManagementStrategy = PathManagementStrategy.Manual;
+      } else {
+        settings.application.pathManagementStrategy = PathManagementStrategy.RcFiles;
+      }
     }
   },
 };


### PR DESCRIPTION
This sets the default path management strategy to `Manual` on Windows` 

Recent testing has shown that `RcFiles` can cause Rancher Desktop to hang on Windows during the initialization step, so it's better to allow a manual path management strategy to be enforced. 