### PR TITLE
Update sizing for progress bar elements

### DIFF
--- a/pkg/rancher-desktop/components/BackendProgress.vue
+++ b/pkg/rancher-desktop/components/BackendProgress.vue
@@ -127,19 +127,19 @@ export default BackendProgress;
     display: flex;
     flex-direction: row;
     white-space: nowrap;
-    width: 100%;
     align-items: center;
+    flex: 1;
 
     .details {
       text-align: end;
       text-overflow: ellipsis;
       overflow: hidden;
       padding-right: 0.25rem;
-      width: 60%;
+      flex: 1;
     }
 
     .progress-bar {
-      width: 40%;
+      max-width: 12rem;
     }
 
     .duration {

--- a/pkg/rancher-desktop/components/StatusBar.vue
+++ b/pkg/rancher-desktop/components/StatusBar.vue
@@ -92,13 +92,12 @@ footer {
   .left-column {
     display: flex;
     white-space: nowrap;
-    width: 70%;
   }
 
   .right-column {
     display: flex;
     justify-content: flex-end;
-    width: 30%;
+    flex: 1;
   }
 
   .status-bar-item {


### PR DESCRIPTION
This updates the sizing for progress bar elements so that progress bar messages are no longer truncated unnecessarily.

## Screenshots

### Before

![CleanShot 2023-12-15 at 14 42 38@2x](https://github.com/rancher-sandbox/rancher-desktop/assets/78947/f8e953b7-fd23-45b9-a048-00bc5f4e19fb)

### After

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/835961/2d397750-e5a6-4967-96c5-7d21b1417969)


closes #6229