### PR TITLE
Misc BATS fixes

### DIFF
--- a/bats/README.md
+++ b/bats/README.md
@@ -18,6 +18,10 @@ If the repository will be cloned on Win32, prior to cloning it, it's important t
 Note that changing `crlf` settings is not needed when you clone it inside a WSL distro.
 Regardless of the repository location, the BATS tests can be executed ONLY from inside a WSL distribution. So, if the repository is cloned on Win32, the repository can be located within a WSL distro from /mnt/c, as it represents the `C:` drive on Windows.
 
+### On Linux:
+
+ImageMagick is required to take screenshots on failure.
+
 ### All platforms:
 
 From the root directory of the Git repository, run the following commands to install BATS and its helper libraries into the BATS test directory:

--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -17,7 +17,11 @@ load '../helpers/load'
 }
 
 @test 'verify rancher' {
-    run try --max 9 --delay 10 curl --insecure --silent --show-error "https://localhost:8443/dashboard/auth/login"
+    local max_tries=9
+    if [[ -n $CI ]]; then
+        max_tries=30
+    fi
+    run try --max $max_tries --delay 10 curl --insecure --silent --show-error "https://localhost:8443/dashboard/auth/login"
     assert_success
     assert_output --partial "Rancher Dashboard"
     run ctrctl logs rancher

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -1,6 +1,7 @@
 wait_for_kubelet() {
     local desired_version="${1:-$RD_KUBERNETES_PREV_VERSION}"
     local timeout="$(($(date +%s) + 10 * 60))"
+    trace "waiting for Kubernetes ${desired_version} to be available"
     while true; do
         until kubectl get --raw /readyz &>/dev/null; do
             assert [ "$(date +%s)" -lt "$timeout" ]

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -101,6 +101,7 @@ setup() {
 
 teardown() {
     if [ -z "$BATS_TEST_SKIPPED" ] && [ -z "$BATS_TEST_COMPLETED" ]; then
+        capture_logs
         take_screenshot
     fi
 

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -243,14 +243,22 @@ capture_logs() {
 
 take_screenshot() {
     if taking_screenshots; then
+        local image_path
+        image_path="$(unique_filename "${PATH_BATS_LOGS}/${BATS_SUITE_TEST_NUMBER}-${BATS_TEST_DESCRIPTION}" .png)"
+        mkdir -p "$PATH_BATS_LOGS"
         if is_macos; then
-            local file
-            file=$(unique_filename "${PATH_BATS_LOGS}/${BATS_SUITE_TEST_NUMBER}-${BATS_TEST_DESCRIPTION}" .png)
-            mkdir -p "$PATH_BATS_LOGS"
             # The terminal app must have "Screen Recording" permission;
             # otherwise only the desktop background is captured.
             # -x option means "do not play sound"
-            screencapture -x "$file"
+            screencapture -x "$image_path"
+        elif is_linux; then
+            if import -help </dev/null 2>&1 | grep --quiet -E 'Version:.*Magick'; then
+                # `import` from ImageMagick is available.
+                import -window root "$image_path"
+            elif gm import -help </dev/null 2>&1 | grep --quiet -E 'Version:.*Magick'; then
+                # GraphicsMagick is installed (its command is `gm`).
+                gm import -window root "$image_path"
+            fi
         fi
     fi
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -219,6 +219,10 @@ docker_context_exists() {
     run docker_exe context ls -q
     assert_success || return
     assert_line "$RD_DOCKER_CONTEXT"
+    # Ensure that the context actually exists by reading from the file.
+    run docker_exe context inspect "$RD_DOCKER_CONTEXT" --format '{{ .Name }}'
+    assert_success || return
+    assert_output "$RD_DOCKER_CONTEXT"
 }
 
 get_service_pid() {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -2,9 +2,13 @@ wait_for_shell() {
     if is_windows; then
         try --max 24 --delay 5 rdctl shell true
     else
+        # Be at the root directory to avoid issues with limactl automatic
+        # changing to the current directory, which might not exist.
+        pushd /
         try --max 24 --delay 5 rdctl shell test -f /var/run/lima-boot-done
         # wait until sshfs mounts are done
         try --max 12 --delay 5 rdctl shell test -d "$HOME/.rd"
+        popd || :
     fi
 }
 
@@ -259,6 +263,9 @@ assert_service_status() {
 wait_for_service_status() {
     local service_name=$1
     local expect=$2
+
+    trace "waiting for VM to be available"
+    wait_for_shell
 
     trace "waiting for ${service_name} to be ${expect}"
     try --max 30 --delay 5 assert_service_status "$service_name" "$expect"


### PR DESCRIPTION
This is a small grab-bag of BATS fixes while trying to get BATS to run in CI (on Linux).  This does not fix all of the BATS issues; more are likely to show up later.

- Implement screenshoting on error on Linux (using ImageMagick/GraphicsMagick).
- Capture logs on step teardowns, so that we have a better chance of capturing relevant logs (on failure) before we wipe them when restarting the app later.
- Various extra logging to help debugging.
- Strategic `wait_for_backend` calls; this is mainly useful when we end up checking too early (where `rdctl` might fail because we can't ssh to the VM yet, or when we catch the app before it finished shutting down and accidentally think everything has finished starting).
- When checking for a docker (CLI) context to exist, actually make it print out the context to detect cases where the context has been added to `~/.docker/config.json`, but the actual configuration hasn't been added to `~/.docker/contexts/…`.