### PR TITLE
When outputting json in `rdctl snapshot...`, output errors in json blocks.

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -278,3 +278,20 @@ wait_for_container_engine() {
     trace "waiting for container engine info to be available"
     try --max 12 --delay 10 get_container_engine_info
 }
+
+wait_for_backend() {
+    local timeout="$(($(date +%s) + 10 * 60))"
+    while true; do
+        run rdctl api /v1/backend_state
+        if ((status == 0)); then
+            run jq_output .vmState
+            case "$output" in
+            STARTED) return 0 ;;
+            DISABLED) return 0 ;;
+            esac
+        fi
+        assert [ "$(date +%s)" -lt "$timeout" ]
+        sleep 1
+    done
+    return 1
+}

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -38,7 +38,7 @@ func init() {
 	snapshotErrors = make([]error, 0)
 }
 
-func exitWithJSONOrErrorCondition(e error) error {
+func exitWithJsonOrErrorCondition(e error) error {
 	if e != nil {
 		snapshotErrors = append(snapshotErrors, e)
 	}

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -42,20 +42,22 @@ func exitWithJsonOrErrorCondition(e error) error {
 		snapshotErrors = append(snapshotErrors, e)
 	}
 	if outputJsonFormat {
+		exitStatus := 0
 		for _, snapshotError := range snapshotErrors {
 			if snapshotError != nil {
-				errorPayload := errorPayloadType{snapshotError.Error() }
+				exitStatus = 1
+				errorPayload := errorPayloadType{snapshotError.Error()}
 				jsonBuffer, err := json.Marshal(errorPayload)
 				if err != nil {
-					return fmt.Errorf("error json-converting error messages: %w", err)
+					snapshotErrors = append(snapshotErrors, fmt.Errorf("error json-converting error messages: %w", err))
+					return errors.Join(snapshotErrors...)
 				}
 				fmt.Fprintf(os.Stdout, string(jsonBuffer)+"\n")
 			}
 		}
-		return nil
-	} else {
-		return errors.Join(snapshotErrors...)
+		os.Exit(exitStatus)
 	}
+	return errors.Join(snapshotErrors...)
 }
 
 // If the main process is running, stops the backend, calls the

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -17,7 +17,7 @@ var snapshotCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := wrapSnapshotOperation(createSnapshot)(cmd, args)
-		return exitWithJSONOrErrorCondition(err)
+		return exitWithJsonOrErrorCondition(err)
 	},
 }
 

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
+	"runtime"
 
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/spf13/cobra"
 )
@@ -12,21 +14,33 @@ var snapshotCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a snapshot",
 	Args:  cobra.ExactArgs(1),
-	RunE:  wrapSnapshotOperation(createSnapshot),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		err := wrapSnapshotOperation(createSnapshot)(cmd, args)
+		return exitWithJSONOrErrorCondition(err)
+	},
 }
 
 func init() {
 	snapshotCmd.AddCommand(snapshotCreateCmd)
+	snapshotCreateCmd.Flags().BoolVarP(&outputJsonFormat, "json", "", false, "output json format")
 }
 
-func createSnapshot(cmd *cobra.Command, args []string) error {
-	paths, err := p.GetPaths()
+func createSnapshot(_ *cobra.Command, args []string) error {
+	appPaths, err := paths.GetPaths()
 	if err != nil {
 		return fmt.Errorf("failed to get paths: %w", err)
 	}
-	manager := snapshot.NewManager(paths)
+	manager := snapshot.NewManager(appPaths)
 	if _, err := manager.Create(args[0]); err != nil {
 		return fmt.Errorf("failed to create snapshot: %w", err)
+	}
+	// exclude snapshots directory from time machine backups if on macOS
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to add exclusion to TimeMachine: %w", err)
+		}
 	}
 	return nil
 }

