### PR TITLE
Restart the backend after creating snapshot produces error

### DIFF
--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -72,6 +72,10 @@ func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, resetOnFail
 	if err := wrappedFunction(); err != nil {
 		if resetOnFailure {
 			factoryreset.DeleteData(appPaths, true)
+		} else {
+			if err := ensureBackendStarted(); err != nil {
+				snapshotErrors = append(snapshotErrors, err)
+			}
 		}
 		return err
 	}

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -72,12 +72,9 @@ func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, resetOnFail
 	if err := wrappedFunction(); err != nil {
 		if resetOnFailure {
 			factoryreset.DeleteData(appPaths, true)
-		} else {
-			if err := ensureBackendStarted(); err != nil {
-				snapshotErrors = append(snapshotErrors, err)
-			}
+			return err
 		}
-		return err
+		snapshotErrors = append(snapshotErrors, err)
 	}
 	// Note that this does not wait for the backend to be in the
 	// STARTED (or DISABLED if k8s is disabled) state. This allows


### PR DESCRIPTION
Closes #5764.

Note that #5764 refers to an older version of the code. It is now impossible to reproduce the problem in the manner described, because we check the passed snapshot name before creating or restoring a snapshot. `main` now behaves as @torchiaf seems to expect in the description, except:
- The backend is not restarted when `manager.Create()` fails. This PR corrects this.
- The backend is not restarted when `manager.Restore()` fails. This would be impossible anyways, since we do a factory reset in this case. #5809 seems to be about this, so I've left this part as it is.

We may not want to make this change, but I'm going to create this PR in case we do.