### PR TITLE
Fix issue with `undefined` environment variables in build scripts

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -60,6 +60,7 @@ class Builder {
 
   async build() {
     console.log('Building...');
+    buildUtils.isDevelopment = false;
     await this.buildRenderer();
     await buildUtils.buildPreload();
     await buildUtils.buildMain();

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -15,7 +15,6 @@ import _ from 'lodash';
 import tar from 'tar-stream';
 import webpack from 'webpack';
 
-import { isDevEnv } from '@pkg/utils/environment';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 import babelConfig from 'babel.config';
 
@@ -30,9 +29,7 @@ export default {
   /**
    * Determine if we are building for a development build.
    */
-  get isDevelopment() {
-    return isDevEnv;
-  },
+  isDevelopment: true,
 
   get serial() {
     return process.argv.includes('--serial');
@@ -175,7 +172,7 @@ export default {
         ],
       },
       plugins: [
-        new webpack.EnvironmentPlugin({ NODE_ENV: process.env.NODE_ENV || 'production' }),
+        new webpack.EnvironmentPlugin({ NODE_ENV: mode }),
       ],
     };
   },


### PR DESCRIPTION
This PR addresses an issue where environment variables can be undefined while running project scripts.

## Context

This fixes a regression introduced in #5358

It became clear that there were issues with how we were consuming environment variables that are set via scripts while investigating issues with e2e tests in #5287. Ultimately, this issue involves `isDevEnv` of `pkg/rancher-desktop/utils/environment.ts` accessing environment variables during import before they are assigned further down. This can cause conflicts with mode and NODE_ENV, which Webpack 5 (used in the nuxt removal) is more strict about.

This behavior can be confirmed by adding some console statements [^1] in `pkg/rancher-desktop/utils/environment.ts` to validate the values before and after this change.

[^1]: Console statement used `console.log({ isDev, isE2E, NODE_ENV: process.env.NODE_ENV, RD_TEST: process.env.RD_TEST });`

close #5416