### PR TITLE
package.json: Remove eslint-plugin-standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-nuxt": "4.0.0",
     "eslint-plugin-promise": "5.2.0",
-    "eslint-plugin-standard": "4.0.0",
     "eslint-plugin-vue": "8.7.1",
     "extract-zip": "2.0.1",
     "jest": "29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6514,11 +6514,6 @@ eslint-plugin-promise@5.2.0, eslint-plugin-promise@^5.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz#a596acc32981627eb36d9d75f9666ac1a4564971"
   integrity sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==
 
-eslint-plugin-standard@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
-  integrity sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==
-
 eslint-plugin-unicorn@^39.0.0:
   version "39.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-39.0.0.tgz#ee76d4f3bf37c605d89fa449d5e7c0c44c54b0cc"


### PR DESCRIPTION
That doesn't appear to be used anymore.

Checked that `yarn lint` still passes (which means `eslint` is running fine).