### PR TITLE
Migrate API-based settings payloads so the API can handle a settings payloads with an earlier version.

### DIFF
--- a/bats/tests/preferences/move-from-roaming-to-local.bats
+++ b/bats/tests/preferences/move-from-roaming-to-local.bats
@@ -13,7 +13,7 @@ local_setup() {
     start_container_engine
     wait_for_container_engine
 
-    rdctl api -X PUT /settings --body '{ "version": '"$(get_setting .version)"', "WSL": {"integrations": { "beaker" : true }}}'
+    rdctl api -X PUT /settings --body '{ "version": 9, "WSL": {"integrations": { "beaker" : true }}}'
     rdctl shutdown
     mkdir -p "$ROAMING_HOME"
     mv "$PATH_CONFIG_FILE" "$ROAMING_HOME/settings.json"

--- a/bats/tests/preferences/verify-settings.bats
+++ b/bats/tests/preferences/verify-settings.bats
@@ -19,7 +19,7 @@ proxy_set() {
     local field=$1
     local value=$2
 
-    payload=$(printf '{ "version": %d, "experimental": { "virtualMachine": { "proxy": { "%s": %s }}}}' "$(get_setting .version)" "$field" "$value")
+    payload=$(printf '{ "version": 10, "experimental": { "virtualMachine": { "proxy": { "%s": %s }}}}' "$field" "$value")
     run rdctl api settings -X PUT --body "$payload"
     assert_failure
     assert_output --partial "Changing field \"experimental.virtualMachine.proxy.${field}\" via the API isn't supported"
@@ -48,7 +48,7 @@ proxy_set() {
     assert_success
     run jq_output .experimental.virtualMachine.proxy
     assert_success
-    payload=$(printf '{ "version": %s, "experimental": { "virtualMachine": { "proxy": %s } } }' "$(get_setting .version)" "$output")
+    payload=$(printf '{ "version": 10, "experimental": { "virtualMachine": { "proxy": %s }}}' "$output")
     run rdctl api settings -X PUT --body "$payload"
     assert_success
 }

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -476,7 +476,7 @@ describe('settings', () => {
     it('correctly migrates earlier no-proxy settings', () => {
       /**
        * This test verifies that we're no longer running into problems when
-       * the migrator tries to access the value of a non-existent property.
+       * the migrator tries to access the value of a nonexistent property.
        *
        * The bug, issue 5618, was that the migrator erroneously assumed
        * that when users were migrating to version N, they were submitting a settings file

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -474,6 +474,14 @@ describe('settings', () => {
     });
 
     it('correctly migrates earlier no-proxy settings', () => {
+      /**
+       * This test verifies that we're no longer running into problems when
+       * the migrator tries to access the value of a non-existent property.
+       *
+       * The bug, issue 5618, was that the migrator erroneously assumed
+       * that when users were migrating to version N, they were submitting a settings file
+       * that was based on the default settings of version N - 1.
+       */
       const s: RecursivePartial<settings.Settings> = {
         version:      1 as typeof settings.CURRENT_SETTINGS_VERSION,
         experimental: {
@@ -490,26 +498,6 @@ describe('settings', () => {
           virtualMachine: {
             proxy: {
               noproxy: ['1.2.3.4', '11.12.13.14', '21.22.23.24'],
-            },
-          },
-        },
-      };
-
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
-    });
-
-    it('correctly migrates version-8 extension settings ', () => {
-      const s: Record<string, any> = {
-        version:    8 as typeof settings.CURRENT_SETTINGS_VERSION,
-        extensions: { 'hi folks': 'spring', 'goodbye all': 'winter' },
-      };
-      const expected: RecursivePartial<settings.Settings> = {
-        version:     settings.CURRENT_SETTINGS_VERSION,
-        application: {
-          extensions: {
-            installed: {
-              'hi folks':    'spring',
-              'goodbye all': 'winter',
             },
           },
         },

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -610,7 +610,7 @@ describe('settings', () => {
         1: [
           {
             kubernetes: {
-              rancherMode: 'cattleguard',
+              rancherMode: 'cattle',
             },
           },
           {

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -440,13 +440,12 @@ describe('settings', () => {
       }).toThrowError('updating settings requires specifying an API version, but "no way" is not a proper config version');
     });
 
-    it('allows a negative version field', () => {
+    it('complains about a negative version field', () => {
       const s: RecursivePartial<settings.Settings> = { version: -7 as unknown as typeof settings.CURRENT_SETTINGS_VERSION };
-      const expected: RecursivePartial<settings.Settings> = {
-        version: settings.CURRENT_SETTINGS_VERSION,
-      };
 
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
+      expect(() => {
+        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s);
+      }).toThrowError('updating settings requires specifying an API version, but "-7" is not a positive number');
     });
 
     it('version-9 no-proxy settings are correctly migrated', () => {

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -424,7 +424,7 @@ describe('settings', () => {
   });
 
   describe('migrations', () => {
-    it('empty settings complains about a missing version field', () => {
+    it("complains about empty settings because there's no version field", () => {
       const s: RecursivePartial<settings.Settings> = {};
 
       expect(() => {
@@ -448,7 +448,7 @@ describe('settings', () => {
       }).toThrowError('updating settings requires specifying an API version, but "-7" is not a positive number');
     });
 
-    it('version-9 no-proxy settings are correctly migrated', () => {
+    it('correctly migrates version-9 no-proxy settings', () => {
       const s: RecursivePartial<settings.Settings> = {
         version:      9 as typeof settings.CURRENT_SETTINGS_VERSION,
         experimental: {
@@ -473,7 +473,7 @@ describe('settings', () => {
       expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
     });
 
-    it('earlier no-proxy settings are correctly migrated', () => {
+    it('correctly migrates earlier no-proxy settings', () => {
       const s: RecursivePartial<settings.Settings> = {
         version:      1 as typeof settings.CURRENT_SETTINGS_VERSION,
         experimental: {
@@ -498,7 +498,7 @@ describe('settings', () => {
       expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
     });
 
-    it('version-8 extension settings are correctly migrated', () => {
+    it('correctly migrates version-8 extension settings ', () => {
       const s: Record<string, any> = {
         version:    8 as typeof settings.CURRENT_SETTINGS_VERSION,
         extensions: { 'hi folks': 'spring', 'goodbye all': 'winter' },
@@ -518,7 +518,7 @@ describe('settings', () => {
       expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
     });
 
-    it('unrecognized settings are left unchanged', () => {
+    it('leaves unrecognized settings unchanged', () => {
       const s: Record<string, any> = {
         version:        1 as typeof settings.CURRENT_SETTINGS_VERSION,
         registeredCows: '2021-05-17T08:57:17 +07:00',
@@ -546,7 +546,7 @@ describe('settings', () => {
       expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
     });
 
-    it('all old settings are updated', () => {
+    it('updates all old settings going back to version 1', () => {
       const s: Record<string, any> = {
         version:    1 as typeof settings.CURRENT_SETTINGS_VERSION,
         kubernetes: {

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -751,11 +751,11 @@ describe('settings', () => {
       it.each(Object.entries(expectedMigrations))('migrate from %i', (version, beforeAndAfter) => {
         const [fromSettings, toSettings] = beforeAndAfter;
         const existingVersion = parseInt(version, 10);
+        const targetVersion = existingVersion + 1;
 
-        (settings as any).CURRENT_SETTINGS_VERSION = existingVersion + 1;
-        fromSettings.version = existingVersion as unknown as typeof settings.CURRENT_SETTINGS_VERSION;
-        toSettings.version = (existingVersion + 1) as unknown as typeof settings.CURRENT_SETTINGS_VERSION;
-        expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(fromSettings)).toEqual(toSettings);
+        fromSettings.version = existingVersion;
+        toSettings.version = targetVersion;
+        expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(fromSettings, targetVersion)).toEqual(toSettings);
       });
     });
   });

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -763,11 +763,8 @@ describe('settings', () => {
       it.each(Object.entries(expectedMigrations))('migrate from %i', (version, beforeAndAfter) => {
         const [fromSettings, toSettings] = beforeAndAfter;
         const existingVersion = parseInt(version, 10);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const nextVersion = (existingVersion + 1) as unknown as typeof settings.CURRENT_SETTINGS_VERSION;
 
-        // eslint-disable-next-line no-eval
-        eval('settings["CURRENT_SETTINGS_VERSION"] = nextVersion');
+        (settings as any).CURRENT_SETTINGS_VERSION = existingVersion + 1;
         fromSettings.version = existingVersion as unknown as typeof settings.CURRENT_SETTINGS_VERSION;
         toSettings.version = (existingVersion + 1) as unknown as typeof settings.CURRENT_SETTINGS_VERSION;
         expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(fromSettings)).toEqual(toSettings);

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -482,8 +482,9 @@ function migrateSettingsToCurrentVersion(settings: Record<string, any>): Setting
  * The contents of settings files go through the unexported function `migrateSettingsToCurrentVersion`
  * which assigns any missing defaults at the end. This function does not fill in missing values.
  * @param settings - a possibly partial settings object.
+ * @param targetVersion - used for unit testing, to run a specific step from version n to n + 1, and not the full migration
  */
-export function migrateSpecifiedSettingsToCurrentVersion(settings: Record<string, any>): RecursivePartial<Settings> {
+export function migrateSpecifiedSettingsToCurrentVersion(settings: Record<string, any>, targetVersion:number = CURRENT_SETTINGS_VERSION): RecursivePartial<Settings> {
   const firstPart = 'updating settings requires specifying an API version';
   let loadedVersion = settings.version;
 
@@ -494,16 +495,16 @@ export function migrateSpecifiedSettingsToCurrentVersion(settings: Record<string
   } else if (loadedVersion <= 0) {
     // Avoid someone specifying a number like -1000000000000 and burning CPU cycles in the loop below
     throw new TypeError(`${ firstPart }, but "${ loadedVersion }" is not a positive number`);
-  } else if (loadedVersion >= CURRENT_SETTINGS_VERSION) {
+  } else if (loadedVersion >= targetVersion) {
     // This will elicit an error message from the validator
     return settings;
   }
-  for (; loadedVersion < CURRENT_SETTINGS_VERSION; loadedVersion++) {
+  for (; loadedVersion < targetVersion; loadedVersion++) {
     if (updateTable[loadedVersion]) {
       updateTable[loadedVersion](settings);
     }
   }
-  settings.version = CURRENT_SETTINGS_VERSION;
+  settings.version = targetVersion;
 
   return settings;
 }

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -702,7 +702,7 @@ describe(SettingsValidator, () => {
   });
 
   it('should complain about unchangeable fields', () => {
-    const unchangeableFieldsAndValues = { version: -1 };
+    const unchangeableFieldsAndValues = { version: settings.CURRENT_SETTINGS_VERSION + 1 };
 
     // Check that we _don't_ ask for update when we have errors.
     const input = { application: { telemetry: { enabled: !cfg.application.telemetry.enabled } } };


### PR DESCRIPTION
Fixes #4939

Migrating deployment profiles is covered in issue 5901

To reiterate, this means that the version field is no longer needed in a settings payload, but it's more efficient to specify it.

I took the version field out of the bats tests, because these tests should be as simple as possible, but it's left in `rdctl set`, because we want that to be as efficient as possible. Also, leaving it in finds the problem where someone is using a version of rdctl with a newer prefs version than the server, which isn't supported.