### PR TITLE
Handle invalid locked k8s version field

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -817,7 +817,7 @@ function showErrorDialog(title: string, message: string, fatal?: boolean) {
     Electron.dialog.showErrorBox(title, message);
   }
   if (fatal) {
-    process.exit(0);
+    Electron.app.quit();
   }
 }
 
@@ -830,8 +830,12 @@ async function handleFailure(payload: any) {
     ({ name: titlePart, message } = payload);
   } else if (payload instanceof LockedFieldError) {
     showErrorDialog(titlePart, payload.message, true);
+
+    return;
   } else if (payload instanceof DeploymentProfileError) {
     showErrorDialog('Failed to load the deployment profile', payload.message, true);
+
+    return;
   } else if (payload instanceof Error) {
     secondaryMessage = payload.toString();
   } else if (typeof payload === 'number') {

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -22,12 +22,10 @@ local_teardown_file() {
     # Have to set the version field or RD will think we're trying to change a locked field.
     RD_KUBERNETES_PREV_VERSION=NattyBo
     start_kubernetes
-    # Don't do the full wait_for_container_engine because RD will shut down in the middle
+    # Don't do wait_for_container_engine because RD will shut down in the middle
     # and the function will take a long time to time out making futile queries.
-    trace "waiting for api /settings to be callable"
-    try --max 30 --delay 5 rdctl api /settings
-    # Can't wait for the kubernetes server because it isn't going to start
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Kubernetes was unable to start: LockedFieldError: Locked kubernetes version 'NattyBo' isn't a valid version"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 2 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Locked kubernetes version 'NattyBo' isn't a valid version"
 }
 
 @test 'recreate profile with a valid k8s version' {
@@ -35,9 +33,10 @@ local_teardown_file() {
 }
 
 @test 'fails to start app with a specified k8s version != locked k8s version' {
+    factory_reset
     # Have to set the version field or RD will think we're trying to change a locked field.
     RD_KUBERNETES_PREV_VERSION=v1.27.2
     start_kubernetes
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Kubernetes was unable to start: LockedFieldError: Error in deployment profiles:"
-    assert_file_contains "$PATH_LOGS/background.log" "field 'kubernetes.version' is locked"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 2 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "field 'kubernetes.version' is locked"
 }

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -1,0 +1,35 @@
+load '../helpers/load'
+
+local_setup() {
+    RD_USE_PROFILE=true
+}
+
+@test 'initial factory reset' {
+    factory_reset
+}
+
+@test 'create profile' {
+    PROFILE_TYPE=$PROFILE_LOCKED
+    RD_USE_PROFILE=true
+    create_profile
+    profile_exists
+    add_profile_string kubernetes.version NattyBo
+    profile_exists
+}
+
+@test 'fails to start app with new profile' {
+    PROFILE_TYPE=$PROFILE_LOCKED
+    # Have to set the version field or RD will think we're trying to change a locked field.
+    RD_KUBERNETES_PREV_VERSION=NattyBo
+    start_kubernetes
+    # Don't do the full wait_for_container_engine because RD will shut down in the middle
+    # and the function will take a long time to time out making futile queries.
+    trace "waiting for api /settings to be callable"
+    try --max 30 --delay 5 rdctl api /settings
+    # Can't wait for the kubernetes server because it isn't going to start
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Kubernetes was unable to start: LockedFieldError: Locked kubernetes version 'NattyBo' isn't a valid version"
+}
+
+@test 'remove profiles' {
+    foreach_profile delete_profile
+}

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -3,7 +3,10 @@ import merge from 'lodash/merge';
 import semver from 'semver';
 
 import { BackendSettings } from '@pkg/backend/backend';
-import { ContainerEngine } from '@pkg/config/settings';
+import { LockedFieldError } from '@pkg/config/commandLineOptions';
+import { ContainerEngine, Settings } from '@pkg/config/settings';
+import * as settingsImpl from '@pkg/config/settingsImpl';
+import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
 import Logging from '@pkg/utils/logging';
 import { showMessageBox } from '@pkg/window';
 
@@ -122,15 +125,31 @@ export default class BackendHelper {
     return engineName === ContainerEngine.MOBY && semver.gte(kubeVersion, '1.24.1') && semver.lte(kubeVersion, '1.24.3');
   }
 
+  static checkForLockedVersion(newVersion: semver.SemVer, cfg: BackendSettings, sv: SettingsValidator): void {
+    const [, errors] = sv.validateSettings(cfg as Settings, { kubernetes: { version: newVersion.raw } }, settingsImpl.getLockedSettings());
+
+    if (errors.length > 0) {
+      if (errors.some(err => err.match(/field '.*' is locked/))) {
+        throw new LockedFieldError(`Error in deployment profiles:\n${ errors.join('\n') }`);
+      } else {
+        throw new Error(`Validation errors for requested version ${ newVersion }: ${ errors.join('\n') }`);
+      }
+    }
+  }
+
   /**
    * Validate the cfg.kubernetes.version string
    * If it's valid and available, use it.
    * Otherwise fall back to the first (recommended) available version.
    */
-  static async getDesiredVersion(currentConfigVersionString: string|undefined, availableVersions: semver.SemVer[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
+  static async getDesiredVersion(cfg: BackendSettings, availableVersions: semver.SemVer[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
+    const currentConfigVersionString = cfg?.kubernetes?.version;
     let storedVersion: semver.SemVer|null;
     let matchedVersion: semver.SemVer|undefined;
     const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a valid version.`;
+    const sv = new SettingsValidator();
+    const lockedSettings = settingsImpl.getLockedSettings();
+    const versionIsLocked = lockedSettings.kubernetes?.version ?? false;
 
     // If we're here either there's no existing cfg.k8s.version, or it isn't valid
     if (!availableVersions.length) {
@@ -142,6 +161,7 @@ export default class BackendHelper {
       throw new Error('No kubernetes version available.');
     }
 
+    sv.k8sVersions = availableVersions.map(v => v.version);
     if (currentConfigVersionString) {
       storedVersion = semver.parse(currentConfigVersionString);
       if (storedVersion) {
@@ -159,7 +179,14 @@ export default class BackendHelper {
           }
         });
         if (matchedVersion) {
+          // This throws a LockedFieldError if it fails.
+          this.checkForLockedVersion(matchedVersion, cfg, sv);
+
           return matchedVersion;
+        } else if (versionIsLocked) {
+          // This is a bit subtle. If we're here, the user specified a nonexistent version in the locked manifest.
+          // We can't switch to the default version, so throw a fatal error.
+          throw new LockedFieldError(`Locked kubernetes version ${ currentConfigVersionString } isn't available.`);
         }
       }
       const message = invalidK8sVersionMainMessage;
@@ -180,6 +207,7 @@ export default class BackendHelper {
       }
     }
     // No (valid) stored version; save the default one.
+    // Because no version was specified, there can't be a locked version field, so no need to call checkForLockedVersion
     settingsWriter({ kubernetes: { version: availableVersions[0].version } });
 
     return availableVersions[0];

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -188,6 +188,10 @@ export default class BackendHelper {
           // We can't switch to the default version, so throw a fatal error.
           throw new LockedFieldError(`Locked kubernetes version ${ currentConfigVersionString } isn't available.`);
         }
+      } else if (versionIsLocked) {
+        // If we're here, the user specified a non-version in the locked manifest.
+        // We can't switch to the default version, so throw a fatal error.
+        throw new LockedFieldError(`Locked kubernetes version '${ currentConfigVersionString }' isn't a valid version.`);
       }
       const message = invalidK8sVersionMainMessage;
       const detail = `Falling back to the most recent stable version of ${ availableVersions[0] }`;

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -299,7 +299,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
 
-      return await BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -75,7 +75,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     return (async() => {
       const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
 
-      return await BackendHelper.getDesiredVersion(this.cfg?.kubernetes?.version, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();
   }
 


### PR DESCRIPTION
Fixes #5203

More checks that any specified k8s field is valid, and doesn't conflict with the locked field, if given.

And also verify that if the k8s version field is locked, that it's also valid.

## Waiting on PR 5199