### PR TITLE
WSL-Helper: Satisfy the linter

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -201,6 +201,7 @@ dports
 dri
 DSL
 Duex
+dupl
 dword
 eagerzeroedthick
 eastus
@@ -273,6 +274,8 @@ globalrole
 globalrolebinding
 Gluster
 gname
+gocritic
+gocyclo
 gofmt
 goland
 golangci
@@ -728,6 +731,8 @@ storybookjs
 strem
 stretchr
 stringifying
+structcheck
+stylecheck
 subshells
 subvar
 sumologic

--- a/.github/workflows/config/.golangci.yaml
+++ b/.github/workflows/config/.golangci.yaml
@@ -1,4 +1,8 @@
 linters-settings:
+  dogsled:
+    # syscall.Syscall() has three return values, and we often don't care about
+    # the results, especially on Windows.
+    max-blank-identifiers: 3
   dupl:
     threshold: 100
   funlen:
@@ -36,6 +40,8 @@ linters-settings:
       - '3'
     ignored-functions:
       - strings.SplitN
+      - os.FileMode # file permissions
+      - os.MkdirAll # file permissions
 
   lll:
     line-length: 140
@@ -51,7 +57,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - dupl
     - errcheck
@@ -106,6 +111,7 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
-        - gosec
+        - dupl # Ignore code duplication in tests
         - errcheck
         - gocritic
+        - gosec

--- a/.github/workflows/wsl-helper-build.yaml
+++ b/.github/workflows/wsl-helper-build.yaml
@@ -1,11 +1,10 @@
-# This workflow builds the WSL Helper
-name: 'GitHub Runner: WSL Helper'
+name: 'Lint: WSL-Helper'
 
 on:
