### PR TITLE
Mac signing: add jit entitlement to qemu

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -22,6 +22,7 @@ entitlements:
     - Contents/Resources/resources/darwin/lima/bin/qemu-system-aarch64
     - Contents/Resources/resources/darwin/lima/bin/qemu-system-x86_64
     entitlements:
+    - com.apple.security.cs.allow-jit
     - com.apple.security.hypervisor
   - paths:
     - Contents/Frameworks/Rancher Desktop Helper (GPU).app

--- a/scripts/lib/sign-macos.ts
+++ b/scripts/lib/sign-macos.ts
@@ -98,7 +98,7 @@ export async function sign(workDir: string): Promise<string> {
       }
     }
 
-    await spawnFile('codesign', [...args, filePath]);
+    await spawnFile('codesign', [...args, filePath], { stdio: 'inherit' });
   }
 
   console.log('Verifying application signature...');
@@ -144,7 +144,7 @@ export async function sign(workDir: string): Promise<string> {
   if (!dmgFile) {
     throw new Error(`Could not find signed disk image`);
   }
-  await spawnFile('codesign', ['--sign', certFingerprint, '--timestamp', dmgFile]);
+  await spawnFile('codesign', ['--sign', certFingerprint, '--timestamp', dmgFile], { stdio: 'inherit' });
 
   return dmgFile;
 }


### PR DESCRIPTION
qemu requires the jit entitlement, otherwise it fails with:
> qemu-system-x86_64: allocate 1073741824 bytes for jit buffer: Invalid argument

This also fixes the sign script to use stdio when running codesign so that we can get the failure messages for debugging.

Fixes #6117