### PR TITLE
Don't pre register traefik ports

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -121,14 +121,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           const k8sPortForwarding = `127.0.0.1:${ k8sPort }=${ gatewayIP }:${ k8sPort }`;
 
           args.push('--port-forward', k8sPortForwarding);
-
-          if (this.cfg?.kubernetes.options.traefik) {
-            const ingressIP = this.cfg?.kubernetes.ingress.localhostOnly ? '127.0.0.1' : '0.0.0.0';
-
-            for (const port of [80, 443]) {
-              args.push('--port-forward', `${ ingressIP }:${ port }=${ gatewayIP }:${ port }`);
-            }
-          }
         }
 
         return childProcess.spawn(exe, args, {


### PR DESCRIPTION
Currently, we manually [register](https://github.com/rancher-sandbox/rancher-desktop/blob/f70a197758a9c41aae9734ec89190f0843ae45a9/pkg/rancher-desktop/backend/wsl.ts#L123) port 443 and 80 if traefik is enabled, however, now that the port forwarding is performed automatically in the new namespace network this causes an error in the logs as these service ports are being discovered in the guest agent by the auto service discovery.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4971