### PR TITLE
Deployment profile testing with BATS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,6 @@ jobs:
     - run: npm run build
     - run: npm run lint:nofix
     - name: Install shfmt
-      run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.6.0
+      run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
     - run: make -C bats lint
     - run: npm test

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -9,9 +9,8 @@ containers:
 # https://www.shellcheck.net/wiki/SC1091 -- Not following: xxx was not specified as input (see shellcheck -x)
 # https://www.shellcheck.net/wiki/SC2034 -- xxx appears unused. Verify use (or export if used externally)
 # https://www.shellcheck.net/wiki/SC2154 -- xxx is referenced but not assigned
-# https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to avoid masking return values
 
-SC_EXCLUDES ?= SC1091,SC2034,SC2154,SC2155
+SC_EXCLUDES ?= SC1091,SC2034,SC2154
 
 .PHONY: lint
 lint:

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -1,6 +1,4 @@
 load '../helpers/load'
-assert=assert
-refute=refute
 
 @test 'factory reset' {
     factory_reset
@@ -154,20 +152,6 @@ rdctl_factory_reset() {
     else
         assert_exists "$PATH_CACHE"
     fi
-}
-
-refute_failure() {
-    assert_success
-}
-
-refute_not_exists() {
-    assert_exists "$@"
-}
-
-before() {
-    assert=refute
-    refute=assert
-    "$@"
 }
 
 check_directories() {

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -12,7 +12,7 @@ local_setup() {
 }
 
 write_allow_list() { # list
-    local list=${1-}
+    local list=${1:-}
     local allowed=true
 
     if [ -z "$list" ]; then

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -97,7 +97,8 @@ encoded_id() { # variant
 }
 
 @test 'compose - with a long name' {
-    local name="$(id vm-compose)-with-an-unusually-long-name-yes-it-is-very-long"
+    local name
+    name="$(id vm-compose)-with-an-unusually-long-name-yes-it-is-very-long"
 
     ctrctl tag "$(id vm-compose)" "$name"
     rdctl extension install "$name"

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -17,8 +17,9 @@ assert_file_contents_equal() { # $have $want
     assert_file_exist "$have"
     assert_file_exist "$want"
 
-    local have_hash="$(md5sum "$have" | cut -d ' ' -f 1)"
-    local want_hash="$(md5sum "$want" | cut -d ' ' -f 1)"
+    local have_hash want_hash
+    have_hash="$(md5sum "$have" | cut -d ' ' -f 1)"
+    want_hash="$(md5sum "$want" | cut -d ' ' -f 1)"
     if [ "$have_hash" != "$want_hash" ]; then
         printf "expected : %s (%s)\nactual   : %s (%s)" \
             "$want" "$want_hash" "$have" "$have_hash" |

--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -14,12 +14,6 @@ else
     CONTAINER_ENGINE_SERVICE=docker
 fi
 
-if is_unix; then
-    RC_SERVICE=rc-service
-elif is_windows; then
-    RC_SERVICE=wsl-service
-fi
-
 if is_macos; then
     CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-osxkeychain"
 elif is_linux; then
@@ -85,7 +79,4 @@ rdshell() {
 }
 rdsudo() {
     rdshell sudo "$@"
-}
-rc_service() {
-    rdsudo "$RC_SERVICE" "$@"
 }

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -111,7 +111,7 @@ if using_networking_tunnel && ! is_windows; then
 fi
 
 ########################################################################
-if ! is_unix && [ -n "${RD_MOUNT_TYPE-}" ]; then
+if ! is_unix && [ -n "${RD_MOUNT_TYPE:-}" ]; then
     fatal "RD_MOUNT_TYPE only works on Linux and macOS"
 fi
 

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -56,11 +56,26 @@ using_ghcr_images() {
 }
 
 ########################################################################
+: "${RD_DELETE_PROFILES:=true}"
+
+deleting_profiles() {
+    is_true "$RD_DELETE_PROFILES"
+}
+
+########################################################################
 : "${RD_USE_IMAGE_ALLOW_LIST:=false}"
 
 using_image_allow_list() {
     is_true "$RD_USE_IMAGE_ALLOW_LIST"
 }
+
+########################################################################
+# RD_USE_PROFILE is for internal use. It uses a profile instead of
+# settings.json to set initial values for WSL integrations and allowed
+# images list because when settings.json exists the default profile is
+# ignored.
+
+: "${RD_USE_PROFILE:=false}"
 
 ########################################################################
 : "${RD_USE_VZ_EMULATION:=false}"
@@ -125,6 +140,10 @@ validate_enum RD_9P_PROTOCOL_VERSION 9p2000 9p2000.u 9p2000.L
 : "${RD_9P_SECURITY_MODEL:=none}"
 
 validate_enum RD_9P_SECURITY_MODEL passthrough mapped-xattr mapped-file none
+
+########################################################################
+# Use RD_PROTECTED_DOT in profile settings for WSL distro names
+: "${RD_PROTECTED_DOT:=·}"
 
 ########################################################################
 # RD_LOCATION specifies the location where Rancher Desktop is installed

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -62,7 +62,8 @@ export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
 # If called from foo() this function will call local_foo() if it exist.
 call_local_function() {
-    local func="local_$(calling_function)"
+    local func
+    func="local_$(calling_function)"
     if [ "$(type -t "$func")" = "function" ]; then
         eval "$func"
     fi

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -47,6 +47,9 @@ source "$PATH_BATS_HELPERS/paths.bash"
 # and PATH_* variables from paths.bash
 source "$PATH_BATS_HELPERS/commands.bash"
 
+# profile.bash uses is_xxx() from os.bash
+source "$PATH_BATS_HELPERS/profile.bash"
+
 # vm.bash uses various PATH_* variables from paths.bash,
 # rdctl from commands.bash, and jq_output from utils.bash
 source "$PATH_BATS_HELPERS/vm.bash"
@@ -74,14 +77,14 @@ setup_file() {
 }
 
 teardown_file() {
-    call_local_function
-
     capture_logs
 
-    # On Linux & Windows if we don't shutdown Rancher Desktop bats test don't terminate
+    # On Linux & Windows if we don't shutdown Rancher Desktop bats tests don't terminate
     if is_linux || is_windows; then
         run rdctl shutdown
     fi
+
+    call_local_function
 }
 
 setup() {
@@ -95,9 +98,9 @@ setup() {
 }
 
 teardown() {
-    call_local_function
-
     if [ -z "$BATS_TEST_SKIPPED" ] && [ -z "$BATS_TEST_COMPLETED" ]; then
         take_screenshot
     fi
+
+    call_local_function
 }

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -23,7 +23,7 @@ Linux)
 esac
 
 is_linux() {
-    if [ -z "${1-}" ]; then
+    if [ -z "${1:-}" ]; then
         test "$OS" = linux
     else
         test "$OS" = linux -a "$ARCH" = "$1"
@@ -31,7 +31,7 @@ is_linux() {
 }
 
 is_macos() {
-    if [ -z "${1-}" ]; then
+    if [ -z "${1:-}" ]; then
         test "$OS" = darwin
     else
         test "$OS" = darwin -a "$ARCH" = "$1"
@@ -39,7 +39,7 @@ is_macos() {
 }
 
 is_windows() {
-    if [ -z "${1-}" ]; then
+    if [ -z "${1:-}" ]; then
         test "$OS" = windows
     else
         test "$OS" = windows -a "$ARCH" = "$1"

--- a/bats/tests/helpers/profile.bash
+++ b/bats/tests/helpers/profile.bash
@@ -1,0 +1,338 @@
+case $OS in
+darwin)
+    PROFILE_SYSTEM_DEFAULTS=/Library/Preferences/io.rancherdesktop.profile.defaults.plist
+    PROFILE_SYSTEM_LOCKED=/Library/Preferences/io.rancherdesktop.profile.locked.plist
+    PROFILE_USER_DEFAULTS="${HOME}${PROFILE_SYSTEM_DEFAULTS}"
+    PROFILE_USER_LOCKED="${HOME}${PROFILE_SYSTEM_LOCKED}"
+    ;;
+linux)
+    PROFILE_SYSTEM_DEFAULTS=/etc/rancher-desktop/defaults.json
+    PROFILE_SYSTEM_LOCKED=/etc/rancher-desktop/locked.json
+    PROFILE_USER_DEFAULTS="${HOME}/.config/rancher-desktop.defaults.json"
+    PROFILE_USER_LOCKED="${HOME}/.config/rancher-desktop.locked.json"
+    ;;
+windows)
+    PROFILE='Software\Policies\Rancher Desktop'
+    PROFILE_SYSTEM_DEFAULTS="HKLM\\${PROFILE}\\Defaults"
+    PROFILE_SYSTEM_LOCKED="HKLM\\${PROFILE}\\Locked"
+    PROFILE_USER_DEFAULTS="HKCU\\${PROFILE}\\Defaults"
+    PROFILE_USER_LOCKED="HKCU\\${PROFILE}\\Locked"
+
+    # The legacy profiles (for both system and user) are supported for backward
+    # compatibility with Rancher Desktop 1.8.x. For BATS purposes the legacy
+    # user profiles have the advantage of being writable without admin rights.
+    PROFILE='Software\Rancher Desktop\Profile'
+    PROFILE_SYSTEM_LEGACY_DEFAULTS="HKLM\\${PROFILE}\\Defaults"
+    PROFILE_SYSTEM_LEGACY_LOCKED="HKLM\\${PROFILE}\\Locked"
+    PROFILE_USER_LEGACY_DEFAULTS="HKCU\\${PROFILE}\\Defaults"
+    PROFILE_USER_LEGACY_LOCKED="HKCU\\${PROFILE}\\Locked"
+    ;;
+esac
+
+PROFILE_SYSTEM=system
+PROFILE_SYSTEM_LEGACY=system-legacy
+PROFILE_USER=user
+PROFILE_USER_LEGACY=user-legacy
+
+PROFILE_DEFAULTS=defaults
+PROFILE_LOCKED=locked
+
+# Default location is a writable user location
+if is_windows; then
+    PROFILE_LOCATION=$PROFILE_USER_LEGACY
+else
+    PROFILE_LOCATION=$PROFILE_USER
+fi
+PROFILE_TYPE=$PROFILE_DEFAULTS
+
+# profile_location is a registry key on Windows, or a filename on macOS and Linux.
+profile_location() {
+    local profile=$(to_upper "profile_${PROFILE_LOCATION}_${PROFILE_TYPE}" | tr - _)
+    echo "${!profile}"
+}
+
+# Execute command for each profile
+foreach_profile() {
+    local locations=("$PROFILE_SYSTEM" "$PROFILE_USER")
+    if is_windows; then
+        locations+=("$PROFILE_SYSTEM_LEGACY" "$PROFILE_USER_LEGACY")
+    fi
+
+    local PROFILE_LOCATION PROFILE_TYPE
+    for PROFILE_LOCATION in "${locations[@]}"; do
+        for PROFILE_TYPE in "$PROFILE_DEFAULTS" "$PROFILE_LOCKED"; do
+            "$@"
+        done
+    done
+}
+
+# Check if profile exists
+profile_exists() {
+    case $OS in
+    darwin | linux)
+        [[ -f $(profile_location) ]]
+        ;;
+    windows)
+        profile_reg query &>/dev/null
+        ;;
+    esac
+}
+
+# Create empty profile
+create_profile() {
+    case $OS in
+    darwin)
+        profile_plutil -create xml1
+        ;;
+    linux)
+        local filename=$(profile_location)
+        profile_sudo mkdir -p "$(dirname "$filename")"
+        echo "{}" | profile_cat "$filename"
+        ;;
+    windows)
+        # Make sure any old profile data at this location is removed
+        run profile_reg delete "."
+        ;;
+    esac
+}
+
+# Completely remove the profile. Ignores error if profile doesn't exist
+delete_profile() {
+    if deleting_profiles; then
+        case $OS in
+        darwin | linux)
+            run profile_sudo rm -f "$(profile_location)"
+            ;;
+        windows)
+            run profile_reg delete "."
+            ;;
+        esac
+    fi
+}
+
+# Export/copy profile to a directory
+export_profile() {
+    local dir=$1
+    if profile_exists; then
+        local export="${dir}/profile.${PROFILE_LOCATION}.${PROFILE_TYPE}"
+        case $OS in
+        darwin | linux)
+            local filename=$(profile_location)
+            # Keep .plist or .json file extension
+            cp "$filename" "${export}.${filename##*.}"
+            ;;
+        windows)
+            profile_reg export "${export}.reg" /y
+            ;;
+        esac
+    fi
+}
+
+# Add boolean setting; value must be "true" or "false"
+add_profile_bool() {
+    local setting=$1
+    local value=$2
+
+    case $OS in
+    darwin)
+        profile_plutil -replace "$setting" -bool "$value"
+        ;;
+    linux)
+        profile_jq ".${setting} = ${value}"
+        ;;
+    windows)
+        if [[ $value == true ]]; then
+            profile_reg add "$setting" /t REG_DWORD /d 1
+        else
+            profile_reg add "$setting" /t REG_DWORD /d 0
+        fi
+        ;;
+    esac
+}
+
+add_profile_int() {
+    local setting=$1
+    local value=$2
+
+    case $OS in
+    darwin)
+        profile_plutil -replace "$setting" -integer "$value"
+        ;;
+    linux)
+        profile_jq ".${setting} = ${value}"
+        ;;
+    windows)
+        profile_reg add "$setting" /t REG_DWORD /d "$value"
+        ;;
+    esac
+}
+
+add_profile_string() {
+    local setting=$1
+    local value=$2
+
+    case $OS in
+    darwin)
+        profile_plutil -replace "$setting" -string "$value"
+        ;;
+    linux)
+        profile_jq ".${setting} = $(json_string "$value")"
+        ;;
+    windows)
+        profile_reg add "$setting" /t REG_SZ /d "$value"
+        ;;
+    esac
+}
+
+add_profile_list() {
+    local setting=$1
+    shift
+
+    local elem
+    case $OS in
+    darwin)
+        profile_plutil -replace "$setting" -array
+        for elem in "$@"; do
+            profile_plutil -insert "$setting" -string "$elem" -append
+        done
+        ;;
+    linux)
+        profile_jq ".${setting} = []"
+        for elem in "$@"; do
+            profile_jq ".${setting} += [$(json_string "$elem")]"
+        done
+        ;;
+    windows)
+        # TODO: what happens when the values contain whitespace or quote characters?
+        profile_reg add "$setting" /t REG_MULTI_SZ /d "$(join_map '\0' echo "$@")"
+        ;;
+    esac
+}
+
+# Remove a key or named value from the profile.
+# Use a trailing dot to specify that the setting points to a key, e.g. "foo.bar.".
+# It only makes a difference on Windows but will work on all platforms.
+remove_profile_entry() {
+    local setting=$1
+
+    case $OS in
+    darwin)
+        run profile_plutil -remove "${setting%.}"
+        ;;
+    linux)
+        run profile_jq "del(.${setting%.})"
+        ;;
+    windows)
+        run profile_reg delete "$setting"
+        ;;
+    esac
+}
+
+################################################################################
+# functions defined below this line are implementation detail and should not
+# be called directly from any tests.
+################################################################################
+
+# Returns number of setting segments (separated by dots), e.g. foo.bar.baz returns 3
+count_setting_segments() {
+    echo "${1//./$'\n'}" | wc -l
+}
+
+# Usage: profile_jq $expr
+#
+# Applies $expr against the profile and updates it in-places.
+profile_jq() {
+    local expr=$1
+    local filename=$(profile_location)
+    # Need to use a temp file to avoid truncating the file before it has been read.
+    jq "$expr" "$filename" | profile_cat "${filename}.tmp"
+    profile_sudo mv "${filename}.tmp" "$filename"
+}
+
+# Usage: profile_plutil $action $options
+#
+# For -insert|-replace|-remove actions it will make sure all higher level
+# dictionaries are created first because plutil doesn't do it by itself.
+profile_plutil() {
+    local action=$1
+
+    # Make sure all the dictionaries for the setting path exist
+    if [[ $action =~ ^-insert|-replace|-remove$ ]]; then
+        local setting=$2
+        local count=$(count_setting_segments "$setting")
+        if ((count > 1)); then
+            local index
+            for index in $(seq $((count - 1))); do
+                local keypath=$(echo "$setting" | cut -d . -f 1-"$index")
+                # Ignore error if dictionary already exists
+                run profile_sudo plutil -insert "$keypath" -dictionary "$(profile_location)"
+            done
+        fi
+    fi
+
+    profile_sudo plutil "$@" "$(profile_location)"
+}
+
+# Usage: profile_reg $action $options
+#    or: profile_reg add|delete $setting $options
+#
+# Determines the $reg_key from both the profile_location() and the $setting.
+# Setting `foo.bar.baz` means `foo\bar` is the reg_subkey, and `baz` is the value name.
+#
+# Special case `foo.bar.` is used only for "delete" action and specifies `foo\bar`
+# as the subkey to be deleted (including all values under the key).
+profile_reg() {
+    local action=$1
+    shift
+
+    local reg_key=$(profile_location)
+    if [[ $action =~ ^add|delete$ ]]; then
+        local setting=$1
+        shift
+
+        local count=$(count_setting_segments "$setting")
+        if ((count > 1)); then
+            local reg_subkey=$(echo "$setting" | cut -d . -f 1-"$((count - 1))")
+            # reg_key uses backslashes instead of dot separators
+            reg_key="${reg_key}\\${reg_subkey//./\\}"
+        fi
+
+        local reg_value_name=$(echo "$setting" | cut -d . -f "$count")
+        # reg_value_name may be empty when deleting a registry key instead of a named value
+        if [[ -n $reg_value_name ]]; then
+            # turn protected dots back into regular dots again
+            set - /v "${reg_value_name//$RD_PROTECTED_DOT/.}" "$@"
+        fi
+
+        # Delete entries (and overwrite existing ones) without prompt
+        set - "$@" /f
+    fi
+
+    reg.exe "$action" "$reg_key" "$@"
+}
+
+profile_sudo() {
+    # TODO How can we make this work on Windows?
+    if [[ $PROFILE_LOCATION == system ]]; then
+        sudo -n "$@"
+    else
+        "$@"
+    fi
+}
+
+profile_cat() {
+    profile_sudo tee "$1" >/dev/null
+}
+
+ensure_profile_is_deleted() {
+    delete_profile
+    if profile_exists; then
+        fatal "Cannot delete $(profile_location)"
+    fi
+}
+
+# Only run this once per test file. It cannot be part of setup_file() because
+# we want to be able to call fatal() and skip the rest of the tests.
+if [[ -z ${BATS_SUITE_TEST_NUMBER-} ]] && deleting_profiles; then
+    foreach_profile ensure_profile_is_deleted
+fi

