### PR TITLE
Exclude `babel.config.js` in `tsconfig`

### DIFF
--- a/pkg/rancher-desktop/tsconfig.json
+++ b/pkg/rancher-desktop/tsconfig.json
@@ -33,6 +33,7 @@
   "exclude": [
     "node_modules",
     ".nuxt",
-    "dist"
+    "dist",
+    "babel.config.js"
   ]
 }


### PR DESCRIPTION
The tsconfig located under `pkg/rancher-desktop/tsconfig.json` has long generated the following error:

```
Cannot write file '/home/phillip/Development/rancher-desktop/babel.config.js' because it would overwrite input file.ts
```

TypeScript is trying to compile `babel.config.js` into a new JavaScript file and overwrite the existing one, which it can't do. Excluding `babel.config.js` resolves the issue.