### PR TITLE
Enable Cancel button during snapshots create/restore operations

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1442,6 +1442,10 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     return await Snapshots.restore(name);
   }
 
+  async cancelSnapshot() {
+    return await Snapshots.cancel();
+  }
+
   async deleteSnapshot(context: CommandWorkerInterface.CommandContext, name: string) {
     return await Snapshots.delete(name);
   }

--- a/background.ts
+++ b/background.ts
@@ -790,6 +790,10 @@ ipcMainProxy.on('snapshot', (event, args) => {
   event.reply('snapshot', args);
 });
 
+ipcMainProxy.on('snapshot/cancel', () => {
+  window.send('snapshot/cancel');
+});
+
 ipcMainProxy.on('dialog/error', (event, args) => {
   window.getWindow(args.dialog)?.webContents.send('dialog/error', args);
 });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "core-js": "3.25.3",
     "cross-spawn": "7.0.3",
     "crypto-browserify": "3.12.0",
+    "ctrlc-windows": "2.1.0",
     "dayjs": "1.11.10",
     "dompurify": "3.0.6",
     "electron-updater": "6.1.7",

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -22,28 +22,7 @@ function formatDate(value: string) {
   };
 }
 
-interface Data {
-  value: Snapshot
-}
-
-interface Methods {
-  restore: () => void,
-  remove: () => void,
-  showConfirmationDialog: (type: 'restore' | 'delete') => Promise<number>,
-  showRestoringSnapshotDialog: () => Promise<void>,
-}
-
-interface Computed {
-  snapshot: Snapshot & { formattedCreateDate: { date: string, time: string } | null },
-  isRestoreDisabled: boolean,
-  getK8sState: EngineStates,
-}
-
-interface Props {
-  value: Snapshot
-}
-
-export default Vue.extend<Data, Methods, Computed, Props>({
+export default Vue.extend({
   name:  'snapshot-card',
   props: {
     value: {
@@ -54,7 +33,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
 
   computed: {
     ...mapGetters('k8sManager', { getK8sState: 'getK8sState' }),
-    snapshot() {
+    snapshot(): Snapshot & { formattedCreateDate: { date: string, time: string } | null } {
       return {
         ...this.value,
         formattedCreateDate: formatDate(this.value.created),

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
           }
         });
 
-        await this.showRestoringSnapshotDialog();
+        await this.showRestoringSnapshotDialog('restore');
         ipcRenderer.removeAllListeners('dialog/mounted');
       }
     },
@@ -124,15 +124,17 @@ export default Vue.extend({
       return confirm.response;
     },
 
-    async showRestoringSnapshotDialog() {
+    async showRestoringSnapshotDialog(type: 'restore' | 'delete') {
       const snapshot = this.snapshot.name.length > 32 ? `${ this.snapshot.name.substring(0, 30) }...` : this.snapshot.name;
 
       await ipcRenderer.invoke(
         'show-snapshots-blocking-dialog',
         {
           window: {
-            buttons:  [],
-            cancelId: 1,
+            buttons: [
+              this.t(`snapshots.dialog.${ type }.actions.cancel`),
+            ],
+            cancelId: 0,
           },
           format: {
             header:            this.t('snapshots.dialog.restoring.header', { snapshot }),

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -53,6 +53,20 @@ export default Vue.extend({
       /** Clear old event on Snapshots page */
       ipcRenderer.send('snapshot', null);
 
+      let snapshotCancelled = false;
+
+      ipcRenderer.once('snapshot/cancel', () => {
+        snapshotCancelled = true;
+        ipcRenderer.send(
+          'snapshot',
+          {
+            type:         'restore',
+            result:       'cancel',
+            snapshotName: this.snapshot?.name,
+          },
+        );
+      });
+
       if (ok) {
         ipcRenderer.send('preferences-close');
         ipcRenderer.on('dialog/mounted', async() => {
@@ -70,11 +84,14 @@ export default Vue.extend({
               });
           } else {
             ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
-            ipcRenderer.send('snapshot', {
-              type:         'restore',
-              result:       'success',
-              snapshotName: this.snapshot?.name,
-            });
+            ipcRenderer.send(
+              'snapshot',
+              {
+                type:         'restore',
+                result:       snapshotCancelled ? 'cancel' : 'success',
+                snapshotName: this.snapshot?.name,
+              },
+            );
           }
         });
 

--- a/pkg/rancher-desktop/main/snapshots/snapshots.ts
+++ b/pkg/rancher-desktop/main/snapshots/snapshots.ts
@@ -1,3 +1,5 @@
+import { exec } from 'child_process';
+
 import { Snapshot, SpawnResult } from '@pkg/main/snapshots/types';
 import { spawnFile } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
@@ -92,6 +94,26 @@ class SnapshotsImpl {
     if (response.error) {
       throw new SnapshotsError(args, response);
     }
+  }
+
+  cancel() {
+    const command = 'rdctl snapshot';
+
+    exec(`ps aux | grep "${ command }" | grep -v grep`, (error, stdout) => {
+      if (error) {
+        return;
+      }
+
+      const processes = stdout.split('\n');
+
+      processes.forEach((proc) => {
+        const [_user, pid, ..._rest] = proc.split(/\s+/);
+
+        if (Number(pid)) {
+          process.kill(Number(pid), 'SIGTERM');
+        }
+      });
+    });
   }
 }
 

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -89,8 +89,10 @@ export default Vue.extend({
         'show-snapshots-blocking-dialog',
         {
           window: {
-            buttons:  [],
-            cancelId: 1,
+            buttons: [
+              this.t(`snapshots.dialog.creating.actions.cancel`),
+            ],
+            cancelId: 0,
           },
           format: {
             header:          this.t('snapshots.dialog.creating.header', { snapshot: name }),

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -14,24 +14,7 @@ const defaultName = () => {
   return `Snap_${ dateString }`;
 };
 
-interface Data {
-  name: string,
-  description: string,
-  creating: boolean,
-}
-
-interface Methods {
-  goBack: (event: SnapshotEvent | null) => void;
-  submit: () => void;
-  showCreatingSnapshotDialog: () => Promise<void>;
-}
-
-interface Computed {
-  snapshots: Snapshot[];
-  valid: boolean;
-}
-
-export default Vue.extend<Data, Methods, Computed, never>({
+export default Vue.extend({
   components: {
     Banner,
     LabeledInput,
@@ -48,7 +31,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
 
   computed: {
     ...mapGetters('snapshots', { snapshots: 'list' }),
-    valid() {
+    valid(): boolean {
       return !!this.name && !this.snapshots.find((s: Snapshot) => s.name === this.name);
     },
   },

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -60,6 +60,18 @@ export default Vue.extend({
       /** TODO limit description length */
       const { name, description } = this;
 
+      let snapshotCancelled = false;
+
+      ipcRenderer.once('snapshot/cancel', () => {
+        snapshotCancelled = true;
+
+        this.goBack({
+          type:         'create',
+          result:       'cancel',
+          snapshotName: name,
+        });
+      });
+
       ipcRenderer.on('dialog/mounted', async() => {
         const error = await this.$store.dispatch('snapshots/create', { name, description });
 
@@ -70,7 +82,7 @@ export default Vue.extend({
 
           this.goBack({
             type:         'create',
-            result:       'success',
+            result:       snapshotCancelled ? 'cancel' : 'success',
             snapshotName: name,
           });
         }

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -106,6 +106,7 @@ export default Vue.extend({
       );
     },
     cancelSnapshot() {
+      ipcRenderer.send('snapshot/cancel');
       fetch(
         `http://localhost:${ this.credentials?.port }/v1/snapshots/cancel`,
         {

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -75,7 +75,12 @@ export default Vue.extend({
 
         return;
       }
-      ipcRenderer.send('dialog/close', { response: index });
+
+      if (index === this.cancelId) {
+        this.cancelSnapshot();
+      }
+
+      ipcRenderer.send('dialog/close', { response: index, eventType: this.snapshotEventType });
     },
     isDarwin() {
       return os.platform().startsWith('darwin');
@@ -91,6 +96,20 @@ export default Vue.extend({
         `http://localhost:${ this.credentials?.port }/v1/shutdown`,
         {
           method:  'PUT',
+          headers: new Headers({
+            Authorization: `Basic ${ window.btoa(
+              `${ this.credentials?.user }:${ this.credentials?.password }`,
+            ) }`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        },
+      );
+    },
+    cancelSnapshot() {
+      fetch(
+        `http://localhost:${ this.credentials?.port }/v1/snapshots/cancel`,
+        {
+          method:  'POST',
           headers: new Headers({
             Authorization: `Basic ${ window.btoa(
               `${ this.credentials?.user }:${ this.credentials?.password }`,

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -95,6 +95,7 @@ export interface IpcMainEvents {
 
   // #region Snapshots
   'snapshot': (event: SnapshotEvent | null) => void;
+  'snapshot/cancel': () => void;
   // #endregion
 }
 
@@ -219,5 +220,6 @@ export interface IpcRendererEvents {
 
   // #region Snapshots
   'snapshot': (event: SnapshotEvent | null) => void;
+  'snapshot/cancel': () => void;
   // #endregion
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5655,6 +5655,11 @@ csstype@^3.1.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
+ctrlc-windows@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-2.1.0.tgz#f2096a96ac1d03181e0ec808c2c8a67fdc20b300"
+  integrity sha512-OrX5KI+K+2NMN91QIhYZdW7VDO2YsSdTZW494pA7Nvw/wBdU2hz+MGP006bR978zOTrG6Q8EIeJvLJmLqc6MsQ==
+
 custom-event-polyfill@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"


### PR DESCRIPTION
This enables the cancel button on the snapshot create/restore blocking dialogs. Clicking on the cancel button will identify and terminate active rdctl snapshot processes.

## Screenshots

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/69220f08-914a-4606-9966-65cbae931fa1)

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/919adab1-31b7-4532-9678-b3bf1d306670)

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/9489d319-1dbe-4036-b9e7-1dd82e555ef5)
