### PR TITLE
Move supports_vz_emulation to helpers/os.bash

### DIFF
--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -84,8 +84,8 @@ using_vz_emulation() {
     is_true "$RD_USE_VZ_EMULATION"
 }
 
-if using_vz_emulation && ! is_macos; then
-    fatal "RD_USE_VZ_EMULATION only works on macOS"
+if using_vz_emulation && ! supports_vz_emulation; then
+    fatal "RD_USE_VZ_EMULATION is not supported on this OS or OS version"
 fi
 
 ########################################################################

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -84,6 +84,11 @@ sudo_needs_password() {
 supports_vz_emulation() {
     if is_macos; then
         version=$(/usr/bin/sw_vers -productVersion)
+        # Make sure the version has at least 2 dots because
+        # sometimes the reported version is just e.g. 12.7 or 14.0.
+        until [[ $version =~ \..+\. ]]; do
+            version="${version}.0"
+        done
         major_minor_version="${version%.*}"
         major_version="${major_minor_version%.*}"
         minor_version="${major_minor_version#*.}"

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -80,3 +80,21 @@ sudo_needs_password() {
     run sudo --non-interactive --reset-timestamp true
     ((status != 0))
 }
+
+supports_vz_emulation() {
+    if is_macos; then
+        version=$(/usr/bin/sw_vers -productVersion)
+        major_minor_version="${version%.*}"
+        major_version="${major_minor_version%.*}"
+        minor_version="${major_minor_version#*.}"
+        if ((major_version >= 14)); then
+            return 0
+        elif ((major_version == 13)); then
+            # Versions 13.0.x .. 13.2.x work only on x86_64, not aarch64
+            if ((minor_version >= 3)) || [[ "$(uname -m)" == x86_64 ]]; then
+                return 0
+            fi
+        fi
+    fi
+    return 1
+}

--- a/bats/tests/helpers/os.bash
+++ b/bats/tests/helpers/os.bash
@@ -89,14 +89,14 @@ supports_vz_emulation() {
         until [[ $version =~ \..+\. ]]; do
             version="${version}.0"
         done
-        major_minor_version="${version%.*}"
-        major_version="${major_minor_version%.*}"
-        minor_version="${major_minor_version#*.}"
+        major_minor_version=${version%.*}
+        major_version=${major_minor_version%.*}
+        minor_version=${major_minor_version#*.}
         if ((major_version >= 14)); then
             return 0
         elif ((major_version == 13)); then
             # Versions 13.0.x .. 13.2.x work only on x86_64, not aarch64
-            if ((minor_version >= 3)) || [[ "$(uname -m)" == x86_64 ]]; then
+            if ((minor_version >= 3)) || [[ $(uname -m) == x86_64 ]]; then
                 return 0
             fi
         fi

--- a/bats/tests/preferences/surface-invalid-args.bats
+++ b/bats/tests/preferences/surface-invalid-args.bats
@@ -8,24 +8,6 @@ local_setup() {
     factory_reset
 }
 
-supports_vz_emulation() {
-    if is_macos; then
-        version=$(/usr/bin/sw_vers -productVersion)
-        major_minor_version="${version%.*}"
-        major_version="${major_minor_version%.*}"
-        minor_version="${major_minor_version#*.}"
-        if ((major_version >= 14)); then
-            return 0
-        elif ((major_version == 13)); then
-            # Versions 13.0.x .. 13.2.x work only on x86_64, not aarch64
-            if ((minor_version >= 3)) || [[ "$(uname -m)" == x86_64 ]]; then
-                return 0
-            fi
-        fi
-    fi
-    return 1
-}
-
 @test 'mac-specific failure for unacceptable start setting' {
     if ! is_macos; then
         skip 'need a mac for the --experimental.virtual-machine.type setting'


### PR DESCRIPTION
That way the function can be used to validate the `RD_USE_VZ_EMULATION` setting.

Also make sure all macOS versions include 2 dots, e.g. 14.0 → 14.0.0.

Fixes #5739
Fixes #5741
