### PR TITLE
Win32: Trivial installer fixes

### DIFF
--- a/src/go/wsl-helper/wix/check_windows.go
+++ b/src/go/wsl-helper/wix/check_windows.go
@@ -30,7 +30,6 @@ const (
 // IsWSLInstalledImpl checks if WSL is installed; it outputs results by setting
 // the `WSLINSTALLED` Windows Installer property.
 func IsWSLInstalledImpl(hInstall MSIHANDLE) uint32 {
-	defer msiCloseHandle.Call(uintptr(hInstall))
 	ctx := context.Background()
 
 	writer := &msiWriter{hInstall: hInstall}

--- a/src/go/wsl-helper/wix/helpers_windows.go
+++ b/src/go/wsl-helper/wix/helpers_windows.go
@@ -57,7 +57,7 @@ func (w *msiWriter) Write(message []byte) (int, error) {
 	// We always set up a record where *0 is just "[1]" to avoid issues if
 	// the message contains formatting; this is analogous to calling
 	// `Sprintf("%s", ...)``
-	data := []string{"1", strings.TrimRight(string(message), "\r\n")}
+	data := []string{"[1]", strings.TrimRight(string(message), "\r\n")}
 	err := submitMessage(w.hInstall, INSTALLMESSAGE_INFO, data)
 	if err != nil {
 		return 0, err

--- a/src/go/wsl-helper/wix/install_windows.go
+++ b/src/go/wsl-helper/wix/install_windows.go
@@ -26,7 +26,6 @@ import (
 // InstallWindowsFeatureImpl installs the Windows features necessary for WSL to
 // be installed.  This needs to be run elevated.
 func InstallWindowsFeatureImpl(hInstall MSIHANDLE) uint32 {
-	defer msiCloseHandle.Call(uintptr(hInstall))
 	ctx := context.Background()
 
 	writer := &msiWriter{hInstall: hInstall}
@@ -53,7 +52,6 @@ func InstallWindowsFeatureImpl(hInstall MSIHANDLE) uint32 {
 // This assumes WSL was not previously installed.
 // This needs to be run as the user.
 func InstallWSLImpl(hInstall MSIHANDLE) uint32 {
-	defer msiCloseHandle.Call(uintptr(hInstall))
 	ctx := context.Background()
 
 	writer := &msiWriter{hInstall: hInstall}


### PR DESCRIPTION
- Revert a325314308b91555c270162478dac93c5e24ce09 because the Windows Installer logs complain about us closing the handles that got passed in.
- Fix logging issue introduced in cb2e4f71a5f899b9168ea1403e906b9c78670c19