### PR TITLE
Stop updating `containersList` after value is received

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -259,6 +259,10 @@ export default {
           ipcRenderer.send('containers-namespaced-containers-read');
 
           containerCheckInterval = setInterval(() => {
+            if (this.containersList) {
+              return;
+            }
+
             ipcRenderer.send('containers-namespaced-read');
 
             // Reads containers in current namespace.


### PR DESCRIPTION
This implements the same behavior that is currently in place for the code path that runs for the moby container engine. This path would ultimately get cleaned up as a result of #6153 and the behavior for polling containers in  #5775.

closes #6189 