### PR TITLE
Add support to specify PR instead of BRANCH to install ci builds

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -9,7 +9,7 @@ on:
         description: Override repository (e.g. rancher-desktop)
         type: string
       branch:
-        description: Override branch (e.g. main)
+        description: Override branch (e.g. main, or PR#)
         type: string
       tests:
         description: 'Tests (e.g. tests/containers/*)'
@@ -48,6 +48,8 @@ jobs:
         : ${OWNER:=$GH_OWNER}
         : ${REPO:=${GH_REPOSITORY#$GH_OWNER/}}
         : ${BRANCH:=$GH_REF_NAME}
+        # If BRANCH is a number, assume it is supposed to be a PR
+        [[ $BRANCH =~ ^[0-9]+$ ]] && PR=$BRANCH
         "$TMPDIR/$SCRIPT"
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
E.g. run `PR=5600 ./scripts/install-latest-ci.sh`.

Also for the Github Action assume that a numeric branch name is a PR.