### PR TITLE
Add Restart Tray Button and Command

### DIFF
--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -101,6 +101,11 @@ interface MainEventNames {
   'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
 
   /**
+   * Emitted on application relaunch.
+   */
+  'relaunch'(): void;
+
+  /**
    * Emitted on application quit.  Note that at this point we're committed to
    * quitting.
    */

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -101,11 +101,6 @@ interface MainEventNames {
   'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
 
   /**
-   * Emitted on application relaunch.
-   */
-  'relaunch'(): void;
-
-  /**
    * Emitted on application quit.  Note that at this point we're committed to
    * quitting.
    */

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -95,8 +95,8 @@ export class Tray {
       label: 'Restart Rancher Desktop',
       type:  'normal',
       click() {
-        Electron.app.relaunch();
-        Electron.app.exit();
+        mainEvents.emit('relaunch');
+        mainEvents.emit('quit');
       }
     },
     {

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -91,6 +91,15 @@ export class Tray {
     },
     { type: 'separator' },
     {
+      id:    'restart',
+      label: 'Restart Rancher Desktop',
+      type:  'normal',
+      click() {
+        Electron.app.relaunch();
+        Electron.app.exit();
+      }
+    },
+    {
       label: 'Quit Rancher Desktop',
       role:  'quit',
       type:  'normal',

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -95,8 +95,8 @@ export class Tray {
       label: 'Restart Rancher Desktop',
       type:  'normal',
       click() {
-        mainEvents.emit('relaunch');
-        mainEvents.emit('quit');
+        Electron.app.relaunch();
+        Electron.app.quit();
       }
     },
     {

--- a/src/go/rdctl/cmd/restart.go
+++ b/src/go/rdctl/cmd/restart.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shutdown"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type restartSettingsStruct struct {
+	Verbose         bool
+	WaitForShutdown bool
+}
+
+// restartCmd represents the restart command
+var restartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the running Rancher Desktop application",
+	Long:  `Restart the running Rancher Desktop application.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := cobra.NoArgs(cmd, args); err != nil {
+			return err
+		}
+		if commonShutdownSettings.Verbose {
+			logrus.SetLevel(logrus.TraceLevel)
+		}
+		cmd.SilenceUsage = true
+		result, err := doShutdown(&commonShutdownSettings, shutdown.Shutdown)
+		if err != nil {
+			return err
+		}
+		if result != nil {
+			fmt.Println(string(result))
+		}
+		return doStartOrSetCommand(cmd)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(restartCmd)
+	restartCmd.Flags().BoolVar(&commonShutdownSettings.Verbose, "verbose", false, "be verbose")
+	restartCmd.Flags().BoolVar(&commonShutdownSettings.WaitForShutdown, "wait", true, "wait for restart to be confirmed")
+	restartCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "path to main executable")
+	restartCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "avoid displaying dialog boxes")
+}

--- a/src/go/rdctl/cmd/restart.go
+++ b/src/go/rdctl/cmd/restart.go
@@ -24,9 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-var restartVerbose bool
-
 // restartCmd represents the restart command
 var restartCmd = &cobra.Command{
 	Use:   "restart",
@@ -36,14 +33,12 @@ var restartCmd = &cobra.Command{
 		if err := cobra.NoArgs(cmd, args); err != nil {
 			return err
 		}
-		if restartVerbose {
+		if commonShutdownSettings.Verbose {
 			logrus.SetLevel(logrus.TraceLevel)
 		}
+		commonShutdownSettings.WaitForShutdown = true
 		cmd.SilenceUsage = true
-		result, err := doShutdown(&shutdownSettingsStruct{
-			Verbose:         restartVerbose,
-			WaitForShutdown: true,
-		}, shutdown.Shutdown)
+		result, err := doShutdown(&commonShutdownSettings, shutdown.Shutdown)
 		if err != nil {
 			return err
 		}
@@ -56,7 +51,7 @@ var restartCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(restartCmd)
-	restartCmd.Flags().BoolVar(&restartVerbose, "verbose", false, "be verbose")
+	restartCmd.Flags().BoolVar(&commonShutdownSettings.Verbose, "verbose", false, "be verbose")
 	restartCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "path to main executable")
 	restartCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "avoid displaying dialog boxes")
 }

--- a/src/go/rdctl/cmd/restart.go
+++ b/src/go/rdctl/cmd/restart.go
@@ -24,10 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type restartSettingsStruct struct {
-	Verbose         bool
-	WaitForShutdown bool
-}
+
+var restartVerbose bool
 
 // restartCmd represents the restart command
 var restartCmd = &cobra.Command{
@@ -38,11 +36,14 @@ var restartCmd = &cobra.Command{
 		if err := cobra.NoArgs(cmd, args); err != nil {
 			return err
 		}
-		if commonShutdownSettings.Verbose {
+		if restartVerbose {
 			logrus.SetLevel(logrus.TraceLevel)
 		}
 		cmd.SilenceUsage = true
-		result, err := doShutdown(&commonShutdownSettings, shutdown.Shutdown)
+		result, err := doShutdown(&shutdownSettingsStruct{
+			Verbose:         restartVerbose,
+			WaitForShutdown: true,
+		}, shutdown.Shutdown)
 		if err != nil {
 			return err
 		}
@@ -55,8 +56,7 @@ var restartCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(restartCmd)
-	restartCmd.Flags().BoolVar(&commonShutdownSettings.Verbose, "verbose", false, "be verbose")
-	restartCmd.Flags().BoolVar(&commonShutdownSettings.WaitForShutdown, "wait", true, "wait for restart to be confirmed")
+	restartCmd.Flags().BoolVar(&restartVerbose, "verbose", false, "be verbose")
 	restartCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "path to main executable")
 	restartCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "avoid displaying dialog boxes")
 }


### PR DESCRIPTION
## Motivation

The motivation behind the proposed changes is to address the frequent occurrence of crashes, particularly for people living with experimental features regularly. Currently, when crashes happen, users commonly resort to using the command `rdctl shutdown --wait && rdctl start` to restart quickly. However, this approach is not ideal in terms of user experience and efficiency. To enhance the user experience and provide a more convenient solution for restarting after crashes, the addition of a restart button on the tray menu and a corresponding `rdctl` command line option is proposed.

## Changes Made

The following changes will be implemented:

1. **Tray Menu Restart Button:** A restart button will be added to the tray menu of the application specifically for edgerunners who live with experimental features regularly. This button will provide users with a direct and accessible option to restart the application in the event of a crash. Clicking on this button will initiate the restart process, eliminating the need for users to manually enter command line instructions.

2. **rdctl Command Line Enhancement:** A new command line option, `rdctl restart`, will be introduced. This option will streamline the process of restarting the application through the command line interface. Users will be able to simply execute `rdctl restart` instead of the existing, more complex `rdctl shutdown --wait && rdctl start` sequence. This change will make the restart process more intuitive and efficient for command line users.