--- a/bats/tests/helpers/profile.bash
+++ b/bats/tests/helpers/profile.bash
@@ -343,6 +343,6 @@ ensure_profile_is_deleted() {
 
 # Only run this once per test file. It cannot be part of setup_file() because
 # we want to be able to call fatal() and skip the rest of the tests.
-if [[ -z ${BATS_SUITE_TEST_NUMBER-} ]] && deleting_profiles; then
+if [[ -z ${BATS_SUITE_TEST_NUMBER:-} ]] && deleting_profiles; then
     foreach_profile ensure_profile_is_deleted
 fi

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -89,7 +89,7 @@ join_map() {
     local elem result
     for elem in "$@"; do
         elem=$(eval "$map" '"$elem"')
-        if [[ -z $result ]]; then
+        if [[ -z ${result:-} ]]; then
             result=$elem
         else
             result="${result}${sep}${elem}"

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -8,7 +8,8 @@ to_upper() {
 
 is_true() {
     # case-insensitive check; false values: '', '0', 'no', and 'false'
-    local value=$(to_lower "$1")
+    local value
+    value=$(to_lower "$1")
     if [[ $value =~ ^(0|no|false)?$ ]]; then
         false
     else
@@ -176,7 +177,8 @@ update_allowed_patterns() {
     local enabled=$1
     shift
 
-    local patterns=$(join_map ", " image_without_tag_as_json_string "$@")
+    local patterns
+    patterns=$(join_map ", " image_without_tag_as_json_string "$@")
 
     # TODO TODO TODO
     # Once https://github.com/rancher-sandbox/rancher-desktop/issues/4939 has been
@@ -218,7 +220,8 @@ unique_filename() {
 
 capture_logs() {
     if capturing_logs && [ -d "$PATH_LOGS" ]; then
-        local logdir=$(unique_filename "${PATH_BATS_LOGS}/${RD_TEST_FILENAME}")
+        local logdir
+        logdir=$(unique_filename "${PATH_BATS_LOGS}/${RD_TEST_FILENAME}")
         mkdir -p "$logdir"
         cp -LR "$PATH_LOGS/" "$logdir"
         echo "${BATS_TEST_DESCRIPTION:-teardown}" >"$logdir/test_description"
@@ -231,7 +234,8 @@ capture_logs() {
 take_screenshot() {
     if taking_screenshots; then
         if is_macos; then
-            local file=$(unique_filename "${PATH_BATS_LOGS}/${BATS_SUITE_TEST_NUMBER}-${BATS_TEST_DESCRIPTION}" .png)
+            local file
+            file=$(unique_filename "${PATH_BATS_LOGS}/${BATS_SUITE_TEST_NUMBER}-${BATS_TEST_DESCRIPTION}" .png)
             mkdir -p "$PATH_BATS_LOGS"
             # The terminal app must have "Screen Recording" permission;
             # otherwise only the desktop background is captured.

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -203,7 +203,7 @@ EOF
 # will return /tmp/image.png, or /tmp/image_2.png, etc.
 unique_filename() {
     local basename=$1
-    local extension=${2-}
+    local extension=${2:-}
     local index=1
     local suffix=""
 

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -191,7 +191,7 @@ assert_service_status() {
     local service_name=$1
     local expect=$2
 
-    run rc_service "$service_name" status
+    run rdsudo rc-service "$service_name" status
     # Some services (e.g. k3s) report non-zero status when not running
     if [[ $expect == started ]]; then
         assert_success || return

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -10,7 +10,8 @@ wait_for_shell() {
 }
 
 pkill_by_path() {
-    local arg=$(readlink -f "$1")
+    local arg
+    arg=$(readlink -f "$1")
     if [[ -n $arg ]]; then
         pkill -f "$arg"
     fi
@@ -215,7 +216,8 @@ rdctl_api_settings() {
 }
 
 wait_for_container_engine() {
-    local CALLER=$(this_function)
+    local CALLER
+    CALLER=$(this_function)
 
     trace "waiting for api /settings to be callable"
     try --max 30 --delay 5 rdctl_api_settings

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -106,7 +106,7 @@ start_container_engine() {
     if using_ghcr_images; then
         registry="ghcr.io"
     fi
-    if is_true "${RD_USE_PROFILE-}"; then
+    if is_true "${RD_USE_PROFILE:-}"; then
         if is_windows; then
             # Translate any dots in the distro name into $RD_PROTECTED_DOT (e.g. "Ubuntu-22.04")
             # so that they are not treated as setting separator characters.

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -23,7 +23,8 @@ local_setup() {
 
 get_host() {
     if is_windows; then
-        local LB_IP=$(kubectl get svc traefik --namespace kube-system | awk 'NR==2{print $4}')
+        local LB_IP
+        LB_IP=$(kubectl get svc traefik --namespace kube-system | awk 'NR==2{print $4}')
         echo "$LB_IP.sslip.io"
     else
         echo "localhost"

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -2,7 +2,8 @@
 
 load '../helpers/load'
 # Ensure subshells don't inherit a path that includes ~/.rd/bin
-export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
+export PATH
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v /.rd/bin | tr '\n' ':')
 
 local_setup() {
     if is_windows; then

--- a/bats/tests/profile/sample.bats
+++ b/bats/tests/profile/sample.bats
@@ -1,0 +1,100 @@
+load '../helpers/load'
+
+local_setup() {
+    # profile settings should be the opposite of the default config
+    if using_docker; then
+        PROFILE_CONTAINER_ENGINE=containerd
+    else
+        PROFILE_CONTAINER_ENGINE=moby
+    fi
+    PROFILE_START_IN_BACKGROUND=true
+    RD_USE_PROFILE=true
+}
+
+local_teardown_file() {
+    foreach_profile delete_profile
+}
+
+rdctl_api_settings() {
+    run rdctl api /settings
+    echo "$output"
+    assert_success || return
+    refute_output undefined
+}
+
+start_app() {
+    # Store WSL integration and allowed images list in locked profile instead of settings.json
+    PROFILE_TYPE=$PROFILE_LOCKED
+    start_container_engine
+    try --max 20 --delay 5 rdctl_api_settings
+
+    RD_CONTAINER_ENGINE=$(jq_output .containerEngine.name)
+    wait_for_container_engine
+}
+
+verify_settings() {
+    PROFILE_TYPE=$PROFILE_LOCKED
+    run profile_exists
+    "${assert}_success"
+
+    PROFILE_TYPE=$PROFILE_DEFAULTS
+    run profile_exists
+    "${assert}_success"
+
+    run get_setting .containerEngine.name
+    "${assert}_output" "$PROFILE_CONTAINER_ENGINE"
+
+    run get_setting .application.startInBackground
+    "${assert}_output" "$PROFILE_START_IN_BACKGROUND"
+}
+
+@test 'initial factory reset' {
+    factory_reset
+}
+
+@test 'start up without profile' {
+    RD_USE_PROFILE=false
+    start_app
+}
+
+@test 'verify default settings' {
+    before verify_settings
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'create profile' {
+    PROFILE_TYPE=$PROFILE_LOCKED
+    create_profile
+    add_profile_string containerEngine.name "$PROFILE_CONTAINER_ENGINE"
+
+    PROFILE_TYPE=$PROFILE_DEFAULTS
+    create_profile
+    add_profile_bool application.startInBackground "$PROFILE_START_IN_BACKGROUND"
+}
+
+@test 'start app with new profile' {
+    RD_CONTAINER_ENGINE=""
+    start_app
+}
+
+@test 'verify profile settings' {
+    verify_settings
+}
+
+@test 'change defaults profile setting' {
+    rdctl set --application.start-in-background=false
+}
+
+@test 'restart app' {
+    rdctl shutdown
+    RD_CONTAINER_ENGINE=""
+    start_app
+}
+
+@test 'verify that defaults settings are not applied again' {
+    PROFILE_START_IN_BACKGROUND=false
+    verify_settings
+}

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -103,7 +103,8 @@ skip_for_insecure_registry() {
 }
 
 verify_default_credStore() {
-    local CREDHELPER_NAME="$(basename "$CRED_HELPER" .exe | sed s/^docker-credential-//)"
+    local CREDHELPER_NAME
+    CREDHELPER_NAME="$(basename "$CRED_HELPER" .exe | sed s/^docker-credential-//)"
     run jq -r .credsStore "$DOCKER_CONFIG_FILE"
     assert_success
     assert_output "$CREDHELPER_NAME"

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -157,8 +157,8 @@ verify_default_credStore() {
 @test 'restart container engine to refresh certs' {
     skip_for_insecure_registry
 
-    rc_service "$CONTAINER_ENGINE_SERVICE" restart
-    rc_service --ifstarted openresty restart
+    rdsudo rc-service "$CONTAINER_ENGINE_SERVICE" restart
+    rdsudo rc-service --ifstarted openresty restart
     wait_for_container_engine
     # when Moby is stopped, the containers are stopped as well
     if using_docker; then


### PR DESCRIPTION
This PR contains both the BATS framework for testing deployment profiles, and a sample test to demonstrate how to use it.

It works for macOS using user profiles. Testing system profiles will require password-less sudo.

The code has not been tested on Windows yet. It is only expected to work for the user-legacy location on Windows; every other location requires admin access and is out of scope for this PR.