### PR TITLE
Add the --no-modal-dialogs flag to rdctl start.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -212,6 +212,7 @@ Electron.app.whenReady().then(async() => {
         k8smanager.noModalDialogs = noModalDialogs = TransientSettings.value.noModalDialogs;
       }
     } catch (err) {
+      noModalDialogs = TransientSettings.value.noModalDialogs;
       if (err instanceof LockedFieldError || err instanceof DeploymentProfileError) {
         // This will end up calling `showErrorDialog(<title>, <message>, fatal=true)`
         // and the `fatal` part means we're expecting the app to shutdown.

--- a/bats/README.md
+++ b/bats/README.md
@@ -68,6 +68,18 @@ cd bats
 RD_LOCATION=dist ./bats-core/bin/bats ...
 ```
 
+### RD_NO_MODAL_DIALOGS
+
+By default, bats tests are run with the `--no-modal-dialogs` option so fatal errors are written to `background.log`,
+rather than appearing in a blocking modal dialog box. If you *want* those dialog boxes, you can specify
+
+```
+cd bats
+RD_NO_MODAL_DIALOGS=false ./bats-core/bin/bats ...
+```
+
+The default value for this environment variable is `true`.
+
 ## Writing BATS Tests
 
 1. Add BATS test by creating files with `.bats` extension under `./bats/tests/FOLDER_NAME`

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -28,6 +28,13 @@ capturing_logs() {
 }
 
 ########################################################################
+: "${RD_NO_MODAL_DIALOGS:=true}"
+
+suppressing_modal_dialogs() {
+    is_true "$RD_NO_MODAL_DIALOGS"
+}
+
+########################################################################
 : "${RD_TAKE_SCREENSHOTS:=false}"
 
 taking_screenshots() {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -120,11 +120,18 @@ EOF
         for arg in "${args[@]}"; do
             api_args+=("$(apify_arg "$arg")")
         done
+        if suppressing_modal_dialogs; then
+            # Don't apify this option
+            api_args+=(--no-modal-dialogs)
+        fi
 
         npm run dev -- "${api_args[@]}" "$@" &
     else
         # Detach `rdctl start` because on Windows the process may not exit until
         # Rancher Desktop itself quits.
+        if suppressing_modal_dialogs; then
+            args+=(--no-modal-dialogs)
+        fi
         RD_TEST=bats rdctl start "${args[@]}" "$@" &
     fi
 }

--- a/scripts/generateCliCode.ts
+++ b/scripts/generateCliCode.ts
@@ -241,7 +241,7 @@ class Generator {
     const usageParts = [usageNote];
 
     if (rawEnums) {
-      usageParts.push(`(Allowed values: [${ rawEnums.join(', ' ) }])`);
+      usageParts.push(`(allowed values: [${ rawEnums.join(', ' ) }])`);
     }
 
     return usageParts.join(' ').trim();

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -55,9 +55,9 @@ is subject to change without any advance notice.
 
 func init() {
 	rootCmd.AddCommand(apiCmd)
-	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "Method to use")
-	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "", "File containing JSON payload to upload (- for standard input)")
-	apiCmd.Flags().StringVarP(&apiSettings.Body, "body", "b", "", "JSON payload to upload")
+	apiCmd.Flags().StringVarP(&apiSettings.Method, "method", "X", "", "method to use")
+	apiCmd.Flags().StringVarP(&apiSettings.InputFile, "input", "", "", "file containing JSON payload to upload (- for standard input)")
+	apiCmd.Flags().StringVarP(&apiSettings.Body, "body", "b", "", "string containing JSON payload to upload")
 }
 
 func doAPICommand(cmd *cobra.Command, args []string) error {

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -50,8 +50,8 @@ var noModalDialogs bool
 func init() {
 	rootCmd.AddCommand(startCmd)
 	options.UpdateCommonStartAndSetCommands(startCmd)
-	startCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "Path to main executable.")
-	startCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "Avoid displaying dialog boxes.")
+	startCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "path to main executable")
+	startCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "avoid displaying dialog boxes")
 }
 
 /**

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -45,11 +45,13 @@ If it's running, behaves the same as 'rdctl set ...'.
 }
 
 var applicationPath string
+var noModalDialogs bool
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	options.UpdateCommonStartAndSetCommands(startCmd)
 	startCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "Path to main executable.")
+	startCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "Avoid displaying dialog boxes.")
 }
 
 /**
@@ -87,6 +89,9 @@ func doStartCommand(cmd *cobra.Command) error {
 		if err != nil {
 			return fmt.Errorf("failed to locate main Rancher Desktop executable: %w\nplease retry with the --path option", err)
 		}
+	}
+	if noModalDialogs {
+		commandLineArgs = append(commandLineArgs, "--no-modal-dialogs")
 	}
 	return launchApp(applicationPath, commandLineArgs)
 }


### PR DESCRIPTION
Fixes: #4985

Now locked-field error messages can be written to `background.log` instead of a dialog box.