### PR TITLE
Stop using AppData/Roaming on windows

### DIFF
--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -18,7 +18,6 @@ jobs:
       - run: wsl --unregister rancher-desktop-data
         continue-on-error: true
       - run: Remove-Item -Path "$HOME/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item -Path "$HOME/AppData/Roaming/rancher-desktop" -Recurse -Force -ErrorAction Ignore
       - name: Remove golang module cache
         run: Remove-Item -Path "$HOME/go/pkg/mod" -Recurse -Force -ErrorAction Ignore
       - uses: actions/checkout@v4

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -153,7 +153,7 @@ rdctl_factory_reset() {
 
 check_directories() {
     # Check if all expected directories are created after starting application/ are deleted after a factory reset
-    delete_dir=("$PATH_CONFIG_FILE" "$PATH_LOGS" "$PATH_APP_HOME/credential-server.json" "$PATH_APP_HOME/rd-engine.json")
+    delete_dir=("$PATH_LOGS" "$PATH_APP_HOME/credential-server.json" "$PATH_APP_HOME/rd-engine.json")
     if is_unix; then
         # On Windows "$PATH_CONFIG" == "$PATH_APP_HOME"
         delete_dir+=("$HOME/.rd" "$LIMA_HOME" "$PATH_CONFIG")
@@ -167,8 +167,8 @@ check_directories() {
 
     if is_windows; then
         # On Windows $PATH_CONFIG is the same as $PATH_APP_HOME
-        delete_dir+=("$PATH_DISTRO" "$PATH_DISTRO_DATA")
-        # What about  $PATH_APP_HOME/vtunnel-config.yaml ?
+        delete_dir+=("$PATH_CONFIG_FILE" "$PATH_DISTRO" "$PATH_DISTRO_DATA")
+        # TODO: What about  $PATH_APP_HOME/vtunnel-config.yaml ?
     fi
 
     for dir in "${delete_dir[@]}"; do

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -156,22 +156,22 @@ rdctl_factory_reset() {
 
 check_directories() {
     # Check if all expected directories are created after starting application/ are deleted after a factory reset
-    delete_dir=("$PATH_CONFIG")
+    delete_dir=("$PATH_CONFIG_FILE" "$PATH_LOGS" "$PATH_APP_HOME/credential-server.json" "$PATH_APP_HOME/rd-engine.json")
     if is_unix; then
-        delete_dir+=("$HOME/.rd")
-        delete_dir+=("$PATH_APP_HOME/credential-server.json" "$PATH_APP_HOME/rd-engine.json" "$LIMA_HOME" "$PATH_LOGS")
+        # On Windows "$PATH_CONFIG" == "$PATH_APP_HOME"
+        delete_dir+=("$HOME/.rd" "$LIMA_HOME" "$PATH_CONFIG")
         # We can't make any general assertion on AppHome/snapshots - we don't know if it was created or not
         # So just assert on the other members of AppHome
-        # if is_macos; then
         # TODO on macOS (not implemented by `rdctl factory-reset`)
         # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
         # this one only exists after an update has been downloaded
         # ~/Library/Application Support/Caches/rancher-desktop-updater
-        # fi
     fi
 
     if is_windows; then
-        delete_dir+=("$PATH_LOGS" "$PATH_DISTRO" "$PATH_DISTRO_DATA" "$PATH_APP_HOME")
+        # On Windows $PATH_CONFIG is the same as $PATH_APP_HOME
+        delete_dir+=("$PATH_DISTRO" "$PATH_DISTRO_DATA")
+        # What about  $PATH_APP_HOME/vtunnel-config.yaml ?
     fi
 
     for dir in "${delete_dir[@]}"; do

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -146,9 +146,6 @@ rdctl_factory_reset() {
 
     if [[ $1 == "--remove-kubernetes-cache=true" ]]; then
         assert_not_exist "$PATH_CACHE"
-        if is_windows; then
-            assert_not_exist "$PATH_DATA"
-        fi
     else
         assert_exists "$PATH_CACHE"
     fi

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -102,7 +102,6 @@ if is_windows; then
     PATH_EXTENSIONS="$PATH_APP_HOME/extensions"
     PATH_SNAPSHOTS="$PATH_APP_HOME/rancher-desktop/snapshots"
 
-
     set_path_resources \
         "$PROGRAMFILES/Rancher Desktop" \
         "$LOCALAPPDATA/Programs/Rancher Desktop" \

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -94,7 +94,6 @@ if is_windows; then
 
     PATH_APP_HOME="$LOCALAPPDATA/rancher-desktop"
     PATH_CONFIG="$LOCALAPPDATA/rancher-desktop"
-    PATH_DATA="$LOCALAPPDATA/rancher-desktop"
     PATH_CACHE="$PATH_APP_HOME/cache"
     PATH_LOGS="$PATH_APP_HOME/logs"
     PATH_DISTRO="$PATH_APP_HOME/distro"

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -89,19 +89,19 @@ win32env() {
 }
 
 if is_windows; then
-    APPDATA="$(win32env APPDATA)"
     LOCALAPPDATA="$(win32env LOCALAPPDATA)"
     PROGRAMFILES="$(win32env ProgramFiles)"
 
-    PATH_APP_HOME="$APPDATA/rancher-desktop"
-    PATH_CONFIG="$APPDATA/rancher-desktop"
+    PATH_APP_HOME="$LOCALAPPDATA/rancher-desktop"
+    PATH_CONFIG="$LOCALAPPDATA/rancher-desktop"
     PATH_DATA="$LOCALAPPDATA/rancher-desktop"
-    PATH_CACHE="$PATH_DATA/cache"
-    PATH_LOGS="$PATH_DATA/logs"
-    PATH_DISTRO="$PATH_DATA/distro"
-    PATH_DISTRO_DATA="$PATH_DATA/distro-data"
-    PATH_EXTENSIONS="$PATH_DATA/extensions"
-    PATH_SNAPSHOTS="$LOCALAPPDATA/rancher-desktop/snapshots"
+    PATH_CACHE="$PATH_APP_HOME/cache"
+    PATH_LOGS="$PATH_APP_HOME/logs"
+    PATH_DISTRO="$PATH_APP_HOME/distro"
+    PATH_DISTRO_DATA="$PATH_APP_HOME/distro-data"
+    PATH_EXTENSIONS="$PATH_APP_HOME/extensions"
+    PATH_SNAPSHOTS="$PATH_APP_HOME/rancher-desktop/snapshots"
+
 
     set_path_resources \
         "$PROGRAMFILES/Rancher Desktop" \

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -27,6 +27,9 @@ let lockedSettings: LockedSettingsType = {};
 let _isFirstRun = false;
 let settings: Settings | undefined;
 
+// This is used to track whether we moved the settings.json from Roaming to Local on Windows
+let didAppdataRoamingMigration = false;
+
 /**
  * Load the settings file from disk, doing any migrations as necessary.
  */
@@ -109,6 +112,12 @@ export function load(deploymentProfiles: DeploymentProfileType): Settings {
     return finishConfiguringSettings(loadFromDisk(), deploymentProfiles);
   } catch (err: any) {
     if (err.code === 'ENOENT') {
+      if (migrateSettingsLocationOnWindows()) {
+        // If this call succeeds, call the function again. There's a global boolean that guards
+        // the call from succeeding more than once in a run (or more likely, more than once forever).
+        return load(deploymentProfiles);
+      }
+
       return createSettings(deploymentProfiles);
     } else {
       // JSON problems in the settings file will be caught, and we let any
@@ -250,6 +259,34 @@ function fileIsWritable(path: string) {
   } catch (_) {
     return false;
   }
+}
+
+function migrateSettingsLocationOnWindows(): boolean {
+  if (didAppdataRoamingMigration || process.platform !== 'win32') {
+    return false;
+  }
+  const appData = process.env['APPDATA'];
+  const rdAppHomeDir = paths.appHome;
+
+  if (!appData || !rdAppHomeDir) {
+    return false;
+  }
+  const oldConfigPath = join(appData, 'rancher-desktop', 'settings.json');
+  const newConfigPath = join(rdAppHomeDir, 'settings.json');
+
+  if (!fileExists(oldConfigPath) || fileExists(newConfigPath)) {
+    return false;
+  }
+  try {
+    fs.copyFileSync(oldConfigPath, newConfigPath);
+    didAppdataRoamingMigration = true;
+
+    return true;
+  } catch {
+    // Ignore any other problems, so create a new settings file.
+  }
+
+  return false;
 }
 
 /**

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -260,7 +260,7 @@ function fileIsWritable(path: string) {
 
 /*
  * The purpose of this function is to let RD stop using AppData\Roaming on Windows, and store almost everything
- * in Local\Roaming. The only file it needs to preserve is `AppData\Roaming\rancher-desktop\settings.json`.
+ * in AppData\Local. The only file it needs to preserve is `AppData\Roaming\rancher-desktop\settings.json`.
  * This is called by the loader when it doesn't find that file in `Local\...`. So it looks to see if it's
  * in `Roaming\...`, and if it is, will move it to `Local\...` and then load it.
  */

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -23,17 +23,17 @@ jest.mock('electron', () => {
 describe('paths', () => {
   const cases: Record<keyof Paths, expectedData> = {
     appHome: {
-      win32:  '%APPDATA%/rancher-desktop/',
+      win32:  '%LOCALAPPDATA%/rancher-desktop/',
       linux:  '%HOME%/.local/share/rancher-desktop/',
       darwin: '%HOME%/Library/Application Support/rancher-desktop/',
     },
     altAppHome: {
-      win32:  '%APPDATA%/rancher-desktop/',
+      win32:  '%LOCALAPPDATA%/rancher-desktop/',
       linux:  '%HOME%/.rd/',
       darwin: '%HOME%/.rd/',
     },
     config: {
-      win32:  '%APPDATA%/rancher-desktop/',
+      win32:  '%LOCALAPPDATA%/rancher-desktop/',
       linux:  '%HOME%/.config/rancher-desktop/',
       darwin: '%HOME%/Library/Preferences/rancher-desktop/',
     },

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/spf13/cobra"
 )
 
@@ -66,11 +66,11 @@ func DefineGlobalFlags(rootCmd *cobra.Command) {
 		}
 		configDir = filepath.Join(configDir, "rancher-desktop")
 	} else {
-		paths, err := p.GetPaths()
+		appPaths, err := paths.GetPaths()
 		if err != nil {
 			log.Fatalf("failed to get paths: %s", err)
 		}
-		configDir = paths.AppHome
+		configDir = appPaths.AppHome
 	}
 	DefaultConfigPath = filepath.Join(configDir, "rd-engine.json")
 	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", fmt.Sprintf("config file (default %s)", DefaultConfigPath))
@@ -138,10 +138,10 @@ func isWSLDistro() bool {
 	return fi.Mode()&os.ModeSymlink == os.ModeSymlink
 }
 
-func getAppDataPath() (string, error) {
+func getLocalAppDataPath() (string, error) {
 	var outBuf bytes.Buffer
 	// changes the codepage to 65001 which is UTF-8
-	subCommand := `chcp 65001 >nul & echo %APPDATA%`
+	subCommand := `chcp 65001 >nul & echo %LOCALAPPDATA%`
 	cmd := exec.Command("cmd.exe", "/c", subCommand)
 	cmd.Stdout = &outBuf
 	// We are intentionally not using CombinedOutput and
@@ -154,7 +154,7 @@ func getAppDataPath() (string, error) {
 }
 
 func wslifyConfigDir() (string, error) {
-	path, err := getAppDataPath()
+	path, err := getLocalAppDataPath()
 	if err != nil {
 		return "", err
 	}

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -206,10 +206,6 @@ func deleteWindowsData(keepSystemImages bool, appName string) error {
 func getDirectoriesToDelete(keepSystemImages bool, appName string) ([]string, error) {
 	// Ordered from least important to most, so that if delete fails we
 	// still keep some useful data.
-	appData, err := directories.GetRoamingAppDataDirectory()
-	if err != nil {
-		return nil, fmt.Errorf("could not get AppData folder: %w", err)
-	}
 	localAppData, err := directories.GetLocalAppDataDirectory()
 	if err != nil {
 		return nil, fmt.Errorf("could not get LocalAppData folder: %w", err)
@@ -264,8 +260,14 @@ func getDirectoriesToDelete(keepSystemImages bool, appName string) ([]string, er
 	if deleteLocalRDAppData {
 		dirs = append(dirs, localRDAppData)
 	}
-
-	dirs = append(dirs, path.Join(appData, appName))
+	roamingAppData, err := directories.GetRoamingAppDataDirectory()
+	if err == nil {
+		dirs = append(dirs, path.Join(roamingAppData, appName))
+		// Electron stores some files in AppData\Roaming\Rancher Desktop
+		dirs = append(dirs, path.Join(roamingAppData, "Rancher Desktop"))
+	} else {
+		logrus.Errorf("Could not get AppData (roaming) folder: %s\n", err)
+	}
 	return dirs, nil
 }
 

--- a/src/go/rdctl/pkg/paths/paths_windows.go
+++ b/src/go/rdctl/pkg/paths/paths_windows.go
@@ -26,11 +26,7 @@ func GetPaths(getResourcesPathFuncs ...func() (string, error)) (Paths, error) {
 	if localAppData == "" {
 		localAppData = filepath.Join(homeDir, "AppData", "Local")
 	}
-	appData := os.Getenv("APPDATA")
-	if appData == "" {
-		appData = filepath.Join(homeDir, "AppData", "Roaming")
-	}
-	appHome := filepath.Join(appData, appName)
+	appHome := filepath.Join(localAppData, appName)
 	paths := Paths{
 		AppHome:       appHome,
 		AltAppHome:    appHome,

--- a/src/go/rdctl/pkg/paths/paths_windows_test.go
+++ b/src/go/rdctl/pkg/paths/paths_windows_test.go
@@ -23,9 +23,9 @@ func TestGetPaths(t *testing.T) {
 			t.Errorf("Unexpected error getting user home directory: %s", err)
 		}
 		expectedPaths := Paths{
-			AppHome:       filepath.Join(homeDir, "AppData", "Roaming", appName),
-			AltAppHome:    filepath.Join(homeDir, "AppData", "Roaming", appName),
-			Config:        filepath.Join(homeDir, "AppData", "Roaming", appName),
+			AppHome:       filepath.Join(homeDir, "AppData", "Local", appName),
+			AltAppHome:    filepath.Join(homeDir, "AppData", "Local", appName),
+			Config:        filepath.Join(homeDir, "AppData", "Local", appName),
 			Logs:          filepath.Join(homeDir, "AppData", "Local", appName, "logs"),
 			Cache:         filepath.Join(homeDir, "AppData", "Local", appName, "cache"),
 			WslDistro:     filepath.Join(homeDir, "AppData", "Local", appName, "distro"),
@@ -58,9 +58,9 @@ func TestGetPaths(t *testing.T) {
 		}
 
 		expectedPaths := Paths{
-			AppHome:       filepath.Join(environment["APPDATA"], appName),
-			AltAppHome:    filepath.Join(environment["APPDATA"], appName),
-			Config:        filepath.Join(environment["APPDATA"], appName),
+			AppHome:       filepath.Join(environment["LOCALAPPDATA"], appName),
+			AltAppHome:    filepath.Join(environment["LOCALAPPDATA"], appName),
+			Config:        filepath.Join(environment["LOCALAPPDATA"], appName),
 			Logs:          environment["RD_LOGS_DIR"],
 			Cache:         filepath.Join(environment["LOCALAPPDATA"], appName, "cache"),
 			WslDistro:     filepath.Join(environment["LOCALAPPDATA"], appName, "distro"),

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -42,17 +42,16 @@ func GetRDPath() (string, error) {
 	dir, err := directories.GetLocalAppDataDirectory()
 	if err == nil {
 		dataPaths = append(dataPaths, dir)
+	} else {
+		dataPaths = append(dataPaths, filepath.Join(homedir, "AppData", "Local"))
 	}
 	// %APPDATA%
 	dir, err = directories.GetRoamingAppDataDirectory()
 	if err == nil {
 		dataPaths = append(dataPaths, dir)
+	} else {
+		dataPaths = append(dataPaths, filepath.Join(homedir, "AppData", "Roaming"))
 	}
-	dataPaths = append(
-		dataPaths,
-		filepath.Join(homedir, "AppData", "Local"),
-		filepath.Join(homedir, "AppData", "Roaming"),
-	)
 	for _, dataDir := range dataPaths {
 		candidatePath := filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe")
 		_, err := os.Stat(candidatePath)

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -37,8 +37,8 @@ func GetRDPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	candidatePath := filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe")
-	_, err := os.Stat(candidatePath)
+	candidatePath = filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe")
+	_, err = os.Stat(candidatePath)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("failed to check existence of %q: %w", candidatePath, err)
 	}

--- a/src/go/rdctl/pkg/utils/utils_windows.go
+++ b/src/go/rdctl/pkg/utils/utils_windows.go
@@ -33,34 +33,17 @@ func GetRDPath() (string, error) {
 		return candidatePath, nil
 	}
 
-	homedir, err := os.UserHomeDir()
+	dataDir, err := directories.GetLocalAppDataDirectory()
 	if err != nil {
-		homedir = ""
+		return "", err
 	}
-	dataPaths := []string{}
-	// %LOCALAPPDATA%
-	dir, err := directories.GetLocalAppDataDirectory()
+	candidatePath := filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe")
+	_, err := os.Stat(candidatePath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("failed to check existence of %q: %w", candidatePath, err)
+	}
 	if err == nil {
-		dataPaths = append(dataPaths, dir)
-	} else {
-		dataPaths = append(dataPaths, filepath.Join(homedir, "AppData", "Local"))
-	}
-	// %APPDATA%
-	dir, err = directories.GetRoamingAppDataDirectory()
-	if err == nil {
-		dataPaths = append(dataPaths, dir)
-	} else {
-		dataPaths = append(dataPaths, filepath.Join(homedir, "AppData", "Roaming"))
-	}
-	for _, dataDir := range dataPaths {
-		candidatePath := filepath.Join(dataDir, "Programs", "Rancher Desktop", "Rancher Desktop.exe")
-		_, err := os.Stat(candidatePath)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return "", fmt.Errorf("failed to check existence of %q: %w", candidatePath, err)
-		}
-		if err == nil {
-			return candidatePath, nil
-		}
+		return candidatePath, nil
 	}
 
 	return "", errors.New("search locations exhausted")


### PR DESCRIPTION
Fixes #5378

Note also that the code copies `settings.json` from `Roaming/` to `Local/` if it fails to find it in `AppData/Local/rancher-desktop/`.