### PR TITLE
Replace `BrowserView.webContents.destroy()`

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -379,11 +379,7 @@ export function closeExtension() {
     return;
   }
 
-  /**
-   * TODO: ISSUE #4394 Replace undocumented `webContents.destroy()` with
-   * `webcontents.close()`
-   */
-  (view.webContents as any).destroy();
+  view.webContents.close();
 
   const window = getWindow('main');
 


### PR DESCRIPTION
Previously, we used the undocumented method `BrowserView.webContents.destroy()` because our Electron version lacked support for `BrowserView.webContents.close()`. With the recent Electron update, we can now use the recommended `close()` method instead of relying on the undocumented one.

closes #4394 