### PR TITLE
Use `clean-html` directive for snapshots content

### DIFF
--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -181,8 +181,8 @@ export default Vue.extend({
         <div class="created">
           <span
             v-if="snapshot.formattedCreateDate"
+            v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
             class="value"
-            v-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
           />
         </div>
       </div>

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -95,8 +95,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
         @close="snapshotEvent=null"
       >
         <span
+          v-clean-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName, error: snapshotEvent.error }, true)"
           class="event-message"
-          v-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName, error: snapshotEvent.error }, true)"
         />
       </Banner>
     </div>

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -145,9 +145,10 @@ export default Vue.extend({
           <h1 v-if="errorTitle">
             {{ errorTitle }}
           </h1>
-          <h1 v-else>
-            {{ header }}
-          </h1>
+          <h1
+            v-else
+            v-clean-html="header"
+          />
         </slot>
       </div>
       <hr class="separator">
@@ -164,8 +165,8 @@ export default Vue.extend({
               <div class="created">
                 <span
                   v-if="snapshot.formattedCreateDate"
+                  v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
                   class="value"
-                  v-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
                 />
               </div>
             </div>
@@ -183,8 +184,8 @@ export default Vue.extend({
         class="message"
       >
         <span
+          v-clean-html="errorDescription"
           class="value"
-          v-html="errorDescription"
         />
       </div>
       <div
@@ -193,8 +194,8 @@ export default Vue.extend({
       >
         <slot name="message">
           <span
+            v-clean-html="message"
             class="value"
-            v-html="message"
           />
         </slot>
       </div>
@@ -207,7 +208,7 @@ export default Vue.extend({
             class="banner mb-20 info-banner"
             color="info"
           >
-            <span v-html="info" />
+            <span v-clean-html="info" />
           </Banner>
         </slot>
       </div>
@@ -220,7 +221,7 @@ export default Vue.extend({
             class="banner mb-20"
             color="error"
           >
-            <span v-html="error" />
+            <span v-clean-html="error" />
             <a
               href="#"
               @click.prevent="showLogs"


### PR DESCRIPTION
This replaces the usage of `v-html` with `v-clean-html` for all snapshot content. 

closes #6221
closes #6220