### PR TITLE
Stop ignoring snapshot-create errors.

### DIFF
--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -76,13 +76,13 @@ local_setup() {
     for action in restore delete; do
         run rdctl snapshot "$action" 'the-nomadic-pond'
         assert_failure
-        assert_output "Error: can't find snapshot \"the-nomadic-pond\""
+        assert_output --partial "Error: failed to $action snapshot \"the-nomadic-pond\": can't find snapshot \"the-nomadic-pond\""
 
         run rdctl snapshot "$action" 'the-nomadic-pond' --json
         assert_failure
         run jq_output '.error'
         assert_success
-        assert_output "can't find snapshot \"the-nomadic-pond\""
+        assert_output "failed to $action snapshot \"the-nomadic-pond\": can't find snapshot \"the-nomadic-pond\""
     done
 }
 
@@ -95,7 +95,7 @@ local_setup() {
     assert_failure
     run jq_output '.error'
     assert_success
-    assert_output "invalid name \"$SNAPSHOT\": name already exists"
+    assert_output "name \"$SNAPSHOT\" already exists"
     assert_exists "$PATH_CONFIG_FILE"
 }
 

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -41,7 +41,7 @@ func createSnapshot(args []string) error {
 	}
 	// Report on invalid names before locking and shutting down the backend
 	if err := manager.ValidateName(name); err != nil {
-		return nil
+		return err
 	}
 
 	// Ideally we would not use the deprecated syscall package,

--- a/src/go/rdctl/cmd/snapshotDelete.go
+++ b/src/go/rdctl/cmd/snapshotDelete.go
@@ -29,7 +29,7 @@ func deleteSnapshot(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
 	if err = manager.Delete(args[0]); err != nil {
-		return fmt.Errorf("failed to delete snapshot: %w", err)
+		return fmt.Errorf("failed to delete snapshot %q: %w", args[0], err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #6088

And get the snapshot bats tests passing again.