### PR TITLE
Update rancher-icons from 2.0.9 to 2.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "native-reg": "1.1.1",
     "node-fetch": "2.6.7",
     "node-forge": "1.3.1",
-    "rancher-icons": "rancher/icons#v2.0.9",
+    "rancher-icons": "rancher/icons#v2.0.18",
     "ref-napi": "3.0.3",
     "ref-struct-di": "1.1.1",
     "semver": "7.4.0",

--- a/pkg/rancher-desktop/assets/styles/global/_tooltip.scss
+++ b/pkg/rancher-desktop/assets/styles/global/_tooltip.scss
@@ -192,6 +192,6 @@
 }
 
 //icon tooltip
-.icon-info.has-tooltip {
+.icon-info-circle.has-tooltip {
   font-size: 14px;
 }

--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -219,7 +219,7 @@ export default {
               label:   this.t('images.manager.table.action.scan'),
               action:  'scanImage',
               enabled: true,
-              icon:    'icon icon-info',
+              icon:    'icon icon-info-circle',
             },
           ].filter(x => x.enabled);
           // ActionMenu callbacks - SortableTable assumes that these methods live

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -153,7 +153,7 @@ export default {
           v-if="imageManagerProcessFinishedWithFailure"
           color="error"
         >
-          <span class="icon icon-info icon-lg " />
+          <span class="icon icon-info-circle icon-lg " />
           {{ errorText }}
         </banner>
       </slot>

--- a/pkg/rancher-desktop/components/Tabbed/Tab.vue
+++ b/pkg/rancher-desktop/components/Tabbed/Tab.vue
@@ -84,7 +84,7 @@ export default {
   >
     <h2 v-if="shouldShowHeader">
       {{ label }}
-      <i v-if="tooltip" v-tooltip="tooltip" class="icon icon-info icon-lg" />
+      <i v-if="tooltip" v-tooltip="tooltip" class="icon icon-info-circle icon-lg" />
     </h2>
     <slot v-bind="{active}" />
   </section>

--- a/pkg/rancher-desktop/components/form/LabeledTooltip.vue
+++ b/pkg/rancher-desktop/components/form/LabeledTooltip.vue
@@ -22,10 +22,10 @@ export default {
 <template>
   <div ref="container" class="labeled-tooltip" :class="{[status]: true, hoverable: hover}">
     <template v-if="hover">
-      <i v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value}" class="icon icon-info status-icon" />
+      <i v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value}" class="icon icon-info-circle status-icon" />
     </template>
     <template v-else>
-      <i :class="{'hover':!value}" class="icon icon-info status-icon" />
+      <i :class="{'hover':!value}" class="icon icon-info-circle status-icon" />
       <div v-if="value" class="tooltip" x-placement="bottom">
         <div class="tooltip-arrow" />
         <div class="tooltip-inner">

--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -56,7 +56,7 @@ export default Vue.extend({
         <i
           v-else-if="legendTooltip"
           v-tooltip="legendTooltip"
-          class="icon icon-info icon-lg"
+          class="icon icon-info-circle icon-lg"
         />
       </slot>
     </legend>

--- a/pkg/rancher-desktop/pages/images/add.vue
+++ b/pkg/rancher-desktop/pages/images/add.vue
@@ -11,7 +11,7 @@
       </div>
       <alert
         v-if="allowedImagesAlert"
-        :icon="'icon-info'"
+        :icon="'icon-info-circle'"
         :banner-text="allowedImagesAlert"
         :color="'info'"
       />

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -21,7 +21,7 @@
           color="error"
         >
           {{ hasError }}
-          <span class="icon icon-info icon-lg " />
+          <span class="icon icon-info-circle icon-lg " />
           {{ errorText }}
         </banner>
       </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17207,9 +17207,9 @@ rancher-icons@rancher/icons#v2.0.0:
   version "2.0.0"
   resolved "https://codeload.github.com/rancher/icons/tar.gz/557a218db623f25193ed9bb2dba0fed964215bdc"
 
-rancher-icons@rancher/icons#v2.0.9:
-  version "2.0.9"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/09048239918c9eccf49f7770948efef63fb04f24"
+rancher-icons@rancher/icons#v2.0.18:
+  version "2.0.18"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/d8b4f221386c80105bc1456490c9ce591daec5fc"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Update the package and replace `icon-info` by `icon-info-circle` to keep the former version.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5209