### PR TITLE
Bats needs to use preferences version 8 in the API.

### DIFF
--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -89,7 +89,7 @@ update_allowed_patterns() {
     local patterns=$2
     rdctl api settings -X PUT --input - <<EOF
 {
-  "version": 7,
+  "version": 8,
   "containerEngine": {
     "allowedImages": {
       "enabled": $enabled,

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -99,7 +99,7 @@ start_container_engine() {
     mkdir -p "$PATH_CONFIG"
     cat <<EOF >"$PATH_CONFIG_FILE"
 {
-  "version": 7,
+  "version": 8,
   "WSL": { "integrations": $wsl_integrations },
   "containerEngine": {
     "allowedImages": {


### PR DESCRIPTION
Tests are failing because they're still using `"version": 7` in `-X PUT settings` API calls.