### PR TITLE
Move `UnregisterWSL()` to `wsl` package

### DIFF
--- a/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
@@ -3,6 +3,7 @@ package factoryreset
 import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
 	"github.com/sirupsen/logrus"
 )
 
@@ -10,7 +11,8 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
-	if err := UnregisterWSL(); err != nil {
+	w := wsl.WSLImpl{}
+	if err := w.UnregisterDistros(); err != nil {
 		logrus.Errorf("could not unregister WSL: %s", err)
 		return err
 	}

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -35,8 +35,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const CREATE_NO_WINDOW = 0x08000000
-
 var (
 	pKernel32      = windows.NewLazySystemDLL("kernel32.dll")
 	pEnumProcesses = pKernel32.NewProc("K32EnumProcesses")

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
@@ -50,7 +49,7 @@ var (
 
 func CheckProcessWindows() (bool, error) {
 	cmd := exec.Command("tasklist", "/NH", "/FI", "IMAGENAME eq Rancher Desktop.exe", "/FO", "CSV")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: CREATE_NO_WINDOW}
+	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 	allOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("Failed to run %q: %w", cmd, err)

--- a/src/go/rdctl/pkg/wsl/wsl_windows.go
+++ b/src/go/rdctl/pkg/wsl/wsl_windows.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 	"golang.org/x/text/encoding/unicode"
 )
-
-const CREATE_NO_WINDOW = 0x08000000
 
 type WSL interface {
 	// Deletes all WSL distros pertaining to Rancher Desktop.
@@ -28,7 +26,7 @@ type WSLImpl struct{}
 
 func (wsl WSLImpl) UnregisterDistros() error {
 	cmd := exec.Command("wsl", "--list", "--quiet")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: CREATE_NO_WINDOW}
+	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 	rawBytes, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error getting current WSLs: %w", err)
@@ -49,7 +47,7 @@ func (wsl WSLImpl) UnregisterDistros() error {
 
 	for _, wsl := range wslsToKill {
 		cmd := exec.Command("wsl", "--unregister", wsl)
-		cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: CREATE_NO_WINDOW}
+		cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 		if err := cmd.Run(); err != nil {
 			logrus.Errorf("Error unregistering WSL %s: %s\n", wsl, err)
 		}

--- a/src/go/rdctl/pkg/wsl/wsl_windows.go
+++ b/src/go/rdctl/pkg/wsl/wsl_windows.go
@@ -49,7 +49,7 @@ func (wsl WSLImpl) UnregisterDistros() error {
 		cmd := exec.Command("wsl", "--unregister", wsl)
 		cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 		if err := cmd.Run(); err != nil {
-			logrus.Errorf("Error unregistering WSL %s: %s\n", wsl, err)
+			logrus.Errorf("Error unregistering WSL distribution %s: %s\n", wsl, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
It makes more sense to me to have all of the WSL functionality under the `wsl` package. I know we didn't discuss this as a team at all, so feel free to close if you disagree.