### PR TITLE
Stop skipping the getTags tests because registry.opensuse.org is back

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/__tests__/registry.spec.ts
+++ b/pkg/rancher-desktop/backend/containerClient/__tests__/registry.spec.ts
@@ -18,11 +18,7 @@ describe('Headers', () => {
   });
 });
 
-/***
- * Skipping these tests while the registry is down for migration
- * TODO: Re-enable these tests rancher-sandbox/rancher-desktop/issues/5390
- */
-describe.skip('DockerRegistry', () => {
+describe('DockerRegistry', () => {
   describe('getTags', () => {
     it('should get tags from unauthenticated registry', async() => {
       const reference = 'registry.opensuse.org/opensuse/leap';


### PR DESCRIPTION
The test was temporarily skipped in #5392 while the registry was moved to a different data center.

Fixes #5391