### PR TITLE
Enable golangci-lint for build monitor

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -95,3 +95,4 @@ ignore$
 ^\Qpkg/rancher-desktop/utils/_demo_metadata.js\E$
 (?:^|/)pkg/rancher-desktop/nuxt/
 ^\Qsrc/disk-images/github-runner-linux/root/etc/sysconfig/network/ifcfg-\E
+^\Q.github/workflows/config/.golangci.yaml\E$

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -270,6 +270,7 @@ Gluster
 gname
 gofmt
 goland
+golangci
 gomod
 googlegke
 googleoauth

--- a/.github/workflows/.golangci.yaml
+++ b/.github/workflows/.golangci.yaml
@@ -1,0 +1,111 @@
+linters-settings:
+  dupl:
+    threshold: 100
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+  gocyclo:
+    min-complexity: 15
+  gomnd:
+    # don't include the "operation" and "assign"
+    checks:
+      - argument
+      - case
+      - condition
+      - return
+    ignored-numbers:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+    ignored-functions:
+      - strings.SplitN
+
+  lll:
+    line-length: 140
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+  # don't enable:
+  # - asciicheck
+  # - funlen
+  # - scopelint
+  # - gochecknoglobals
+  # - gocognit
+  # - godot
+  # - godox
+  # - goerr113
+  # - interfacer
+  # - maligned
+  # - nestif
+  # - prealloc
+  # - testpackage
+  # - revive
+  # - wsl
+  # - depguard # Requires configuration and by default only allows stdlib imports
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
+        - errcheck
+        - gocritic

--- a/.github/workflows/config/.golangci.yaml
+++ b/.github/workflows/config/.golangci.yaml
@@ -56,7 +56,6 @@ linters:
     - dupl
     - errcheck
     - exportloopref
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
@@ -88,6 +87,7 @@ linters:
   # - funlen
   # - scopelint
   # - gochecknoglobals
+  # - gochecknoinits
   # - gocognit
   # - godot
   # - godox

--- a/.github/workflows/github-runner-monitor-build.yaml
+++ b/.github/workflows/github-runner-monitor-build.yaml
@@ -19,7 +19,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-        sparse-checkout: src/go/github-runner-monitor
+        sparse-checkout: |
+          src/go/github-runner-monitor
+          .github/workflows/config
     - uses: actions/setup-go@v4
       with:
         go-version-file: src/go/github-runner-monitor/go.mod
@@ -36,6 +38,6 @@ jobs:
     - uses: golangci/golangci-lint-action@v3.7.0
       # This is only safe because this workflow does not allow writing
       with:
-        args: --config=.golangci.yaml --verbose --timeout 3m
+        args: --config=${{ github.workspace }}/.github/workflows/config/.golangci.yaml  --verbose --timeout 3m
         working-directory: src/go/github-runner-monitor
         only-new-issues: true

--- a/.github/workflows/github-runner-monitor-build.yaml
+++ b/.github/workflows/github-runner-monitor-build.yaml
@@ -36,5 +36,6 @@ jobs:
     - uses: golangci/golangci-lint-action@v3.7.0
       # This is only safe because this workflow does not allow writing
       with:
+        args: --config=.golangci.yaml --verbose --timeout 3m
         working-directory: src/go/github-runner-monitor
         only-new-issues: true

--- a/src/go/github-runner-monitor/cmd/root.go
+++ b/src/go/github-runner-monitor/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var perRunnerMemory = 6 * 1024
 var rootCmd = &cobra.Command{
 	Use:   "github-runner-linux",
 	Short: "Manage ephemeral GitHub runners for Rancher Desktop",
@@ -82,7 +83,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if err = monitor.Monitor(ctx, config); err != nil {
+		if err = monitor.Monitor(ctx, &config); err != nil {
 			return fmt.Errorf("failed to monitor: %w", err)
 		}
 
@@ -105,7 +106,7 @@ func init() {
 	flags.StringP("repo", "r", "rancher-desktop", "GitHub repository")
 	flags.StringSliceP("labels", "l", []string{"self-hosted", "Linux", "X64", "ephemeral"}, "Labels to apply to the runners")
 	flags.Int("cpus", 3, "Number of vCPUs per runner")
-	flags.Int("memory", 6*1024, "Memory amount per runner, in megabytes")
+	flags.Int("memory", perRunnerMemory, "Memory amount per runner, in megabytes")
 	flags.String("disk", "", "Disk image to use for the VM")
 	flags.SortFlags = false
 	cobra.OnInitialize(initConfig)

--- a/src/go/github-runner-monitor/pkg/monitor/monitor.go
+++ b/src/go/github-runner-monitor/pkg/monitor/monitor.go
@@ -42,7 +42,7 @@ type Config struct {
 
 // Monitor the GitHub repository and spawn new VMs when the number of active
 // runners is less than the configured amount.
-func Monitor(ctx context.Context, c Config) error {
+func Monitor(ctx context.Context, c *Config) error {
 	client := github.NewClient(nil).WithAuthToken(c.AuthToken)
 	wg := &sync.WaitGroup{}
 
@@ -69,7 +69,7 @@ monitorLoop:
 // added to before creating the GitHub-side runner record, and removed once that
 // has been removed.  This is used to ensure we do not end up exiting before we
 // clean up.
-func monitorOnce(ctx context.Context, c Config, client *github.Client, wg *sync.WaitGroup) error {
+func monitorOnce(ctx context.Context, c *Config, client *github.Client, wg *sync.WaitGroup) error {
 	runners, _, err := client.Actions.ListRunners(ctx, c.Owner, c.Repo, nil)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve list of runners: %w", err)
@@ -118,7 +118,7 @@ runnerLoop:
 	removeRunner := func() {
 		runner := config.GetRunner()
 		if runner != nil {
-			// Don't use the given context; that might have been cancelled (and
+			// Don't use the given context; that might have been canceled (and
 			// lead to us removing the runner).  Use a new background context
 			// instead.
 			logrus.Tracef("Unregistering runner %s", name)
@@ -138,7 +138,7 @@ runnerLoop:
 	if configString == "" {
 		return fmt.Errorf("got invalid runner config")
 	}
-	machineDone, err := machines.Run(ctx, machines.Config{
+	machineDone, err := machines.Run(ctx, &machines.Config{
 		Name:      name,
 		Cpus:      fmt.Sprintf("%d", c.Cpus),
 		Memory:    fmt.Sprintf("%dM", c.Memory),


### PR DESCRIPTION
Adds a `.golangci.yaml` that will be shared across all golang repos under `src/go`. Also, enables the configuration argument for the  `GitHub Runner: Build Monitor`.