### PR TITLE
Address two particular e2e failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 task:
   name: E2E/Integration Tests
-  timeout_in: 45
+  # As of 2023-07-18 "There is a hard limit of 2 hours for free tasks."
+  timeout_in: 60
   container:
     image: ubuntu:20.04
     kvm: true # required for E2E/Integrations tests

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -270,7 +270,7 @@ export async function waitForRestartVM(progressBar: Locator, options = { timeout
     const nowTime = new Date().valueOf();
 
     if (nowTime > endTime) {
-      break;
+      throw new Error(`Failed to see the VM restart after ${ options.timeout / 1000 } seconds`);
     }
     await util.promisify(setTimeout)(options.interval);
   }

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -211,15 +211,6 @@ export async function teardown(app: ElectronApplication, filename: string) {
   }
 }
 
-/**
- * helm teardown
- * it ensure that all helm test installation contents will be deleted.
- */
-export async function tearDownHelm() {
-  await helm('repo', 'remove', 'bitnami');
-  await kubectl('delete', 'deploy', 'nginx-sample', '--namespace', 'default');
-}
-
 export function getResourceBinDir(): string {
   const srcDir = path.dirname(__dirname);
 


### PR DESCRIPTION
Fixes #4988

The first is sometimes the postinstall process times out. Increased from 45 to 60 minutes in `.cirrus.yml`

The other problem is that when an `rdctl` command causes a VM-reset in the UI, the test code needs to be in sync
with the state of the UI. The solution here is to realize that it needs to spend a few seconds actually shutting down 
the current services and VM, giving the e2e code enough time to wait for when the VM is restarted. Yes, technically it's still a race condition, but this means a delay of many seconds between two synchronous lines of JS code, which seems unlikely.