### PR TITLE
Re-sign docker-credential-osxkeychain with a new ad-hoc signature

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -493,8 +493,10 @@ export class DockerProvidedCredHelpers implements Dependency, GitHubDependency {
       const expectedChecksum = await findChecksum(`${ baseURL }/checksums.txt`, fullBinName);
       const binName = context.platform.startsWith('win') ? `${ baseName }.exe` : baseName;
       const destPath = path.join(context.binDir, binName);
+      // starting with the 0.7.0 the upstream releases have a broken ad-hoc signature
+      const codesign = context.platform === 'darwin';
 
-      promises.push(download(sourceURL, destPath, { expectedChecksum } ));
+      promises.push(download(sourceURL, destPath, { expectedChecksum, codesign } ));
     }
 
     await Promise.all(promises);

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -2,7 +2,7 @@
  * Helpers for downloading files.
  */
 
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
@@ -19,6 +19,8 @@ export type DownloadOptions = {
   overwrite?: boolean;
   // The file mode required.
   access?: number;
+  // The file needs a new ad-hoc signature.
+  codesign?: boolean;
 };
 
 export type ArchiveDownloadOptions = DownloadOptions & {
@@ -101,6 +103,14 @@ export async function download(url: string, destPath: string, options: DownloadO
         console.error(ex);
       }
     }
+  }
+
+  if (options.codesign) {
+    spawnSync(
+      'codesign',
+      ['--force', '--sign', '-', destPath],
+      { stdio: 'inherit' },
+    );
   }
 }
 


### PR DESCRIPTION
The signature from upstream has been broken since the 0.7.0 release.

This is only relevant for local development and for CI builds; for release builds we resign the binary with a proper developer signature anyways.

Fixes #3171