### PR TITLE
GitHub Actions: Try to install setuptools for python

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           go-version: '^1.21'
           cache-dependency-path: src/go/**/go.sum
+      # For now, we don't need to `pip install setuptools` because we're not on
+      # Python 3.12; we will need that later, however.
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Disable admin-access before start up

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -31,6 +31,10 @@ jobs:
         with:
           go-version: '^1.21'
           cache-dependency-path: src/go/**/go.sum
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install setuptools
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         #The next steps is a workaround for an unexpected failure in launching electron before running e2e tests

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -54,8 +54,9 @@ jobs:
     - name: Flag build for M1
       if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
       run: echo "M1=1" >> "${GITHUB_ENV}"
-      # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
-    - run: yarn install --frozen-lockfile --network-timeout 1000000
+    - run: pip install setuptools
+    - # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
+      run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build
     - run: yarn package --${{ matrix.platform }} --publish=never
     - name: Build bats.tar.gz

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -34,6 +34,11 @@ jobs:
           node-version: '16.x'
           cache: yarn
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - run: pip install setuptools
       - run: yarn install --frozen-lockfile
 
       - run: yarn rddepman

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
       with:
         go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
+    - run: pip install setuptools
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn lint:nofix

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -32,6 +32,11 @@ jobs:
           node-version: '16.x'
           cache: yarn
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - run: pip install setuptools
       - run: yarn install --frozen-lockfile
 
       - run: yarn ucmonitor

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -41,6 +41,7 @@ jobs:
     - name: Flag build for M1
       if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
       run: echo "M1=1" >> "${GITHUB_ENV}"
+    - run: pip install setuptools
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn package --${{ matrix.platform }} --publish=never

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -39,6 +39,10 @@ jobs:
           go-version: '^1.21'
           cache: 'true'
           cache-dependency-path: src/go/**/go.sum
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install setuptools
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run e2e Tests


### PR DESCRIPTION
Python 3.12 no longer ships with distutils, but node-gyp needs it. We in turn need that in `yarn install`.