### PR TITLE
Prevent closing snapshot dialog when lock clears

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -933,8 +933,8 @@ ipcMainProxy.on('dialog/error', (event, args) => {
   window.getWindow(args.dialog)?.webContents.send('dialog/error', args);
 });
 
-ipcMainProxy.on('dialog/close', (event, args) => {
-  window.getWindow(args.dialog)?.close();
+ipcMainProxy.on('dialog/close', (_event, args) => {
+  window.getWindow(args.dialog)?.webContents.send('dialog/close', args);
 });
 
 ipcMainProxy.handle('versions/macOs', () => {

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
                 errorButton:      this.t('snapshots.dialog.restore.error.buttonText'),
               });
           } else {
-            ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
+            ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog', snapshotEventType: 'restore' });
             ipcRenderer.send(
               'snapshot',
               {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -91,7 +91,7 @@ export default {
       this.showCreatingSnapshotDialog(action);
     });
     ipcRenderer.on('backend-unlocked', () => {
-      ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
+      ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog', snapshotEventType: 'backend-lock' });
     });
 
     ipcRenderer.send('backend-state-check');
@@ -160,10 +160,11 @@ export default {
             cancelId: 1,
           },
           format: {
-            header:          action || this.t('snapshots.dialog.generic.header', {}, true),
+            header:            action || this.t('snapshots.dialog.generic.header', {}, true),
             /** TODO: put here operation type information from 'state' */
-            message:         this.t('snapshots.dialog.generic.message', {}, true),
-            showProgressBar: true,
+            message:           this.t('snapshots.dialog.generic.message', {}, true),
+            showProgressBar:   true,
+            snapshotEventType: 'backend-lock',
           },
         },
       );

--- a/pkg/rancher-desktop/main/snapshots/types.ts
+++ b/pkg/rancher-desktop/main/snapshots/types.ts
@@ -1,5 +1,5 @@
 export type SnapshotEvent = {
-  type?: 'restore' | 'delete' | 'create' | 'confirm',
+  type?: 'restore' | 'delete' | 'create' | 'confirm' | 'backend-lock',
   result?: 'success' | 'cancel' | 'error',
   error?: string,
   snapshotName?: string,

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
         if (error) {
           ipcRenderer.send('dialog/error', { dialog: 'SnapshotsDialog', error });
         } else {
-          ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog' });
+          ipcRenderer.send('dialog/close', { dialog: 'SnapshotsDialog', snapshotEventType: 'create' });
 
           this.goBack({
             type:         'create',
@@ -107,9 +107,10 @@ export default Vue.extend({
             cancelId: 0,
           },
           format: {
-            header:          this.t('snapshots.dialog.creating.header', { snapshot: name }),
-            showProgressBar: true,
-            message:         this.t('snapshots.dialog.creating.message', { snapshot: name }, true),
+            header:            this.t('snapshots.dialog.creating.header', { snapshot: name }),
+            showProgressBar:   true,
+            message:           this.t('snapshots.dialog.creating.message', { snapshot: name }, true),
+            snapshotEventType: 'create',
           },
         },
       );

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -65,12 +65,25 @@ export default Vue.extend({
       ipcRenderer.send('dialog/ready');
     });
 
+    ipcRenderer.on('dialog/close', (_event, args) => {
+      if (args.snapshotEventType !== this.snapshotEventType) {
+        return;
+      }
+      ipcRenderer.send(
+        'dialog/close',
+        {
+          response:  this.response,
+          eventType: this.snapshotEventType,
+        });
+    });
+
     ipcRenderer.send('dialog/mounted');
   },
 
   beforeDestroy() {
     ipcRenderer.removeAllListeners('dialog/error');
     ipcRenderer.removeAllListeners('dialog/options');
+    ipcRenderer.removeAllListeners('dialog/close');
   },
 
   methods: {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -217,6 +217,7 @@ export interface IpcRendererEvents {
   'dialog/populate': (...args: any) => void;
   'dialog/size': (size: { width: number; height: number }) => void;
   'dialog/options': (...args: any) => void;
+  'dialog/close': (...args: any) => void;
   'dialog/error': (args: any) => void;
   'dialog/info': (args: Record<string, string>) => void;
   'dashboard-open': () => void;


### PR DESCRIPTION
This aims to ensure that the blocking snapshot dialogs will only close when the dialog window:

  a. receives the `dialog/close` signal
  b. contains a `snapshotEventType` that matches the source of the signal

The original implementation would indiscriminately close a dialog window when the main window receives a signal that a backend lock has cleared. This was problematic in snapshot operations that might result in an error, because they would then clear the backend lock resulting in the blocking dialog closing before the error message could be relayed to the user.

closes #6206 