### PR TITLE
Fix a broken bats test.

### DIFF
--- a/bats/tests/profile/create-profile-output.bats
+++ b/bats/tests/profile/create-profile-output.bats
@@ -294,7 +294,7 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Rancher Desktop\defaults\application\extensions]
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Rancher Desktop\defaults\application\extensions\allowed]
 "enabled"=dword:1
-"list"=hex(7):00,00,00,00
+"list"=hex(7):00,00
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Rancher Desktop\defaults\application\extensions\installed]
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Rancher Desktop\defaults\containerEngine]
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Rancher Desktop\defaults\containerEngine\allowedImages]


### PR DESCRIPTION
No associated issue.

In a multi-zero-terminated string, `00,00` denotes an empty list. `00,00,00,00` denotes a list containing one empty string, which causes RD to fail on startup, and is never desired.