### PR TITLE
Refactor `settings.load` into more sensible functions

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -200,7 +200,15 @@ Electron.app.whenReady().then(async() => {
 
       throw ex;
     }
-    cfg = settings.load(deploymentProfiles);
+    try {
+      cfg = settings.load(deploymentProfiles);
+      settings.updateLockedFields(deploymentProfiles.locked);
+    } catch (err: any) {
+      const titlePart = err.name || 'Failed to load settings';
+      const message = err.message || err.toString();
+
+      showErrorDialog(titlePart, message, true);
+    }
     try {
       // The profile loader did rudimentary type-validation on profiles, but the validator checks for things
       // like invalid strings for application.pathManagementStrategy.

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -296,7 +296,8 @@ describe('settings', () => {
         test('all fields are unlocked', async() => {
           const profiles = await readDeploymentProfiles();
 
-          settings.load(profiles);
+          settings.createSettings(profiles);
+          settings.updateLockedFields(profiles.locked);
           verifyAllFieldsAreUnlocked(settings.getLockedSettings());
         });
       });
@@ -325,7 +326,8 @@ describe('settings', () => {
                 .mockImplementation(createMocker(system, user));
               const profiles = await readDeploymentProfiles();
 
-              settings.load(profiles);
+              settings.createSettings(profiles);
+              settings.updateLockedFields(profiles.locked);
               if (shouldLock) {
                 verifyAllFieldsAreLocked(settings.getLockedSettings());
               } else {

--- a/pkg/rancher-desktop/store/applicationSettings.ts
+++ b/pkg/rancher-desktop/store/applicationSettings.ts
@@ -1,7 +1,7 @@
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
-import { load as loadSettings } from '@pkg/config/settings';
+import { getSettings } from '@pkg/config/settings';
 import type { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -16,7 +16,7 @@ type State = {
 export const state: () => State = () => {
   // While we load the settings from disk here, we only otherwise interact with
   // the settings only via ipcRenderer.
-  const cfg = loadSettings({ defaults: {}, locked: {} });
+  const cfg = getSettings();
 
   return {
     pathManagementStrategy: cfg.application.pathManagementStrategy,

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -6,7 +6,7 @@ import Electron, {
 } from 'electron';
 
 import * as K8s from '@pkg/backend/k8s';
-import { load as loadSettings } from '@pkg/config/settings';
+import { getSettings } from '@pkg/config/settings';
 import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import { isDevEnv } from '@pkg/utils/environment';
 import Logging from '@pkg/utils/logging';
@@ -178,7 +178,7 @@ export function openMain() {
   }
 
   window.on('closed', () => {
-    const cfg = loadSettings({ defaults: {}, locked: {} });
+    const cfg = getSettings();
 
     if (cfg.application.window.quitOnClose) {
       BrowserWindow.getAllWindows().forEach((window) => {


### PR DESCRIPTION
Fixes #5022

This breaks the `settings.load` function into three main parts - one for loading an existing settings.json file, one for creating a new one, and common code used by both after the settings object has been created or loaded.

There's also a `getSettings` function, because overloading `settings.load` to create, load from disk, and retrieve from memory was too complex and error-prone.

Also the default memory value is calculated on the default settings object, because it's extremely unlikely to change while the program is running (ignore what it means for RD to run on a multi-node system and get handed over from one machine to another).