### PR TITLE
try() is not a variant of run()

### DIFF
--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -38,8 +38,8 @@ while (<>) {
         undef $run;
         $problems++;
     }
-    # Matches any line starting with "run " or "try "
-    if (/^\s*(run|try)\s/) {
+    # Matches any line starting with "run "
+    if (/^\s*(run)\s/) {
         $run = $_;
     }
     # Reset $. line counter for next input file

--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -66,7 +66,6 @@ verify_no_nginx() {
 
 @test 'but fails to stand up a pod for forbidden image' {
     try --max 18 --delay 10 verify_no_nginx
-    assert_success
 }
 
 @test 'set patterns with the allowed list disabled' {

--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -17,7 +17,7 @@ load '../helpers/load'
 }
 
 @test 'verify rancher' {
-    try --max 9 --delay 10 curl --insecure --silent --show-error "https://localhost:8443/dashboard/auth/login"
+    run try --max 9 --delay 10 curl --insecure --silent --show-error "https://localhost:8443/dashboard/auth/login"
     assert_success
     assert_output --partial "Rancher Dashboard"
     run ctrctl logs rancher

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -43,7 +43,6 @@ switch_back_verify_post_switch_containers() {
     local name=$1
     switch_container_engine "${name}"
     try --max 12 --delay 5 verify_post_switch_containers
-    assert_success
 }
 
 @test 'switch back to moby and verify containers' {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -1,10 +1,8 @@
 wait_for_shell() {
     if is_unix; then
         try --max 24 --delay 5 rdctl shell test -f /var/run/lima-boot-done
-        assert_success
         # wait until sshfs mounts are done
         try --max 12 --delay 5 rdctl shell test -d "$HOME/.rd"
-        assert_success
     fi
     rdctl shell sync
 }

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -47,7 +47,7 @@ get_host() {
 }
 
 @test 'verify rancher' {
-    try --max 9 --delay 10 curl --insecure --silent --show-error "https://$(get_host)/dashboard/auth/login"
+    run try --max 9 --delay 10 curl --insecure --silent --show-error "https://$(get_host)/dashboard/auth/login"
     assert_success
     assert_output --partial "Rancher Dashboard"
     run kubectl get secret --namespace cattle-system bootstrap-secret -o json

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -62,13 +62,11 @@ assert_traefik_pods_are_up() {
 @test 'disable traefik' {
     # First check whether the traefik pods are up from the first launch
     try --max 30 --delay 10 assert_traefik_pods_are_up
-    assert_success
     # Disable traefik
     rdctl set --kubernetes.options.traefik=FALSE
     wait_for_apiserver
     # Check if the traefik pods go down
     try --max 30 --delay 10 assert_traefik_pods_are_down
-    assert_success
 }
 
 @test 'enable traefik' {
@@ -77,11 +75,10 @@ assert_traefik_pods_are_up() {
     wait_for_apiserver
     # Check if the traefik pods come up
     try --max 30 --delay 10 assert_traefik_pods_are_up
-    assert_success
-    try --max 30 --delay 10 curl --head "http://$(get_host):80"
+    run try --max 30 --delay 10 curl --head "http://$(get_host):80"
     assert_success
     assert_output --regexp 'HTTP/[0-9.]* 404'
-    try --max 30 --delay 10 curl --head --insecure "https://$(get_host):443"
+    run try --max 30 --delay 10 curl --head --insecure "https://$(get_host):443"
     assert_success
     assert_output --regexp 'HTTP/[0-9.]* 404'
 }

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -41,7 +41,6 @@ verify_nginx() {
 
 @test 'verify nginx before upgrade' {
     try verify_nginx
-    assert_success
 }
 
 verify_busybox() {
@@ -51,7 +50,6 @@ verify_busybox() {
 
 @test 'verify busybox before upgrade' {
     try verify_busybox
-    assert_success
 }
 
 verify_images() {
@@ -104,12 +102,10 @@ verify_nginx_after_change_k8s() {
 
 @test 'verify nginx after upgrade' {
     try verify_nginx_after_change_k8s
-    assert_success
 }
 
 @test 'verify busybox after upgrade' {
     try verify_busybox
-    assert_success
 }
 
 @test 'verify images after upgrade' {
@@ -127,10 +123,8 @@ verify_nginx_after_change_k8s() {
         # See https://github.com/containerd/nerdctl/issues/665#issuecomment-1372862742
         # BUG BUG BUG
         try nerdctl start nginx-no-restart
-        assert_success
     fi
     try verify_nginx
-    assert_success
 }
 
 @test 'downgrade kubernetes' {
@@ -146,7 +140,6 @@ verify_nginx_after_change_k8s() {
 @test 'verify nginx after downgrade' {
     # nginx should still be running because it is not managed by kubernetes
     try verify_nginx_after_change_k8s
-    assert_success
 }
 
 @test 'verify busybox is gone after downgrade' {

--- a/bats/tests/k8s/wordpress.bats
+++ b/bats/tests/k8s/wordpress.bats
@@ -42,7 +42,7 @@ local_setup() {
     assert_success
 
     # Load the homepage; that can take a while because all the pods are still restarting
-    try --max 9 --delay 10 curl --silent --show-error "http://localhost:$output"
+    run try --max 9 --delay 10 curl --silent --show-error "http://localhost:$output"
     assert_success
     assert_output --regexp "(Just another WordPress site|<title>User&#039;s Blog!</title>)"
 }

--- a/bats/tests/preferences/verify-paths.bats
+++ b/bats/tests/preferences/verify-paths.bats
@@ -59,7 +59,6 @@ no_bashrc_path_manager() {
 @test 'move to manual path-management' {
     rdctl set --application.path-management-strategy=manual
     try --max 5 --delay 2 no_bashrc_path_manager
-    assert_success
 }
 
 @test 'bash unmanaged' {

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -67,7 +67,6 @@ create_registry() {
 wait_for_registry() {
     # registry port is forwarded to host
     try --max 10 --delay 5 curl -k --silent --show-error "https://localhost:$REGISTRY_PORT/v2/_catalog"
-    assert_success
 }
 
 using_insecure_registry() {


### PR DESCRIPTION
It will fail with a non-zero exit code when not successful, so there is no need to `assert_success` after calling `try` without `run`. And while it does capture the command output in $output, that is an implementation detail that tests should not rely on; they have to call `run try` to set $output and $status.

Exiting with non-zero status was part of 431fa12 and outputting the command output back to stdout was implemented in d678dba.

There are 2 `assert_success` lines in `bats/tests/helpers/vm.bash` that are not removed here to avoid a merge conflict with #5090 which does already remove them.