-  #push:
-  #  paths: [ src/go/wsl-helper/** ]
-  #pull_request:
-  #  paths: [ src/go/wsl-helper/** ]
+  push:
+    paths: [ src/go/wsl-helper/** ]
+  pull_request:
+    paths: [ src/go/wsl-helper/** ]
   workflow_dispatch:
 
 permissions:
@@ -40,11 +39,6 @@ jobs:
       env:
         GOOS: linux
         CGO_ENABLED: '0'
-    - uses: actions/upload-artifact@v3
-      with:
-        name: wsl-helper-linux
-        path: src/go/wsl-helper/wsl-helper
-        if-no-files-found: error
     - uses: golangci/golangci-lint-action@v3.7.0
       # This is only safe because this workflow does not allow writing
       with:

--- a/src/go/wsl-helper/cmd/certificates_windows.go
+++ b/src/go/wsl-helper/cmd/certificates_windows.go
@@ -64,6 +64,6 @@ var certificatesCmd = &cobra.Command{
 func init() {
 	certificatesCmd.Flags().StringSlice("stores", []string{"CA", "ROOT"}, "Certificate stores to enumerate")
 	certificatesViper.AutomaticEnv()
-	certificatesViper.BindPFlags(certificatesCmd.Flags())
+	_ = certificatesViper.BindPFlags(certificatesCmd.Flags())
 	rootCmd.AddCommand(certificatesCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
@@ -43,6 +43,6 @@ var dockerproxyKillCmd = &cobra.Command{
 
 func init() {
 	dockerproxyKillViper.AutomaticEnv()
-	dockerproxyKillViper.BindPFlags(dockerproxyKillCmd.Flags())
+	_ = dockerproxyKillViper.BindPFlags(dockerproxyKillCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyKillCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -64,6 +64,6 @@ func init() {
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")
 	dockerproxyServeViper.AutomaticEnv()
-	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	_ = dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -54,6 +54,6 @@ func init() {
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port docker is listening on")
 	dockerproxyServeViper.AutomaticEnv()
-	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	_ = dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -49,6 +49,6 @@ func init() {
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")
 	dockerproxyStartViper.AutomaticEnv()
-	dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
+	_ = dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyStartCmd)
 }

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -32,15 +32,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type kubeConfig struct {
-	Clusters []struct {
-		Cluster struct {
-			Server string
-			Extras map[string]interface{} `yaml:",inline"`
-		} `yaml:"cluster"`
-		Name   string                 `yaml:"name"`
+type kubeConfigCluster struct {
+	Cluster struct {
+		Server string
 		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:"clusters"`
+	} `yaml:"cluster"`
+	Name   string                 `yaml:"name"`
+	Extras map[string]interface{} `yaml:",inline"`
+}
+type kubeConfig struct {
+	Clusters []kubeConfigCluster `yaml:"clusters"`
 	Contexts []struct {
 		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
@@ -52,6 +53,11 @@ type kubeConfig struct {
 	} `yaml:"users"`
 	Extras map[string]interface{} `yaml:",inline"`
 }
+
+const (
+	// kubeconfigExistTimeout is the time we wait for kubeconfig to appear.
+	kubeconfigExistTimeout = 10 * time.Second
+)
 
 var (
 	k3sKubeconfigViper = viper.New()
@@ -81,11 +87,11 @@ var k3sKubeconfigCmd = &cobra.Command{
 			}
 		}()
 		var err error
-		timeout := time.After(10 * time.Second)
+		timeout := time.After(kubeconfigExistTimeout)
 		var configFile *os.File
 		select {
 		case <-timeout:
-			return fmt.Errorf("Timed out waiting for k3s kubeconfig to exist")
+			return fmt.Errorf("timed out waiting for k3s kubeconfig to exist")
 		case configFile = <-ch:
 			break
 		}
@@ -172,6 +178,6 @@ func init() {
 	k3sKubeconfigCmd.Flags().String("k3sconfig", "/etc/rancher/k3s/k3s.yaml", "Path to k3s kubeconfig")
 	k3sKubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
 	k3sKubeconfigViper.AutomaticEnv()
-	k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
+	_ = k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
 	k3sCmd.AddCommand(k3sKubeconfigCmd)
 }

--- a/src/go/wsl-helper/cmd/kill_process_windows.go
+++ b/src/go/wsl-helper/cmd/kill_process_windows.go
@@ -37,6 +37,6 @@ var killProcessCmd = &cobra.Command{
 func init() {
 	killProcessCmd.Flags().Int("pid", 0, "PID of process to kill")
 	killProcessViper.AutomaticEnv()
-	killProcessViper.BindPFlags(killProcessCmd.Flags())
+	_ = killProcessViper.BindPFlags(killProcessCmd.Flags())
 	rootCmd.AddCommand(killProcessCmd)
 }

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -54,6 +54,7 @@ var kubeconfigCmd = &cobra.Command{
 
 		if winConfigPath == "" {
 			//lint:ignore ST1005 The capitalization is for a proper noun.
+			//nolint:stylecheck // The capitalization is for a proper noun.
 			return errors.New("Windows kubeconfig not supplied")
 		}
 
@@ -86,9 +87,9 @@ var kubeconfigCmd = &cobra.Command{
 			return err
 		}
 
-		cleanConfig := removeExistingRDConfig(rdCluster, &linuxConfig)
+		cleanConfig := removeExistingRDConfig(rdCluster, linuxConfig)
 
-		kubeConfig, err := updateKubeConfig(winConfig, *cleanConfig, rdNetworking)
+		kubeConfig, err := updateKubeConfig(winConfig, cleanConfig, rdNetworking)
 		if err != nil {
 			return fmt.Errorf("failed to construct kubeconfig: %w", err)
 		}
@@ -110,29 +111,32 @@ var kubeconfigCmd = &cobra.Command{
 	},
 }
 
-func readKubeConfig(configPath string) (kubeConfig, error) {
+func readKubeConfig(configPath string) (*kubeConfig, error) {
 	var config kubeConfig
 	configFile, err := os.Open(configPath)
 	if err != nil {
-		return config, fmt.Errorf("could not open kubeconfig file %s: %w", configPath, err)
+		return nil, fmt.Errorf("could not open kubeconfig file %s: %w", configPath, err)
 	}
 	defer configFile.Close()
 	err = yaml.NewDecoder(configFile).Decode(&config)
 	if err != nil {
-		return config, fmt.Errorf("could not read kubeconfig %s: %w", configPath, err)
+		return nil, fmt.Errorf("could not read kubeconfig %s: %w", configPath, err)
 	}
 
-	return config, nil
+	return &config, nil
 }
 
-// updateKubeConfig reads the kube config from windows side it also
-// modifies the cluster's server host to an appropriate address.
-// It then merges the config with an existing configuration on
-// users distro and returns the merged config.
-func updateKubeConfig(winConfig, linuxConfig kubeConfig, rdNetworking bool) (kubeConfig, error) {
+// updateKubeConfig updates the Linux-side kubeconfig with the rancher-desktop
+// cluster read from Windows (ignoring all other clusters from the Windows side).
+// While doing so, it ensures that the server address will be correct.
+// It updates the Linux kubeconfig in-place and returns it.
+func updateKubeConfig(winConfig, linuxConfig *kubeConfig, rdNetworking bool) (*kubeConfig, error) {
+	// We act on a copy of the Windows config to avoid mutating it.
+	winConfigCopy := *winConfig
+	winConfigCopy.Clusters = append([]kubeConfigCluster{}, winConfig.Clusters...)
 	for clusterIdx, cluster := range winConfig.Clusters {
 		// Ignore any non rancher-desktop clusters
-		if winConfig.Clusters[clusterIdx].Name != rdCluster {
+		if winConfigCopy.Clusters[clusterIdx].Name != rdCluster {
 			continue
 		}
 		server, err := url.Parse(cluster.Cluster.Server)
@@ -144,7 +148,7 @@ func updateKubeConfig(winConfig, linuxConfig kubeConfig, rdNetworking bool) (kub
 		if !rdNetworking {
 			ip, err := getClusterIP()
 			if err != nil {
-				return winConfig, err
+				return nil, err
 			}
 
 			host = ip.String()
@@ -153,21 +157,16 @@ func updateKubeConfig(winConfig, linuxConfig kubeConfig, rdNetworking bool) (kub
 			host = net.JoinHostPort(host, server.Port())
 		}
 		server.Host = host
-		winConfig.Clusters[clusterIdx].Cluster.Server = server.String()
+		winConfigCopy.Clusters[clusterIdx].Cluster.Server = server.String()
 	}
-	return mergeKubeConfigs(winConfig, linuxConfig), nil
+	return mergeKubeConfigs(&winConfigCopy, linuxConfig), nil
 }
 
+// removeExistingRDConfig removes the rancher-desktop configuration from the
+// passed in kubeconfig in-place, and returns the modified input.
 func removeExistingRDConfig(name string, config *kubeConfig) *kubeConfig {
 	// Remove clusters with the specified name
-	var filteredClusters []struct {
-		Cluster struct {
-			Server string
-			Extras map[string]interface{} `yaml:",inline"`
-		} `yaml:"cluster"`
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	}
+	var filteredClusters []kubeConfigCluster
 	for _, cluster := range config.Clusters {
 		if cluster.Name != name {
 			filteredClusters = append(filteredClusters, cluster)
@@ -202,7 +201,10 @@ func removeExistingRDConfig(name string, config *kubeConfig) *kubeConfig {
 	return config
 }
 
-func mergeKubeConfigs(winConfig, linuxConfig kubeConfig) kubeConfig {
+// mergeKubeConfig updates the Linux kubeconfig with the Rancher Desktop
+// cluster configuration read from the Windows kubeconfig, returning the
+// Linux kubeconfig that has been updated in-place.
+func mergeKubeConfigs(winConfig, linuxConfig *kubeConfig) *kubeConfig {
 	for _, ctx := range winConfig.Clusters {
 		if ctx.Name == rdCluster {
 			linuxConfig.Clusters = append(linuxConfig.Clusters, ctx)
@@ -228,6 +230,6 @@ func init() {
 	kubeconfigCmd.PersistentFlags().String("kubeconfig", "", "Path to Windows kubeconfig, in /mnt/... form.")
 	kubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
 	kubeconfigViper.AutomaticEnv()
-	kubeconfigViper.BindPFlags(kubeconfigCmd.PersistentFlags())
+	_ = kubeconfigViper.BindPFlags(kubeconfigCmd.PersistentFlags())
 	rootCmd.AddCommand(kubeconfigCmd)
 }

--- a/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
@@ -45,8 +45,8 @@ var wslIntegrationDockerPluginCmd = &cobra.Command{
 func init() {
 	wslIntegrationDockerPluginCmd.Flags().String("plugin", "", "Full path to plugin")
 	wslIntegrationDockerPluginCmd.Flags().Bool("state", false, "Desired state")
-	wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin")
+	_ = wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin")
 	wslIntegrationDockerPluginViper.AutomaticEnv()
-	wslIntegrationDockerPluginViper.BindPFlags(wslIntegrationDockerPluginCmd.Flags())
+	_ = wslIntegrationDockerPluginViper.BindPFlags(wslIntegrationDockerPluginCmd.Flags())
 	wslIntegrationCmd.AddCommand(wslIntegrationDockerPluginCmd)
 }

--- a/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
@@ -54,8 +54,8 @@ var wslIntegrationStateCmd = &cobra.Command{
 
 func init() {
 	wslIntegrationStateCmd.Flags().Var(&enumValue{val: "show", allowed: []string{"show", "set", "delete"}}, "mode", "Operation mode")
-	wslIntegrationStateCmd.MarkFlagRequired("mode")
+	_ = wslIntegrationStateCmd.MarkFlagRequired("mode")
 	wslIntegrationStateViper.AutomaticEnv()
-	wslIntegrationStateViper.BindPFlags(wslIntegrationStateCmd.Flags())
+	_ = wslIntegrationStateViper.BindPFlags(wslIntegrationStateCmd.Flags())
 	wslIntegrationCmd.AddCommand(wslIntegrationStateCmd)
 }

--- a/src/go/wsl-helper/pkg/certificates/certificates_windows.go
+++ b/src/go/wsl-helper/pkg/certificates/certificates_windows.go
@@ -60,7 +60,7 @@ func GetSystemCertificates(storeName string) (<-chan Entry, error) {
 	ch := make(chan Entry)
 	go func() {
 		defer close(ch)
-		defer windows.CertCloseStore(store, 0)
+		defer windows.CertCloseStore(store, 0) //nolint:errcheck // We can't do anything about it if this fails
 		var certCtx *windows.CertContext
 		var err error
 		for {

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -82,7 +82,7 @@ type bindManager struct {
 // empty, then the bind is incomplete (the container create failed) and it
 // should not be used.
 type bindManagerEntry struct {
-	ContainerId string
+	ContainerID string `json:"ContainerId"`
 	HostPath    string
 }
 
@@ -169,7 +169,7 @@ func (b *bindManager) makeMount() string {
 }
 
 // prepareMountPath creates target directory or file, as mount point
-func (b *bindManager) prepareMountPath(target string, bindKey string) error {
+func (b *bindManager) prepareMountPath(target, bindKey string) error {
 	mountPath := path.Join(b.mountRoot, bindKey)
 	hostPathStat, err := os.Stat(target)
 	if os.IsNotExist(err) {
@@ -206,7 +206,11 @@ type containersCreateRequestBody struct {
 }
 
 // munge incoming request for POST /containers/create
-func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
+func (b *bindManager) mungeContainersCreateRequest(
+	req *http.Request,
+	contextValue *dockerproxy.RequestContextValue,
+	templates map[string]string,
+) error {
 	body := containersCreateRequestBody{}
 	err := readRequestBodyJSON(req, &body)
 	if err != nil {
@@ -220,19 +224,19 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 	modified := false
 	for bindIndex, bind := range body.HostConfig.Binds {
 		logrus.WithField(fmt.Sprintf("bind %d", bindIndex), bind).Trace("got bind")
-		host, container, options, isPath := platform.ParseBindString(bind)
-		if !isPath {
+		bindConfig := platform.ParseBindString(bind)
+		if !bindConfig.IsHostPath {
 			continue
 		}
 
 		bindKey := b.makeMount()
-		binds[bindKey] = host
-		host = path.Join(b.mountRoot, bindKey)
+		binds[bindKey] = bindConfig.Src
+		bindConfig.Src = path.Join(b.mountRoot, bindKey)
 		modified = true
-		if options == "" {
-			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s", host, container)
+		if bindConfig.Options == "" {
+			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s", bindConfig.Src, bindConfig.Dest)
 		} else {
-			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s:%s", host, container, options)
+			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s:%s", bindConfig.Src, bindConfig.Dest, bindConfig.Options)
 		}
 	}
 
@@ -282,12 +286,16 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 
 // containersCreateResponseBody describes the contents of a /containers/create response.
 type containersCreateResponseBody struct {
-	Id       string
+	ID       string `json:"Id"`
 	Warnings []string
 }
 
 // munge outgoing response for POST /containers/create
-func (b *bindManager) mungeContainersCreateResponse(resp *http.Response, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
+func (b *bindManager) mungeContainersCreateResponse(
+	resp *http.Response,
+	contextValue *dockerproxy.RequestContextValue,
+	templates map[string]string,
+) error {
 	binds, ok := (*contextValue)[contextKey].(*map[string]string)
 	if !ok {
 		// No binds, meaning either the user didn't specify any, or we didn't need to remap.
@@ -312,9 +320,9 @@ func (b *bindManager) mungeContainersCreateResponse(resp *http.Response, context
 	}
 
 	b.Lock()
-	for mountId, hostPath := range *binds {
-		b.entries[mountId] = bindManagerEntry{
-			ContainerId: body.Id,
+	for mountID, hostPath := range *binds {
+		b.entries[mountID] = bindManagerEntry{
+			ContainerID: body.ID,
 			HostPath:    hostPath,
 		}
 	}
@@ -332,12 +340,16 @@ func (b *bindManager) mungeContainersCreateResponse(resp *http.Response, context
 // munge incoming request to activate the mount, on
 // POST /containers/{id}/start
 // POST /containers/{id}/restart
-func (b *bindManager) mungeContainersStartRequest(req *http.Request, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
+func (b *bindManager) mungeContainersStartRequest(
+	req *http.Request,
+	contextValue *dockerproxy.RequestContextValue,
+	templates map[string]string,
+) error {
 	// Look up all the mappings this container needs
 	mapping := make(map[string]string)
 	b.RLock()
 	for key, data := range b.entries {
-		if data.ContainerId == templates["id"] {
+		if data.ContainerID == templates["id"] {
 			mapping[key] = data.HostPath
 		}
 	}
@@ -375,7 +387,11 @@ func (b *bindManager) mungeContainersStartRequest(req *http.Request, contextValu
 // munge outgoing response to deactivate the mount, on
 // POST /containers/{id}/start
 // POST /containers/{id}/restart
-func (b *bindManager) mungeContainersStartResponse(req *http.Response, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
+func (b *bindManager) mungeContainersStartResponse(
+	req *http.Response,
+	contextValue *dockerproxy.RequestContextValue,
+	templates map[string]string,
+) error {
 	binds, ok := (*contextValue)[contextKey].(*map[string]string)
 	if !ok {
 		// No binds, meaning we didn't do any mounting; nothing to undo here.
@@ -405,7 +421,11 @@ func (b *bindManager) mungeContainersStartResponse(req *http.Response, contextVa
 }
 
 // DELETE /containers/{id}
-func (b *bindManager) mungeContainersDeleteResponse(resp *http.Response, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
+func (b *bindManager) mungeContainersDeleteResponse(
+	resp *http.Response,
+	contextValue *dockerproxy.RequestContextValue,
+	templates map[string]string,
+) error {
 	logEntry := logrus.WithField("templates", templates)
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
 		logEntry.WithField("status-code", resp.StatusCode).Debug("unexpected status code")
@@ -416,14 +436,14 @@ func (b *bindManager) mungeContainersDeleteResponse(resp *http.Response, context
 
 	var toDelete []string
 	for key, data := range b.entries {
-		if data.ContainerId == templates["id"] {
+		if data.ContainerID == templates["id"] {
 			toDelete = append(toDelete, key)
 		}
 	}
 	for _, key := range toDelete {
 		delete(b.entries, key)
 	}
-	b.persist()
+	_ = b.persist()
 	return nil
 }
 

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -42,7 +41,7 @@ func TestNewBindManager(t *testing.T) {
 	// We're not testing loading the state here; if it happens to fail, we'll
 	// just have to skip the test.
 	if err != nil {
-		t.Skip(fmt.Sprintf("skipping test, got error %s", err))
+		t.Skipf("skipping test, got error %s", err)
 	} else {
 		mountPoint, err := platform.GetWSLMountPoint()
 		assert.NoError(t, err)
@@ -63,7 +62,7 @@ func TestBindManagerPersist(t *testing.T) {
 	assert.NoFileExists(t, original.statePath)
 	original.entries = map[string]bindManagerEntry{
 		"foo": {
-			ContainerId: "hello",
+			ContainerID: "hello",
 			HostPath:    "world",
 		},
 	}
@@ -111,7 +110,7 @@ func TestContainersCreate(t *testing.T) {
 
 		// Handle the response
 		buf, err = json.Marshal(&containersCreateResponseBody{
-			Id: "hello",
+			ID: "hello",
 		})
 		require.NoError(t, err)
 		resp := &http.Response{
@@ -136,14 +135,14 @@ func TestContainersCreate(t *testing.T) {
 
 		// Assert state
 		assert.Len(t, bindManager.entries, 1)
-		var mountId string
+		var mountID string
 		var entry bindManagerEntry
-		for mountId, entry = range bindManager.entries {
+		for mountID, entry = range bindManager.entries {
 		}
-		assert.NotEmpty(t, mountId)
-		assert.Equal(t, "hello", entry.ContainerId)
-		assert.Equal(t, "hello", responseBody.Id)
-		expectedMount := path.Join(bindManager.mountRoot, mountId)
+		assert.NotEmpty(t, mountID)
+		assert.Equal(t, "hello", entry.ContainerID)
+		assert.Equal(t, "hello", responseBody.ID)
+		expectedMount := path.Join(bindManager.mountRoot, mountID)
 		expectedBind := fmt.Sprintf("%s:/foo", expectedMount)
 		assert.Equal(t, expectedBind, requestBody.HostConfig.Binds[0])
 	})
@@ -184,7 +183,7 @@ func TestContainersCreate(t *testing.T) {
 
 		// Handle the response
 		buf, err = json.Marshal(&containersCreateResponseBody{
-			Id: "hello",
+			ID: "hello",
 		})
 		require.NoError(t, err)
 		resp := &http.Response{
@@ -209,21 +208,21 @@ func TestContainersCreate(t *testing.T) {
 
 		// Assert state
 		assert.Len(t, bindManager.entries, 1)
-		var mountId string
+		var mountID string
 		var entry bindManagerEntry
-		for mountId, entry = range bindManager.entries {
+		for mountID, entry = range bindManager.entries {
 		}
-		assert.NotEmpty(t, mountId)
-		assert.Equal(t, "hello", entry.ContainerId)
+		assert.NotEmpty(t, mountID)
+		assert.Equal(t, "hello", entry.ContainerID)
 		assert.ElementsMatch(t, []*models.Mount{
 			{
 				Consistency: "cached",
-				Source:      path.Join(bindManager.mountRoot, mountId),
+				Source:      path.Join(bindManager.mountRoot, mountID),
 				Target:      "/host",
 				Type:        "bind",
 			},
 		}, requestBody.HostConfig.Mounts)
-		assert.Equal(t, "hello", responseBody.Id)
+		assert.Equal(t, "hello", responseBody.ID)
 	})
 }
 
@@ -237,7 +236,7 @@ func TestContainersStart(t *testing.T) {
 		mountRoot: t.TempDir(),
 		entries: map[string]bindManagerEntry{
 			"mount-id": {
-				ContainerId: "container-id",
+				ContainerID: "container-id",
 				HostPath:    hostPath,
 			},
 		},
@@ -266,7 +265,7 @@ func TestContainersStart(t *testing.T) {
 	// getBindMounts returns a map of bind mount directory -> underlying path
 	// Note that this may also return items that are not bind mounts.
 	getBindMounts := func() (map[string]string, error) {
-		mountBuf, err := ioutil.ReadFile("/proc/self/mountinfo")
+		mountBuf, err := os.ReadFile("/proc/self/mountinfo")
 		if err != nil {
 			return nil, fmt.Errorf("could not read /proc/self/mountinfo: %w", err)
 		}
@@ -306,7 +305,7 @@ func TestContainerDelete(t *testing.T) {
 		mountRoot: t.TempDir(),
 		entries: map[string]bindManagerEntry{
 			"mount-id": {
-				ContainerId: "container-id",
+				ContainerID: "container-id",
 				HostPath:    hostPath,
 			},
 		},

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
@@ -48,19 +48,19 @@ func mungeContainersCreate(req *http.Request, contextValue *dockerproxy.RequestC
 	modified := false
 	for bindIndex, bind := range body.HostConfig.Binds {
 		logrus.WithField(fmt.Sprintf("bind %d", bindIndex), bind).Debug("got bind")
-		host, container, options, isPath := platform.ParseBindString(bind)
-		if isPath {
-			translated, err := platform.TranslatePathFromClient(host)
+		bindConfig := platform.ParseBindString(bind)
+		src := bindConfig.Src
+		if bindConfig.IsHostPath {
+			src, err = platform.TranslatePathFromClient(bindConfig.Src)
 			if err != nil {
-				return fmt.Errorf("could not translate bind path %s: %w", host, err)
+				return fmt.Errorf("could not translate bind path %s: %w", bindConfig.Src, err)
 			}
-			host = translated
 			modified = true
 		}
-		if options == "" {
-			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s", host, container)
+		if bindConfig.Options == "" {
+			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s", src, bindConfig.Dest)
 		} else {
-			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s:%s", host, container, options)
+			body.HostConfig.Binds[bindIndex] = fmt.Sprintf("%s:%s:%s", src, bindConfig.Dest, bindConfig.Options)
 		}
 	}
 

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
@@ -106,10 +106,20 @@ func Listen(endpoint string) (net.Listener, error) {
 	return listener, nil
 }
 
-// ParseBindString parses a HostConfig.Binds entry, returning the (<host-src> or
-// <volume-name>), <container-dest>, and (optional) <options>.  Additionally, it
-// also returns a boolean indicating if the first argument is a host path.
-func ParseBindString(input string) (string, string, string, bool) {
+// bindConfig is the result of calling ParseBindString.
+type bindConfig struct {
+	// The source of the bind, either a host path or a volume name.
+	Src string
+	// The destination of the bind.
+	Dest string
+	// Optional extra Options.
+	Options string
+	// Whether the src field is a host path.
+	IsHostPath bool
+}
+
+// ParseBindString parses a HostConfig.Binds entry.
+func ParseBindString(input string) bindConfig {
 	// The volumes here are [<host-src>:]<container-dest>[:options]
 	// For a first pass, let's just assume there are no colons in any of this...
 	// The API spec says that if the first part is a host path, then it _must_
@@ -119,18 +129,36 @@ func ParseBindString(input string) (string, string, string, bool) {
 	lastIndex := strings.LastIndex(input, ":")
 	if firstIndex < 0 {
 		// just /foo -- map the same path on the host to the container.
-		return input, input, "", hostIsPath
+		return bindConfig{
+			Src:        input,
+			Dest:       input,
+			IsHostPath: hostIsPath,
+		}
 	}
 	start := input[:firstIndex]
 	end := input[lastIndex+1:]
 	if lastIndex > firstIndex {
 		// /foo:/bar:ro
 		middle := input[firstIndex+1 : lastIndex]
-		return start, middle, end, hostIsPath
+		return bindConfig{
+			Src:        start,
+			Dest:       middle,
+			Options:    end,
+			IsHostPath: hostIsPath,
+		}
 	}
 	// either /foo:/bar or /foo:ro
 	if strings.HasPrefix(end, "/") {
-		return start, end, "", hostIsPath
+		return bindConfig{
+			Src:        start,
+			Dest:       end,
+			IsHostPath: hostIsPath,
+		}
 	}
-	return start, start, end, hostIsPath
+	return bindConfig{
+		Src:        start,
+		Dest:       start,
+		Options:    end,
+		IsHostPath: hostIsPath,
+	}
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows_test.go
@@ -41,11 +41,11 @@ func TestParseBindString(t *testing.T) {
 
 	for input, expected := range cases {
 		t.Run(input, func(t *testing.T) {
-			host, container, options, isPath := ParseBindString(input)
-			assert.Equal(t, expected.host, host)
-			assert.Equal(t, expected.container, container)
-			assert.Equal(t, expected.options, options)
-			assert.Equal(t, expected.isPath, isPath)
+			hostConfig := ParseBindString(input)
+			assert.Equal(t, expected.host, hostConfig.Src)
+			assert.Equal(t, expected.container, hostConfig.Dest)
+			assert.Equal(t, expected.options, hostConfig.Options)
+			assert.Equal(t, expected.isPath, hostConfig.IsHostPath)
 		})
 	}
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
@@ -18,16 +18,22 @@ package platform
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// mountPointField is the zero-indexed field offset in mountinfo
+	// https://www.kernel.org/doc/html/latest/filesystems/proc.html#proc-pid-mountinfo-information-about-mounts
+	mountPointField = 4
+)
+
 // Get the WSL mount point; typically, this is /mnt/wsl.
 // If we fail to find one, we will use /mnt/wsl instead.
 func GetWSLMountPoint() (string, error) {
-	buf, err := ioutil.ReadFile("/proc/self/mountinfo")
+	buf, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return "", fmt.Errorf("error reading mounts: %w", err)
 	}
@@ -37,9 +43,9 @@ func GetWSLMountPoint() (string, error) {
 			continue
 		}
 		fields := strings.Split(line, " ")
-		if len(fields) >= 5 {
-			if strings.HasSuffix(fields[4], "/wsl") {
-				return fields[4], nil
+		if len(fields) >= mountPointField+1 {
+			if strings.HasSuffix(fields[mountPointField], "/wsl") {
+				return fields[mountPointField], nil
 			}
 		}
 	}

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -35,13 +35,21 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/util"
 )
 
-// defaultProxyEndpoint is the path on which dockerd should listen on, relative
-// to the WSL mount point.
-const defaultProxyEndpoint = "rancher-desktop/run/docker.sock"
+const (
+	// defaultProxyEndpoint is the path on which dockerd should listen on, relative
+	// to the WSL mount point.
+	defaultProxyEndpoint = "rancher-desktop/run/docker.sock"
+
+	// fileExistPollInterval is the time between polling to see if the file exists.
+	fileExistPollInterval = 500 * time.Millisecond
+
+	// dockerSocketTimeout is the time to wait for the docker socket to exist.
+	dockerSocketTimeout = 30 * time.Second
+)
 
 // waitForFileToExist will block until the given path exists.  If the given
 // timeout is reached, an error will be returned.
-func waitForFileToExist(path string, timeout time.Duration) error {
+func waitForFileToExist(filePath string, timeout time.Duration) error {
 	timer := time.After(timeout)
 	ready := make(chan struct{})
 	expired := false
@@ -51,11 +59,11 @@ func waitForFileToExist(path string, timeout time.Duration) error {
 		// We just do polling here, since inotify / fanotify both have fairly
 		// low limits on the concurrent number of watchers.
 		for !expired {
-			_, err := os.Lstat(path)
+			_, err := os.Lstat(filePath)
 			if err == nil {
 				return
 			}
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(fileExistPollInterval)
 		}
 	}()
 
@@ -64,7 +72,7 @@ func waitForFileToExist(path string, timeout time.Duration) error {
 		return nil
 	case <-timer:
 		expired = true
-		return fmt.Errorf("timed out waiting for %s to exist", path)
+		return fmt.Errorf("timed out waiting for %s to exist", filePath)
 	}
 }
 
@@ -96,8 +104,11 @@ func Start(port uint32, dockerSocket string, args []string) error {
 		return fmt.Errorf("could not set up docker socket: %w", err)
 	}
 
-	args = append(args, fmt.Sprintf("--host=unix://%s", dockerSocket))
-	args = append(args, "--host=unix:///var/run/docker.sock")
+	args = append(
+		args,
+		fmt.Sprintf("--host=unix://%s", dockerSocket),
+		"--host=unix:///var/run/docker.sock",
+	)
 	cmd := exec.Command(dockerd, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -116,7 +127,7 @@ func Start(port uint32, dockerSocket string, args []string) error {
 	}()
 
 	// Wait for the docker socket to exist...
-	err = waitForFileToExist(dockerSocket, 30*time.Second)
+	err = waitForFileToExist(dockerSocket, dockerSocketTimeout)
 	if err != nil {
 		return err
 	}
@@ -127,7 +138,7 @@ func Start(port uint32, dockerSocket string, args []string) error {
 	}
 	defer listener.Close()
 
-	sigch := make(chan os.Signal)
+	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, unix.SIGTERM)
 	go func() {
 		<-sigch
@@ -142,8 +153,6 @@ func Start(port uint32, dockerSocket string, args []string) error {
 		}
 		go handleConnection(conn, dockerSocket)
 	}
-
-	return nil
 }
 
 // handleConnection handles piping the connection from the client to the docker

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -13,6 +13,8 @@ import (
 )
 
 // KillOthers will kill any other processes with the executable.
+//
+//nolint:gocyclo // TODO: clean up function
 func KillOthers(args ...string) error {
 	selfPid := fmt.Sprintf("%d", os.Getpid())
 	selfFile, err := os.Readlink("/proc/self/exe")

--- a/src/go/wsl-helper/pkg/process/kill_windows.go
+++ b/src/go/wsl-helper/pkg/process/kill_windows.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	//nolint:stylecheck // The constant name matches Win32 API.
 	ATTACH_PARENT_PROCESS = math.MaxUint32
 )
 
@@ -50,7 +51,7 @@ func Kill(pid int) error {
 	}
 	// Prevent _this_ process from being affected by Ctrl+C (so we exit cleanly).
 	// Ignore any errors if this fails.
-	setConsoleCtrlHandler.Call(uintptr(unsafe.Pointer(nil)), 1)
+	_, _, _ = setConsoleCtrlHandler.Call(uintptr(unsafe.Pointer(nil)), 1)
 
 	err = windows.GenerateConsoleCtrlEvent(windows.CTRL_C_EVENT, 0)
 	if err != nil {

--- a/src/go/wsl-helper/pkg/process/wait_windows.go
+++ b/src/go/wsl-helper/pkg/process/wait_windows.go
@@ -36,6 +36,7 @@ func WaitPid(pid uint32) error {
 		return fmt.Errorf("could not get handle to process %d: %w", pid, err)
 	}
 	hProc := windows.Handle(hProcRaw)
+	//nolint:errcheck // We can't do anything about it if this fails
 	defer windows.CloseHandle(hProc)
 
 	logEntry.Trace("waiting for process")

--- a/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
@@ -13,8 +13,10 @@ type utf16Writer struct {
 }
 
 func (w *utf16Writer) Write(p []byte) (int, error) {
+	buf := make([]byte, 0, len(p)+2)
+	copy(buf, p)
 	output := windows.UTF16PtrToString(
-		(*uint16)(unsafe.Pointer(unsafe.SliceData(append(p, 0, 0)))),
+		(*uint16)(unsafe.Pointer(unsafe.SliceData(append(buf, 0, 0)))),
 	)
 	n, err := w.Writer.Write(
 		unsafe.Slice(unsafe.StringData(output), len(output)),

--- a/src/go/wsl-helper/wix/check_windows.go
+++ b/src/go/wsl-helper/wix/check_windows.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	//nolint:stylecheck // Windows Installer exposed properties by convention use all caps.
 	PROP_WSL_INSTALLED = "WSLINSTALLED"
 )
 

--- a/src/go/wsl-helper/wix/helpers_windows.go
+++ b/src/go/wsl-helper/wix/helpers_windows.go
@@ -26,6 +26,7 @@ import (
 
 type messageType uintptr
 
+//nolint:stylecheck // Constants follow style of Windows API
 const (
 	INSTALLMESSAGE_INFO        messageType = 0x04000000
 	INSTALLMESSAGE_ACTIONSTART messageType = 0x08000000
@@ -36,7 +37,7 @@ func submitMessage(hInstall MSIHANDLE, message messageType, data []string) error
 	if record == 0 {
 		return fmt.Errorf("failed to create record")
 	}
-	defer msiCloseHandle.Call(record)
+	defer msiCloseHandle.Call(record) //nolint:errcheck // We can't usefully handle the error.
 	for i, item := range data {
 		buf, err := windows.UTF16PtrFromString(item)
 		if err != nil {
@@ -75,7 +76,7 @@ func setProperty(hInstall MSIHANDLE, name, value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to encode property value %q: %w", value, err)
 	}
-	msiSetPropertyW.Call(
+	_, _, _ = msiSetPropertyW.Call(
 		uintptr(hInstall),
 		uintptr(unsafe.Pointer(nameBuf)),
 		uintptr(unsafe.Pointer(valueBuf)),

--- a/src/go/wsl-helper/wix/imports_windows.go
+++ b/src/go/wsl-helper/wix/imports_windows.go
@@ -21,12 +21,10 @@ import "golang.org/x/sys/windows"
 type MSIHANDLE uint32
 
 var (
-	dllKernel32         = windows.NewLazySystemDLL("kernel32.dll")
 	dllMsi              = windows.NewLazySystemDLL("msi.dll")
 	msiCloseHandle      = dllMsi.NewProc("MsiCloseHandle")
 	msiCreateRecord     = dllMsi.NewProc("MsiCreateRecord")
 	msiRecordSetStringW = dllMsi.NewProc("MsiRecordSetStringW")
 	msiProcessMessage   = dllMsi.NewProc("MsiProcessMessage")
 	msiSetPropertyW     = dllMsi.NewProc("MsiSetPropertyW")
-	outputDebugStringW  = dllKernel32.NewProc("OutputDebugStringW")
 )

--- a/src/go/wsl-helper/wix/install_windows.go
+++ b/src/go/wsl-helper/wix/install_windows.go
@@ -37,7 +37,7 @@ func InstallWindowsFeatureImpl(hInstall MSIHANDLE) uint32 {
 	})
 
 	log.Infof("Installing Windows feature...")
-	submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
+	_ = submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
 		"", "InstalWindowsFeature", "Installing required Windows features...", "<unused>",
 	})
 	if err := wslutils.DismDoInstall(ctx, log); err != nil {
@@ -63,7 +63,7 @@ func InstallWSLImpl(hInstall MSIHANDLE) uint32 {
 	})
 
 	log.Info("Installing WSL...")
-	submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
+	_ = submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
 		"", "InstallWSL", "Installing Windows Subsystem for Linux...", "<unused>",
 	})
 	if err := wslutils.InstallWSL(ctx, log); err != nil {


### PR DESCRIPTION
Mostly by documenting cases where we ignore a particular linter rule. Note that we dropped the "deadcode" linter because it's deprecated and replaced by the "unused" linter (which is already enabled).

Fixes #6160