### PR TITLE
GitHub Actions: Always run `setup-go` before `yarn install`

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -32,6 +32,10 @@ jobs:
         with:
           node-version: '18.16.x'
           cache: yarn
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '^1.21'
+          cache-dependency-path: src/go/**/go.sum
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -36,6 +36,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '^1.21'
+          cache-dependency-path: src/go/**/go.sum
+
       - run: pip install setuptools
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -91,6 +91,10 @@ jobs:
       with:
         node-version: '18.16.x'
         cache: yarn
+    - uses: actions/setup-go@v4
+      with:
+        go-version: '^1.21'
+        cache-dependency-path: src/go/**/go.sum
     - run: yarn install --frozen-lockfile
     - name: Download installer (exe)
       id: exe


### PR DESCRIPTION
Currently, `yarn install` always builds some golang executables; this means we need to run `setup-go` beforehand to ensure that we have a valid version of the go toolchain installed.