### PR TITLE
Generate plist output from list-settings.

### DIFF
--- a/bats/tests/preferences/list-settings-output.bats
+++ b/bats/tests/preferences/list-settings-output.bats
@@ -98,7 +98,7 @@ RD_USE_IMAGE_ALLOW_LIST=true
 }
 
 @test 'verify plutil is ok with the generated plist output' {
-    if !is_mac ; then
+    if ! is_mac; then
         skip
     fi
     run bash -o pipefail -c "rdctl list-settings --output plist | plutil -s -"

--- a/bats/tests/preferences/list-settings-output.bats
+++ b/bats/tests/preferences/list-settings-output.bats
@@ -85,6 +85,27 @@ RD_USE_IMAGE_ALLOW_LIST=true
     assert_output --partial '"showMuted"=dword:0'
 }
 
+@test 'generates plist output' {
+    run rdctl list-settings --output plist
+    assert_success
+    # Just match a few of the lines near the start and the end of the output.
+    # The unit tests do more comprehensive output checking.
+    assert_output --partial '<?xml version="1.0" encoding="UTF-8"?>'
+    assert_output --partial '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+    assert_output --partial '<plist version="1.0">'
+    assert_output --partial '    <key>application</key>'
+    assert_output --partial '</plist>'
+}
+
+@test 'verify plutil is ok with the generated plist output' {
+    if !is_mac ; then
+        skip
+    fi
+    run bash -o pipefail -c "rdctl list-settings --output plist | plutil -s -"
+    assert_success
+    assert_output ""
+}
+
 @test 'needs a shutdown' {
     rdctl shutdown
 }

--- a/src/go/rdctl/go.mod
+++ b/src/go/rdctl/go.mod
@@ -3,6 +3,7 @@ module github.com/rancher-sandbox/rancher-desktop/src/go/rdctl
 go 1.17
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/docker/docker v20.10.22+incompatible
 	github.com/rancher-sandbox/rancher-desktop/src/go/privileged-service v0.0.0-20221207202230-8eef0a706010
 	github.com/sirupsen/logrus v1.9.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/src/go/rdctl/go.sum
