### PR TITLE
Stop clearing locked fields when the prefs are accessed by calling `settings.load()`

### DIFF
--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -166,6 +166,7 @@ describe('settings', () => {
 
     beforeEach(() => {
       jest.spyOn(fs, 'writeFileSync').mockImplementation(() => { });
+      settings.clearSettings();
     });
     afterEach(() => {
       mock.mockRestore();

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -225,12 +225,23 @@ export async function clear() {
 }
 
 /**
+ * Used for unit testing only.
+ * Could be used in core code if we ever want to reload changed deployment profiles, but that isn't needed now.
+ */
+export function clearSettings() {
+  settings = undefined;
+}
+
+/**
  * Load the settings file or create it if not present.  If the settings have
  * already been loaded, return it without re-loading from disk.
  */
 export function load(deploymentProfiles: DeploymentProfileType): Settings {
+  if (settings) {
+    return settings;
+  }
   try {
-    settings ??= loadFromDisk();
+    settings = loadFromDisk();
   } catch (err: any) {
     settings = clone(defaultSettings);
     if (err.code === 'ENOENT') {


### PR DESCRIPTION
Fixes #5007 

This change actually implements the comment before the function.