### PR TITLE
Use specific Rancher Manager chart version instead of latest

### DIFF
--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -39,6 +39,7 @@ get_host() {
         --create-namespace
     helm upgrade \
         --install rancher rancher-latest/rancher \
+        --version "${RD_RANCHER_IMAGE_TAG#v}" \
         --namespace cattle-system \
         --set hostname="$(get_host)" \
         --wait \


### PR DESCRIPTION
The test checks if the /dashboard/auth/login page includes the substring "Rancher Dashboard". This is no longer true in the 2.7.5 release. To have predictable test results we need to pin the version.