### PR TITLE
Quit Rancher Desktop when a snapshot fails to restore

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -787,7 +787,7 @@ ipcMainProxy.on('snapshot', (event, args) => {
 });
 
 ipcMainProxy.on('dialog/error', (event, args) => {
-  window.getWindow(args.dialog)?.webContents.send('dialog/error', args.error);
+  window.getWindow(args.dialog)?.webContents.send('dialog/error', args);
 });
 
 ipcMainProxy.on('dialog/close', (event, args) => {

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4749,6 +4749,10 @@ snapshots:
       actions:
         ok: 'Restore'
         cancel: 'Cancel'
+      error:
+        header: 'Error restoring snapshot'
+        description: "Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again."
+        buttonText: 'Quit Rancher Desktop'
     delete:
       header: Permanently delete snapshot?
       info: 'text'

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
 import dayjs from 'dayjs';
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
+import { State as EngineStates } from '@pkg/backend/k8s';
 import { Snapshot } from '@pkg/main/snapshots/types';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -32,7 +34,9 @@ interface Methods {
 }
 
 interface Computed {
-  snapshot: Snapshot & { formattedCreateDate: { date: string, time: string } | null }
+  snapshot: Snapshot & { formattedCreateDate: { date: string, time: string } | null },
+  isRestoreDisabled: boolean,
+  getK8sState: EngineStates,
 }
 
 interface Props {
@@ -49,11 +53,17 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   },
 
   computed: {
+    ...mapGetters('k8sManager', { getK8sState: 'getK8sState' }),
     snapshot() {
       return {
         ...this.value,
         formattedCreateDate: formatDate(this.value.created),
       };
+    },
+    isRestoreDisabled(): boolean {
+      const k8sState = this.getK8sState;
+
+      return ![EngineStates.STARTED, EngineStates.DISABLED, EngineStates.ERROR].includes(k8sState);
     },
   },
 
@@ -138,9 +148,10 @@ export default Vue.extend<Data, Methods, Computed, Props>({
             cancelId: 1,
           },
           format: {
-            header:          this.t('snapshots.dialog.restoring.header', { snapshot }),
-            message:         this.t('snapshots.dialog.restoring.message', { snapshot }, true),
-            showProgressBar: true,
+            header:            this.t('snapshots.dialog.restoring.header', { snapshot }),
+            message:           this.t('snapshots.dialog.restoring.message', { snapshot }, true),
+            showProgressBar:   true,
+            snapshotEventType: 'restore',
           },
         },
       );
@@ -184,6 +195,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       </button>
       <button
         class="btn btn-xs role-primary restore"
+        :disabled="isRestoreDisabled"
         @click="restore"
       >
         {{ t('snapshots.card.action.restore') }}

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -80,7 +80,15 @@ export default Vue.extend<Data, Methods, Computed, Props>({
           const error = await this.$store.dispatch('snapshots/restore', this.snapshot.name);
 
           if (error) {
-            ipcRenderer.send('dialog/error', { dialog: 'SnapshotsDialog', error });
+            ipcRenderer.send(
+              'dialog/error',
+              {
+                dialog:           'SnapshotsDialog',
+                error,
+                errorTitle:       this.t('snapshots.dialog.restore.error.header'),
+                errorDescription: this.t('snapshots.dialog.restore.error.description', { snapshot: this.snapshot.name }, true),
+                errorButton:      this.t('snapshots.dialog.restore.error.buttonText'),
+              });
           } else {
             ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
             ipcRenderer.send('snapshot', {

--- a/pkg/rancher-desktop/main/snapshots/types.ts
+++ b/pkg/rancher-desktop/main/snapshots/types.ts
@@ -19,6 +19,7 @@ export interface SnapshotDialog {
   info?: string | null,
   showProgressBar?: boolean,
   type?: string,
+  snapshotEventType?: SnapshotEvent['type'],
 }
 
 export interface Snapshot {

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -18,6 +18,9 @@ export default Vue.extend({
       info:              '',
       bodyStyle:         {},
       error:             '',
+      errorTitle:        '',
+      errorDescription:  '',
+      errorButton:       '',
       buttons:           [],
       response:          0,
       cancelId:          0,
@@ -37,8 +40,11 @@ export default Vue.extend({
   },
 
   mounted() {
-    ipcRenderer.on('dialog/error', (_event, error) => {
-      this.error = error;
+    ipcRenderer.on('dialog/error', (_event, args) => {
+      this.error = args.error;
+      this.errorTitle = args.errorTitle;
+      this.errorDescription = args.errorDescription;
+      this.errorButton = args.errorButton;
     });
 
     ipcRenderer.on('dialog/options', (_event, { window, format }) => {
@@ -109,7 +115,12 @@ export default Vue.extend({
         class="header"
       >
         <slot name="header">
-          <h1>{{ header }}</h1>
+          <h1 v-if="errorTitle">
+            {{ errorTitle }}
+          </h1>
+          <h1 v-else>
+            {{ header }}
+          </h1>
         </slot>
       </div>
       <hr class="separator">
@@ -141,7 +152,16 @@ export default Vue.extend({
         </slot>
       </div>
       <div
-        v-if="message"
+        v-if="errorDescription"
+        class="message"
+      >
+        <span
+          class="value"
+          v-html="errorDescription"
+        />
+      </div>
+      <div
+        v-else-if="message"
         class="message"
       >
         <slot name="message">
@@ -193,7 +213,12 @@ export default Vue.extend({
             :class="'role-secondary'"
             @click="close(cancelId)"
           >
-            {{ t('snapshots.dialog.buttons.error') }}
+            <template v-if="errorButton">
+              {{ errorButton }}
+            </template>
+            <template v-else>
+              {{ t('snapshots.dialog.buttons.error') }}
+            </template>
           </button>
         </template>
         <template v-else>

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -181,7 +181,7 @@ export interface IpcRendererEvents {
   'dialog/populate': (...args: any) => void;
   'dialog/size': (size: {width: number, height: number}) => void;
   'dialog/options': (...args: any) => void;
-  'dialog/error': (error: string) => void;
+  'dialog/error': (args: any) => void;
   'dashboard-open': () => void;
   // #endregion
 


### PR DESCRIPTION
This PR quits Rancher Desktop when a snapshot fails to restore. It also disables the Restore button while Rancher Desktop is starting, this is compromise that will eliminate a failure mode that happens when attempting to restore from a snapshot while Rancher Desktop is starting. 

## Notes

Rancher Desktop should only quit when the two following conditions are fulfilled: 

1. A Snapshot is being restored 
2. The restore process fails

Other modes of failure during the snapshot creation process should behave as they did before

closes #5809 