### PR TITLE
Add more output on result of captureCommand.

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1070,11 +1070,19 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   protected async captureCommand(...command: string[]): Promise<string>;
   protected async captureCommand(options: wslExecOptions, ...command: string[]): Promise<string>;
   protected async captureCommand(optionsOrArg: wslExecOptions | string, ...command: string[]): Promise<string> {
-    if (typeof optionsOrArg === 'string') {
-      return await this.execCommand({ capture: true }, optionsOrArg, ...command);
-    }
+    let result: string;
+    let debugArg: string;
 
-    return await this.execCommand({ ...optionsOrArg, capture: true }, ...command);
+    if (typeof optionsOrArg === 'string') {
+      result = await this.execCommand({ capture: true }, optionsOrArg, ...command);
+      debugArg = optionsOrArg;
+    } else {
+      result = await this.execCommand({ ...optionsOrArg, capture: true }, ...command);
+      debugArg = JSON.stringify(optionsOrArg);
+    }
+    console.debug(`captureCommand:\ncommand: (${ debugArg } ${ command.map(s => `'${ s }'`).join(' ') })\noutput: <${ result }>`);
+
+    return result;
   }
 
   /** Get the IPv4 address of the VM, assuming it's already up. */

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -654,13 +654,13 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
    * - Figures out what the /mnt/DRIVE-LETTER path should be
    */
   async wslify(windowsPath: string, distro?: string): Promise<string> {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 1; i <= 10; i++) {
       const result: string = (await this.captureCommand({ distro }, 'wslpath', '-a', '-u', windowsPath)).trimEnd();
 
       if (result) {
         return result;
       }
-      console.log(`Failed to convert <${ windowsPath } to a wsl path, retrying${ i > 0 ? ` try #${ i + 1 }` : ' ' }`);
+      console.log(`Failed to convert '${ windowsPath }' to a wsl path, retry #${ i }`);
       await util.promisify(setTimeout)(100);
     }
 


### PR DESCRIPTION
Also give a stronger warning message when `wslify(path)` returns an empty string.