### PR TITLE
Wait for backend lock to clear before starting backend

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -272,34 +272,7 @@ Electron.app.whenReady().then(async() => {
       return;
     }
 
-    await doFirstRunDialog();
-
-    if (gone) {
-      console.log('User triggered quit during first-run');
-
-      return;
-    }
-
-    buildApplicationMenu();
-
-    Electron.app.setAboutPanelOptions({
-      // TODO: Update this to 2021-... as dev progresses
-      // also needs to be updated in electron-builder.yml
-      copyright:          'Copyright © 2021-2023 SUSE LLC',
-      applicationName:    `${ Electron.app.name } by SUSE`,
-      applicationVersion: `Version ${ await getVersion() }`,
-      iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
-    });
-
-    if (!cfg.application.hideNotificationIcon) {
-      Tray.getInstance(cfg).show();
-    }
-
-    if (!cfg.application.startInBackground) {
-      window.openMain();
-    } else if (Electron.app.dock) {
-      Electron.app.dock.hide();
-    }
+    await initUI();
 
     try {
       await dockerDirManager.ensureCredHelperConfigured();
@@ -323,6 +296,37 @@ Electron.app.whenReady().then(async() => {
     Electron.app.quit();
   }
 });
+
+async function initUI() {
+  await doFirstRunDialog();
+
+  if (gone) {
+    console.log('User triggered quit during first-run');
+
+    return;
+  }
+
+  buildApplicationMenu();
+
+  Electron.app.setAboutPanelOptions({
+    // TODO: Update this to 2021-... as dev progresses
+    // also needs to be updated in electron-builder.yml
+    copyright:          'Copyright © 2021-2023 SUSE LLC',
+    applicationName:    `${ Electron.app.name } by SUSE`,
+    applicationVersion: `Version ${ await getVersion() }`,
+    iconPath:           path.join(paths.resources, 'icons', 'logo-square-512.png'),
+  });
+
+  if (!cfg.application.hideNotificationIcon) {
+    Tray.getInstance(cfg).show();
+  }
+
+  if (!cfg.application.startInBackground) {
+    window.openMain();
+  } else if (Electron.app.dock) {
+    Electron.app.dock.hide();
+  }
+}
 
 async function doFirstRunDialog() {
   if (!noModalDialogs && settingsImpl.firstRunDialogNeeded()) {

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4793,6 +4793,8 @@ snapshots:
     delete:
       success: "Deleted '<b>'{snapshot}'</b>'"
       error: 'Delete error: {error}'
+    lock:
+      info: "A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>."
 
 
 ##############################

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -91,15 +91,16 @@ export default {
     ipcRenderer.on('window/blur', (event, blur) => {
       this.blur = blur;
     });
-    ipcRenderer.once('backend-locked', (event) => {
+    ipcRenderer.on('backend-locked', (event) => {
       ipcRenderer.send('preferences-close');
       this.showCreatingSnapshotDialog();
     });
-    ipcRenderer.once('backend-unlocked', () => {
+    ipcRenderer.on('backend-unlocked', () => {
       ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
-      ipcRenderer.removeAllListeners('backend-locked');
     });
+
     ipcRenderer.send('backend-state-check');
+
     ipcRenderer.on('k8s-check-state', (event, state) => {
       this.$store.dispatch('k8sManager/setK8sState', state);
     });

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -127,6 +127,8 @@ interface MainEventNames {
    * Responds by emitting a backend-locked-update.
    */
   'backend-locked-check'(): void;
+
+  'dialog-info'(args: Record<string, string>): void;
 }
 
 /**

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -47,6 +47,10 @@ export default Vue.extend({
       this.errorButton = args.errorButton;
     });
 
+    ipcRenderer.on('dialog/info', (_event, args) => {
+      this.info = this.t(args.infoKey, {}, true);
+    });
+
     ipcRenderer.on('dialog/options', (_event, { window, format }) => {
       this.header = format.header;
       this.message = format.message;
@@ -177,7 +181,7 @@ export default Vue.extend({
       >
         <slot name="info">
           <Banner
-            class="banner mb-20"
+            class="banner mb-20 info-banner"
             color="info"
           >
             <span v-html="info" />
@@ -329,5 +333,9 @@ export default Vue.extend({
       justify-content: flex-start;
       flex-direction: row-reverse;
     }
+  }
+
+  .info-banner::v-deep code {
+    padding: 2px;
   }
 </style>

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -182,6 +182,7 @@ export interface IpcRendererEvents {
   'dialog/size': (size: {width: number, height: number}) => void;
   'dialog/options': (...args: any) => void;
   'dialog/error': (args: any) => void;
+  'dialog/info': (args: Record<string, string>) => void;
   'dashboard-open': () => void;
   // #endregion
 


### PR DESCRIPTION
This resolves race conditions that can occur during the init routine for Rancher Desktop by ensuring that a `backend.lock` file does not exist before starting the backend. 

This also improves the behavior of the snapshot dialogs by updating relevant event listeners in the default layout. Rancher Desktop now listens for events more than once, ensuring that we always display the dialog if a lock exists while starting Rancher Desktop. This change also provides us with the added benefit of `rdclt snapshot` operations triggering the dialog.

closes #5849
closes #5846
closes #5695