### PR TITLE
Windows: Terminate docker socket proxy correctly

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -484,6 +484,13 @@ Electron.app.on('before-quit', async(event) => {
 
   try {
     await k8smanager?.stop();
+    try {
+      await mainEvents.invoke('shutdown-integrations');
+    } catch (ex) {
+      if (!`${ ex }`.includes('No handlers registered')) {
+        throw ex;
+      }
+    }
 
     console.log(`2: Child exited cleanly.`);
   } catch (ex: any) {

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -308,7 +308,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
               );
             },
             destroy: async(child) => {
-              child.kill('SIGTERM');
+              child?.kill('SIGTERM');
               // Ensure we kill the WSL-side process; sometimes things can get out
               // of sync.
               await this.execCommand({ distro, root: true },

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -107,6 +107,12 @@ interface MainEventNames {
   'extensions/ui/uninstall'(id: string): void;
 
   /**
+   * Emitted on application quit, used to shut down any integrations.  This
+   * requires feedback from the handler to know when all tasks are complete.
+   */
+  'shutdown-integrations'(): Promise<void>;
+
+  /**
    * Emitted on application quit.  Note that at this point we're committed to
    * quitting.
    */
@@ -155,7 +161,7 @@ type HandlerParams<eventName extends keyof MainEventNames> =
  */
 type HandlerReturn<eventName extends keyof MainEventNames> =
   IsHandler<eventName> extends true
-  ? ReturnType<MainEventNames[eventName]>
+  ? Awaited<ReturnType<MainEventNames[eventName]>>
   : never;
 
 /**

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -114,12 +114,12 @@ func readKubeConfig(configPath string) (kubeConfig, error) {
 	var config kubeConfig
 	configFile, err := os.Open(configPath)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("could not open kubeconfig file %s: %w", configPath, err)
 	}
 	defer configFile.Close()
 	err = yaml.NewDecoder(configFile).Decode(&config)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("could not read kubeconfig %s: %w", configPath, err)
 	}
 
 	return config, nil

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -57,14 +57,11 @@ func KillOthers(args ...string) error {
 			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read command line")
 			continue
 		}
-		// Drop any --verbose command line flags; the process may have it set if
-		// debug mode is on, which the caller wouldn't expect.
-		procCmd = bytes.ReplaceAll(procCmd, []byte("\x00--verbose\x00"), []byte{0})
 		procArgs := bytes.SplitN(procCmd, []byte{0}, 2)
 		if len(procArgs) < 2 {
 			logrus.WithField("pid", proc.Name()).Trace("pid has no args")
 			continue
-		} else if !bytes.Equal(argsBytes, procArgs[1]) {
+		} else if !bytes.HasPrefix(procArgs[1], argsBytes) {
 			// pid args are not the expected args
 			logrus.WithFields(logrus.Fields{
 				"pid":           proc.Name(),

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -2,8 +2,8 @@ package process
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -38,7 +38,9 @@ func KillOthers(args ...string) error {
 		procFile, err := os.Readlink(path.Join("/proc", proc.Name(), "exe"))
 		if err != nil {
 			// pid died, or we don't have permissions, or it's not a pid.
-			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read exe")
+			if !errors.Is(err, os.ErrNotExist) {
+				logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read exe")
+			}
 			continue
 		}
 		if selfFile != procFile {
@@ -49,7 +51,7 @@ func KillOthers(args ...string) error {
 			}).Trace("pid has different executable")
 			continue
 		}
-		procCmd, err := ioutil.ReadFile(path.Join("/proc", proc.Name(), "cmdline"))
+		procCmd, err := os.ReadFile(path.Join("/proc", proc.Name(), "cmdline"))
 		if err != nil {
 			// pid died, or we don't have permissions, or it's not a pid.
 			logrus.WithError(err).WithField("pid", proc.Name()).Debug("could not read command line")
@@ -62,7 +64,7 @@ func KillOthers(args ...string) error {
 		if len(procArgs) < 2 {
 			logrus.WithField("pid", proc.Name()).Trace("pid has no args")
 			continue
-		} else if bytes.Compare(argsBytes, procArgs[1]) != 0 {
+		} else if !bytes.Equal(argsBytes, procArgs[1]) {
 			// pid args are not the expected args
 			logrus.WithFields(logrus.Fields{
 				"pid":           proc.Name(),


### PR DESCRIPTION
This tries harder to shut down the wsl-helper docker socket proxy process (found in foreign WSL distros).  In particular, dd0b39efe1e81881a6d128bdb1d93feee5152430 ensures that we manually kill everything on shutdown.

Fixes #6083

The scenario that I could reproduce most reliably was:
- Start Rancher Desktop
- Once the docker socket proxy process starts, but _before_ the whole app startup has finished, quit Rancher Desktop.