### PR TITLE
Shorten Kubernetes version label

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -166,6 +166,10 @@ suffix:
 app:
   name: Rancher Desktop
   update: "There's one last step to finish updating Rancher Desktop"
+firstRun:
+  kubernetesVersion:
+    legend: Kubernetes Version
+    cachedOnly: (cached versions only)
 marketplace:
   title: Extensions
   noResults: No extension found for the search criteria

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -9,8 +9,9 @@
       :is-locked="kubernetesLocked"
       @input="handleDisableKubernetesCheckbox"
     />
-    <label>
-      Please select a Kubernetes version{{ offlineCheck() }}:
+    <rd-fieldset
+      :legend-text="t('firstRun.kubernetesVersion.legend') + offlineCheck()"
+    >
       <rd-select
         v-model="settings.kubernetes.version"
         :is-locked="kubernetesVersionLocked"
@@ -42,7 +43,7 @@
           </option>
         </optgroup>
       </rd-select>
-    </label>
+    </rd-fieldset>
     <rd-fieldset
       :legend-text="t('containerEngine.label')"
       :is-locked="engineSelectorLocked"
@@ -230,7 +231,7 @@ export default Vue.extend({
       this.$store.dispatch('applicationSettings/setPathManagementStrategy', val);
     },
     offlineCheck() {
-      return this.cachedVersionsOnly ? ' (cached versions only)' : '';
+      return this.cachedVersionsOnly ? ` ${ this.t('firstRun.kubernetesVersion.cachedOnly') }` : '';
     },
   },
 });


### PR DESCRIPTION
Shorten the Kubernetes version label from "Please select a Kubernetes version" to "Kubernetes Version" to fit better into the form.

| Before | After |
| --------- |--------- |
| ![Screenshot_2023-06-23_15-29-04](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/3c9705a6-8da2-46ec-ad08-bb938e3aaa6f) | ![Screenshot_2023-06-23_15-52-26](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/f64e7fd9-8bd6-4c36-abb4-33fc18167cd1) |
| ![Screenshot_2023-06-23_16-06-05](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/2639805c-134c-4ac4-9c39-ac5e9004aeef) | ![Screenshot_2023-06-23_15-55-04](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/e5e2359d-e49e-446c-9318-d4b3f22ef46e) |

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4847