### PR TITLE
CI: E2E: Use GitHub-hosted runners for Linux

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   e2e-tests:
     timeout-minutes: 150
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,9 +44,13 @@ jobs:
               }
             }
           EOF
+      - name: Enable kvm access
+        run: sudo chmod a+rwx /dev/kvm
       - name: Run e2e Tests
         continue-on-error: false
-        run: yarn test:e2e
+        run: >-
+          xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24'
+          yarn test:e2e
         env:
           RD_DEBUG_ENABLED: '1'
           CI: true


### PR DESCRIPTION
GitHub runners now appear to allow nested virtualization, so our E2E tests now pass on them.  They also appear to be faster.

We needed to do two things to make this work:
- Run the test under xvfb, so that we can create windows.  (We previously did this as part of the runner, instead of the test script.)
- Allow the test user to access the KVM kernel module.  Since this is a VM, I just made it publicly accessible.