### PR TITLE
Make sure the default containerd namespace always exists

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1924,6 +1924,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         switch (config.containerEngine.name) {
         case ContainerEngine.CONTAINERD:
           await this.startService('containerd');
+          try {
+            await this.execCommand({
+              root:          true,
+              expectFailure: true,
+            },
+            'ctr', '--address', '/run/k3s/containerd/containerd.sock', 'namespaces', 'create', 'default');
+          } catch {
+            // expecting failure because the namespace may already exist
+          }
           break;
         case ContainerEngine.MOBY:
           await this.startService('docker');

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1515,6 +1515,15 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         case ContainerEngine.CONTAINERD:
           await this.progressTracker.action('Starting buildkit', 0,
             this.startService('buildkitd'));
+          try {
+            await this.execCommand({
+              root:          true,
+              expectFailure: true,
+            },
+            'ctr', '--address', '/run/k3s/containerd/containerd.sock', 'namespaces', 'create', 'default');
+          } catch {
+            // expecting failure because the namespace may already exist
+          }
           this.#containerEngineClient = new NerdctlClient(this);
           break;
         case ContainerEngine.MOBY:

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -106,7 +106,7 @@ export const defaultSettings = {
   portForwarding: { includeKubernetesServices: false },
   images:         {
     showAll:   true,
-    namespace: 'k8s.io',
+    namespace: 'default',
   },
   containers: {
     showAll:   true,

--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -156,8 +156,7 @@ export default {
         return;
       }
       if (!this.imageNamespaces.includes(this.settings.images.namespace)) {
-        const K8S_NAMESPACE = 'k8s.io';
-        const defaultNamespace = this.imageNamespaces.includes(K8S_NAMESPACE) ? K8S_NAMESPACE : this.imageNamespaces[0];
+        const defaultNamespace = this.imageNamespaces.includes('default') ? 'default' : this.imageNamespaces[0];
 
         ipcRenderer.invoke('settings-write',
           { images: { namespace: defaultNamespace } } );


### PR DESCRIPTION
Only tested on macOS.

Also includes a change to make `default` the default namespace for the Images page.