### PR TITLE
Bump lima to get timestamps on boot.sh messages

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-lima: 0.19.0.rd2
+lima: 0.19.0.rd3
 limaAndQemu: 1.31.2
 alpineLimaISO:
   isoVersion: 0.2.31.rd11


### PR DESCRIPTION
The cherry-picked change is https://github.com/rancher-sandbox/lima/compare/ef739161deaa0dd78870e7e872d8bb371cd6376f...92f90816793f6ce010cf1b8e31b8ef152758e44a#diff-f30a08edd04710e1218daf7e0a42e158bb327e09233638e091095a820ab07448