### PR TITLE
Add spacing to project links on general page

### DIFF
--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -6,8 +6,8 @@
     <div>
       <ul>
         <li>Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack</li>
-        <li>
-          Project Links:
+        <li class="project-links">
+          <span>Project Links:</span>
           <a href="https://github.com/rancher-sandbox/rancher-desktop">Homepage</a>
           <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Issues</a>
         </li>
@@ -151,5 +151,9 @@ export default {
       margin-bottom: .5em;
     }
   }
+}
+
+.project-links > * {
+  margin-right: .25em;
 }
 </style>


### PR DESCRIPTION
This looks like a regression that was introduced in the Nuxt removal #5287.

## Before

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/e1f8343b-bae0-43dd-8e0a-cfd6de2d3735)

## After

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/76ab375b-9add-4f4b-b017-1152f81c23f5)

closes #5824