### PR TITLE
flatpak: Use id instead of app-id

### DIFF
--- a/packaging/linux/flatpak.yaml
+++ b/packaging/linux/flatpak.yaml
@@ -1,5 +1,5 @@
 # This file is unused and just kept for reference for plain flatpak builds
-app-id: io.rancherdesktop.app
+id: io.rancherdesktop.app
 branch: main
 runtime: org.freedesktop.Platform
 runtime-version: '21.08'


### PR DESCRIPTION
`app-id` is deprecated