### PR TITLE
Make truncation in `rdctl` utf8-aware

### DIFF
--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -83,23 +83,29 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 	fmt.Fprintf(writer, "NAME\tCREATED\tDESCRIPTION\n")
 	for _, aSnapshot := range snapshots {
 		prettyCreated := aSnapshot.Created.Format(time.RFC1123)
-		desc := aSnapshot.Description
-		idx := strings.Index(desc, "\n")
-		if idx >= 0 {
-			// If the description starts with a newline, it will appear empty in this view.
-			// Use the json view to get the full description
-			desc = desc[0:idx]
-		}
-		if len(desc) > 63 {
-			desc = desc[0:60] + "..."
-		} else if idx >= 0 {
-			// The string was truncated because of a newline, so add an ellipsis to show that
-			// Do this even if the newline was the last character - we've still truncated *something*.
-			desc += "..."
-		}
-
+		desc := truncate(aSnapshot.Description, 63)
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, prettyCreated, desc)
 	}
 	writer.Flush()
 	return nil
+}
+
+// Truncates a string to either the first newline or a maximum number of
+// runes. Also removes leading and trailing whitespace.
+func truncate(input string, maxRunes int) string {
+	var truncated bool
+	input = strings.TrimSpace(input)
+	if newlineIndex := strings.Index(input, "\n"); newlineIndex >= 0 {
+		input = input[:newlineIndex]
+		truncated = true
+	}
+	runeInput := []rune(input)
+	if len(runeInput) > maxRunes-1 {
+		runeInput = runeInput[0 : maxRunes-1]
+		truncated = true
+	}
+	if truncated {
+		return string(runeInput) + "…"
+	}
+	return string(runeInput)
 }

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -83,7 +83,7 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 	fmt.Fprintf(writer, "NAME\tCREATED\tDESCRIPTION\n")
 	for _, aSnapshot := range snapshots {
 		prettyCreated := aSnapshot.Created.Format(time.RFC1123)
-		desc := truncate(aSnapshot.Description, 63)
+		desc := truncateAtNewlineOrMaxRunes(aSnapshot.Description, 63)
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, prettyCreated, desc)
 	}
 	writer.Flush()
@@ -92,8 +92,8 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 
 // Truncates a string to either the first newline or a maximum number of
 // runes. Also removes leading and trailing whitespace.
