### PR TITLE
Don't try to modify experimental.virtualMachine.proxy settings on Unix

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -68,12 +68,16 @@ verify_no_nginx() {
     try --max 18 --delay 10 verify_no_nginx
 }
 
-@test 'ignores duplicate whitespace in string-list properties' {
+@test 'ignores duplicate whitespace in allowed images list' {
     version="$(get_setting .version)"
     run rdctl api -X PUT settings --body '{"containerEngine": {"allowedImages": {"patterns": ["c-stub", " ", "d-stub", "    ", "e-stub", ""] }}, "version": '"$version"'}'
     assert_success
     assert_output --partial 'settings updated; no restart required'
+}
 
+@test 'ignores duplicate whitespace in noproxy list' {
+    skip_on_unix "experimental.virtualMachine.proxy is only supported on Windows right now"
+    version="$(get_setting .version)"
     run rdctl api -X PUT settings --body '{"experimental": {"virtualMachine": {"proxy": {"noproxy": ["c-stub", " ", "d-stub", "    ", "e-stub", ""] }}}, "version": '"$version"'}'
     assert_success
     assert_output --partial 'settings updated; no restart required'

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -52,13 +52,13 @@ is_unix() {
 
 skip_on_windows() {
     if is_windows; then
-        skip "This test is not applicable on Windows."
+        skip "${1:-This test is not applicable on Windows.}"
     fi
 }
 
 skip_on_unix() {
     if is_unix; then
-        skip "This test is not applicable on MacOS/Linux."
+        skip "${1:-This test is not applicable on MacOS/Linux.}"
     fi
 }
 


### PR DESCRIPTION
Trying to modify the proxy settings on non-Windows machines throws an error since #5540 has been merged.