### PR TITLE
On macOS use md5 instead of md5sum

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,3 +1,4 @@
+coreutils
 distatus
 dword
 emoji

--- a/bats/tests/extensions/install.bats
+++ b/bats/tests/extensions/install.bats
@@ -12,8 +12,14 @@ assert_file_contents_equal() { # $have $want
     assert_file_exist "$want"
 
     local have_hash want_hash
-    have_hash="$(md5sum "$have" | cut -d ' ' -f 1)"
-    want_hash="$(md5sum "$want" | cut -d ' ' -f 1)"
+    if is_macos; then
+        # md5sum is not available on macOS unless you install GNU coreutils
+        have_hash="$(md5 -q "$have")"
+        want_hash="$(md5 -q "$want")"
+    else
+        have_hash="$(md5sum "$have" | cut -d ' ' -f 1)"
+        want_hash="$(md5sum "$want" | cut -d ' ' -f 1)"
+    fi
     if [ "$have_hash" != "$want_hash" ]; then
         printf "expected : %s (%s)\nactual   : %s (%s)" \
             "$want" "$want_hash" "$have" "$have_hash" |


### PR DESCRIPTION
Because `md5sum` is only available when you install GNU `coreutils` via Homebrew or similar.

I just tried a full BATS run on a freshly installed Sonoma beta (only installed iTerm, Rancher Desktop, and the `bats.tar.gz` tarball), and this was the only test that failed.

An alternative could have been `openssl md5`; that should be available anywhere. But I think this change is fine too.