### PR TITLE
Update selected namespace for containerd

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -244,6 +244,8 @@ export default {
     isNerdCtl: {
       handler(newVal) {
         if (newVal) {
+          this.selectedNamespace = this.settings.containers.namespace;
+
           ipcRenderer.on('containers-namespaces', (_event, namespaces) => {
             this.containersNamespaces = namespaces;
             this.checkSelectedNamespace();


### PR DESCRIPTION
This ensures that the selected namespace for the containers page is set when containerd is the active container engine. 

closes #6191