### PR TITLE
CI: Test macOS signing during CI

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -3,6 +3,7 @@ abbrv
 ACTIONSTART
 activedirectory
 addexclusion
+addext
 addgroup
 addlabel
 addrepo
@@ -214,6 +215,7 @@ einfo
 electronjs
 elko
 elog
+endgroup
 endscript
 engineimage
 epinio
@@ -364,6 +366,8 @@ KDM
 keychain
 keycloak
 keycloakoidc
+keyform
+keyout
 Kgm
 kiali
 kib

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -137,14 +137,14 @@ jobs:
       env:
         OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}
 
-  sign:
-    name: Test Signing
+  sign-win:
+    name: Test Signing (Windows)
     needs: package
     runs-on: windows-2022
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
       (github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
@@ -153,7 +153,6 @@ jobs:
       with:
         persist-credentials: false
     - name: Install Windows dependencies
-      if: runner.os == 'Windows'
       shell: powershell
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
     - uses: actions/setup-go@v5
@@ -167,13 +166,12 @@ jobs:
       # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - uses: actions/download-artifact@v4
-      if: runner.os == 'Windows'
+      name: Download artifact
       with:
         name: Rancher Desktop-win.zip
-    - if: runner.os == 'Windows'
+    - name: Generate test signing certificate
       shell: powershell
       run: |
-        # Generate a test signing certificate
         $cert = New-SelfSignedCertificate `
           -Type Custom `
           -Subject "CN=Rancher-Sandbox, C=CA" `
@@ -182,13 +180,92 @@ jobs:
           -FriendlyName "Rancher-Sandbox Code Signing" `
           -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
         Write-Output $cert
-        $env:CSC_FINGERPRINT = $cert.Thumbprint
-        # Run the signing script
-        yarn sign -- (Get-Item "Rancher Desktop*-win.zip")
-        # Check that the msi file was signed by the expected cert
+        Write-Output "CSC_FINGERPRINT=$($cert.Thumbprint)" `
+          | Out-File -Append -Encoding ASCII "${env:GITHUB_ENV}"
+      timeout-minutes: 1
+    - name: Sign artifact
+      shell: powershell
+      run: yarn sign (Get-Item "Rancher Desktop*-win.zip")
+      timeout-minutes: 10
+    - name: Verify installer signature
+      shell: powershell
+      run: |
         $usedCert = (Get-AuthenticodeSignature -FilePath 'dist\Rancher Desktop Setup*.msi').SignerCertificate
         Write-Output $usedCert
-        if ($cert -ne $usedCert) {
-          Write-Output "Expected Certificate" $cert "Actual Certificate" $usedCert
+        if ($usedCert.Thumbprint -ne $env:CSC_FINGERPRINT) {
           Throw "Installer signed with wrong certificate"
         }
+      timeout-minutes: 1
+
+  sign-mac:
+    name: Test Signing (macOS)
+    needs: package
+    strategy:
+      matrix:
+        include:
+        - arch: aarch64
+        # skip x86_64, we don't need to duplicate the testing for now.
+    runs-on: macos-12
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '^1.21'
+        cache-dependency-path: src/go/**/go.sum
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18.16.x'
+        cache: yarn
+      # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
+    - run: yarn install --frozen-lockfile --network-timeout 1000000
+    - uses: actions/download-artifact@v4
+      name: Download artifact
+      with:
+        name: Rancher Desktop-mac.${{ matrix.arch }}.zip
+    - name: Generate test signing certificate
+      run: |
+        openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
+          -keyform pem -sha256 -days 3650 -nodes -subj \
+          "/C=CA/CN=RD Test Signing Key" \
+          -addext keyUsage=critical,digitalSignature \
+          -addext extendedKeyUsage=critical,codeSigning
+        # Create a custom keychain so we can unlock it properly.
+        security create-keychain -p "" tmp.keychain
+        security default-keychain -d user -s tmp.keychain
+        security unlock-keychain -p "" tmp.keychain
+        security import key.pem -k tmp.keychain -t priv -A
+        security import cert.pem -k tmp.keychain -t cert -A
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+          -k "" tmp.keychain
+        # Print out the valid certificates for debugging.
+        security find-identity
+        # Determine the key fingerprint.
+        awk_expr='/)/ { print $2 ; exit }'
+        hash="$(security find-identity | awk "$awk_expr")"
+        echo "CSC_FINGERPRINT=${hash}" >> "$GITHUB_ENV"
+      timeout-minutes: 1
+    - name: Flag build for M1
+      if: matrix.arch == 'aarch64'
+      run: echo "M1=1" >> "${GITHUB_ENV}"
+    - name: Sign artifact
+      run: |
+        for zip in Rancher\ Desktop-*mac*.zip; do
+          echo "::group::Signing ${zip}"
+          yarn sign --skip-notarize --skip-constraints "${zip}"
+          echo "::endgroup::"
+        done
+      timeout-minutes: 15
+    - name: Verify signature
+      run: |
+        codesign --verify --deep --strict --verbose=2 dist/*.dmg
+        codesign --verify --deep --strict --verbose=2 dist/*.zip
+      timeout-minutes: 5

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { flipFuses, FuseV1Options, FuseVersion } from '@electron/fuses';
 import { LinuxPackager } from 'app-builder-lib/out/linuxPackager';
 import { LinuxTargetHelper } from 'app-builder-lib/out/targets/LinuxTargetHelper';
-import { executeAppBuilder } from 'builder-util';
+import { executeAppBuilder, log } from 'builder-util';
 import {
   AfterPackContext, Arch, build, CliOptions, Configuration, LinuxTargetSpecificOptions,
 } from 'electron-builder';
@@ -103,7 +103,7 @@ class Builder {
   }
 
   async package(): Promise<CliOptions> {
-    console.log('Packaging...');
+    log.info('Packaging...');
 
     // Build the electron builder configuration to include the version data
     const config: ReadWrite<Configuration> = yaml.parse(await fs.promises.readFile('packaging/electron-builder.yml', 'utf-8'));


### PR DESCRIPTION
This enables running a version of the signing script during CI, so that we can check it's not catastrophically broken.  Note that this cannot test everything (because CI doesn't have access to production certificates), so we will still need some manual testing.

- Add macOS signing to the package step, where we currently test Windows signing.
- Add option to skip launch constraints embedding for mac, because CI runs macOS 11/12, and they do not support it (we need at least 13)
- Update macOS signing to never publish.
- Use a custom packager factory on macOS to avoid generating blockmap files as that take too long on CI for some reason (even though it takes less than a minute locally).
- Use electron-builder logging for more uniform output.