### PR TITLE
Snapshot description field PR

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -211,6 +211,7 @@ epinio
 EPONY
 ERRFILE
 errgroup
+Errorln
 estargz
 ESXi
 etcdbackup
@@ -326,6 +327,7 @@ ioctl
 ipaddr
 ipam
 ipfs
+isexcluded
 isthebestmeshuggahalbum
 istio
 istiod

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -279,19 +279,19 @@ wait_for_container_engine() {
     try --max 12 --delay 10 get_container_engine_info
 }
 
-wait_for_backend() {
-    local timeout="$(($(date +%s) + 10 * 60))"
-    while true; do
-        run rdctl api /v1/backend_state
-        if ((status == 0)); then
-            run jq_output .vmState
-            case "$output" in
-            STARTED) return 0 ;;
-            DISABLED) return 0 ;;
-            esac
-        fi
-        assert [ "$(date +%s)" -lt "$timeout" ]
-        sleep 1
-    done
+assert_backend_available() {
+    run rdctl api /v1/backend_state
+    if ((status == 0)); then
+        run jq_output .vmState
+        case "$output" in
+        ERROR) return 0 ;;
+        STARTED) return 0 ;;
+        DISABLED) return 0 ;;
+        esac
+    fi
     return 1
+}
+
+wait_for_backend() {
+    try --max 60 --delay 10 assert_backend_available
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -279,6 +279,8 @@ wait_for_container_engine() {
     try --max 12 --delay 10 get_container_engine_info
 }
 
+# See definition of `State` in
+# pkg/rancher-desktop/backend/backend.ts for an explanation of each state.
 assert_backend_available() {
     run rdctl api /v1/backend_state
     if ((status == 0)); then

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -162,7 +162,7 @@ line somewhere in this description"
     assert_success
     # Shouldn't have the whole description, but part of it
     refute_output --partial "$description"
-    assert_output --partial "$part1"
+    assert_output --partial "${part1}..."
 }
 
 @test "factory-reset doesn't delete a non-empty snapshots directory" {

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -87,30 +87,30 @@ local_setup() {
 }
 
 @test "attempt to create a snapshot with an existing name is flagged and doesn't do factory-reset" {
-    # RD state is currently stopped, so best to shut it down
+    # Shutdown RD for faster snapshot creation
+    # Also verify that the failed creation doesn't trigger a factory-reset and remove settings.json
     rdctl shutdown
-    assert_exists "$PATH_APP_HOME/rd-engine.json"
+    assert_exists "$PATH_CONFIG_FILE"
     run rdctl snapshot create "$SNAPSHOT" --json
     assert_failure
     run jq_output '.error'
+    assert_success
     assert_output "invalid name \"$SNAPSHOT\": name already exists"
-    assert_exists "$PATH_APP_HOME/rd-engine.json"
+    assert_exists "$PATH_CONFIG_FILE"
 }
 
 @test 'can create a snapshot where proposed name is a current ID' {
     run ls -1 "$PATH_SNAPSHOTS"
     assert_success
     refute_output ""
-    run head -n 1 <<<"$output"
-    assert_success
-    refute_output ""
-    snapshot_id=$output
+    snapshot_id="${lines[0]}"
+    test -n "$snapshot_id"
     snapshot_description="second snapshot made with the --description option with \\ and \" and '."
 
     rdctl snapshot create "$snapshot_id" --description "$snapshot_description"
     run rdctl snapshot list --json
     assert_success
-    run jq_output "$(printf 'select(.name == "%s").description' "$snapshot_id")"
+    run jq_output "select(.name == \"$snapshot_id\").description"
     assert_success
     assert_output "$snapshot_description"
 
@@ -129,7 +129,7 @@ local_setup() {
 
     run rdctl snapshot list --json
     assert_success
-    run jq_output "$(printf 'select(.name == "%s").description' "$snapshot_name")"
+    run jq_output "select(.name == \"$snapshot_name\").description"
     assert_success
     assert_output "$long_description"
 
@@ -144,15 +144,15 @@ local_setup() {
 
 @test 'table view truncates descriptions at an internal newline' {
     snapshot_name=retinal_asparagus
+    newline=$'\n'
     part1="there's a new"
-    description="$part1
-line somewhere in this description"
+    description="${part1}${newline}line somewhere in this description"
 
     rdctl snapshot create "$snapshot_name" --description "$description"
 
     run rdctl snapshot list --json
     assert_success
-    run jq_output "$(printf 'select(.name == "%s").description' "$snapshot_name")"
+    run jq_output "select(.name == \"$snapshot_name\").description"
     assert_success
     assert_output "$description"
 

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -24,12 +24,14 @@ local_setup() {
 
 @test 'shutdown, make a snapshot, and run factory-reset' {
     rdctl shutdown
+
     snapshot_description="first snapshot"
     rdctl snapshot create "$SNAPSHOT" --description "$snapshot_description"
     run rdctl snapshot list
     assert_success
     assert_output --partial "$SNAPSHOT"
     assert_output --partial "$snapshot_description"
+
     rdctl factory-reset
 }
 
@@ -104,12 +106,13 @@ local_setup() {
     refute_output ""
     snapshot_id=$output
     snapshot_description="second snapshot made with the --description option with \\ and \" and '."
+
     rdctl snapshot create "$snapshot_id" --description "$snapshot_description"
     run rdctl snapshot list --json
     assert_success
     run jq_output "$(printf 'select(.name == "%s").description' "$snapshot_id")"
     assert_success
-    assert_output --partial "$snapshot_description"
+    assert_output "$snapshot_description"
 
     # And we can delete that snapshot
     run rdctl snapshot delete "$snapshot_id" --json

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -84,6 +84,16 @@ local_setup() {
     done
 }
 
+@test "attempt to create a snapshot with an existing name is flagged and doesn't do factory-reset" {
+    # RD state is currently stopped, so best to shut it down
+    rdctl shutdown
+    assert_exists "$PATH_APP_HOME/rd-engine.json"
+    run rdctl snapshot create "$SNAPSHOT" --json
+    assert_failure
+    run jq_output '.error'
+    assert_output "failed to create snapshot: invalid name \"$SNAPSHOT\": name already exists"
+}
+
 @test 'can create a snapshot where proposed name is a current ID' {
     run ls -1 "$PATH_SNAPSHOTS"
     assert_success

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -121,7 +121,7 @@ local_setup() {
 }
 
 @test 'very long descriptions are truncated in the table view' {
-    snapshot_name=aarons_farm
+    snapshot_name=armadillo_farm
     description_part="very long description names are truncated in the table view"
     long_description="$description_part, repeat: $description_part"
 
@@ -143,7 +143,7 @@ local_setup() {
 }
 
 @test 'table view truncates descriptions at an internal newline' {
-    snapshot_name=petes_circus
+    snapshot_name=retinal_asparagus
     part1="there's a new"
     description="$part1
 line somewhere in this description"

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -91,7 +91,8 @@ local_setup() {
     run rdctl snapshot create "$SNAPSHOT" --json
     assert_failure
     run jq_output '.error'
-    assert_output "failed to create snapshot: invalid name \"$SNAPSHOT\": name already exists"
+    assert_output "invalid name \"$SNAPSHOT\": name already exists"
+    assert_exists "$PATH_APP_HOME/rd-engine.json"
 }
 
 @test 'can create a snapshot where proposed name is a current ID' {

--- a/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
+++ b/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
@@ -49,7 +49,7 @@ local_setup() {
     assert_output --partial containerd
 }
 
-@test 'delete all the snapshots' {
+@test 'delete the snapshot and verify there are no others' {
     rdctl snapshot delete "$SNAPSHOT"
     run rdctl snapshot list --json
     assert_success

--- a/bats/tests/snapshots/test-snapshot-list.bats
+++ b/bats/tests/snapshots/test-snapshot-list.bats
@@ -89,6 +89,7 @@ local_setup() {
 }
 
 @test 'create a snapshot with k8s off' {
+    # This tests that wait_for_backend accepts the DISABLED state as a final state.
     rdctl snapshot create anime-walnut-festival
     wait_for_container_engine
     wait_for_backend

--- a/bats/tests/snapshots/test-snapshot-list.bats
+++ b/bats/tests/snapshots/test-snapshot-list.bats
@@ -26,7 +26,7 @@ local_setup() {
     assert_output 'No snapshots present.'
 }
 
-@test 'create three snapshots with RD turned off, allowing for restarts' {
+@test 'create three snapshots with RD turned off, spaced every 5 seconds' {
     # It's much faster to create snapshots when RD isn't running.
     rdctl shutdown
 

--- a/bats/tests/snapshots/test-snapshot-list.bats
+++ b/bats/tests/snapshots/test-snapshot-list.bats
@@ -26,28 +26,20 @@ local_setup() {
     assert_output 'No snapshots present.'
 }
 
-@test 'create three snapshots, allowing for restarts' {
-    # Ensure the app is up and running
-    wait_for_container_engine
-    wait_for_apiserver
-    wait_for_backend
+@test 'create three snapshots with RD turned off, allowing for restarts' {
+    # It's much faster to create snapshots when RD isn't running.
+    rdctl shutdown
+
     # Sleep 5 seconds after creating each snapshot so later we can verify
     # that the differences in each snapshot's creation time makes sense.
 
     rdctl snapshot create cows_fish_capers
     sleep 5
-    wait_for_container_engine
-    wait_for_apiserver
-    wait_for_backend
+
     rdctl snapshot create world-buffalo-federation
     sleep 5
-    wait_for_container_engine
-    wait_for_apiserver
-    wait_for_backend
+
     rdctl snapshot create run-like-an-antelope
-    wait_for_container_engine
-    wait_for_apiserver
-    wait_for_backend
 }
 
 @test 'verify snapshot-list output with snapshots' {
@@ -75,17 +67,14 @@ local_setup() {
 }
 
 @test 'verify k8s is off' {
+    start_container_engine
+    wait_for_container_engine
+    wait_for_backend
     run rdctl api /v1/settings
     assert_success
     run jq_output .kubernetes.enabled
     assert_success
-    case $output in
-    "true")
-        rdctl set --kubernetes.enabled=false
-        wait_for_container_engine
-        wait_for_backend
-        ;;
-    esac
+    assert_output "false"
 }
 
 @test 'create a snapshot with k8s off' {

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/factoryreset"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/spf13/cobra"
 )
 
@@ -64,11 +63,7 @@ func exitWithJsonOrErrorCondition(e error) error {
 // If the main process is running, stops the backend, calls the
 // passed function, and restarts the backend. If it cannot connect
 // to the main process, just calls the passed function.
-func wrapSnapshotOperation(cmd *cobra.Command, resetOnFailure bool, wrappedFunction cobraFunc) error {
-	appPaths, err := paths.GetPaths()
-	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
-	}
+func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, resetOnFailure bool, wrappedFunction cobraFunc) error {
 	if err := createBackendLock(appPaths.AppHome); err != nil {
 		return err
 	}
@@ -88,16 +83,6 @@ func wrapSnapshotOperation(cmd *cobra.Command, resetOnFailure bool, wrappedFunct
 	// keeping the state of the backend lock file in sync with the
 	// main process backendIsLocked variable.
 	return ensureBackendStarted()
-}
-
-func getSnapshotIdAndManager(args []string) (snapshot.Manager, string, error) {
-	appPaths, err := paths.GetPaths()
-	if err != nil {
-		return snapshot.Manager{}, "", fmt.Errorf("failed to get paths: %w", err)
-	}
-	manager := snapshot.NewManager(appPaths)
-	id, err := manager.GetSnapshotId(args[0])
-	return manager, id, err
 }
 
 func getConnectionInfo() (*config.ConnectionInfo, error) {

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -24,8 +24,6 @@ var snapshotErrors []error
 
 const backendLockName = "backend.lock"
 
-type cobraFunc func() error
-
 var snapshotCmd = &cobra.Command{
 	Use:    "snapshot",
 	Short:  "Manage Rancher Desktop snapshots",
@@ -63,7 +61,7 @@ func exitWithJsonOrErrorCondition(e error) error {
 // If the main process is running, stops the backend, calls the
 // passed function, and restarts the backend. If it cannot connect
 // to the main process, just calls the passed function.
-func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, resetOnFailure bool, wrappedFunction cobraFunc) error {
+func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, resetOnFailure bool, wrappedFunction func() error) error {
 	if err := createBackendLock(appPaths.AppHome); err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -50,11 +50,12 @@ func createSnapshot(cmd *cobra.Command, args []string) error {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
+
 	// exclude snapshots directory from time machine backups if on macOS
 	execCmd := exec.Command("tmutil", "isexcluded", appPaths.Snapshots)
 	output, err := execCmd.CombinedOutput()
 	// If a tmutil command fails, report it, but don't return failure status to the caller,
-	// as the snapshot was definitely created, and we need to continue that processing.
+	// as the snapshot was definitely created, and we need to continue processing it.
 	msg := fmt.Errorf("")
 	if err != nil {
 		msg = fmt.Errorf("`tmutil isexcluded` failed: %w: %s\n", err, output)

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"os/exec"
 	"runtime"
-	"strings"
 )
 
 var snapshotDescription string
@@ -52,21 +51,10 @@ func createSnapshot(cmd *cobra.Command, args []string) error {
 	}
 
 	// exclude snapshots directory from time machine backups if on macOS
-	execCmd := exec.Command("tmutil", "isexcluded", appPaths.Snapshots)
+	execCmd := exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
 	output, err := execCmd.CombinedOutput()
-	// If a tmutil command fails, report it, but don't return failure status to the caller,
-	// as the snapshot was definitely created, and we need to continue processing it.
-	msg := fmt.Errorf("")
 	if err != nil {
-		msg = fmt.Errorf("`tmutil isexcluded` failed: %w: %s\n", err, output)
-	} else if !strings.Contains(string(output), "[Excluded]") {
-		execCmd = exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
-		output, err = execCmd.CombinedOutput()
-		if err != nil {
-			msg = fmt.Errorf("`tmutil addexclusion` failed to add exclusion to TimeMachine: %w: %s\n", err, output)
-		}
-	}
-	if msg.Error() != "" {
+		msg := fmt.Errorf("`tmutil addexclusion` failed to add exclusion to TimeMachine: %w: %s", err, output)
 		if outputJsonFormat {
 			snapshotErrors = append(snapshotErrors, msg)
 		} else {

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -10,37 +10,45 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var snapshotDescription string
+
 var snapshotCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a snapshot",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := wrapSnapshotOperation(createSnapshot)(cmd, args)
-		return exitWithJsonOrErrorCondition(err)
+		return exitWithJsonOrErrorCondition(createSnapshot(cmd, args))
 	},
 }
 
 func init() {
 	snapshotCmd.AddCommand(snapshotCreateCmd)
-	snapshotCreateCmd.Flags().BoolVarP(&outputJsonFormat, "json", "", false, "output json format")
+	snapshotCreateCmd.Flags().BoolVar(&outputJsonFormat, "json", false, "output json format")
+	snapshotCreateCmd.Flags().StringVar(&snapshotDescription, "description", "", "snapshot description")
 }
 
-func createSnapshot(_ *cobra.Command, args []string) error {
-	appPaths, err := paths.GetPaths()
-	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
-	}
-	manager := snapshot.NewManager(appPaths)
-	if _, err := manager.Create(args[0]); err != nil {
-		return fmt.Errorf("failed to create snapshot: %w", err)
-	}
-	// exclude snapshots directory from time machine backups if on macOS
-	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to add exclusion to TimeMachine: %w", err)
+func createSnapshot(cmd *cobra.Command, args []string) error {
+	return wrapSnapshotOperation(func(_ *cobra.Command) error {
+		appPaths, err := paths.GetPaths()
+		if err != nil {
+			return fmt.Errorf("failed to get paths: %w", err)
 		}
-	}
-	return nil
+		manager := snapshot.NewManager(appPaths)
+		if _, err := manager.Create(args[0], snapshotDescription); err != nil {
+			return fmt.Errorf("failed to create snapshot %q: %w", args[0], err)
+		}
+		// exclude snapshots directory from time machine backups if on macOS
+		if runtime.GOOS == "darwin" {
+			appPaths, err := paths.GetPaths()
+			if err != nil {
+				return fmt.Errorf("failed to get paths: %w", err)
+			}
+			cmd := exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("failed to add exclusion to TimeMachine: %w", err)
+			}
+		}
+		return nil
+	})(cmd)
 }

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -29,14 +29,14 @@ func init() {
 }
 
 func createSnapshot(cmd *cobra.Command, args []string) error {
-	return wrapSnapshotOperation(func(_ *cobra.Command) error {
+	return wrapSnapshotOperation(cmd, false, func() error {
 		appPaths, err := paths.GetPaths()
 		if err != nil {
 			return fmt.Errorf("failed to get paths: %w", err)
 		}
 		manager := snapshot.NewManager(appPaths)
 		if _, err := manager.Create(args[0], snapshotDescription); err != nil {
-			return fmt.Errorf("failed to create snapshot %q: %w", args[0], err)
+			return fmt.Errorf("failed to create snapshot: %w", err)
 		}
 		// exclude snapshots directory from time machine backups if on macOS
 		if runtime.GOOS == "darwin" {
@@ -50,5 +50,5 @@ func createSnapshot(cmd *cobra.Command, args []string) error {
 			}
 		}
 		return nil
-	})(cmd)
+	})
 }

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -35,7 +35,7 @@ func createSnapshot(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get paths: %w", err)
 	}
 	manager := snapshot.NewManager(appPaths)
-	if err := manager.ValidateNewName(args[0]); err != nil {
+	if err := manager.ValidateName(args[0]); err != nil {
 		return err
 	}
 	err = wrapSnapshotOperation(cmd, appPaths, false, func() error {

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -81,10 +82,21 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 		return nil
 	}
 	writer := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
-	fmt.Fprintf(writer, "NAME\tDESCRIPTION\tCREATED\n")
+	fmt.Fprintf(writer, "NAME\tCREATED\tDESCRIPTION\n")
 	for _, aSnapshot := range snapshots {
 		prettyCreated := aSnapshot.Created.Format(time.RFC1123)
-		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, aSnapshot.Description, prettyCreated)
+		desc := aSnapshot.Description
+		idx := strings.Index(desc, "\n")
+		if idx >= 0 {
+			// If the description starts with a newline, it will appear empty in this view.
+			// Use the json view to get the full description
+			desc = desc[0: idx]
+		}
+		if len(desc) > 63 {
+			desc = desc[0:60]+"..."
+		}
+
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, prettyCreated, desc)
 	}
 	writer.Flush()
 	return nil

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -90,10 +90,14 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 		if idx >= 0 {
 			// If the description starts with a newline, it will appear empty in this view.
 			// Use the json view to get the full description
-			desc = desc[0: idx]
+			desc = desc[0:idx]
 		}
 		if len(desc) > 63 {
-			desc = desc[0:60]+"..."
+			desc = desc[0:60] + "..."
+		} else if idx >= 0 {
+			// The string was truncated because of a newline, so add an ellipsis to show that
+			// Do this even if the newline was the last character - we've still truncated *something*.
+			desc += "..."
 		}
 
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, prettyCreated, desc)

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -81,10 +81,10 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 		return nil
 	}
 	writer := tabwriter.NewWriter(os.Stdout, 0, 4, 4, ' ', 0)
-	fmt.Fprintf(writer, "NAME\tCREATED\n")
+	fmt.Fprintf(writer, "NAME\tDESCRIPTION\tCREATED\n")
 	for _, aSnapshot := range snapshots {
 		prettyCreated := aSnapshot.Created.Format(time.RFC1123)
-		fmt.Fprintf(writer, "%s\t%s\n", aSnapshot.Name, prettyCreated)
+		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, aSnapshot.Description, prettyCreated)
 	}
 	writer.Flush()
 	return nil

--- a/src/go/rdctl/cmd/snapshotRestore.go
+++ b/src/go/rdctl/cmd/snapshotRestore.go
@@ -26,10 +26,10 @@ func restoreSnapshot(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return wrapSnapshotOperation(func(_ *cobra.Command) error {
+	return wrapSnapshotOperation(cmd, true, func() error {
 		if err := manager.Restore(id); err != nil {
 			return fmt.Errorf("failed to restore snapshot %q: %w", args[0], err)
 		}
 		return nil
-	})(cmd)
+	})
 }

--- a/src/go/rdctl/cmd/snapshotRestore.go
+++ b/src/go/rdctl/cmd/snapshotRestore.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 
 	"github.com/spf13/cobra"
 )
@@ -22,11 +24,16 @@ func init() {
 }
 
 func restoreSnapshot(cmd *cobra.Command, args []string) error {
-	manager, id, err := getSnapshotIdAndManager(args)
+	appPaths, err := paths.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
+	manager := snapshot.NewManager(appPaths)
+	id, err := manager.GetSnapshotId(args[0])
 	if err != nil {
 		return err
 	}
-	return wrapSnapshotOperation(cmd, true, func() error {
+	return wrapSnapshotOperation(cmd, appPaths, true, func() error {
 		if err := manager.Restore(id); err != nil {
 			return fmt.Errorf("failed to restore snapshot %q: %w", args[0], err)
 		}

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -61,14 +61,9 @@ func (manager *Manager) GetSnapshotId(desiredName string) (string, error) {
 	return "", fmt.Errorf(`can't find snapshot %q`, desiredName)
 }
 
-// Make this a map because in tests we validate more than one name in a run
-// If the non-test code needs to create more than one snapshot in a single run,
-// this variable shouldn't need to be changed
-var validateNameChecked = make(map[string]bool)
-
-// ValidateNewName - does syntactic validation on the name
+// ValidateName - does syntactic validation on the name
 // This assumes that we will only want to create a single snapshot
-func (manager Manager) ValidateNewName(name string) error {
+func (manager Manager) ValidateName(name string) error {
 	// validate name
 	currentSnapshots, err := manager.List()
 	if err != nil {
@@ -82,20 +77,11 @@ func (manager Manager) ValidateNewName(name string) error {
 	if !nameRegexp.MatchString(name) {
 		return fmt.Errorf("invalid name %q: %w", name, ErrInvalidName)
 	}
-	validateNameChecked[name] = true
 	return nil
 }
 
 // Creates a new snapshot.
 func (manager Manager) Create(name, description string) (*Snapshot, error) {
-	_, ok := validateNameChecked[name]
-	if !ok {
-		err := manager.ValidateNewName(name)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ID for snapshot: %w", err)

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -61,7 +61,9 @@ func (manager *Manager) GetSnapshotId(desiredName string) (string, error) {
 	return "", fmt.Errorf(`can't find snapshot %q`, desiredName)
 }
 
-// Make this a map just in case we support creating more than one snapshot in a run
+// Make this a map because in tests we validate more than one name in a run
+// If the non-test code needs to create more than one snapshot in a single run,
+// this variable shouldn't need to be changed
 var validateNameChecked = make(map[string]bool)
 
 // ValidateNewName - does syntactic validation on the name

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -62,7 +62,6 @@ func (manager *Manager) GetSnapshotId(desiredName string) (string, error) {
 }
 
 // ValidateName - does syntactic validation on the name
-// This assumes that we will only want to create a single snapshot
 func (manager Manager) ValidateName(name string) error {
 	// validate name
 	currentSnapshots, err := manager.List()

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -62,7 +62,7 @@ func (manager *Manager) GetSnapshotId(desiredName string) (string, error) {
 }
 
 // Creates a new snapshot.
-func (manager Manager) Create(name string) (*Snapshot, error) {
+func (manager Manager) Create(name, description string) (*Snapshot, error) {
 	// validate name
 	currentSnapshots, err := manager.List()
 	if err != nil {
@@ -82,9 +82,10 @@ func (manager Manager) Create(name string) (*Snapshot, error) {
 		return nil, fmt.Errorf("failed to generate ID for snapshot: %w", err)
 	}
 	snapshot := Snapshot{
-		Created: time.Now(),
-		Name:    name,
-		ID:      id.String(),
+		Created:     time.Now(),
+		Name:        name,
+		ID:          id.String(),
+		Description: description,
 	}
 
 	// do operations that can fail, rolling back if failure is encountered

--- a/src/go/rdctl/pkg/snapshot/manager_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_test.go
@@ -17,10 +17,10 @@ func TestManager(t *testing.T) {
 		paths, _ := populateFiles(t, true)
 		manager := newTestManager(paths)
 		snapshotName := "test-snapshot"
-		if _, err := manager.Create(snapshotName); err != nil {
+		if _, err := manager.Create(snapshotName, ""); err != nil {
 			t.Fatalf("failed to create first snapshot: %s", err)
 		}
-		if _, err := manager.Create(snapshotName); !errors.Is(err, ErrNameExists) {
+		if _, err := manager.Create(snapshotName, ""); !errors.Is(err, ErrNameExists) {
 			t.Fatalf("failed to return error upon second snapshot with name %q", snapshotName)
 		}
 	})
@@ -39,7 +39,7 @@ func TestManager(t *testing.T) {
 			invalidNames = append(invalidNames, fmt.Sprintf("invalid%sname", c)) // spellcheck-ignore-line
 		}
 		for _, invalidName := range invalidNames {
-			if _, err := manager.Create(invalidName); !errors.Is(err, ErrInvalidName) {
+			if _, err := manager.Create(invalidName, ""); !errors.Is(err, ErrInvalidName) {
 				t.Errorf("name %q is invalid but no error was returned", invalidName)
 			}
 		}
@@ -50,7 +50,7 @@ func TestManager(t *testing.T) {
 		manager := newTestManager(paths)
 		for i := range []int{1, 2, 3} {
 			snapshotName := fmt.Sprintf("test-snapshot-%d", i)
-			if _, err := manager.Create(snapshotName); err != nil {
+			if _, err := manager.Create(snapshotName, ""); err != nil {
 				t.Fatalf("failed to create snapshot %q: %s", snapshotName, err)
 			}
 		}
@@ -66,7 +66,7 @@ func TestManager(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		paths, _ := populateFiles(t, true)
 		manager := newTestManager(paths)
-		snapshot, err := manager.Create("test-snapshot")
+		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}

--- a/src/go/rdctl/pkg/snapshot/manager_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_test.go
@@ -1,7 +1,6 @@
 package snapshot
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -17,10 +16,13 @@ func TestManager(t *testing.T) {
 		paths, _ := populateFiles(t, true)
 		manager := newTestManager(paths)
 		snapshotName := "test-snapshot"
+		if err := manager.ValidateName(snapshotName); err != nil {
+			t.Fatalf("failed to validate first snapshot: %s", err)
+		}
 		if _, err := manager.Create(snapshotName, ""); err != nil {
 			t.Fatalf("failed to create first snapshot: %s", err)
 		}
-		if _, err := manager.Create(snapshotName, ""); !errors.Is(err, ErrNameExists) {
+		if err := manager.ValidateName(snapshotName); err == nil {
 			t.Fatalf("failed to return error upon second snapshot with name %q", snapshotName)
 		}
 	})
@@ -39,7 +41,7 @@ func TestManager(t *testing.T) {
 			invalidNames = append(invalidNames, fmt.Sprintf("invalid%sname", c)) // spellcheck-ignore-line
 		}
 		for _, invalidName := range invalidNames {
-			if _, err := manager.Create(invalidName, ""); !errors.Is(err, ErrInvalidName) {
+			if err := manager.ValidateName(invalidName); err == nil {
 				t.Errorf("name %q is invalid but no error was returned", invalidName)
 			}
 		}

--- a/src/go/rdctl/pkg/snapshot/manager_unix_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_unix_test.go
@@ -74,7 +74,7 @@ func TestManagerUnix(t *testing.T) {
 
 			// create snapshot
 			testManager := newTestManager(paths)
-			snapshot, err := testManager.Create("test-snapshot")
+			snapshot, err := testManager.Create("test-snapshot", "")
 			if err != nil {
 				t.Fatalf("unexpected error creating snapshot: %s", err)
 			}
@@ -101,7 +101,7 @@ func TestManagerUnix(t *testing.T) {
 		t.Run(fmt.Sprintf("Restore with includeOverrideYaml %t", includeOverrideYaml), func(t *testing.T) {
 			paths, testFiles := populateFiles(t, includeOverrideYaml)
 			manager := newTestManager(paths)
-			snapshot, err := manager.Create("test-snapshot")
+			snapshot, err := manager.Create("test-snapshot", "")
 			if err != nil {
 				t.Fatalf("failed to create snapshot: %s", err)
 			}
@@ -131,7 +131,7 @@ func TestManagerUnix(t *testing.T) {
 		if err := os.Remove(testFiles["override.yaml"].Path); err != nil {
 			t.Fatalf("failed to delete override.yaml: %s", err)
 		}
-		snapshot, err := manager.Create("test-snapshot")
+		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}
@@ -162,7 +162,7 @@ func TestManagerUnix(t *testing.T) {
 	t.Run("Restore should create any needed parent directories", func(t *testing.T) {
 		paths, _ := populateFiles(t, true)
 		manager := newTestManager(paths)
-		snapshot, err := manager.Create("test-snapshot")
+		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}

--- a/src/go/rdctl/pkg/snapshot/manager_windows_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_windows_test.go
@@ -50,7 +50,7 @@ func TestManagerWindows(t *testing.T) {
 
 		// create snapshot
 		testManager := newTestManager(paths)
-		snapshot, err := testManager.Create("test-snapshot")
+		snapshot, err := testManager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("unexpected error creating snapshot: %s", err)
 		}
@@ -70,7 +70,7 @@ func TestManagerWindows(t *testing.T) {
 	t.Run("Restore should work properly", func(t *testing.T) {
 		paths, testFiles := populateFiles(t, false)
 		manager := newTestManager(paths)
-		snapshot, err := manager.Create("test-snapshot")
+		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}
@@ -96,7 +96,7 @@ func TestManagerWindows(t *testing.T) {
 	t.Run("Restore should create any needed parent directories", func(t *testing.T) {
 		paths, _ := populateFiles(t, true)
 		manager := newTestManager(paths)
-		snapshot, err := manager.Create("test-snapshot")
+		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}

--- a/src/go/rdctl/pkg/snapshot/snapshot.go
+++ b/src/go/rdctl/pkg/snapshot/snapshot.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Snapshot struct {
-	Created time.Time `json:"created"`
-	Name    string    `json:"name"`
-	ID      string    `json:"id,omitempty"`
+	Created     time.Time `json:"created"`
+	Name        string    `json:"name"`
+	ID          string    `json:"id,omitempty"`
+	Description string    `json:"description"`
 }
 
 func (s *Snapshot) getTimeString() string {


### PR DESCRIPTION
- Adds the description field to snapshots
- Simplifies the use of the function-wrapper for snapshot-create and -restore
- Splits `manager.Create` to `manager.ValidateName` and `manager.Create` so that
  names can be validated before we start manipulating the lock-file and backend-state

Fixes #5580 
Fixes #5769
Fixes #5773