### PR TITLE
Bump lima to revert the QEMU guest agent communication method

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-lima: 0.19.0.rd2
+lima: 0.19.0.rd5
 limaAndQemu: 1.31.2
 alpineLimaISO:
   isoVersion: 0.2.31.rd11


### PR DESCRIPTION
Fixes #6151

Changes between `0.19.0.rd2` and `0.19.0.rd5` are: https://github.com/rancher-sandbox/lima/compare/ef739161deaa0dd78870e7e872d8bb371cd6376f...12546713676a07d150c790c9eac145d4eb1f9e39