### PR TITLE
Refresh check-spelling metadata for 0.0.22

### DIFF
--- a/.github/actions/spelling/candidate.patterns
+++ b/.github/actions/spelling/candidate.patterns
@@ -12,8 +12,11 @@
 # git index header
 index (?:[0-9a-z]{7,40},|)[0-9a-z]{7,40}\.\.[0-9a-z]{7,40}
 
+# file permissions
+['"`\s][-bcdLlpsw](?:[-r][-w][-Ssx]){2}[-r][-w][-SsTtx]\+?['"`\s]
+
 # css url wrappings
-\burl\([^)]*\)
+\burl\([^)]+\)
 
 # cid urls
 (['"])cid:.*?\g{-1}
@@ -130,6 +133,8 @@ themes\.googleusercontent\.com/static/fonts/[^/\s"]+/v\d+/[^.]+.
 (?:\[`?[0-9a-f]+`?\]\(https:/|)/(?:www\.|)github\.com(?:/[^/\s"]+){2,}(?:/[^/\s")]+)(?:[0-9a-f]+(?:[-0-9a-zA-Z/#.]*|)\b|)
 # GitHub SHAs
 \bgithub\.com(?:/[^/\s"]+){2}[@#][0-9a-f]+\b
+# GitHub SHA refs
+\[([0-9a-f]+)\]\(https://(?:www\.|)github.com/[-\w]+/[-\w]+/commit/\g{-1}[0-9a-f]*
 # GitHub wiki
 \bgithub\.com/(?:[^/]+/){2}wiki/(?:(?:[^/]+/|)_history|[^/]+(?:/_compare|)/[0-9a-f.]{40,})\b
 # githubusercontent
@@ -141,7 +146,7 @@ themes\.googleusercontent\.com/static/fonts/[^/\s"]+/v\d+/[^.]+.
 # git.io
 \bgit\.io/[0-9a-zA-Z]+
 # GitHub JSON
-"node_id": "[-a-zA-Z=;:/0-9+]*"
+"node_id": "[-a-zA-Z=;:/0-9+_]*"
 # Contributor
 \[[^\]]+\]\(https://github\.com/[^/\s"]+/?\)
 # GHSA
@@ -386,6 +391,8 @@ ipfs://[0-9a-zA-Z]{3,}
 
 # URL escaped characters
 \%[0-9A-F][A-F]
+# lower URL escaped characters
+\%[0-9a-f][a-f](?=[a-z]{2,})
 # IPv6
 \b(?:[0-9a-fA-F]{0,4}:){3,7}[0-9a-fA-F]{0,4}\b
 # c99 hex digits (not the full format, just one I've seen)
@@ -418,7 +425,7 @@ sha\d+:[0-9]*[a-f]{3,}[0-9a-f]*
 # hex digits including css/html color classes:
 (?:[\\0][xX]|\\u|[uU]\+|#x?|\%23)[0-9_a-fA-FgGrR]*?[a-fA-FgGrR]{2,}[0-9_a-fA-FgGrR]*(?:[uUlL]{0,3}|[iu]\d+)\b
 # integrity
-integrity=(['"])sha\d+-[-a-zA-Z=;:/0-9+]{40,}\g{-1}
+integrity=(['"])(?:\s*sha\d+-[-a-zA-Z=;:/0-9+]{40,})+\g{-1}
 
 # https://www.gnu.org/software/groff/manual/groff.html
 # man troff content
@@ -433,8 +440,8 @@ integrity=(['"])sha\d+-[-a-zA-Z=;:/0-9+]{40,}\g{-1}
 # Localized .desktop content
 Name\[[^\]]+\]=.*
 
-# IServiceProvider
-\bI(?=(?:[A-Z][a-z]{2,})+\b)
+# IServiceProvider / isAThing
+\b(?:I|isA)(?=(?:[A-Z][a-z]{2,})+\b)
 
 # crypt
 (['"])\$2[ayb]\$.{56}\g{-1}
@@ -444,6 +451,9 @@ Name\[[^\]]+\]=.*
 
 # go.sum
 \bh1:\S+
+
+# scala modules
+("[^"]+"\s*%%?\s*){2,3}"[^"]+"
 
 # Input to GitHub JSON
 content: (['"])[-a-zA-Z=;:/0-9+]*=\g{-1}
@@ -456,7 +466,7 @@ content: (['"])[-a-zA-Z=;:/0-9+]*=\g{-1}
 
 # Python string prefix / binary prefix
 # Note that there's a high false positive rate, remove the `?=` and search for the regex to see if the matches seem like reasonable strings
-(?<!')\b(?:B|BR|Br|F|FR|Fr|R|RB|RF|Rb|Rf|U|UR|Ur|b|bR|br|f|fR|fr|r|rB|rF|rb|rf|u|uR|ur)'(?:[A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})
+(?<!')\b(?:B|BR|Br|F|FR|Fr|R|RB|RF|Rb|Rf|U|UR|Ur|b|bR|br|f|fR|fr|r|rB|rF|rb|rf|u|uR|ur)'(?=[A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})
 
 # Regular expressions for (P|p)assword
 \([A-Z]\|[a-z]\)[a-z]+
@@ -473,13 +483,27 @@ content: (['"])[-a-zA-Z=;:/0-9+]*=\g{-1}
 # javascript replace regex
 \.replace\(/[^/\s"]*/[gim]*\s*,
 # assign regex
-= /[^*].*/
+= /[^*]*?(?:[a-z]{3,}|[A-Z]{3,}|[A-Z][a-z]{2,}).*/
+# perl regex test
+[!=]~ (?:/.*/|m\{.*?\}|m<.*?>|m([|!/@#,;']).*?\g{-1})
+
+# perl qr regex
+(?<!\$)\bqr(?:\{.*?\}|<.*?>|\(.*?\)|([|!/@#,;']).*?\g{-1})
 
 # Go regular expressions
 regexp?\.MustCompile\(`[^`]*`\)
 
+# regex choice
+\(\?:[^)]+\|[^)]+\)
+
+# proto
+^\s*(\w+)\s\g{-1} =
+
 # sed regular expressions
 sed 's/(?:[^/]*?[a-zA-Z]{3,}[^/]*?/){2}
+
+# node packages
+(["'])\@[^/'" ]+/[^/'" ]+\g{-1}
 
 # go install
 go install(?:\s+[a-z]+\.[-@\w/.]+)+
@@ -495,7 +519,7 @@ go install(?:\s+[a-z]+\.[-@\w/.]+)+
 -[0-9a-f]{10}-\w{5}\s
 
 # posthog secrets
-posthog\.init\((['"])phc_[^"',]+\g{-1},
+([`'"])phc_[^"',]+\g{-1}
 
 # xcode
 
@@ -512,21 +536,29 @@ customObjectInstantitationMethod
 \.fa-[-a-z0-9]+
 
 # bearer auth
-(['"])Bearer .*?\g{-1}
+(['"])Bear[e][r] .*?\g{-1}
 
 # basic auth
 (['"])Basic [-a-zA-Z=;:/0-9+]{3,}\g{-1}
 
 # base64 encoded content
-(['"])[-a-zA-Z=;:/0-9+]+=\g{-1}
+([`'"])[-a-zA-Z=;:/0-9+]+=\g{-1}
 # base64 encoded content in xml/sgml
-#>[-a-zA-Z=;:/0-9+]+=</
+>[-a-zA-Z=;:/0-9+]+=</
+# base64 encoded content, possibly wrapped in mime
+(?:^|[\s=;:?])[-a-zA-Z=;:/0-9+]{50,}(?:[\s=;:?]|$)
+
+# encoded-word
+=\?[-a-zA-Z0-9"*%]+\?[BQ]\?[^?]{0,75}\?=
 
 # Time Zones
 \b(?:Africa|Atlantic|America|Antarctica|Asia|Australia|Europe|Indian|Pacific)(?:/\w+)+
 
 # linux kernel info
 ^(?:bugs|flags|Features)\s+:.*
+
+# systemd mode
+systemd.*?running in system mode \([-+].*\)$
 
 # Update Lorem based on your content (requires `ge` and `w` from https://github.com/jsoref/spelling; and `review` from https://github.com/check-spelling/check-spelling/wiki/Looking-for-items-locally )
 # grep '^[^#].*lorem' .github/actions/spelling/patterns.txt|perl -pne 's/.*i..\?://;s/\).*//' |tr '|' "\n"|sort -f |xargs -n1 ge|perl -pne 's/^[^:]*://'|sort -u|w|sed -e 's/ .*//'|w|review -
@@ -544,8 +576,11 @@ customObjectInstantitationMethod
 # This corpus only had capital letters, but you probably want lowercase ones as well.
 \b[LN]'+[a-z]{2,}\b
 
-# latex
+# latex (check-spelling <= 0.0.21)
 \\(?:n(?:ew|ormal|osub)|r(?:enew)|t(?:able(?:of|)|he|itle))(?=[a-z]+)
+
+# latex (check-spelling >= 0.0.22)
+\\\w{2,}\{
 
 # eslint
 "varsIgnorePattern": ".+"
@@ -556,9 +591,14 @@ customObjectInstantitationMethod
 # in a version of check-spelling after @0.0.21 printf markers won't be automatically consumed
 # printf markers
 #(?<!\\)\\[nrt](?=[a-z]{2,})
+# alternate markers if you run into latex and friends
+#(?<!\\)\\[nrt](?=[a-z]{2,})(?=.*['"`])
 
 # apache
 a2(?:en|dis)
+
+# weak e-tag
+W/"[^"]+"
 
 # the negative lookahead here is to allow catching 'templatesz' as a misspelling
 # but to otherwise recognize a Windows path with \templates\foo.template or similar:
@@ -568,13 +608,19 @@ a2(?:en|dis)
 
 # version suffix <word>v#
 (?:(?<=[A-Z]{2})V|(?<=[a-z]{2}|[A-Z]{2})v)\d+(?:\b|(?=[a-zA-Z_]))
-# Compiler flags (Scala)
-(?:^|[\t ,>"'`=(])-J-[DPWXY](?=[A-Z]{2,}|[A-Z][a-z]|[a-z]{2,})
-# Compiler flags
-#(?:^|[\t ,>"'`=(])-[DPWXYLlf](?=[A-Z]{2,}|[A-Z][a-z]|[a-z]{2,})
+
+# Compiler flags (Unix, Java/Scala)
+# Use if you have things like `-Pdocker` and want to treat them as `docker`
+#(?:^|[\t ,>"'`=(])-(?:(?:J-|)[DPWXY]|[Llf])(?=[A-Z]{2,}|[A-Z][a-z]|[a-z]{2,})
+
+# Compiler flags (Windows / PowerShell)
+# This is a subset of the more general compiler flags pattern.
+# It avoids matching `-Path` to prevent it from being treated as `ath`
+#(?:^|[\t ,"'`=(])-(?:[DPL](?=[A-Z]{2,})|[WXYlf](?=[A-Z]{2,}|[A-Z][a-z]|[a-z]{2,}))
 
 # Compiler flags (linker)
 ,-B
+
 # curl arguments
 \b(?:\\n|)curl(?:\s+-[a-zA-Z]{1,2}\b)*(?:\s+-[a-zA-Z]{3,})(?:\s+-[a-zA-Z]+)*
 # set arguments

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -21,7 +21,6 @@ alpline
 amazonec
 amazoneks
 ANamespace
-anchore
 andsection
 apify
 apiservice
@@ -88,7 +87,6 @@ bulkable
 bulkaction
 Buttondrop
 cacerts
-camelcase
 camelpunch
 CAPI
 caroot
@@ -169,7 +167,6 @@ decamelize
 dedot
 deepmap
 deepmerge
-defattr
 destinationrule
 DETECTEXCEPTIONS
 developercertificate
@@ -232,6 +229,7 @@ externalservice
 factoryreset
 fakercfile
 fanotify
+fattr
 fav
 fcb
 fdx
@@ -273,6 +271,7 @@ googlegke
 googleoauth
 gosec
 govet
+govmm
 gpg
 gpu
 grafana
@@ -291,8 +290,6 @@ Hec
 heketi
 helmcharts
 hicolor
-HKCU
-HKLM
 HMR
 hocs
 horizontalpodautoscaler
@@ -507,14 +504,12 @@ nspr
 nss
 nullglob
 nuxt
-nuxtjs
 nxt
 nydus
 oapi
 objectset
 octicons
 oidc
-oldpackage
 onecore
 oom
 openapitools
@@ -604,7 +599,6 @@ ranchertest
 rawdata
 rcfiles
 rcompare
-rdconfig
 rdctl
 rddepman
 rdinstall
@@ -698,7 +692,6 @@ ssd
 sshfs
 sslip
 Ssr
-ssr
 statefulset
 stoinks
 storageclass

--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -20,8 +20,14 @@
 # s.b. JavaScript
 \bJavascript\b
 
+# s.b. macOS or Mac OS X or ...
+\bMacOS\b
+
 # s.b. Microsoft
 \bMicroSoft\b
+
+# s.b. TypeScript
+\bTypescript\b
 
 # s.b. another
 \ban[- ]other\b
@@ -38,7 +44,7 @@
 # s.b. into
 # when not phrasal and when `in order to` would be wrong:
 # https://thewritepractice.com/into-vs-in-to/
-#\sin to\s
+#\sin to\s(?!if\b)
 
 # s.b. is obsolete
 \bis obsolescent\b
@@ -52,15 +58,21 @@
 # s.b. less than
 \bless then\b
 
+# s.b. one of
+\bon of\b
+
 # s.b. otherwise
 \bother[- ]wise\b
+
+# s.b. or (more|less)
+\bore (?:more|less)\b
 
 # s.b. nonexistent
 \bnon existing\b
 \b[Nn]o[nt][- ]existent\b
 
 # s.b. brief / details/ param / return / retval
-(?:^\s*|(?:\*|//|/*)\s+`)[\\@](?:breif|(?:detail|detials)|(?:params|prama?)|ret(?:uns?)|retvl)\b
+(?:^\s*|(?:\*|//|/*)\s+`)[\\@](?:breif|(?:detail|detials)|(?:params(?!\.)|prama?)|ret(?:uns?)|retvl)\b
 
 # s.b. preexisting
 [Pp]re[- ]existing
@@ -92,5 +104,16 @@
 # s.b. (coarse|fine)-grained
 \b(?:coarse|fine) grained\b
 
-# Reject duplicate words
+# s.b. neither/nor -- or reword
+#\bnot\b[^.?!"/(]+\bnor\b
+
+# probably a double negative
+# s.b. neither/nor (plus rewording the beginning)
+\bnot\b[^.?!"/]*\bneither\b[^.?!"/(]*\bnor\b
+
+# In English, it is generally wrong to have the same word twice in a row without punctuation.
+# Duplicated words are generally mistakes.
+# There are a few exceptions where it is acceptable (e.g. "that that").
+# If the highlighted doubled word pair is in a code snippet, you can write a pattern to mask it.
+# If the highlighted doubled word pair is in prose, have someone read the English before you dismiss this error.
 \s([A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})\s\g{-1}\s

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,53 +1,52 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
 
 # Automatically suggested patterns
-# hit-count: 2030 file-count: 6
+# hit-count: 1262 file-count: 4
 # ANSI color codes
 (?:\\(?:u00|x)1[Bb]|\x1b|\\u\{1[Bb]\})\[\d+(?:;\d+|)m
 
-# hit-count: 1143 file-count: 19
+# hit-count: 743 file-count: 13
 # hex runs
 \b[0-9a-fA-F]{16,}\b
 
-# hit-count: 446 file-count: 98
+# hit-count: 739 file-count: 6
+# base64 encoded content, possibly wrapped in mime
+(?:^|[\s=;:?])[-a-zA-Z=;:/0-9+]{50,}(?:[\s=;:?]|$)
+
+# hit-count: 215 file-count: 101
 # https/http/file urls
 (?:\b(?:https?|ftp|file)://)[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]
 
-# hit-count: 185 file-count: 7
+# hit-count: 94 file-count: 3
 # sha
 sha\d+:[0-9]*[a-f]{3,}[0-9a-f]*
 
-# hit-count: 52 file-count: 13
+# hit-count: 46 file-count: 34
+# GitHub SHAs (markdown)
+(?:\[`?[0-9a-f]+`?\]\(https:/|)/(?:www\.|)github\.com(?:/[^/\s"]+){2,}(?:/[^/\s")]+)(?:[0-9a-f]+(?:[-0-9a-zA-Z/#.]*|)\b|)
+
+# hit-count: 44 file-count: 10
 # version suffix <word>v#
 (?:(?<=[A-Z]{2})V|(?<=[a-z]{2}|[A-Z]{2})v)\d+(?:\b|(?=[a-zA-Z_]))
 
-# hit-count: 43 file-count: 1
-# AWS S3
-\b\w*\.s3[^.]*\.amazonaws\.com/[-\w/&#%_?:=]*
-
-# hit-count: 38 file-count: 4
-# uuid:
-\b[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\b
+# hit-count: 25 file-count: 25
+# node packages
+(["'])\@[^/'" ]+/[^/'" ]+\g{-1}
 
 # hit-count: 16 file-count: 9
 # in a version of check-spelling after @0.0.21 printf markers won't be automatically consumed
 # printf markers
 (?<!\\)\\n(?=[a-z]{2,})
 
-# hit-count: 14 file-count: 3
-# URL escaped characters
-\%[0-9A-F][A-F]
+# hit-count: 10 file-count: 2
+# uuid:
+\b[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\b
 
-# hit-count: 13 file-count: 3
-# hex digits including css/html color classes:
-(?:[\\0][xX]|[uU]\+|#x?|\%23)[0-9_a-fA-FgGrR]*?[a-fA-FgGrR]{2,}[0-9_a-fA-FgGrR]*(?:[uUlL]{0,3}|[iu]\d+)\b
-\\u[0-9A-F]{4}
-
-# hit-count: 12 file-count: 3
+# hit-count: 10 file-count: 1
 # css url wrappings
-\burl\([^)]*\)
+\burl\([^)]+\)
 
-# hit-count: 9 file-count: 9
+# hit-count: 8 file-count: 8
 # JavaScript regular expressions
 # javascript test regex
 /.*/[gim]*\.test\(
@@ -56,48 +55,61 @@ sha\d+:[0-9]*[a-f]{3,}[0-9a-f]*
 # javascript replace regex
 \.replace\(/[^/\s"]*/[gim]*\s*,
 
-# hit-count: 7 file-count: 6
-# assign regex
-= /[^*].*/
-
-# hit-count: 5 file-count: 3
-# sha-... -- uses a fancy capture
-(\\?['"]|&quot;)[0-9a-f]{40,}\g{-1}
-
-# hit-count: 5 file-count: 3
+# hit-count: 6 file-count: 4
 # tar arguments
 \b(?:\\n|)g?tar(?:\.exe|)(?:(?:\s+--[-a-zA-Z]+|\s+-[a-zA-Z]+|\s[ABGJMOPRSUWZacdfh-pr-xz]+\b)(?:=[^ ]*|))+
+
+# hit-count: 4 file-count: 3
+# base64 encoded content
+([`'"])[-a-zA-Z=;:/0-9+]+=\g{-1}
+
+# hit-count: 4 file-count: 2
+# URL escaped characters
+\%[0-9A-F][A-F]
 
 # hit-count: 4 file-count: 2
 # go install
 go install(?:\s+[a-z]+\.[-@\w/.]+)+
 
-# hit-count: 3 file-count: 2
-# IServiceProvider
-\bI(?=(?:[A-Z][a-z]{2,})+\b)
+# hit-count: 3 file-count: 3
+# stackexchange -- https://stackexchange.com/feeds/sites
+\b(?:askubuntu|serverfault|stack(?:exchange|overflow)|superuser).com/(?:questions/\w+/[-\w]+|a/)
 
 # hit-count: 3 file-count: 2
-# javascript match regex
-\.match\(/[^/\s"]*/[gim]*\s*
+# hex digits including css/html color classes:
+(?:[\\0][xX]|\\u|[uU]\+|#x?|\%23)[0-9_a-fA-FgGrR]*?[a-fA-FgGrR]{2,}[0-9_a-fA-FgGrR]*(?:[uUlL]{0,3}|[iu]\d+)\b
 
 # hit-count: 3 file-count: 2
-# base64 encoded content
-(['"])[-a-zA-Z=;:/0-9+]+=\g{-1}
+# IServiceProvider / isAThing
+\b(?:I|isA)(?=(?:[A-Z][a-z]{2,})+\b)
 
 # hit-count: 2 file-count: 2
-# data url in parens
-\(data:(?:[^) ][^)]*?|)(?:[A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})[^)]*\)
+# sha-... -- uses a fancy capture
+(\\?['"]|&quot;)[0-9a-f]{40,}\g{-1}
 
-# hit-count: 1 file-count: 1
-# Go regular expressions
-regexp?\.MustCompile\(`[^`]*`\)
+# hit-count: 2 file-count: 2
+# assign regex
+= /[^*]*?(?:[a-z]{3,}|[A-Z]{3,}|[A-Z][a-z]{2,}).*/
+
+# hit-count: 2 file-count: 2
+# regex choice
+\(\?:[^)]+\|[^)]+\)
 
 # hit-count: 1 file-count: 1
 # gist github
 \bgist\.github\.com/[^/\s"]+/[0-9a-f]+
 
-# GitHub repositories and paths from there
-\bgithub\.com/[/a-zA-Z0-f_-]*/
+# hit-count: 1 file-count: 1
+# lower URL escaped characters
+\%[0-9a-f][a-f](?=[a-z]{2,})
+
+# hit-count: 1 file-count: 1
+# javascript match regex
+\.match\(/[^/\s"]*/[gim]*\s*
+
+# hit-count: 1 file-count: 1
+# Go regular expressions
+regexp?\.MustCompile\(`[^`]*`\)
 
 # Questionably acceptable forms of `in to`
 # Personally, I prefer `log into`, but people object
@@ -107,9 +119,6 @@ regexp?\.MustCompile\(`[^`]*`\)
 # to opt in
 \bto opt in\b
 
-# check-spelling@v0.0.21
-\\r(?:ancher|esources)
-
 # typos in translation keys
 ^\s*(?:calllback|objectReferance|requriedInt):$
 
@@ -118,20 +127,19 @@ regexp?\.MustCompile\(`[^`]*`\)
 
 # adduser and friends
 \s-g (\w+)\s+\g{-1}\s
-
 # acceptable duplicates
 # ls directory listings
 [-bcdlpsw](?:[-r][-w][-Ssx]){3}\s+\d+\s+\S+\s+\S+\s+\d+\s+
 # mount
 \bmount\s+-t\s+(\w+)\s+\g{-1}\b
 # C types and repeated CSS values
-\s(BUG|builder|center|div|inherit|long|LONG|none|normal|solid|thin|TODO|transparent|very)(?: \g{-1})+\s
+\s(auto|BUG|builder|center|div|inherit|long|LONG|none|normal|solid|thin|TODO|transparent|very)(?: \g{-1})+\s
 # C struct
 \bstruct\s+(\w+)\s+\g{-1}\b
 # go templates
 \s(\w+)\s+\g{-1}\s+\`(?:graphql|inject|json|yaml):
 # doxygen / javadoc / .net
-(?:[\\@](?:brief|groupname|t?param|return|retval)|(?:public|private)(?:\s+static|\s+readonly)*)\s+(\w+)\s+\g{-1}\s
+(?:[\\@](?:brief|groupname|t?param|return|retval)|(?:public|private)(?:\s+static|\s+readonly)*)(?:\s+\{\w+\}|)\s+(\w+)\s+\g{-1}\s
 
 # Commit message -- Signed-off-by and friends
 ^\s*(?:(?:Based-on-patch|Co-authored|Helped|Mentored|Reported|Reviewed|Signed-off)-by|Thanks-to): (?:[^<]*<[^>]*>|[^<]*)\s*$

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -154,3 +154,6 @@ regexp?\.MustCompile\(`[^`]*`\)
 
 # Allow golangci in GitHub workflows:
 \buses:\s*golangci/golangci-lint-action\b
+
+# on macOS, MacOS is used for the internal folder name within an app...
+(["/])MacOS\g{-1}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -101,33 +101,33 @@ jobs:
         post_comment: 0
         use_magic_file: 1
         experimental_apply_changes_via_bot: ${{ github.repository_owner != 'rancher-sandbox' && 1 }}
+        report-timing: 1
+        warnings: bad-regex,binary-file,deprecated-feature,large-file,limited-references,no-newline-at-eof,noisy-file,non-alpha-in-dictionary,token-is-substring,unexpected-line-ending,whitespace-in-dictionary,minified-file,unsupported-configuration,no-files-to-check
         use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
         extra_dictionary_limit: 20
-        dictionary_source_prefixes: |
-          {"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20220816/dictionaries/", "cspell1": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/"}
         extra_dictionaries:
-          cspell1:software-terms/dict/softwareTerms.txt
-          cspell1:k8s/dict/k8s.txt
-          cspell1:node/dict/node.txt
-          cspell1:aws/aws.txt
-          cspell1:python/src/python/python-lib.txt
-          cspell1:php/dict/php.txt
-          cspell1:typescript/dict/typescript.txt
-          cspell1:golang/dict/go.txt
-          cspell1:filetypes/filetypes.txt
-          cspell1:html/dict/html.txt
-          cspell1:npm/dict/npm.txt
-          cspell1:shell/dict/shell-all-words.txt
-          cspell1:fullstack/dict/fullstack.txt
-          cspell1:python/src/common/extra.txt
-          cspell1:java/src/java.txt
-          cspell1:dotnet/dict/dotnet.txt
-          cspell1:css/dict/css.txt
-          cspell1:django/dict/django.txt
-          cspell1:docker/src/docker-words.txt
-          cspell1:cpp/src/stdlib-cmath.txt
-          cspell1:python/src/python/python.txt
-          cspell1:powershell/dict/powershell.txt
+          cspell:software-terms/dict/softwareTerms.txt
+          cspell:k8s/dict/k8s.txt
+          cspell:node/dict/node.txt
+          cspell:aws/aws.txt
+          cspell:golang/dict/go.txt
+          cspell:php/dict/php.txt
+          cspell:python/src/python/python-lib.txt
+          cspell:typescript/dict/typescript.txt
+          cspell:npm/dict/npm.txt
+          cspell:shell/dict/shell-all-words.txt
+          cspell:html/dict/html.txt
+          cspell:filetypes/filetypes.txt
+          cspell:fullstack/dict/fullstack.txt
+          cspell:python/src/common/extra.txt
+          cspell:java/src/java.txt
+          cspell:dotnet/dict/dotnet.txt
+          cspell:css/dict/css.txt
+          cspell:django/dict/django.txt
+          cspell:docker/src/docker-words.txt
+          cspell:cpp/src/stdlib-cmath.txt
+          cspell:python/src/python/python.txt
+          cspell:powershell/dict/powershell.txt
 
   update:
     name: Update PR

--- a/background.ts
+++ b/background.ts
@@ -354,7 +354,7 @@ async function checkPrerequisites() {
     break;
   }
   case 'darwin': {
-    // Required: MacOS-10.15(Darwin-19) or newer
+    // Required: macOS-10.15(Darwin-19) or newer
     if (semver.gt('10.15.0', getMacOsVersion())) {
       messageId = 'macOS-release';
     }

--- a/bats/README.md
+++ b/bats/README.md
@@ -95,7 +95,7 @@ After finishing to develop a BATS test suite, you can locally verify the syntax 
 
   1. Make sure to have installed `shellcheck` and `shfmt`.
 
-     On MacOS:
+     On macOS:
      - Assuming you have Homebrew:
        ```sh
        brew install shfmt shellcheck

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -58,7 +58,7 @@ skip_on_windows() {
 
 skip_on_unix() {
     if is_unix; then
-        skip "${1:-This test is not applicable on MacOS/Linux.}"
+        skip "${1:-This test is not applicable on macOS/Linux.}"
     fi
 }
 

--- a/pkg/rancher-desktop/assets/specs/README.md
+++ b/pkg/rancher-desktop/assets/specs/README.md
@@ -17,7 +17,7 @@ go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen
 ```
 mkdir tmp
 docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli:v5.4.2 generate -i /local/src/assets/specs/command-api.yaml -g html -o /local/tmp/
-open tmp/index.html # (MacOS)
+open tmp/index.html # (macOS)
 start tmp/index.html # (Powershell)
 xdg-open tmp/index.html # (linux, replace with path to a specific browser if you prefer).
 ```

--- a/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
+++ b/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
@@ -38,7 +38,7 @@ export default Vue.extend({
         this.$data.reason = 'Requires Windows version 10-1909 or newer';
         break;
       case 'macOS-release':
-        this.$data.reason = 'Requires MacOS version 10.15 or newer';
+        this.$data.reason = 'Requires macOS version 10.15 or newer';
         break;
       case 'linux-nested':
         this.$data.reason = 'Nested virtualization not enabled on this host';

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -12,7 +12,7 @@ light & dark mode.
 
 ## Prerequisites
 
-### MacOS
+### macOS
 
 `screencapture` is required. It is part of the OS, so doesn't need to be installed
 separately. See https://ss64.com/osx/screencapture.html

--- a/src/go/rdctl/cmd/createProfile.go
+++ b/src/go/rdctl/cmd/createProfile.go
@@ -54,7 +54,7 @@ var createProfileCmd = &cobra.Command{
 	Long: `Use this to generate deployment profiles for Rancher Desktop settings.
 You can either convert the current listings in operation, or
 specify a JSON snippet, and convert that to the desired target.
-MacOS plist files can be placed in the appropriate directory, while ".reg" files
+macOS plist files can be placed in the appropriate directory, while ".reg" files
 can be imported into the Windows registry using the "eg import FILE" command.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cobra.NoArgs(cmd, args); err != nil {


### PR DESCRIPTION
This is a follow-up to #5615 -- it refreshes the configuration but mostly updates the dictionaries to their new locations.

You can see it passing here https://github.com/jsoref/rancher-desktop/actions/runs/6355021978