### PR TITLE
Always delete the lock when cancelling a create or restore operation.

### DIFF
--- a/pkg/rancher-desktop/main/snapshots/snapshots.ts
+++ b/pkg/rancher-desktop/main/snapshots/snapshots.ts
@@ -1,4 +1,6 @@
 import { exec } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 import util from 'util';
 
 import { Snapshot, SpawnResult } from '@pkg/main/snapshots/types';
@@ -135,6 +137,12 @@ class SnapshotsImpl {
       }
     } catch (error) {
       console.error('Error:', error);
+    }
+    try {
+      // The above code does not always result in the immediate deletion of the lockfile, so remove it now
+      await asyncExec(`${ command } unlock`);
+    } catch (ex) {
+      console.error(`Unlocking the snapshot should never fail, but got error: ${ ex }`);
     }
   }
 }


### PR DESCRIPTION
Fixes #6168

There seem to be two ways the lock file gets deleted here.

1: The `cancel` request happens late enough in the process that
   the `Unlock` call is made in the main `rdctl snapshot OP` action

2. After about 15 seconds, the VM is restarted, and the lock is cleared. I haven't figured out what does that (because the only calls to `Unlock` are in the `rdctl snapshot { create, remove } ops`, but explicitly deleting the lockfile in cancel seems harmless.