### PR TITLE
Revert "WSL-Helper: Satisfy the linter"

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -201,7 +201,6 @@ dports
 dri
 DSL
 Duex
-dupl
 dword
 eagerzeroedthick
 eastus
@@ -274,8 +273,6 @@ globalrole
 globalrolebinding
 Gluster
 gname
-gocritic
-gocyclo
 gofmt
 goland
 golangci
@@ -731,8 +728,6 @@ storybookjs
 strem
 stretchr
 stringifying
-structcheck
-stylecheck
 subshells
 subvar
 sumologic

--- a/.github/workflows/config/.golangci.yaml
+++ b/.github/workflows/config/.golangci.yaml
@@ -1,8 +1,4 @@
 linters-settings:
-  dogsled:
-    # syscall.Syscall() has three return values, and we often don't care about
-    # the results, especially on Windows.
-    max-blank-identifiers: 3
   dupl:
     threshold: 100
   funlen:
@@ -40,8 +36,6 @@ linters-settings:
       - '3'
     ignored-functions:
       - strings.SplitN
-      - os.FileMode # file permissions
-      - os.MkdirAll # file permissions
 
   lll:
     line-length: 140
@@ -57,6 +51,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - deadcode
     - dogsled
     - dupl
     - errcheck
@@ -111,7 +106,6 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
-        - dupl # Ignore code duplication in tests
+        - gosec
         - errcheck
         - gocritic
-        - gosec

--- a/.github/workflows/wsl-helper-build.yaml
+++ b/.github/workflows/wsl-helper-build.yaml
@@ -1,10 +1,11 @@
-name: 'Lint: WSL-Helper'
+# This workflow builds the WSL Helper
+name: 'GitHub Runner: WSL Helper'
 
 on:
