### PR TITLE
WSL-Helper: Use a temporary name

### DIFF
--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -76,21 +76,21 @@ test.describe('WSL Integrations', () => {
           utf16le: true,
         },
         ...['alpha', 'beta', 'gamma'].flatMap(distro => [
-          ...[['bin', 'docker-compose'], ['wsl-helper']].flatMap(tool => ([
+          ...[['bin', 'docker-compose'], ['wsl-helper-1.11.1']].flatMap(tool => ([
             {
               args:   ['--distribution', distro, '--exec', '/bin/wslpath', '-a', '-u', path.join(process.cwd(), 'resources', 'linux', ...tool)],
               mode:   'repeated',
               stdout: `/${ distro }/${ tool.join('/') }`,
             }])),
-          ...[['bin', 'docker-buildx'], ['wsl-helper']].flatMap(tool => ([
+          ...[['bin', 'docker-buildx'], ['wsl-helper-1.11.1']].flatMap(tool => ([
             {
               args:   ['--distribution', distro, '--exec', '/bin/wslpath', '-a', '-u', path.join(process.cwd(), 'resources', 'linux', ...tool)],
               mode:   'repeated',
               stdout: `/${ distro }/${ tool.join('/') }`,
             }])),
           ...[
-            [`/${ distro }/wsl-helper`, 'kubeconfig', '--enable=false'],
-            [`/${ distro }/wsl-helper`, 'kubeconfig', '--enable=true'],
+            [`/${ distro }/wsl-helper-1.11.1`, 'kubeconfig', '--enable=false'],
+            [`/${ distro }/wsl-helper-1.11.1`, 'kubeconfig', '--enable=true'],
             ['/bin/sh', '-c', 'mkdir -p "$HOME/.docker/cli-plugins"'],
             ['/bin/sh', '-c',
               `if [ ! -e "$HOME/.docker/cli-plugins/docker-compose" -a ! -L "$HOME/.docker/cli-plugins/docker-compose" ] ; then
@@ -112,28 +112,28 @@ test.describe('WSL Integrations', () => {
             stdout: '/dev/null',
           },
           {
-            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper`, 'docker-proxy', 'serve', '--verbose'],
+            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper-1.11.1`, 'docker-proxy', 'serve', '--verbose'],
             mode:   'repeated',
             stdout: '/dev/null',
           },
           {
-            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper`, 'docker-proxy', 'kill', '--verbose'],
+            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper-1.11.1`, 'docker-proxy', 'kill', '--verbose'],
             mode:   'repeated',
             stdout: '/dev/null',
           },
         ]),
         {
-          args:   ['--distribution', 'alpha', '--exec', '/alpha/wsl-helper', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'alpha', '--exec', '/alpha/wsl-helper-1.11.1', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.alpha ?? false).toString(),
         },
         {
-          args:   ['--distribution', 'beta', '--exec', '/beta/wsl-helper', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'beta', '--exec', '/beta/wsl-helper-1.11.1', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.beta ?? true).toString(),
         },
         {
-          args:   ['--distribution', 'gamma', '--exec', '/gamma/wsl-helper', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'gamma', '--exec', '/gamma/wsl-helper-1.11.1', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.gamma ?? 'some error').toString(),
         },

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -54,6 +54,7 @@ import clone from '@pkg/utils/clone';
 import Logging from '@pkg/utils/logging';
 import { wslHostIPv4Address } from '@pkg/utils/networks';
 import paths from '@pkg/utils/paths';
+import { executable } from '@pkg/utils/resources';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
 import { defined, RecursivePartial } from '@pkg/utils/typeUtils';
 
@@ -1745,7 +1746,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     // We need to get the Linux path to our helper executable; it is easier to
     // just get WSL to do the transformation for us.
 
-    return this.wslify(path.join(paths.resources, 'linux', 'wsl-helper'), distro);
+    return this.wslify(executable('wsl-helper-linux'), distro);
   }
 
   /**

--- a/pkg/rancher-desktop/utils/resources.ts
+++ b/pkg/rancher-desktop/utils/resources.ts
@@ -15,8 +15,8 @@ const executableMap: Record<string, string[] | undefined> = {
   kubectl:            undefined,
   nerdctl:            undefined,
   rdctl:              undefined,
-  'wsl-helper':       [paths.resources, process.platform, platformBinary('wsl-helper')],
-  'wsl-helper-linux': [paths.resources, 'linux', 'wsl-helper'],
+  'wsl-helper':       [paths.resources, process.platform, platformBinary('wsl-helper-1.11.1')],
+  'wsl-helper-linux': [paths.resources, 'linux', 'wsl-helper-1.11.1'],
 };
 
 function platformBinary(name: string): string {

--- a/pkg/rancher-desktop/utils/resources.ts
+++ b/pkg/rancher-desktop/utils/resources.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import path from 'path';
 
 import memoize from 'lodash/memoize';
@@ -6,14 +5,37 @@ import memoize from 'lodash/memoize';
 import paths from '@pkg/utils/paths';
 
 /**
+ * executableMap is a mapping of valid executable names and their path.
+ * If the value is `undefined`, then it's assumed to be an executable in the
+ * user-accessible `bin` directory.
+ * Otherwise, it's an array containing the path to the executable.
+ */
+const executableMap: Record<string, string[] | undefined> = {
+  docker:             undefined,
+  kubectl:            undefined,
+  nerdctl:            undefined,
+  rdctl:              undefined,
+  'wsl-helper':       [paths.resources, process.platform, platformBinary('wsl-helper')],
+  'wsl-helper-linux': [paths.resources, 'linux', 'wsl-helper'],
+};
+
+function platformBinary(name: string): string {
+  return process.platform === 'win32' ? `${ name }.exe` : name;
+}
+
+/**
  * Gets the absolute path to an executable. Adds ".exe" to the end
  * if running on Windows.
  * @param name The name of the binary, without file extension.
  */
-function _executable(name: string) {
-  const osSpecificName = os.platform().startsWith('win') ? `${ name }.exe` : name;
+function _executable(name: keyof typeof executableMap): string {
+  const parts = executableMap[name];
 
-  return path.join(paths.resources, os.platform(), 'bin', osSpecificName);
+  if (parts === undefined) {
+    return path.join(paths.resources, process.platform, 'bin', platformBinary(name));
+  }
+
+  return path.join(...parts);
 }
 export const executable = memoize(_executable);
 

--- a/pkg/rancher-desktop/utils/wslVersion.ts
+++ b/pkg/rancher-desktop/utils/wslVersion.ts
@@ -3,11 +3,9 @@
  * version.
  */
 
-import path from 'path';
-
 import { spawnFile } from '@pkg/utils/childProcess';
 import logging from '@pkg/utils/logging';
-import paths from '@pkg/utils/paths';
+import { executable } from '@pkg/utils/resources';
 
 type WSLVersionInfo = {
     installed: boolean;
@@ -28,8 +26,8 @@ const console = logging['wsl-version'];
  * Get information about the currently installed WSL version.
  */
 export default async function getWSLVersion(): Promise<WSLVersionInfo> {
-  const wslHelper = path.join(paths.resources, 'win32', 'wsl-helper.exe');
-  const { stdout } = await spawnFile(wslHelper, ['wsl', 'info'], { stdio: ['ignore', 'pipe', console] });
+  const { stdout } = await spawnFile(executable('wsl-helper'),
+    ['wsl', 'info'], { stdio: ['ignore', 'pipe', console] });
 
   return JSON.parse(stdout);
 }

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -269,7 +269,8 @@ export default {
      * @param platform The platform to build for.
      */
     const buildPlatform = async(platform: 'linux' | 'win32') => {
-      const exeName = platform === 'win32' ? 'wsl-helper.exe' : 'wsl-helper';
+      const exeRoot = 'wsl-helper-1.11.1';
+      const exeName = `${ exeRoot }${ platform === 'win32' ? '.exe' : '' }`;
       const outFile = path.join(this.rootDir, 'resources', platform, exeName);
 
       await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', outFile, '.', {

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -64,7 +64,7 @@ export async function sign(workDir: string) {
   const binDir = path.join(resourcesRootDir, 'bin');
   const whiteList: Record<string, Array<string>> = {
     '.':                ['Rancher Desktop.exe'],
-    [resourcesRootDir]: ['wsl-helper.exe'],
+    [resourcesRootDir]: ['wsl-helper-1.11.1.exe'],
     [internalDir]:      ['host-resolver.exe', 'host-switch.exe', 'privileged-service.exe', 'steve.exe', 'vtunnel.exe'],
     [binDir]:           ['docker.exe', 'docker-credential-none.exe', 'nerdctl.exe', 'rdctl.exe'],
   };


### PR DESCRIPTION
We have issues with wsl-helper (the Linux executable) not being stopped correctly on uninstall; this means that when the new executable runs on an upgrade/downgrade, we get confusing errors (segfaults and sigill).  Avoid this temporarily by renaming the executable until we have a more permanent fix.

It's recommended to review this commit-at-a-time; when we change the name again we only need to look at the second one.