### PR TITLE
Delay fetching containers until Rancher Desktop is in ready state

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -201,7 +201,11 @@ export default {
       if (window.ddClient && this.isK8sReady) {
         this.ddClient = window.ddClient;
 
-        await this.getContainers();
+        try {
+          await this.getContainers();
+        } catch (error) {
+          console.error('There was a problem fetching containers:', { error });
+        }
       }
     }, 1000);
   },

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -73,6 +73,7 @@ import { shell } from 'electron';
 import { mapGetters } from 'vuex';
 
 let ddClientReady = false;
+let containerCheckInterval = null;
 
 export default {
   name:       'Containers',
@@ -190,7 +191,7 @@ export default {
     });
 
     // INFO: We need to set ddClientReady outside of the component in the global scope so it won't re-render when we get the list.
-    setInterval(async() => {
+    containerCheckInterval = setInterval(async() => {
       if (ddClientReady || this.containersList) {
         return;
       }
@@ -206,6 +207,7 @@ export default {
   },
   beforeDestroy() {
     ddClientReady = false;
+    clearInterval(containerCheckInterval);
   },
   methods: {
     handleSelection(item) {

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -70,6 +70,7 @@
 import SortableTable from '@pkg/components/SortableTable';
 import { BadgeState } from '@rancher/components';
 import { shell } from 'electron';
+import { mapGetters } from 'vuex';
 
 let ddClientReady = false;
 
@@ -114,6 +115,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters('k8sManager', { isK8sReady: 'isReady' }),
     rows() {
       if (!this.containersList) {
         return [];
@@ -195,7 +197,7 @@ export default {
 
       console.debug('Checking for containers...');
 
-      if (window.ddClient) {
+      if (window.ddClient && this.isK8sReady) {
         this.ddClient = window.ddClient;
 
         await this.getContainers();

--- a/pkg/rancher-desktop/store/k8sManager.js
+++ b/pkg/rancher-desktop/store/k8sManager.js
@@ -1,3 +1,4 @@
+import { State as EngineStates } from '@pkg/backend/k8s';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export const state = () => ({ k8sState: ipcRenderer.sendSync('k8s-state') });
@@ -17,5 +18,8 @@ export const actions = {
 export const getters = {
   getK8sState({ k8sState }) {
     return k8sState;
+  },
+  isReady({ k8sState }) {
+    return [EngineStates.STARTED, EngineStates.DISABLED].includes(k8sState);
   },
 };


### PR DESCRIPTION
This introduces a mechanism similar to Port Forwarding & Images, which fetches containers only after Rancher Desktop has reached a ready state.

A timing issue existed where the IPC handler could be invoked before it was properly registered. This resulted in an uncaught runtime error that would overlay the UI with an error message explaining this behavior. This issue was frequently encountered when navigating to the Containers page while Rancher Desktop was starting for the first time.

This also clears the interval that checks for containers to prevent any additional messages from being printed to the console after navigating away from the Containers page.

closes #5652.