### PR TITLE
feat: shorter SHA in container name if existent

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -128,10 +128,10 @@ export default {
 
       return containers.map((container) => {
         container.state = container.State;
-        container.containerName = container.Names[0].replace(
+        container.containerName = this.shortSha(container.Names[0].replace(
           /_[a-z0-9-]{36}_[0-9]+/,
           '',
-        );
+        ));
         container.started =
           container.State === 'running' ? container.Status : '';
         container.imageName = container.Image;
@@ -279,11 +279,16 @@ export default {
       }
     },
     shortSha(sha) {
-      if (!sha.startsWith('sha256:')) {
-        return sha;
+      const prefix = 'sha256:';
+
+      if (sha.includes(prefix)) {
+        const startIndex = sha.indexOf(prefix) + prefix.length;
+        const actualSha = sha.slice(startIndex);
+
+        return `${ sha.slice(0, startIndex) }${ actualSha.slice(0, 3) }..${ actualSha.slice(-3) }`;
       }
 
-      return `${ sha.slice(0, 10) }..${ sha.slice(-5) }`;
+      return sha;
     },
     getTooltipConfig(sha) {
       if (!sha.startsWith('sha256:')) {


### PR DESCRIPTION
Fixes #5890

## What
We short images names that start with SHA, this PR refactors it so we check for more scenarios, such as `nginx@sha256:...` which will help reduce the size of the column.

### Testing scenarios
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/30b40aca-9de4-435b-b219-a96ddc96fe3e)


## UI display
### Before
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/87b6581b-11b5-4b10-a277-51cfd08a9773)

### After
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/a8d097f1-99e7-419b-800a-d1957b866de8)

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/4c8f1c1c-435b-4edc-b211-fdfb4f4789dd)
