### PR TITLE
Disable quit in tray during snapshot process

### DIFF
--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -92,6 +92,7 @@ export class Tray {
     },
     { type: 'separator' },
     {
+      id:    'quit',
       label: 'Quit Rancher Desktop',
       role:  'quit',
       type:  'normal',
@@ -350,11 +351,11 @@ export class Tray {
       networkStatusItem.label = `Network status: ${ this.currentNetworkStatus }`;
     }
 
-    for (const item of this.contextMenuItems) {
-      if (item.id === 'preferences' || item.id === 'dashboard' || item.id === 'contexts') {
+    this.contextMenuItems
+      .filter(item => item.id && ['preferences', 'dashboard', 'contexts', 'quit'].includes(item.id))
+      .forEach((item) => {
         item.enabled = !this.backendIsLocked;
-      }
-    }
+      });
 
     const contextMenu = Electron.Menu.buildFromTemplate(this.contextMenuItems);
 


### PR DESCRIPTION
This adds an id for the "quit" context menu item in the tray menu and filtering by using array methods.

closes #5854  