### PR TITLE
rdctl: Fix `rdctl setup --auto-start` on Linux without AppImage

### DIFF
--- a/src/go/rdctl/cmd/factoryReset.go
+++ b/src/go/rdctl/cmd/factoryReset.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/factoryreset"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shutdown"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,9 +41,6 @@ Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached Kuberne
 		if err := cobra.NoArgs(cmd, args); err != nil {
 			return err
 		}
-		if commonShutdownSettings.Verbose {
-			logrus.SetLevel(logrus.TraceLevel)
-		}
 		cmd.SilenceUsage = true
 		commonShutdownSettings.WaitForShutdown = false
 		_, err := doShutdown(&commonShutdownSettings, shutdown.FactoryReset)
@@ -62,5 +58,4 @@ Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached Kuberne
 func init() {
 	rootCmd.AddCommand(factoryResetCmd)
 	factoryResetCmd.Flags().BoolVar(&removeKubernetesCache, "remove-kubernetes-cache", false, "If specified, also removes the cached Kubernetes images.")
-	factoryResetCmd.Flags().BoolVar(&commonShutdownSettings.Verbose, "verbose", false, "Be verbose")
 }

--- a/src/go/rdctl/cmd/root.go
+++ b/src/go/rdctl/cmd/root.go
@@ -18,16 +18,18 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "rdctl",
-	Short: "A CLI for Rancher Desktop",
-	Long:  `The eventual goal of this CLI is to enable any UI-based operation to be done from the command-line as well.`,
+	Use:               "rdctl",
+	Short:             "A CLI for Rancher Desktop",
+	Long:              `The eventual goal of this CLI is to enable any UI-based operation to be done from the command-line as well.`,
+	PersistentPreRunE: config.PersistentPreRunE,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -22,12 +22,10 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shutdown"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 type shutdownSettingsStruct struct {
-	Verbose         bool
 	WaitForShutdown bool
 }
 
@@ -41,9 +39,6 @@ var shutdownCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := cobra.NoArgs(cmd, args); err != nil {
 			return err
-		}
-		if commonShutdownSettings.Verbose {
-			logrus.SetLevel(logrus.TraceLevel)
 		}
 		cmd.SilenceUsage = true
 		result, err := doShutdown(&commonShutdownSettings, shutdown.Shutdown)
@@ -59,7 +54,6 @@ var shutdownCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(shutdownCmd)
-	shutdownCmd.Flags().BoolVar(&commonShutdownSettings.Verbose, "verbose", false, "be verbose")
 	shutdownCmd.Flags().BoolVar(&commonShutdownSettings.WaitForShutdown, "wait", true, "wait for shutdown to be confirmed")
 }
 

--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +44,7 @@ type ConnectionInfo struct {
 
 var (
 	connectionSettings ConnectionInfo
+	verbose            bool
 
 	configPath string
 	// DefaultConfigPath - used to differentiate not being able to find a user-specified config file from the default
@@ -71,6 +73,7 @@ func DefineGlobalFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringVar(&connectionSettings.Host, "host", "", "default is 127.0.0.1; most useful for WSL")
 	rootCmd.PersistentFlags().IntVar(&connectionSettings.Port, "port", 0, "overrides the port setting in the config file")
 	rootCmd.PersistentFlags().StringVar(&connectionSettings.Password, "password", "", "overrides the password setting in the config file")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Be verbose")
 }
 
 // GetConnectionInfo returns the connection details of the application API server.
@@ -161,4 +164,12 @@ func wslifyConfigDir() (string, error) {
 		return "", err
 	}
 	return strings.TrimRight(outBuf.String(), "\r\n"), err
+}
+
+// PersistentPreRunE is meant to be executed as the cobra hook
+func PersistentPreRunE(cmd *cobra.Command, args []string) error {
+	if verbose {
+		logrus.SetLevel(logrus.TraceLevel)
+	}
+	return nil
 }


### PR DESCRIPTION
In BATS, we're testing Rancher Desktop without using AppImage.  This makes the auto-start test fail because it can't figure out where the application is (because it assumes AppImage).

Fix the implementation to detect when we're _not_ using AppImage, and use the normal code path for finding the main `rancher-desktop` executable in that case.