### PR TITLE
Updater: MSI: Don't be quiet if we need to elevate

### DIFF
--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -45,13 +45,6 @@ jobs:
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn package
-    - name: Upload Windows exe installer
-      if: runner.os == 'Windows'
-      uses: actions/upload-artifact@v4
-      with:
-        name: Rancher Desktop Setup.exe
-        path: dist/Rancher Desktop*.exe
-        if-no-files-found: error
     - name: Upload Windows installer
       if: runner.os == 'Windows'
       uses: actions/upload-artifact@v4
@@ -59,12 +52,14 @@ jobs:
         name: Rancher Desktop Setup.msi
         path: dist/Rancher Desktop*.msi
         if-no-files-found: error
+    - if: runner.os == 'Windows'
+      run: cat dist/electron-builder.yaml
     - name: Upload Windows build information
       if: runner.os == 'Windows'
       uses: actions/upload-artifact@v4
       with:
         name: build-info.yml
-        path: dist/latest.yml
+        path: dist/electron-builder.yaml
         if-no-files-found: error
     - name: Upload macOS archive
       uses: actions/upload-artifact@v4

--- a/pkg/rancher-desktop/main/update/MSIUpdater.ts
+++ b/pkg/rancher-desktop/main/update/MSIUpdater.ts
@@ -93,14 +93,15 @@ export default class MsiUpdater extends NsisUpdater {
       '/lv*', path.join(paths.logs, 'msiexec.log'),
       '/i', options.installerPath,
     ];
+    const elevate = options.isAdminRightsRequired || this.shouldElevate;
 
-    if (options.isSilent) {
+    if (options.isSilent && !elevate) {
       args.push('/quiet');
     } else {
       args.push('/passive');
     }
 
-    args.push(`MSIINSTALLPERUSER=${ options.isAdminRightsRequired || this.shouldElevate ? '0' : '1' }`);
+    args.push(`MSIINSTALLPERUSER=${ elevate ? '0' : '1' }`);
 
     if (options.isForceRunAfter) {
       args.push('RDRUNAFTERINSTALL=1');

--- a/scripts/populate-update-server.ts
+++ b/scripts/populate-update-server.ts
@@ -252,7 +252,7 @@ async function main() {
   const packageURL = new URL(JSON.parse(await fs.promises.readFile('package.json', 'utf-8')).repository.url);
   const [packageOwner, packageRepo] = packageURL.pathname.replace(/\.git$/, '').split('/').filter(x => x);
   const buildInfo = yaml.parse(await fs.promises.readFile(buildInfoPath, 'utf-8'));
-  const tag: string = buildInfo.version.replace(/^v?/, 'v');
+  const tag: string = buildInfo.extraMetadata.version.replace(/^v?/, 'v');
 
   console.log(`Publishing ${ tag } from ${ owner }/${ repo } (upstream is ${ packageOwner }/${ packageRepo })...`);
   if (packageOwner === owner && packageRepo === repo) {


### PR DESCRIPTION
If we need to elevate, then using `msiexec /quiet` will just make the install fail.  Make it `/passive` instead; the user gets to see the installer prompt but there will be no options.

This helps with #6377 but if the user can't elevate (they are not the administrator of the machine and can't do anything about it) they will not be able to get back into Rancher Desktop.

(This is untested, therefore it's a draft.)