### PR TITLE
Fix global timeouts on Linux when running e2e tests.

### DIFF
--- a/e2e/config/playwright-config.ts
+++ b/e2e/config/playwright-config.ts
@@ -9,7 +9,7 @@ const timeScale = process.env.CI ? 2 : 1;
 const config: Config<PlaywrightTestOptions> = {
   testDir,
   outputDir,
-  timeout:       5 * 60 * 1000 * timeScale,
+  timeout:       10 * 60 * 1000 * timeScale,
   globalTimeout: 30 * 60 * 1000 * timeScale,
   workers:       1,
   reporter:      'list',

--- a/screenshots/playwright-config.ts
+++ b/screenshots/playwright-config.ts
@@ -14,7 +14,7 @@ process.env.RD_MOCK_FOR_SCREENSHOTS = 'true';
 const config: Config<PlaywrightTestOptions> = {
   testDir,
   outputDir,
-  timeout:       5 * 60 * 1000 * timeScale,
+  timeout:       10 * 60 * 1000 * timeScale,
   globalTimeout: 30 * 60 * 1000 * timeScale,
   workers:       1,
   reporter:      'list',


### PR DESCRIPTION
No related issue.

This is with file startup-profiles.e2e.spec.ts, but we might as well keep the screenshots config in sync with the e2e one.