### PR TITLE
Prevent cancelling snapshot in confirmation dialogs

### DIFF
--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -130,10 +130,11 @@ export default Vue.extend({
             cancelId: 0,
           },
           format: {
-            header:          this.t(`snapshots.dialog.${ type }.header`, { snapshot: this.snapshot.name }),
-            snapshot:        this.snapshot,
-            message:         type === 'restore' ? this.t(`snapshots.dialog.${ type }.info`, { }, true) : '',
-            showProgressBar: true,
+            header:            this.t(`snapshots.dialog.${ type }.header`, { snapshot: this.snapshot.name }),
+            snapshot:          this.snapshot,
+            message:           type === 'restore' ? this.t(`snapshots.dialog.${ type }.info`, { }, true) : '',
+            showProgressBar:   true,
+            snapshotEventType: 'confirm',
           },
         },
       );

--- a/pkg/rancher-desktop/main/snapshots/types.ts
+++ b/pkg/rancher-desktop/main/snapshots/types.ts
@@ -1,5 +1,5 @@
 export type SnapshotEvent = {
-  type?: 'restore' | 'delete' | 'create',
+  type?: 'restore' | 'delete' | 'create' | 'confirm',
   result?: 'success' | 'cancel' | 'error',
   error?: string,
   snapshotName?: string,

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -81,7 +81,7 @@ export default Vue.extend({
         return;
       }
 
-      if (index === this.cancelId) {
+      if (!this.error && this.snapshotEventType !== 'confirm' && index === this.cancelId) {
         await this.cancelSnapshot();
       }
 


### PR DESCRIPTION
This prevents invoking the cancel api endpoint from snapshot confirmation dialogs, as well as from snapshot blocking dialogs when a snapshot operation return an error.