### PR TITLE
UI: Containers: force cwd

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -262,6 +262,7 @@ export default {
         const { stderr, stdout } = await this.ddClient.docker.cli.exec(
           command,
           [...ids],
+          { cwd: '/' },
         );
 
         if (stderr) {


### PR DESCRIPTION
Otherwise we end up with errors when running in AppImage where the application directory is not mapped into the VM.