### PR TITLE
BATS test for `ctrctl run --init`

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -9,6 +9,7 @@ https
 qword
 skopeo
 ssh
+tini
 ubuntu
 vinzenz
 workarounds

--- a/bats/tests/containers/init.bats
+++ b/bats/tests/containers/init.bats
@@ -1,0 +1,21 @@
+# verify that running a container with --init is working
+
+load '../helpers/load'
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start container engine' {
+    start_container_engine
+    wait_for_container_engine
+}
+
+@test 'run container with init process' {
+    run ctrctl run --rm --init "$IMAGE_BUSYBOX" ps -ef
+    assert_success
+    # PID   USER     TIME  COMMAND
+    #     1 root      0:00 /sbin/docker-init -- ps -ef
+    #     1 root      0:00 /sbin/tini -- ps -ef
+    assert_line --regexp '^ +1 .+ /sbin/(docker-init|tini) -- ps -ef$'
+}

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -81,7 +81,7 @@ teardown_file() {
     capture_logs
 
     # On Linux & Windows if we don't shutdown Rancher Desktop bats tests don't terminate
-    if is_linux || is_windows; then
+    if is_linux || is_windows || [[ $RD_LOCATION == dev ]]; then
         run rdctl shutdown
     fi
 


### PR DESCRIPTION
This requires that `/usr/bin/docker-init` and `/usr/bin/tini` exist (and are symlinks to `/sbin/tini-static`).

Closes #5150 

Support has been added previously by adding the symlink for `/usr/bin/tini` in alpine-lima and wsl-distro; this PR only adds a test.

Tested with `containerd` and `moby` on macOS. Needs testing on Windows!