### PR TITLE
Return .../limactl.ventura when on MacOS Ventura+.

### DIFF
--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -10,6 +10,8 @@ import util from 'util';
 
 import buildUtils from './lib/build-utils';
 
+import { readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
+
 const sleep = util.promisify(setTimeout);
 
 class E2ETestRunner extends events.EventEmitter {
@@ -97,6 +99,11 @@ class E2ETestRunner extends events.EventEmitter {
 
   async run() {
     try {
+      const deploymentProfiles = await readDeploymentProfiles();
+
+      if (Object.keys(deploymentProfiles.defaults).length > 0 || Object.keys(deploymentProfiles.locked).length > 0) {
+        throw new Error("Trying to run e2e tests with existing deployment profiles isn't supported.");
+      }
       process.env.NODE_ENV = 'test';
       process.env.RD_TEST = 'e2e';
 

--- a/src/go/rdctl/pkg/directories/lima_home.go
+++ b/src/go/rdctl/pkg/directories/lima_home.go
@@ -19,9 +19,12 @@ package directories
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 )
 
 func SetupLimaHome() error {
@@ -54,6 +57,20 @@ func SetupLimaHome() error {
 	return nil
 }
 
+func getOSMajorVersion() (int, error) {
+	// syscall.Uname isn't available on macOS, so we need to shell out.
+	// This is only called once by `rdctl shutdown` and once by `rdctl shell` so there's no need to memoize the result
+	version, err := exec.Command("uname", "-r").CombinedOutput()
+	if err != nil {
+		return -1, err
+	}
+	before, _, found := strings.Cut(string(version), ".")
+	if !found || len(before) == 0 {
+		return -1, fmt.Errorf("Expected a version string, got: %s", string(version))
+	}
+	return strconv.Atoi(before)
+}
+
 func GetLimactlPath() (string, error) {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -62,6 +79,14 @@ func GetLimactlPath() (string, error) {
 	execPath, err = filepath.EvalSymlinks(execPath)
 	if err != nil {
 		return "", err
+	}
+	if runtime.GOOS == "darwin" {
+		majorVersion, err := getOSMajorVersion()
+		if err == nil && majorVersion >= 22 {
+			// https://en.wikipedia.org/wiki/MacOS_version_history: maps darwin versions to macOS release version numbers and names
+			// macOS 13 | Ventura | 22
+			return path.Join(path.Dir(path.Dir(execPath)), "lima", "bin", "limactl.ventura"), nil
+		}
 	}
 	return path.Join(path.Dir(path.Dir(execPath)), "lima", "bin", "limactl"), nil
 }


### PR DESCRIPTION
Fixes #5016

This is already happening in the javascript backend.