### PR TITLE
Add experimental flag to Containers & Snapshots nav items

### DIFF
--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -17,6 +17,14 @@
             class="nav-badge"
             :label="item.error.toString()"
           />
+          <i
+            v-if="item.experimental"
+            v-tooltip="{
+              content: t('prefs.experimental'),
+              placement: 'right',
+            }"
+            :class="`icon icon-flask`"
+          />
         </NuxtLink>
       </li>
     </ul>
@@ -180,12 +188,14 @@ ul {
         padding: 0;
 
         a {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
             color: var(--body-text);
             text-decoration: none;
             line-height: 24px;
             padding: 7.5px 10px;
             letter-spacing: 1.4px;
-            display: block;
             outline: none;
         }
 
@@ -204,6 +214,7 @@ a {
     background-color: var(--nav-active);
   }
 }
+
 .nav-badge {
   line-height: initial;
   letter-spacing: initial;

--- a/pkg/rancher-desktop/window/constants.ts
+++ b/pkg/rancher-desktop/window/constants.ts
@@ -1,9 +1,9 @@
 export const mainRoutes = [
   { route: '/General' },
-  { route: '/Containers' },
+  { route: '/Containers', experimental: true },
   { route: '/PortForwarding' },
   { route: '/Images' },
-  { route: '/Snapshots' },
+  { route: '/Snapshots', experimental: true },
   { route: '/Troubleshooting' },
   { route: '/Diagnostics' },
   { route: '/Extensions' },


### PR DESCRIPTION
This adds an experimental icon to the navigation items for Containers & Snapshots.

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/7c233add-4879-489d-9ef4-c0499c57210a)
