### PR TITLE
Remove xargs in factory reset iptables cleanup

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -38,7 +38,10 @@ factory_reset() {
         run wsl sudo ip link delete nerdctl0
 
         wsl sudo iptables -F
-        wsl sudo iptables -L | awk '/^Chain CNI/ {print $2}' | xargs -I{} wsl sudo iptables -X {}
+        local rule
+        wsl sudo iptables -L | awk '/^Chain CNI/ {print $2}' | while IFS= read -r rule; do
+            wsl sudo iptables -X "$rule"
+        done
     fi
     rdctl factory-reset
 }


### PR DESCRIPTION
The wsl argument to xargs is not being triggered as a function, therefore, it is being replaced by a loop.