### PR TITLE
Revert "Bump check-spelling/check-spelling from 0.0.21 to 0.0.22"

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true
@@ -147,7 +147,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: apply spelling updates
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         experimental_apply_changes_via_bot: 1
         checkout: true


### PR DESCRIPTION
This reverts commit 014c56b4e0d30a358dad0f502bd2558479444eed.