### PR TITLE
Add -i option to `docker run` to work around bug on Windows

### DIFF
--- a/bats/tests/containers/init.bats
+++ b/bats/tests/containers/init.bats
@@ -12,7 +12,12 @@ load '../helpers/load'
 }
 
 @test 'run container with init process' {
-    run ctrctl run --rm --init "$IMAGE_BUSYBOX" ps -ef
+    # BUG BUG BUG
+    # The following `ctrctl run` command includes the `-i` option to work around a docker
+    # bug on Windows: https://github.com/rancher-sandbox/rancher-desktop/issues/3239
+    # It is harmless in other configurations, but should not be required here.
+    # BUG BUG BUG
+    run ctrctl run -i --rm --init "$IMAGE_BUSYBOX" ps -ef
     assert_success
     # PID   USER     TIME  COMMAND
     #     1 root      0:00 /sbin/docker-init -- ps -ef


### PR DESCRIPTION
See https://github.com/rancher-sandbox/rancher-desktop/issues/3239