### PR TITLE
Fix `checkMulti` validator

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -360,10 +360,12 @@ export default class SettingsValidator {
 
   protected checkMulti<S, C, D>(...validators: ValidatorFunc<S, C, D>[]) {
     return (mergedSettings: S, currentValue: C, desiredValue: D, errors: string[], fqname: string) => {
-      let retval = false;
+      let retval = true;
 
       for (const validator of validators) {
-        retval ||= validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
+        // No further validation is performed if the left-hand side is not truthy.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment#description
+        retval &&= validator.call(this, mergedSettings, currentValue, desiredValue, errors, fqname);
       }
 
       return retval;


### PR DESCRIPTION
Do not stop the validation as soon as the first validator returns true. Continue until there is either no validator left or the result is false.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5173