### PR TITLE
Add support for VZ NAT networking

### DIFF
--- a/e2e/pages/preferences/virtualMachine.ts
+++ b/e2e/pages/preferences/virtualMachine.ts
@@ -18,6 +18,7 @@ export class VirtualMachineNav {
   readonly qemu: Locator;
   readonly vz: Locator;
   readonly useRosetta: Locator;
+  readonly vzNAT: Locator;
   readonly socketVmNet: Locator;
   readonly tabHardware: Locator;
   readonly tabVolumes: Locator;
@@ -42,6 +43,7 @@ export class VirtualMachineNav {
     this.qemu = page.locator('[data-test="QEMU"]');
     this.vz = page.locator('[data-test="VZ"]');
     this.useRosetta = page.locator('[data-test="useRosetta"]');
+    this.vzNAT = page.locator('[data-test="vzNAT"]');
     this.socketVmNet = page.locator('[data-test="socketVmNet"]');
     this.tabHardware = page.locator('.tab >> text=Hardware');
     this.tabVolumes = page.locator('.tab >> text=Volumes');

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -168,12 +168,13 @@ test.describe.serial('Main App Test', () => {
       await expect(virtualMachine.vz).not.toBeDisabled();
       await virtualMachine.vz.click();
       await expect(virtualMachine.useRosetta).toBeVisible();
-
       if (os.arch() === 'arm64') {
         await expect(virtualMachine.useRosetta).not.toBeDisabled();
       } else {
         await expect(virtualMachine.useRosetta).toBeDisabled();
       }
+      await expect(virtualMachine.vzNAT).toBeVisible();
+      await expect(virtualMachine.vzNAT).not.toBeDisabled();
     }
   });
 

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -523,6 +523,9 @@ components:
                 useRosetta:
                   type: boolean
                   x-rd-platforms: [darwin]
+                vzNAT:
+                  type: boolean
+                  x-rd-platforms: [darwin]
                 proxy:
                   type: object
                   x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -364,9 +364,12 @@ virtualMachine:
       vz:
         label: VZ
         description: Use the Apple Virtualization framework.
-  useRosetta:
-    legend: VZ Option
-    label: Enable Rosetta support
+  vzOptions:
+    label: VZ Options
+    rosetta:
+      label: Enable Rosetta support
+    vzNAT:
+      label: Enable VZ NAT networking
 
 containerEngine:
   label: Container Engine

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -163,14 +163,20 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
         class="col span-6 vz-sub-options"
       >
         <rd-fieldset
-          data-test="useRosetta"
-          :legend-text="t('virtualMachine.useRosetta.legend')"
+          data-test="vzOptions"
+          :legend-text="t('virtualMachine.vzOptions.label')"
         >
           <rd-checkbox
-            :label="t('virtualMachine.useRosetta.label')"
+            :label="t('virtualMachine.vzOptions.rosetta.label')"
             :value="preferences.experimental.virtualMachine.useRosetta"
             :is-locked="isPreferenceLocked('experimental.virtualMachine.useRosetta')"
             @input="onChange('experimental.virtualMachine.useRosetta', $event)"
+          />
+          <rd-checkbox
+            :label="t('virtualMachine.vzOptions.vzNAT.label')"
+            :value="preferences.experimental.virtualMachine.vzNAT"
+            :is-locked="isPreferenceLocked('experimental.virtualMachine.vzNAT')"
+            @input="onChange('experimental.virtualMachine.vzNAT', $event)"
           />
         </rd-fieldset>
       </div>

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -113,6 +113,8 @@ export const defaultSettings = {
       type:        VMType.QEMU,
       /** can only be used when type is VMType.VZ, and only on aarch64 */
       useRosetta:  false,
+      /** Use VZ NAT for network bridging */
+      vzNAT:       process.platform === 'darwin',
       /** macOS only: if set, use socket_vmnet instead of vde_vmnet. */
       socketVMNet: false,
       mount:       {

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -76,6 +76,7 @@ describe(SettingsValidator, () => {
       ['experimental', 'virtualMachine', 'mount', 'type'],
       ['experimental', 'virtualMachine', 'type'],
       ['experimental', 'virtualMachine', 'useRosetta'],
+      ['experimental', 'virtualMachine', 'vzNAT'],
       ['kubernetes', 'version'],
       ['version'],
       ['WSL', 'integrations'],

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -123,6 +123,7 @@ export default class SettingsValidator {
           socketVMNet:      this.checkPlatform('darwin', this.checkBoolean),
           networkingTunnel: this.checkPlatform('win32', this.checkBoolean),
           useRosetta:       this.checkPlatform('darwin', this.checkRosetta),
+          vzNAT:            this.checkPlatform('darwin', this.checkVzNAT),
           type:             this.checkPlatform('darwin', this.checkMulti(
             this.checkEnum(...Object.values(VMType)),
             this.checkVMType),
@@ -301,6 +302,11 @@ export default class SettingsValidator {
       }
     }
 
+    return currentValue !== desiredValue;
+  }
+
+  protected checkVzNAT(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
+    // VZ NAT is added for VZ machines, and ignored for others
     return currentValue !== desiredValue;
   }
 

--- a/src/go/rdctl/pkg/plist/plist_test.go
+++ b/src/go/rdctl/pkg/plist/plist_test.go
@@ -277,6 +277,8 @@ func TestJsonToPlistFormat(t *testing.T) {
         <string>qemu</string>
         <key>useRosetta</key>
         <false/>
+				<key>vzNAT</key>
+        <true/>
         <key>proxy</key>
         <dict>
           <key>enabled</key>

--- a/src/go/rdctl/pkg/reg/reg_test.go
+++ b/src/go/rdctl/pkg/reg/reg_test.go
@@ -265,6 +265,7 @@ func TestJsonToRegFormat(t *testing.T) {
     "virtualMachine": {
       "type": "qemu",
       "useRosetta": false,
+			"vzNAT": true,
       "socketVMNet": false,
       "mount": {
         "type": "reverse-sshfs",


### PR DESCRIPTION
Closes #5176

For Apple VM running in VZ mode, add checkbox allowing using VZ NAT networking.

VZ NAT is bridged networking which does not require root permission.

More information about VZ NAT for downstream Lima can be found here https://lima-vm.io/?file=docs/network.md