### PR TITLE
Remove `cronstrue` & `cron-validator` deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,6 @@
         "bufferutil": "4.0.7",
         "cookie-universal-nuxt": "2.2.2",
         "core-js": "3.25.3",
-        "cron-validator": "1.3.1",
-        "cronstrue": "2.21.0",
         "dayjs": "1.11.5",
         "dompurify": "3.0.1",
         "electron-updater": "^5.3.0",
@@ -15243,14 +15241,6 @@
     "node_modules/cron-validator": {
       "version": "1.3.1",
       "license": "MIT"
-    },
-    "node_modules/cronstrue": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.21.0.tgz",
-      "integrity": "sha512-YxabE1ZSHA1zJZMPCTSEbc0u4cRRenjqqTgCwJT7OvkspPSvfYFITuPFtsT+VkBuavJtFv2kJXT+mKSnlUJxfg==",
-      "bin": {
-        "cronstrue": "bin/cli.js"
-      }
     },
     "node_modules/cross-env": {
       "version": "6.0.3",
@@ -47087,11 +47077,6 @@
     },
     "cron-validator": {
       "version": "1.3.1"
-    },
-    "cronstrue": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.21.0.tgz",
-      "integrity": "sha512-YxabE1ZSHA1zJZMPCTSEbc0u4cRRenjqqTgCwJT7OvkspPSvfYFITuPFtsT+VkBuavJtFv2kJXT+mKSnlUJxfg=="
     },
     "cross-env": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "bufferutil": "4.0.7",
     "cookie-universal-nuxt": "2.2.2",
     "core-js": "3.25.3",
-    "cron-validator": "1.3.1",
-    "cronstrue": "2.21.0",
     "dayjs": "1.11.5",
     "dompurify": "3.0.1",
     "electron-updater": "^5.3.0",


### PR DESCRIPTION
This removes `cronstrue` & `cron-validator` deps from Rancher Desktop. 

These dependencies were added earlier in Rancher Desktop's development to support copying the `LabeledInput` component from Dashboard (28e27fae29485269969fb8c13719235d2b83c68e). We now consume `LabeledInput` via `@rancher/components` and these dependencies are no longer needed. 