### PR TITLE
Do not activate extension parent item when child selected

### DIFF
--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -135,7 +135,13 @@ export default {
       // It is needed e.g. for sub-route /images/add not matching /Images
       const nuxt: NuxtApp = (this as any).$nuxt;
 
-      return nuxt.$route.path.split('/')[1] === route.substring(1).toLowerCase();
+      // Prevents the parent item "Extensions" to be shown as active if an extension child (e.g. Epinio, Logs Explorer,
+      // ...) is selected.
+      if (nuxt.$route.name !== 'rdx-root-src-id') {
+        return nuxt.$route.path.split('/')[1] === route.substring(1).toLowerCase();
+      }
+
+      return false;
     },
   },
 };


### PR DESCRIPTION
Do not activate the parent navigation item "Extensions" if one of the actual extensions (e.g. Epinio, Logs Explorer, ...) is selected.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5367