### PR TITLE
Drop use of ctrlc-windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "core-js": "3.25.3",
     "cross-spawn": "7.0.3",
     "crypto-browserify": "3.12.0",
-    "ctrlc-windows": "2.1.0",
     "dayjs": "1.11.10",
     "dompurify": "3.0.6",
     "electron-updater": "6.1.7",

--- a/src/go/wsl-helper/cmd/kill_process_windows.go
+++ b/src/go/wsl-helper/cmd/kill_process_windows.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/process"
+)
+
+var killProcessViper = viper.New()
+
+// killProcessCmd is the `wsl-helper kill-process` command.
+var killProcessCmd = &cobra.Command{
+	Use:   "kill-process",
+	Short: "Kill a given process",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := process.Kill(killProcessViper.GetInt("pid"))
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	killProcessCmd.Flags().Int("pid", 0, "PID of process to kill")
+	killProcessViper.AutomaticEnv()
+	killProcessViper.BindPFlags(killProcessCmd.Flags())
+	rootCmd.AddCommand(killProcessCmd)
+}

--- a/src/go/wsl-helper/cmd/kill_process_windows.go
+++ b/src/go/wsl-helper/cmd/kill_process_windows.go
@@ -30,11 +30,7 @@ var killProcessCmd = &cobra.Command{
 	Use:   "kill-process",
 	Short: "Kill a given process",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := process.Kill(killProcessViper.GetInt("pid"))
-		if err != nil {
-			return err
-		}
-		return nil
+		return process.Kill(killProcessViper.GetInt("pid"))
 	},
 }
 

--- a/src/go/wsl-helper/pkg/process/imports_windows.go
+++ b/src/go/wsl-helper/pkg/process/imports_windows.go
@@ -16,15 +16,12 @@ limitations under the License.
 
 package process
 
-import (
-	"fmt"
-	"os/exec"
-)
+import "golang.org/x/sys/windows"
 
-func Launch(executable string, args ...string) error {
-	err := exec.Command(executable, args...).Start()
-	if err != nil {
-		return fmt.Errorf("failed to start %s: %w", executable, err)
-	}
-	return nil
-}
+var (
+	kernel32Dll           = windows.NewLazySystemDLL("kernel32.dll")
+	openProcess           = kernel32Dll.NewProc("OpenProcess")
+	attachConsole         = kernel32Dll.NewProc("AttachConsole")
+	freeConsole           = kernel32Dll.NewProc("FreeConsole")
+	setConsoleCtrlHandler = kernel32Dll.NewProc("SetConsoleCtrlHandler")
+)

--- a/src/go/wsl-helper/pkg/process/kill_windows.go
+++ b/src/go/wsl-helper/pkg/process/kill_windows.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func Kill(pid int) error {
+	if pid < 1 {
+		return fmt.Errorf("cannot kill process: invalid pid: %d", pid)
+	}
+
+	// Try to re-attach to the default console
+	defer func() {
+		_, _, _ = freeConsole.Call()
+		_, _, _ = attachConsole.Call(0xFFFFFFFF)
+	}()
+
+	// Detach from the current console; if this fails (and we stay attached to the
+	// current console), AttachConsole() will fail later, so we don't need to
+	// check the return value.
+	_, _, _ = freeConsole.Call()
+
+	rv, _, err := attachConsole.Call(uintptr(pid))
+	if rv == 0 {
+		return fmt.Errorf("failed to attach to console: %w", err)
+	}
+	// Prevent _this_ process from being affected by Ctrl+C (so we exit cleanly).
+	// Ignore any errors if this fails.
+	setConsoleCtrlHandler.Call(uintptr(unsafe.Pointer(nil)), 1)
+
+	err = windows.GenerateConsoleCtrlEvent(windows.CTRL_C_EVENT, 0)
+	if err != nil {
+		return fmt.Errorf("failed to generate Ctrl+C: %w", err)
+	}
+	return nil
+}

--- a/src/go/wsl-helper/pkg/process/kill_windows.go
+++ b/src/go/wsl-helper/pkg/process/kill_windows.go
@@ -18,9 +18,14 @@ package process
 
 import (
 	"fmt"
+	"math"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
+)
+
+const (
+	ATTACH_PARENT_PROCESS = math.MaxUint32
 )
 
 func Kill(pid int) error {
@@ -31,7 +36,7 @@ func Kill(pid int) error {
 	// Try to re-attach to the default console
 	defer func() {
 		_, _, _ = freeConsole.Call()
-		_, _, _ = attachConsole.Call(0xFFFFFFFF)
+		_, _, _ = attachConsole.Call(ATTACH_PARENT_PROCESS)
 	}()
 
 	// Detach from the current console; if this fails (and we stay attached to the

--- a/src/go/wsl-helper/pkg/process/wait_windows.go
+++ b/src/go/wsl-helper/pkg/process/wait_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package process
 
 import (
@@ -22,18 +23,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var (
-	kernel32Dll = windows.MustLoadDLL("Kernel32.dll")
-)
-
 // WaitPid waits for the process with the given PID to exit before returning.
 func WaitPid(pid uint32) error {
 	logEntry := logrus.WithField("pid", pid)
 	logEntry.Trace("trying to wait for process")
-	openProcess, err := kernel32Dll.FindProc("OpenProcess")
-	if err != nil {
-		return fmt.Errorf("could not find OpenProcess: %w", err)
-	}
 	hProcRaw, _, err := openProcess.Call(
 		windows.SYNCHRONIZE,
 		0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5649,11 +5649,6 @@ csstype@^3.1.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-ctrlc-windows@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-2.1.0.tgz#f2096a96ac1d03181e0ec808c2c8a67fdc20b300"
-  integrity sha512-OrX5KI+K+2NMN91QIhYZdW7VDO2YsSdTZW494pA7Nvw/wBdU2hz+MGP006bR978zOTrG6Q8EIeJvLJmLqc6MsQ==
-
 custom-event-polyfill@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"


### PR DESCRIPTION
The ctrlc-windows npm package contains a rust executable; rust by default depends on vcruntime140.dll.  This means that on machines without the correct MSVC redistributables installed, Rancher Desktop will fail to start due to failing to import the native module.

Luckily, what we need from it is simple enough that we can just re-implement the necessary functionality as part of wsl-helper.