### PR TITLE
Don't prompt for sudo password when not required

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,6 +1,7 @@
 emoji
 github
 https
+passwordless
 ssh
 ubuntu
 workarounds

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -111,6 +111,21 @@ if using_networking_tunnel && ! is_windows; then
 fi
 
 ########################################################################
+: "${RD_USE_SOCKET_VMNET:=false}"
+
+using_socket_vmnet() {
+    is_true "$RD_USE_SOCKET_VMNET"
+}
+
+if using_socket_vmnet && ! is_macos; then
+    fatal "RD_USE_SOCKET_VMNET only works on macOS"
+fi
+
+if using_socket_vmnet && sudo_needs_password; then
+    fatal "RD_USE_SOCKET_VMNET requires passwordless sudo"
+fi
+
+########################################################################
 if ! is_unix && [ -n "${RD_MOUNT_TYPE:-}" ]; then
     fatal "RD_MOUNT_TYPE only works on Linux and macOS"
 fi

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -28,6 +28,7 @@ show_info() { # @test
         fi
         printf "$format" "Using image allow list:" "$(bool using_image_allow_list)"
         if is_macos; then
+            printf "$format" "Using socket_vmnet:" "$(bool using_socket_vmnet)"
             printf "$format" "Using VZ emulation:" "$(bool using_vz_emulation)"
         fi
         if is_windows; then

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -74,3 +74,9 @@ needs_port() {
         fi
     fi
 }
+
+sudo_needs_password() {
+    # Check if we can run /usr/bin/true (or /bin/true) without requiring a password
+    run sudo --non-interactive --reset-timestamp true
+    ((status != 0))
+}

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -88,12 +88,18 @@ start_container_engine() {
         --application.updater.enabled=false
         --kubernetes.enabled=false
     )
+    local admin_access=false
+
     if [ -n "$RD_CONTAINER_ENGINE" ]; then
         args+=(--container-engine.name="$RD_CONTAINER_ENGINE")
     fi
+    if using_socket_vmnet; then
+        args+=(--experimental.virtual-machine.socket-vmnet)
+        admin_access=true
+    fi
     if is_unix; then
         args+=(
-            --application.admin-access=false
+            --application.admin-access="$admin_access"
             --application.path-management-strategy rcfiles
             --virtual-machine.memory-in-gb 6
             --experimental.virtual-machine.mount.type="$RD_MOUNT_TYPE"


### PR DESCRIPTION
This makes it possible to run BATS with RD_USE_SOCKET_VMNET on hosts that allow passwordless `sudo`.

But it also means that as a user with passwordless `sudo` you can now enable admin mode without getting asked for your password after each reboot of the host.
