### PR TITLE
Bundle `libcairo` inside AppImage

### DIFF
--- a/packaging/linux/appimage.yml
+++ b/packaging/linux/appimage.yml
@@ -4,9 +4,10 @@ build:
   packages:
     - unzip
     - ImageMagick
+    - libcairo2
 
 script:
-  - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin
+  - rm -rf $BUILD_APPDIR/* && mkdir -p $BUILD_APPDIR/opt/rancher-desktop $BUILD_APPDIR/usr/share/metainfo $BUILD_APPDIR/usr/bin $BUILD_APPDIR/usr/lib64
   - unzip $BUILD_SOURCE_DIR/rancher-desktop.zip -d $BUILD_APPDIR/opt/rancher-desktop
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/rancher-desktop.desktop $BUILD_APPDIR
   - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop/resources/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop.png
@@ -14,5 +15,6 @@ script:
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/bin/qemu-* $BUILD_APPDIR/usr/bin
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/share/qemu $BUILD_APPDIR/usr/share
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/lib $BUILD_APPDIR/usr
+  - cp /usr/lib64/libcairo* $BUILD_APPDIR/usr/lib64/
   - ln -s ../../opt/rancher-desktop/rancher-desktop $BUILD_APPDIR/usr/bin/rancher-desktop
   - ln -s ../share/qemu $BUILD_APPDIR/usr/bin/pc_bios


### PR DESCRIPTION
Closes #6122.

Fedora 39 uses a version of `libcairo` that is newer than other distros. This newer version appears to have removed a symbol that is required for Rancher Desktop. The fix is to bundle the older version of `libcairo` inside the AppImage. Other package formats do not have this problem.