### PR TITLE
Remove experimental badge from socket_vmnet option

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineNetwork.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineNetwork.vue
@@ -33,7 +33,6 @@ export default Vue.extend({
     <rd-fieldset
       data-test="socketVmNet"
       :legend-text="t('virtualMachine.socketVmNet.legend')"
-      :is-experimental="true"
     >
       <rd-checkbox
         :label="t('virtualMachine.socketVmNet.label')"


### PR DESCRIPTION
vde_vmnet is already deprecated in upstream and doesn't include all the fixes that have been applied to socket_vmnet. It is also not supported by Lima for VZ emulation; so we silently pick socket_vmnet when admin mode is enabled together with VZ emulation. socket_vmnet is functionally identical, except it is missing the vde_switch mechanism, which we are not using anyways.