### PR TITLE
Partially refactor `rdctl` factory reset code to use new `paths` package

### DIFF
--- a/src/go/rdctl/cmd/factoryReset.go
+++ b/src/go/rdctl/cmd/factoryReset.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/factoryreset"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shutdown"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,7 +51,11 @@ Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached Kuberne
 		if err != nil {
 			return err
 		}
-		return factoryreset.DeleteData(removeKubernetesCache)
+		paths, err := paths.GetPaths()
+		if err != nil {
+			return fmt.Errorf("failed to get paths: %w", err)
+		}
+		return factoryreset.DeleteData(paths, removeKubernetesCache)
 	},
 }
 

--- a/src/go/rdctl/pkg/factoryreset/delete_data.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data.go
@@ -34,22 +34,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func getStandardDirs() (string, string, string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", "", "", err
-	}
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return "", "", "", err
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", "", "", err
-	}
-	return configDir, cacheDir, homeDir, nil
-}
-
 // Most of the errors in this function are reported, but we continue to try to delete things,
 // because there isn't really a dependency graph here.
 // For example, if we can't delete the Lima VM, that doesn't mean we can't remove docker files

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -1,0 +1,44 @@
+package factoryreset
+
+import (
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
+	"github.com/sirupsen/logrus"
+	"os"
+	"path"
+)
+
+func DeleteData(removeKubernetesCache bool) error {
+	if err := autostart.EnsureAutostart(false); err != nil {
+		logrus.Errorf("Failed to remove autostart configuration: %s", err)
+	}
+
+	configDir, cacheDir, homeDir, err := getStandardDirs()
+	if err != nil {
+		return err
+	}
+	libraryPath := path.Join(homeDir, "Library")
+
+	altAppHomePath := path.Join(homeDir, ".rd")
+	appHomePath := path.Join(configDir, "rancher-desktop")
+	cachePath := path.Join(cacheDir, "rancher-desktop")
+	logsPath := os.Getenv("RD_LOGS_DIR")
+	if logsPath == "" {
+		logsPath = path.Join(libraryPath, "Logs", "rancher-desktop")
+	}
+	settingsPath := path.Join(libraryPath, "Preferences", "rancher-desktop")
+	updaterPath := path.Join(configDir, "Caches", "rancher-desktop-updater")
+
+	pathList := []string{
+		altAppHomePath,
+		appHomePath,
+		logsPath,
+		settingsPath,
+		updaterPath,
+	}
+	if removeKubernetesCache {
+		pathList = append(pathList, cachePath)
+	} else {
+		pathList = append(pathList, path.Join(cachePath, "updater-longhorn.json"))
+	}
+	return deleteUnixLikeData(homeDir, altAppHomePath, path.Join(homeDir, ".config"), pathList)
+}

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -1,44 +1,40 @@
 package factoryreset
 
 import (
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
-	"github.com/sirupsen/logrus"
 	"os"
-	"path"
+	"path/filepath"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(removeKubernetesCache bool) error {
+func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
 
-	configDir, cacheDir, homeDir, err := getStandardDirs()
-	if err != nil {
-		return err
-	}
-	libraryPath := path.Join(homeDir, "Library")
-
-	altAppHomePath := path.Join(homeDir, ".rd")
-	appHomePath := path.Join(configDir, "rancher-desktop")
-	cachePath := path.Join(cacheDir, "rancher-desktop")
-	logsPath := os.Getenv("RD_LOGS_DIR")
-	if logsPath == "" {
-		logsPath = path.Join(libraryPath, "Logs", "rancher-desktop")
-	}
-	settingsPath := path.Join(libraryPath, "Preferences", "rancher-desktop")
-	updaterPath := path.Join(configDir, "Caches", "rancher-desktop-updater")
-
 	pathList := []string{
-		altAppHomePath,
-		appHomePath,
-		logsPath,
-		settingsPath,
-		updaterPath,
+		paths.AltAppHome,
+		paths.AppHome,
+		paths.Logs,
+		paths.Config,
 	}
-	if removeKubernetesCache {
-		pathList = append(pathList, cachePath)
+
+	// Get path that electron-updater stores cache data in. Technically this
+	// is the wrong directory to use for cache data, but it is set by electron-updater.
+	// TODO: investigate changing the directory electron-updater uses
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		logrus.Errorf("failed to get config dir: %s", err)
 	} else {
-		pathList = append(pathList, path.Join(cachePath, "updater-longhorn.json"))
+		pathList = append(pathList, filepath.Join(configDir, "Caches", "rancher-desktop-updater"))
 	}
-	return deleteUnixLikeData(homeDir, altAppHomePath, path.Join(homeDir, ".config"), pathList)
+
+	if removeKubernetesCache {
+		pathList = append(pathList, paths.Cache)
+	} else {
+		pathList = append(pathList, filepath.Join(paths.Cache, "updater-longhorn.json"))
+	}
+	return deleteUnixLikeData(paths, pathList)
 }

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -1,0 +1,48 @@
+package factoryreset
+
+import (
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
+	"github.com/sirupsen/logrus"
+	"os"
+	"path"
+)
+
+func DeleteData(removeKubernetesCache bool) error {
+	if err := autostart.EnsureAutostart(false); err != nil {
+		logrus.Errorf("Failed to remove autostart configuration: %s", err)
+	}
+
+	configHomePath, cacheHomePath, homeDir, err := getStandardDirs()
+	if err != nil {
+		return err
+	}
+
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		dataDir = path.Join(homeDir, ".local", "share")
+	}
+	altAppHomePath := path.Join(homeDir, ".rd")
+	cachePath := path.Join(cacheHomePath, "rancher-desktop")
+	configPath := path.Join(configHomePath, "rancher-desktop")
+	electronConfigPath := path.Join(configHomePath, "Rancher Desktop")
+	dataHomePath := path.Join(dataDir, "rancher-desktop")
+
+	pathList := []string{
+		altAppHomePath,
+		configPath,
+		electronConfigPath,
+		path.Join(homeDir, ".local", "state", "rancher-desktop"),
+	}
+	logsPath := os.Getenv("RD_LOGS_DIR")
+	if logsPath != "" {
+		pathList = append(pathList, logsPath, path.Join(dataHomePath, "lima"))
+	} else {
+		pathList = append(pathList, path.Join(dataHomePath))
+	}
+	if removeKubernetesCache {
+		pathList = append(pathList, cachePath)
+	} else {
+		pathList = append(pathList, path.Join(cachePath, "updater-longhorn.json"))
+	}
+	return deleteUnixLikeData(homeDir, altAppHomePath, configHomePath, pathList)
+}

