### PR TITLE
Add text to icon-only buttons

### DIFF
--- a/pkg/rancher-desktop/assets/styles/rancher-desktop.scss
+++ b/pkg/rancher-desktop/assets/styles/rancher-desktop.scss
@@ -37,6 +37,12 @@ label > button:first-child:not(.btn-sm) {
   outline: 10px dashed red !important;
 }
 
+.btn-icon-text {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 :root {
   --preferences-content-padding: 0.75rem;
 }

--- a/pkg/rancher-desktop/components/Preferences/ButtonOpen.vue
+++ b/pkg/rancher-desktop/components/Preferences/ButtonOpen.vue
@@ -12,44 +12,12 @@ export default Vue.extend({
 
 <template>
   <button
-    class="btn role-fab ripple"
+    class="btn role-secondary btn-icon-text"
     @click="openPreferences"
   >
     <span
       class="icon icon-gear"
     />
+    {{ t('nav.userMenu.preferences') }}
   </button>
 </template>
-
-<style lang="scss" scoped>
-  // We make use of the term Floating Action Button (fab) here because the
-  // design of this button is reminiscent of floating actions buttons from
-  // Material Design
-  button.role-fab {
-    all: revert;
-    cursor: pointer;
-    font-size: 1.875rem;
-    line-height: 0;
-    border: 0;
-    padding: 0.5rem;
-    background: none;
-    color: var(--body-text);
-    transition: background 400ms;
-    border-radius: 50%;
-  }
-
-  button.ripple {
-    background-position: center;
-    transition: background 0.8s;
-  }
-
-  .ripple:hover {
-    background: var(--tooltip-bg) radial-gradient(circle, transparent 1%, var(--tooltip-bg) 1%) center/15000%;
-  }
-
-  .ripple:active {
-    background-color: var(--default);
-    background-size: 100%;
-    transition: background 0s;
-  }
-</style>

--- a/pkg/rancher-desktop/components/__tests__/PreferencesButton.spec.ts
+++ b/pkg/rancher-desktop/components/__tests__/PreferencesButton.spec.ts
@@ -4,15 +4,13 @@ import PreferencesButton from '../Preferences/ButtonOpen.vue';
 
 describe('Preferences/ButtonOpen.vue', () => {
   it(`renders a button`, () => {
-    const wrapper = shallowMount(PreferencesButton, {});
+    const wrapper = shallowMount(PreferencesButton, { mocks: { t: jest.fn() } });
 
-    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-fab', 'ripple']);
+    expect(wrapper.find('button').classes()).toStrictEqual(['btn', 'role-secondary', 'btn-icon-text']);
   });
 
   it(`emits 'open-preferences' on click`, () => {
-    const wrapper = shallowMount(
-      PreferencesButton,
-      { });
+    const wrapper = shallowMount(PreferencesButton, { mocks: { t: jest.fn() } });
 
     wrapper.find('button').trigger('click');
 


### PR DESCRIPTION
~Add text to prefrences button. Add text to check- and x-icon on port-forwarding.~

![Screenshot_2023-11-27_18-10-45](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/edf9a8b8-e496-4166-9534-b6ce3acdadda)
![Screenshot_2023-11-27_18-13-19](https://github.com/rancher-sandbox/rancher-desktop/assets/8761082/b35d8892-0599-473d-b969-467449b855ab)

~There are also a plus- and minus-icon on the Preferences -> Container Engine -> Allowed Images page. They're part of the string-list component and need to be adapted here: https://github.com/rancher/dashboard/blob/master/pkg/rancher-components/src/components/StringList/StringList.vue~

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4851