### PR TITLE
Fix registry/cred.bats for Moby on Windows in WSL (not using Windows .exe)

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -19,11 +19,8 @@ if is_macos; then
 elif is_linux; then
     CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-pass"
 elif is_windows; then
-    if using_windows_exe; then
-        CRED_HELPER="$PATH_RESOURCES/win32/bin/docker-credential-wincred.exe"
-    else
-        CRED_HELPER="$PATH_RESOURCES/$PLATFORM/bin/docker-credential-pass"
-    fi
+    # Our docker-cli for WSL defaults to "wincred.exe" as well
+    CRED_HELPER="$PATH_RESOURCES/win32/bin/docker-credential-wincred.exe"
 fi
 
 if is_windows; then

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -2,6 +2,16 @@ load '../helpers/load'
 
 local_setup() {
     REGISTRY_PORT="5050"
+    if is_windows && ! using_windows_exe; then
+        # TODO TODO TODO
+        # RD will only modify the Windows version of .docker/config.json;
+        # there is no WSL integration support for it. Therefore this test
+        # always needs to modify the Windows version and not touch the
+        # Linux one. This may change depending on:
+        # https://github.com/rancher-sandbox/rancher-desktop/issues/5523
+        # TODO TODO TODO
+        USERPROFILE="$(win32env USERPROFILE)"
+    fi
     DOCKER_CONFIG_FILE="$USERPROFILE/.docker/config.json"
 
     TEMP=/tmp


### PR DESCRIPTION
We always use `wincred.exe` as the credential help and have it hardcoded as the default in our WSL `docker` binary.

The Rancher Desktop application on Windows will only modify the ~/.docker/config.json in the %USERPROFILE% folder and not the version inside the distro, even when WSL integration is enabled.

Test should now work for all configurations, but specifically fixes the issues for

```shell
RD_CONTAINER_ENGINE=moby ./bats-core/bin/bats -T tests/registry/creds.bats
```