### PR TITLE
RDX: Expose API to main window

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -25,6 +25,7 @@ import BackendProgress from '@pkg/components/BackendProgress.vue';
 import Header from '@pkg/components/Header.vue';
 import Nav from '@pkg/components/Nav.vue';
 import TheTitle from '@pkg/components/TheTitle.vue';
+import initExtensions from '@pkg/preload/extensions';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { mainRoutes } from '@pkg/window';
 
@@ -74,6 +75,7 @@ export default {
   },
 
   beforeMount() {
+    initExtensions();
     ipcRenderer.on('k8s-check-state', (event, state) => {
       this.$store.dispatch('k8sManager/setK8sState', state);
     });


### PR DESCRIPTION
This introduces the extension API to the main window, so that we can use it to implement listing containers.

Note that quite a few of the APIs require knowing what extension cotext the request is coming from, and therefore are not implemented yet.

This is for #5096.