### PR TITLE
Prevent invalid configurations (9p + VZ, virtiofs + QEMU on macOS) via rdctl

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -862,5 +862,16 @@ describe(SettingsValidator, () => {
         'experimental.virtual-machine.mount.type is \"reverse-sshfs\" or \"virtiofs\".',
       );
     });
+
+    it('should reject QEMU if mount type is virtiofs on macOS', () => {
+      const [needToUpdate, errors] = subject.validateSettings(
+        _.merge({}, cfg, getMountTypeSetting(MountType.VIRTIOFS)), getVMTypeSetting(VMType.QEMU));
+
+      checkForError(
+        needToUpdate, errors,
+        'Setting experimental.virtualMachine.type to \"qemu\" requires that ' +
+        'experimental.virtual-machine.mount.type is \"reverse-sshfs\" or \"9p\".',
+      );
+    });
   });
 });

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -316,6 +316,13 @@ export default class SettingsValidator {
 
         return false;
       }
+      if (mergedSettings.experimental.virtualMachine.mount.type === MountType.NINEP) {
+        errors.push(
+          `Setting ${ fqname } to "${ VMType.VZ }" requires that experimental.virtual-machine.mount.type is ` +
+          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.VIRTIOFS }".`);
+
+        return false;
+      }
     }
 
     return currentValue !== desiredValue;

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -324,6 +324,15 @@ export default class SettingsValidator {
         return false;
       }
     }
+    if (desiredValue === VMType.QEMU) {
+      if (mergedSettings.experimental.virtualMachine.mount.type === MountType.VIRTIOFS && os.platform() === 'darwin') {
+        errors.push(
+          `Setting ${ fqname } to "${ VMType.QEMU }" requires that experimental.virtual-machine.mount.type is ` +
+          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.NINEP }".`);
+
+        return false;
+      }
+    }
 
     return currentValue !== desiredValue;
   }


### PR DESCRIPTION
- Prevent VZ being selected in combination with 9p
- Prevent QEMU selection with virtiofs on macOS

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5542