### PR TITLE
`vee-validate` experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "tar-stream": "3.0.0",
     "utf-8-validate": "6.0.3",
     "v-tooltip": "2.1.3",
+    "vee-validate": "3",
     "vue": "2.6.14",
     "vue-js-modal": "2.0.1",
     "vue-router": "3.6.5",

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -32,6 +32,11 @@ export default Vue.extend({
       kubernetesPort:     6443,
       versions:           [] as VersionEntry[],
       cachedVersionsOnly: false,
+      rules:              {
+        name:  'k8s_port',
+        rule:  'required',
+        error: 'Kubernetes port is required',
+      },
     };
   },
   computed: {
@@ -152,6 +157,7 @@ export default Vue.extend({
         :disabled="isKubernetesDisabled"
         :value="preferences.kubernetes.port"
         :is-locked="isPreferenceLocked('kubernetes.port')"
+        :rules="rules"
         @input="onChange('kubernetes.port', castToNumber($event.target.value))"
       />
     </rd-fieldset>

--- a/pkg/rancher-desktop/components/RdInput.vue
+++ b/pkg/rancher-desktop/components/RdInput.vue
@@ -1,10 +1,16 @@
 <script lang="ts">
+import { ValidationProvider } from 'vee-validate';
 import Vue from 'vue';
 
 export default Vue.extend({
   name:         'rd-input',
+  components:   { ValidationProvider },
   inheritAttrs: false,
   props:        {
+    rules: {
+      type:    [String, Object],
+      default: null,
+    },
     value: {
       type:    [String, Number],
       default: null,
@@ -22,25 +28,39 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div class="rd-input-container">
-    <input
-      :value="value"
-      :class="{ 'locked' : isLocked && !$attrs.disabled }"
-      :disabled="$attrs.disabled || isLocked"
-      v-bind="$attrs"
-      v-on="$listeners"
-    />
-    <slot name="after">
-      <i
-        v-if="isLocked"
-        v-tooltip="{
-          content: tooltip || t('preferences.locked.tooltip'),
-          placement: 'right'
-        }"
-        class="icon icon-lock"
+  <ValidationProvider
+    v-slot="v"
+    :name="rules.name"
+    slim
+    :rules="rules.rule"
+    class="validation"
+  >
+    <div class="rd-input-container">
+      <input
+        :value="value"
+        :class="{ 'locked' : isLocked && !$attrs.disabled }"
+        :disabled="$attrs.disabled || isLocked"
+        v-bind="$attrs"
+        v-on="$listeners"
       />
-    </slot>
-  </div>
+      <slot name="after">
+        <i
+          v-if="isLocked"
+          v-tooltip="{
+            content: tooltip || t('preferences.locked.tooltip'),
+            placement: 'right'
+          }"
+          class="icon icon-lock"
+        />
+        <span
+          v-if="!v.valid && !v.untouched"
+          class="errors"
+        >
+          {{ rules.error }}
+        </span>
+      </slot>
+    </div>
+  </ValidationProvider>
 </template>
 
 <style lang="scss" scoped>
@@ -56,5 +76,8 @@ export default Vue.extend({
         color: var(--input-locked-text);
       }
     }
+  }
+  .errors {
+    color: var(--error);
   }
 </style>

--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -1,15 +1,21 @@
 <script lang="ts">
+import { ValidationObserver } from 'vee-validate';
 import Vue from 'vue';
 
 import LabeledBadge from '@pkg/components/form/LabeledBadge.vue';
 import TooltipIcon from '@pkg/components/form/TooltipIcon.vue';
+
 /**
  * Groups several controls as well as labels
  */
 export default Vue.extend({
   name:       'rd-fieldset',
-  components: { TooltipIcon, LabeledBadge },
-  props:      {
+  components: {
+    TooltipIcon,
+    LabeledBadge,
+    ValidationObserver,
+  },
+  props: {
     legendText: {
       type:    String,
       default: '',
@@ -42,39 +48,44 @@ export default Vue.extend({
 </script>
 
 <template>
-  <fieldset class="rd-fieldset">
-    <legend>
-      <slot name="legend">
-        <span>{{ legendText }}</span>
-        <labeled-badge
-          v-if="badgeText"
-          :text="badgeText"
-        />
-        <tooltip-icon
-          v-if="isExperimental"
-        />
-        <i
-          v-if="isLocked"
-          v-tooltip="{
-            content: lockedTooltip,
-            placement: 'right'
-          }"
-          class="icon icon-lock"
-        />
-        <i
-          v-else-if="legendTooltip"
-          v-tooltip="legendTooltip"
-          class="icon icon-info-circle icon-lg"
-        />
+  <ValidationObserver
+    ref="validator"
+    slim
+  >
+    <fieldset class="rd-fieldset">
+      <legend>
+        <slot name="legend">
+          <span>{{ legendText }}</span>
+          <labeled-badge
+            v-if="badgeText"
+            :text="badgeText"
+          />
+          <tooltip-icon
+            v-if="isExperimental"
+          />
+          <i
+            v-if="isLocked"
+            v-tooltip="{
+              content: lockedTooltip,
+              placement: 'right'
+            }"
+            class="icon icon-lock"
+          />
+          <i
+            v-else-if="legendTooltip"
+            v-tooltip="legendTooltip"
+            class="icon icon-info-circle icon-lg"
+          />
+        </slot>
+      </legend>
+      <slot
+        name="default"
+        :is-locked="isLocked"
+      >
+        <!-- Slot content -->
       </slot>
-    </legend>
-    <slot
-      name="default"
-      :is-locked="isLocked"
-    >
-      <!-- Slot content -->
-    </slot>
-  </fieldset>
+    </fieldset>
+  </ValidationObserver>
 </template>
 
 <style lang="scss" scoped>

--- a/pkg/rancher-desktop/nuxt.config.js
+++ b/pkg/rancher-desktop/nuxt.config.js
@@ -66,6 +66,7 @@ export default {
     '~/plugins/directives',
     '~/plugins/clean-html-directive',
     { src: '~/plugins/extend-router' },
+    '~/plugins/vee-validate',
   ],
   router: {
     mode:          'hash',

--- a/pkg/rancher-desktop/plugins/vee-validate.js
+++ b/pkg/rancher-desktop/plugins/vee-validate.js
@@ -1,0 +1,14 @@
+import { extend as veeExtend } from 'vee-validate';
+import * as veeRules from 'vee-validate/dist/rules';
+
+function extend(rule) {
+  const veeRule = (veeRules || [])[rule];
+
+  veeExtend(rule, {
+    ...veeRule,
+    params:  ['message'],
+    message: '{message}'
+  });
+}
+
+extend('required');

--- a/yarn.lock
+++ b/yarn.lock
@@ -20085,6 +20085,11 @@ vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vee-validate@3:
+  version "3.4.15"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.4.15.tgz#d1b2fe2120d28bd833efadce15d73b482f6f7bcb"
+  integrity sha512-qEtvq9X2N7l5pjBe/6YGrrIBHxJA4KTrb3QrER3qzM7fzkH730m8LyVWMIzM47l//618nlUa7VvTdMFTRKr8tQ==
+
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"


### PR DESCRIPTION
Related Issue: https://github.com/rancher/dashboard/issues/8365

This is an example of `vee-validate` used as Form validator in preferences dialog.

### How to test ###

- Go to Preferences -> Kubernetes tab
- Try to assign a `null` value into 'Kubernetes Port' field