### PR TITLE
Pass rancher-desktop context when invoking the docker executable on the host

### DIFF
--- a/pkg/rancher-desktop/backend/images/mobyImageProcessor.ts
+++ b/pkg/rancher-desktop/backend/images/mobyImageProcessor.ts
@@ -31,6 +31,10 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
   protected async runImagesCommand(args: string[], sendNotifications = true): Promise<imageProcessor.childResultType> {
     const subcommandName = args[0];
 
+    if (this.executor.backend !== 'wsl' && !args.includes('--context')) {
+      args.unshift('--context', 'rancher-desktop');
+    }
+
     return await this.processChildOutput(spawn(executable('docker'), args), subcommandName, sendNotifications);
   }
 


### PR DESCRIPTION
Fixes #3156

See the issue to repro

Working with extensions when the current extension is not `rancher-desktop` is covered in issue #5397