### PR TITLE
WSL: Import CAs from the system

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "dompurify": "3.0.1",
     "electron-updater": "5.3.0",
     "express": "4.18.1",
-    "ffi-napi": "4.0.3",
     "fs-extra": "11.1.1",
     "http-proxy-agent": "5.0.0",
     "http-proxy-middleware": "2.0.6",
@@ -80,8 +79,6 @@
     "node-forge": "1.3.1",
     "os-browserify": "0.3.0",
     "rancher-icons": "rancher/icons#v2.0.19",
-    "ref-napi": "3.0.3",
-    "ref-struct-di": "1.1.1",
     "semver": "7.5.4",
     "socks-proxy-agent": "8.0.2",
     "sudo-prompt": "9.2.1",
@@ -123,7 +120,6 @@
     "@types/cross-spawn": "6.0.2",
     "@types/dompurify": "3.0.0",
     "@types/ejs": "3.1.2",
-    "@types/ffi-napi": "4.0.7",
     "@types/jest": "29.5.2",
     "@types/lodash": "4.14.196",
     "@types/marked": "4.0.8",
@@ -133,8 +129,6 @@
     "@types/node-forge": "1.3.1",
     "@types/plist": "3.0.2",
     "@types/ps-tree": "1.1.3",
-    "@types/ref-napi": "3.0.5",
-    "@types/ref-struct-di": "1.1.6",
     "@types/semver": "7.5.0",
     "@types/tar-stream": "2.2.2",
     "@types/which": "3.0.0",
@@ -189,9 +183,6 @@
     "vue-jest": "3.0.7",
     "vue-template-compiler": "2.7.14",
     "webpack": "5.88.2"
-  },
-  "resolutions": {
-    "@types/ref-napi": "3.0.5"
   },
   "optionalDependencies": {
     "dmg-license": "1.0.11"

--- a/pkg/rancher-desktop/main/networking/win-ca.ts
+++ b/pkg/rancher-desktop/main/networking/win-ca.ts
@@ -1,0 +1,74 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import path from 'path';
+import tls from 'tls';
+
+import * as childProcess from '@pkg/utils/childProcess';
+import AsyncCallbackIterator from '@pkg/utils/iterator';
+import Logging from '@pkg/utils/logging';
+import paths from '@pkg/utils/paths';
+
+/**
+ * Asynchronously enumerate the certificate authorities that should be used to
+ * build the Rancher Desktop trust store, in PEM format in undefined order.
+ */
+export default async function* getWinCertificates(): AsyncIterable<string> {
+  // Windows will dynamically download CA certificates on demand by default;
+  // this means that if we just enumerate the Windows certificate store, we will
+  // be missing some standard certificates.  To approximate the desired
+  // behaviour, we will enumerate both the Windows store as well as the OpenSSL
+  // one built into NodeJS.
+
+  const exePath = path.join(paths.resources, 'win32', 'wsl-helper.exe');
+  let buffer = '';
+  const proc = childProcess.spawn(exePath, ['certificates'], {
+    stdio:       ['ignore', 'pipe', await Logging['networking-ca'].fdStream],
+    windowsHide: true,
+  });
+  const iterator = new AsyncCallbackIterator<string>();
+
+  proc.stdout.on('data', async(chunk: string | Buffer) => {
+    try {
+      if (Buffer.isBuffer(chunk)) {
+        buffer += chunk.toString('utf-8');
+      } else {
+        buffer += chunk;
+      }
+      while (true) {
+        const [match] = /^.*?-----END CERTIFICATE-----\r?\n?/.exec(buffer) ?? [];
+
+        if (!match) {
+          break;
+        }
+        buffer = buffer.substring(match.length);
+        await iterator.emit(match);
+      }
+    } catch (ex) {
+      await iterator.error(ex);
+    }
+  });
+  proc.on('exit', (code, signal) => {
+    if (!(code === 0 || signal === 'SIGTERM')) {
+      iterator.error(code || signal);
+    } else {
+      iterator.end();
+    }
+  });
+
+  yield * iterator;
+  yield * tls.rootCertificates;
+}

--- a/pkg/rancher-desktop/utils/__tests__/iterator.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/iterator.spec.ts
@@ -1,0 +1,46 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import AsyncCallbackIterator from '../iterator';
+
+describe('AsyncCallbackIterator', () => {
+  test('can iterate items', async() => {
+    const subject = new AsyncCallbackIterator<number>();
+    const results: number[] = [];
+
+    setTimeout(() => subject.emit(1), 100);
+    setTimeout(() => subject.emit(2), 200);
+    setTimeout(() => subject.end(), 300);
+
+    for await (const val of subject) {
+      results.push(val);
+    }
+
+    expect(results).toEqual([1, 2]);
+  }, 1_000);
+
+  test('can handle exceptions', async() => {
+    const subject = new AsyncCallbackIterator<number>();
+
+    setTimeout(() => subject.error('hello'), 100);
+
+    await expect(async() => {
+      for await (const val of subject) {
+        fail(`Got unexpected value ${ val }`);
+      }
+    }).rejects.toEqual('hello');
+  });
+});

--- a/pkg/rancher-desktop/utils/childProcess.ts
+++ b/pkg/rancher-desktop/utils/childProcess.ts
@@ -244,7 +244,7 @@ export async function spawnFile(
     ...options,
     stdio:       mungedStdio,
   });
