### PR TITLE
Set the correct permission on the host file

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -426,7 +426,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   }
 
   protected async updateHostsFile(distro: string) {
-    const entry = '192.168.1.2,gateway.rancher-desktop.internal';
+    const entry = '192.168.1.2 gateway.rancher-desktop.internal';
 
     try {
       console.debug(`Update ${ distro } host file`);

--- a/src/go/wsl-helper/cmd/update_host_linux.go
+++ b/src/go/wsl-helper/cmd/update_host_linux.go
@@ -45,7 +45,7 @@ var updateHostsFileCmd = &cobra.Command{
 func init() {
 	updateHostsFileCmd.Flags().StringSlice(
 		"entries",
-		[]string{fmt.Sprintf("%s,%s", host.GatewayIP, host.GatewayDomain)},
+		[]string{fmt.Sprintf("%s %s", host.GatewayIP, host.GatewayDomain)},
 		"Array of host file entries to append")
 	updateHostsFileCmd.Flags().Bool("remove", false, "Remove RD gateway from hosts file")
 	rootCmd.AddCommand(updateHostsFileCmd)

--- a/src/go/wsl-helper/pkg/host/hostfile.go
+++ b/src/go/wsl-helper/pkg/host/hostfile.go
@@ -35,8 +35,8 @@ const (
 // provided in the following format, e.g.:
 //
 //	newEntries := []string{
-//	  "127.0.0.1,example.com",
-//	  "127.0.0.1,another-example.com",
+//	  "127.0.0.1 example.com",
+//	  "127.0.0.1 another-example.com",
 //	}
 func AppendHostsFile(entries []string, hostsFilePath string) error {
 	exist, err := configExist(hostsFilePath)
@@ -60,7 +60,7 @@ func AppendHostsFile(entries []string, hostsFilePath string) error {
 		return err
 	}
 	for _, entry := range entries {
-		_, err := writer.WriteString(strings.ReplaceAll(entry, ",", " ") + "\n")
+		_, err := writer.WriteString(entry + "\n")
 		if err != nil {
 			return fmt.Errorf("error writing to /etc/hosts file: %w", err)
 		}
@@ -130,6 +130,10 @@ func RemoveHostsFileEntry(hostsFilePath string) error {
 	}
 
 	if err := tempFile.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Chmod(tempFile.Name(), 0644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes the delimiter that was misinterpreted by cobra.
Also, sets the correct permission on the host file. 