### PR TITLE
Bump to https-proxy-agent 7.0.1 and update client code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "fs-extra": "11.1.0",
     "http-proxy-agent": "5.0.0",
     "http-proxy-middleware": "2.0.6",
-    "https-proxy-agent": "5.0.1",
+    "https-proxy-agent": "7.0.1",
     "intl-messageformat": "10.2.5",
     "jquery": "3.6.3",
     "jsonpath": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5818,6 +5818,13 @@ agent-base@6, agent-base@6.0.2, agent-base@^6.0.2:
   dependencies:
     debug "4"
 
+agent-base@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.0.tgz#536802b76bc0b34aa50195eb2442276d613e3434"
+  integrity sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==
+  dependencies:
+    debug "^4.3.4"
+
 aggregate-error@^3.0.0, aggregate-error@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -12047,7 +12054,15 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
-https-proxy-agent@5.0.1, https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
+https-proxy-agent@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz#0277e28f13a07d45c663633841e20a40aaafe0ab"
+  integrity sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
+
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==


### PR DESCRIPTION
Fixes #5057

See also #4622 to see how the client code was changed going from 5.x to 6.0

6.0 was a breaking change, so we needed to update the client code. There hasn't been a breaking
change since then, and no client change appears necessary.

References:
# 5009 - how the 6.x version broke proxies
  - above introduced by #4622 
 
- Upstream issue: https://github.com/TooTallNate/proxy-agents/issues/207
  - Failed to detect the end of the returned headers, which is why our error messages were complaining about `<HTML><HEAD>…`
  - Fixed in [TooTall's ](https://github.com/TooTallNate/proxy-agents/pull/212)
  - Released in https-proxy-agent v7.0.1 on July 10, 2023

If someone with all the required network pieces could test this change so it breaks with the 1.9.0 release but works here, that would be great. FWICT the failure happened at startup while collecting certs.
