### PR TITLE
Revert back to cgroup v1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,6 +1,6 @@
 limaAndQemu: 1.31.2
 alpineLimaISO:
-  isoVersion: 0.2.31.rd5
+  isoVersion: 0.2.31.rd4
   alpineVersion: 3.18.0
 WSLDistro: "0.46"
 kuberlr: 0.4.2


### PR DESCRIPTION
While it seems like switching to v2 solves an issue with `buildkit`, it also creates a bunch of regressions with `k3d` and the `rancher/rancher` docker image and breaks compatibility with `k3s` versions before `1.20`.