### PR TITLE
Build M1 version of rdctl and docker-credential-none

### DIFF
--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -444,7 +444,8 @@ export default {
       cwd: path.join(this.rootDir, 'src', 'go', name),
       env: {
         ...process.env,
-        GOOS: this.mapPlatformToGoOS(platform),
+        GOOS:   this.mapPlatformToGoOS(platform),
+        GOARCH: this.mapArchToGoArch(this.arch),
       },
     });
   },


### PR DESCRIPTION
With this change, the only remaining program requiring Rosetta will be `kuberlr`, which is a more complicated issue:

```console
$ find . -type f -exec file {} \; | grep x86_64
./Contents/Resources/resources/darwin/bin/kuberlr: Mach-O 64-bit executable x86_64
```