### PR TITLE
Signing: also produce signed zip file on macOS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -68,6 +68,7 @@ bindir
 binfmt
 bitnami
 blkio
+blockmap
 bootfs
 bosco
 bottlesofbeeronthewall

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -44,7 +44,7 @@ interface ElectronBuilderConfiguration {
   }
 }
 
-export async function sign(workDir: string): Promise<string> {
+export async function sign(workDir: string): Promise<string[]> {
   const certFingerprint = process.env.CSC_FINGERPRINT ?? '';
   const certPassword = process.env.CSC_KEY_PASSWORD ?? '';
 
@@ -98,7 +98,7 @@ export async function sign(workDir: string): Promise<string> {
 
   await signFn(...filesToSign);
 
-  return await buildWiX(workDir, unpackedDir, signFn);
+  return [await buildWiX(workDir, unpackedDir, signFn)];
 }
 
 /**


### PR DESCRIPTION
We use the zip file for upgrades on macOS; therefore, we need to ensure we emit a zip file during signing there so that we can have an artifact with signed applications for the user to upgrade to.