### PR TITLE
E2E: Windows: Fix keys for Kubernetes version

### DIFF
--- a/e2e/startup-profiles.e2e.spec.ts
+++ b/e2e/startup-profiles.e2e.spec.ts
@@ -80,13 +80,13 @@ async function createDefaultUserRegistryProfileWithIncorrectTypes() {
 async function createDefaultUserRegistryProfileWithValidDataButNoVersion() {
   const base = 'HKCU\\SOFTWARE\\Rancher Desktop\\Profile\\Defaults\\kubernetes';
 
-  await addRegistryEntry(base, 'version', 'REG_DWORD', '1');
+  await addRegistryEntry(base, 'version', 'REG_SZ', '1.21.0');
 }
 
 async function createLockedUserRegistryProfileWithValidDataButNoVersion() {
   const base = 'HKCU\\SOFTWARE\\Rancher Desktop\\Profile\\Locked\\kubernetes';
 
-  await addRegistryEntry(base, 'version', 'REG_DWORD', '1');
+  await addRegistryEntry(base, 'version', 'REG_SZ', '1.21.0');
 }
 
 test.describe.serial('track startup windows based on existing profiles and settings', () => {

--- a/pkg/rancher-desktop/main/networking/index.ts
+++ b/pkg/rancher-desktop/main/networking/index.ts
@@ -30,7 +30,7 @@ export default async function setupNetworking() {
       httpsOptions.ca.push(cert);
     }
   } catch (ex) {
-    console.error(ex);
+    console.error('Error getting system certificates:', ex);
     throw ex;
   }
 


### PR DESCRIPTION
It's a string, not a number.  This caused the tests to fail on Windows.

Also added a fix for the networking error logging; sometimes it was just logging `2` which was… not useful.