### PR TITLE
Remove friendly-errors plugin in vue config

### DIFF
--- a/pkg/rancher-desktop/vue.config.js
+++ b/pkg/rancher-desktop/vue.config.js
@@ -17,7 +17,7 @@ module.exports = {
   outputDir:           path.resolve(rootDir, 'dist', 'app'),
   productionSourceMap: false,
 
-  chainWebpack: (config) => {
+  chainWebpack: (/** @type import('webpack-chain') */ config) => {
     config.target('electron-renderer');
     config.resolve.alias.set('@pkg', path.resolve(rootDir, 'pkg', 'rancher-desktop'));
 
@@ -41,6 +41,7 @@ module.exports = {
         featureExtensions:       true,
       }),
     }]);
+    config.plugins.delete('friendly-errors');
   },
 
   css: {


### PR DESCRIPTION
This plugin does things like clearing the screen and reformats errors, which ironically makes it harder to figure out what went wrong when things break.