### PR TITLE
Emit event when an unsupported extension is uninstalled

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -557,6 +557,10 @@ ipcMainProxy.handle('settings-write', (event, arg) => {
 
 mainEvents.on('settings-write', writeSettings);
 
+mainEvents.on('extensions/ui/uninstall', (id) => {
+  window.send('ok:extensions/uninstall', id);
+});
+
 ipcMainProxy.on('extensions/open', (_event, id, path) => {
   window.openExtension(id, path);
 });

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -251,6 +251,7 @@ export class ExtensionManagerImpl implements ExtensionManager {
         // If this extension is explicitly not supported, don't re-install it.
         console.log(`Uninstalling unsupported extension ${ repo }:${ tag }`);
         mainEvents.emit('settings-write', { application: { extensions: { installed: { [repo]: undefined } } } });
+        mainEvents.emit('extensions/ui/uninstall', repo);
         continue;
       }
 

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -101,6 +101,12 @@ interface MainEventNames {
   'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
 
   /**
+   * Emitted when an extension is uninstalled via the extension manager.
+   * @param id The ID of the extension that was uninstalled.
+   */
+  'extensions/ui/uninstall'(id: string): void;
+
+  /**
    * Emitted on application quit.  Note that at this point we're committed to
    * quitting.
    */


### PR DESCRIPTION
This introduces a new main event that can be used to relay to the UI that an extension has been uninstalled because it is unsupported after changing container engines.

closes #5428 