### PR TITLE
CI: Package: Disable macOS keychain auto-lock

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -242,6 +242,7 @@ jobs:
         security create-keychain -p "" tmp.keychain
         security default-keychain -d user -s tmp.keychain
         security unlock-keychain -p "" tmp.keychain
+        security set-keychain-settings -u tmp.keychain # Disable keychain auto-lock
         security import key.pem -k tmp.keychain -t priv -A
         security import cert.pem -k tmp.keychain -t cert -A
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s \


### PR DESCRIPTION
By default, new keychains are set up to auto-lock after five minutes.  This happened to be _right_ on the edge of how long everything else takes, so we got intermittent timeouts during test signing in CI because the system was waiting for the user to input the (empty) keychain password.

Since we're creating the temporary keychain ourselves anyway, just set it to never expire instead.

This should resolve issues with the CI sometimes failing on `main`.