### PR TITLE
Check automatic updates while taking screenshots

### DIFF
--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -22,7 +22,7 @@ test.describe.serial('Main App Test', () => {
 
   test.beforeAll(async({ colorScheme }) => {
     createDefaultSettings({
-      application:     { updater: { enabled: true } },
+      application:     { updater: { enabled: false } },
       containerEngine: { allowedImages: { enabled: true, patterns: ['rancher/example'] } },
       diagnostics:     { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
     });


### PR DESCRIPTION
The automatic update setting needs to be set to `false`, initially. Further down the checkbox is clicked once to enable the apply button:

```
// enable Apply button
await e2ePreferences.application.automaticUpdatesCheckbox.click();
```

If the setting is set to `true`, it would result in an unchecked checkbox while taking the screenshots.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4138

Note: I'll leave the PR in draft mode because I can test it on Windows. If someone has a Windows system at hand, it would be great to take a look at the screenshot results first.