### PR TITLE
Use Go 1.21 in `rdctl`

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -26,7 +26,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.18'
+          go-version: '^1.21'
           cache-dependency-path: src/go/**/go.sum
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.18'
+          go-version: '^1.21'
           cache-dependency-path: src/go/**/go.sum
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -45,7 +45,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.18'
+        go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
@@ -157,7 +157,7 @@ jobs:
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.18'
+        go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         cache: yarn
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.18'
+        go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
     - run: yarn install --frozen-lockfile
     - run: yarn build

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/setup-go@v4
       with:
-        go-version: '^1.18'
+        go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.18'
+          go-version: '^1.21'
           cache: 'true'
           cache-dependency-path: src/go/**/go.sum
       - name: Install dependencies

--- a/src/go/docker-credential-none/go.mod
+++ b/src/go/docker-credential-none/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/docker-credential-none
 
-go 1.18
+go 1.21
 
 require (
 	github.com/docker/cli v24.0.6+incompatible

--- a/src/go/docker-credential-none/go.sum
+++ b/src/go/docker-credential-none/go.sum
@@ -8,6 +8,7 @@ github.com/docker/docker v23.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bc
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/go/extension-proxy/go.mod
+++ b/src/go/extension-proxy/go.mod
@@ -1,3 +1,3 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/extension-port-forwarder
 
-go 1.20
+go 1.21

--- a/src/go/mock-wsl/go.mod
+++ b/src/go/mock-wsl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/e2e/assets/mock-wsl
 
-go 1.18
+go 1.21
 
 require (
 	golang.org/x/exp v0.0.0-20220428152302-39d4317da171

--- a/src/go/nerdctl-stub/generate/go.mod
+++ b/src/go/nerdctl-stub/generate/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/nerdctl-stub/generate
 
-go 1.17
+go 1.21
 
 require github.com/sirupsen/logrus v1.8.1
 

--- a/src/go/nerdctl-stub/go.mod
+++ b/src/go/nerdctl-stub/go.mod
@@ -1,9 +1,16 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/nerdctl-stub
 
-go 1.16
+go 1.21
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sys v0.12.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/src/go/nerdctl-stub/go.sum
+++ b/src/go/nerdctl-stub/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -7,17 +6,11 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/go/privileged-service/go.mod
+++ b/src/go/privileged-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/privileged-service
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Microsoft/go-winio v0.5.2

--- a/src/go/privileged-service/go.sum
+++ b/src/go/privileged-service/go.sum
@@ -32,3 +32,4 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/go/rdctl/go.mod
+++ b/src/go/rdctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/rdctl
 
-go 1.17
+go 1.21
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/src/go/vtunnel/go.mod
+++ b/src/go/vtunnel/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/vtunnel
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Microsoft/go-winio v0.6.1

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/src/go/wsl-helper/go.sum
+++ b/src/go/wsl-helper/go.sum
@@ -69,6 +69,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -175,6 +176,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -220,6 +222,7 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -258,6 +261,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=


### PR DESCRIPTION
This PR also updates the version of Go used in github actions to 1.21.