### PR TITLE
E2E: Don't package logs in GitHub CI

### DIFF
--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -156,8 +156,8 @@ export function reportAsset(testPath: string, type: 'trace' | 'log' = 'trace') {
 }
 
 export async function packageLogs(testPath: string) {
-  if (!process.env.CI) {
-    console.log('Skipping packaging logs, not running in CI');
+  if (!process.env.CIRRUS_CI) {
+    console.log('Skipping packaging logs, not running in CirrusCI');
 
     return;
   }


### PR DESCRIPTION
We only needed the tar file because CirrusCI only supported single-file uploads; GitHub is set to upload the whole directory.  This avoids the use of tar on Windows, which is having issues with file permissions (the log files are in use).