--- a/src/go/rdctl/pkg/factoryreset/delete_data_test.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_test.go
@@ -21,7 +21,6 @@ package factoryreset
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"testing"
@@ -169,9 +168,11 @@ func TestAddManagedBlock(t *testing.T) {
 	for _, path := range filenames {
 		assert.NoError(t, addBlock(path))
 	}
-	output, err := exec.Command("grep", append([]string{"-l", "MANAGED BY RANCHER DESKTOP"}, filenames...)...).CombinedOutput()
-	assert.NoError(t, err)
-	assert.Equal(t, len(strings.Split(string(output), "\n"))-1, len(filenames))
+	for _, filename := range filenames {
+		contents, err := os.ReadFile(filename)
+		assert.NoError(t, err)
+		assert.Contains(t, string(contents), "MANAGED BY RANCHER DESKTOP")
+	}
 }
 
 func verifyMgmtRemoved(t *testing.T, dotFile string) {

--- a/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
@@ -2,10 +2,11 @@ package factoryreset
 
 import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(removeKubernetesCache bool) error {
+func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}

--- a/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
@@ -1,0 +1,26 @@
+package factoryreset
+
+import (
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
+	"github.com/sirupsen/logrus"
+)
+
+func DeleteData(removeKubernetesCache bool) error {
+	if err := autostart.EnsureAutostart(false); err != nil {
+		logrus.Errorf("Failed to remove autostart configuration: %s", err)
+	}
+	if err := unregisterWSL(); err != nil {
+		logrus.Errorf("could not unregister WSL: %s", err)
+		return err
+	}
+	if err := deleteWindowsData(!removeKubernetesCache, "rancher-desktop"); err != nil {
+		logrus.Errorf("could not delete data: %s", err)
+		return err
+	}
+	if err := clearDockerContext(); err != nil {
+		logrus.Errorf("could not clear docker context: %s", err)
+		return err
+	}
+	logrus.Infoln("successfully cleared data.")
+	return nil
+}

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -151,7 +151,7 @@ func KillRancherDesktop() error {
 				return nil
 			})
 			if err != nil {
-				logrus.Debugf("failed to get process name of pid %d: %w (skipping)", pid, err)
+				logrus.Debugf("failed to get process name of pid %d: %s (skipping)", pid, err)
 				return
 			}
 

--- a/src/go/rdctl/pkg/paths/paths_windows_test.go
+++ b/src/go/rdctl/pkg/paths/paths_windows_test.go
@@ -23,8 +23,8 @@ func TestGetPaths(t *testing.T) {
 			t.Errorf("Unexpected error getting user home directory: %s", err)
 		}
 		expectedPaths := Paths{
-			AppHome:       filepath.Join(homeDir, "AppData", "Roaming"),
-			AltAppHome:    filepath.Join(homeDir, "AppData", "Roaming"),
+			AppHome:       filepath.Join(homeDir, "AppData", "Roaming", appName),
+			AltAppHome:    filepath.Join(homeDir, "AppData", "Roaming", appName),
 			Config:        filepath.Join(homeDir, "AppData", "Roaming", appName),
 			Logs:          filepath.Join(homeDir, "AppData", "Local", appName, "logs"),
 			Cache:         filepath.Join(homeDir, "AppData", "Local", appName, "cache"),
@@ -60,7 +60,7 @@ func TestGetPaths(t *testing.T) {
 			AppHome:       filepath.Join(environment["APPDATA"], appName),
 			AltAppHome:    filepath.Join(environment["APPDATA"], appName),
 			Config:        filepath.Join(environment["APPDATA"], appName),
-			Logs:          filepath.Join(environment["LOCALAPPDATA"], appName, "logs"),
+			Logs:          environment["RD_LOGS_DIR"],
 			Cache:         filepath.Join(environment["LOCALAPPDATA"], appName, "cache"),
 			WslDistro:     filepath.Join(environment["LOCALAPPDATA"], appName, "distro"),
 			WslDistroData: filepath.Join(environment["LOCALAPPDATA"], appName, "distro-data"),


### PR DESCRIPTION
Related to #5062.

The need for this work became clear while I was working on the macOS and Linux snapshots backend (#5115). It doesn't use `paths.Paths` in every place it should, just the places that are most important for #5115. The rest of the refactoring can be done when there is less time pressure.

In the interest of keeping things moving, I'm going to take this out of draft without having tested it on macOS. I'd say the following tests need to be run to feel confident in this change:
- `rdctl` unit tests
- the `containers/factory-reset.bats` BATS test