### PR TITLE
Handle invalid k8s versions at startup

### DIFF
--- a/bats/tests/k8s/specify-invalid-k8s-version.bats
+++ b/bats/tests/k8s/specify-invalid-k8s-version.bats
@@ -7,7 +7,7 @@ load '../helpers/load'
 @test 'invalid k8s version' {
     start_kubernetes --kubernetes.version=moose
     wait_for_container_engine
-    # Can't use wait_for_api_server because it hardwires a valid k8s version and we're specifying an invalid one here.
+    # Can't use wait_for_api_server because it hard-wires a valid k8s version and we're specifying an invalid one here.
     # and we're specifying an invalid one here
     local timeout="$(($(date +%s) + 10 * 60))"
     until kubectl get --raw /readyz &>/dev/null; do

--- a/bats/tests/k8s/specify-invalid-k8s-version.bats
+++ b/bats/tests/k8s/specify-invalid-k8s-version.bats
@@ -1,0 +1,28 @@
+load '../helpers/load'
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'invalid k8s version' {
+    start_kubernetes --kubernetes.version=moose
+    wait_for_container_engine
+    # Can't use wait_for_api_server because it hardwires a valid k8s version and we're specifying an invalid one here.
+    # and we're specifying an invalid one here
+    local timeout="$(($(date +%s) + 10 * 60))"
+    until kubectl get --raw /readyz &>/dev/null; do
+        assert [ "$(date +%s)" -lt "$timeout" ]
+        sleep 1
+    done
+    # No way there's a race-condition here.
+    # The version was checked and written to the log file before starting k8s,
+    # and we have to wait a few minutes before k8s is ready and we're at the next line.
+    assert_file_contains "$PATH_LOGS/kube.log" "Requested kubernetes version moose is not a valid version. Falling back to the most recent stable version of"
+}
+
+# on macOS it still hangs without this
+@test 'shutdown' {
+    if is_macos; then
+        rdctl shutdown
+    fi
+}

--- a/bats/tests/k8s/specify-invalid-k8s-version.bats
+++ b/bats/tests/k8s/specify-invalid-k8s-version.bats
@@ -17,7 +17,7 @@ load '../helpers/load'
     # No way there's a race-condition here.
     # The version was checked and written to the log file before starting k8s,
     # and we have to wait a few minutes before k8s is ready and we're at the next line.
-    assert_file_contains "$PATH_LOGS/kube.log" "Requested kubernetes version moose is not a valid version. Falling back to the most recent stable version of"
+    assert_file_contains "$PATH_LOGS/kube.log" "Requested kubernetes version 'moose' is not a valid version. Falling back to the most recent stable version of"
 }
 
 # on macOS it still hangs without this

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -132,6 +132,16 @@ export default class BackendHelper {
     let matchedVersion: semver.SemVer|undefined;
     const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a valid version.`;
 
+    // If we're here either there's no existing cfg.k8s.version, or it isn't valid
+    if (!availableVersions.length) {
+      if (currentConfigVersionString) {
+        console.log(invalidK8sVersionMainMessage);
+      } else {
+        console.log('Internal error: no available kubernetes versions found.');
+      }
+      throw new Error('No kubernetes version available.');
+    }
+
     if (currentConfigVersionString) {
       storedVersion = semver.parse(currentConfigVersionString);
       if (storedVersion) {
@@ -152,17 +162,6 @@ export default class BackendHelper {
           return matchedVersion;
         }
       }
-    }
-    // If we're here either there's no existing cfg.k8s.version, or it isn't valid
-    if (!availableVersions.length) {
-      if (currentConfigVersionString) {
-        console.log(invalidK8sVersionMainMessage);
-      } else {
-        console.log('Internal error: no available kubernetes versions found.');
-      }
-      throw new Error('No kubernetes version available.');
-    }
-    if (currentConfigVersionString) {
       const message = invalidK8sVersionMainMessage;
       const detail = `Falling back to the most recent stable version of ${ availableVersions[0] }`;
 
@@ -180,7 +179,7 @@ export default class BackendHelper {
         await showMessageBox(options, true);
       }
     }
-    // No (valid) stored version; save the selected one.
+    // No (valid) stored version; save the default one.
     settingsWriter({ kubernetes: { version: availableVersions[0].version } });
 
     return availableVersions[0];

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -298,28 +298,8 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
   protected get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
-      const storedVersion = semver.parse(this.cfg?.kubernetes?.version);
-      const version = storedVersion ?? availableVersions[0];
 
-      if (!version) {
-        throw new Error('No version available');
-      }
-
-      const matchedVersion = availableVersions.find(v => v.compare(version) === 0);
-
-      if (matchedVersion) {
-        if (!storedVersion) {
-          // No (valid) stored version; save the selected one.
-          this.vm.writeSetting({ kubernetes: { version: matchedVersion.version } });
-        }
-
-        return matchedVersion;
-      }
-
-      console.error(`Could not use saved version ${ version.raw }, not in ${ availableVersions }`);
-      this.vm.writeSetting({ kubernetes: { version: availableVersions[0].version } });
-
-      return availableVersions[0];
+      return BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -299,7 +299,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
 
-      return BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -75,7 +75,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
 
-      return BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -16,9 +16,12 @@ import * as K8s from '@pkg/backend/k8s';
 import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 import { checkConnectivity } from '@pkg/main/networking';
+import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 import { showMessageBox } from '@pkg/window';
+
+const console = Logging.kube;
 
 export default class WSLKubernetesBackend extends events.EventEmitter implements K8s.KubernetesBackend {
   constructor(vm: WSLBackend) {


### PR DESCRIPTION
Fixes #4952

First, the invalid version can come from a deployment profile, the command-line, or be manually written into an existing settings file. All of them are handled the same way.

Currently we quietly change an invalid version to the default k8s version, usually the most recent stable version.

The first change here is to log this change to `kube.log`. Also this code was made shared between lima and wsl, so this should all work on Windows.

The second change is to prevent mysterious `TypeError: Invalid version` messages from propagating to a UI dialog box. This was caused by `availableVersions.find(v => v.compare(version) === 0)`. If `version` is null, this will throw an uncaught `TypeError` exception.

The third change is to add a bats test to verify this works.