### PR TITLE
Allow for undefined `HostPort`

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -302,8 +302,8 @@ export default {
           return;
         }
 
-        const firstPort = ports[0].HostPort;
-        const secondPort = ports[1].HostPort;
+        const firstPort = ports[0]?.HostPort || '';
+        const secondPort = ports[1]?.HostPort || '';
 
         uniquePorts[`${ firstPort }:${ secondPort }`] = true;
       });


### PR DESCRIPTION
This assigns a default value of an empty string when a port is `null` or `undefined` to ensure that the containers list will still render, even if there are no ports associated with a particular container.

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/0e52ae21-4f38-486d-85eb-972354e0ec5d)

closes #5761 