### PR TITLE
Also mount /private/var/folders and /private/tmp into the VM

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -620,7 +620,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     const extraDirs = [paths.cache, paths.logs, paths.resources];
 
     if (os.platform() === 'darwin') {
-      locations.push('/Volumes', '/var/folders');
+      // /var and /tmp are symlinks to /private/var and /private/tmp
+      locations.push('/Volumes', '/var/folders', '/private/tmp', '/private/var/folders');
     }
     for (const extraDir of extraDirs) {
       const found = locations.some((loc) => {


### PR DESCRIPTION
On macOS `/var` and `/tmp` are just symlinks to `/private/var` and `/private/tmp`. Mounting the symlink endpoints into the VM makes sure things work even if the user resolves the symlinks first on the host.

Fixes #6070