### PR TITLE
Refactor snapshot create/delete and the locking functionality

### DIFF
--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -2,15 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"time"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/spf13/cobra"
 )
 
@@ -19,9 +13,6 @@ type errorPayloadType struct {
 }
 
 var outputJsonFormat bool
-var snapshotErrors []error
-
-const backendLockName = "backend.lock"
 
 var snapshotCmd = &cobra.Command{
 	Use:   "snapshot",
@@ -30,151 +21,21 @@ var snapshotCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(snapshotCmd)
-	snapshotErrors = make([]error, 0)
 }
 
 func exitWithJsonOrErrorCondition(e error) error {
-	if e != nil {
-		snapshotErrors = append(snapshotErrors, e)
-	}
 	if outputJsonFormat {
 		exitStatus := 0
-		for _, snapshotError := range snapshotErrors {
-			if snapshotError != nil {
-				exitStatus = 1
-				errorPayload := errorPayloadType{snapshotError.Error()}
-				jsonBuffer, err := json.Marshal(errorPayload)
-				if err != nil {
-					snapshotErrors = append(snapshotErrors, fmt.Errorf("error json-converting error messages: %w", err))
-					return errors.Join(snapshotErrors...)
-				}
-				fmt.Fprintf(os.Stdout, string(jsonBuffer)+"\n")
+		if e != nil {
+			exitStatus = 1
+			errorPayload := errorPayloadType{e.Error()}
+			jsonBuffer, err := json.Marshal(errorPayload)
+			if err != nil {
+				return fmt.Errorf("error json-converting error messages: %w", err)
 			}
+			_, _ = fmt.Fprintln(os.Stdout, string(jsonBuffer))
 		}
 		os.Exit(exitStatus)
 	}
-	return errors.Join(snapshotErrors...)
-}
-
-// If the main process is running, stops the backend, calls the
-// passed function, and restarts the backend. If it cannot connect
-// to the main process, just calls the passed function.
-func wrapSnapshotOperation(cmd *cobra.Command, appPaths paths.Paths, restartOnFailure bool, wrappedFunction func() error) error {
-	if err := createBackendLock(appPaths.AppHome); err != nil {
-		return err
-	}
-	defer removeBackendLock(appPaths.AppHome)
-	if err := ensureBackendStopped(cmd); err != nil {
-		return err
-	}
-	if err := wrappedFunction(); err != nil {
-		if !restartOnFailure {
-			return err
-		}
-		snapshotErrors = append(snapshotErrors, err)
-	}
-	// Note that this does not wait for the backend to be in the
-	// STARTED (or DISABLED if k8s is disabled) state. This allows
-	// removeBackendLock() to be called as a deferred function while
-	// keeping the state of the backend lock file in sync with the
-	// main process backendIsLocked variable.
-	return ensureBackendStarted()
-}
-
-func ensureBackendStarted() error {
-	connectionInfo, err := config.GetConnectionInfo(true)
-	if err != nil || connectionInfo == nil {
-		return err
-	}
-	rdClient := client.NewRDClient(connectionInfo)
-	desiredState := client.BackendState{
-		VMState: "STARTED",
-		Locked:  false,
-	}
-	err = rdClient.UpdateBackendState(desiredState)
-	if err != nil && !errors.Is(err, client.ErrConnectionRefused) {
-		return fmt.Errorf("failed to restart backend: %w", err)
-	}
-	return nil
-}
-
-func ensureBackendStopped(cmd *cobra.Command) error {
-	connectionInfo, err := config.GetConnectionInfo(true)
-	if err != nil || connectionInfo == nil {
-		return err
-	}
-
-	// Ensure backend is running if the main process is running at all
-	rdClient := client.NewRDClient(connectionInfo)
-	state, err := rdClient.GetBackendState()
-	if errors.Is(err, client.ErrConnectionRefused) {
-		// If we cannot connect to the server, assume that the main
-		// process is not running.
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to get backend state: %w", err)
-	}
-	if state.VMState != "STARTED" && state.VMState != "DISABLED" {
-		return fmt.Errorf("Rancher Desktop must be fully running or fully shut down to do a snapshot-%s action, state is currently %v", cmd.Name(), state.VMState)
-	}
-
-	// Stop and lock the backend
-	desiredState := client.BackendState{
-		VMState: "STOPPED",
-		Locked:  true,
-	}
-	if err := rdClient.UpdateBackendState(desiredState); err != nil {
-		return fmt.Errorf("failed to stop backend: %w", err)
-	}
-	if err := waitForVMState(rdClient, []string{"STOPPED"}); err != nil {
-		return fmt.Errorf("error waiting for backend to stop: %w", err)
-	}
-
-	return nil
-}
-
-// Normally snapshots can be created at state STARTED or DISABLED
-func waitForVMState(rdClient client.RDClient, desiredStates []string) error {
-	interval := 1 * time.Second
-	numIntervals := 120
-	for i := 0; i < numIntervals; i = i + 1 {
-		state, err := rdClient.GetBackendState()
-		if err != nil {
-			return fmt.Errorf("failed to poll backend state: %w", err)
-		}
-		for _, desiredState := range desiredStates {
-			if state.VMState == desiredState {
-				return nil
-			}
-		}
-		time.Sleep(interval)
-	}
-	return fmt.Errorf("timed out waiting for backend state in %s", desiredStates)
-}
-
-func createBackendLock(appHome string) error {
-	if err := os.MkdirAll(appHome, 0o755); err != nil {
-		return fmt.Errorf("failed to create backend lock parent directory: %w", err)
-	}
-	// Create an empty file whose presence signifies that the
-	// backend is locked.
-	lockPath := filepath.Join(appHome, backendLockName)
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL, 0o644)
-	if errors.Is(err, os.ErrExist) {
-		return errors.New("backend lock file already exists; if there is no snapshot operation in progress, you can remove this error with `rdctl snapshot unlock`")
-	} else if err != nil {
-		return fmt.Errorf("unexpected error acquiring backend lock: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to close backend lock file descriptor: %s", err)
-	}
-	return nil
-}
-
-func removeBackendLock(appHome string) error {
-	lockPath := filepath.Join(appHome, backendLockName)
-	if err := os.RemoveAll(lockPath); err != nil {
-		return fmt.Errorf("failed to remove backend lock: %w", err)
-	}
-	return nil
+	return e
 }

--- a/src/go/rdctl/cmd/snapshot.go
+++ b/src/go/rdctl/cmd/snapshot.go
@@ -33,7 +33,7 @@ func exitWithJsonOrErrorCondition(e error) error {
 			if err != nil {
 				return fmt.Errorf("error json-converting error messages: %w", err)
 			}
-			_, _ = fmt.Fprintln(os.Stdout, string(jsonBuffer))
+			fmt.Fprintln(os.Stdout, string(jsonBuffer))
 		}
 		os.Exit(exitStatus)
 	}

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,7 +17,7 @@ var snapshotCreateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return exitWithJsonOrErrorCondition(createSnapshot(cmd, args))
+		return exitWithJsonOrErrorCondition(createSnapshot(args))
 	},
 }
 
