### PR TITLE
Handle case where set/start proposed changed field kubernetes.version is locked.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -935,7 +935,7 @@ function validateEarlySettings(cfg: settings.Settings, newSettings: RecursivePar
   // We'd have to add more code to report that.
   // It isn't worth adding that code yet. It might never be needed.
   const newSettingsForValidation = _.omit(newSettings, 'kubernetes.version');
-  const errors = (new SettingsValidator().validateSettings(cfg, newSettingsForValidation, lockedFields))[1];
+  const [, errors] = new SettingsValidator().validateSettings(cfg, newSettingsForValidation, lockedFields);
 
   if (errors.length > 0) {
     throw new LockedFieldError(`Error in deployment profiles:\n${ errors.join('\n') }`);
@@ -966,9 +966,11 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
       // We don't want to verify the proposed version makes sense (if it doesn't, we'll assign the default version later).
       // Here we just want to make sure that if we're changing the version to a different value from the current one,
       // the field isn't locked.
+      //
+
       let currentK8sVersions = (await k8smanager.kubeBackend.availableVersions).map(entry => entry.version.version);
 
-      if (currentK8sVersions.length === 0 || (currentK8sVersions.length === 1 && currentK8sVersions[0] === '0.0.0')) {
+      if (currentK8sVersions.length === 0) {
         clearVersionsAfterTesting = true;
         currentK8sVersions = [newSettings.kubernetes.version];
         if (existingSettings.kubernetes.version) {

--- a/background.ts
+++ b/background.ts
@@ -963,11 +963,9 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
 
     if (newSettings.kubernetes?.version && this.settingsValidator.k8sVersions.length === 0) {
       // If we're starting up (by running `rdctl start...`) we probably haven't loaded all the k8s versions yet.
-      // We don't want to verify the proposed version makes sense (if it doesn't, we'll assign the default version later).
+      // We don't want to verify if the proposed version makes sense (if it doesn't, we'll assign the default version later).
       // Here we just want to make sure that if we're changing the version to a different value from the current one,
       // the field isn't locked.
-      //
-
       let currentK8sVersions = (await k8smanager.kubeBackend.availableVersions).map(entry => entry.version.version);
 
       if (currentK8sVersions.length === 0) {

--- a/background.ts
+++ b/background.ts
@@ -935,7 +935,7 @@ function validateEarlySettings(cfg: settings.Settings, newSettings: RecursivePar
   // We'd have to add more code to report that.
   // It isn't worth adding that code yet. It might never be needed.
   const newSettingsForValidation = _.omit(newSettings, 'kubernetes.version');
-  const [_needToUpdate, errors] = new SettingsValidator().validateSettings(cfg, newSettingsForValidation, lockedFields);
+  const errors = (new SettingsValidator().validateSettings(cfg, newSettingsForValidation, lockedFields))[1];
 
   if (errors.length > 0) {
     throw new LockedFieldError(`Error in deployment profiles:\n${ errors.join('\n') }`);
@@ -952,7 +952,6 @@ function validateEarlySettings(cfg: settings.Settings, newSettings: RecursivePar
  * The `requestShutdown` method is a special case that never returns.
  */
 class BackgroundCommandWorker implements CommandWorkerInterface {
-  protected k8sVersions: string[] = [];
   protected settingsValidator = new SettingsValidator();
 
   /**
@@ -960,12 +959,32 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
    * initialization.
    */
   protected async validateSettings(existingSettings: settings.Settings, newSettings: RecursivePartial<settings.Settings>) {
-    if (this.k8sVersions.length === 0) {
-      this.k8sVersions = (await k8smanager.kubeBackend.availableVersions).map(entry => entry.version.version);
-      this.settingsValidator.k8sVersions = this.k8sVersions;
+    let clearVersionsAfterTesting = false;
+
+    if (newSettings.kubernetes?.version && this.settingsValidator.k8sVersions.length === 0) {
+      // If we're starting up (by running `rdctl start...`) we probably haven't loaded all the k8s versions yet.
+      // We don't want to verify the proposed version makes sense (if it doesn't, we'll assign the default version later).
+      // Here we just want to make sure that if we're changing the version to a different value from the current one,
+      // the field isn't locked.
+      let currentK8sVersions = (await k8smanager.kubeBackend.availableVersions).map(entry => entry.version.version);
+
+      if (currentK8sVersions.length === 0 || (currentK8sVersions.length === 1 && currentK8sVersions[0] === '0.0.0')) {
+        clearVersionsAfterTesting = true;
+        currentK8sVersions = [newSettings.kubernetes.version];
+        if (existingSettings.kubernetes.version) {
+          currentK8sVersions.push(existingSettings.kubernetes.version);
+        }
+      }
+      this.settingsValidator.k8sVersions = currentK8sVersions;
     }
 
-    return this.settingsValidator.validateSettings(existingSettings, newSettings, settings.getLockedSettings());
+    const result = this.settingsValidator.validateSettings(existingSettings, newSettings, settings.getLockedSettings());
+
+    if (clearVersionsAfterTesting) {
+      this.settingsValidator.k8sVersions = [];
+    }
+
+    return result;
   }
 
   getSettings() {

--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -70,6 +70,8 @@ test.describe('Locked fields', () => {
   }
 
   test.describe.configure({ mode: 'serial' });
+  const lockedK8sVersion = '1.26.3';
+  const proposedK8sVersion = '1.26.1';
 
   test.beforeAll(async() => {
     await tool('rdctl', 'factory-reset', '--verbose');
@@ -85,7 +87,7 @@ test.describe('Locked fields', () => {
     await saveUserProfile();
     await createUserProfile(
       { containerEngine: { allowedImages: { enabled: true } } },
-      { containerEngine: { allowedImages: { enabled: true, patterns: ['c', 'd', 'f'] } } },
+      { containerEngine: { allowedImages: { enabled: true, patterns: ['c', 'd', 'f'] } }, kubernetes: { version: lockedK8sVersion } },
     );
     electronApp = await startRancherDesktop(__filename);
     context = electronApp.context();
@@ -122,6 +124,16 @@ test.describe('Locked fields', () => {
       .resolves.toMatchObject({
         stdout: '',
         stderr: expect.stringContaining("field 'containerEngine.allowedImages.enabled' is locked"),
+      });
+    await expect(rdctl(['set', `--kubernetes.version=${ proposedK8sVersion }`]))
+      .resolves.toMatchObject({
+        stdout: '',
+        stderr: expect.stringContaining("field 'kubernetes.version' is locked"),
+      });
+    await expect(rdctl(['set', `--kubernetes.version=${ lockedK8sVersion }`]))
+      .resolves.toMatchObject({
+        stdout: expect.stringContaining('Status: no changes necessary.'),
+        stderr: '',
       });
   });
 });

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -178,7 +178,7 @@ export default class MockBackend extends events.EventEmitter implements VMExecut
 }
 
 class MockKubernetesBackend extends events.EventEmitter implements KubernetesBackend {
-  readonly availableVersions = Promise.resolve([{ version: new semver.SemVer('0.0.0'), channels: ['latest'] }]);
+  readonly availableVersions = Promise.resolve([]);
   version = '';
   desiredPort = 9443;
 

--- a/pkg/rancher-desktop/config/commandLineOptions.ts
+++ b/pkg/rancher-desktop/config/commandLineOptions.ts
@@ -116,13 +116,14 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
     newSettings = _.merge(newSettings, getObjectRepresentation(fqFieldName as RecursiveKeys<Settings>, finalValue));
   }
   const settingsValidator = new SettingsValidator();
+  const newKubernetesVersion = newSettings.kubernetes?.version;
 
-  if (_.has(newSettings, 'kubernetes.version')) {
+  if (newKubernetesVersion) {
     // RD hasn't loaded the supported k8s versions yet, so fake the list.
     // If the field is locked, we don't need to know what it's locked to,
     // just that the proposed version is different from the current version.
-    /// The current version doesn't have to be the locked version, but will be after processing ends.
-    const limitedK8sVersionList: Array<string> = [newSettings.kubernetes?.version ?? ''];
+    // The current version doesn't have to be the locked version, but will be after processing ends.
+    const limitedK8sVersionList: Array<string> = [newKubernetesVersion];
 
     if (cfg.kubernetes.version) {
       limitedK8sVersionList.push(cfg.kubernetes.version);


### PR DESCRIPTION
Fixes #5047 

At startup we don't know yet which versions of kubernetes are available. This just verifies we aren't trying to change a locked field via startup or `rdctl set`