-func truncate(input string, maxRunes int) string {
-	var truncated bool
+func truncateAtNewlineOrMaxRunes(input string, maxRunes int) string {
+	truncated := false
 	input = strings.TrimSpace(input)
 	if newlineIndex := strings.Index(input, "\n"); newlineIndex >= 0 {
 		input = input[:newlineIndex]
@@ -101,7 +101,7 @@ func truncate(input string, maxRunes int) string {
 	}
 	runeInput := []rune(input)
 	if len(runeInput) > maxRunes-1 {
-		runeInput = runeInput[0 : maxRunes-1]
+		runeInput = runeInput[:maxRunes-1]
 		truncated = true
 	}
 	if truncated {

--- a/src/go/rdctl/cmd/snapshotList_test.go
+++ b/src/go/rdctl/cmd/snapshotList_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestTruncate(t *testing.T) {
+func TestTruncateToNewlineOrMaxRunes(t *testing.T) {
 	testCases := []struct {
 		Input     string
 		MaxLength int
@@ -52,7 +52,7 @@ func TestTruncate(t *testing.T) {
 	for _, testCase := range testCases {
 		description := fmt.Sprintf("truncate case %+v", testCase)
 		t.Run(description, func(t *testing.T) {
-			result := truncate(testCase.Input, testCase.MaxLength)
+			result := truncateAtNewlineOrMaxRunes(testCase.Input, testCase.MaxLength)
 			assert.Equal(t, testCase.Expected, result)
 		})
 	}

--- a/src/go/rdctl/cmd/snapshotList_test.go
+++ b/src/go/rdctl/cmd/snapshotList_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	testCases := []struct {
+		Input     string
+		MaxLength int
+		Expected  string
+	}{
+		{
+			Input:     "this string 🔥✨🎉 is 40 bytes\nlong",
+			MaxLength: 14,
+			Expected:  "this string 🔥…",
+		},
+		{
+			Input:     "this string 🔥✨🎉 is 40 bytes\nlong",
+			MaxLength: 15,
+			Expected:  "this string 🔥✨…",
+		},
+		{
+			Input:     "this string 🔥✨🎉 is 40 bytes\nlong",
+			MaxLength: 22,
+			Expected:  "this string 🔥✨🎉 is 40…",
+		},
+		{
+			Input:     "this string 🔥✨🎉 is 40 bytes\nlong",
+			MaxLength: 31,
+			Expected:  "this string 🔥✨🎉 is 40 bytes…",
+		},
+		{
+			Input:     "this string 🔥✨🎉 is 40 bytes\nlong",
+			MaxLength: 28,
+			Expected:  "this string 🔥✨🎉 is 40 bytes…",
+		},
+		{
+			Input:     "",
+			MaxLength: 15,
+			Expected:  "",
+		},
+		{
+			Input:     "\nthis is a test\n",
+			MaxLength: 20,
+			Expected:  "this is a test",
+		},
+	}
+
+	for _, testCase := range testCases {
+		description := fmt.Sprintf("truncate case %+v", testCase)
+		t.Run(description, func(t *testing.T) {
+			result := truncate(testCase.Input, testCase.MaxLength)
+			assert.Equal(t, testCase.Expected, result)
+		})
+	}
+}

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -60,8 +60,8 @@ func (manager *Manager) SnapshotDirectory(snapshot Snapshot) string {
 	return filepath.Join(manager.Paths.Snapshots, snapshot.ID)
 }
 
-// ValidateName checks that the passed name is a valid snapshot name
-// and that it is not used by an existing snapshot.
+// ValidateName checks that name is a valid snapshot name and that
+// it is not used by an existing snapshot.
 func (manager *Manager) ValidateName(name string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("snapshot name must not be the empty string")
@@ -233,10 +233,9 @@ func (manager *Manager) Restore(ctx context.Context, name string) (err error) {
 }
 
 func checkForInvalidCharacter(name string) error {
-	runeName := []rune(name)
-	for idx, r := range runeName {
-		if !unicode.IsPrint(r) {
-			return fmt.Errorf("invalid character %q at position %d in name: all characters must be printable or a space", r, idx)
+	for idx, c := range name {
+		if !unicode.IsPrint(c) {
+			return fmt.Errorf("invalid character %q at position %d in name: all characters must be printable or a space", c, idx)
 		}
 	}
 	return nil

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -60,29 +60,30 @@ func (manager *Manager) SnapshotDirectory(snapshot Snapshot) string {
 	return filepath.Join(manager.Paths.Snapshots, snapshot.ID)
 }
 
-// ValidateName - does syntactic validation on the name
+// ValidateName checks that the passed name is a valid snapshot name
+// and that it is not used by an existing snapshot.
 func (manager *Manager) ValidateName(name string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("snapshot name must not be the empty string")
 	}
-	reportedName := name
-	if len(reportedName) > nameDisplayCutoffSize {
-		reportedName = reportedName[0:nameDisplayCutoffSize] + "…"
-	}
-	if len(name) > maxNameLength {
-		return fmt.Errorf(`invalid name %q: max length is %d, %d were specified`, reportedName, maxNameLength, len(name))
+	runeName := []rune(name)
+	if len(runeName) > maxNameLength {
+		errMsgName := truncate(name, nameDisplayCutoffSize)
+		return fmt.Errorf(`invalid name %q: max length is %d, %d were specified`, errMsgName, maxNameLength, len(runeName))
 	}
 	if err := checkForInvalidCharacter(name); err != nil {
 		return err
 	}
 	if unicode.IsSpace(rune(name[0])) {
-		return fmt.Errorf(`invalid name %q: must not start with a white-space character`, reportedName)
+		errMsgName := truncate(name, nameDisplayCutoffSize)
+		return fmt.Errorf(`invalid name %q: must not start with a white-space character`, errMsgName)
 	}
-	if unicode.IsSpace(rune(name[len(name)-1])) {
-		if len(name) > nameDisplayCutoffSize {
-			reportedName = "…" + name[len(name)-nameDisplayCutoffSize:]
+	if unicode.IsSpace(runeName[len(runeName)-1]) {
+		errMsgName := name
+		if len(runeName) > nameDisplayCutoffSize {
+			errMsgName = "…" + string(runeName[len(runeName)-nameDisplayCutoffSize:])
 		}
-		return fmt.Errorf(`invalid name %q: must not end with a white-space character`, reportedName)
+		return fmt.Errorf(`invalid name %q: must not end with a white-space character`, errMsgName)
 	}
 	currentSnapshots, err := manager.List(false)
 	if err != nil {
@@ -90,7 +91,8 @@ func (manager *Manager) ValidateName(name string) error {
 	}
 	for _, currentSnapshot := range currentSnapshots {
 		if currentSnapshot.Name == name {
-			return fmt.Errorf("name %q already exists", name)
+			errMsgName := truncate(name, nameDisplayCutoffSize)
+			return fmt.Errorf("name %q already exists", errMsgName)
 		}
 	}
 	return nil
@@ -231,9 +233,10 @@ func (manager *Manager) Restore(ctx context.Context, name string) (err error) {
 }
 
 func checkForInvalidCharacter(name string) error {
-	for idx, c := range name {
-		if !unicode.IsPrint(c) {
-			return fmt.Errorf("invalid character value %d at position %d in name: all characters must be printable or a space", c, idx)
+	runeName := []rune(name)
+	for idx, r := range runeName {
+		if !unicode.IsPrint(r) {
+			return fmt.Errorf("invalid character %q at position %d in name: all characters must be printable or a space", r, idx)
 		}
 	}
 	return nil
@@ -246,4 +249,14 @@ func contextIsDone(ctx context.Context) bool {
 	default:
 		return false
 	}
+}
+
+// Does a utf8-aware truncation of input to maximum maxChars
+// unicode code points. Adds an ellipsis if truncation occurred.
+func truncate(input string, maxChars int) string {
+	runeInput := []rune(input)
+	if len(runeInput) > maxChars {
+		return string(runeInput[0:maxChars-1]) + "…"
+	}
+	return input
 }

--- a/src/go/rdctl/pkg/snapshot/manager_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -123,22 +124,9 @@ func TestManager(t *testing.T) {
 			// check that we are truncating the name properly in the error message
 			if len(testCase.ExpectedErrMsgName) > 0 {
 				if !strings.Contains(err.Error(), testCase.ExpectedErrMsgName) {
-					t.Errorf("error %q does not contain name %q", err, testCase.ExpectedErrMsgName)
+					t.Errorf("error %q does not contain name %q", err, strconv.Quote(testCase.ExpectedErrMsgName))
 				}
 			}
-
-			// if err := manager.ValidateName(nameWithTab); err == nil {
-			// 	t.Error("name with tab is invalid but no error was returned")
-			// } else if !strings.Contains(err.Error(), "invalid character value 9 at position 16 in name: all characters must be printable or a space") {
-			// 	t.Errorf("failed to report unprintable character in name, got %s", err.Error())
-			// }
-			// longishNameEndingWithSpace := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
-			// endOfLongishString := longishNameEndingWithSpace[len(longishNameEndingWithSpace)-nameDisplayCutoffSize:]
-			// if err := manager.ValidateName(longishNameEndingWithSpace); err == nil {
-			// 	t.Error(" name ending with space not caught")
-			// } else if !strings.Contains(err.Error(), "…"+endOfLongishString) {
-			// 	t.Errorf("Longish invalid name not truncated as expected")
-			// }
 		})
 	}
 

--- a/src/go/rdctl/pkg/snapshot/manager_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_test.go
@@ -63,12 +63,12 @@ func TestManager(t *testing.T) {
 		{
 			Name:               " 12345678911234567892123456我喜欢鸡肉",
 			ExpectedError:      "must not start with a white-space character",
-			ExpectedErrMsgName: "12345678911234567892123456我喜…",
+			ExpectedErrMsgName: " 12345678911234567892123456我喜…",
 		},
 		{
 			Name:               `can't end with a "space" `,
 			ExpectedError:      "must not end with a white-space character",
-			ExpectedErrMsgName: `can't end with a \"space\" `,
+			ExpectedErrMsgName: `can't end with a "space" `,
 		},
 		{
 			Name:               `我喜欢鸡肉1234567891123456789212345 `,
@@ -123,7 +123,7 @@ func TestManager(t *testing.T) {
 			}
 			// check that we are truncating the name properly in the error message
 			if len(testCase.ExpectedErrMsgName) > 0 {
-				if !strings.Contains(err.Error(), testCase.ExpectedErrMsgName) {
+				if !strings.Contains(err.Error(), strconv.Quote(testCase.ExpectedErrMsgName)) {
 					t.Errorf("error %q does not contain name %q", err, strconv.Quote(testCase.ExpectedErrMsgName))
 				}
 			}

--- a/src/go/rdctl/pkg/snapshot/manager_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_test.go
@@ -42,55 +42,105 @@ func TestManager(t *testing.T) {
 		}
 	})
 
-	t.Run("ValidateName should disallow invalid names", func(t *testing.T) {
-		paths, _ := populateFiles(t, true)
-		manager := newTestManager(paths)
-		oversizeName :=
-			// 251 characters is too long (and the indentation here is what our linter demands)
-			"12345678911234567892123456789312345678941234567895123456789612345678971234567898" +
-				"12345678991234567890123456789112345678921234567893123456789412345678951234567896" +
-				"12345678971234567898123456789912345678901234567891123456789212345678931234567894" +
-				"12345678951"
-		nameWithTab := "can't contain a \t tab"
-		invalidNames := []string{
-			"", // empty string not allowed
-			" can't start with a space",
-			`can't end with a "space" `,
-			oversizeName,
-			nameWithTab,
-			"can't contain a \n newline",
-			"can't contain a \r carriage-return",
-			"can't contain a \x00 null-byte",
-			"can't contain a \x07 control character",
-		}
-		for _, invalidName := range invalidNames {
-			if err := manager.ValidateName(invalidName); err == nil {
-				t.Errorf("name %q is invalid but no error was returned", invalidName)
+	testCases := []struct {
+		Name          string
+		ExpectedError string
+		// When the name we are validating is above a certain length, it should
+		// be truncated to a certain length in the error message. Otherwise, it
+		// should be left as is.
+		ExpectedErrMsgName string
+	}{
+		{
+			Name:          "", // empty string not allowed
+			ExpectedError: "snapshot name must not be the empty string",
+		},
+		{
+			Name:               " can't start with a space",
+			ExpectedError:      "must not start with a white-space character",
+			ExpectedErrMsgName: " can't start with a space",
+		},
+		{
+			Name:               " 12345678911234567892123456我喜欢鸡肉",
+			ExpectedError:      "must not start with a white-space character",
+			ExpectedErrMsgName: "12345678911234567892123456我喜…",
+		},
+		{
+			Name:               `can't end with a "space" `,
+			ExpectedError:      "must not end with a white-space character",
+			ExpectedErrMsgName: `can't end with a \"space\" `,
+		},
+		{
+			Name:               `我喜欢鸡肉1234567891123456789212345 `,
+			ExpectedError:      "must not end with a white-space character",
+			ExpectedErrMsgName: `…喜欢鸡肉1234567891123456789212345 `,
+		},
+		{
+			Name:               "filename_too_long_workaround",
+			ExpectedError:      "max length is",
+			ExpectedErrMsgName: "12345678911234567892123456789…",
+		},
+		{
+			Name:          "can't contain a \t tab",
+			ExpectedError: `invalid character '\t' at position 16 in name: all characters must be printable or a space`,
+		},
+		{
+			Name:          "can't contain a \n newline",
+			ExpectedError: `invalid character '\n' at position 16 in name: all characters must be printable or a space`,
+		},
+		{
+			Name:          "can't contain a \r carriage-return",
+			ExpectedError: `invalid character '\r' at position 16 in name: all characters must be printable or a space`,
+		},
+		{
+			Name:          "can't contain a \x00 null-byte",
+			ExpectedError: `invalid character '\x00' at position 16 in name: all characters must be printable or a space`,
+		},
+		{
+			Name:          "can't contain a \a control character",
+			ExpectedError: `invalid character '\a' at position 16 in name: all characters must be printable or a space`,
+		},
+	}
+	for _, testCase := range testCases {
+		description := fmt.Sprintf("ValidateName should disallow invalid names (case %+v)", testCase)
+		t.Run(description, func(t *testing.T) {
+			paths, _ := populateFiles(t, true)
+			manager := newTestManager(paths)
+			// The test case name is used in the name of a file inside the temporary
+			// directory, which means it is limited in length. Work around this.
+			if testCase.Name == "filename_too_long_workaround" {
+				// 251 characters is too long (and the indentation here is what our linter demands)
+				testCase.Name = "12345678911234567892123456789312345678941234567895123456789612345678971234567898" +
+					"12345678991234567890123456789112345678921234567893123456789412345678951234567896" +
+					"12345678971234567898123456789912345678901234567891123456789212345678931234567894" +
+					"12345678951"
 			}
-		}
-		// The above loop verifies that each invalid name is found invalid.
-		// The following code verifies that we get the actual
-		err := manager.ValidateName(oversizeName)
-		if err == nil {
-			t.Error("oversize name is invalid but no error was returned")
-		} else if !strings.Contains(err.Error(), "…") {
-			t.Errorf("No ellipsis in reported name")
-		}
-		err = manager.ValidateName(nameWithTab)
-		if err == nil {
-			t.Error("name with tab is invalid but no error was returned")
-		} else if !strings.Contains(err.Error(), "invalid character value 9 at position 16 in name: all characters must be printable or a space") {
-			t.Errorf("failed to report unprintable character in name, got %s", err.Error())
-		}
-		longishNameEndingWithSpace := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
-		endOfLongishString := longishNameEndingWithSpace[len(longishNameEndingWithSpace)-nameDisplayCutoffSize:]
-		err = manager.ValidateName(longishNameEndingWithSpace)
-		if err == nil {
-			t.Error(" name ending with space not caught")
-		} else if !strings.Contains(err.Error(), "…"+endOfLongishString) {
-			t.Errorf("Longish invalid name not truncated as expected")
-		}
-	})
+			err := manager.ValidateName(testCase.Name)
+			if err == nil {
+				t.Errorf("expected error but got err == nil")
+			} else if !strings.Contains(err.Error(), testCase.ExpectedError) {
+				t.Errorf("unexpected error %q", err)
+			}
+			// check that we are truncating the name properly in the error message
+			if len(testCase.ExpectedErrMsgName) > 0 {
+				if !strings.Contains(err.Error(), testCase.ExpectedErrMsgName) {
+					t.Errorf("error %q does not contain name %q", err, testCase.ExpectedErrMsgName)
+				}
+			}
+
+			// if err := manager.ValidateName(nameWithTab); err == nil {
+			// 	t.Error("name with tab is invalid but no error was returned")
+			// } else if !strings.Contains(err.Error(), "invalid character value 9 at position 16 in name: all characters must be printable or a space") {
+			// 	t.Errorf("failed to report unprintable character in name, got %s", err.Error())
+			// }
+			// longishNameEndingWithSpace := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
+			// endOfLongishString := longishNameEndingWithSpace[len(longishNameEndingWithSpace)-nameDisplayCutoffSize:]
+			// if err := manager.ValidateName(longishNameEndingWithSpace); err == nil {
+			// 	t.Error(" name ending with space not caught")
+			// } else if !strings.Contains(err.Error(), "…"+endOfLongishString) {
+			// 	t.Errorf("Longish invalid name not truncated as expected")
+			// }
+		})
+	}
 
 	t.Run("Should create these valid names", func(t *testing.T) {
 		paths, _ := populateFiles(t, true)
@@ -103,6 +153,7 @@ func TestManager(t *testing.T) {
 				"12345678971234567898123456789912345678901234567891123456789212345678931234567894" +
 				"1234567895",
 			"french student: élève",
+			"我喜欢鸡肉",
 		}
 		for _, validName := range validNames {
 			if err := manager.ValidateName(validName); err != nil {


### PR DESCRIPTION
Closes #5803.

I did my best to find all of the places where we don't do utf8-aware truncation, but I could easily have missed some - let me know if you are aware of any others!