### PR TITLE
CI: GitHub runner monitor: disable CGO

### DIFF
--- a/.github/workflows/github-runner-monitor-build.yaml
+++ b/.github/workflows/github-runner-monitor-build.yaml
@@ -26,6 +26,8 @@ jobs:
         cache-dependency-path: src/go/github-runner-monitor/go.sum
     - run: go build .
       working-directory: src/go/github-runner-monitor
+      env:
+        CGO_ENABLED: '0'
     - uses: actions/upload-artifact@v3
       with:
         name: github-runner-linux


### PR DESCRIPTION
We don't seem to need it; this avoids issues when running on hosts that have older glibc than the CI we build on.