### PR TITLE
Prepare for 1.12.3

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -68,6 +68,7 @@ bindir
 binfmt
 bitnami
 blkio
+blockmap
 bootfs
 bosco
 bottlesofbeeronthewall

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rancher-desktop",
   "productName": "Rancher Desktop",
   "license": "Apache-2.0",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "author": {
     "name": "SUSE",
     "email": "containers@suse.com"

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,9 +1,9 @@
 lima: 0.19.0.rd5
 limaAndQemu: 1.31.2
 alpineLimaISO:
-  isoVersion: 0.2.31.rd11
+  isoVersion: 0.2.31.rd12
   alpineVersion: 3.18.0
-WSLDistro: "0.51"
+WSLDistro: 0.51.1
 kuberlr: 0.4.4
 helm: 3.13.3
 dockerCLI: 24.0.7

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -44,7 +44,7 @@ interface ElectronBuilderConfiguration {
   }
 }
 
-export async function sign(workDir: string): Promise<string> {
+export async function sign(workDir: string): Promise<string[]> {
   const certFingerprint = process.env.CSC_FINGERPRINT ?? '';
   const certPassword = process.env.CSC_KEY_PASSWORD ?? '';
 
@@ -98,7 +98,7 @@ export async function sign(workDir: string): Promise<string> {
 
   await signFn(...filesToSign);
 
-  return await buildWiX(workDir, unpackedDir, signFn);
+  return [await buildWiX(workDir, unpackedDir, signFn)];
 }
 
 /**

--- a/src/go/nerdctl-stub/nerdctl_commands_generated.go
+++ b/src/go/nerdctl-stub/nerdctl_commands_generated.go
@@ -140,6 +140,7 @@ var commands = map[string]commandDefinition{
 		commandPath: "build",
 		subcommands: map[string]struct{}{},
 		options: map[string]argHandler{
+			"--allow":         ignoredArgHandler,
 			"--build-arg":     ignoredArgHandler,
 			"--buildkit-host": ignoredArgHandler,
 			"--cache-from":    ignoredArgHandler,
@@ -179,6 +180,7 @@ var commands = map[string]commandDefinition{
 		commandPath: "builder build",
 		subcommands: map[string]struct{}{},
 		options: map[string]argHandler{
+			"--allow":         ignoredArgHandler,
 			"--build-arg":     ignoredArgHandler,
 			"--buildkit-host": ignoredArgHandler,
 			"--cache-from":    ignoredArgHandler,
@@ -1229,6 +1231,7 @@ var commands = map[string]commandDefinition{
 		commandPath: "image build",
 		subcommands: map[string]struct{}{},
 		options: map[string]argHandler{
+			"--allow":         ignoredArgHandler,
 			"--build-arg":     ignoredArgHandler,
 			"--buildkit-host": ignoredArgHandler,
 			"--cache-from":    ignoredArgHandler,


### PR DESCRIPTION
* Bumps package version to 1.12.3
* Updates runc to 1.1.12 and buildkit to 0.12.5 to address CVEs.
* Cherry-picks changes to macOS signing script, but does not include 19d237a.

