### PR TITLE
Run screenshots script with containerd by default

### DIFF
--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -10,6 +10,8 @@ import {
   createDefaultSettings, createUserProfile, reportAsset, teardown, tool,
 } from '../e2e/utils/TestUtils';
 
+import { ContainerEngine } from '@pkg/config/settings';
+
 import type { ElectronApplication, BrowserContext, Page } from '@playwright/test';
 
 const isWin = os.platform() === 'win32';
@@ -25,8 +27,11 @@ test.describe.serial('Main App Test', () => {
   test.beforeAll(async({ colorScheme }) => {
     createDefaultSettings({
       application:     { updater: { enabled: false } },
-      containerEngine: { allowedImages: { enabled: false, patterns: ['rancher/example'] } },
-      diagnostics:     { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
+      containerEngine: {
+        allowedImages: { enabled: false, patterns: ['rancher/example'] },
+        name:          ContainerEngine.CONTAINERD,
+      },
+      diagnostics: { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
     });
 
     // Not supporting locked fields on Windows yet


### PR DESCRIPTION
The screenshots script needs to be run with container engine containerd by default. Otherwise, the "Namespace" dropdown list on the "Images" will be empty on the screens.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/5712