### PR TITLE
E2E: Backend: ensure old settings have valid Kubernetes version

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -89,6 +89,17 @@ test.describe.serial('KubernetesBackend', () => {
     test('should detect changes', async() => {
       const currentSettings = (await get('/v1/settings')) as Settings;
 
+      if (!currentSettings.kubernetes.version) {
+        // The Kubernetes version could be empty if it's previously disabled.
+        // Set something.
+        const updatedSettings: RecursivePartial<Settings> = {
+          kubernetes: { version: '1.23.4' },
+          version:    10 as Settings['version'],
+        };
+
+        await expect(put('/v1/settings', updatedSettings)).resolves.toBeDefined();
+      }
+
       const newSettings: RecursivePartial<Settings> = {
         containerEngine: { name: getAlternateSetting(currentSettings, 'containerEngine.name', ContainerEngine.CONTAINERD, ContainerEngine.MOBY) },
         kubernetes:      {


### PR DESCRIPTION
If the user previously started Rancher Desktop offline (or otherwise caused the version to be invalid), we would end up failing when we tried to compare the existing version to the new proposed version because semver would fail to parse the empty string.  Avoid this by manually setting the version to a valid string before continuing.