### PR TITLE
Add progress bar to snapshot dialogs

### DIFF
--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -4,11 +4,12 @@ import os from 'os';
 import { Banner } from '@rancher/components';
 import Vue from 'vue';
 
+import BackendProgress from '@pkg/components/BackendProgress.vue';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name:       'snapshots-dialog',
-  components: { Banner },
+  components: { Banner, BackendProgress },
   layout:     'dialog',
   data() {
     return {
@@ -206,6 +207,7 @@ export default Vue.extend({
         </slot>
       </div>
     </div>
+    <BackendProgress class="progress" />
     <div
       class="dialog-actions"
       :class="{ 'dialog-actions-reverse': isDarwin() }"


### PR DESCRIPTION
This adds a progress bar to the snapshot dialogs.

## Screenshots

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/bded4ab8-cd3e-4648-9ed8-93b58553446e)

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/fdc3a1be-c67d-4690-9329-3d9ead7a8778)
