### PR TITLE
Use "$IMAGE_BUSYBOX" instead of "alpine" image

### DIFF
--- a/bats/tests/containers/host-connectivity.bats
+++ b/bats/tests/containers/host-connectivity.bats
@@ -26,7 +26,7 @@ skip_on_legacy_networking() {
 
 verify_host_connectivity() {
     skip_on_legacy_networking
-    run ctrctl run --rm alpine ping -c 5 "$1"
+    run ctrctl run --rm "$IMAGE_BUSYBOX" timeout -s INT 10 ping -c 5 "$1"
     assert_success
     assert_output --partial "5 packets transmitted, 5 packets received, 0% packet loss"
 }


### PR DESCRIPTION
We don't have "alpine" in the ghcr.io mirror, but we can just use "busybox" instead.

Also make sure `ping` terminates; it can potentially hang until it receives a SIGINT.