### PR TITLE
On macOS, move the other config files into `~/Library/Preferences/rancher-desktop`

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -162,7 +162,7 @@ check_directories() {
         # We can't make any general assertion on AppHome/snapshots - we don't know if it was created or not
         # So just assert on the other members of AppHome
         if is_macos; then
-            delete_dir+=("$PATH_APP_HOME/credential-server.json" "$PATH_APP_HOME/lima" "$PATH_APP_HOME/rd-engine.json" "$PATH_LOGS")
+            delete_dir+=("$PATH_APP_HOME/lima" "$PATH_LOGS")
             # TODO on macOS (not implemented by `rdctl factory-reset`)
             # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
             # this one only exists after an update has been downloaded

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -66,7 +66,7 @@ encoded_id() { # variant
 
 @test 'extension API - require auth' {
     local port
-    run cat "${PATH_APP_HOME}/rd-engine.json"
+    run cat "${PATH_CONFIG}/rd-engine.json"
     assert_success
     port="$(jq_output .port)"
     assert [ -n "$port" ]

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -49,7 +49,7 @@ test.describe.serial('KubernetesBackend', () => {
     });
 
     test('should emit connection information', async() => {
-      const dataPath = path.join(paths.appHome, 'rd-engine.json');
+      const dataPath = path.join(paths.config, 'rd-engine.json');
       const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
 
       serverState = JSON.parse(dataRaw);

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -257,7 +257,7 @@ describeWithCreds('Credentials server', () => {
   });
 
   test('should emit connection information', async() => {
-    const dataPath = path.join(paths.appHome, 'credential-server.json');
+    const dataPath = path.join(paths.config, 'credential-server.json');
     const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
 
     serverState = JSON.parse(dataRaw);

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -132,7 +132,7 @@ test.describe('Command server', () => {
   });
 
   test('should emit connection information', async() => {
-    const dataPath = path.join(paths.appHome, 'rd-engine.json');
+    const dataPath = path.join(paths.config, 'rd-engine.json');
     const dataRaw = await fs.promises.readFile(dataPath, 'utf-8');
 
     serverState = JSON.parse(dataRaw);
@@ -571,8 +571,8 @@ test.describe('Command server', () => {
     test.describe('config-file and parameters', () => {
       test.describe("when the config-file doesn't exist", () => {
         let parameters: string[];
-        const configFilePath = path.join(paths.appHome, 'rd-engine.json');
-        const backupPath = path.join(paths.appHome, 'rd-engine.json.bak');
+        const configFilePath = path.join(paths.config, 'rd-engine.json');
+        const backupPath = path.join(paths.config, 'rd-engine.json.bak');
 
         test.beforeAll(async() => {
           const dataRaw = await fs.promises.readFile(configFilePath, 'utf-8');

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -4,7 +4,7 @@
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
-export const CURRENT_SETTINGS_VERSION = 9 as const;
+export const CURRENT_SETTINGS_VERSION = 10 as const;
 
 export enum VMType {
   QEMU = 'qemu',

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -401,7 +401,7 @@ const updateTable: Record<number, (settings: any) => void> = {
     // paths.config === paths.appHome on linux and Windows, so this only needs to be done on macOS
     if (process.platform === 'darwin') {
       for (const filename of ['credential-server.json', 'rd-engine.json']) {
-        // Ignore non-existent files (but if we're moving from settings 9 to 10 on macOS, they should exist
+        // Ignore nonexistent files (but if we're moving from settings 9 to 10 on macOS, they should exist
         fs.rmSync(join(paths.appHome, filename), { force: true });
       }
     }

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -395,6 +395,17 @@ const updateTable: Record<number, (settings: any) => void> = {
       delete settings.extensions;
     }
   },
+  9: (_) => {
+    // On macOS, this version deletes credential-server.json and rd-engine.json from paths.appHome
+    // This happens on startup, so new instances of these files will be created in paths.config
+    // paths.config === paths.appHome on linux and Windows, so this only needs to be done on macOS
+    if (process.platform === 'darwin') {
+      for (const filename of ['credential-server.json', 'rd-engine.json']) {
+        // Ignore non-existent files (but if we're moving from settings 9 to 10 on macOS, they should exist
+        fs.rmSync(join(paths.appHome, filename), { force: true });
+      }
+    }
+  },
 };
 
 function migrateSettingsToCurrentVersion(settings: Settings) {

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -102,9 +102,9 @@ export class HttpCommandServer {
         upstreamServerAddress: `${ localHost }:${ SERVER_PORT }`,
       });
     }
-    const statePath = path.join(paths.appHome, SERVER_FILE_BASENAME);
+    const statePath = path.join(paths.config, SERVER_FILE_BASENAME);
 
-    await fs.promises.mkdir(paths.appHome, { recursive: true });
+    await fs.promises.mkdir(paths.config, { recursive: true });
     await fs.promises.writeFile(statePath,
       jsonStringifyWithWhiteSpace(this.externalState),
       { mode: 0o600 });

--- a/pkg/rancher-desktop/main/credentialServer/httpCredentialHelperServer.ts
+++ b/pkg/rancher-desktop/main/credentialServer/httpCredentialHelperServer.ts
@@ -46,7 +46,7 @@ function requireJSONOutput(stdout: string): boolean {
 }
 
 export function getServerCredentialsPath(): string {
-  return path.join(paths.appHome, SERVER_FILE_BASENAME);
+  return path.join(paths.config, SERVER_FILE_BASENAME);
 }
 
 function ensureEndsWithNewline(s: string) {

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -24,7 +24,7 @@ describe('paths', () => {
   const cases: Record<keyof Paths, expectedData> = {
     appHome: {
       win32:  '%APPDATA%/rancher-desktop/',
-      linux:  '%HOME%/.config/rancher-desktop/',
+      linux:  '%HOME%/.local/share/rancher-desktop/',
       darwin: '%HOME%/Library/Application Support/rancher-desktop/',
     },
     altAppHome: {
@@ -134,7 +134,7 @@ describe('paths', () => {
     const platform = os.platform();
 
     if (['darwin', 'linux'].includes(platform)) {
-      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toEqual(platform === 'darwin');
+      expect(pathsToDelete.some( dir => paths.lima.startsWith(dir))).toBeTruthy();
       expect(pathsToDelete.some( dir => '/bobs/friendly/llama/farm'.startsWith(dir))).toBeFalsy();
     }
   });

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -20,6 +20,7 @@ package config
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -64,6 +65,13 @@ func DefineGlobalFlags(rootCmd *cobra.Command) {
 		if configDir, err = wslifyConfigDir(); err != nil {
 			log.Fatalf("Can't get WSL config-dir: %v", err)
 		}
+	} else if runtime.GOOS == "darwin" {
+		// os.UserConfigDir() => ~/Library/Application Support, not ~/Library/Preferences
+		configDir = os.Getenv("HOME")
+		if configDir == "" {
+			log.Fatalf("Can't get the home directory: %v", errors.New("$HOME is not defined"))
+		}
+		configDir += "/Library/Preferences"
 	} else {
 		configDir, err = os.UserConfigDir()
 		if err != nil {

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -14,16 +14,10 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		logrus.Errorf("Error getting home directory: %s", err)
-	}
-
 	pathList := []string{
 		paths.AltAppHome,
 		paths.Config,
 		paths.Logs,
-		filepath.Join(homeDir, ".local", "state", "rancher-desktop"),
 	}
 
 	// Electron stores things in ~/.config/Rancher Desktop. This is difficult
@@ -40,7 +34,7 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	} else {
 		pathList = append(pathList, filepath.Join(paths.Cache, "updater-longhorn.json"))
 	}
-	appHomeDirs := addAppHomeWithoutSnapshots(filepath.Dir(paths.Lima))
+	appHomeDirs := addAppHomeWithoutSnapshots(paths.AppHome)
 	pathList = append(pathList, appHomeDirs...)
 	return deleteUnixLikeData(paths, pathList)
 }

--- a/src/go/rdctl/pkg/paths/paths_linux.go
+++ b/src/go/rdctl/pkg/paths/paths_linux.go
@@ -36,7 +36,7 @@ func GetPaths(getResourcesPathFuncs ...func() (string, error)) (Paths, error) {
 	}
 	altAppHome := filepath.Join(homeDir, ".rd")
 	paths := Paths{
-		AppHome:                 filepath.Join(configHome, appName),
+		AppHome:                 filepath.Join(dataHome, appName),
 		AltAppHome:              altAppHome,
 		Config:                  filepath.Join(configHome, appName),
 		Cache:                   filepath.Join(cacheHome, appName),

--- a/src/go/rdctl/pkg/paths/paths_linux_test.go
+++ b/src/go/rdctl/pkg/paths/paths_linux_test.go
@@ -24,7 +24,7 @@ func TestGetPaths(t *testing.T) {
 			t.Errorf("Unexpected error getting user home directory: %s", err)
 		}
 		expectedPaths := Paths{
-			AppHome:                 filepath.Join(homeDir, ".config", appName),
+			AppHome:                 filepath.Join(homeDir, ".local/share", appName),
 			AltAppHome:              filepath.Join(homeDir, ".rd"),
 			Config:                  filepath.Join(homeDir, ".config", appName),
 			Logs:                    filepath.Join(homeDir, ".local/share", appName, "logs"),
@@ -62,7 +62,7 @@ func TestGetPaths(t *testing.T) {
 		}
 
 		expectedPaths := Paths{
-			AppHome:                 filepath.Join(environment["XDG_CONFIG_HOME"], appName),
+			AppHome:                 filepath.Join(environment["XDG_DATA_HOME"], appName),
 			AltAppHome:              filepath.Join(homeDir, ".rd"),
 			Config:                  filepath.Join(environment["XDG_CONFIG_HOME"], appName),
 			Logs:                    environment["RD_LOGS_DIR"],


### PR DESCRIPTION
Fixes #5419

For some reason (probably that paths set `AppHome` to `~/L/Prefs/r-d` and not `~/L/AS/r-d`), on macOS, `rd-engine.json` and `credential-server.json` weren't put in the prefs directory.

Note that by bumping the settings version to 10, we can check for files in their legacy location just once, rather than every time in `rdctl/factory-reset`.

There's no need to move files from the legacy location to the new one, because their contents are reset every time Rancher Desktop starts up.