### PR TITLE
Only try to parse snapshots whose directory is named with a valid UUID

### DIFF
--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -107,6 +107,9 @@ func (manager Manager) List() ([]Snapshot, error) {
 	}
 	snapshots := make([]Snapshot, 0, len(dirEntries))
 	for _, dirEntry := range dirEntries {
+		if _, err := uuid.Parse(dirEntry.Name()); err != nil {
+			continue
+		}
 		snapshot := Snapshot{}
 		metadataPath := filepath.Join(manager.Paths.Snapshots, dirEntry.Name(), "metadata.json")
 		contents, err := os.ReadFile(metadataPath)


### PR DESCRIPTION
Closes #5740.

I think the problem is that somehow, a `.DS_Store` entry made its way into the snapshots directory. Obviously, `.DS_Store` isn't a valid snapshot, so trying to parse it failed.