### PR TITLE
Install limactl and lima-guestagent from rancher-desktop-lima repo

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,9 +6,8 @@ appId: io.rancherdesktop.app
 asar: true
 extraResources:
 - resources/
-- '!resources/darwin/lima-*.tgz'
-- '!resources/darwin/limactl-*.tgz'
-- '!resources/linux/lima-*.tgz'
+- '!resources/darwin/lima*.tgz'
+- '!resources/linux/lima*.tgz'
 - '!resources/host/'
 files:
 - dist/app/**/*

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,3 +1,4 @@
+lima: 0.18.0.rd5
 limaAndQemu: 1.31.2
 alpineLimaISO:
   isoVersion: 0.2.31.rd10

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -31,6 +31,7 @@ export type AlpineLimaISOVersion = {
 };
 
 export type DependencyVersions = {
+  lima: string;
   limaAndQemu: string;
   alpineLimaISO: AlpineLimaISOVersion;
   WSLDistro: string;

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import buildUtils from './lib/build-utils';
 
-import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
@@ -30,6 +30,7 @@ const userTouchedDependencies = [
 
 // Dependencies that are specific to unix hosts.
 const unixDependencies = [
+  new Lima(),
   new LimaAndQemu(),
   new AlpineLimaISO(),
 ];

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { Octokit } from 'octokit';
 
-import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
@@ -36,6 +36,7 @@ const dependencies: Dependency[] = [
   new tools.Steve(),
   new tools.RancherDashboard(),
   new tools.ECRCredHelper(),
+  new Lima(),
   new LimaAndQemu(),
   new AlpineLimaISO(),
   new WSLDistro(),

--- a/scripts/unreleased-change-monitor.ts
+++ b/scripts/unreleased-change-monitor.ts
@@ -1,6 +1,6 @@
 import { Octokit } from 'octokit';
 
-import { LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import * as tools from 'scripts/dependencies/tools';
 import { WSLDistro, HostResolverHost, HostSwitch } from 'scripts/dependencies/wsl';
 import {
@@ -19,6 +19,7 @@ type UnreleasedChangeMonitoringDependency = Dependency & GitHubDependency;
 type DependencyState = { dependency: UnreleasedChangeMonitoringDependency } & HasUnreleasedChangesResult;
 
 const dependencies: UnreleasedChangeMonitoringDependency[] = [
+  new Lima(),
   new LimaAndQemu(),
   new WSLDistro(),
   new tools.DockerCLI(),


### PR DESCRIPTION
And ignore the version bundled with lima-and-qemu. That way we can update lima independently from qemu (and *_vmnet daemons).