### PR TITLE
WSL: Integrations: use marker

### DIFF
--- a/src/go/wsl-helper/cmd/enum.go
+++ b/src/go/wsl-helper/cmd/enum.go
@@ -13,19 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
-import (
-	"github.com/spf13/cobra"
-)
+import "fmt"
 
-// k3sCmd represents the k3s command
-var wslCmd = &cobra.Command{
-	Use:    "wsl",
-	Short:  "Commands for interacting with WSL",
-	Hidden: true,
+// enumValue describes an enumeration for use with github.com/spf13/pflag
+type enumValue struct {
+	allowed []string // Allowed values
+	val     string   // Current value
 }
 
-func init() {
-	rootCmd.AddCommand(wslCmd)
+func (v *enumValue) String() string {
+	return v.val
+}
+
+func (v *enumValue) Set(newVal string) error {
+	for _, candidate := range v.allowed {
+		if candidate == newVal {
+			v.val = candidate
+			return nil
+		}
+	}
+	return fmt.Errorf("value %q is not one of the allowed values: %+v", newVal, v.allowed)
+}
+
+func (v *enumValue) Type() string {
+	return "enum"
 }

--- a/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/integration"
+)
+
+var wslIntegrationStateViper = viper.New()
+
+// wslIntegrationStateCmd represents the `wsl integration-state` command.
+var wslIntegrationStateCmd = &cobra.Command{
+	Use:   "integration-state",
+	Short: "Manage markers for WSL integration state",
+	Long:  "Manage markers for Rancher Desktop WSL distro integration state",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		mode := cmd.Flags().Lookup("mode").Value.String()
+		switch mode {
+		case "show":
+			return integration.Show()
+		case "set":
+			logrus.Trace("Setting wsl integration state marker")
+			return integration.Set()
+		case "delete":
+			logrus.Trace("Deleting wsl integration state marker")
+			return integration.Delete()
+		default:
+			return fmt.Errorf("unknown operation %q", mode)
+		}
+	},
+}
+
+func init() {
+	wslIntegrationStateCmd.Flags().Var(&enumValue{val: "show", allowed: []string{"show", "set", "delete"}}, "mode", "Operation mode")
+	wslIntegrationStateCmd.MarkFlagRequired("mode")
+	wslIntegrationStateViper.AutomaticEnv()
+	wslIntegrationStateViper.BindPFlags(wslIntegrationStateCmd.Flags())
+	wslCmd.AddCommand(wslIntegrationStateCmd)
+}

--- a/src/go/wsl-helper/pkg/integration/integration.go
+++ b/src/go/wsl-helper/pkg/integration/integration.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package integration manages the marker file to indicate if a WSL distribution
+// is being integrated with Rancher Desktop.
+package integration
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+const (
+	markerPath     = "/.rancher-desktop-integration"
+	markerContents = "This file is used to mark Rancher Desktop WSL integration.\n"
+)
+
+// Set the current distribution as being integrated with Rancher Desktop.
+func Set() error {
+	return os.WriteFile(markerPath, []byte(markerContents), 0o644)
+}
+
+// Delete any markers claiming the current distribution is integrated with
+// Rancher Desktop.
+func Delete() error {
+	if err := os.Remove(markerPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+// Check if the current distribution is being integrated with Rancher Desktop;
+// prints, on stdout, either "true", "false", or an error message.
+func Show() error {
+	if _, err := os.Stat(markerPath); err == nil {
+		fmt.Println("true")
+	} else if errors.Is(err, os.ErrNotExist) {
+		fmt.Println("false")
+	} else {
+		fmt.Printf("%s\n", err)
+	}
+	return nil
+}


### PR DESCRIPTION
- Rather than checking to see if the kubeconfig is a symlink, determine if integration is set up in a distro by writing a file to the root directory to ensure that we do the correct thing if kubernetes is disabled (also, because we need to change how kubeconfig management works).
- Re-organize how we do the integrations so we can always set the flag file after everything else.