### PR TITLE
Remove explicit call to rdctl shutdown

### DIFF
--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -77,8 +77,8 @@ teardown_file() {
 
     capture_logs
 
-    # On Linux if we don't shutdown Rancher Desktop the bats test doesn't terminate
-    if is_linux; then
+    # On Linux & Windows if we don't shutdown Rancher Desktop bats test don't terminate
+    if is_linux || is_windows; then
         run rdctl shutdown
     fi
 }


### PR DESCRIPTION
Currently teardown file has an explicit condition to calls rdctl shutdown on linux only. This will remove the condition to also call it on Windows.