+++ b/src/go/rdctl/go.sum
@@ -636,6 +636,7 @@ github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb/go.mod h1:82TxjOpWQiPmywlbIaB2ZkqJoSYJdLGPgAJDvM3PbKc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1654,6 +1655,7 @@ gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/go/rdctl/pkg/plist/plist.go
+++ b/src/go/rdctl/pkg/plist/plist.go
@@ -1,0 +1,154 @@
+// Package reg is responsible for converting ServerSettingsForJSON structures into
+// importable Windows registry files by running `reg import FILE`.
+//
+// Note that the `reg` command must be run with administrator privileges because it
+// modifies either a section of `HKEY_LOCAL_MACHINE` or `HKEY_CURRENT_USER\SOFTWARE\Policies`,
+// both of which require escalated privileges to be modified.
+
+package plist
+
+import (
+	"encoding/json"
+	"fmt"
+	options "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/options/generated"
+	"reflect"
+	"sort"
+
+	"strings"
+)
+
+func xmlEscape(s string) string {
+	s1 := strings.ReplaceAll(s, "&", "&amp;")
+	s2 := strings.ReplaceAll(s1, "<", "&lt;")
+	s3 := strings.ReplaceAll(s2, ">", "&gt;")
+	return s3
+}
+
+const indentChange = "  "
+
+type mapKeyWithString struct {
+	mapKey    reflect.Value
+	stringKey string
+}
+
+func sortKeys(mapKeys []reflect.Value) []mapKeyWithString {
+	retVals := make([]mapKeyWithString, len(mapKeys))
+	for idx, key := range mapKeys {
+		mapKeyAsString := key.String()
+		retVals[idx] = mapKeyWithString{key, mapKeyAsString}
+	}
+	sort.Slice(retVals, func(i, j int) bool {
+		return retVals[i].stringKey < retVals[j].stringKey
+	})
+	return retVals
+}
+
+// convertToPListLines recursively reflects the supplied value into lines for a plist
+func convertToPListLines(v reflect.Value, indent string) ([]string, error) {
+	kind := v.Kind()
+	switch kind {
+	case reflect.Struct:
+		numFields := v.NumField()
+		returnedLines := []string{indent + "<dict>"}
+		for i := 0; i < numFields; i++ {
+			fieldTag := v.Type().Field(i).Tag.Get("json")
+			fieldName := strings.Replace(fieldTag, ",omitempty", "", 1)
+			newRetLines, err := convertToPListLines(v.Field(i), indent+indentChange)
+			if err != nil {
+				return nil, err
+			}
+			if len(newRetLines) == 0 {
+				continue
+			}
+			returnedLines = append(returnedLines, fmt.Sprintf(`%s<key>%s</key>`, indent+indentChange, fieldName))
+			returnedLines = append(returnedLines, newRetLines...)
+		}
+		if len(returnedLines) == 1 {
+			return nil, nil
+		}
+		returnedLines = append(returnedLines, indent+"</dict>")
+		return returnedLines, nil
+	case reflect.Ptr:
+		if v.IsNil() {
+			return nil, nil
+		} else {
+			return convertToPListLines(v.Elem(), indent)
+		}
+	case reflect.Slice, reflect.Array:
+		// Currently, all arrays in the options are arrays of strings
+		numValues := v.Len()
+		if numValues == 0 {
+			return nil, nil
+		}
+		retLines := make([]string, numValues+2)
+		retLines[0] = indent + "<array>"
+		for i := 0; i < numValues; i++ {
+			retLines[i+1] = fmt.Sprintf("%s<string>%s</string>", indent+indentChange, xmlEscape(v.Index(i).String()))
+		}
+		retLines[numValues+1] = indent + "</array>"
+		return retLines, nil
+	case reflect.Map:
+		numValues := len(v.MapKeys())
+		if numValues == 0 {
+			return nil, nil
+		}
+		returnedLines := []string{indent + "<dict>"}
+		typedKeys := sortKeys(v.MapKeys())
+		for _, typedKey := range typedKeys {
+			keyAsString := typedKey.stringKey
+			innerLines, err := convertToPListLines(v.MapIndex(typedKey.mapKey), indent+indentChange)
+			if err != nil {
+				return nil, err
+			} else if len(innerLines) > 0 {
+				returnedLines = append(returnedLines, fmt.Sprintf(`%s<key>%s</key>`, indent+indentChange, keyAsString))
+				returnedLines = append(returnedLines, innerLines...)
+			}
+		}
+		if len(returnedLines) == 1 {
+			return nil, nil
+		}
+		returnedLines = append(returnedLines, indent+"</dict>")
+		return returnedLines, nil
+	case reflect.Interface:
+		if v.IsNil() {
+			return nil, nil
+		}
+		return convertToPListLines(v.Elem(), indent)
+	case reflect.Bool:
+		boolValue := map[bool]string{true: "true", false: "false"}[v.Bool()]
+		return []string{fmt.Sprintf("%s<%s/>", indent, boolValue)}, nil
+	case reflect.Int, reflect.Int8, reflect.Int16,
+		reflect.Int32, reflect.Uint, reflect.Uint8, reflect.Uint16,
+		reflect.Uint32, reflect.Int64, reflect.Uint64:
+		return []string{fmt.Sprintf("%s<integer>%d</integer>", indent, v.Int())}, nil
+	case reflect.Float32:
+		return []string{fmt.Sprintf("%s<float>%f</float>", indent, v.Float())}, nil
+	case reflect.String:
+		return []string{fmt.Sprintf("%s<string>%s</string>", indent, xmlEscape(v.String()))}, nil
+	}
+	return nil, fmt.Errorf("convertToPListLines: don't know how to process kind: %s, (%T), value: %v", kind, v, v)
+}
+
+// JsonToPlist converts the json settings to a reg file
+func JsonToPlist(settingsBodyAsJSON string) (string, error) {
+	var settingsJSON options.ServerSettingsForJSON
+
+	if err := json.Unmarshal([]byte(settingsBodyAsJSON), &settingsJSON); err != nil {
+		return "", fmt.Errorf("error in json: %s\n", err)
+	}
+	lines, err := convertToPListLines(reflect.ValueOf(settingsJSON), indentChange)
+	if err != nil {
+		return "", err
+	}
+	headerLines := []string{`<?xml version="1.0" encoding="UTF-8"?>`,
+		`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">`,
+		`<plist version="1.0">`,
+	}
+	trailerLines := []string{"</plist>", ""}
+	if len(lines) == 0 {
+		lines = []string{"  <dict/>"}
+	}
+	headerLines = append(headerLines, lines...)
+	headerLines = append(headerLines, trailerLines...)
+	return strings.Join(headerLines, "\n"), nil
+}

