### PR TITLE
Lima: work around buildkit issues on alpine

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/buildkit-wrapper
+++ b/pkg/rancher-desktop/assets/scripts/buildkit-wrapper
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This script mounts cgroup v2 from /sys/fs/cgroup/unified to /sys/fs/cgroup
+# before launching buildkitd.  This works around a buildkit issue [1] where it
+# treats cgroup v1/hybrid as if it were cgroup v2.
+#
+# [1]: https://github.com/moby/buildkit/issues/4108
+#
+# Usage: $0 <buildkitd args...>
+
+set -o errexit -o nounset -o xtrace
+
+if [ -z "${BUILDKIT_WRAPPER_INSIDE:-}" ]; then
+  exec /usr/bin/env BUILDKIT_WRAPPER_INSIDE=1 /usr/bin/unshare --mount --propagation shared "$0" "$@"
+fi
+unset BUILDKIT_WRAPPER_INSIDE
+
+/bin/mount -o bind,private /sys/fs/cgroup/unified /sys/fs/cgroup
+exec /usr/local/bin/buildkitd "$@"

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -31,6 +31,7 @@ import DEPENDENCY_VERSIONS from '@pkg/assets/dependencies.yaml';
 import DEFAULT_CONFIG from '@pkg/assets/lima-config.yaml';
 import NETWORKS_CONFIG from '@pkg/assets/networks-config.yaml';
 import FLANNEL_CONFLIST from '@pkg/assets/scripts/10-flannel.conflist';
+import BUILDKIT_WRAPPER_SCRIPT from '@pkg/assets/scripts/buildkit-wrapper';
 import SERVICE_BUILDKITD_CONF from '@pkg/assets/scripts/buildkit.confd';
 import SERVICE_BUILDKITD_INIT from '@pkg/assets/scripts/buildkit.initd';
 import DOCKER_CREDENTIAL_SCRIPT from '@pkg/assets/scripts/docker-credential-rancher-desktop';
@@ -1699,8 +1700,11 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   protected async writeBuildkitScripts() {
+    const conf = `${ SERVICE_BUILDKITD_CONF }\nbuildkitd_command="/usr/local/bin/buildkit-wrapper"\n`;
+
     await this.writeFile(`/etc/init.d/buildkitd`, SERVICE_BUILDKITD_INIT, 0o755);
-    await this.writeFile(`/etc/conf.d/buildkitd`, SERVICE_BUILDKITD_CONF, 0o644);
+    await this.writeFile(`/etc/conf.d/buildkitd`, conf, 0o644);
+    await this.writeFile(`/usr/local/bin/buildkit-wrapper`, BUILDKIT_WRAPPER_SCRIPT, 0o755);
   }
 
   protected async configureOpenResty(config: BackendSettings) {


### PR DESCRIPTION
Newer versions of buildkit try to use cgroupns; however, they also do so on cgroup v1, which is a bit broken.  We can work around this:

- Use the OpenRC default of hybrid cgroups
- Write a wrapper that bind mounts /sys/fs/cgroup/unified (cgroup v2) on top of /sys/fs/cgroup (cgroup v1)

That way buildkitd only sees cgroup v2 and everything works out correctly. We _only_ do this for buildkit, so that anything expecting cgroup v1 (e.g. Rancher) can work correctly.

**Note**: We will need to coordinate alpine-lima (using the new buildkit, etc.). Be sure to test with a release of that that has the broken buildkit.