### PR TITLE
RDX: Fix getting container names

### DIFF
--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -429,7 +429,7 @@ class Client implements v1.DockerDesktopClient {
           Ports:      details.NetworkSettings.Ports ?? {},
           ...pick(details.Config, 'Labels'),
           ...pick(details.State, ['Status', 'State']),
-          Names:      c.Names.split(/\s+/g),
+          Names:      typeof c.Names === 'string' ? c.Names.split(/\s+/g) : Array.from(c.Names),
           Created:    Date.parse(c.CreatedAt).valueOf(),
         };
       });

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -426,7 +426,7 @@ class Client implements v1.DockerDesktopClient {
           HostConfig: details.HostConfig ?? {},
           SizeRootFs: details.SizeRootFs ?? -1,
           SizeRw:     details.SizeRw ?? -1,
-          Ports:      details.NetworkSettings.Ports ?? {},
+          Ports:      details.NetworkSettings?.Ports ?? {},
           ...pick(details.Config, 'Labels'),
           ...pick(details.State, ['Status', 'State']),
           Names:      typeof c.Names === 'string' ? c.Names.split(/\s+/g) : Array.from(c.Names),


### PR DESCRIPTION
This fixes #5870 where the container name output is broken with nerdctl.

~I believe this is fallout from https://github.com/containerd/nerdctl/pull/2594~
I have it backwards: it's _fixed_ by that PR (which we don't have yet).