### PR TITLE
Disable "Add Image" button when preferences change

### DIFF
--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -67,14 +67,14 @@ export default {
   },
 
   watch: {
-    imageManagerState: {
+    state: {
       handler(state) {
         this.$store.dispatch(
           'page/setHeader',
           { title: this.t('images.title') },
         );
 
-        if (!state) {
+        if (!state || state === 'IMAGE_MANAGER_UNREADY') {
           return;
         }
 

--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -26,6 +26,11 @@ import Images from '@pkg/components/Images.vue';
 import { defaultSettings } from '@pkg/config/settings';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
+const ImageMangerStates = Object.freeze({
+  UNREADY: 'IMAGE_MANAGER_UNREADY',
+  READY:   'READY',
+});
+
 export default {
   components: { Images },
   data() {
@@ -40,10 +45,10 @@ export default {
   computed: {
     state() {
       if (![K8sState.STARTED, K8sState.DISABLED].includes(this.k8sState)) {
-        return 'IMAGE_MANAGER_UNREADY';
+        return ImageMangerStates.UNREADY;
       }
 
-      return this.imageManagerState ? 'READY' : 'IMAGE_MANAGER_UNREADY';
+      return this.imageManagerState ? ImageMangerStates.READY : ImageMangerStates.UNREADY;
     },
     rancherImages() {
       return this.images
@@ -74,7 +79,7 @@ export default {
           { title: this.t('images.title') },
         );
 
-        if (!state || state === 'IMAGE_MANAGER_UNREADY') {
+        if (!state || state === ImageMangerStates.UNREADY) {
           return;
         }
 


### PR DESCRIPTION
This addresses an issue where the "Add Image" button remained active even when certain preferences requiring a system restart were modified. We achieve this by modifying the watcher to monitor the K8S state instead of relying on the Image Manager state.

Upon investigation, it was discovered that the Image Manager (`pkg/rancher-desktop/backend/images/imageProcessor.ts`) enters a "ready" state only during the initial startup and maintains this state throughout subsequent restarts. Consequently, the `readiness-changed` event is emitted a single time during the first startup, resulting in the UI failing to receive an `images-check-state` event when settings are modified.

closes #5457