### PR TITLE
Display error message when docker config is invalid

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -270,7 +270,12 @@ Electron.app.whenReady().then(async() => {
       Electron.app.dock.hide();
     }
 
-    await dockerDirManager.ensureCredHelperConfigured();
+    try {
+      await dockerDirManager.ensureCredHelperConfigured();
+    } catch (ex) {
+      console.error('Error ensuring credential helper configured:', ex);
+      handleFailure(ex);
+    }
 
     if (os.platform() === 'linux' || os.platform() === 'darwin') {
       try {

--- a/background.ts
+++ b/background.ts
@@ -272,9 +272,15 @@ Electron.app.whenReady().then(async() => {
 
     try {
       await dockerDirManager.ensureCredHelperConfigured();
-    } catch (ex) {
-      console.error('Error ensuring credential helper configured:', ex);
-      handleFailure(ex);
+    } catch (ex: any) {
+      const errorTitle = 'Error configuring credential helper';
+
+      console.error(`${ errorTitle }:`, ex);
+
+      const title = ex.title ?? errorTitle;
+      const message = ex.message ?? ex.toString();
+
+      showErrorDialog(title, message, true);
     }
 
     if (os.platform() === 'linux' || os.platform() === 'darwin') {

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -75,7 +75,7 @@ export default class DockerDirManager {
       return JSON.parse(rawConfig);
     } catch (error: any) {
       if (error.code !== 'ENOENT') {
-        throw error;
+        throw new Error(`Failed to parse Docker config file '${ this.dockerConfigPath }'. Error: ${ error.message }`);
       }
       console.log('No docker config file found');
 


### PR DESCRIPTION
This change allows Rancher Desktop to start and displays a "Kubernetes Error" dialog when there is an issue with reading the docker config. The error message should read 

> Error: Failed to parse Docker config file '/home/phillip/.docker/config.json'. Error: Bad control character in string literal in JSON at position 19

closes #5005