### PR TITLE
CI: Windows-E2E: enable on push

### DIFF
--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -1,9 +1,12 @@
 name: e2e tests on Windows
 
 on:
-  schedule:
-    - cron: '13 5 * * 1-5'
-  workflow_dispatch: {}
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
 defaults:
   run:
     shell: powershell
@@ -20,7 +23,6 @@ jobs:
       - run: wsl --version
       - name: Stop Docker daemon
         run: Stop-Service -Name docker
-        shell: powershell
       - uses: actions/checkout@v4
         with:
           persist-credentials: false


### PR DESCRIPTION
Since we're not using GitHub-hosted runners, it's safe to turn on running Windows E2E tests on push.

This is in draft until #6345 is merged.