### PR TITLE
Run xargs iptables in RD distro

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -33,6 +33,7 @@ else
 fi
 
 CONTAINERD_NAMESPACE=default
+WSL_DISTRO=rancher-desktop
 
 no_cr() {
     tr -d '\r'
@@ -79,4 +80,7 @@ rdshell() {
 }
 rdsudo() {
     rdshell sudo "$@"
+}
+wsl() {
+    wsl.exe -d "$WSL_DISTRO" "$@"
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -33,12 +33,12 @@ factory_reset() {
             true
         fi
     fi
-    if is_windows && wsl.exe -d rancher-desktop true >/dev/null; then
-        run wsl.exe --distribution rancher-desktop sudo ip link delete docker0
-        run wsl.exe --distribution rancher-desktop sudo ip link delete nerdctl0
+    if is_windows && wsl true >/dev/null; then
+        run wsl sudo ip link delete docker0
+        run wsl sudo ip link delete nerdctl0
 
-        wsl.exe --distribution rancher-desktop sudo iptables -F
-        wsl.exe --distribution rancher-desktop sudo iptables -L | awk '/^Chain CNI/ {print $2}' | xargs -I{} sudo iptables -X {}
+        wsl sudo iptables -F
+        wsl sudo iptables -L | awk '/^Chain CNI/ {print $2}' | xargs -I{} wsl sudo iptables -X {}
     fi
     rdctl factory-reset
 }


### PR DESCRIPTION
This change defines a function for wsl with default to rancher-desktop distro. Also, allows the `xargs iptables` call to get triggered inside the rancher-desktop distro.