### PR TITLE
Notify main window when settings update

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -156,6 +156,7 @@ mainEvents.on('settings-update', async(newSettings) => {
   }
 
   await runRdctlSetup(newSettings);
+  window.send('preferences/changed');
 });
 
 mainEvents.handle('settings-fetch', () => {


### PR DESCRIPTION
Send the `preferences/changed` event to notify the main window that settings have been changed. This is a fairly benign event that prompts the frontend to fetch Preferences and update its store.

closes #6227