### PR TITLE
Remove heading & body defaults from `EmptyState`

### DIFF
--- a/pkg/rancher-desktop/components/EmptyState.vue
+++ b/pkg/rancher-desktop/components/EmptyState.vue
@@ -8,17 +8,20 @@ export default Vue.extend({
       default: 'icon-alert',
     },
     heading: {
-      type:    String,
-      default: 'Empty state',
+      type:     String,
+      required: true,
     },
     body: {
       type:    String,
-      default: 'This is an example of an empty state.',
+      default: '',
     },
   },
   computed: {
     hasPrimaryActionSlot(): boolean {
       return !!this.$slots['primary-action'];
+    },
+    hasBody(): boolean {
+      return !!this.body || !!this.$slots['body'];
     },
   },
 });
@@ -39,7 +42,10 @@ export default Vue.extend({
         {{ heading }}
       </slot>
     </div>
-    <div class="empty-state-body">
+    <div
+      v-if="hasBody"
+      class="empty-state-body"
+    >
       <slot name="body">
         {{ body }}
       </slot>


### PR DESCRIPTION
This removes the default text for the `heading` and `body` props in the `EmptyState` component.

The default values for the `heading` and `body` props served as a "demo" to showcase the appearance and behavior of the `EmptyState` component. However, relying on default values in this manner can introduce unintended consequences, as they may inadvertently display content that is not relevant to the specific usage of the component.

closes #5673 