### PR TITLE
Adds tooltip for new scenarios & for container name when the `sha` is truncated.

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -289,7 +289,7 @@ export default {
       return sha;
     },
     getTooltipConfig(sha) {
-      if (!sha.startsWith('sha256:')) {
+      if (!sha.includes('sha256:')) {
         return { content: undefined };
       }
 

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -11,6 +11,13 @@
       :loading="!containersList"
       @selection="handleSelection"
     >
+      <template #col:containerName="{row}">
+        <td>
+          <span v-tooltip="getTooltipConfig(row.containerName)">
+            {{ shortSha(row.containerName) }}
+          </span>
+        </td>
+      </template>
       <template #col:ports="{ row }">
         <td>
           <div class="port-container">
@@ -56,7 +63,6 @@
           />
         </td>
       </template>
-
       <template #col:imageName="{row}">
         <td>
           <span v-tooltip="getTooltipConfig(row.imageName)">
@@ -128,10 +134,10 @@ export default {
 
       return containers.map((container) => {
         container.state = container.State;
-        container.containerName = this.shortSha(container.Names[0].replace(
+        container.containerName = container.Names[0].replace(
           /_[a-z0-9-]{36}_[0-9]+/,
           '',
-        ));
+        );
         container.started =
         container.State === 'running' ? container.Status : '';
         container.imageName = container.Image;


### PR DESCRIPTION
After merging https://github.com/rancher-sandbox/rancher-desktop/pull/5983 I noticed that the tooltip was not working for the new scenario, this PR solves that plus, it also adds a tooltip for the `name` column when the SHA was truncated.

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/88777903/a898f81a-b1c4-4229-90ac-c4a4c8e17eb5)
