### PR TITLE
Display app name as "Rancher Desktop by SUSE"

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -286,7 +286,7 @@ Electron.app.whenReady().then(async() => {
       // TODO: Update this to 2021-... as dev progresses
       // also needs to be updated in electron-builder.yml
       copyright:          'Copyright © 2021-2023 SUSE LLC',
-      applicationName:    Electron.app.name,
+      applicationName:    `${ Electron.app.name } by SUSE`,
       applicationVersion: `Version ${ await getVersion() }`,
       iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
     });

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -33,7 +33,7 @@ test.describe.serial('Main App Test', () => {
   test('should land on General page', async() => {
     const navPage = new NavPage(page);
 
-    await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop');
+    await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop by SUSE');
   });
 
   test('should navigate to Port Forwarding and check elements', async() => {

--- a/e2e/utils/ProfileUtils.ts
+++ b/e2e/utils/ProfileUtils.ts
@@ -201,7 +201,7 @@ export async function testForFirstRunWindow(testPath: string) {
 
     try {
       await retry(async() => {
-        await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop');
+        await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop by SUSE');
       });
       page = openedPage;
       windowCountForMainPage = windowCount;
@@ -252,7 +252,7 @@ export async function testForNoFirstRunWindow(testPath: string) {
 
     try {
       await retry(async() => {
-        await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop');
+        await expect(navPage.mainTitle).toHaveText('Welcome to Rancher Desktop by SUSE');
       });
       page = openedPage;
       windowCountForMainPage = windowCount;

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -279,7 +279,7 @@ portForwarding:
   sortableTables:
     noRows: There are no port forwarding entries to show
 general:
-  title: Welcome to Rancher Desktop
+  title: Welcome to Rancher Desktop by SUSE
   description: Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
 about:
   title: About

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h2 data-test="k8s-settings-header">
-      Welcome to Rancher Desktop
+      Welcome to Rancher Desktop by SUSE
     </h2>
     <rd-checkbox
       label="Enable Kubernetes"

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="first-run-container">
     <h2 data-test="k8s-settings-header">
       Welcome to Rancher Desktop by SUSE
     </h2>
@@ -243,6 +243,12 @@ export default Vue.extend({
 });
 </script>
 
+<style lang="scss">
+  html {
+    height: initial;
+  }
+</style>
+
 <style lang="scss" scoped>
   .button-area {
     align-self: flex-end;
@@ -250,5 +256,9 @@ export default Vue.extend({
 
   .select-k8s-version {
     margin-top: 0.5rem;
+  }
+
+  .first-run-container {
+    width: 26rem;
   }
 </style>


### PR DESCRIPTION
Both in the "General" page and the "About" box.

Fixes #5822