### PR TITLE
Show progress bars only in blocking dialogs

### DIFF
--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
             header:            this.t(`snapshots.dialog.${ type }.header`, { snapshot: this.snapshot.name }),
             snapshot:          this.snapshot,
             message:           type === 'restore' ? this.t(`snapshots.dialog.${ type }.info`, { }, true) : '',
-            showProgressBar:   true,
+            showProgressBar:   false,
             snapshotEventType: 'confirm',
           },
         },

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -26,6 +26,7 @@ export default Vue.extend({
       response:          0,
       cancelId:          0,
       snapshotEventType: '',
+      showProgressBar:   false,
       credentials:       {
         user:     '',
         password: '',
@@ -58,6 +59,7 @@ export default Vue.extend({
       this.snapshot = format.snapshot;
       this.info = format.info;
       this.snapshotEventType = format.snapshotEventType;
+      this.showProgressBar = format.showProgressBar;
       this.bodyStyle = this.calculateBodyStyle(format.type);
       this.buttons = window.buttons || [];
       this.cancelId = window.cancelId;
@@ -227,7 +229,10 @@ export default Vue.extend({
         </slot>
       </div>
     </div>
-    <BackendProgress class="progress" />
+    <backend-progress
+      v-if="showProgressBar"
+      class="progress"
+    />
     <div
       class="dialog-actions"
       :class="{ 'dialog-actions-reverse': isDarwin() }"


### PR DESCRIPTION
This utilizes the `showProgressBar` formatting option in the snapshot dialogs to disable the progress bar during confirmation dialogs. 

closes #6204