-  push:
-    paths: [ src/go/wsl-helper/** ]
-  pull_request:
-    paths: [ src/go/wsl-helper/** ]
+  #push:
+  #  paths: [ src/go/wsl-helper/** ]
+  #pull_request:
+  #  paths: [ src/go/wsl-helper/** ]
   workflow_dispatch:
 
 permissions:
@@ -39,6 +40,11 @@ jobs:
       env:
         GOOS: linux
         CGO_ENABLED: '0'
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wsl-helper-linux
+        path: src/go/wsl-helper/wsl-helper
+        if-no-files-found: error
     - uses: golangci/golangci-lint-action@v3.7.0
       # This is only safe because this workflow does not allow writing
       with:

--- a/src/go/wsl-helper/cmd/certificates_windows.go
+++ b/src/go/wsl-helper/cmd/certificates_windows.go
@@ -64,6 +64,6 @@ var certificatesCmd = &cobra.Command{
 func init() {
 	certificatesCmd.Flags().StringSlice("stores", []string{"CA", "ROOT"}, "Certificate stores to enumerate")
 	certificatesViper.AutomaticEnv()
-	_ = certificatesViper.BindPFlags(certificatesCmd.Flags())
+	certificatesViper.BindPFlags(certificatesCmd.Flags())
 	rootCmd.AddCommand(certificatesCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_kill_linux.go
@@ -43,6 +43,6 @@ var dockerproxyKillCmd = &cobra.Command{
 
 func init() {
 	dockerproxyKillViper.AutomaticEnv()
-	_ = dockerproxyKillViper.BindPFlags(dockerproxyKillCmd.Flags())
+	dockerproxyKillViper.BindPFlags(dockerproxyKillCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyKillCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -64,6 +64,6 @@ func init() {
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")
 	dockerproxyServeViper.AutomaticEnv()
-	_ = dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -54,6 +54,6 @@ func init() {
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port docker is listening on")
 	dockerproxyServeViper.AutomaticEnv()
-	_ = dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
+	dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyServeCmd)
 }

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -49,6 +49,6 @@ func init() {
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")
 	dockerproxyStartViper.AutomaticEnv()
-	_ = dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
+	dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags())
 	dockerproxyCmd.AddCommand(dockerproxyStartCmd)
 }

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -32,16 +32,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type kubeConfigCluster struct {
-	Cluster struct {
-		Server string
-		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:"cluster"`
-	Name   string                 `yaml:"name"`
-	Extras map[string]interface{} `yaml:",inline"`
-}
 type kubeConfig struct {
-	Clusters []kubeConfigCluster `yaml:"clusters"`
+	Clusters []struct {
+		Cluster struct {
+			Server string
+			Extras map[string]interface{} `yaml:",inline"`
+		} `yaml:"cluster"`
+		Name   string                 `yaml:"name"`
+		Extras map[string]interface{} `yaml:",inline"`
+	} `yaml:"clusters"`
 	Contexts []struct {
 		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
@@ -53,11 +52,6 @@ type kubeConfig struct {
 	} `yaml:"users"`
 	Extras map[string]interface{} `yaml:",inline"`
 }
-
-const (
-	// kubeconfigExistTimeout is the time we wait for kubeconfig to appear.
-	kubeconfigExistTimeout = 10 * time.Second
-)
 
 var (
 	k3sKubeconfigViper = viper.New()
@@ -87,11 +81,11 @@ var k3sKubeconfigCmd = &cobra.Command{
 			}
 		}()
 		var err error
-		timeout := time.After(kubeconfigExistTimeout)
+		timeout := time.After(10 * time.Second)
 		var configFile *os.File
 		select {
 		case <-timeout:
-			return fmt.Errorf("timed out waiting for k3s kubeconfig to exist")
+			return fmt.Errorf("Timed out waiting for k3s kubeconfig to exist")
 		case configFile = <-ch:
 			break
 		}
@@ -178,6 +172,6 @@ func init() {
 	k3sKubeconfigCmd.Flags().String("k3sconfig", "/etc/rancher/k3s/k3s.yaml", "Path to k3s kubeconfig")
 	k3sKubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
 	k3sKubeconfigViper.AutomaticEnv()
-	_ = k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
+	k3sKubeconfigViper.BindPFlags(k3sKubeconfigCmd.Flags())
 	k3sCmd.AddCommand(k3sKubeconfigCmd)
 }

--- a/src/go/wsl-helper/cmd/kill_process_windows.go
+++ b/src/go/wsl-helper/cmd/kill_process_windows.go
@@ -37,6 +37,6 @@ var killProcessCmd = &cobra.Command{
 func init() {
 	killProcessCmd.Flags().Int("pid", 0, "PID of process to kill")
 	killProcessViper.AutomaticEnv()
-	_ = killProcessViper.BindPFlags(killProcessCmd.Flags())
+	killProcessViper.BindPFlags(killProcessCmd.Flags())
 	rootCmd.AddCommand(killProcessCmd)
 }

--- a/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
@@ -45,8 +45,8 @@ var wslIntegrationDockerPluginCmd = &cobra.Command{
 func init() {
 	wslIntegrationDockerPluginCmd.Flags().String("plugin", "", "Full path to plugin")
 	wslIntegrationDockerPluginCmd.Flags().Bool("state", false, "Desired state")
-	_ = wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin")
+	wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin")
 	wslIntegrationDockerPluginViper.AutomaticEnv()
-	_ = wslIntegrationDockerPluginViper.BindPFlags(wslIntegrationDockerPluginCmd.Flags())
+	wslIntegrationDockerPluginViper.BindPFlags(wslIntegrationDockerPluginCmd.Flags())
 	wslIntegrationCmd.AddCommand(wslIntegrationDockerPluginCmd)
 }

--- a/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_state_linux.go
@@ -54,8 +54,8 @@ var wslIntegrationStateCmd = &cobra.Command{
 
 func init() {
 	wslIntegrationStateCmd.Flags().Var(&enumValue{val: "show", allowed: []string{"show", "set", "delete"}}, "mode", "Operation mode")
-	_ = wslIntegrationStateCmd.MarkFlagRequired("mode")
+	wslIntegrationStateCmd.MarkFlagRequired("mode")
 	wslIntegrationStateViper.AutomaticEnv()
-	_ = wslIntegrationStateViper.BindPFlags(wslIntegrationStateCmd.Flags())
+	wslIntegrationStateViper.BindPFlags(wslIntegrationStateCmd.Flags())
 	wslIntegrationCmd.AddCommand(wslIntegrationStateCmd)
 }

--- a/src/go/wsl-helper/pkg/certificates/certificates_windows.go
+++ b/src/go/wsl-helper/pkg/certificates/certificates_windows.go
@@ -60,7 +60,7 @@ func GetSystemCertificates(storeName string) (<-chan Entry, error) {
 	ch := make(chan Entry)
 	go func() {
 		defer close(ch)
-		defer windows.CertCloseStore(store, 0) //nolint:errcheck // We can't do anything about it if this fails
+		defer windows.CertCloseStore(store, 0)
 		var certCtx *windows.CertContext
 		var err error
 		for {

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -41,7 +42,7 @@ func TestNewBindManager(t *testing.T) {
 	// We're not testing loading the state here; if it happens to fail, we'll
 	// just have to skip the test.
 	if err != nil {
-		t.Skipf("skipping test, got error %s", err)
+		t.Skip(fmt.Sprintf("skipping test, got error %s", err))
 	} else {
 		mountPoint, err := platform.GetWSLMountPoint()
 		assert.NoError(t, err)
@@ -62,7 +63,7 @@ func TestBindManagerPersist(t *testing.T) {
 	assert.NoFileExists(t, original.statePath)
 	original.entries = map[string]bindManagerEntry{
 		"foo": {
-			ContainerID: "hello",
+			ContainerId: "hello",
 			HostPath:    "world",
 		},
 	}
@@ -110,7 +111,7 @@ func TestContainersCreate(t *testing.T) {
 
 		// Handle the response
 		buf, err = json.Marshal(&containersCreateResponseBody{
-			ID: "hello",
+			Id: "hello",
 		})
 		require.NoError(t, err)
 		resp := &http.Response{
@@ -135,14 +136,14 @@ func TestContainersCreate(t *testing.T) {
 
 		// Assert state
 		assert.Len(t, bindManager.entries, 1)
-		var mountID string
+		var mountId string
 		var entry bindManagerEntry
-		for mountID, entry = range bindManager.entries {
+		for mountId, entry = range bindManager.entries {
 		}
-		assert.NotEmpty(t, mountID)
-		assert.Equal(t, "hello", entry.ContainerID)
-		assert.Equal(t, "hello", responseBody.ID)
-		expectedMount := path.Join(bindManager.mountRoot, mountID)
+		assert.NotEmpty(t, mountId)
+		assert.Equal(t, "hello", entry.ContainerId)
+		assert.Equal(t, "hello", responseBody.Id)
+		expectedMount := path.Join(bindManager.mountRoot, mountId)
 		expectedBind := fmt.Sprintf("%s:/foo", expectedMount)
 		assert.Equal(t, expectedBind, requestBody.HostConfig.Binds[0])
 	})
@@ -183,7 +184,7 @@ func TestContainersCreate(t *testing.T) {
 
 		// Handle the response
 		buf, err = json.Marshal(&containersCreateResponseBody{
-			ID: "hello",
+			Id: "hello",
 		})
 		require.NoError(t, err)
 		resp := &http.Response{
@@ -208,21 +209,21 @@ func TestContainersCreate(t *testing.T) {
 
 		// Assert state
 		assert.Len(t, bindManager.entries, 1)
-		var mountID string
+		var mountId string
 		var entry bindManagerEntry
-		for mountID, entry = range bindManager.entries {
+		for mountId, entry = range bindManager.entries {
 		}
-		assert.NotEmpty(t, mountID)
-		assert.Equal(t, "hello", entry.ContainerID)
+		assert.NotEmpty(t, mountId)
+		assert.Equal(t, "hello", entry.ContainerId)
 		assert.ElementsMatch(t, []*models.Mount{
 			{
 				Consistency: "cached",
-				Source:      path.Join(bindManager.mountRoot, mountID),
+				Source:      path.Join(bindManager.mountRoot, mountId),
 				Target:      "/host",
 				Type:        "bind",
 			},
 		}, requestBody.HostConfig.Mounts)
-		assert.Equal(t, "hello", responseBody.ID)
+		assert.Equal(t, "hello", responseBody.Id)
 	})
 }
 
@@ -236,7 +237,7 @@ func TestContainersStart(t *testing.T) {
 		mountRoot: t.TempDir(),
 		entries: map[string]bindManagerEntry{
 			"mount-id": {
-				ContainerID: "container-id",
+				ContainerId: "container-id",
 				HostPath:    hostPath,
 			},
 		},
@@ -265,7 +266,7 @@ func TestContainersStart(t *testing.T) {
 	// getBindMounts returns a map of bind mount directory -> underlying path
 	// Note that this may also return items that are not bind mounts.
 	getBindMounts := func() (map[string]string, error) {
-		mountBuf, err := os.ReadFile("/proc/self/mountinfo")
+		mountBuf, err := ioutil.ReadFile("/proc/self/mountinfo")
 		if err != nil {
 			return nil, fmt.Errorf("could not read /proc/self/mountinfo: %w", err)
 		}
@@ -305,7 +306,7 @@ func TestContainerDelete(t *testing.T) {
 		mountRoot: t.TempDir(),
 		entries: map[string]bindManagerEntry{
 			"mount-id": {
-				ContainerID: "container-id",
+				ContainerId: "container-id",
 				HostPath:    hostPath,
 			},
 		},

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows_test.go
@@ -41,11 +41,11 @@ func TestParseBindString(t *testing.T) {
 
 	for input, expected := range cases {
 		t.Run(input, func(t *testing.T) {
-			hostConfig := ParseBindString(input)
-			assert.Equal(t, expected.host, hostConfig.Src)
-			assert.Equal(t, expected.container, hostConfig.Dest)
-			assert.Equal(t, expected.options, hostConfig.Options)
-			assert.Equal(t, expected.isPath, hostConfig.IsHostPath)
+			host, container, options, isPath := ParseBindString(input)
+			assert.Equal(t, expected.host, host)
+			assert.Equal(t, expected.container, container)
+			assert.Equal(t, expected.options, options)
+			assert.Equal(t, expected.isPath, isPath)
 		})
 	}
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/wsl_mountpoint_linux.go
@@ -18,22 +18,16 @@ package platform
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// mountPointField is the zero-indexed field offset in mountinfo
-	// https://www.kernel.org/doc/html/latest/filesystems/proc.html#proc-pid-mountinfo-information-about-mounts
-	mountPointField = 4
-)
-
 // Get the WSL mount point; typically, this is /mnt/wsl.
 // If we fail to find one, we will use /mnt/wsl instead.
 func GetWSLMountPoint() (string, error) {
-	buf, err := os.ReadFile("/proc/self/mountinfo")
+	buf, err := ioutil.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return "", fmt.Errorf("error reading mounts: %w", err)
 	}
@@ -43,9 +37,9 @@ func GetWSLMountPoint() (string, error) {
 			continue
 		}
 		fields := strings.Split(line, " ")
-		if len(fields) >= mountPointField+1 {
-			if strings.HasSuffix(fields[mountPointField], "/wsl") {
-				return fields[mountPointField], nil
+		if len(fields) >= 5 {
+			if strings.HasSuffix(fields[4], "/wsl") {
+				return fields[4], nil
 			}
 		}
 	}

--- a/src/go/wsl-helper/pkg/process/kill_others_linux.go
+++ b/src/go/wsl-helper/pkg/process/kill_others_linux.go
@@ -13,8 +13,6 @@ import (
 )
 
 // KillOthers will kill any other processes with the executable.
-//
-//nolint:gocyclo // TODO: clean up function
 func KillOthers(args ...string) error {
 	selfPid := fmt.Sprintf("%d", os.Getpid())
 	selfFile, err := os.Readlink("/proc/self/exe")

--- a/src/go/wsl-helper/pkg/process/kill_windows.go
+++ b/src/go/wsl-helper/pkg/process/kill_windows.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	//nolint:stylecheck // The constant name matches Win32 API.
 	ATTACH_PARENT_PROCESS = math.MaxUint32
 )
 
@@ -51,7 +50,7 @@ func Kill(pid int) error {
 	}
 	// Prevent _this_ process from being affected by Ctrl+C (so we exit cleanly).
 	// Ignore any errors if this fails.
-	_, _, _ = setConsoleCtrlHandler.Call(uintptr(unsafe.Pointer(nil)), 1)
+	setConsoleCtrlHandler.Call(uintptr(unsafe.Pointer(nil)), 1)
 
 	err = windows.GenerateConsoleCtrlEvent(windows.CTRL_C_EVENT, 0)
 	if err != nil {

--- a/src/go/wsl-helper/pkg/process/wait_windows.go
+++ b/src/go/wsl-helper/pkg/process/wait_windows.go
@@ -36,7 +36,6 @@ func WaitPid(pid uint32) error {
 		return fmt.Errorf("could not get handle to process %d: %w", pid, err)
 	}
 	hProc := windows.Handle(hProcRaw)
-	//nolint:errcheck // We can't do anything about it if this fails
 	defer windows.CloseHandle(hProc)
 
 	logEntry.Trace("waiting for process")

--- a/src/go/wsl-helper/pkg/wsl-utils/dism_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/dism_windows.go
@@ -37,20 +37,16 @@ const (
 	kWindowsFeature = "VirtualMachinePlatform"
 	// DISM_ONLINE_IMAGE is the DISM "image path" that signifies we're trying
 	// to modify the running Windows installation.
-	//nolint:stylecheck // Constant name follows Win32 API
 	DISM_ONLINE_IMAGE         = "DISM_{53BFAE52-B167-4E2F-A258-0A37B57FF845}"
 	DismLogErrorsWarningsInfo = 2
-	// win32ErrorMask is used to turn a HRESULT_FROM_WIN32(x) back into a Win32
-	// error code.
-	win32ErrorMask = 0xFFFF
 )
 
 var (
-	dllDismAPI        = windows.NewLazySystemDLL("dismapi.dll")
-	dismInitialize    = dllDismAPI.NewProc("DismInitialize")
-	dismOpenSession   = dllDismAPI.NewProc("DismOpenSession")
-	dismCloseSession  = dllDismAPI.NewProc("DismCloseSession")
-	dismEnableFeature = dllDismAPI.NewProc("DismEnableFeature")
+	dllDismApi        = windows.NewLazySystemDLL("dismapi.dll")
+	dismInitialize    = dllDismApi.NewProc("DismInitialize")
+	dismOpenSession   = dllDismApi.NewProc("DismOpenSession")
+	dismCloseSession  = dllDismApi.NewProc("DismCloseSession")
+	dismEnableFeature = dllDismApi.NewProc("DismEnableFeature")
 )
 
 func errorFromHResult(hr int32, err error) error {
@@ -91,9 +87,8 @@ func DismDoInstall(ctx context.Context, log *logrus.Entry) error {
 		uintptr(unsafe.Pointer(&session)),
 	)
 	if hr != uintptr(windows.S_OK) {
-		return errorFromWin32("failed to open DISM session", hr&win32ErrorMask, err)
+		return errorFromWin32("failed to open DISM session", hr&0xFFFF, err)
 	}
-	//nolint:errcheck // We can't do anything about any failures here.
 	defer dismCloseSession.Call(uintptr(session))
 
 	if buf, err = windows.UTF16PtrFromString(kWindowsFeature); err != nil {

--- a/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
@@ -13,10 +13,8 @@ type utf16Writer struct {
 }
 
 func (w *utf16Writer) Write(p []byte) (int, error) {
-	buf := make([]byte, 0, len(p)+2)
-	copy(buf, p)
 	output := windows.UTF16PtrToString(
-		(*uint16)(unsafe.Pointer(unsafe.SliceData(append(buf, 0, 0)))),
+		(*uint16)(unsafe.Pointer(unsafe.SliceData(append(p, 0, 0)))),
 	)
 	n, err := w.Writer.Write(
 		unsafe.Slice(unsafe.StringData(output), len(output)),

--- a/src/go/wsl-helper/wix/check_windows.go
+++ b/src/go/wsl-helper/wix/check_windows.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	//nolint:stylecheck // Windows Installer exposed properties by convention use all caps.
 	PROP_WSL_INSTALLED = "WSLINSTALLED"
 )
 

--- a/src/go/wsl-helper/wix/helpers_windows.go
+++ b/src/go/wsl-helper/wix/helpers_windows.go
@@ -26,7 +26,6 @@ import (
 
 type messageType uintptr
 
-//nolint:stylecheck // Constants follow style of Windows API
 const (
 	INSTALLMESSAGE_INFO        messageType = 0x04000000
 	INSTALLMESSAGE_ACTIONSTART messageType = 0x08000000
@@ -37,7 +36,7 @@ func submitMessage(hInstall MSIHANDLE, message messageType, data []string) error
 	if record == 0 {
 		return fmt.Errorf("failed to create record")
 	}
-	defer msiCloseHandle.Call(record) //nolint:errcheck // We can't usefully handle the error.
+	defer msiCloseHandle.Call(record)
 	for i, item := range data {
 		buf, err := windows.UTF16PtrFromString(item)
 		if err != nil {
@@ -76,7 +75,7 @@ func setProperty(hInstall MSIHANDLE, name, value string) error {
 	if err != nil {
 		return fmt.Errorf("failed to encode property value %q: %w", value, err)
 	}
-	_, _, _ = msiSetPropertyW.Call(
+	msiSetPropertyW.Call(
 		uintptr(hInstall),
 		uintptr(unsafe.Pointer(nameBuf)),
 		uintptr(unsafe.Pointer(valueBuf)),

--- a/src/go/wsl-helper/wix/imports_windows.go
+++ b/src/go/wsl-helper/wix/imports_windows.go
@@ -21,10 +21,12 @@ import "golang.org/x/sys/windows"
 type MSIHANDLE uint32
 
 var (
+	dllKernel32         = windows.NewLazySystemDLL("kernel32.dll")
 	dllMsi              = windows.NewLazySystemDLL("msi.dll")
 	msiCloseHandle      = dllMsi.NewProc("MsiCloseHandle")
 	msiCreateRecord     = dllMsi.NewProc("MsiCreateRecord")
 	msiRecordSetStringW = dllMsi.NewProc("MsiRecordSetStringW")
 	msiProcessMessage   = dllMsi.NewProc("MsiProcessMessage")
 	msiSetPropertyW     = dllMsi.NewProc("MsiSetPropertyW")
+	outputDebugStringW  = dllKernel32.NewProc("OutputDebugStringW")
 )

--- a/src/go/wsl-helper/wix/install_windows.go
+++ b/src/go/wsl-helper/wix/install_windows.go
@@ -37,7 +37,7 @@ func InstallWindowsFeatureImpl(hInstall MSIHANDLE) uint32 {
 	})
 
 	log.Infof("Installing Windows feature...")
-	_ = submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
+	submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
 		"", "InstalWindowsFeature", "Installing required Windows features...", "<unused>",
 	})
 	if err := wslutils.DismDoInstall(ctx, log); err != nil {
@@ -63,7 +63,7 @@ func InstallWSLImpl(hInstall MSIHANDLE) uint32 {
 	})
 
 	log.Info("Installing WSL...")
-	_ = submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
+	submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
 		"", "InstallWSL", "Installing Windows Subsystem for Linux...", "<unused>",
 	})
 	if err := wslutils.InstallWSL(ctx, log); err != nil {


### PR DESCRIPTION
This reverts commit 83e2eb2bcb88d86b1559a6e081c307f8520a33d0.

This change was not supposed to be merged before the 1.12 release. Reverting because it introduces a bug into `wsl-helper kubeconfig`.