### PR TITLE
BATS: fix profile tests

### DIFF
--- a/bats/tests/profile/create-profile-output.bats
+++ b/bats/tests/profile/create-profile-output.bats
@@ -213,8 +213,8 @@ assert_check_registry_output() {
     assert_success
 
     # We need to formulate /tmp as a directory both sides can see.
-    bashSideTemp=$(wslpath -a /tmp)           # e.g.: /mnt/c/tmp
-    winSideTemp=$(wslpath -w "$bashSideTemp") # c:\tmp
+    winSideTemp=$(wslpath -a -m /tmp)            # //wsl$/distro/tmp
+    bashSideTemp=$(wslpath -a -u "$winSideTemp") # /tmp
     testFile=test.reg
     salt=$$
     # Can't write into ...\Policies\ as non-administrator, so populate a different directory.
@@ -238,7 +238,7 @@ assert_check_registry_output() {
     if ! is_windows; then
         skip "Test requires the reg utility and only works on Windows"
     fi
-    run rdctl create-profile --output reg --hive=HKCU --type=defaults --input <(json_with_special_chars)
+    run rdctl create-profile --output reg --hive=HKCU --type=defaults --input - <<<"$(json_with_special_chars)"
     assert_check_registry_output
 }
 

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -24,8 +24,10 @@ local_teardown_file() {
     start_kubernetes
     # Don't do wait_for_container_engine because RD will shut down in the middle
     # and the function will take a long time to time out making futile queries.
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
-    try --max 2 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Locked kubernetes version 'NattyBo' isn't a valid version"
+    # The app should exit gracefully; after that we can check for contents.
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited cleanly."
+    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    assert_file_contains "$PATH_LOGS/background.log" "Locked kubernetes version 'NattyBo' isn't a valid version"
 }
 
 @test 'recreate profile with a valid k8s version' {
@@ -37,6 +39,8 @@ local_teardown_file() {
     # Have to set the version field or RD will think we're trying to change a locked field.
     RD_KUBERNETES_PREV_VERSION=v1.27.2
     start_kubernetes
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
-    try --max 2 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "field 'kubernetes.version' is locked"
+    # The app should exit gracefully; after that we can check for contents.
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited cleanly."
+    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    assert_file_contains "$PATH_LOGS/background.log" 'field "kubernetes.version" is locked'
 }


### PR DESCRIPTION
- How we got a WSL/Win32 path mapping was incorrect (it aborted)
- Passing around non-standard fds to children didn't work
- Fix up how we scrape logs on exit (and the change in quoting).