### PR TITLE
Bump helm from 3.12.0 to 3.12.1 

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -4,7 +4,7 @@ alpineLimaISO:
   alpineVersion: 3.18.0
 WSLDistro: "0.41"
 kuberlr: 0.4.2
-helm: 3.12.0
+helm: 3.12.1
 dockerCLI: 24.0.2
 dockerBuildx: 0.10.5
 dockerCompose: 2.18.1


### PR DESCRIPTION
It looks like #4970 was created incorrectly (oops) and we _didn't_ merge this into `main`.