--- a/src/go/rdctl/pkg/plist/plist_test.go
+++ b/src/go/rdctl/pkg/plist/plist_test.go
@@ -1,0 +1,335 @@
+package plist
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJsonToPlistFormat(t *testing.T) {
+	t.Run("handles empty bodies", func(t *testing.T) {
+		s, err := JsonToPlist("{}")
+		assert.NoError(t, err)
+		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>
+`, s)
+	})
+
+	t.Run("Handles arrays", func(t *testing.T) {
+		jsonBody := `{"application": { "extensions": { "allowed": {
+        "enabled": false,
+        "list": ["wink", "blink", "drink"]
+     } } }, "containerEngine": { "name": "beatrice" }}`
+		s, err := JsonToPlist(jsonBody)
+		assert.NoError(t, err)
+		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>application</key>
+    <dict>
+      <key>extensions</key>
+      <dict>
+        <key>allowed</key>
+        <dict>
+          <key>enabled</key>
+          <false/>
+          <key>list</key>
+          <array>
+            <string>wink</string>
+            <string>blink</string>
+            <string>drink</string>
+          </array>
+        </dict>
+      </dict>
+    </dict>
+    <key>containerEngine</key>
+    <dict>
+      <key>name</key>
+      <string>beatrice</string>
+    </dict>
+  </dict>
+</plist>
+`, s)
+	})
+
+	t.Run("Handles everything", func(t *testing.T) {
+		jsonBody := `{
+  "version": 9,
+  "application": {
+    "adminAccess": false,
+    "debug": false,
+    "extensions": {
+      "allowed": {
+        "enabled": false,
+        "list": [
+          "<wi & nk>",
+          "blink",
+          "ok"
+        ]
+      },
+      "installed": {}
+    },
+    "pathManagementStrategy": "rcfiles",
+    "telemetry": {
+      "enabled": true
+    },
+    "updater": {
+      "enabled": true
+    },
+    "autoStart": false,
+    "startInBackground": false,
+    "hideNotificationIcon": false,
+    "window": {
+      "quitOnClose": false
+    }
+  },
+  "containerEngine": {
+    "allowedImages": {
+      "enabled": false,
+      "patterns": []
+    },
+    "name": "moby"
+  },
+  "virtualMachine": {
+    "memoryInGB": 4,
+    "numberCPUs": 2,
+    "hostResolver": true
+  },
+  "WSL": {
+    "integrations": {
+      "first": true,
+      "second": false,
+      "third": true
+    }
+  },
+  "kubernetes": {
+    "version": "1.27.3",
+    "port": 6443,
+    "enabled": true,
+    "options": {
+      "traefik": true,
+      "flannel": true
+    },
+    "ingress": {
+      "localhostOnly": false
+    }
+  },
+  "portForwarding": {
+    "includeKubernetesServices": false
+  },
+  "images": {
+    "showAll": true,
+    "namespace": "k8s.io"
+  },
+  "diagnostics": {
+    "showMuted": false,
+    "mutedChecks": {
+      "moss": true,
+      "dial": false
+    }
+  },
+  "experimental": {
+    "virtualMachine": {
+      "type": "qemu",
+      "useRosetta": false,
+      "socketVMNet": false,
+      "mount": {
+        "type": "reverse-sshfs",
+        "9p": {
+          "securityModel": "none",
+          "protocolVersion": "9p2000.L",
+          "msizeInKib": 128,
+          "cacheMode": "mmap"
+        }
+      },
+      "networkingTunnel": false,
+      "proxy": {
+        "enabled": false,
+        "address": "",
+        "password": "",
+        "port": 3128,
+        "username": ""
+      }
+    }
+  }
+}
+`
+		s, err := JsonToPlist(jsonBody)
+		assert.NoError(t, err)
+		assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>version</key>
+    <integer>9</integer>
+    <key>application</key>
+    <dict>
+      <key>adminAccess</key>
+      <false/>
+      <key>debug</key>
+      <false/>
+      <key>extensions</key>
+      <dict>
+        <key>allowed</key>
+        <dict>
+          <key>enabled</key>
+          <false/>
+          <key>list</key>
+          <array>
+            <string>&lt;wi &amp; nk&gt;</string>
+            <string>blink</string>
+            <string>ok</string>
+          </array>
+        </dict>
+      </dict>
+      <key>pathManagementStrategy</key>
+      <string>rcfiles</string>
+      <key>telemetry</key>
+      <dict>
+        <key>enabled</key>
+        <true/>
+      </dict>
+      <key>updater</key>
+      <dict>
+        <key>enabled</key>
+        <true/>
+      </dict>
+      <key>autoStart</key>
+      <false/>
+      <key>startInBackground</key>
+      <false/>
+      <key>hideNotificationIcon</key>
+      <false/>
+      <key>window</key>
+      <dict>
+        <key>quitOnClose</key>
+        <false/>
+      </dict>
+    </dict>
+    <key>containerEngine</key>
+    <dict>
+      <key>name</key>
+      <string>moby</string>
+      <key>allowedImages</key>
+      <dict>
+        <key>enabled</key>
+        <false/>
+      </dict>
+    </dict>
+    <key>virtualMachine</key>
+    <dict>
+      <key>memoryInGB</key>
+      <integer>4</integer>
+      <key>numberCPUs</key>
+      <integer>2</integer>
+      <key>hostResolver</key>
+      <true/>
+    </dict>
+    <key>kubernetes</key>
+    <dict>
+      <key>version</key>
+      <string>1.27.3</string>
+      <key>port</key>
+      <integer>6443</integer>
+      <key>enabled</key>
+      <true/>
+      <key>options</key>
+      <dict>
+        <key>traefik</key>
+        <true/>
+        <key>flannel</key>
+        <true/>
+      </dict>
+      <key>ingress</key>
+      <dict>
+        <key>localhostOnly</key>
+        <false/>
+      </dict>
+    </dict>
+    <key>experimental</key>
+    <dict>
+      <key>virtualMachine</key>
+      <dict>
+        <key>socketVMNet</key>
+        <false/>
+        <key>mount</key>
+        <dict>
+          <key>type</key>
+          <string>reverse-sshfs</string>
+          <key>9p</key>
+          <dict>
+            <key>securityModel</key>
+            <string>none</string>
+            <key>protocolVersion</key>
+            <string>9p2000.L</string>
+            <key>msizeInKib</key>
+            <integer>128</integer>
+            <key>cacheMode</key>
+            <string>mmap</string>
+          </dict>
+        </dict>
+        <key>networkingTunnel</key>
+        <false/>
+        <key>type</key>
+        <string>qemu</string>
+        <key>useRosetta</key>
+        <false/>
+        <key>proxy</key>
+        <dict>
+          <key>enabled</key>
+          <false/>
+          <key>address</key>
+          <string></string>
+          <key>password</key>
+          <string></string>
+          <key>port</key>
+          <integer>3128</integer>
+          <key>username</key>
+          <string></string>
+        </dict>
+      </dict>
+    </dict>
+    <key>WSL</key>
+    <dict>
+      <key>integrations</key>
+      <dict>
+        <key>first</key>
+        <true/>
+        <key>second</key>
+        <false/>
+        <key>third</key>
+        <true/>
+      </dict>
+    </dict>
+    <key>portForwarding</key>
+    <dict>
+      <key>includeKubernetesServices</key>
+      <false/>
+    </dict>
+    <key>images</key>
+    <dict>
+      <key>showAll</key>
+      <true/>
+      <key>namespace</key>
+      <string>k8s.io</string>
+    </dict>
+    <key>diagnostics</key>
+    <dict>
+      <key>showMuted</key>
+      <false/>
+      <key>mutedChecks</key>
+      <dict>
+        <key>dial</key>
+        <false/>
+        <key>moss</key>
+        <true/>
+      </dict>
+    </dict>
+  </dict>
+</plist>
+`, s)
+	})
+}


### PR DESCRIPTION
Fixes #4567

Uses the same reflection technique as for registry output because none of the main plist generators I found were ignoring empty JSON structures.