### PR TITLE
CI: Use GitHub-hosted runners for Windows E2E

### DIFF
--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -8,18 +8,19 @@ defaults:
   run:
     shell: powershell
 jobs:
-
   e2e-tests:
     timeout-minutes: 90
-    runs-on: [self-hosted, Windows, X64, win11]
+    runs-on: windows-latest
     steps:
-      - run: wsl --unregister rancher-desktop
+      - name: Update any pre-installed WSL
+        run: wsl --update
         continue-on-error: true
-      - run: wsl --unregister rancher-desktop-data
-        continue-on-error: true
-      - run: Remove-Item -Path "$HOME/AppData/Local/rancher-desktop" -Recurse -Force -ErrorAction Ignore
-      - name: Remove golang module cache
-        run: Remove-Item -Path "$HOME/go/pkg/mod" -Recurse -Force -ErrorAction Ignore
+      - name: Install WSL2 from the Store as necessary
+        run: wsl --install --no-distribution
+      - run: wsl --version
+      - name: Stop Docker daemon
+        run: Stop-Service -Name docker
+        shell: powershell
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -522,6 +522,7 @@ describeWithCreds('Credentials server', () => {
         'https://bobs.fish/clams05': 'none',
       },
     };
+    let existingDockerConfig: Buffer | undefined;
 
     test.beforeAll(async() => {
       const platform = os.platform();
@@ -535,7 +536,22 @@ describeWithCreds('Credentials server', () => {
       } else {
         throw new Error(`Unexpected platform of ${ platform }`);
       }
+      try {
+        existingDockerConfig = await fs.promises.readFile(dockerConfigPath);
+      } catch (ex) {
+        if (Object(ex).code !== 'ENOENT') {
+          throw ex;
+        }
+      }
       await fs.promises.writeFile(dockerConfigPath, JSON.stringify(dockerConfig, undefined, 2));
+    });
+
+    test.afterAll(async() => {
+      if (existingDockerConfig) {
+        await fs.promises.writeFile(dockerConfigPath, existingDockerConfig);
+      } else {
+        await fs.promises.unlink(dockerConfigPath);
+      }
     });
 
     // removeEntries and addEntry return Promise<void>,

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -304,7 +304,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     this.progressTracker = new ProgressTracker((progress) => {
       this.progress = progress;
       this.emit('progress');
-    });
+    }, console);
 
     if (!(process.env.RD_TEST ?? '').includes('e2e')) {
       process.on('exit', async() => {

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -106,7 +106,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     this.progressTracker = new ProgressTracker((progress) => {
       this.progress = progress;
       this.emit('progress');
-    });
+    }, console);
 
     this.hostSwitchProcess = new BackgroundProcess('host-switch.exe', {
       spawn: async() => {


### PR DESCRIPTION
This enables using GitHub-hosted runners for E2E testing, now that it seems to support nested virtualization.

This also fixes a test so that another test passes (… yay).

For details, please look at the commit messages.

We should do a follow-up to enable Windows E2E tests on push (like we do for the Linux ones).  This seems to finish in ~25 minutes (the Linux ones now take ~20 minutes, and it used to take ~40 minutes on our own runners).