### PR TITLE
Get snapshot title from lockfile during init

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -86,9 +86,9 @@ export default {
     ipcRenderer.on('window/blur', (event, blur) => {
       this.blur = blur;
     });
-    ipcRenderer.on('backend-locked', (event) => {
+    ipcRenderer.on('backend-locked', (_event, action) => {
       ipcRenderer.send('preferences-close');
-      this.showCreatingSnapshotDialog();
+      this.showCreatingSnapshotDialog(action);
     });
     ipcRenderer.on('backend-unlocked', () => {
       ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
@@ -151,7 +151,7 @@ export default {
         this.$router.push({ path: this.paths[idx] });
       }
     },
-    showCreatingSnapshotDialog() {
+    showCreatingSnapshotDialog(action) {
       ipcRenderer.invoke(
         'show-snapshots-blocking-dialog',
         {
@@ -160,9 +160,8 @@ export default {
             cancelId: 1,
           },
           format: {
-            /** ToDo put here operation type and snapshot name from 'state' */
-            header:          this.t('snapshots.dialog.generic.header', {}, true),
-            /** ToDo put here operation type information from 'state' */
+            header:          action || this.t('snapshots.dialog.generic.header', {}, true),
+            /** TODO: put here operation type information from 'state' */
             message:         this.t('snapshots.dialog.generic.message', {}, true),
             showProgressBar: true,
           },

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -655,8 +655,8 @@ export class HttpCommandServer {
     }
   }
 
-  protected getBackendState(_: express.Request, response: express.Response, context: commandContext): Promise<void> {
-    const backendState = this.commandWorker.getBackendState();
+  protected async getBackendState(_: express.Request, response: express.Response, context: commandContext): Promise<void> {
+    const backendState = await this.commandWorker.getBackendState();
 
     console.debug('GET backend_state: succeeded 200');
     response.status(200).json(backendState);
@@ -671,7 +671,7 @@ export class HttpCommandServer {
     const state = JSON.parse(data);
 
     try {
-      this.commandWorker.setBackendState(state);
+      await this.commandWorker.setBackendState(state);
     } catch (ex) {
       console.error(`error in setBackendState:`, ex);
       statusCode = 500;
@@ -800,9 +800,9 @@ export interface CommandWorkerInterface {
   getTransientSettings: (context: commandContext) => string;
   updateTransientSettings: (context: commandContext, newTransientSettings: RecursivePartial<TransientSettings>) => Promise<[string, string]>;
   /** Get the state of the backend */
-  getBackendState: () => BackendState;
+  getBackendState: () => Promise<BackendState>;
   /** Set the desired state of the backend */
-  setBackendState: (state: BackendState) => void;
+  setBackendState: (state: BackendState) => Promise<void>;
 
   // #region extensions
   /** List the installed extensions with their versions */

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -126,7 +126,7 @@ interface MainEventNames {
    * actions that could cause problems with snapshot operations (as of the time of
    * writing snapshots is the sole use for this).
    */
-  'backend-locked-update'(backendIsLocked: string): void;
+  'backend-locked-update'(backendIsLocked: string, action?: string): void;
 
   /**
    * Emitted when a component wants to check the state of the backend lock.

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -148,7 +148,7 @@ export interface IpcMainInvokeEvents {
  * process, i.e. webContents.send() -> ipcRenderer.on().
  */
 export interface IpcRendererEvents {
-  'backend-locked': () => void;
+  'backend-locked': (action?: string) => void;
   'backend-unlocked': () => void;
   'settings-update': (settings: import('@pkg/config/settings').Settings) => void;
   'settings-read': (settings: import('@pkg/config/settings').Settings) => void;


### PR DESCRIPTION
This displays the `backend.lock` action if one exists during the Rancher Desktop init. 

This also does some additional refactoring so that the `backendIsLocked` variable is no longer global. The usage of the global variable makes it difficult to reason about when `backendIsLocked` would mutate. Now, if we want to inquire about the locked state, we utilize the function `doesBackendLockExist()`. 

## Screenshots

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/1a8d15e6-9eeb-406e-9156-c8fcd71cd8e2)

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/03af6e2a-bf06-4490-a772-adcdb19343c9)