--- a/src/go/rdctl/cmd/snapshotDelete.go
+++ b/src/go/rdctl/cmd/snapshotDelete.go
@@ -24,11 +24,11 @@ func deleteSnapshot(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	paths, err := p.GetPaths()
 	if err != nil {
-		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
+		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
 	}
 	manager := snapshot.NewManager(paths)
 	if err = manager.Delete(args[0]); err != nil {
-		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to delete snapshot: %w", err))
+		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to delete snapshot: %w", err))
 	}
 	return nil
 }

--- a/src/go/rdctl/cmd/snapshotDelete.go
+++ b/src/go/rdctl/cmd/snapshotDelete.go
@@ -12,19 +12,23 @@ var snapshotDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
 	Short: "Delete a snapshot",
 	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		paths, err := p.GetPaths()
-		if err != nil {
-			return fmt.Errorf("failed to get paths: %w", err)
-		}
-		manager := snapshot.NewManager(paths)
-		if err = manager.Delete(args[0]); err != nil {
-			return fmt.Errorf("failed to delete snapshot: %w", err)
-		}
-		return nil
-	},
+	RunE:  deleteSnapshot,
 }
 
 func init() {
 	snapshotCmd.AddCommand(snapshotDeleteCmd)
+	snapshotDeleteCmd.Flags().BoolVarP(&outputJsonFormat, "json", "", false, "output json format")
+}
+
+func deleteSnapshot(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	paths, err := p.GetPaths()
+	if err != nil {
+		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
+	}
+	manager := snapshot.NewManager(paths)
+	if err = manager.Delete(args[0]); err != nil {
+		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to delete snapshot: %w", err))
+	}
+	return nil
 }

--- a/src/go/rdctl/cmd/snapshotDelete.go
+++ b/src/go/rdctl/cmd/snapshotDelete.go
@@ -12,7 +12,10 @@ var snapshotDeleteCmd = &cobra.Command{
 	Use:   "delete <id>",
 	Short: "Delete a snapshot",
 	Args:  cobra.ExactArgs(1),
-	RunE:  deleteSnapshot,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := deleteSnapshot(cmd, args)
+		return exitWithJsonOrErrorCondition(err)
+	},
 }
 
 func init() {
@@ -24,11 +27,11 @@ func deleteSnapshot(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 	paths, err := p.GetPaths()
 	if err != nil {
-		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
+		return fmt.Errorf("failed to get paths: %w", err)
 	}
 	manager := snapshot.NewManager(paths)
 	if err = manager.Delete(args[0]); err != nil {
-		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to delete snapshot: %w", err))
+		return fmt.Errorf("failed to delete snapshot: %w", err)
 	}
 	return nil
 }

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -37,7 +37,7 @@ var snapshotListCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return listSnapshot()
+		return exitWithJsonOrErrorCondition(listSnapshot())
 	},
 }
 
