### PR TITLE
Simplify GetConnectionInfo() call

### DIFF
--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -68,7 +68,7 @@ func doAPICommand(cmd *cobra.Command, args []string) error {
 	var err error
 	var errorPacket *client.APIError
 
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/createProfile.go
+++ b/src/go/rdctl/cmd/createProfile.go
@@ -101,7 +101,7 @@ func createProfile() (string, error) {
 			// This should have been caught in validateProfileFormatFlags
 			return "", fmt.Errorf(`no input format specified: must specify exactly one input format of "--input FILE|-", "--body|-b STRING", or "--from-settings"`)
 		}
-		connectionInfo, err := config.GetConnectionInfo()
+		connectionInfo, err := config.GetConnectionInfo(false)
 		if err != nil {
 			return "", fmt.Errorf("failed to get connection info: %w", err)
 		}

--- a/src/go/rdctl/cmd/extensionInstall.go
+++ b/src/go/rdctl/cmd/extensionInstall.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 func installExtension(args []string) error {
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/extensionList.go
+++ b/src/go/rdctl/cmd/extensionList.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func listExtensions() error {
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/extensionUninstall.go
+++ b/src/go/rdctl/cmd/extensionUninstall.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 func uninstallExtension(args []string) error {
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func getListSettings() ([]byte, error) {
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func doSetCommand(cmd *cobra.Command) error {
-	connectionInfo, err := config.GetConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -65,8 +65,8 @@ func init() {
 
 func doShutdown(shutdownSettings *shutdownSettingsStruct, initiatingCommand shutdown.InitiatingCommand) ([]byte, error) {
 	var output []byte
-	connectionInfo, err := config.GetConnectionInfo()
-	if err == nil {
+	connectionInfo, err := config.GetConnectionInfo(true)
+	if err == nil && connectionInfo != nil {
 		rdClient := client.NewRDClient(connectionInfo)
 		request, err := rdClient.DoRequest("PUT", client.VersionCommand("", "shutdown"))
 		output, _ = client.ProcessRequestForUtility(request, err)

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -81,22 +81,8 @@ func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, restartOnFa
 	return ensureBackendStarted()
 }
 
-func getConnectionInfo() (*config.ConnectionInfo, error) {
-	connectionInfo, err := config.GetConnectionInfo()
-	// If we cannot get connection info from config file (and it
-	// is not specified by the user) then assume main process is
-	// not running.
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to get connection info: %w", err)
-	}
-	return connectionInfo, nil
-}
-
 func ensureBackendStarted() error {
-	connectionInfo, err := getConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(true)
 	if err != nil || connectionInfo == nil {
 		return err
 	}
@@ -113,7 +99,7 @@ func ensureBackendStarted() error {
 }
 
 func ensureBackendStopped(cmd *cobra.Command) error {
-	connectionInfo, err := getConnectionInfo()
+	connectionInfo, err := config.GetConnectionInfo(true)
 	if err != nil || connectionInfo == nil {
 		return err
 	}

--- a/src/go/rdctl/pkg/client/client.go
+++ b/src/go/rdctl/pkg/client/client.go
@@ -56,11 +56,11 @@ func NewRDClient(connectionInfo *config.ConnectionInfo) *RDClientImpl {
 	}
 }
 
-func (client *RDClientImpl) makeURL(host string, port string, command string) string {
+func (client *RDClientImpl) makeURL(host string, port int, command string) string {
 	if strings.HasPrefix(command, "/") {
-		return fmt.Sprintf("http://%s:%s%s", host, port, command)
+		return fmt.Sprintf("http://%s:%d%s", host, port, command)
 	}
-	return fmt.Sprintf("http://%s:%s/%s", host, port, command)
+	return fmt.Sprintf("http://%s:%d/%s", host, port, command)
 }
 
 func (client *RDClientImpl) DoRequest(method string, command string) (*http.Response, error) {


### PR DESCRIPTION
Remove all the special code to delay reporting when the config file is missing because the user just executed a factory reset; it doesn't seem to be used anywhere.

This commit also implements reading a `host` setting from the config file, which seems to have been missing from the original code.

Fixes #5792