### PR TITLE
Displaying exposed ports in table

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -194,13 +194,12 @@ containers:
     noRows: There are no containers to show
   manage:
     table:
-      showMore: more...
       header:
         state: State
         containerName: Name
         image: Image
         ports: Port(s)
-        started: Started
+        started: Uptime
         actions: Actions
 
 images:

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -343,7 +343,7 @@ export default {
 
   &-content {
     display: none;
-    position: absolute;
+    position: fixed;
     z-index: 1;
     padding-top: 5px;
     border-start-start-radius: var(--border-radius);

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="containers">
     <SortableTable
+      ref="sortableTableRef"
       :headers="headers"
       key-field="Id"
       :rows="rows"
@@ -27,11 +28,12 @@
             <div
               v-if="shouldHaveDropdown(row.Ports)"
               class="dropdown"
+              @mouseenter="addDropDownPosition"
+              @mouseleave="clearDropDownPosition"
             >
               <span>
                 ...
               </span>
-
               <div class="dropdown-content">
                 <a
                   v-for="port in getUniquePorts(row.Ports).slice(2)"
@@ -216,6 +218,36 @@ export default {
     handleSelection(item) {
       this.selected = [...item];
     },
+    clearDropDownPosition(e) {
+      const target = e.target;
+
+      const dropdownContent = target.querySelector('.dropdown-content');
+
+      if (dropdownContent) {
+        dropdownContent.style.top = '';
+      }
+    },
+    addDropDownPosition(e) {
+      const table = this.$refs.sortableTableRef.$el;
+      const target = e.target;
+
+      const dropdownContent = target.querySelector('.dropdown-content');
+
+      if (dropdownContent) {
+        const dropdownRect = target.getBoundingClientRect();
+        const tableRect = table.getBoundingClientRect();
+        const targetTopPos = dropdownRect.top - tableRect.top;
+        const tableHeight = tableRect.height;
+
+        if (targetTopPos < tableHeight / 2) {
+          // Show dropdownContent below the target
+          dropdownContent.style.top = `${ dropdownRect.bottom }px`;
+        } else {
+          // Show dropdownContent above the target
+          dropdownContent.style.top = `${ dropdownRect.top - dropdownContent.getBoundingClientRect().height }px`;
+        }
+      }
+    },
     async getContainers() {
       const containers = await this.ddClient?.docker.listContainers({ all: true });
 
@@ -353,7 +385,6 @@ export default {
     display: none;
     position: fixed;
     z-index: 1;
-    padding-top: 5px;
     border-start-start-radius: var(--border-radius);
     background: var(--default);
     padding: 5px;

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -29,7 +29,7 @@
               class="dropdown"
             >
               <span>
-                {{ t('containers.manage.table.showMore') }}
+                ...
               </span>
 
               <div class="dropdown-content">
@@ -292,23 +292,26 @@ export default {
 
       return { content: sha };
     },
-    getUniquePorts(obj) {
-      const uniquePorts = {};
+    getUniquePorts(ports) {
+      const keys = Object.keys(ports);
 
-      Object.keys(obj).forEach((key) => {
-        const ports = obj[key];
+      const uniquePortMap = keys.map((key) => {
+        const values = ports[key];
+        const hostPorts = values.map(value => value.HostPort);
+        const uniqueHostPorts = [...new Set(hostPorts)];
 
-        if (!ports) {
-          return;
-        }
-
-        const firstPort = ports[0]?.HostPort || '';
-        const secondPort = ports[1]?.HostPort || '';
-
-        uniquePorts[`${ firstPort }:${ secondPort }`] = true;
+        return { [key]: uniqueHostPorts };
       });
 
-      return Object.keys(uniquePorts);
+      const displayMap = uniquePortMap.map((element) => {
+        const key = Object.keys(element)[0];
+        const values = element[key];
+        const port = key.split('/')[0];
+
+        return values.map(value => `${ value }:${ port }`);
+      });
+
+      return [].concat.apply([], displayMap);
     },
     shouldHaveDropdown(ports) {
       if (!ports) {
@@ -341,6 +344,11 @@ export default {
   position: relative;
   display: inline-block;
 
+  span {
+    cursor: pointer;
+    padding: 5px;
+  }
+
   &-content {
     display: none;
     position: fixed;
@@ -349,6 +357,7 @@ export default {
     border-start-start-radius: var(--border-radius);
     background: var(--default);
     padding: 5px;
+    transition: all 0.5s ease-in-out;
 
     a {
       display: block;
@@ -375,6 +384,6 @@ export default {
 
 .port-container {
   display: flex;
-  flex-direction: column;
+  gap: 5px;
 }
 </style>


### PR DESCRIPTION
Fixes: [5759](https://github.com/rancher-sandbox/rancher-desktop/issues/5759) [#5895](https://github.com/rancher-sandbox/rancher-desktop/issues/5895) [#5883](https://github.com/rancher-sandbox/rancher-desktop/issues/5883)

### For 5759, clipping
![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/ba4df0d9-7074-4024-8a4c-19875a407be0)

### For [#5895](https://github.com/rancher-sandbox/rancher-desktop/issues/5895), incorrect port mapping
- It should correctly map all the ports, it can be tested with `docker run -d -p 5500:80 -p 5600:443 -p 1400:80 -p 1337:80 -p 444:132 -p 545:341 --restart=always nginx`

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/871c5824-032b-4c4a-b5b3-475d0173b38b)


### Additional changes:
- It also changes the layout of the ports horizontally instead of vertically and removes the `more` from `more...` to allow more space for the ports. 
- Renames `Started` -> `Uptime`

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/5d929b8c-9ca5-4f78-a786-a88c6e42ae53)

