### PR TITLE
Make swagger generation quieter

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/generate.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/generate.go
@@ -21,7 +21,7 @@ import (
 )
 
 //go:generate -command swagger go run github.com/go-swagger/go-swagger/cmd/swagger@v0.30.5
-//go:generate swagger generate server --skip-validation --config-file swagger-configuration.yaml --server-package models --spec swagger.yaml
+//go:generate swagger generate server --quiet --skip-validation --config-file swagger-configuration.yaml --server-package models --spec swagger.yaml
 
 func init() {
 }


### PR DESCRIPTION
At this point we don't need the swagger output (typically shown on `yarn install`) — we haven't needed to debug it a a long time, and the output is just noise.