### PR TITLE
Check for test environment using `RD_TEST` instead of `NODE_ENV`

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -305,7 +305,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       this.emit('progress');
     });
 
-    if (!(process.env.NODE_ENV ?? '').includes('test')) {
+    if (!(process.env.RD_TEST ?? '').includes('e2e')) {
       process.on('exit', async() => {
         // Attempt to shut down any stray qemu processes.
         await this.lima('stop', '--force', MACHINE_NAME);

--- a/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
+++ b/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
@@ -1,5 +1,7 @@
 import { DiagnosticsCategory, DiagnosticsChecker } from './types';
 
+import { isDevEnv } from '@pkg/utils/environment';
+
 /**
  * Sample tests for testing
  */
@@ -15,10 +17,7 @@ class CheckTesting implements DiagnosticsChecker {
 
   category = DiagnosticsCategory.Testing;
   applicable(): Promise<boolean> {
-    const isDevEnv = /^dev/i.test(process.env.NODE_ENV ?? '');
-    const isE2ETest = /^e2e/i.test(process.env.RD_TEST ?? '');
-
-    return Promise.resolve((isDevEnv || isE2ETest) && !process.env.RD_MOCK_FOR_SCREENSHOTS);
+    return Promise.resolve(isDevEnv && !process.env.RD_MOCK_FOR_SCREENSHOTS);
   }
 
   check() {

--- a/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
+++ b/pkg/rancher-desktop/main/diagnostics/testCheckers.ts
@@ -15,7 +15,10 @@ class CheckTesting implements DiagnosticsChecker {
 
   category = DiagnosticsCategory.Testing;
   applicable(): Promise<boolean> {
-    return Promise.resolve(/^dev|test/i.test(process.env.NODE_ENV ?? '') && !process.env.RD_MOCK_FOR_SCREENSHOTS);
+    const isDevEnv = /^dev/i.test(process.env.NODE_ENV ?? '');
+    const isE2ETest = /^e2e/i.test(process.env.RD_TEST ?? '');
+
+    return Promise.resolve((isDevEnv || isE2ETest) && !process.env.RD_MOCK_FOR_SCREENSHOTS);
   }
 
   check() {

--- a/pkg/rancher-desktop/utils/environment.ts
+++ b/pkg/rancher-desktop/utils/environment.ts
@@ -3,4 +3,7 @@
  * @returns True if Rancher Desktop is running in a development or test
  * environment
  */
-export const isDevEnv = /^(?:dev|test)/i.test(process.env.NODE_ENV || '');
+const isDev = /^(?:dev|test)/i.test(process.env.NODE_ENV || '');
+const isE2E = /^e2e/i.test(process.env.RD_TEST ?? '');
+
+export const isDevEnv = isDev || isE2E;

--- a/pkg/rancher-desktop/utils/logging.ts
+++ b/pkg/rancher-desktop/utils/logging.ts
@@ -197,7 +197,7 @@ export default new Proxy<Module>({}, {
  * the system, so that logs from another instance are not deleted.
  */
 export function clearLoggingDirectory(): void {
-  if (process.env.NODE_ENV === 'test' || process.type !== 'browser') {
+  if (process.env.RD_TEST === 'e2e' || process.type !== 'browser') {
     return;
   }
 

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -104,7 +104,6 @@ class E2ETestRunner extends events.EventEmitter {
       if (Object.keys(deploymentProfiles.defaults).length > 0 || Object.keys(deploymentProfiles.locked).length > 0) {
         throw new Error("Trying to run e2e tests with existing deployment profiles isn't supported.");
       }
-      process.env.NODE_ENV = 'test';
       process.env.RD_TEST = 'e2e';
 
       // Set feature flags

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -30,7 +30,10 @@ export default {
    * Determine if we are building for a development build.
    */
   get isDevelopment() {
-    return /^(?:dev|test)/.test(process.env.NODE_ENV ?? '');
+    const isDevEnv = /^dev/i.test(process.env.NODE_ENV ?? '');
+    const isE2ETest = /^e2e/i.test(process.env.RD_TEST ?? '');
+
+    return isDevEnv || isE2ETest;
   },
 
   get serial() {

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -15,6 +15,7 @@ import _ from 'lodash';
 import tar from 'tar-stream';
 import webpack from 'webpack';
 
+import { isDevEnv } from '@pkg/utils/environment';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 import babelConfig from 'babel.config';
 
@@ -30,10 +31,7 @@ export default {
    * Determine if we are building for a development build.
    */
   get isDevelopment() {
-    const isDevEnv = /^dev/i.test(process.env.NODE_ENV ?? '');
-    const isE2ETest = /^e2e/i.test(process.env.RD_TEST ?? '');
-
-    return isDevEnv || isE2ETest;
+    return isDevEnv;
   },
 
   get serial() {


### PR DESCRIPTION
This change supports #5287 by updating environment variable checks by replacing checks for a value or `test` in `NODE_ENV` with a check for `e2e` in `RD_TEST`.

In addition to removing nuxt, #5287 transitions the project to webpack 5, which changes how `mode` behaves[^1]. To avoid conflicts with the default `mode` behavior and `NODE_ENV`, we can now rely on testing the `RD_TEST` environment variable.

[^1]:https://webpack.js.org/configuration/mode/#usage