@@ -28,35 +27,25 @@ func init() {
 	snapshotCreateCmd.Flags().StringVar(&snapshotDescription, "description", "", "snapshot description")
 }
 
-func createSnapshot(cmd *cobra.Command, args []string) error {
-	appPaths, err := paths.GetPaths()
+func createSnapshot(args []string) error {
+	manager, err := snapshot.NewManager()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	manager := snapshot.NewManager(appPaths)
-	if err := manager.ValidateName(args[0]); err != nil {
-		return err
-	}
-	err = wrapSnapshotOperation(cmd, appPaths, true, func() error {
-		if _, err := manager.Create(args[0], snapshotDescription); err != nil {
-			return fmt.Errorf("failed to create snapshot: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
+	if _, err := manager.Create(args[0], snapshotDescription); err != nil {
+		return fmt.Errorf("failed to create snapshot: %w", err)
 	}
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
 
 	// exclude snapshots directory from time machine backups if on macOS
-	execCmd := exec.Command("tmutil", "addexclusion", appPaths.Snapshots)
+	execCmd := exec.Command("tmutil", "addexclusion", manager.Paths.Snapshots)
 	output, err := execCmd.CombinedOutput()
 	if err != nil {
 		msg := fmt.Errorf("`tmutil addexclusion` failed to add exclusion to TimeMachine: %w: %s", err, output)
 		if outputJsonFormat {
-			snapshotErrors = append(snapshotErrors, msg)
+			return msg
 		} else {
 			logrus.Errorln(msg)
 		}

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -28,11 +28,17 @@ func init() {
 }
 
 func createSnapshot(args []string) error {
+	name := args[0]
 	manager, err := snapshot.NewManager()
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	if _, err := manager.Create(args[0], snapshotDescription); err != nil {
+	// Report on invalid names before locking and shutting down the backend
+	if err := manager.ValidateName(name); err != nil {
+		return nil
+	}
+
+	if _, err := manager.Create(name, snapshotDescription); err != nil {
 		return fmt.Errorf("failed to create snapshot: %w", err)
 	}
 

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -35,11 +35,11 @@ func createSnapshot(args []string) error {
 	if _, err := manager.Create(args[0], snapshotDescription); err != nil {
 		return fmt.Errorf("failed to create snapshot: %w", err)
 	}
+
+	// exclude snapshots directory from time machine backups if on macOS
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
-
-	// exclude snapshots directory from time machine backups if on macOS
 	execCmd := exec.Command("tmutil", "addexclusion", manager.Paths.Snapshots)
 	output, err := execCmd.CombinedOutput()
 	if err != nil {

--- a/src/go/rdctl/cmd/snapshotDelete.go
+++ b/src/go/rdctl/cmd/snapshotDelete.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/spf13/cobra"
 )
@@ -24,17 +23,12 @@ func init() {
 	snapshotDeleteCmd.Flags().BoolVarP(&outputJsonFormat, "json", "", false, "output json format")
 }
 
-func deleteSnapshot(cmd *cobra.Command, args []string) error {
-	appPaths, err := paths.GetPaths()
+func deleteSnapshot(_ *cobra.Command, args []string) error {
+	manager, err := snapshot.NewManager()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	manager := snapshot.NewManager(appPaths)
-	id, err := manager.GetSnapshotId(args[0])
-	if err != nil {
-		return err
-	}
-	if err = manager.Delete(id); err != nil {
+	if err = manager.Delete(args[0]); err != nil {
 		return fmt.Errorf("failed to delete snapshot: %w", err)
 	}
 	return nil

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -9,7 +9,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/spf13/cobra"
 )
@@ -48,11 +47,10 @@ func init() {
 }
 
 func listSnapshot() error {
-	paths, err := p.GetPaths()
+	manager, err := snapshot.NewManager()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	manager := snapshot.NewManager(paths)
 	snapshots, err := manager.List(false)
 	if err != nil {
 		return fmt.Errorf("failed to list snapshots: %w", err)

--- a/src/go/rdctl/cmd/snapshotRestore.go
+++ b/src/go/rdctl/cmd/snapshotRestore.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 
 	"github.com/spf13/cobra"
@@ -24,19 +23,12 @@ func init() {
 }
 
 func restoreSnapshot(cmd *cobra.Command, args []string) error {
-	appPaths, err := paths.GetPaths()
+	manager, err := snapshot.NewManager()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	manager := snapshot.NewManager(appPaths)
-	id, err := manager.GetSnapshotId(args[0])
-	if err != nil {
-		return err
+	if err := manager.Restore(args[0]); err != nil {
+		return fmt.Errorf("failed to restore snapshot %q: %w", args[0], err)
 	}
-	return wrapSnapshotOperation(cmd, appPaths, false, func() error {
-		if err := manager.Restore(id); err != nil {
-			return fmt.Errorf("failed to restore snapshot %q: %w", args[0], err)
-		}
-		return nil
-	})
+	return nil
 }

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -32,5 +32,6 @@ func unlockSnapshot() error {
 	if err != nil {
 		return fmt.Errorf("failed to get paths: %w", err)
 	}
-	return lock.Unlock(appPaths, false)
+	backendLock := &lock.BackendLock{}
+	return backendLock.Unlock(appPaths, false)
 }

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -2,8 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lock"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
 	"github.com/spf13/cobra"
 )
 
@@ -28,10 +27,9 @@ func init() {
 }
 
 func unlockSnapshot() error {
-	appPaths, err := paths.GetPaths()
+	manager, err := snapshot.NewManager()
 	if err != nil {
-		return fmt.Errorf("failed to get paths: %w", err)
+		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	backendLock := &lock.BackendLock{}
-	return backendLock.Unlock(appPaths, false)
+	return manager.Unlock(manager.Paths, false)
 }

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lock"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/spf13/cobra"
 )
 
@@ -24,13 +25,12 @@ normal circumstances.`,
 func init() {
 	snapshotCmd.AddCommand(snapshotUnlockCmd)
 	snapshotUnlockCmd.Flags().BoolVarP(&outputJsonFormat, "json", "", false, "output json format")
-
 }
 
 func unlockSnapshot() error {
-	paths, err := p.GetPaths()
+	appPaths, err := paths.GetPaths()
 	if err != nil {
 		return fmt.Errorf("failed to get paths: %w", err)
 	}
-	return removeBackendLock(paths.AppHome)
+	return lock.Unlock(appPaths, false)
 }

--- a/src/go/rdctl/pkg/lock/lock.go
+++ b/src/go/rdctl/pkg/lock/lock.go
@@ -13,9 +13,17 @@ import (
 
 const backendLockName = "backend.lock"
 
+type BackendLocker interface {
+	Lock(appPaths paths.Paths, action string) error
+	Unlock(appPaths paths.Paths, restart bool) error
+}
+
+type BackendLock struct {
+}
+
 // Lock the backend by creating the lock file and shutting down the VM.
 // The lock file will be deleted if Lock returns an error (e.g. the backend couldn't be stopped).
-func Lock(appPaths paths.Paths, action string) error {
+func (lock *BackendLock) Lock(appPaths paths.Paths, action string) error {
 	if err := os.MkdirAll(appPaths.AppHome, 0o755); err != nil {
 		return fmt.Errorf("failed to create backend lock parent directory %q: %w", appPaths.AppHome, err)
 	}
@@ -38,7 +46,7 @@ func Lock(appPaths paths.Paths, action string) error {
 }
 
 // Unlock the backend by removing the lock file. Restart the VM if the file was deleted and `restart` is true.
-func Unlock(appPaths paths.Paths, restart bool) error {
+func (lock *BackendLock) Unlock(appPaths paths.Paths, restart bool) error {
 	lockPath := filepath.Join(appPaths.AppHome, backendLockName)
 	err := os.RemoveAll(lockPath)
 	if err == nil && restart {

--- a/src/go/rdctl/pkg/lock/lock.go
+++ b/src/go/rdctl/pkg/lock/lock.go
@@ -1,0 +1,119 @@
+package lock
+
+import (
+	"errors"
+	"fmt"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const backendLockName = "backend.lock"
+
+// Lock the backend by creating the lock file and shutting down the VM.
+// The lock file will be deleted if Lock returns an error (e.g. the backend couldn't be stopped).
+func Lock(appPaths paths.Paths, action string) error {
+	if err := os.MkdirAll(appPaths.AppHome, 0o755); err != nil {
+		return fmt.Errorf("failed to create backend lock parent directory %q: %w", appPaths.AppHome, err)
+	}
+	// Create an empty file whose presence signifies that the backend is locked.
+	lockPath := filepath.Join(appPaths.AppHome, backendLockName)
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, os.ErrExist) {
+		return errors.New("backend lock file already exists; if there is no snapshot operation in progress, you can remove this error with `rdctl snapshot unlock`")
+	} else if err != nil {
+		return fmt.Errorf("unexpected error acquiring backend lock: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to close backend lock file descriptor: %s", err)
+	}
+	err = ensureBackendStopped(action)
+	if err != nil {
+		_ = os.Remove(lockPath)
+	}
+	return err
+}
+
+// Unlock the backend by removing the lock file. Restart the VM if the file was deleted and `restart` is true.
+func Unlock(appPaths paths.Paths, restart bool) error {
+	lockPath := filepath.Join(appPaths.AppHome, backendLockName)
+	err := os.RemoveAll(lockPath)
+	if err == nil && restart {
+		err = ensureBackendStarted()
+	}
+	return err
+}
+
+func ensureBackendStarted() error {
+	connectionInfo, err := config.GetConnectionInfo(true)
+	if err != nil || connectionInfo == nil {
+		return err
+	}
+	rdClient := client.NewRDClient(connectionInfo)
+	desiredState := client.BackendState{
+		VMState: "STARTED",
+		Locked:  false,
+	}
+	err = rdClient.UpdateBackendState(desiredState)
+	if err != nil && !errors.Is(err, client.ErrConnectionRefused) {
+		return fmt.Errorf("failed to restart backend: %w", err)
+	}
+	return nil
+}
+
+func ensureBackendStopped(action string) error {
+	connectionInfo, err := config.GetConnectionInfo(true)
+	if err != nil || connectionInfo == nil {
+		return err
+	}
+
+	// Ensure backend is running if the main process is running at all
+	rdClient := client.NewRDClient(connectionInfo)
+	state, err := rdClient.GetBackendState()
+	if errors.Is(err, client.ErrConnectionRefused) {
+		// If we cannot connect to the server, assume that the main
+		// process is not running.
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get backend state: %w", err)
+	}
+	if state.VMState != "STARTED" && state.VMState != "DISABLED" {
+		return fmt.Errorf("Rancher Desktop must be fully running or fully shut down to do a snapshot-%s action, state is currently %v", action, state.VMState)
+	}
+
+	// Stop and lock the backend
+	desiredState := client.BackendState{
+		VMState: "STOPPED",
+		Locked:  true,
+	}
+	if err := rdClient.UpdateBackendState(desiredState); err != nil {
+		return fmt.Errorf("failed to stop backend: %w", err)
+	}
+	if err := waitForVMState(rdClient, []string{"STOPPED"}); err != nil {
+		return fmt.Errorf("error waiting for backend to stop: %w", err)
+	}
+
+	return nil
+}
+
+// Normally snapshots can be created at state STARTED or DISABLED
+func waitForVMState(rdClient client.RDClient, desiredStates []string) error {
+	interval := 1 * time.Second
+	numIntervals := 120
+	for i := 0; i < numIntervals; i = i + 1 {
+		state, err := rdClient.GetBackendState()
+		if err != nil {
+			return fmt.Errorf("failed to poll backend state: %w", err)
+		}
+		for _, desiredState := range desiredStates {
+			if state.VMState == desiredState {
+				return nil
+			}
+		}
+		time.Sleep(interval)
+	}
+	return fmt.Errorf("timed out waiting for backend state in %s", desiredStates)
+}

--- a/src/go/rdctl/pkg/lock/mock.go
+++ b/src/go/rdctl/pkg/lock/mock.go
@@ -1,0 +1,14 @@
+package lock
+
+import "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+
+type MockBackendLock struct {
+}
+
+func (lock *MockBackendLock) Lock(appPaths paths.Paths, action string) error {
+	return nil
+}
+
+func (lock *MockBackendLock) Unlock(appPaths paths.Paths, restart bool) error {
+	return nil
+}

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/google/uuid"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lock"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 )
 
@@ -18,56 +20,53 @@ const completeFileContents = "The presence of this file indicates that this snap
 const maxNameLength = 250
 const nameDisplayCutoffSize = 30
 
-var ErrNameExists = errors.New("name already exists")
-var ErrIncompleteSnapshot = errors.New("snapshot is not complete")
-
-func writeMetadataFile(appPaths paths.Paths, snapshot Snapshot) error {
-	snapshotDir := filepath.Join(appPaths.Snapshots, snapshot.ID)
-	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create snapshot directory: %w", err)
-	}
-	metadataPath := filepath.Join(snapshotDir, "metadata.json")
-	metadataFile, err := os.Create(metadataPath)
-	if err != nil {
-		return fmt.Errorf("failed to create metadata file: %w", err)
-	}
-	defer metadataFile.Close()
-	encoder := json.NewEncoder(metadataFile)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(snapshot); err != nil {
-		return fmt.Errorf("failed to write metadata file: %w", err)
-	}
-	return nil
-}
-
 // Manager handles all snapshot-related functionality.
 type Manager struct {
-	Paths       paths.Paths
-	Snapshotter Snapshotter
+	Snapshotter
+	paths.Paths
+	// The mutex is only included so that `go vet` will throw an error if this struct is ever copied because
+	// the Snapshotter contains a pointer back to the Manager, which would not get updated by the copy.
+	sync.Mutex
 }
 
-func NewManager(paths paths.Paths) Manager {
-	return Manager{
-		Paths:       paths,
-		Snapshotter: NewSnapshotterImpl(paths),
+func NewManager(p ...paths.Paths) (*Manager, error) {
+	var manager Manager
+	manager.Snapshotter = NewSnapshotterImpl(&manager)
+	if len(p) == 0 {
+		var err error
+		manager.Paths, err = paths.GetPaths()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		manager.Paths = p[0]
 	}
+	return &manager, nil
 }
 
-func (manager Manager) GetSnapshotId(desiredName string) (string, error) {
+func (manager *Manager) Snapshot(name string) (Snapshot, error) {
 	snapshots, err := manager.List(false)
 	if err != nil {
-		return "", fmt.Errorf("failed to list snapshots: %w", err)
+		return Snapshot{}, fmt.Errorf("failed to list snapshots: %w", err)
 	}
 	for _, candidate := range snapshots {
-		if desiredName == candidate.Name {
-			return candidate.ID, nil
+		if name == candidate.Name {
+			return candidate, nil
 		}
 	}
-	return "", fmt.Errorf(`can't find snapshot %q`, desiredName)
+	return Snapshot{}, fmt.Errorf(`can't find snapshot %q`, name)
+}
+
+func (manager *Manager) SnapshotDirectory(snapshot Snapshot) string {
+	return filepath.Join(manager.Paths.Snapshots, snapshot.ID)
+}
+
+func (manager *Manager) RemoveSnapshotDirectory(snapshot Snapshot) {
+	_ = os.RemoveAll(manager.SnapshotDirectory(snapshot))
 }
 
 // ValidateName - does syntactic validation on the name
-func (manager Manager) ValidateName(name string) error {
+func (manager *Manager) ValidateName(name string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("snapshot name must not be the empty string")
 	}
@@ -96,41 +95,71 @@ func (manager Manager) ValidateName(name string) error {
 	}
 	for _, currentSnapshot := range currentSnapshots {
 		if currentSnapshot.Name == name {
-			return fmt.Errorf("invalid name %q: %w", name, ErrNameExists)
+			return fmt.Errorf("name %q already exists", name)
 		}
 	}
 	return nil
 }
 
+func (manager *Manager) WriteMetadataFile(snapshot Snapshot) (err error) {
+	snapshotDir := manager.SnapshotDirectory(snapshot)
+	if err = os.MkdirAll(snapshotDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+	metadataPath := filepath.Join(snapshotDir, "metadata.json")
+	metadataFile, err := os.Create(metadataPath)
+	if err != nil {
+		return fmt.Errorf("failed to create metadata file: %w", err)
+	}
+	defer metadataFile.Close()
+	encoder := json.NewEncoder(metadataFile)
+	encoder.SetIndent("", "  ")
+	if err = encoder.Encode(snapshot); err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+	return
+}
+
 // Create a new snapshot.
-func (manager Manager) Create(name, description string) (*Snapshot, error) {
+func (manager *Manager) Create(name, description string) (snapshot Snapshot, err error) {
+	// Report on invalid names before locking and shutting down the backend
+	if err = manager.ValidateName(name); err != nil {
+		return
+	}
 	id, err := uuid.NewRandom()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate ID for snapshot: %w", err)
+		return snapshot, fmt.Errorf("failed to generate ID for snapshot: %w", err)
 	}
-	snapshot := Snapshot{
+	snapshot = Snapshot{
 		Created:     time.Now(),
 		Name:        name,
 		ID:          id.String(),
 		Description: description,
 	}
-
-	// do operations that can fail, rolling back if failure is encountered
-	snapshotDir := filepath.Join(manager.Paths.Snapshots, snapshot.ID)
-	if err := manager.Snapshotter.CreateFiles(snapshot); err != nil {
-		if err2 := os.RemoveAll(snapshotDir); err2 != nil {
-			err = errors.Join(err, fmt.Errorf("failed to delete created snapshot directory: %w", err2))
-		}
-		return nil, err
+	if err = lock.Lock(manager.Paths, "create"); err != nil {
+		return
 	}
-
-	return &snapshot, nil
+	defer func() {
+		if err != nil {
+			manager.RemoveSnapshotDirectory(snapshot)
+		}
+		_ = lock.Unlock(manager.Paths, true)
+	}()
+	// Revalidate the name in case another process created a snapshot with the same name in the gap
+	// between our first validation and creating the lock file.
+	if err = manager.ValidateName(name); err != nil {
+		return
+	}
+	if err = manager.WriteMetadataFile(snapshot); err == nil {
+		err = manager.CreateFiles(snapshot)
+	}
+	return
 }
 
 // List snapshots that are present on the system. If includeIncomplete is
 // true, includes snapshots that are currently being created, are currently
 // being deleted, or are otherwise incomplete and cannot be restored from.
-func (manager Manager) List(includeIncomplete bool) ([]Snapshot, error) {
+func (manager *Manager) List(includeIncomplete bool) ([]Snapshot, error) {
 	dirEntries, err := os.ReadDir(manager.Paths.Snapshots)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return []Snapshot{}, fmt.Errorf("failed to read snapshots directory: %w", err)
@@ -149,6 +178,7 @@ func (manager Manager) List(includeIncomplete bool) ([]Snapshot, error) {
 		if err := json.Unmarshal(contents, &snapshot); err != nil {
 			return []Snapshot{}, fmt.Errorf("failed to unmarshal contents of %q: %w", metadataPath, err)
 		}
+		// TODO this should be done by the caller
 		snapshot.Created = snapshot.Created.Local()
 
 		completeFilePath := filepath.Join(manager.Paths.Snapshots, snapshot.ID, completeFileName)
@@ -165,40 +195,33 @@ func (manager Manager) List(includeIncomplete bool) ([]Snapshot, error) {
 }
 
 // Delete a snapshot.
-func (manager Manager) Delete(id string) error {
-	snapshotDir := filepath.Join(manager.Paths.Snapshots, id)
+func (manager *Manager) Delete(name string) error {
+	snapshot, err := manager.Snapshot(name)
+	if err != nil {
+		return err
+	}
+	snapshotDir := manager.SnapshotDirectory(snapshot)
 	// Remove complete.txt file. This must be done first because restoring
 	// from a partially-deleted snapshot could result in errors.
-	completeFilePath := filepath.Join(snapshotDir, completeFileName)
-	if err := os.RemoveAll(completeFilePath); err != nil {
-		return fmt.Errorf("failed to remove %q: %w", completeFileName, err)
-	}
-	if err := os.RemoveAll(snapshotDir); err != nil {
-		return fmt.Errorf("failed to remove dir %q: %w", snapshotDir, err)
-	}
-	return nil
+	err = os.RemoveAll(filepath.Join(snapshotDir, completeFileName))
+	return errors.Join(err, os.RemoveAll(snapshotDir))
 }
 
 // Restore Rancher Desktop to the state saved in a snapshot.
-func (manager Manager) Restore(id string) error {
-	// Before doing anything, ensure that the snapshot is complete
-	completeFilePath := filepath.Join(manager.Paths.Snapshots, id, completeFileName)
-	if _, err := os.Stat(completeFilePath); err != nil {
-		return fmt.Errorf("snapshot %q: %w", id, ErrIncompleteSnapshot)
-	}
-
-	// Get metadata about snapshot
-	metadataPath := filepath.Join(manager.Paths.Snapshots, id, "metadata.json")
-	contents, err := os.ReadFile(metadataPath)
+func (manager *Manager) Restore(name string) (err error) {
+	snapshot, err := manager.Snapshot(name)
 	if err != nil {
-		return fmt.Errorf("failed to read metadata for snapshot %q: %w", id, err)
-	}
-	snapshot := Snapshot{}
-	if err := json.Unmarshal(contents, &snapshot); err != nil {
-		return fmt.Errorf("failed to unmarshal contents of %q: %w", metadataPath, err)
+		return err
 	}
 
-	if err := manager.Snapshotter.RestoreFiles(snapshot); err != nil {
+	if err := lock.Lock(manager.Paths, "restore"); err != nil {
+		return err
+	}
+	defer func() {
+		// Don't restart the backend if the restore failed
+		_ = lock.Unlock(manager.Paths, err == nil)
+	}()
+	if err = manager.RestoreFiles(snapshot); err != nil {
 		return fmt.Errorf("failed to restore files: %w", err)
 	}
 
@@ -207,7 +230,7 @@ func (manager Manager) Restore(id string) error {
 
 func checkForInvalidCharacter(name string) error {
 	for idx, c := range name {
-		if !unicode.IsPrint(rune(c)) {
+		if !unicode.IsPrint(c) {
 			return fmt.Errorf("invalid character value %d at position %d in name: all characters must be printable or a space", c, idx)
 		}
 	}

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -115,10 +115,6 @@ func (manager *Manager) writeMetadataFile(snapshot Snapshot) error {
 
 // Create a new snapshot.
 func (manager *Manager) Create(name, description string) (snapshot Snapshot, err error) {
-	// Report on invalid names before locking and shutting down the backend
-	if err = manager.ValidateName(name); err != nil {
-		return
-	}
 	id, err := uuid.NewRandom()
 	if err != nil {
 		return snapshot, fmt.Errorf("failed to generate ID for snapshot: %w", err)
@@ -141,8 +137,7 @@ func (manager *Manager) Create(name, description string) (snapshot Snapshot, err
 			err = unlockErr
 		}
 	}()
-	// Revalidate the name in case another process created a snapshot with the same name in the gap
-	// between our first validation and creating the lock file.
+	// (Re)validate the name after acquiring the lock in case another process created a snapshot with the same name
 	if err = manager.ValidateName(name); err != nil {
 		return
 	}

--- a/src/go/rdctl/pkg/snapshot/manager_unix_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_unix_test.go
@@ -5,11 +5,11 @@ package snapshot
 import (
 	"errors"
 	"fmt"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lock"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 )
 
 func populateFiles(t *testing.T, includeOverrideYaml bool) (paths.Paths, map[string]TestFile) {
@@ -65,7 +65,11 @@ func populateFiles(t *testing.T, includeOverrideYaml bool) (paths.Paths, map[str
 }
 
 func newTestManager(appPaths paths.Paths) *Manager {
-	manager, _ := NewManager(appPaths)
+	manager := &Manager{
+		Paths:         appPaths,
+		Snapshotter:   NewSnapshotterImpl(),
+		BackendLocker: &lock.MockBackendLock{},
+	}
 	return manager
 }
 

--- a/src/go/rdctl/pkg/snapshot/manager_unix_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_unix_test.go
@@ -9,45 +9,46 @@ import (
 	"path/filepath"
 	"testing"
 
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 )
 
-func populateFiles(t *testing.T, includeOverrideYaml bool) (p.Paths, map[string]TestFile) {
+func populateFiles(t *testing.T, includeOverrideYaml bool) (paths.Paths, map[string]TestFile) {
 	baseDir := t.TempDir()
-	paths := p.Paths{
+	appPaths := paths.Paths{
+		AppHome:   baseDir,
 		Config:    filepath.Join(baseDir, "config"),
 		Lima:      filepath.Join(baseDir, "lima"),
 		Snapshots: filepath.Join(baseDir, "snapshots"),
 	}
 	testFiles := map[string]TestFile{
 		"settings.json": {
-			Path:     filepath.Join(paths.Config, "settings.json"),
+			Path:     filepath.Join(appPaths.Config, "settings.json"),
 			Contents: `{"test": "settings.json"}`,
 		},
 		"basedisk": {
-			Path:     filepath.Join(paths.Lima, "0", "basedisk"),
+			Path:     filepath.Join(appPaths.Lima, "0", "basedisk"),
 			Contents: "basedisk contents",
 		},
 		"diffdisk": {
-			Path:     filepath.Join(paths.Lima, "0", "diffdisk"),
+			Path:     filepath.Join(appPaths.Lima, "0", "diffdisk"),
 			Contents: "diffdisk contents",
 		},
 		"user": {
-			Path:     filepath.Join(paths.Lima, "_config", "user"),
+			Path:     filepath.Join(appPaths.Lima, "_config", "user"),
 			Contents: "user SSH key",
 		},
 		"user.pub": {
-			Path:     filepath.Join(paths.Lima, "_config", "user.pub"),
+			Path:     filepath.Join(appPaths.Lima, "_config", "user.pub"),
 			Contents: "user public SSH key",
 		},
 		"lima.yaml": {
-			Path:     filepath.Join(paths.Lima, "0", "lima.yaml"),
+			Path:     filepath.Join(appPaths.Lima, "0", "lima.yaml"),
 			Contents: "this is yaml",
 		},
 	}
 	if includeOverrideYaml {
 		testFiles["override.yaml"] = TestFile{
-			Path:     filepath.Join(paths.Lima, "_config", "override.yaml"),
+			Path:     filepath.Join(appPaths.Lima, "_config", "override.yaml"),
 			Contents: "test: override.yaml",
 		}
 	}
@@ -60,34 +61,36 @@ func populateFiles(t *testing.T, includeOverrideYaml bool) (p.Paths, map[string]
 			t.Fatalf("failed to create test file %q: %s", file.Path, err)
 		}
 	}
-	return paths, testFiles
+	return appPaths, testFiles
 }
 
-func newTestManager(paths p.Paths) Manager {
-	return NewManager(paths)
+func newTestManager(appPaths paths.Paths) *Manager {
+	manager, _ := NewManager(appPaths)
+	return manager
 }
 
 func TestManagerUnix(t *testing.T) {
 	for _, includeOverrideYaml := range []bool{true, false} {
 		t.Run(fmt.Sprintf("Create with includeOverrideYaml %t", includeOverrideYaml), func(t *testing.T) {
-			paths, _ := populateFiles(t, includeOverrideYaml)
+			appPaths, _ := populateFiles(t, includeOverrideYaml)
 
 			// create snapshot
-			testManager := newTestManager(paths)
+			testManager := newTestManager(appPaths)
 			snapshot, err := testManager.Create("test-snapshot", "")
 			if err != nil {
 				t.Fatalf("unexpected error creating snapshot: %s", err)
 			}
 
 			// ensure desired files are present
+			snapshotDir := testManager.SnapshotDirectory(snapshot)
 			snapshotFiles := []string{
-				filepath.Join(paths.Snapshots, snapshot.ID, "settings.json"),
-				filepath.Join(paths.Snapshots, snapshot.ID, "basedisk"),
-				filepath.Join(paths.Snapshots, snapshot.ID, "diffdisk"),
-				filepath.Join(paths.Snapshots, snapshot.ID, "metadata.json"),
+				filepath.Join(snapshotDir, "settings.json"),
+				filepath.Join(snapshotDir, "basedisk"),
+				filepath.Join(snapshotDir, "diffdisk"),
+				filepath.Join(snapshotDir, "metadata.json"),
 			}
 			if includeOverrideYaml {
-				snapshotFiles = append(snapshotFiles, filepath.Join(paths.Snapshots, snapshot.ID, "override.yaml"))
+				snapshotFiles = append(snapshotFiles, filepath.Join(snapshotDir, "override.yaml"))
 			}
 			for _, file := range snapshotFiles {
 				if _, err := os.ReadFile(file); err != nil {
@@ -99,8 +102,8 @@ func TestManagerUnix(t *testing.T) {
 
 	for _, includeOverrideYaml := range []bool{true, false} {
 		t.Run(fmt.Sprintf("Restore with includeOverrideYaml %t", includeOverrideYaml), func(t *testing.T) {
-			paths, testFiles := populateFiles(t, includeOverrideYaml)
-			manager := newTestManager(paths)
+			appPaths, testFiles := populateFiles(t, includeOverrideYaml)
+			manager := newTestManager(appPaths)
 			snapshot, err := manager.Create("test-snapshot", "")
 			if err != nil {
 				t.Fatalf("failed to create snapshot: %s", err)
@@ -110,7 +113,7 @@ func TestManagerUnix(t *testing.T) {
 					t.Fatalf("failed to modify %s: %s", testFileName, err)
 				}
 			}
-			if err := manager.Restore(snapshot.ID); err != nil {
+			if err := manager.Restore(snapshot.Name); err != nil {
 				t.Fatalf("failed to restore snapshot: %s", err)
 			}
 			for testFileName, testFile := range testFiles {
@@ -126,8 +129,8 @@ func TestManagerUnix(t *testing.T) {
 	}
 
 	t.Run("Restore should delete override.yaml if restoring to a snapshot without it", func(t *testing.T) {
-		paths, testFiles := populateFiles(t, true)
-		manager := newTestManager(paths)
+		appPaths, testFiles := populateFiles(t, true)
+		manager := newTestManager(appPaths)
 		if err := os.Remove(testFiles["override.yaml"].Path); err != nil {
 			t.Fatalf("failed to delete override.yaml: %s", err)
 		}
@@ -140,7 +143,7 @@ func TestManagerUnix(t *testing.T) {
 				t.Fatalf("failed to modify %s: %s", testFileName, err)
 			}
 		}
-		if err := manager.Restore(snapshot.ID); err != nil {
+		if err := manager.Restore(snapshot.Name); err != nil {
 			t.Fatalf("failed to restore snapshot: %s", err)
 		}
 		overrideYamlPath := testFiles["override.yaml"].Path
@@ -160,18 +163,18 @@ func TestManagerUnix(t *testing.T) {
 	})
 
 	t.Run("Restore should create any needed parent directories", func(t *testing.T) {
-		paths, _ := populateFiles(t, true)
-		manager := newTestManager(paths)
+		appPaths, _ := populateFiles(t, true)
+		manager := newTestManager(appPaths)
 		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}
-		for _, dir := range []string{paths.Config, paths.Lima} {
+		for _, dir := range []string{appPaths.Config, appPaths.Lima} {
 			if err := os.RemoveAll(dir); err != nil {
 				t.Fatalf("failed to remove directory: %s", err)
 			}
 		}
-		if err := manager.Restore(snapshot.ID); err != nil {
+		if err := manager.Restore(snapshot.Name); err != nil {
 			t.Fatalf("failed to restore snapshot: %s", err)
 		}
 	})

--- a/src/go/rdctl/pkg/snapshot/manager_windows_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_windows_test.go
@@ -37,7 +37,7 @@ func populateFiles(t *testing.T, _ bool) (paths.Paths, map[string]TestFile) {
 
 func newTestManager(appPaths paths.Paths) *Manager {
 	manager, _ := NewManager(appPaths)
-	snapshotter := NewSnapshotterImpl(appPaths)
+	snapshotter := NewSnapshotterImpl()
 	snapshotter.WSL = wsl.MockWSL{}
 	manager.Snapshotter = snapshotter
 	return manager

--- a/src/go/rdctl/pkg/snapshot/manager_windows_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_windows_test.go
@@ -2,11 +2,12 @@ package snapshot
 
 import (
 	"errors"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lock"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
 )
 
 func populateFiles(t *testing.T, _ bool) (paths.Paths, map[string]TestFile) {
@@ -36,10 +37,12 @@ func populateFiles(t *testing.T, _ bool) (paths.Paths, map[string]TestFile) {
 }
 
 func newTestManager(appPaths paths.Paths) *Manager {
-	manager, _ := NewManager(appPaths)
-	snapshotter := NewSnapshotterImpl()
-	snapshotter.WSL = wsl.MockWSL{}
-	manager.Snapshotter = snapshotter
+	manager := &Manager{
+		Paths:         appPaths,
+		Snapshotter:   NewSnapshotterImpl(),
+		BackendLocker: &lock.MockBackendLock{},
+	}
+	manager.Snapshotter.WSL = wsl.MockWSL{}
 	return manager
 }
 

--- a/src/go/rdctl/pkg/snapshot/manager_windows_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_windows_test.go
@@ -6,13 +6,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
 )
 
-func populateFiles(t *testing.T, _ bool) (p.Paths, map[string]TestFile) {
+func populateFiles(t *testing.T, _ bool) (paths.Paths, map[string]TestFile) {
 	baseDir := t.TempDir()
-	paths := p.Paths{
+	appPaths := paths.Paths{
 		Config:        filepath.Join(baseDir, "config"),
 		Snapshots:     filepath.Join(baseDir, "snapshots"),
 		WslDistro:     filepath.Join(baseDir, "wslDistro"),
@@ -20,7 +19,7 @@ func populateFiles(t *testing.T, _ bool) (p.Paths, map[string]TestFile) {
 	}
 	testFiles := map[string]TestFile{
 		"settings.json": {
-			Path:     filepath.Join(paths.Config, "settings.json"),
+			Path:     filepath.Join(appPaths.Config, "settings.json"),
 			Contents: `{"test": "settings.json"}`,
 		},
 	}
@@ -33,12 +32,12 @@ func populateFiles(t *testing.T, _ bool) (p.Paths, map[string]TestFile) {
 			t.Fatalf("failed to create test file %q: %s", file.Path, err)
 		}
 	}
-	return paths, testFiles
+	return appPaths, testFiles
 }
 
-func newTestManager(paths p.Paths) Manager {
-	manager := NewManager(paths)
-	snapshotter := NewSnapshotterImpl(paths)
+func newTestManager(appPaths paths.Paths) *Manager {
+	manager, _ := NewManager(appPaths)
+	snapshotter := NewSnapshotterImpl(appPaths)
 	snapshotter.WSL = wsl.MockWSL{}
 	manager.Snapshotter = snapshotter
 	return manager
@@ -46,10 +45,10 @@ func newTestManager(paths p.Paths) Manager {
 
 func TestManagerWindows(t *testing.T) {
 	t.Run("Create should create the necessary files", func(t *testing.T) {
-		paths, _ := populateFiles(t, false)
+		appPaths, _ := populateFiles(t, false)
 
 		// create snapshot
-		testManager := newTestManager(paths)
+		testManager := newTestManager(appPaths)
 		snapshot, err := testManager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("unexpected error creating snapshot: %s", err)
@@ -57,8 +56,8 @@ func TestManagerWindows(t *testing.T) {
 
 		// ensure desired files are present
 		snapshotFiles := []string{
-			filepath.Join(paths.Snapshots, snapshot.ID, "settings.json"),
-			filepath.Join(paths.Snapshots, snapshot.ID, "metadata.json"),
+			filepath.Join(appPaths.Snapshots, snapshot.ID, "settings.json"),
+			filepath.Join(appPaths.Snapshots, snapshot.ID, "metadata.json"),
 		}
 		for _, file := range snapshotFiles {
 			if _, err := os.ReadFile(file); err != nil {
@@ -68,8 +67,8 @@ func TestManagerWindows(t *testing.T) {
 	})
 
 	t.Run("Restore should work properly", func(t *testing.T) {
-		paths, testFiles := populateFiles(t, false)
-		manager := newTestManager(paths)
+		appPaths, testFiles := populateFiles(t, false)
+		manager := newTestManager(appPaths)
 		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
@@ -94,16 +93,16 @@ func TestManagerWindows(t *testing.T) {
 	})
 
 	t.Run("Restore should create any needed parent directories", func(t *testing.T) {
-		paths, _ := populateFiles(t, true)
-		manager := newTestManager(paths)
+		appPaths, _ := populateFiles(t, true)
+		manager := newTestManager(appPaths)
 		snapshot, err := manager.Create("test-snapshot", "")
 		if err != nil {
 			t.Fatalf("failed to create snapshot: %s", err)
 		}
 		testDirs := []string{
-			paths.Config,
-			paths.WslDistro,
-			paths.WslDistroData,
+			appPaths.Config,
+			appPaths.WslDistro,
+			appPaths.WslDistroData,
 		}
 		for _, testDir := range testDirs {
 			if err := os.RemoveAll(testDir); err != nil {

--- a/src/go/rdctl/pkg/snapshot/snapshotter.go
+++ b/src/go/rdctl/pkg/snapshot/snapshotter.go
@@ -1,5 +1,7 @@
 package snapshot
 
+import "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+
 // Types that implement Snapshotter are responsible for copying/creating
 // files that need to be copied/created for the creation and restoration of
 // snapshots.
@@ -7,9 +9,9 @@ type Snapshotter interface {
 	// Does all of the things that can fail when creating a snapshot,
 	// so that the snapshot creation can easily be rolled back upon
 	// a failure.
-	CreateFiles(snapshot Snapshot) error
+	CreateFiles(appPaths paths.Paths, snapshotDir string) error
 	// Like CreateFiles, but for restoring: does all of the things
 	// that can fail when restoring a snapshot so that restoration can
 	// easily be rolled back in the event of a failure.
-	RestoreFiles(snapshot Snapshot) error
+	RestoreFiles(appPaths paths.Paths, snapshotDir string) error
 }


### PR DESCRIPTION
The manager functions (Create/Restore/Delete) all take a `name` argument and do their own validation.

They also perform the backend locking/unlocking. The corresponding functions have been moved from the `cmd/snapshot` package to `pkg/lock`.

Snapshot methods all return only a single error, not a list.

The `ID` (directory name) is mostly unused now, most methods use a `Snapshot` argument.

Incomplete snapshots are mostly invisible (so don't need extra code to deal with).

`NewManager()` initializes Paths by itself.

Fixes #5709
Fixes #5798 
Fixes #5831