### PR TITLE
Add --description-from-stdin and --description-from-file to `rdctl snapshot create`.

### DIFF
--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -100,18 +100,9 @@ local_setup() {
 }
 
 @test 'rejects attempts to create a snapshot with different description sources' {
-    run rdctl snapshot create --description abc --description-from-stdin my-happy-snapshot-1
+    run rdctl snapshot create --description abc --description-from my-sad-file my-happy-snapshot-2
     assert_failure
-    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
-
-    run rdctl snapshot create --description abc --description-from-file my-sad-file my-happy-snapshot-2
-    assert_failure
-    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
-
-    run rdctl snapshot create --description-from-stdin --description-from-file my-shredded-file my-happy-snapshot-3
-    assert_failure
-    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
-
+    assert_output --partial "Error: can't specify more than one option from \"--description\" and \"--description-from\""
 }
 
 @test 'can create a snapshot where proposed name is a current ID' {

--- a/bats/tests/snapshots/create-use-snapshot.bats
+++ b/bats/tests/snapshots/create-use-snapshot.bats
@@ -99,6 +99,21 @@ local_setup() {
     assert_exists "$PATH_CONFIG_FILE"
 }
 
+@test 'rejects attempts to create a snapshot with different description sources' {
+    run rdctl snapshot create --description abc --description-from-stdin my-happy-snapshot-1
+    assert_failure
+    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
+
+    run rdctl snapshot create --description abc --description-from-file my-sad-file my-happy-snapshot-2
+    assert_failure
+    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
+
+    run rdctl snapshot create --description-from-stdin --description-from-file my-shredded-file my-happy-snapshot-3
+    assert_failure
+    assert_output --partial "Error: can't specify more than one option from \"--description\", \"--description-from-file\" \"--description-from-stdin\""
+
+}
+
 @test 'can create a snapshot where proposed name is a current ID' {
     run ls -1 "$PATH_SNAPSHOTS"
     assert_success

--- a/bats/tests/snapshots/test-snapshot-list.bats
+++ b/bats/tests/snapshots/test-snapshot-list.bats
@@ -5,10 +5,10 @@ local_setup() {
     NON_ALNUM_SNAPSHOT_NAME='@#$%'
     MULTI_WORD_SNAPSHOT_NAME='=with '\''single'\'' and "double" quotes, /slashes/, and \backslashes\.'
     EMOJI_SNAPSHOT_NAME="emoji's 😍 are cool"
-    NON_ALNUM_DESC='description for non-alnum-snapshot-name'
-    MULTI_WORD_DESC='description for multi-word-snapshot-name'
-    EMOJI_DESC='description for emoji-snapshot-name'
-    TEMP=/tmp
+    NON_ALNUM_DESCRIPTION='description for non-alnum-snapshot-name'
+    MULTI_WORD_DESCRIPTION='description for multi-word-snapshot-name'
+    EMOJI_DESCRIPTION='description for emoji-snapshot-name'
+    TEMP=$BATS_FILE_TMPDIR
     if is_windows; then
         TEMP="$(wslpath_from_win32_env TEMP)"
     fi
@@ -43,15 +43,15 @@ local_setup() {
     # Sleep 5 seconds after creating each snapshot so later we can verify
     # that the differences in each snapshot's creation time makes sense.
 
-    rdctl snapshot create --description-from-stdin "$NON_ALNUM_SNAPSHOT_NAME" <<<"$NON_ALNUM_DESC"
+    rdctl snapshot create --description-from - "$NON_ALNUM_SNAPSHOT_NAME" <<<"$NON_ALNUM_DESCRIPTION"
     sleep 5
 
-    rdctl snapshot create --description-from-file - "$MULTI_WORD_SNAPSHOT_NAME" <<<"$MULTI_WORD_DESC"
+    rdctl snapshot create --description-from - "$MULTI_WORD_SNAPSHOT_NAME" <<<"$MULTI_WORD_DESCRIPTION"
     sleep 5
 
-    DESC_FILE="$TEMP/emoji-ss-desc.txt"
-    echo "$EMOJI_DESC" >"$DESC_FILE"
-    rdctl snapshot create --description-from-file "$DESC_FILE" "$EMOJI_SNAPSHOT_NAME"
+    DESC_FILE="$TEMP/emoji-snapshot-description.txt"
+    echo "$EMOJI_DESCRIPTION" >"$DESC_FILE"
+    rdctl snapshot create --description-from "$DESC_FILE" "$EMOJI_SNAPSHOT_NAME"
 }
 
 created() {
@@ -77,15 +77,14 @@ created() {
     # so a difference of 4.9999 could show up as 4
     ((TIME2 - TIME1 > 4))
 
-    rdctl snapshot list 1>&3
     run rdctl snapshot list
     assert_success
     assert_output --partial "$NON_ALNUM_SNAPSHOT_NAME"
     assert_output --partial "$MULTI_WORD_SNAPSHOT_NAME"
     assert_output --partial "$EMOJI_SNAPSHOT_NAME"
-    assert_output --partial "$NON_ALNUM_DESC"
-    assert_output --partial "$MULTI_WORD_DESC"
-    assert_output --partial "$EMOJI_DESC"
+    assert_output --partial "$NON_ALNUM_DESCRIPTION"
+    assert_output --partial "$MULTI_WORD_DESCRIPTION"
+    assert_output --partial "$EMOJI_DESCRIPTION"
 }
 
 @test 'verify k8s is off' {

--- a/bats/tests/snapshots/test-snapshot-list.bats
+++ b/bats/tests/snapshots/test-snapshot-list.bats
@@ -5,6 +5,13 @@ local_setup() {
     NON_ALNUM_SNAPSHOT_NAME='@#$%'
     MULTI_WORD_SNAPSHOT_NAME='=with '\''single'\'' and "double" quotes, /slashes/, and \backslashes\.'
     EMOJI_SNAPSHOT_NAME="emoji's 😍 are cool"
+    NON_ALNUM_DESC='description for non-alnum-snapshot-name'
+    MULTI_WORD_DESC='description for multi-word-snapshot-name'
+    EMOJI_DESC='description for emoji-snapshot-name'
+    TEMP=/tmp
+    if is_windows; then
+        TEMP="$(wslpath_from_win32_env TEMP)"
+    fi
 }
 
 @test 'factory reset and delete all the snapshots' {
@@ -36,13 +43,15 @@ local_setup() {
     # Sleep 5 seconds after creating each snapshot so later we can verify
     # that the differences in each snapshot's creation time makes sense.
 
-    rdctl snapshot create "$NON_ALNUM_SNAPSHOT_NAME"
+    rdctl snapshot create --description-from-stdin "$NON_ALNUM_SNAPSHOT_NAME" <<<"$NON_ALNUM_DESC"
     sleep 5
 
-    rdctl snapshot create "$MULTI_WORD_SNAPSHOT_NAME"
+    rdctl snapshot create --description-from-file - "$MULTI_WORD_SNAPSHOT_NAME" <<<"$MULTI_WORD_DESC"
     sleep 5
 
-    rdctl snapshot create "$EMOJI_SNAPSHOT_NAME"
+    DESC_FILE="$TEMP/emoji-ss-desc.txt"
+    echo "$EMOJI_DESC" >"$DESC_FILE"
+    rdctl snapshot create --description-from-file "$DESC_FILE" "$EMOJI_SNAPSHOT_NAME"
 }
 
 created() {
@@ -68,11 +77,15 @@ created() {
     # so a difference of 4.9999 could show up as 4
     ((TIME2 - TIME1 > 4))
 
+    rdctl snapshot list 1>&3
     run rdctl snapshot list
     assert_success
     assert_output --partial "$NON_ALNUM_SNAPSHOT_NAME"
     assert_output --partial "$MULTI_WORD_SNAPSHOT_NAME"
     assert_output --partial "$EMOJI_SNAPSHOT_NAME"
+    assert_output --partial "$NON_ALNUM_DESC"
+    assert_output --partial "$MULTI_WORD_DESC"
+    assert_output --partial "$EMOJI_DESC"
 }
 
 @test 'verify k8s is off' {

--- a/src/go/rdctl/cmd/snapshotCreate.go
+++ b/src/go/rdctl/cmd/snapshotCreate.go
@@ -18,35 +18,24 @@ import (
 )
 
 var snapshotDescription string
-var snapshotDescriptionFromFile string
-var snapshotDescriptionFromStdin bool
+var snapshotDescriptionFrom string
 
 var snapshotCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a snapshot",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		snapshotValueCount := 0
-		if snapshotDescription != "" {
-			snapshotValueCount += 1
-		}
-		if snapshotDescriptionFromFile != "" {
-			snapshotValueCount += 1
-		}
-		if snapshotDescriptionFromStdin {
-			snapshotValueCount += 1
-		}
-		if snapshotValueCount > 1 {
-			return fmt.Errorf(`can't specify more than one option from "--description", "--description-from-file" "--description-from-stdin"`)
+		if snapshotDescription != "" && snapshotDescriptionFrom != "" {
+			return fmt.Errorf(`can't specify more than one option from "--description" and "--description-from"`)
 		}
 		cmd.SilenceUsage = true
-		if snapshotDescriptionFromStdin || snapshotDescriptionFromFile != "" {
+		if snapshotDescriptionFrom != "" {
 			var bytes []byte
 			var err error
-			if snapshotDescriptionFromStdin || snapshotDescriptionFromFile == "-" {
+			if snapshotDescriptionFrom == "-" {
 				bytes, err = io.ReadAll(os.Stdin)
 			} else {
-				bytes, err = os.ReadFile(snapshotDescriptionFromFile)
+				bytes, err = os.ReadFile(snapshotDescriptionFrom)
 			}
 			if err != nil {
 				return err
@@ -61,8 +50,7 @@ func init() {
 	snapshotCmd.AddCommand(snapshotCreateCmd)
 	snapshotCreateCmd.Flags().BoolVar(&outputJsonFormat, "json", false, "output json format")
 	snapshotCreateCmd.Flags().StringVar(&snapshotDescription, "description", "", "snapshot description")
-	snapshotCreateCmd.Flags().StringVar(&snapshotDescriptionFromFile, "description-from-file", "", "snapshot description from a file (or - for stdin)")
-	snapshotCreateCmd.Flags().BoolVar(&snapshotDescriptionFromStdin, "description-from-stdin", false, "snapshot description from standard input")
+	snapshotCreateCmd.Flags().StringVar(&snapshotDescriptionFrom, "description-from", "", "snapshot description from a file (or - for stdin)")
 }
 
 func createSnapshot(args []string) error {


### PR DESCRIPTION
Fixes #5881