### PR TITLE
Surface invalid command-line arguments.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -171,9 +171,14 @@ Electron.app.whenReady().then(async() => {
   try {
     const commandLineArgs = getCommandLineArgs();
 
-    // Reset `noModalDialogs` on non-error paths, but if an error occurs during command processing,
-    // we'll need to know whether this was set in advance. It's very unlikely that a string option is set
-    // to this exact string though.
+    // Normally `noModalDialogs` is set when we call `updateFromCommandLine(.., commandLineArgs)`
+    // But if there's an error either in that function, or before, we'll need to know if we should
+    // display the error in a modal-dialog or not. So check the current command-line arguments for that.
+    //
+    // It's very unlikely that a string option is set to this exact string though.
+    // `rdctl start --images.namespace --no-modal-dialogs`
+    // is syntactically correct, but unlikely (because why would someone create a
+    // containerd namespace called "--no-modal-dialogs"?
     noModalDialogs = commandLineArgs.includes('--no-modal-dialogs');
     setupProtocolHandlers();
 
@@ -1115,9 +1120,6 @@ function validateEarlySettings(cfg: settings.Settings, newSettings: RecursivePar
 
   if (errors.length > 0) {
     throw new LockedFieldError(`Error in deployment profiles:\n${ errors.join('\n') }`);
-  }
-  if (errors.length > 0) {
-    throw new FatalCommandLineOptionError(`Error in command-line options:\n${ errors.join('\n') }`);
   }
 }
 

--- a/bats/tests/preferences/surface-invalid-args.bats
+++ b/bats/tests/preferences/surface-invalid-args.bats
@@ -16,13 +16,11 @@ supports_vz_emulation() {
         minor_version="${major_minor_version#*.}"
         if ((major_version >= 14)); then
             return 0
-        elif ((major_version <= 12)); then
-            return 1
-        elif ((minor_version >= 3)); then
-            return 0
-        elif [[ "$(uname -m)" == x86_64 ]]; then
-            # Versions 12.0.x .. 12.2.x work only on x86, not m1
-            return 0
+        elif ((major_version == 13)); then
+            # Versions 13.0.x .. 13.2.x work only on x86_64, not aarch64
+            if ((minor_version >= 3)) || [[ "$(uname -m)" == x86_64 ]]; then
+                return 0
+            fi
         fi
     fi
     return 1

--- a/bats/tests/preferences/surface-invalid-args.bats
+++ b/bats/tests/preferences/surface-invalid-args.bats
@@ -1,0 +1,61 @@
+load '../helpers/load'
+
+local_setup() {
+    if is_windows; then
+        skip "test not applicable on Windows"
+    fi
+}
+
+@test 'initial factory reset' {
+    factory_reset
+}
+
+can_set_vm_to_vz() {
+    if ! is_macos; then
+        false
+    else
+        version=$(/usr/bin/sw_vers -productVersion)
+        majorMinorVersion="${version%.*}"
+        majorVersion="${majorMinorVersion%.*}"
+        minorVersion="${majorMinorVersion#*.}"
+        if ((majorVersion >= 14)); then
+            true
+        elif ((majorVersion <= 12)); then
+            false
+        elif ((minorVersion >= 3)); then
+            true
+        else
+            case "$(uname -m)" in
+            x86_64) true ;;
+            *) false ;;
+            esac
+        fi
+    fi
+}
+
+@test 'mac-specific failure for unacceptable start setting' {
+    if ! is_macos; then
+        skip 'need a mac for the --experimental.virtual-machine.type setting'
+    elif can_set_vm_to_vz; then
+        skip 'no error setting experimental.virtualMachine.type to "vz" on this platform'
+    fi
+    # Don't use launch_the_application so we can check non-dev-mode error messages
+    if using_dev_mode; then
+        yarn dev --experimental.virtualMachine.type vz --no-modal-dialogs &
+    else
+        rdctl start --experimental.virtual-machine.type vz --no-modal-dialogs
+    fi
+    try --max 36 --delay 5 assert_file_contains \
+        "$PATH_LOGS/background.log" \
+        'Setting experimental.virtualMachine.type to "vz" on Intel requires macOS 13.0 (Ventura) or later.'
+    rdctl shutdown
+}
+
+@test 'report unrecognized options in the log file' {
+    if ! using_dev_mode; then
+        skip 'hard to get unrecognized options past rdctl-start; run this test in dev-mode'
+    fi
+    yarn dev --his-face-rings-a-bell --no-modal-dialogs &
+    try --max 36 --delay 5 assert_file_contains "$PATH_LOGS/settings.log" "Unrecognized command-line argument --his-face-rings-a-bell"
+    rdctl shutdown
+}

--- a/pkg/rancher-desktop/config/commandLineOptions.ts
+++ b/pkg/rancher-desktop/config/commandLineOptions.ts
@@ -14,6 +14,8 @@ const console = Logging.settings;
 
 export class LockedFieldError extends Error {}
 
+export class FatalCommandLineOptionError extends Error {}
+
 /**
  * Takes an array of strings, presumably from a command-line used to launch the app.
  * Key operations:
@@ -73,6 +75,7 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
     if (currentValue === undefined) {
       // Ignore unrecognized command-line options until we get to one we recognize
       if (processingExternalArguments) {
+        console.warn(`Unrecognized command-line argument ${ arg }`);
         continue;
       }
       throw new Error(`Can't evaluate command-line argument ${ arg } -- no such entry in current settings at ${ join(paths.config, 'settings.json') }`);
@@ -138,6 +141,9 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
 
     if (errors.some(error => /field ".+?" is locked/.test(error))) {
       throw new LockedFieldError(errorString);
+    }
+    if (settingsValidator.isFatal) {
+      throw new FatalCommandLineOptionError(errorString);
     }
     throw new Error(errorString);
   }

--- a/pkg/rancher-desktop/config/commandLineOptions.ts
+++ b/pkg/rancher-desktop/config/commandLineOptions.ts
@@ -134,7 +134,7 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
     }
     settingsValidator.k8sVersions = limitedK8sVersionList;
   }
-  const [needToUpdate, errors] = settingsValidator.validateSettings(cfg, newSettings, lockedFields);
+  const [needToUpdate, errors, isFatal] = settingsValidator.validateSettings(cfg, newSettings, lockedFields);
 
   if (errors.length > 0) {
     const errorString = `Error in command-line options:\n${ errors.join('\n') }`;
@@ -142,7 +142,7 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
     if (errors.some(error => /field ".+?" is locked/.test(error))) {
       throw new LockedFieldError(errorString);
     }
-    if (settingsValidator.isFatal) {
+    if (isFatal) {
       throw new FatalCommandLineOptionError(errorString);
     }
     throw new Error(errorString);

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -182,9 +182,9 @@ describe(SettingsValidator, () => {
           }
 
           const input = _.set({}, keyPath, invalidValue);
-          const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+          const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, input);
 
-          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+          expect({ needToUpdate, errors, isFatal }).toEqual({
             needToUpdate: false,
             errors:       [`Invalid value for "${ prefix }${ key }": <${ JSON.stringify(invalidValue) }>`],
             isFatal:      false,
@@ -250,9 +250,9 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject setting to NONE', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg, { containerEngine: { name: settings.ContainerEngine.NONE } });
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { containerEngine: { name: settings.ContainerEngine.NONE } });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [expect.stringContaining('Invalid value for "containerEngine.name": <"">;')],
         isFatal:      true,
@@ -276,12 +276,12 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject invalid values', () => {
-      const [needToUpdate, errors] = subject.validateSettings(
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(
         cfg,
         { containerEngine: { name: 'pikachu' as settings.ContainerEngine } },
       );
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [expect.stringContaining('Invalid value for "containerEngine.name": <"pikachu">; must be one of ["containerd","moby","docker"]')],
         isFatal:      true,
@@ -295,9 +295,9 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject invalid values', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: 3 as unknown as Record<string, boolean> } });
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { WSL: { integrations: 3 as unknown as Record<string, boolean> } });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['Proposed field "WSL.integrations" should be an object, got <3>.'],
         isFatal:      false,
@@ -306,9 +306,9 @@ describe(SettingsValidator, () => {
 
     it('should reject being set on non-Windows', () => {
       spyPlatform.mockReturnValue('haiku');
-      const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { foo: true } } });
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { WSL: { integrations: { foo: true } } });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Changing field "WSL.integrations" via the API isn't supported.`],
         isFatal:      true,
@@ -316,9 +316,9 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject invalid configuration', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { distribution: 3 as unknown as boolean } } });
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { WSL: { integrations: { distribution: 3 as unknown as boolean } } });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['Invalid value for "WSL.integrations.distribution": <3>'],
         isFatal:      false,
@@ -349,14 +349,14 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject an unknown version', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg, {
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, {
         kubernetes: {
           version: '3.2.1',
           enabled: true,
         },
       });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Kubernetes version "3.2.1" not found.`],
         isFatal:      false,
@@ -375,7 +375,7 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject a non-version value', () => {
-      const [needToUpdate, errors] = subject.validateSettings(
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(
         cfg,
         {
           kubernetes: {
@@ -384,7 +384,7 @@ describe(SettingsValidator, () => {
           },
         });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Kubernetes version "pikachu" not found.`],
         isFatal:      false,
@@ -415,10 +415,10 @@ describe(SettingsValidator, () => {
     });
 
     it('should reject invalid values', () => {
-      const [needToUpdate, errors] = subject.validateSettings(cfg,
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg,
         { application: { pathManagementStrategy: 'invalid value' as PathManagementStrategy } });
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Invalid value for "application.pathManagementStrategy": <"invalid value">; must be one of ["manual","rcfiles"]`],
         isFatal:      true,
@@ -436,9 +436,9 @@ describe(SettingsValidator, () => {
           },
         },
       };
-      const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "pattern2"'],
         isFatal:      false,
@@ -453,9 +453,9 @@ describe(SettingsValidator, () => {
           },
         },
       };
-      const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "pattern1", "Pattern2"'],
         isFatal:      false,
@@ -470,11 +470,12 @@ describe(SettingsValidator, () => {
           },
         },
       };
-      const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+      expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "", "\t", "  "'],
+        isFatal:      false,
       });
     });
     it('allows exactly one whitespace value', () => {
@@ -512,9 +513,9 @@ describe(SettingsValidator, () => {
 
           it("can't be changed", () => {
             const input: RecursivePartial<settings.Settings> = { containerEngine: { allowedImages: { enabled: true } } };
-            const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
+            const [needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+            expect({ needToUpdate, errors, isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.enabled" is locked'],
               isFatal:      true,
@@ -543,9 +544,9 @@ describe(SettingsValidator, () => {
                 },
               },
             };
-            const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
+            const [needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+            expect({ needToUpdate, errors, isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
               isFatal:      true,
@@ -560,9 +561,9 @@ describe(SettingsValidator, () => {
                 },
               },
             };
-            const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
+            const [needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+            expect({ needToUpdate, errors, isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
               isFatal:      true,
@@ -632,26 +633,26 @@ describe(SettingsValidator, () => {
           const currentEnabled = allowedImageListConfig.containerEngine.allowedImages.enabled;
           const currentPatterns = allowedImageListConfig.containerEngine.allowedImages.patterns;
           let input: RecursivePartial<settings.Settings> = { containerEngine: { allowedImages: { enabled: !currentEnabled } } };
-          let [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
+          let [needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+          expect({ needToUpdate, errors, isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.enabled" is locked'],
             isFatal:      true,
           });
 
           input = { containerEngine: { allowedImages: { patterns: ['picasso'].concat(currentPatterns) } } };
-          ([needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
-          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+          ([needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
+          expect({ needToUpdate, errors, isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
             isFatal:      true,
           });
 
           input = { containerEngine: { allowedImages: { patterns: currentPatterns.slice(1) } } };
-          ([needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
+          ([needToUpdate, errors, isFatal] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
 
-          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+          expect({ needToUpdate, errors, isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
             isFatal:      true,
@@ -707,9 +708,9 @@ describe(SettingsValidator, () => {
       _.set(input, path, value);
     }
 
-    const [needToUpdate, errors] = subject.validateSettings(cfg, input);
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, input);
 
-    expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+    expect({ needToUpdate, errors, isFatal }).toEqual({
       needToUpdate: false,
       errors:       Object.keys(unchangeableFieldsAndValues).map(key => `Changing field "${ key }" via the API isn't supported.`),
       isFatal:      false,
@@ -742,7 +743,7 @@ describe(SettingsValidator, () => {
 
   // Add some fields that are very unlikely to ever collide with newly introduced fields.
   it('should ignore unrecognized settings', () => {
-    const [needToUpdate, errors] = subject.validateSettings(cfg, {
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, {
       kubernetes: {
         'durian-sharkanodo': 3,
         version:             cfg.version,
@@ -760,7 +761,7 @@ describe(SettingsValidator, () => {
       'feijoa - Alps': [],
     } as unknown as settings.Settings);
 
-    expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
+    expect({ needToUpdate, errors, isFatal }).toEqual({
       needToUpdate: false,
       errors:       expect.objectContaining({ length: 1 }),
       isFatal:      false,

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -184,9 +184,10 @@ describe(SettingsValidator, () => {
           const input = _.set({}, keyPath, invalidValue);
           const [needToUpdate, errors] = subject.validateSettings(cfg, input);
 
-          expect({ needToUpdate, errors }).toEqual({
+          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
             needToUpdate: false,
             errors:       [`Invalid value for "${ prefix }${ key }": <${ JSON.stringify(invalidValue) }>`],
+            isFatal:      false,
           });
         });
 
@@ -251,9 +252,10 @@ describe(SettingsValidator, () => {
     it('should reject setting to NONE', () => {
       const [needToUpdate, errors] = subject.validateSettings(cfg, { containerEngine: { name: settings.ContainerEngine.NONE } });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [expect.stringContaining('Invalid value for "containerEngine.name": <"">;')],
+        isFatal:      true,
       });
     });
 
@@ -279,9 +281,10 @@ describe(SettingsValidator, () => {
         { containerEngine: { name: 'pikachu' as settings.ContainerEngine } },
       );
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [expect.stringContaining('Invalid value for "containerEngine.name": <"pikachu">; must be one of ["containerd","moby","docker"]')],
+        isFatal:      true,
       });
     });
   });
@@ -294,9 +297,10 @@ describe(SettingsValidator, () => {
     it('should reject invalid values', () => {
       const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: 3 as unknown as Record<string, boolean> } });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['Proposed field "WSL.integrations" should be an object, got <3>.'],
+        isFatal:      false,
       });
     });
 
@@ -304,18 +308,20 @@ describe(SettingsValidator, () => {
       spyPlatform.mockReturnValue('haiku');
       const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { foo: true } } });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Changing field "WSL.integrations" via the API isn't supported.`],
+        isFatal:      true,
       });
     });
 
     it('should reject invalid configuration', () => {
       const [needToUpdate, errors] = subject.validateSettings(cfg, { WSL: { integrations: { distribution: 3 as unknown as boolean } } });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['Invalid value for "WSL.integrations.distribution": <3>'],
+        isFatal:      false,
       });
     });
 
@@ -350,9 +356,10 @@ describe(SettingsValidator, () => {
         },
       });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Kubernetes version "3.2.1" not found.`],
+        isFatal:      false,
       });
     });
 
@@ -377,9 +384,10 @@ describe(SettingsValidator, () => {
           },
         });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Kubernetes version "pikachu" not found.`],
+        isFatal:      false,
       });
     });
   });
@@ -410,9 +418,10 @@ describe(SettingsValidator, () => {
       const [needToUpdate, errors] = subject.validateSettings(cfg,
         { application: { pathManagementStrategy: 'invalid value' as PathManagementStrategy } });
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       [`Invalid value for "application.pathManagementStrategy": <"invalid value">; must be one of ["manual","rcfiles"]`],
+        isFatal:      true,
       });
     });
   });
@@ -429,9 +438,10 @@ describe(SettingsValidator, () => {
       };
       const [needToUpdate, errors] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "pattern2"'],
+        isFatal:      false,
       });
     });
     it('complains about multiple duplicates', () => {
@@ -445,9 +455,10 @@ describe(SettingsValidator, () => {
       };
       const [needToUpdate, errors] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "pattern1", "Pattern2"'],
+        isFatal:      false,
       });
     });
     it('complains about multiple duplicates that contain only whitespace lengths', () => {
@@ -461,7 +472,7 @@ describe(SettingsValidator, () => {
       };
       const [needToUpdate, errors] = subject.validateSettings(cfg, input);
 
-      expect({ needToUpdate, errors }).toEqual({
+      expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['field "containerEngine.allowedImages.patterns" has duplicate entries: "", "\t", "  "'],
       });
@@ -503,9 +514,10 @@ describe(SettingsValidator, () => {
             const input: RecursivePartial<settings.Settings> = { containerEngine: { allowedImages: { enabled: true } } };
             const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors }).toEqual({
+            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.enabled" is locked'],
+              isFatal:      true,
             });
           });
           it('can be set to the same value', () => {
@@ -533,9 +545,10 @@ describe(SettingsValidator, () => {
             };
             const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors }).toEqual({
+            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
+              isFatal:      true,
             });
           });
 
@@ -549,9 +562,10 @@ describe(SettingsValidator, () => {
             };
             const [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-            expect({ needToUpdate, errors }).toEqual({
+            expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
               needToUpdate: false,
               errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
+              isFatal:      true,
             });
           });
 
@@ -620,24 +634,27 @@ describe(SettingsValidator, () => {
           let input: RecursivePartial<settings.Settings> = { containerEngine: { allowedImages: { enabled: !currentEnabled } } };
           let [needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings);
 
-          expect({ needToUpdate, errors }).toEqual({
+          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.enabled" is locked'],
+            isFatal:      true,
           });
 
           input = { containerEngine: { allowedImages: { patterns: ['picasso'].concat(currentPatterns) } } };
           ([needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
-          expect({ needToUpdate, errors }).toEqual({
+          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
+            isFatal:      true,
           });
 
           input = { containerEngine: { allowedImages: { patterns: currentPatterns.slice(1) } } };
           ([needToUpdate, errors] = subject.validateSettings(allowedImageListConfig, input, lockedSettings));
 
-          expect({ needToUpdate, errors }).toEqual({
+          expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
             needToUpdate: false,
             errors:       ['field "containerEngine.allowedImages.patterns" is locked'],
+            isFatal:      true,
           });
         });
 
@@ -692,9 +709,10 @@ describe(SettingsValidator, () => {
 
     const [needToUpdate, errors] = subject.validateSettings(cfg, input);
 
-    expect({ needToUpdate, errors }).toEqual({
+    expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
       needToUpdate: false,
       errors:       Object.keys(unchangeableFieldsAndValues).map(key => `Changing field "${ key }" via the API isn't supported.`),
+      isFatal:      false,
     });
   });
 
@@ -742,9 +760,10 @@ describe(SettingsValidator, () => {
       'feijoa - Alps': [],
     } as unknown as settings.Settings);
 
-    expect({ needToUpdate, errors }).toEqual({
+    expect({ needToUpdate, errors, isFatal: subject.isFatal }).toEqual({
       needToUpdate: false,
       errors:       expect.objectContaining({ length: 1 }),
+      isFatal:      false,
     });
   });
 

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -65,13 +65,13 @@ export default class SettingsValidator {
   allowedTransientSettings: TransientSettingsValidationMap | null = null;
   synonymsTable: settingsLike|null = null;
   lockedSettings: LockedSettingsType = { };
-  isFatal = false;
+  protected isFatal = false;
 
   validateSettings(
     currentSettings: Settings,
     newSettings: RecursivePartial<Settings>,
     lockedSettings: LockedSettingsType = {},
-  ): [boolean, string[]] {
+  ): [boolean, string[], boolean] {
     this.lockedSettings = lockedSettings;
     this.isFatal = false;
     this.allowedSettings ||= {
@@ -168,7 +168,7 @@ export default class SettingsValidator {
       '',
     );
 
-    return [needToUpdate && errors.length === 0, errors];
+    return [needToUpdate && errors.length === 0, errors, this.isFatal];
   }
 
   validateTransientSettings(

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -68,13 +68,8 @@ func doStartOrSetCommand(cmd *cobra.Command) error {
 			// `--path | -p` is not a valid option for `rdctl set...`
 			return fmt.Errorf("--path %q specified but Rancher Desktop is already running", applicationPath)
 		}
-		err = doSetCommand(cmd)
-		if err == nil || cmd.Name() == "set" {
-			return err
-		}
+		return doSetCommand(cmd)
 	}
-	// If `set...` failed, try running the original `start` command, if only to give
-	// an error message from the point of view of `start` rather than `set`.
 	cmd.SilenceUsage = true
 	return doStartCommand(cmd)
 }


### PR DESCRIPTION
Fixes #5473

And also report unrecognized command-line options in the settings.log file.