### PR TITLE
Avoid infinite loops at startup when there are problems connecting to the VM or k3s server

### DIFF
--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -818,6 +818,11 @@ export default class K3sHelper extends events.EventEmitter {
         host = await getHost();
 
         if (typeof host === 'undefined') {
+          if (new Date().valueOf() > timeout) {
+            console.log(`timed out after ${ Math.round(timeout / 60_000) } minutes trying to get an IP address for the VM`);
+
+            return;
+          }
           await util.promisify(setTimeout)(500);
           continue;
         }

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -20,7 +20,6 @@ import * as K8s from '@pkg/backend/k8s';
 import { KubeClient } from '@pkg/backend/kube/client';
 import { loadFromString, exportConfig } from '@pkg/backend/kubeconfig';
 import { checkConnectivity } from '@pkg/main/networking';
-import { isUnixError } from '@pkg/typings/unix.interface';
 import DownloadProgressListener from '@pkg/utils/DownloadProgressListener';
 import * as childProcess from '@pkg/utils/childProcess';
 import fetch from '@pkg/utils/fetch';
@@ -812,6 +811,8 @@ export default class K3sHelper extends events.EventEmitter {
     let host: string | undefined;
 
     console.log(`Waiting for K3s server to be ready on port ${ port }...`);
+    const timeout = (new Date().valueOf()) + 300 * 1_000;
+
     while (true) {
       try {
         host = await getHost();
@@ -853,8 +854,8 @@ export default class K3sHelper extends events.EventEmitter {
           socket.on('error', reject);
         });
         break;
-      } catch (error) {
-        if (!isUnixError(error)) {
+      } catch (error: any) {
+        if (!error.code) {
           console.error(error);
 
           return;
@@ -868,6 +869,11 @@ export default class K3sHelper extends events.EventEmitter {
         default:
           // Unrecognized error; log but continue waiting.
           console.error(error);
+        }
+        if (new Date().valueOf() > timeout) {
+          console.log(`failed to connect: ${ error }`);
+
+          return;
         }
         await util.promisify(setTimeout)(1_000);
       }
@@ -1075,41 +1081,50 @@ export default class K3sHelper extends events.EventEmitter {
    */
   async getCompatibleKubectlVersion(version: semver.SemVer): Promise<void> {
     const commandArgs = ['--context', 'rancher-desktop', 'cluster-info'];
+    const numAttempts = 10;
 
-    try {
-      const { stdout, stderr } = await childProcess.spawnFile(executable('kubectl'),
-        commandArgs,
-        { stdio: ['ignore', 'pipe', 'pipe'] });
+    for (let i = 0; i < numAttempts; i++) {
+      try {
+        const { stdout, stderr } = await childProcess.spawnFile(executable('kubectl'),
+          commandArgs,
+          { stdio: ['ignore', 'pipe', 'pipe'] });
 
-      if (stdout) {
-        console.info(stdout);
-      }
-      if (stderr) {
-        console.log(stderr);
-      }
-    } catch (ex: any) {
-      console.error(`Error priming kuberlr: ${ ex }`);
-      console.log(`Output from kuberlr:\nex.stdout: [${ ex.stdout ?? 'none' }],\nex.stderr: [${ ex.stderr ?? 'none' }]`);
-      const pattern = /Right kubectl missing, downloading.+Error while trying to get contents of .+\/kubernetes-release/s;
+        if (stdout) {
+          console.info(stdout);
+        }
+        if (stderr) {
+          console.log(stderr);
+        }
+        break;
+      } catch (ex: any) {
+        if (i < numAttempts - 1) {
+          console.log(`Error trying to run kubectl --context rancher-desktop cluster-info: ${ ex }, attempt ${ i + 1 }, wait 1 sec and retry`);
+          await this.delayForWaitLimiting();
+          continue;
+        }
+        console.error(`Error priming kuberlr: ${ ex }`);
+        console.log(`Output from kuberlr:\nex.stdout: [${ ex.stdout ?? 'none' }],\nex.stderr: [${ ex.stderr ?? 'none' }]`);
+        const pattern = /Right kubectl missing, downloading.+Error while trying to get contents of .+\/kubernetes-release/s;
 
-      if (pattern.test(ex.stderr)) {
-        const major = version.major;
-        const minor = version.minor;
-        const lowMinor = minor === 0 ? 0 : minor - 1;
-        const highMinor = minor + 1;
-        const homeDirName = os.platform().startsWith('win') ? (findHomeDir() ?? '%HOME%') : '~';
-        const kuberlrCacheDirName = `${ os.platform() }-${ process.env.M1 ? 'arm64' : 'amd64' }`;
-        const options: Electron.MessageBoxOptions = {
-          message: "Can't download a compatible version of kubectl in offline-mode",
-          detail:  `Please acquire a version in the range ${ major }.${ lowMinor } - ${ major }.${ highMinor } and install in '${ path.join(homeDirName, '.kuberlr', kuberlrCacheDirName) }'`,
-          type:    'error',
-          buttons: ['OK'],
-          title:   'Network failure',
-        };
+        if (pattern.test(ex.stderr)) {
+          const major = version.major;
+          const minor = version.minor;
+          const lowMinor = minor === 0 ? 0 : minor - 1;
+          const highMinor = minor + 1;
+          const homeDirName = os.platform().startsWith('win') ? (findHomeDir() ?? '%HOME%') : '~';
+          const kuberlrCacheDirName = `${ os.platform() }-${ process.env.M1 ? 'arm64' : 'amd64' }`;
+          const options: Electron.MessageBoxOptions = {
+            message: "Can't download a compatible version of kubectl in offline-mode",
+            detail:  `Please acquire a version in the range ${ major }.${ lowMinor } - ${ major }.${ highMinor } and install in '${ path.join(homeDirName, '.kuberlr', kuberlrCacheDirName) }'`,
+            type:    'error',
+            buttons: ['OK'],
+            title:   'Network failure',
+          };
 
-        await showMessageBox(options, true);
-      } else {
-        console.log('Failed to match a kuberlr network access issue.');
+          await showMessageBox(options, true);
+        } else {
+          console.log('Failed to match a kuberlr network access issue.');
+        }
       }
     }
   }


### PR DESCRIPTION
I still think this is needed.  It comes from issue #5509, but actually has nothing to do with downgrading k8s.