### PR TITLE
Reduced cpu and memory allocation to see how the CI handles the change

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,8 @@ task:
   container:
     image: ubuntu:20.04
     kvm: true # required for E2E/Integrations tests
-    cpu: 8
-    memory: 16G
+    cpu: 3
+    memory: 8G
   env:
     DEBIAN_FRONTEND: noninteractive
     CI: true


### PR DESCRIPTION
One of the measures to address #5345 . The idea of the PR is to observe if the reduced cpu and memory still lets us run the E2E tests without any hiccups. If it does, then we use the reduced cpu/memory as the base to confirm the required compute credits.  