### PR TITLE
WiX: Add executable for icon

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -619,6 +619,7 @@ rancherdesktop
 rancherkubernetesengine
 ranchertest
 rawdata
+rcedit
 rcfiles
 rcompare
 rdctl

--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -32,3 +32,4 @@ resources/resources/win32/internal:
 - privileged-service.exe
 - steve.exe
 - vtunnel.exe
+- '!dummy.exe'

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -27,9 +27,7 @@
     <UIRef Id="WixUI_RD" />
 
     <Property Id="ApplicationFolderName" Value="Rancher Desktop" />
-    <Icon
-      Id="RancherDesktopIcon.exe"
-      SourceFile="$(var.appDir)\Rancher Desktop.exe" />
+    <Icon Id="RancherDesktopIcon.exe" SourceFile="$(var.iconPath)" />
     <Property Id="ARPPRODUCTICON" Value="RancherDesktopIcon.exe" />
     <Property Id="ARPNOMODIFY" Value="1" />
     <Property Id="ARPURLINFOABOUT" Value="https://rancherdesktop.io/" />

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -476,6 +476,7 @@ export default {
       tasks.push(() => this.buildUtility('vtunnel', 'win32', 'internal'));
       tasks.push(() => this.buildUtility('rdctl', 'linux', 'bin'));
       tasks.push(() => this.buildUtility('privileged-service', 'win32', 'internal'));
+      tasks.push(() => this.buildUtility('dummy', 'win32', 'internal'));
     }
     tasks.push(() => this.buildUtility('rdctl', os.platform(), 'bin'));
     tasks.push(() => this.buildUtility('docker-credential-none', os.platform(), 'bin'));

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -206,6 +206,12 @@ export default async function generateFileList(rootPath: string): Promise<string
       return null;
     },
 
+    'resources\\resources\\win32\\internal\\dummy.exe': () => {
+      // This file is used for shortcut icons in the installer; it does not need
+      // to be installed.
+      return null;
+    },
+
     // @ts-ignore
     'resources\\resources\\win32\\internal\\privileged-service.exe': (d, f) => {
       return <Component>

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -75,6 +75,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
   console.log('Writing out WiX definition...');
   await fs.promises.writeFile(path.join(workDir, 'project.wxs'), output);
   console.log('Compiling WiX...');
+  const iconPath = path.join(appDir, 'resources', 'resources', 'win32', 'internal', 'dummy.exe');
   const inputs = [
     path.join(workDir, 'project.wxs'),
     path.join(process.cwd(), 'build', 'wix', 'dialogs.wxs'),
@@ -88,6 +89,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
     [
       '-arch', 'x64',
       `-dappDir=${ appDir }`,
+      `-diconPath=${ iconPath }`, // spellcheck-ignore-line
       `-dlicenseFile=${ path.join(appDir, 'build', 'license.rtf') }`,
       '-nologo',
       '-out', path.join(workDir, `${ path.basename(input, '.wxs') }.wixobj`),

--- a/src/go/dummy/go.mod
+++ b/src/go/dummy/go.mod
@@ -1,0 +1,3 @@
+module github.com/rancher-sandbox/rancher-desktop/src/go/dummy
+
+go 1.21.2

--- a/src/go/dummy/main.go
+++ b/src/go/dummy/main.go
@@ -1,0 +1,6 @@
+// Command dummy is an empty executable; this is used in the Windows installer
+// as an executable to hold icons.
+package main
+
+func main() {
+}


### PR DESCRIPTION
WiX takes the executable to use for icons and makes a copy of it, uncompressed, in the installer.  In our case that was a ~150MB executable with the majority of Chromium.  Instead, create a stub executable with no real code and embed the icon in that file.  This cuts the installer down enough to fit in a CD.