### PR TITLE
When checking for duplicate strings, map all white-space-only strings to one member.

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -68,6 +68,18 @@ verify_no_nginx() {
     try --max 18 --delay 10 verify_no_nginx
 }
 
+@test 'complain about duplicate whitespace in string-list properties' {
+    run rdctl api -X PUT settings --body '{"containerEngine": {"allowedImages": {"patterns": ["c-stub", " ", "d-stub", "    ", "e-stub", ""] }}}'
+    assert_failure
+    assert_output --partial 'field "containerEngine.allowedImages.patterns" has duplicate entries:'
+    refute_output --partial stub
+
+    run rdctl api -X PUT settings --body '{"experimental": {"virtualMachine": {"proxy": {"noproxy": ["c-stub", " ", "d-stub", "    ", "e-stub", ""] }}}}'
+    assert_failure
+    assert_output --partial 'field "experimental.virtualMachine.proxy.noproxy" has duplicate entries:'
+    refute_output --partial stub
+}
+
 @test 'set patterns with the allowed list disabled' {
     update_allowed_patterns false "$IMAGE_NGINX" "$IMAGE_BUSYBOX" "$IMAGE_RUBY"
     # containerEngine.allowedImages.enabled changed, so wait for a restart

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -446,6 +446,38 @@ describe(SettingsValidator, () => {
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "pattern1", "Pattern2"'],
       });
     });
+    it('complains about multiple duplicates that contain only whitespace lengths', () => {
+      const input: RecursivePartial<settings.Settings> = {
+        containerEngine: {
+          allowedImages: {
+            enabled:  true,
+            patterns: ['pattern1', '  ', 'pattern2', '\t', 'pattern3', ''],
+          },
+        },
+      };
+      const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+
+      expect({ needToUpdate, errors }).toEqual({
+        needToUpdate: false,
+        errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "", "\t", "  "'],
+      });
+    });
+    it('allows exactly one whitespace value', () => {
+      const input: RecursivePartial<settings.Settings> = {
+        containerEngine: {
+          allowedImages: {
+            enabled:  true,
+            patterns: ['pattern1', 'pattern2', '\t', 'pattern3'],
+          },
+        },
+      };
+      const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+
+      expect({ needToUpdate, errors }).toEqual({
+        needToUpdate: true,
+        errors:       [],
+      });
+    });
   });
 
   describe('locked fields', () => {

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -513,18 +513,25 @@ export default class SettingsValidator {
   }
 
   protected findDuplicates(list: string[]): string[] {
+    let whiteSpaceMembers = [];
     const firstInstance = new Set<string>();
     const duplicates = new Set<string>();
+    const isWhiteSpaceRE = /^\s*$/;
 
     for (const member of list) {
-      if (!firstInstance.has(member)) {
+      if (isWhiteSpaceRE.test(member)) {
+        whiteSpaceMembers.push(member);
+      } else if (!firstInstance.has(member)) {
         firstInstance.add(member);
       } else {
         duplicates.add(member);
       }
     }
+    if (whiteSpaceMembers.length === 1) {
+      whiteSpaceMembers = [];
+    }
 
-    return Array.from(duplicates);
+    return Array.from(duplicates).concat(whiteSpaceMembers);
   }
 
   protected checkInstalledExtensions(


### PR DESCRIPTION
Fixes #5381

If there is more than one white-space string in a list, give an error message listing them; they don't have to be all identical.

This is an issue for `containerEngine.allowedImages.patterns` when set via the API only, as the UI uses a widget that doesn't pass white-space strings to the API.

The UI for `experimental.virtualMachine.proxy.noproxy` can include white-space, so we need to catch it.