### PR TITLE
WSL-Helper: Drop version suffix

### DIFF
--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -12,8 +12,6 @@
 - '!libGLESv2.dll'      # spellcheck-ignore-line
 - '!vk_swiftshader.dll' # spellcheck-ignore-line
 - '!vulkan-1.dll'       # spellcheck-ignore-line
-resources/resources/win32:
-- wsl-helper-1.11.1.exe
 resources/resources/win32/bin:
 - docker.exe
 - docker-credential-none.exe
@@ -32,4 +30,5 @@ resources/resources/win32/internal:
 - privileged-service.exe
 - steve.exe
 - vtunnel.exe
+- wsl-helper.exe
 - '!dummy.exe'

--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -76,21 +76,21 @@ test.describe('WSL Integrations', () => {
           utf16le: true,
         },
         ...['alpha', 'beta', 'gamma'].flatMap(distro => [
-          ...[['bin', 'docker-compose'], ['wsl-helper-1.11.1']].flatMap(tool => ([
+          ...[['bin', 'docker-compose'], ['internal', 'wsl-helper']].flatMap(tool => ([
             {
               args:   ['--distribution', distro, '--exec', '/bin/wslpath', '-a', '-u', path.join(process.cwd(), 'resources', 'linux', ...tool)],
               mode:   'repeated',
               stdout: `/${ distro }/${ tool.join('/') }`,
             }])),
-          ...[['bin', 'docker-buildx'], ['wsl-helper-1.11.1']].flatMap(tool => ([
+          ...[['bin', 'docker-buildx'], ['internal', 'wsl-helper']].flatMap(tool => ([
             {
               args:   ['--distribution', distro, '--exec', '/bin/wslpath', '-a', '-u', path.join(process.cwd(), 'resources', 'linux', ...tool)],
               mode:   'repeated',
               stdout: `/${ distro }/${ tool.join('/') }`,
             }])),
           ...[
-            [`/${ distro }/wsl-helper-1.11.1`, 'kubeconfig', '--enable=false'],
-            [`/${ distro }/wsl-helper-1.11.1`, 'kubeconfig', '--enable=true'],
+            [`/${ distro }/internal/wsl-helper`, 'kubeconfig', '--enable=false'],
+            [`/${ distro }/internal/wsl-helper`, 'kubeconfig', '--enable=true'],
             ['/bin/sh', '-c', 'mkdir -p "$HOME/.docker/cli-plugins"'],
             ['/bin/sh', '-c',
               `if [ ! -e "$HOME/.docker/cli-plugins/docker-compose" -a ! -L "$HOME/.docker/cli-plugins/docker-compose" ] ; then
@@ -112,28 +112,28 @@ test.describe('WSL Integrations', () => {
             stdout: '/dev/null',
           },
           {
-            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper-1.11.1`, 'docker-proxy', 'serve', '--verbose'],
+            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/internal/wsl-helper`, 'docker-proxy', 'serve', '--verbose'],
             mode:   'repeated',
             stdout: '/dev/null',
           },
           {
-            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/wsl-helper-1.11.1`, 'docker-proxy', 'kill', '--verbose'],
+            args:   ['--distribution', distro, '--user', 'root', '--exec', `/${ distro }/internal/wsl-helper`, 'docker-proxy', 'kill', '--verbose'],
             mode:   'repeated',
             stdout: '/dev/null',
           },
         ]),
         {
-          args:   ['--distribution', 'alpha', '--exec', '/alpha/wsl-helper-1.11.1', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'alpha', '--exec', '/alpha/internal/wsl-helper', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.alpha ?? false).toString(),
         },
         {
-          args:   ['--distribution', 'beta', '--exec', '/beta/wsl-helper-1.11.1', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'beta', '--exec', '/beta/internal/wsl-helper', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.beta ?? true).toString(),
         },
         {
-          args:   ['--distribution', 'gamma', '--exec', '/gamma/wsl-helper-1.11.1', 'kubeconfig', '--show'],
+          args:   ['--distribution', 'gamma', '--exec', '/gamma/internal/wsl-helper', 'kubeconfig', '--show'],
           mode:   'repeated',
           stdout: (opts?.gamma ?? 'some error').toString(),
         },

--- a/pkg/rancher-desktop/utils/resources.ts
+++ b/pkg/rancher-desktop/utils/resources.ts
@@ -15,8 +15,8 @@ const executableMap: Record<string, string[] | undefined> = {
   kubectl:            undefined,
   nerdctl:            undefined,
   rdctl:              undefined,
-  'wsl-helper':       [paths.resources, process.platform, platformBinary('wsl-helper-1.11.1')],
-  'wsl-helper-linux': [paths.resources, 'linux', 'wsl-helper-1.11.1'],
+  'wsl-helper':       [paths.resources, process.platform, 'internal', platformBinary('wsl-helper')],
+  'wsl-helper-linux': [paths.resources, 'linux', 'internal', 'wsl-helper'],
 };
 
 function platformBinary(name: string): string {

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -272,9 +272,9 @@ export default {
      * @param platform The platform to build for.
      */
     const buildPlatform = async(platform: 'linux' | 'win32') => {
-      const exeRoot = 'wsl-helper-1.11.1';
+      const exeRoot = 'wsl-helper';
       const exeName = `${ exeRoot }${ platform === 'win32' ? '.exe' : '' }`;
-      const outFile = path.join(this.rootDir, 'resources', platform, exeName);
+      const outFile = path.join(this.rootDir, 'resources', platform, 'internal', exeName);
 
       await this.spawn('go', 'build', '-ldflags', '-s -w', '-o', outFile, '.', {
         cwd: path.join(this.rootDir, 'src', 'go', 'wsl-helper'),


### PR DESCRIPTION
Now that we have (hopefully) fixed the issue with not terminating the wsl-helper process on shutdown, we can drop the version suffix on the executable, and at the same time move it into the internal/ directory it belongs.

Fixes #6119.