### PR TITLE
Copy kubeconfig extra fields from Windows into WSL

### DIFF
--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -220,6 +220,13 @@ func mergeKubeConfigs(winConfig, linuxConfig kubeConfig) kubeConfig {
 		}
 	}
 
+	if linuxConfig.CurrentContext == "" {
+		linuxConfig.CurrentContext = rdCluster
+	}
+	if len(linuxConfig.Extras) == 0 {
+		linuxConfig.Extras = winConfig.Extras
+	}
+
 	return linuxConfig
 }
 

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -102,11 +102,12 @@ var kubeconfigCmd = &cobra.Command{
 			return err
 		}
 		defer finalKubeConfigFile.Close()
-		err = yaml.NewEncoder(finalKubeConfigFile).Encode(kubeConfig)
+		encoder := yaml.NewEncoder(finalKubeConfigFile)
+		err = encoder.Encode(kubeConfig)
 		if err != nil {
 			return err
 		}
-		return nil
+		return encoder.Close()
 	},
 }
 


### PR DESCRIPTION
Otherwise `apiVersion`, `kind`, and `current-context` will be missing.

Fixes #6096