### PR TITLE
Dependabot: ignore @nuxtjs/eslint-config-typescript >11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,12 @@ updates:
       - # Current Vue config targets webpack 5.
         dependency-name: "webpack"
         versions: [ ">5" ]
+      - # Since we no longer pull in Nuxt (i.e. we have "ejected"), newer
+        # versions of this package mis-detect and think we're using Nuxt 3 (with
+        # Vue 3), and uses the wrong set of linters.  This happened in v12, so
+        # we ignore everything higher than 11.
+        dependency-name: "@nuxtjs/eslint-config-typescript"
+        versions: [ ">11" ]
       - # node-fetch 3+ requires ECMAScript modules, but Electron doesn't
         # support that. See https://github.com/electron/electron/issues/21457
         dependency-name: "node-fetch"


### PR DESCRIPTION
Newer versions try to auto-detect for Nuxt 3; however, since we don't actually have Nuxt listed as a dependency, it mis-detects and thinks we are using Nuxt 3 (using Vue 3) and tries to use the wrong set of lint plugins for Vue.

Since we're not bumping Nuxt ever, we can use a static set of linters here.

This replaces #6375.