### PR TITLE
Rename win32env → wslpath_from_win32_env

### DIFF
--- a/bats/tests/containers/docker-buildx-python3-uname.bats
+++ b/bats/tests/containers/docker-buildx-python3-uname.bats
@@ -11,7 +11,7 @@ local_setup() {
         # so the docker clients can correctly map the bind mounts.
         # We can use host_path() on these paths because they will exist
         # both here and in the rancher-desktop distro.
-        TEMP="$(win32env TEMP)"
+        TEMP="$(wslpath_from_win32_env TEMP)"
     fi
     BUILDX_BUILDER=rd_bats_builder
     WORK_DIR="$TEMP/$BUILDX_BUILDER"

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -81,7 +81,7 @@ if is_linux; then
         "resources/resources"
 fi
 
-win32env() {
+wslpath_from_win32_env() {
     # The cmd.exe _sometimes_ returns an empty string when invoked in a subshell
     # wslpath "$(cmd.exe /c "echo %$1%" 2>/dev/null)" | tr -d "\r"
     # Let's see if powershell.exe avoids this issue
@@ -89,8 +89,8 @@ win32env() {
 }
 
 if is_windows; then
-    LOCALAPPDATA="$(win32env LOCALAPPDATA)"
-    PROGRAMFILES="$(win32env ProgramFiles)"
+    LOCALAPPDATA="$(wslpath_from_win32_env LOCALAPPDATA)"
+    PROGRAMFILES="$(wslpath_from_win32_env ProgramFiles)"
 
     PATH_APP_HOME="$LOCALAPPDATA/rancher-desktop"
     PATH_CONFIG="$LOCALAPPDATA/rancher-desktop"
@@ -112,7 +112,7 @@ PATH_CONFIG_FILE="$PATH_CONFIG/settings.json"
 
 USERPROFILE=$HOME
 if using_windows_exe; then
-    USERPROFILE="$(win32env USERPROFILE)"
+    USERPROFILE="$(wslpath_from_win32_env USERPROFILE)"
 fi
 
 host_path() {

--- a/bats/tests/preferences/move-from-roaming-to-local.bats
+++ b/bats/tests/preferences/move-from-roaming-to-local.bats
@@ -2,7 +2,7 @@ load '../helpers/load'
 
 local_setup() {
     skip_on_unix 'roaming appdata => local appdata migration is windows-only'
-    ROAMING_HOME="$(win32env APPDATA)/rancher-desktop"
+    ROAMING_HOME="$(wslpath_from_win32_env APPDATA)/rancher-desktop"
 }
 
 @test 'factory reset' {

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -10,7 +10,7 @@ local_setup() {
         # Linux one. This may change depending on:
         # https://github.com/rancher-sandbox/rancher-desktop/issues/5523
         # TODO TODO TODO
-        USERPROFILE="$(win32env USERPROFILE)"
+        USERPROFILE="$(wslpath_from_win32_env USERPROFILE)"
     fi
     DOCKER_CONFIG_FILE="$USERPROFILE/.docker/config.json"
 
@@ -20,7 +20,7 @@ local_setup() {
         # so the ctrctl clients can correctly map the bind mounts.
         # We can use host_path() on these paths because they will exist
         # both here and in the rancher-desktop distro.
-        TEMP="$(win32env TEMP)"
+        TEMP="$(wslpath_from_win32_env TEMP)"
     fi
 
     AUTH_DIR="$TEMP/auth"


### PR DESCRIPTION
Because the function doesn't just look up a win32 environment variable but expects it to be a path and translates it into a wsl path.

Fixes #5264