### PR TITLE
GitHub workflows: E2E: Enable Linux on-push

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -2,8 +2,8 @@ name: e2e tests on Linux
 
 on:
   workflow_dispatch:
-  schedule:
-  - cron: '15 8 * * 1-5'
+  push:
+  pull_request:
 
 jobs:
   e2e-tests:
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: main
       # For compatibility with runners without yarn, we need to install node
       # once, install yarn, then install node again to get caching.
       - uses: actions/setup-node@v3
@@ -46,6 +45,7 @@ jobs:
         run: yarn test:e2e
         env:
           RD_DEBUG_ENABLED: '1'
+        timeout-minutes: 60
       - name: Upload failure reports
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -17,6 +17,12 @@ jobs:
         with:
           persist-credentials: false
           ref: main
+      # For compatibility with runners without yarn, we need to install node
+      # once, install yarn, then install node again to get caching.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - run: npm install --global yarn
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -24,6 +24,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # For compatibility with runners without yarn, we need to install node
+      # once, install yarn, then install node again to get caching.
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - run: npm install --global yarn
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'


### PR DESCRIPTION
Also make sure the Windows & Mac platforms also handle the lack of a global yarn executable.