### PR TITLE
Workaround to get a containers screenshot with mocked data.

### DIFF
--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -11,7 +11,7 @@ import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
 import { clearUserProfile } from '../e2e/utils/ProfileUtils';
 import {
-  createDefaultSettings, createUserProfile, reportAsset, teardown, tool,
+  createDefaultSettings, createUserProfile, reportAsset, teardown, tool, waitForRestartVM,
 } from '../e2e/utils/TestUtils';
 
 import { ContainerEngine, CURRENT_SETTINGS_VERSION } from '@pkg/config/settings';
@@ -20,6 +20,20 @@ import type { ElectronApplication, BrowserContext, Page } from '@playwright/test
 
 const isWin = os.platform() === 'win32';
 const isMac = os.platform() === 'darwin';
+
+async function switchEngine(page: Page, containerEngine: string) {
+  await tool('rdctl', 'set', `--container-engine.name=${ containerEngine }`);
+
+  // Wait until progress bar show up. It takes roughly ~60s to start in CI
+  const progressBar = page.locator('.progress');
+
+  await waitForRestartVM(progressBar);
+
+  // Since we just applied new settings, we must wait for the backend to restart.
+  while (await progressBar.count() > 0) {
+    await progressBar.waitFor({ state: 'detached', timeout: Math.round(240_000) });
+  }
+}
 
 test.describe.serial('Main App Test', () => {
   let electronApp: ElectronApplication;
@@ -92,6 +106,11 @@ test.describe.serial('Main App Test', () => {
     });
 
     test('Containers Page', async() => {
+      const containerEngine = JSON.parse(await tool('rdctl', 'list-settings')).containerEngine.name;
+
+      if (containerEngine !== 'moby') {
+        await switchEngine(page, 'moby');
+      }
       const containersPage = await navPage.navigateTo('Containers');
 
       await containersPage.page.exposeFunction('listContainersMock', (options?: any) => {
@@ -105,6 +124,9 @@ test.describe.serial('Main App Test', () => {
 
       await expect(containersPage.page.getByRole('row')).toHaveCount(6);
       await screenshot.take('Containers');
+      if (containerEngine !== 'moby') {
+        await switchEngine(page, containerEngine);
+      }
     });
 
     test('PortForwarding Page', async({ colorScheme }) => {


### PR DESCRIPTION
If not running `moby`, switch to it, do the containers screenshot, and then switch back.

Later: properly mock the containers data when using containerd.