### PR TITLE
Update the main steps for getting started on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ with an existing Windows installation.
    npm config set msbuild_path "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
    ```
 
+   If you get an error message when trying to run `npm config set...`, run `npm config edit` and then add lines like
+
+   ```
+   msvs_version=2022
+   msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe
+   ```
+
+   Do not quote the values to the right side of the equal sign. The quotes aren't needed, and it's possible that some
+   processors will treat them as literal parts of the path, and then fail.
+7. Configure `git` to work with linux- and macos-originated files:
+   ```
+   git config --global --replace-all core.autocrlf false
+   git config --global --replace-all core.eol lf
+   ```
+If you find the `lint:go` tests are failing mysteriously, it's possible that the line-endings are incorrect.
+
 You can now clone the repository and run `yarn`.
 
 [development virtual machine]: https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
@@ -72,9 +88,16 @@ You can now clone the repository and run `yarn`.
 4. Install git, go, nvm, and unzip via `scoop install git go nvm python unzip`.
    Check node version with `nvm list`. If node v18 is not installed or set as the current version, then install using `nvm install 18.16` and set as current using `nvm use 18.xx.xx`.
 5. Install the yarn package manager via `npm install --global yarn`
-6. Install Visual Studio 2017 or higher. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
+6. Install Visual Studio 2017 or higher. As of this writing the latest version is available at [https://visualstudio.microsoft.com/downloads/]; if that's changed, a good search engine should find it.
+7. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
    The [Desktop development with C++] workload needs to be selected, too.
-7. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
+8. Configure `git` to work with linux- and macos-originated files:
+   ```
+   git config --global --replace-all core.autocrlf false
+   git config --global --replace-all core.eol lf
+   ```
+If you find the `lint:go` tests are failing mysteriously, it's possible that the line-endings are incorrect.
+9. Ensure `msbuild_path` and `msvs_version` are configured correctly in `.npmrc` file. Run the following commands to set these properties:
 
    ```
    npm config set msvs_version <visual-studio-version-number>
@@ -87,6 +110,16 @@ You can now clone the repository and run `yarn`.
    npm config set msvs_version 2022
    npm config set msbuild_path "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
    ```
+
+   If you get an error message when trying to run `npm config set...`, run `npm config edit` and then add lines like
+
+   ```
+   msvs_version=2022
+   msbuild_path=C:\Program Files (x86)\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe
+   ```
+
+   Do not quote the values to the right side of the equal sign. They aren't needed, and it's possible that some
+   processor will treat them as literal parts of the path, and then fail.
 
 You can now clone the repository and run `yarn`.
 


### PR DESCRIPTION
Some things were missing, like setting the line-end protocol.

I also like to include URLs when they exist, even if they're obvious.