### PR TITLE
GitHub Actions: Skip Linux E2E on dependabot branches

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -3,6 +3,8 @@ name: e2e tests on Linux
 on:
   workflow_dispatch:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
They still get run as part of the PR.