### PR TITLE
Stop looking for 'Child exited cleanly'.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -467,10 +467,8 @@ Electron.app.on('before-quit', async(event) => {
     await k8smanager?.stop();
 
     console.log(`2: Child exited cleanly.`);
-  } catch (ex) {
-    if (isK8sError(ex)) {
-      console.log(`2: Child exited with code ${ ex.errCode }`);
-    }
+  } catch (ex: any) {
+    console.log(`2: Child exited with code ${ isK8sError(ex) ? ex.errCode : (ex.errCode ?? '<unknown>') }`);
     handleFailure(ex);
   } finally {
     gone = true;

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -25,7 +25,8 @@ local_teardown_file() {
     # Don't do wait_for_container_engine because RD will shut down in the middle
     # and the function will take a long time to time out making futile queries.
     # The app should exit gracefully; after that we can check for contents.
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited"
+    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
     assert_file_contains "$PATH_LOGS/background.log" "Locked kubernetes version 'NattyBo' isn't a valid version"
 }
 
@@ -39,6 +40,7 @@ local_teardown_file() {
     RD_KUBERNETES_PREV_VERSION=v1.27.2
     start_kubernetes
     # The app should exit gracefully; after that we can check for contents.
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited"
+    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
     assert_file_contains "$PATH_LOGS/background.log" 'field "kubernetes.version" is locked'
 }

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -25,8 +25,7 @@ local_teardown_file() {
     # Don't do wait_for_container_engine because RD will shut down in the middle
     # and the function will take a long time to time out making futile queries.
     # The app should exit gracefully; after that we can check for contents.
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited cleanly."
-    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
     assert_file_contains "$PATH_LOGS/background.log" "Locked kubernetes version 'NattyBo' isn't a valid version"
 }
 
@@ -40,7 +39,6 @@ local_teardown_file() {
     RD_KUBERNETES_PREV_VERSION=v1.27.2
     start_kubernetes
     # The app should exit gracefully; after that we can check for contents.
-    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited cleanly."
-    assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
+    try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Error Starting Kubernetes"
     assert_file_contains "$PATH_LOGS/background.log" 'field "kubernetes.version" is locked'
 }


### PR DESCRIPTION
Fixes #5462