### PR TITLE
k3s: Use GITHUB_TOKEN if available

### DIFF
--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -382,7 +382,12 @@ export default class K3sHelper extends events.EventEmitter {
       let channelResponse: Response;
 
       try {
-        channelResponse = await fetch(this.channelApiUrl, { headers: { Accept: this.channelApiAccept } });
+        const headers: HeadersInit = { Accept: this.channelApiAccept };
+
+        if (process.env.GITHUB_TOKEN) {
+          headers.Authorization = `Bearer ${ process.env.GITHUB_TOKEN }`;
+        }
+        channelResponse = await fetch(this.channelApiUrl, { headers });
       } catch (ex: any) {
         console.log(`updateCache: error: ${ ex }`);
         if (!(await checkConnectivity('k3s.io'))) {
@@ -407,7 +412,12 @@ export default class K3sHelper extends events.EventEmitter {
       }
 
       while (wantMoreVersions && url) {
-        const response = await fetch(url, { headers: { Accept: this.releaseApiAccept } });
+        const headers: HeadersInit = { Accept: this.releaseApiAccept };
+
+        if (process.env.GITHUB_TOKEN) {
+          headers.Authorization = `Bearer ${ process.env.GITHUB_TOKEN }`;
+        }
+        const response = await fetch(url, { headers });
 
         console.debug(`Fetching releases from ${ url } -> ${ response.statusText }`);
         if (!response.ok) {


### PR DESCRIPTION
This uses `GITHUB_TOKEN` if it's set when fetching k3s versions.  This is mostly for use in CI, where shared runners are probably very low on IP-based API quota, but using the CI-provided token wouldn't have the same issues.