### PR TITLE
When importing WSL distro in `rdctl`, force distro to be version 2

### DIFF
--- a/src/go/rdctl/pkg/wsl/wsl_windows.go
+++ b/src/go/rdctl/pkg/wsl/wsl_windows.go
@@ -33,7 +33,7 @@ func (wsl WSLImpl) ExportDistro(distroName, fileName string) error {
 }
 
 func (wsl WSLImpl) ImportDistro(distroName, installLocation, fileName string) error {
-	cmd := exec.Command("wsl.exe", "--import", distroName, installLocation, fileName)
+	cmd := exec.Command("wsl.exe", "--import", distroName, installLocation, fileName, "--version", "2")
 	if output, err := cmd.Output(); err != nil {
 		return fmt.Errorf("failed to import WSL distro %q: %w", distroName, wrapWSLError(output, err))
 	}


### PR DESCRIPTION
Closes #5791.