### PR TITLE
Expanded the application description on the General tab

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -280,7 +280,7 @@ portForwarding:
     noRows: There are no port forwarding entries to show
 general:
   title: Welcome to Rancher Desktop
-  description: Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop provides a seamless desktop environment comprising a virtual machine, essential components such as container engines, Kubernetes, and CLI tools such as docker, nerdctl, helm, and more, all wrapped in a user-friendly GUI application.
 about:
   title: About
   versions:


### PR DESCRIPTION
Expanded the application description displayed on the General tab to better match what Rancher Desktop provides at present. Just to note, we have plans to replace the General tab with a dashboard kind of a page and we may or may not retain all the content from the current General tab. 