### PR TITLE
Fix content alignment of Ports column

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -12,35 +12,37 @@
       @selection="handleSelection"
     >
       <template #col:ports="{ row }">
-        <td class="port-container">
-          <a
-            v-for="port in getUniquePorts(row.Ports).slice(0, 2)"
-            :key="port"
-            target="_blank"
-            class="link"
-            @click="openUrl(port)"
-          >
-            {{ port }}
-          </a>
+        <td>
+          <div class="port-container">
+            <a
+              v-for="port in getUniquePorts(row.Ports).slice(0, 2)"
+              :key="port"
+              target="_blank"
+              class="link"
+              @click="openUrl(port)"
+            >
+              {{ port }}
+            </a>
 
-          <div
-            v-if="shouldHaveDropdown(row.Ports)"
-            class="dropdown"
-          >
-            <span>
-              {{ t('containers.manage.table.showMore') }}
-            </span>
+            <div
+              v-if="shouldHaveDropdown(row.Ports)"
+              class="dropdown"
+            >
+              <span>
+                {{ t('containers.manage.table.showMore') }}
+              </span>
 
-            <div class="dropdown-content">
-              <a
-                v-for="port in getUniquePorts(row.Ports).slice(2)"
-                :key="port"
-                target="_blank"
-                class="link"
-                @click="openUrl(port)"
-              >
-                {{ port }}
-              </a>
+              <div class="dropdown-content">
+                <a
+                  v-for="port in getUniquePorts(row.Ports).slice(2)"
+                  :key="port"
+                  target="_blank"
+                  class="link"
+                  @click="openUrl(port)"
+                >
+                  {{ port }}
+                </a>
+              </div>
             </div>
           </div>
         </td>
@@ -376,6 +378,5 @@ export default {
 .port-container {
   display: flex;
   flex-direction: column;
-  margin: 5px 0;
 }
 </style>


### PR DESCRIPTION
This wraps the content of the `port-container` in a `div` tag, allowing the data cell to continue displaying as `table-cell` just like other cells in the table.

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/5a4688a8-de85-441c-ad09-e5a2721a4d9c)

closes #5716 