### PR TITLE
Wait on the backgrounded rdctl process

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -6,6 +6,7 @@ RD_USE_IMAGE_ALLOW_LIST=true
     start_kubernetes
     wait_for_container_engine
     wait_for_apiserver
+    wait_for_rdctl_background_process
 }
 
 @test 'update the list of patterns first time' {

--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -6,6 +6,7 @@ load '../helpers/load'
 
 @test 'Start up Rancher Desktop' {
     start_application
+    wait_for_rdctl_background_process
 }
 
 @test 'Verify that initial Behavior is all set to false' {

--- a/bats/tests/containers/catch-duplicate-api-patterns.bats
+++ b/bats/tests/containers/catch-duplicate-api-patterns.bats
@@ -10,6 +10,7 @@ RD_USE_IMAGE_ALLOW_LIST=true
     run update_allowed_patterns true "$IMAGE_NGINX" "$IMAGE_BUSYBOX" "$IMAGE_RUBY" "$IMAGE_BUSYBOX"
     assert_failure
     assert_output --partial "field 'containerEngine.allowedImages.patterns' has duplicate entries: \"$IMAGE_BUSYBOX\""
+    wait_for_rdctl_background_process
 }
 
 @test 'catch attempts to add duplicate patterns via the API with enabled off' {

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -8,6 +8,7 @@ refute=refute
 
 @test 'Start up Rancher Desktop' {
     start_application
+    wait_for_rdctl_background_process
 }
 
 @test 'Verify that the expected directories were created' {

--- a/bats/tests/containers/host-connectivity.bats
+++ b/bats/tests/containers/host-connectivity.bats
@@ -12,6 +12,7 @@ load '../helpers/load'
 @test 'start container engine' {
     start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 verify_host_connectivity() {

--- a/bats/tests/containers/platform.bats
+++ b/bats/tests/containers/platform.bats
@@ -7,6 +7,7 @@ load '../helpers/load'
 @test 'start container engine' {
     start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 check_uname() {

--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -7,6 +7,7 @@ load '../helpers/load'
 @test 'start container engine' {
     start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'run rancher' {

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -26,6 +26,7 @@ pull_containers() {
     start_container_engine
     wait_for_container_engine
     pull_containers
+    wait_for_rdctl_background_process
 }
 
 @test "switch to containerd" {

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -54,6 +54,7 @@ check_extension_installed() { # refute, name
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'build extension testing image' {

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -24,6 +24,7 @@ encoded_id() { # variant
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'no extensions installed' {

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -42,6 +42,7 @@ encoded_id() { # variant
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'no extensions installed' {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -126,7 +126,15 @@ EOF
         # Detach `rdctl start` because on Windows the process may not exit until
         # Rancher Desktop itself quits.
         RD_TEST=bats rdctl start "${args[@]}" "$@" &
+        RDCTL_PROCESS_ID=$!
     fi
+}
+
+wait_for_rdctl_background_process() {
+    case "${RDCTL_PROCESS_ID:-no}" in
+    0 | no) ;;
+    [0-9][0-9]*) wait "$RDCTL_PROCESS_ID" || true ;;
+    esac
 }
 
 # shellcheck disable=SC2120

--- a/bats/tests/k8s/enable-disable-k8s.bats
+++ b/bats/tests/k8s/enable-disable-k8s.bats
@@ -16,6 +16,7 @@ verify_k8s_is_running() {
     start_kubernetes
     wait_for_apiserver
     verify_k8s_is_running
+    wait_for_rdctl_background_process
 }
 
 @test 'disable kubernetes' {

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -13,6 +13,7 @@ local_setup() {
 @test 'start k8s' {
     start_kubernetes
     wait_for_apiserver
+    wait_for_rdctl_background_process
 }
 
 @test 'add helm repo' {

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -18,6 +18,7 @@ local_setup() {
 @test 'start k8s' {
     start_kubernetes --kubernetes.options.traefik=true
     wait_for_apiserver
+    wait_for_rdctl_background_process
 }
 
 get_host() {

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -13,6 +13,7 @@ ARCH_FOR_KUBERLR=amd64
     # the docker context "rancher-desktop" may not have been written
     # even though the apiserver is already running
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'deploy nginx - always restart' {

--- a/bats/tests/k8s/verify-cached-images.bats
+++ b/bats/tests/k8s/verify-cached-images.bats
@@ -10,6 +10,7 @@ load '../helpers/load'
     # Start first so we can use `rdctl set` in all the calls that change the k8s version
     start_kubernetes
     wait_for_apiserver
+    wait_for_rdctl_background_process
 }
 
 test_k8s_version_has_correct_cached_extension() {

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -21,6 +21,7 @@ local_setup() {
     # the docker context "rancher-desktop" may not have been written
     # even though the apiserver is already running
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 @test 'deploy wordpress' {

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -17,6 +17,7 @@ local_setup() {
 @test 'start app' {
     start_container_engine
     wait_for_container_engine
+    wait_for_rdctl_background_process
 }
 
 # Running `bash -l -c` can cause bats to hang, so close the output file descriptor with '3>&-'
@@ -87,5 +88,11 @@ no_bashrc_path_manager() {
         refute_output --partial "$HOME/.rd/bin/rdctl"
     else
         skip 'fish not found'
+    fi
+}
+
+@test 'shutdown on mac' {
+    if is_macos; then
+        rdctl shutdown
     fi
 }

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -92,6 +92,7 @@ skip_for_insecure_registry() {
         wait_for_shell
         update_allowed_patterns true "$IMAGE_REGISTRY" "$REGISTRY"
     fi
+    wait_for_rdctl_background_process
 }
 
 @test 'wait for container engine' {


### PR DESCRIPTION
Fixes #4517 (although most likely a first draft):

An alternative would be to write the PID for the `rdctl` bg process to a temp file, and then read it during shutdown and wait if necessary. I'll go there if this PR is on the right track but we don't want to require every single first-test after running `rdctl start` to call `wait_for_rdctl_background_process`