### PR TITLE
Actions: cache all golang dependencies

### DIFF
--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.18'
+          cache-dependency-path: src/go/**/go.sum
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         #The next steps is a workaround for an unexpected failure in launching electron before running e2e tests

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -45,6 +45,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.18'
+        cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
       shell: powershell
@@ -156,6 +157,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.18'
+        cache-dependency-path: src/go/**/go.sum
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.18'
+        cache-dependency-path: src/go/**/go.sum
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn lint:nofix

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -32,6 +32,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.18'
+        cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
       shell: powershell

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -32,9 +32,7 @@ jobs:
         with:
           go-version: '^1.18'
           cache: 'true'
-          # This appears to only allow caching one dependency; pick one at
-          # random.
-          cache-dependency-path: src/go/rdctl/go.sum
+          cache-dependency-path: src/go/**/go.sum
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run e2e Tests


### PR DESCRIPTION
It looks like `actions/setup-go@v4` supports caching using multiple `go.sum` files.  This turns on caching for go modules to hopefully speed up CI times.