@@ -49,16 +49,16 @@ func init() {
 func listSnapshot() error {
 	paths, err := p.GetPaths()
 	if err != nil {
-		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
+		return fmt.Errorf("failed to get paths: %w", err)
 	}
 	manager := snapshot.NewManager(paths)
 	snapshots, err := manager.List()
 	if err != nil {
-		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to list snapshots: %w", err))
+		return fmt.Errorf("failed to list snapshots: %w", err)
 	}
 	sort.Sort(SortableSnapshots(snapshots))
 	if outputJsonFormat {
-		return exitWithJsonOrErrorCondition(jsonOutput(snapshots))
+		return jsonOutput(snapshots)
 	}
 	return tabularOutput(snapshots)
 }

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -49,16 +49,16 @@ func init() {
 func listSnapshot() error {
 	paths, err := p.GetPaths()
 	if err != nil {
-		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
+		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
 	}
 	manager := snapshot.NewManager(paths)
 	snapshots, err := manager.List()
 	if err != nil {
-		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to list snapshots: %w", err))
+		return exitWithJsonOrErrorCondition(fmt.Errorf("failed to list snapshots: %w", err))
 	}
 	sort.Sort(SortableSnapshots(snapshots))
 	if outputJsonFormat {
-		return exitWithJSONOrErrorCondition(jsonOutput(snapshots))
+		return exitWithJsonOrErrorCondition(jsonOutput(snapshots))
 	}
 	return tabularOutput(snapshots)
 }

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -16,8 +16,6 @@ import (
 // SortableSnapshots are []snapshot.Snapshot sortable by date created.
 type SortableSnapshots []snapshot.Snapshot
 
-var outputJsonFormat bool
-
 func (snapshots SortableSnapshots) Len() int {
 	return len(snapshots)
 }
@@ -38,6 +36,7 @@ var snapshotListCmd = &cobra.Command{
 	Short:   "List snapshots",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
 		return listSnapshot()
 	},
 }
@@ -50,16 +49,16 @@ func init() {
 func listSnapshot() error {
 	paths, err := p.GetPaths()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to get paths: %w", err))
 	}
 	manager := snapshot.NewManager(paths)
 	snapshots, err := manager.List()
 	if err != nil {
-		return fmt.Errorf("failed to list snapshots: %w", err)
+		return exitWithJSONOrErrorCondition(fmt.Errorf("failed to list snapshots: %w", err))
 	}
 	sort.Sort(SortableSnapshots(snapshots))
 	if outputJsonFormat {
-		return jsonOutput(snapshots)
+		return exitWithJSONOrErrorCondition(jsonOutput(snapshots))
 	}
 	return tabularOutput(snapshots)
 }

--- a/src/go/rdctl/cmd/snapshotRestore.go
+++ b/src/go/rdctl/cmd/snapshotRestore.go
@@ -12,7 +12,11 @@ var snapshotRestoreCmd = &cobra.Command{
 	Use:   "restore <id>",
 	Short: "Restore a snapshot",
 	Args:  cobra.ExactArgs(1),
-	RunE:  wrapSnapshotOperation(restoreSnapshot),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		err := wrapSnapshotOperation(restoreSnapshot)(cmd, args)
+		return exitWithJSONOrErrorCondition(err)
+	},
 }
 
 func init() {

--- a/src/go/rdctl/cmd/snapshotRestore.go
+++ b/src/go/rdctl/cmd/snapshotRestore.go
@@ -15,7 +15,7 @@ var snapshotRestoreCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := wrapSnapshotOperation(restoreSnapshot)(cmd, args)
-		return exitWithJSONOrErrorCondition(err)
+		return exitWithJsonOrErrorCondition(err)
 	},
 }
 

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -16,14 +16,23 @@ This command removes the filesystem lock. It should not be needed under
 normal circumstances.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		paths, err := p.GetPaths()
+		cmd.SilenceUsage = true
+		err := unlockSnapshot()
 		if err != nil {
-			return fmt.Errorf("failed to get paths: %w", err)
+			return exitWithJSONOrErrorCondition(err)
 		}
-		return removeBackendLock(paths.AppHome)
+		return nil
 	},
 }
 
 func init() {
 	snapshotCmd.AddCommand(snapshotUnlockCmd)
+}
+
+func unlockSnapshot() error {
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
+	return removeBackendLock(paths.AppHome)
 }

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -19,7 +19,7 @@ normal circumstances.`,
 		cmd.SilenceUsage = true
 		err := unlockSnapshot()
 		if err != nil {
-			return exitWithJSONOrErrorCondition(err)
+			return exitWithJsonOrErrorCondition(err)
 		}
 		return nil
 	},

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -17,11 +17,7 @@ normal circumstances.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := unlockSnapshot()
-		if err != nil {
-			return exitWithJsonOrErrorCondition(err)
-		}
-		return nil
+		return exitWithJsonOrErrorCondition(unlockSnapshot())
 	},
 }
 


### PR DESCRIPTION
Fixes #5570
Fixes #5638

Also convert array-based JSON to streaming JSON (jq works fine with this).

And more fixes were needed to get the tests here to pass:
* Snapshots can be taken when the backend is in the DISABLED state (k8s off)
* Tests need to verify the backend is back up after creating a snapshot.
  - Add a `waitForBackend` helper to bats to enable this