### PR TITLE
Mac signing follow-up

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -14,19 +14,10 @@ entitlements:
     - '' # This is the main application
     entitlements:
     - com.apple.security.cs.allow-jit
-    - com.apple.security.network.server
-    - com.apple.security.network.client
-  - paths:
-    - Contents/Resources/resources/darwin/lima/bin/limactl
-    entitlements:
-    - com.apple.security.network.server
-    - com.apple.security.network.client
   - paths:
     - Contents/Resources/resources/darwin/lima/bin/limactl.ventura
     entitlements:
     - com.apple.security.virtualization
-    - com.apple.security.network.server
-    - com.apple.security.network.client
   - paths:
     - Contents/Resources/resources/darwin/lima/bin/qemu-system-aarch64
     - Contents/Resources/resources/darwin/lima/bin/qemu-system-x86_64

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,7 +24,7 @@ mac:
   identity: ~ # We sign in a separate step
   extraFiles:
   - build/signing-config-mac.yaml
-  - electron-builder.yml
+  - { from: dist/electron-builder.yaml, to: electron-builder.yml }
 win:
   target: [ zip ]
   signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -44,7 +44,7 @@ interface ElectronBuilderConfiguration {
   }
 }
 
-export async function sign(workDir: string) {
+export async function sign(workDir: string): Promise<string> {
   const certFingerprint = process.env.CSC_FINGERPRINT ?? '';
   const certPassword = process.env.CSC_KEY_PASSWORD ?? '';
 
@@ -97,7 +97,8 @@ export async function sign(workDir: string) {
   }
 
   await signFn(...filesToSign);
-  await buildWiX(workDir, unpackedDir, signFn);
+
+  return await buildWiX(workDir, unpackedDir, signFn);
 }
 
 /**
@@ -158,9 +159,11 @@ async function *findFiles(dir: string): AsyncIterable<string> {
   }
 }
 
-async function buildWiX(workDir: string, unpackedDir: string, signFn: signFileFn) {
+async function buildWiX(workDir: string, unpackedDir: string, signFn: signFileFn): Promise<string> {
   const buildInstaller = (await import('./installer-win32')).default;
   const installerPath = await buildInstaller(workDir, unpackedDir);
 
   await signFn(installerPath);
+
+  return installerPath;
 }


### PR DESCRIPTION
This is the follow-up to #6019 to close #6071.

- Drop unused entitlements.
- Sign the disk image.
- Fix disk image name.
- Generate sha512sum during signing.
