### PR TITLE
Switch to cgroup v2 for extension BATS tests on Lima

### DIFF
--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -47,6 +47,20 @@ check_extension_installed() { # refute, name
 
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'switch to cgroup v2' {
+    # TODO TODO TODO This is a workaround because #5363 hasn't been fixed yet
+    if is_windows; then
+        skip "Skipped because switching cgroup layout is not needed on Windows"
+    fi
+    wait_for_shell
+    rdctl shell sudo sed -E -i 's/#(rc_cgroup_mode).*/\1="unified"/' /etc/rc.conf
+    rdctl shutdown
+    RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'wait for container engine' {
     wait_for_container_engine
 }
 

--- a/bats/tests/extensions/containers.bats
+++ b/bats/tests/extensions/containers.bats
@@ -26,6 +26,20 @@ encoded_id() { # variant
 
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'switch to cgroup v2' {
+    # TODO TODO TODO This is a workaround because #5363 hasn't been fixed yet
+    if is_windows; then
+        skip "Skipped because switching cgroup layout is not needed on Windows"
+    fi
+    wait_for_shell
+    rdctl shell sudo sed -E -i 's/#(rc_cgroup_mode).*/\1="unified"/' /etc/rc.conf
+    rdctl shutdown
+    RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'wait for container engine' {
     wait_for_container_engine
 }
 

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -36,6 +36,20 @@ encoded_id() { # variant
 
 @test 'start container engine' {
     RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'switch to cgroup v2' {
+    # TODO TODO TODO This is a workaround because #5363 hasn't been fixed yet
+    if is_windows; then
+        skip "Skipped because switching cgroup layout is not needed on Windows"
+    fi
+    wait_for_shell
+    rdctl shell sudo sed -E -i 's/#(rc_cgroup_mode).*/\1="unified"/' /etc/rc.conf
+    rdctl shutdown
+    RD_ENV_EXTENSIONS=1 start_container_engine
+}
+
+@test 'wait for container engine' {
     wait_for_container_engine
 }
 


### PR DESCRIPTION
This is just a workaround until #5363 has been fixed. For that reason the hack has been duplicated into each file instead of abstracting it away in the helpers.