### PR TITLE
Replace Snapshot `id` with `name`

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1422,12 +1422,12 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     return await Snapshots.create(snapshot);
   }
 
-  async restoreSnapshot(context: CommandWorkerInterface.CommandContext, id: string) {
-    return await Snapshots.restore(id);
+  async restoreSnapshot(context: CommandWorkerInterface.CommandContext, name: string) {
+    return await Snapshots.restore(name);
   }
 
-  async deleteSnapshot(context: CommandWorkerInterface.CommandContext, id: string) {
-    return await Snapshots.delete(id);
+  async deleteSnapshot(context: CommandWorkerInterface.CommandContext, name: string) {
+    return await Snapshots.delete(name);
   }
 }
 

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -337,7 +337,7 @@ paths:
       summary:  Deletes a snapshot
       parameters:
       - in: query
-        name: id
+        name: name
       responses:
         '200':
           description: The snapshot was deleted.
@@ -354,7 +354,7 @@ paths:
       summary: Restore a snapshot
       parameters:
       - in: query
-        name: id
+        name: name
       responses:
         '202':
           description: The snapshot was restored.

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4780,6 +4780,7 @@ snapshots:
       cancel: 'Cancelled creation of {snapshot}'
     delete:
       success: "Deleted '<b>'{snapshot}'</b>'"
+      error: 'Delete error: {error}'
 
 
 ##############################

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -93,11 +93,13 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       ipcRenderer.send('snapshot', null);
 
       if (ok) {
-        await this.$store.dispatch('snapshots/delete', this.snapshot.name);
+        const error = await this.$store.dispatch('snapshots/delete', this.snapshot.name);
+
         ipcRenderer.send('snapshot', {
           type:         'delete',
-          result:       'success',
-          snapshotName: this.snapshot?.name,
+          result:       error ? 'error' : 'success',
+          error,
+          snapshotName: this.snapshot.name,
         });
       }
     },

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -67,7 +67,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       if (ok) {
         ipcRenderer.send('preferences-close');
         ipcRenderer.on('dialog/mounted', async() => {
-          const error = await this.$store.dispatch('snapshots/restore', this.snapshot.id);
+          const error = await this.$store.dispatch('snapshots/restore', this.snapshot.name);
 
           if (error) {
             ipcRenderer.send('dialog/error', { dialog: 'SnapshotsDialog', error });
@@ -93,7 +93,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       ipcRenderer.send('snapshot', null);
 
       if (ok) {
-        await this.$store.dispatch('snapshots/delete', this.snapshot.id);
+        await this.$store.dispatch('snapshots/delete', this.snapshot.name);
         ipcRenderer.send('snapshot', {
           type:         'delete',
           result:       'success',

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -87,11 +87,11 @@ export default Vue.extend<Data, Methods, Computed, never>({
     <Banner
       v-if="snapshotEvent"
       class="banner mb-20"
-      color="success"
+      :color="snapshotEvent.result"
       :closable="true"
       @close="snapshotEvent=null"
     >
-      <span v-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName }, true)" />
+      <span v-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName, error: snapshotEvent.error }, true)" />
     </Banner>
     <div
       v-for="(item, idx) of snapshots"

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -94,8 +94,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
       <span v-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName }, true)" />
     </Banner>
     <div
-      v-for="item of snapshots"
-      :key="item.id"
+      v-for="(item, idx) of snapshots"
+      :key="idx"
     >
       <SnapshotCard
         class="mb-20"

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -94,8 +94,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
       <span v-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName, error: snapshotEvent.error }, true)" />
     </Banner>
     <div
-      v-for="(item, idx) of snapshots"
-      :key="idx"
+      v-for="(item) of snapshots"
+      :key="item.name"
     >
       <SnapshotCard
         class="mb-20"

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -717,15 +717,15 @@ export class HttpCommandServer {
   }
 
   protected async restoreSnapshot(request: express.Request, response: express.Response, context: commandContext): Promise<void> {
-    const id = request.query.id ?? '';
+    const name = request.query.name ?? '';
 
-    if (!id) {
-      response.status(400).type('txt').send('Snapshot id is required in query parameters');
-    } else if (typeof id !== 'string') {
-      response.status(400).type('txt').send(`Invalid snapshot id ${ JSON.stringify(id) }: not a string.`);
+    if (!name) {
+      response.status(400).type('txt').send('Snapshot name is required in query parameters');
+    } else if (typeof name !== 'string') {
+      response.status(400).type('txt').send(`Invalid snapshot name ${ JSON.stringify(name) }: not a string.`);
     } else {
       try {
-        await this.commandWorker.restoreSnapshot(context, id);
+        await this.commandWorker.restoreSnapshot(context, name);
 
         response.status(200).type('txt').send('Snapshot successfully restored');
       } catch (error: any) {
@@ -739,15 +739,15 @@ export class HttpCommandServer {
   }
 
   protected async deleteSnapshot(request: express.Request, response: express.Response, context: commandContext): Promise<void> {
-    const id = request.query.id ?? '';
+    const name = request.query.name ?? '';
 
-    if (!id) {
-      response.status(400).type('txt').send('Snapshot id is required in query parameters');
-    } else if (typeof id !== 'string') {
-      response.status(400).type('txt').send(`Invalid snapshot id ${ JSON.stringify(id) }: not a string.`);
+    if (!name) {
+      response.status(400).type('txt').send('Snapshot name is required in query parameters');
+    } else if (typeof name !== 'string') {
+      response.status(400).type('txt').send(`Invalid snapshot name ${ JSON.stringify(name) }: not a string.`);
     } else {
       try {
-        await this.commandWorker.deleteSnapshot(context, id);
+        await this.commandWorker.deleteSnapshot(context, name);
 
         response.status(200).type('txt').send('Snapshot successfully deleted');
       } catch (error: any) {
@@ -801,8 +801,8 @@ export interface CommandWorkerInterface {
   // #endregion
   listSnapshots: (context: commandContext) => Promise<Snapshot[]>;
   createSnapshot: (context: commandContext, snapshot: Snapshot) => Promise<void>;
-  deleteSnapshot: (context: commandContext, id: string) => Promise<void>;
-  restoreSnapshot: (context: commandContext, id: string) => Promise<void>;
+  deleteSnapshot: (context: commandContext, name: string) => Promise<void>;
+  restoreSnapshot: (context: commandContext, name: string) => Promise<void>;
 }
 
 // Extend CommandWorkerInterface to have extra types, as these types are used by

--- a/pkg/rancher-desktop/main/snapshots/snapshots.ts
+++ b/pkg/rancher-desktop/main/snapshots/snapshots.ts
@@ -13,8 +13,11 @@ class SnapshotsError {
   readonly isSnapshotError = true;
   message: string;
 
-  constructor(stderr: string) {
-    this.message = parseLines(stderr)[0];
+  constructor(response: SpawnResult) {
+    console.debug(response.stdout);
+    const value = JSON.parse(response.stdout);
+
+    this.message = value?.error;
   }
 }
 
@@ -44,29 +47,26 @@ class SnapshotsImpl {
   }
 
   async create(snapshot: Snapshot) : Promise<void> {
-    const response = await this.rdctl(['snapshot', 'create', snapshot.name]);
+    const response = await this.rdctl(['snapshot', 'create', snapshot.name, '--json']);
 
     if (response.error) {
-      console.debug(response.stderr);
-      throw new SnapshotsError(response.stderr);
+      throw new SnapshotsError(response);
     }
   }
 
   async restore(name: string) : Promise<void> {
-    const response = await this.rdctl(['snapshot', 'restore', name]);
+    const response = await this.rdctl(['snapshot', 'restore', name, '--json']);
 
     if (response.error) {
-      console.debug(response.stderr);
-      throw new SnapshotsError(response.stderr);
+      throw new SnapshotsError(response);
     }
   }
 
   async delete(name: string) : Promise<void> {
-    const response = await this.rdctl(['snapshot', 'delete', name]);
+    const response = await this.rdctl(['snapshot', 'delete', name, '--json']);
 
     if (response.error) {
-      console.debug(response.stderr);
-      throw new SnapshotsError(response.stderr);
+      throw new SnapshotsError(response);
     }
   }
 }

--- a/pkg/rancher-desktop/main/snapshots/snapshots.ts
+++ b/pkg/rancher-desktop/main/snapshots/snapshots.ts
@@ -52,8 +52,8 @@ class SnapshotsImpl {
     }
   }
 
-  async restore(id: string) : Promise<void> {
-    const response = await this.rdctl(['snapshot', 'restore', id]);
+  async restore(name: string) : Promise<void> {
+    const response = await this.rdctl(['snapshot', 'restore', name]);
 
     if (response.error) {
       console.debug(response.stderr);
@@ -61,8 +61,8 @@ class SnapshotsImpl {
     }
   }
 
-  async delete(id: string) : Promise<void> {
-    const response = await this.rdctl(['snapshot', 'delete', id]);
+  async delete(name: string) : Promise<void> {
+    const response = await this.rdctl(['snapshot', 'delete', name]);
 
     if (response.error) {
       console.debug(response.stderr);

--- a/pkg/rancher-desktop/main/snapshots/types.ts
+++ b/pkg/rancher-desktop/main/snapshots/types.ts
@@ -1,6 +1,6 @@
 export type SnapshotEvent = {
   type?: 'restore' | 'delete' | 'create',
-  result?: 'success' | 'cancel',
+  result?: 'success' | 'cancel' | 'error',
   error?: string,
   snapshotName?: string,
 };

--- a/pkg/rancher-desktop/main/snapshots/types.ts
+++ b/pkg/rancher-desktop/main/snapshots/types.ts
@@ -22,7 +22,6 @@ export interface SnapshotDialog {
 }
 
 export interface Snapshot {
-  id: string,
   name: string,
   created: string,
   notes?: string,

--- a/pkg/rancher-desktop/store/snapshots.ts
+++ b/pkg/rancher-desktop/store/snapshots.ts
@@ -51,8 +51,8 @@ export const actions = {
     await dispatch('fetch');
   },
 
-  async delete({ rootState, dispatch }: SnapshotsActionContext, id: string) {
-    const response = await fetchAPI(`/v1/snapshots?id=${ id }`, rootState, { method: 'DELETE' });
+  async delete({ rootState, dispatch }: SnapshotsActionContext, name: string) {
+    const response = await fetchAPI(`/v1/snapshots?name=${ name }`, rootState, { method: 'DELETE' });
 
     if (!response.ok) {
       console.log(`deleteSnapshot: failed: status: ${ response.status }:${ response.statusText }`);
@@ -65,8 +65,8 @@ export const actions = {
     await dispatch('fetch');
   },
 
-  async restore({ rootState }: SnapshotsActionContext, id: string) {
-    const response = await fetchAPI(`/v1/snapshot/restore?id=${ id }`, rootState, { method: 'POST' });
+  async restore({ rootState }: SnapshotsActionContext, name: string) {
+    const response = await fetchAPI(`/v1/snapshot/restore?name=${ name }`, rootState, { method: 'POST' });
 
     if (!response.ok) {
       console.log(`restoreSnapshot: failed: status: ${ response.status }:${ response.statusText }`);


### PR DESCRIPTION
Fixes #5748

The new key for UI & snapshots API is `name` property.

Plus:

- Handle `delete` errors.
- Handle errors in JSON format.