-  const resultMap: Record<number, 'stdout' | 'stderr'> = { 1: 'stdout', 2: 'stderr' };
+  const resultMap = { 1: 'stdout', 2: 'stderr' } as const;
   const result: { stdout?: string, stderr?: string } = {};
 
   if (Array.isArray(mungedStdio)) {

--- a/pkg/rancher-desktop/utils/iterator.ts
+++ b/pkg/rancher-desktop/utils/iterator.ts
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/rancher-desktop/utils/iterator.ts
+++ b/pkg/rancher-desktop/utils/iterator.ts
@@ -1,0 +1,121 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Latch from './latch';
+
+const doneSentinel: unique symbol = Symbol('iterator complete');
+
+/**
+ * AsyncCallbackIterator is a utility class that can be used to convert a
+ * callback-based API to an async iterator.
+ *
+ * Usage:
+ *   const foo = new AsyncCallbackIterator<Number>;
+ *   foo.emit(1);
+ *   foo.emit(2);
+ *   foo.end();
+ *   // elsewhere...
+ *   for await (const n of foo) { ... }
+ * It's also possible to call .error() to indicate an exception.
+ */
+export default class AsyncCallbackIterator<T> implements AsyncIterableIterator<T> {
+  #next: Promise<T | typeof doneSentinel>;
+  #resolve: (value: T | PromiseLike<T> | typeof doneSentinel) => void;
+  #reject: (reason?: any) => void;
+  #done = false;
+
+  // #pending is used to provide backpressure; this will be resolved when we are
+  // ready to emit the next item.
+  #pending = Latch();
+
+  constructor() {
+    this.#resolve = undefined as any;
+    this.#reject = undefined as any;
+    this.#next = new Promise<T|typeof doneSentinel>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+    this.#pending.resolve();
+  }
+
+  /**
+   * Emit an item to the iterator.
+   * @param item The item to emit.
+   */
+  async emit(item: T) {
+    if (this.#done) {
+      throw new Error('Emitting result when end() has been called');
+    }
+    await this.#pending;
+    this.#pending = Latch();
+    if (!this.#done) {
+      this.#resolve(item);
+    }
+  }
+
+  /**
+   * Signal an error to the iterator.
+   * @param reason The error to emit.
+   */
+  async error(reason?: any) {
+    if (this.#done) {
+      throw new Error('Emitting result when end() has been called');
+    }
+    await this.#pending;
+    this.#pending = Latch();
+    if (!this.#done) {
+      this.#reject(reason);
+      this.#done = true;
+    }
+  }
+
+  /**
+   * Notify the iterator that the enumeration has completed.
+   */
+  end() {
+    this.#resolve(doneSentinel);
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+
+  /**
+   * Implement the JavaScript iterator protocol by returning the next result.
+   */
+  async next(): Promise<IteratorResult<T, undefined>> {
+    if (this.#done) {
+      return { done: true, value: undefined };
+    }
+
+    const result = await this.#next;
+
+    if (result === doneSentinel) {
+      this.#done = true;
+      this.#pending.resolve();
+
+      return { done: true, value: undefined };
+    }
+
+    this.#next = new Promise<T|typeof doneSentinel>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+    this.#pending.resolve();
+
+    return { value: result };
+  }
+}

--- a/src/go/wsl-helper/cmd/certificates_windows.go
+++ b/src/go/wsl-helper/cmd/certificates_windows.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/pem"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/certificates"
+)
+
+var certificatesViper = viper.New()
+
+// certificatesCmd represents the `certificates` command.
+var certificatesCmd = &cobra.Command{
+	Use:   "certificates",
+	Short: "Lists the installed system certificates in PEM format",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		for _, storeName := range certificatesViper.GetStringSlice("stores") {
+			ch, err := certificates.GetSystemCertificates(storeName)
+			if err != nil {
+				return err
+			}
+			for entry := range ch {
+				if entry.Err != nil {
+					return entry.Err
+				}
+				if entry.Cert == nil {
+					continue
+				}
+				if entry.Cert.NotAfter.Before(time.Now()) {
+					continue
+				}
+				block := &pem.Block{Type: "CERTIFICATE", Bytes: entry.Cert.Raw}
+				err = pem.Encode(os.Stdout, block)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	certificatesCmd.Flags().StringSlice("stores", []string{"CA", "ROOT"}, "Certificate stores to enumerate")
+	certificatesViper.AutomaticEnv()
+	certificatesViper.BindPFlags(certificatesCmd.Flags())
+	rootCmd.AddCommand(certificatesCmd)
+}

--- a/src/go/wsl-helper/pkg/certificates/certificates_windows.go
+++ b/src/go/wsl-helper/pkg/certificates/certificates_windows.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package certificates is used to enumerate the system certificate authorities
+// on Windows.
+package certificates
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+// Entry is one enumeration result; it hold either a valid certificate or an
+// error.  They are mutually exclusive.
+type Entry struct {
+	Cert *x509.Certificate
+	Err  error
+}
+
+// getCertName returns a string describing the given certificate context.
+func getCertName(ctx *windows.CertContext) string {
+	length := windows.CertGetNameString(ctx, windows.CERT_NAME_FRIENDLY_DISPLAY_TYPE, 0, unsafe.Pointer(nil), nil, 0)
+	if length == 1 {
+		return "<error parsing certificate name>"
+	}
+	buf := make([]uint16, length)
+	_ = windows.CertGetNameString(ctx, windows.CERT_NAME_FRIENDLY_DISPLAY_TYPE, 0, unsafe.Pointer(nil), unsafe.SliceData(buf), length)
+	return windows.UTF16ToString(buf)
+}
+
+// GetSystemCertificates returns the Windows system certificates from the given
+// certificate store.  Typical store names are strings like "CA", "Root", "My".
+func GetSystemCertificates(storeName string) (<-chan Entry, error) {
+	storeNameBytes, err := windows.UTF16PtrFromString(storeName)
+	if err != nil {
+		return nil, err
+	}
+	store, err := windows.CertOpenSystemStore(windows.Handle(0), storeNameBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open store %q: %w", storeName, err)
+	}
+	ch := make(chan Entry)
+	go func() {
+		defer close(ch)
+		defer windows.CertCloseStore(store, 0)
+		var certCtx *windows.CertContext
+		var err error
+		for {
+			certCtx, err = windows.CertEnumCertificatesInStore(store, certCtx)
+			if err != nil {
+				switch {
+				case errors.Is(err, windows.ERROR_NO_MORE_FILES):
+				case errors.Is(err, windows.Errno(windows.CRYPT_E_NOT_FOUND)):
+				default:
+					ch <- Entry{Err: fmt.Errorf("error enumerating certificate in %q: %w", storeName, err)}
+				}
+				break
+			}
+			cert, err := x509.ParseCertificate(unsafe.Slice(certCtx.EncodedCert, certCtx.Length))
+			if err != nil {
+				// Skip invalid certs
+				logrus.Tracef("Skipping invalid certificate %q in %q: %s", getCertName(certCtx), storeName, err)
+				continue
+			}
+			logrus.Tracef("Found cert %q in %q", getCertName(certCtx), storeName)
+			ch <- Entry{Cert: cert}
+		}
+	}()
+	return ch, nil
+}

--- a/src/go/wsl-helper/pkg/certificates/certificates_windows.go
+++ b/src/go/wsl-helper/pkg/certificates/certificates_windows.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Entry is one enumeration result; it hold either a valid certificate or an
+// Entry is one enumeration result; it holds either a valid certificate or an
 // error.  They are mutually exclusive.
 type Entry struct {
 	Cert *x509.Certificate

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,15 +2665,6 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/ffi-napi@4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@types/ffi-napi/-/ffi-napi-4.0.7.tgz#b3a9beeae160c74adca801ca1c9defb1ec0a1a32"
-  integrity sha512-2CvLfgxCUUSj7qVab6/uFLyVpgVd2gEV4H/TQEHHn6kZTV8iTesz9uo0bckhwzsh71atutOv8P3JmvRX2ZvpZg==
-  dependencies:
-    "@types/node" "*"
-    "@types/ref-napi" "*"
-    "@types/ref-struct-di" "*"
-
 "@types/file-loader@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/file-loader/-/file-loader-5.0.0.tgz#c7d06c14a8fc0224661e9a29c4035ba47db826df"
@@ -2948,27 +2939,6 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
-
-"@types/ref-napi@*", "@types/ref-napi@3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/ref-napi/-/ref-napi-3.0.5.tgz#8db441d381737af5c353d7dd89c7593b5f2080c8"
-  integrity sha512-u+L/RdwTuJes3pDypOVR/MtcqzoULu8Z8yulP6Tw5z7eXV1ba1llizNVFtI/m2iPfDy/dPPt+3ar1QCgonTzsw==
-  dependencies:
-    "@types/node" "*"
-
-"@types/ref-struct-di@*":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@types/ref-struct-di/-/ref-struct-di-1.1.9.tgz#cdca2cefbb8a907ac9eb9d6a7f19cfae00bfa092"
-  integrity sha512-B1FsB1BhG1VLx0+IqBaAPXEPH0wCOb+Glaaw/i+nRUwDKFtSqWOziGnTRw05RyrBbrDsMiM0tVWmaujrs016Sw==
-  dependencies:
-    "@types/ref-napi" "*"
-
-"@types/ref-struct-di@1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@types/ref-struct-di/-/ref-struct-di-1.1.6.tgz#9775753b24ba5bf248dd66d79d4fdb7cebef6e95"
-  integrity sha512-+Sa2H3ynDYo2ungR3d5kmNetlkAYNqQVjJvs1k7i6zvo7Zu/qb+OsrXU54RuiOYJCwY9piN+hOd4YRRaiEOqgw==
-  dependencies:
-    "@types/ref-napi" "*"
 
 "@types/relateurl@*":
   version "0.2.29"
@@ -5827,7 +5797,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.0, debug@^3.2.7:
+debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -7272,18 +7242,6 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-ffi-napi@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/ffi-napi/-/ffi-napi-4.0.3.tgz#27a8d42a8ea938457154895c59761fbf1a10f441"
-  integrity sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==
-  dependencies:
-    debug "^4.1.1"
-    get-uv-event-loop-napi-h "^1.0.5"
-    node-addon-api "^3.0.0"
-    node-gyp-build "^4.2.1"
-    ref-napi "^2.0.1 || ^3.0.2"
-    ref-struct-di "^1.1.0"
-
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -7619,24 +7577,12 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-get-symbol-from-current-process-h@^1.0.1, get-symbol-from-current-process-h@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz#510af52eaef873f7028854c3377f47f7bb200265"
-  integrity sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==
-
 get-tsconfig@^4.5.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.6.2.tgz#831879a5e6c2aa24fe79b60340e2233a1e0f472e"
   integrity sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==
   dependencies:
     resolve-pkg-maps "^1.0.0"
-
-get-uv-event-loop-napi-h@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz#42b0b06b74c3ed21fbac8e7c72845fdb7a200208"
-  integrity sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==
-  dependencies:
-    get-symbol-from-current-process-h "^1.0.1"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -10427,11 +10373,6 @@ node-addon-api@^1.6.3, node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-addon-api@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
-  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
-
 node-cache@^4.1.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
@@ -10464,7 +10405,7 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp-build@4, node-gyp-build@^4.2.1, node-gyp-build@^4.3.0:
+node-gyp-build@4, node-gyp-build@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
   integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
@@ -11648,23 +11589,6 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
-
-ref-napi@3.0.3, "ref-napi@^2.0.1 || ^3.0.2":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ref-napi/-/ref-napi-3.0.3.tgz#e259bfc2bbafb3e169e8cd9ba49037dd00396b22"
-  integrity sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==
-  dependencies:
-    debug "^4.1.1"
-    get-symbol-from-current-process-h "^1.0.2"
-    node-addon-api "^3.0.0"
-    node-gyp-build "^4.2.1"
-
-ref-struct-di@1.1.1, ref-struct-di@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ref-struct-di/-/ref-struct-di-1.1.1.tgz#5827b1d3b32372058f177547093db1fe1602dc10"
-  integrity sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==
-  dependencies:
-    debug "^3.1.0"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
This puts back the ability to import CAs from the host system.  We just do it from go, and pick it up from stdout and parse it into JS.  Ideally at some point in the future we would just drop the JS, but today is not that day.
Fixes #5637.