### PR TITLE
Do not disable VZ if macOS version is equal

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -56,7 +56,7 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       return this.preferences.experimental.virtualMachine.type === VMType.VZ;
     },
     vzDisabled(): boolean {
-      return semver.lte(this.macOsVersion.version, '13.0.0') || (this.isArm && semver.lte(this.macOsVersion.version, '13.3.0'));
+      return semver.lt(this.macOsVersion.version, '13.0.0') || (this.isArm && semver.lt(this.macOsVersion.version, '13.3.0'));
     },
     rosettaDisabled(): boolean {
       return !this.isArm;


### PR DESCRIPTION
Disable the VZ option only if the macOS version is lower than required (13.0.0 or 13.3.0 currently). Do not disable the option if the version is equal.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4983