### PR TITLE
SortableTable: Add padding to show box shadow on top

### DIFF
--- a/pkg/rancher-desktop/components/SortableTable/index.vue
+++ b/pkg/rancher-desktop/components/SortableTable/index.vue
@@ -1284,7 +1284,7 @@ $spacing: 10px;
 }
 
 .fixed-header-actions {
-  padding: 0 0 20px 0;
+  padding: 1px 0 20px 0;
   width: 100%;
   z-index: z-index('fixedTableHeader');
   background: transparent;


### PR DESCRIPTION
Add padding to show the box shadow on top of the filter input field.

Before:
![Screenshot_2023-08-18_15-36-51](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/9a8a86cc-64d0-43a2-a541-7ed5dafe5934)

After:
![Screenshot_2023-08-18_15-37-21](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/0713798b-1e0c-474d-9cc2-7b4143e9e5ca)

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3175