### PR TITLE
Add bats test for container published ports

### DIFF
--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -1,0 +1,45 @@
+load '../helpers/load'
+
+skip_unless_host_ip() {
+    if using_windows_exe; then
+        HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL)' | grep -Po 'IP Address:\s+\K[\d.]+')
+    else
+        # TODO determine if the Lima VM has its own IP address
+        HOST_IP=""
+    fi
+    if [[ -z $HOST_IP ]]; then
+        skip "Test requires a routable host ip address"
+    fi
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start container engine' {
+    start_container_engine
+    wait_for_container_engine
+}
+
+run_container_with_published_port() {
+    local container_image="nginx"
+    ctrctl pull "$container_image"
+    ctrctl run -d -p "$@" --restart=no "$container_image"
+}
+
+verify_container_published_port() {
+    run try --max 9 --delay 10 curl --insecure --silent --show-error "$@"
+    assert_success
+    assert_output --partial 'Welcome to nginx!'
+}
+
+@test 'container published port binding on localhost' {
+    run_container_with_published_port "127.0.0.1:8080:80"
+    verify_container_published_port "http://127.0.0.1:8080"
+}
+
+@test 'container published port binding on 0.0.0.0' {
+    skip_unless_host_ip
+    run_container_with_published_port "8081:80"
+    verify_container_published_port "http://$HOST_IP:8081"
+}

--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -1,17 +1,5 @@
 load '../helpers/load'
 
-skip_unless_host_ip() {
-    if using_windows_exe; then
-        HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL)' | grep -Po 'IP Address:\s+\K[\d.]+')
-    else
-        # TODO determine if the Lima VM has its own IP address
-        HOST_IP=""
-    fi
-    if [[ -z $HOST_IP ]]; then
-        skip "Test requires a routable host ip address"
-    fi
-}
-
 @test 'factory reset' {
     factory_reset
 }
@@ -22,9 +10,8 @@ skip_unless_host_ip() {
 }
 
 run_container_with_published_port() {
-    local container_image="nginx"
-    ctrctl pull "$container_image"
-    ctrctl run -d -p "$@" --restart=no "$container_image"
+    ctrctl pull "$IMAGE_NGINX"
+    ctrctl run -d -p "$@" --restart=no "$IMAGE_NGINX"
 }
 
 verify_container_published_port() {
@@ -41,5 +28,5 @@ verify_container_published_port() {
 @test 'container published port binding on 0.0.0.0' {
     skip_unless_host_ip
     run_container_with_published_port "8081:80"
-    verify_container_published_port "http://$HOST_IP:8081"
+    verify_container_published_port "http://${HOST_IP}:8081"
 }

--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -20,12 +20,18 @@ verify_container_published_port() {
     assert_output --partial 'Welcome to nginx!'
 }
 
-@test 'container published port binding on localhost' {
+@test 'container published port binding to localhost' {
     run_container_with_published_port "127.0.0.1:8080:80"
     verify_container_published_port "http://127.0.0.1:8080"
 }
 
-@test 'container published port binding on 0.0.0.0' {
+@test 'container published port binding to localhost should not be accessible via 0.0.0.0' {
+    skip_unless_host_ip
+    run curl --head "http://${HOST_IP}:8080"
+    assert_output --partial "curl: (7) Failed to connect"
+}
+
+@test 'container published port binding to 0.0.0.0' {
     skip_unless_host_ip
     run_container_with_published_port "8081:80"
     verify_container_published_port "http://${HOST_IP}:8081"

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -245,3 +245,15 @@ take_screenshot() {
         fi
     fi
 }
+
+skip_unless_host_ip() {
+    if using_windows_exe; then
+        HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL)' | grep -Po 'IP Address:\s+\K[\d.]+')
+    else
+        # TODO determine if the Lima VM has its own IP address
+        HOST_IP=""
+    fi
+    if [[ -z $HOST_IP ]]; then
+        skip "Test requires a routable host ip address"
+    fi
+}

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -15,18 +15,6 @@ local_setup() {
     needs_port 80
 }
 
-skip_unless_host_ip() {
-    if using_windows_exe; then
-        HOST_IP=$(netsh.exe interface ip show addresses 'vEthernet (WSL)' | grep -Po 'IP Address:\s+\K[\d.]+')
-    else
-        # TODO determine if the Lima VM has its own IP address
-        HOST_IP=""
-    fi
-    if [[ -z $HOST_IP ]]; then
-        skip "Test requires a routable host ip address"
-    fi
-}
-
 assert_traefik_pods_are_down() {
     run kubectl get --all-namespaces pods
 


### PR DESCRIPTION
This test case covers the following scenarios when the container port is published `-p`:

1) Published port is bound to localhost.
2) Published port is bound to 0.0.0.0.

The test is not using the following approach to switch the container engine since the following approach is currently causing failure (also, this is the root cause of the failure in `switch-engine.bats` and requires investigation):

```
rdctl set --container-engine.name=engine_name
wait_for_container_engine
```

Therefore, to run the test for multiple container engines `RD_CONTAINER_ENGINE` environment variable should be used. 