### PR TITLE
Bump electron to 26.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "cross-env": "7.0.3",
     "css-loader": "4.3.0",
     "ejs": "3.1.9",
-    "electron": "26.2.4",
+    "electron": "26.4.3",
     "electron-builder": "23.6.0",
     "electron-notarize": "1.2.2",
     "eslint": "8.39.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6285,10 +6285,10 @@ electron-updater@5.3.0:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@26.2.4:
-  version "26.2.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.4.tgz#36616b2386b083c13ae9188f2d8ccf233c23404a"
-  integrity sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==
+electron@26.4.3:
+  version "26.4.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-26.4.3.tgz#b5ac6919449103dda3be787d44fd221456200d7a"
+  integrity sha512-2U+hYgGQck+/b8+B48JMTcE6UWYDC4BBrLNigmjkpOsPUdVuVJXafXHUN6QKxDxZhbwoc5pbk/xpTFOBP1UCOA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
This bumps electron to 26.4.3.

We're bumping electron again to resolve a reported issue on openSUSE Leap 15.4 where the V8 context would crash on electron 26.2.4.

It looks like this is the electron patch that resolves the V8 issue: https://github.com/electron/electron/pull/40377