### PR TITLE
Revert "Skip extension installation under VZ emulation"

### DIFF
--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -107,11 +107,6 @@ install_extensions() {
 }
 
 @test 'verify all extensions can be installed' {
-    if using_vz_emulation; then
-        # BUG BUG BUG https://github.com/rancher-sandbox/rancher-desktop/issues/5465
-        skip "Skipping extension installation under VZ emulation"
-    fi
-
     #WORKAROUND `rdctl` tries to install extensions before app is ready.
     wait_for_container_engine
     sleep 30
@@ -160,11 +155,6 @@ install_extensions() {
 }
 
 @test 'install only allowed extensions' {
-    if using_vz_emulation; then
-        # BUG BUG BUG https://github.com/rancher-sandbox/rancher-desktop/issues/5465
-        skip "Skipping extension installation under VZ emulation"
-    fi
-
     install_extensions
 }
 


### PR DESCRIPTION
The tests no longer seem to fail with Lima 0.18.0.

Closes #5465