### PR TITLE
E2E: Implement unsetting profiles for Windows

### DIFF
--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -27,7 +27,7 @@ import { expect, test } from '@playwright/test';
 import { NavPage } from './pages/nav-page';
 import { verifyNoSystemProfile } from './utils/ProfileUtils';
 import {
-  createDefaultSettings, createUserProfile, startRancherDesktop, teardown, tool,
+  createDefaultSettings, setUserProfile, startRancherDesktop, teardown, tool,
 } from './utils/TestUtils';
 
 import type { DeploymentProfileType } from '@pkg/config/settings';
@@ -66,7 +66,7 @@ test.describe('Locked fields', () => {
   }
 
   async function restoreUserProfile() {
-    await createUserProfile(deploymentProfile?.defaults ?? null, deploymentProfile?.locked ?? null);
+    await setUserProfile(deploymentProfile?.defaults ?? null, deploymentProfile?.locked ?? null);
   }
 
   test.describe.configure({ mode: 'serial' });
@@ -85,7 +85,7 @@ test.describe('Locked fields', () => {
   test.beforeAll(async() => {
     createDefaultSettings({ containerEngine: { allowedImages: { enabled: true, patterns: ['a', 'b', 'c', 'e'] } } });
     await saveUserProfile();
-    await createUserProfile(
+    await setUserProfile(
       { version: 10 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true } } },
       {
         version:         10,

--- a/e2e/startup-profiles.e2e.spec.ts
+++ b/e2e/startup-profiles.e2e.spec.ts
@@ -31,7 +31,7 @@ import {
   verifySystemProfile,
   verifyUserProfile,
 } from './utils/ProfileUtils';
-import { createUserProfile, reportAsset } from './utils/TestUtils';
+import { setUserProfile, reportAsset } from './utils/TestUtils';
 
 import { CURRENT_SETTINGS_VERSION, Settings } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
@@ -149,7 +149,7 @@ test.describe.serial('track startup windows based on existing profiles and setti
           },
         } as unknown as RecursivePartial<Settings>;
 
-        await createUserProfile(s1, null);
+        await setUserProfile(s1, null);
       }
       // We have a deployment with only a version field, good enough to bypass the first-run dialog.
       await testForNoFirstRunWindow(`${ __filename }-nonexistent-settings`);
@@ -229,7 +229,7 @@ test.describe.serial('track startup windows based on existing profiles and setti
       } else {
         const s1 = { version: 10, kubernetes: { version: ['strawberries', 'limes'] } } as unknown as RecursivePartial<Settings>;
 
-        await createUserProfile(s1, null);
+        await setUserProfile(s1, null);
       }
       const windowCount = await testWaitForLogfile(filename, logPath);
       const contents = await fs.promises.readFile(logPath, { encoding: 'utf-8' });
@@ -255,7 +255,7 @@ test.describe.serial('track startup windows based on existing profiles and setti
       if (process.platform === 'win32') {
         await createDefaultUserRegistryProfileWithValidDataButNoVersion();
       } else {
-        await createUserProfile({ kubernetes: { enabled: false } }, null);
+        await setUserProfile({ kubernetes: { enabled: false } }, null);
       }
       const windowCount = await testWaitForLogfile(filename, logPath);
       const contents = await fs.promises.readFile(logPath, { encoding: 'utf-8' });
@@ -280,7 +280,7 @@ test.describe.serial('track startup windows based on existing profiles and setti
       if (process.platform === 'win32') {
         await createLockedUserRegistryProfileWithValidDataButNoVersion();
       } else {
-        await createUserProfile(null, { kubernetes: { enabled: false } });
+        await setUserProfile(null, { kubernetes: { enabled: false } });
       }
       const windowCount = await testWaitForLogfile(filename, logPath);
       const contents = await fs.promises.readFile(logPath, { encoding: 'utf-8' });

--- a/e2e/utils/ProfileUtils.ts
+++ b/e2e/utils/ProfileUtils.ts
@@ -8,7 +8,7 @@ import util from 'util';
 import { expect, Page } from '@playwright/test';
 
 import {
-  createDefaultSettings, createUserProfile, startRancherDesktop, retry, teardown,
+  createDefaultSettings, setUserProfile, startRancherDesktop, retry, teardown,
 } from './TestUtils';
 import { NavPage } from '../pages/nav-page';
 
@@ -126,7 +126,7 @@ export async function verifyNoRegistrySubtree(hive: string): Promise<void> {
 
 export async function verifyUserProfile(): Promise<void> {
   await clearUserProfile();
-  await createUserProfile({ version: 10 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true } } }, null);
+  await setUserProfile({ version: 10 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true } } }, null);
 }
 
 export async function verifyNoSystemProfile(): Promise<string[]> {

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -11,7 +11,7 @@ import { NavPage } from '../e2e/pages/nav-page';
 import { PreferencesPage } from '../e2e/pages/preferences';
 import { clearUserProfile } from '../e2e/utils/ProfileUtils';
 import {
-  createDefaultSettings, createUserProfile, reportAsset, retry, teardown, tool,
+  createDefaultSettings, setUserProfile, reportAsset, retry, teardown, tool,
 } from '../e2e/utils/TestUtils';
 
 import { ContainerEngine, CURRENT_SETTINGS_VERSION } from '@pkg/config/settings';
@@ -39,7 +39,7 @@ test.describe.serial('Main App Test', () => {
       diagnostics: { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
     });
 
-    await createUserProfile(
+    await setUserProfile(
       { version: 10 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true, patterns: [] } } },
       {},
     );


### PR DESCRIPTION
Previously the unset path was not implemented on Windows (and silently ignored), which meant running E2E tests after would fail without `RD_TEST_ALLOW_PROFILE` being set because the cleanup was ineffective.