### PR TITLE
Update kubeconfig with RD gateway when network tunnel is enabled

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -451,6 +451,8 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   }
 
   protected async syncDistroKubeconfig(distro: string, kubeconfigPath: string, state: boolean) {
+    const rdNetworking = this.settings.experimental?.virtualMachine?.networkingTunnel === true;
+
     try {
       console.debug(`Syncing ${ distro } kubeconfig`);
       await this.execCommand(
@@ -465,6 +467,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
         await this.getLinuxToolPath(distro, 'wsl-helper'),
         'kubeconfig',
         `--enable=${ state && this.settings.kubernetes?.enabled }`,
+        `--rd-networking=${ rdNetworking }`,
       );
     } catch (error: any) {
       if (typeof error?.stdout === 'string') {

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -33,13 +33,25 @@ import (
 
 type kubeConfig struct {
 	Clusters []struct {
-		Name    string `yaml:"name"`
 		Cluster struct {
 			Server string
 			Extras map[string]interface{} `yaml:",inline"`
-		}
+		} `yaml:"cluster"`
+		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:",omitempty"`
+	} `yaml:"clusters"`
+	Contexts []struct {
+		Context struct {
+			Extras map[string]interface{} `yaml:",inline"`
+		} `yaml:"context"`
+		Name   string                 `yaml:"name"`
+		Extras map[string]interface{} `yaml:",inline"`
+	} `yaml:"contexts"`
+	CurrentContext string `yaml:"current-context"`
+	Users          []struct {
+		Name   string                 `yaml:"name"`
+		Extras map[string]interface{} `yaml:",inline"`
+	} `yaml:"users"`
 	Extras map[string]interface{} `yaml:",inline"`
 }
 

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -33,6 +33,7 @@ import (
 
 type kubeConfig struct {
 	Clusters []struct {
+		Name    string `yaml:"name"`
 		Cluster struct {
 			Server string
 			Extras map[string]interface{} `yaml:",inline"`
@@ -42,7 +43,10 @@ type kubeConfig struct {
 	Extras map[string]interface{} `yaml:",inline"`
 }
 
-var k3sKubeconfigViper = viper.New()
+var (
+	k3sKubeconfigViper = viper.New()
+	rdNetworking       bool
+)
 
 // k3sKubeconfigCmd represents the `k3s kubeconfig` command.
 var k3sKubeconfigCmd = &cobra.Command{
@@ -66,6 +70,7 @@ var k3sKubeconfigCmd = &cobra.Command{
 				time.Sleep(time.Second)
 			}
 		}()
+		var err error
 		timeout := time.After(10 * time.Second)
 		var configFile *os.File
 		select {
@@ -74,54 +79,49 @@ var k3sKubeconfigCmd = &cobra.Command{
 		case configFile = <-ch:
 			break
 		}
-		config, err := updateClusterIP(configFile, false)
+
+		var config kubeConfig
+		defer configFile.Close()
+		err = yaml.NewDecoder(configFile).Decode(&config)
 		if err != nil {
 			return err
+		}
+
+		if rdNetworking {
+			// vm-switch in rdNetworking binds to localhost:Port by default.
+			// Since k3s.yaml comes with servers preset at 127.0.0.1, there
+			// is nothing for us to do here, just write the config and return.
+			return yaml.NewEncoder(os.Stdout).Encode(config)
+		}
+		ip, err := getClusterIP()
+		if err != nil {
+			return err
+		}
+		// Fix up any clusters at 127.0.0.1, using the IP address we found.
+		for clusterIdx, cluster := range config.Clusters {
+			server, err := url.Parse(cluster.Cluster.Server)
+			if err != nil {
+				// Ignore any clusters with invalid servers
+				continue
+			}
+			if server.Hostname() != "127.0.0.1" {
+				continue
+			}
+			if server.Port() != "" {
+				server.Host = net.JoinHostPort(ip.String(), server.Port())
+			} else {
+				server.Host = ip.String()
+			}
+			config.Clusters[clusterIdx].Cluster.Server = server.String()
 		}
 		// Emit the result
 		err = yaml.NewEncoder(os.Stdout).Encode(config)
 		if err != nil {
 			return err
 		}
+
 		return nil
 	},
-}
-
-func updateClusterIP(configFile *os.File, rdNetworking bool) (kubeConfig, error) {
-	var config kubeConfig
-	defer configFile.Close()
-	err := yaml.NewDecoder(configFile).Decode(&config)
-	if err != nil {
-		return config, err
-	}
-
-	ip, err := getClusterIP()
-	if err != nil {
-		return config, err
-	}
-	// Fix up any clusters at 127.0.0.1, using the IP address we found.
-	for clusterIdx, cluster := range config.Clusters {
-		server, err := url.Parse(cluster.Cluster.Server)
-		if err != nil {
-			// Ignore any clusters with invalid servers
-			continue
-		}
-		if server.Hostname() != "127.0.0.1" {
-			continue
-		}
-		if rdNetworking {
-			server.Host = "gateway.rancher-desktop.internal:6443"
-		} else {
-			if server.Port() != "" {
-				server.Host = net.JoinHostPort(ip.String(), server.Port())
-			} else {
-				server.Host = ip.String()
-			}
-
-		}
-		config.Clusters[clusterIdx].Cluster.Server = server.String()
-	}
-	return config, nil
 }
 
 func getClusterIP() (net.IP, error) {
@@ -160,6 +160,7 @@ func getClusterIP() (net.IP, error) {
 
 func init() {
 	k3sKubeconfigCmd.Flags().String("k3sconfig", "/etc/rancher/k3s/k3s.yaml", "Path to k3s kubeconfig")
+	k3sKubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
 	k3sKubeconfigViper.AutomaticEnv()
 	k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
 	k3sCmd.AddCommand(k3sKubeconfigCmd)

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -86,12 +86,6 @@ var k3sKubeconfigCmd = &cobra.Command{
 			return err
 		}
 
-		if rdNetworking {
-			// vm-switch in rdNetworking binds to localhost:Port by default.
-			// Since k3s.yaml comes with servers preset at 127.0.0.1, there
-			// is nothing for us to do here, just write the config and return.
-			return yaml.NewEncoder(os.Stdout).Encode(config)
-		}
 		ip, err := getClusterIP()
 		if err != nil {
 			return err
@@ -106,10 +100,15 @@ var k3sKubeconfigCmd = &cobra.Command{
 			if server.Hostname() != "127.0.0.1" {
 				continue
 			}
-			if server.Port() != "" {
-				server.Host = net.JoinHostPort(ip.String(), server.Port())
+			if rdNetworking {
+				server.Host = "gateway.rancher-desktop.internal:6443"
 			} else {
-				server.Host = ip.String()
+				if server.Port() != "" {
+					server.Host = net.JoinHostPort(ip.String(), server.Port())
+				} else {
+					server.Host = ip.String()
+				}
+
 			}
 			config.Clusters[clusterIdx].Cluster.Server = server.String()
 		}

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -41,9 +41,6 @@ type kubeConfig struct {
 		Extras map[string]interface{} `yaml:",inline"`
 	} `yaml:"clusters"`
 	Contexts []struct {
-		Context struct {
-			Extras map[string]interface{} `yaml:",inline"`
-		} `yaml:"context"`
 		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
 	} `yaml:"contexts"`

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -158,11 +158,6 @@ func removeExistingRDConfig(name string, config *kubeConfig) *kubeConfig {
 
 	// Remove contexts with the specified name
 	var filteredContexts []struct {
-		Context struct {
-			Cluster string
-			User    string
-			Extras  map[string]interface{} `yaml:",inline"`
-		} `yaml:"context"`
 		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
 	}

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -21,11 +21,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
 	"path"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"


### PR DESCRIPTION
This updates the kube config with a newly added `gateway.rancher-desktop.internal` hosts file entry when wsl integration is enabled. This PR could be part of https://github.com/rancher-sandbox/rancher-desktop/pull/5722 however, for the sake of clarity I decided to make a separate PR. 