### PR TITLE
Allow electron to assign window titles

### DIFF
--- a/pkg/rancher-desktop/public/index.html
+++ b/pkg/rancher-desktop/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>Rancher Desktop</title>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
This allows the electron browser window to assign a title to Rancher Desktop windows by removing the `<title>` element from `index.html`

closes #5699