### PR TITLE
Allow tray to request backend lock state

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -519,6 +519,10 @@ mainEvents.on('backend-locked-update', () => {
   window.send(backendIsLocked ? 'backend-locked' : 'backend-unlocked');
 });
 
+mainEvents.on('backend-locked-check', () => {
+  mainEvents.emit('backend-locked-update', backendIsLocked);
+});
+
 ipcMainProxy.on('backend-state-check', (event) => {
   event.reply(backendIsLocked ? 'backend-locked' : 'backend-unlocked');
 });

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -121,6 +121,12 @@ interface MainEventNames {
    * writing snapshots is the sole use for this).
    */
   'backend-locked-update'(backendIsLocked: string): void;
+
+  /**
+   * Emitted when a component wants to check the state of the backend lock.
+   * Responds by emitting a backend-locked-update.
+   */
+  'backend-locked-check'(): void;
 }
 
 /**

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -181,6 +181,7 @@ export class Tray {
     this.watchForChanges();
 
     mainEvents.on('backend-locked-update', this.backendStateEvent);
+    mainEvents.emit('backend-locked-check');
     mainEvents.on('k8s-check-state', this.k8sStateChangedEvent);
     mainEvents.on('settings-update', this.settingsUpdateEvent);
 


### PR DESCRIPTION
Allow the tray to independently request the backend lock state by introducing a new 'backend-locked-check' event, which triggers a response to emit 'backend-locked-update'. This change ensures that the tray can handle updates on its own, addressing the issue of event timing during the first run.

closes #5848 