### PR TITLE
Wrap github pull request creation API call in try-catch

### DIFF
--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -84,13 +84,18 @@ async function createDependencyBumpPR(name: string, currentVersion: string | Alp
   const branchName = getBranchName(name, currentVersion, latestVersion);
 
   console.log(`Creating PR "${ title }".`);
-  await getOctokit().rest.pulls.create({
-    owner: GITHUB_OWNER,
-    repo:  GITHUB_REPO,
-    title,
-    base:  MAIN_BRANCH,
-    head:  branchName,
-  });
+  try {
+    await getOctokit().rest.pulls.create({
+      owner: GITHUB_OWNER,
+      repo:  GITHUB_REPO,
+      title,
+      base:  MAIN_BRANCH,
+      head:  branchName,
+    });
+  } catch (err: any) {
+    console.log(JSON.stringify(err.response?.data));
+    throw err;
+  }
 }
 
 type PRSearchFn = ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>;


### PR DESCRIPTION
This is an attempt to debug the ongoing issues with rddepman. A part of the error is not printed out. This part of the error could give us information that allows us to solve the problem. So, this catches the error, prints that part of the error and re-throws the error.