### PR TITLE
Drop rosetta detection

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -922,7 +922,7 @@ ipcMainProxy.handle('versions/macOs', () => {
 });
 
 ipcMainProxy.handle('host/isArm', () => {
-  return Electron.app.runningUnderARM64Translation || process.arch.startsWith('arm');
+  return process.arch === 'arm64';
 });
 
 ipcMainProxy.on('help/preferences/open-url', async() => {
@@ -1191,7 +1191,7 @@ async function getExtensionManager() {
 }
 
 function newK8sManager() {
-  const arch = (Electron.app.runningUnderARM64Translation || os.arch() === 'arm64') ? 'aarch64' : 'x86_64';
+  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
   const mgr = K8sFactory(arch, dockerDirManager);
 
   mgr.on('state-changed', (state: K8s.State) => {

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 
-import Electron from 'electron';
 import _ from 'lodash';
 import semver from 'semver';
 
@@ -304,7 +303,7 @@ export default class SettingsValidator {
 
         return false;
       }
-      if (!Electron.app.runningUnderARM64Translation && os.arch() !== 'arm64') {
+      if (process.arch !== 'arm64') {
         errors.push(`Setting ${ fqname } can only be enabled on aarch64 systems.`);
         this.isFatal = true;
 

--- a/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
+++ b/pkg/rancher-desktop/main/diagnostics/limaDarwin.ts
@@ -1,4 +1,3 @@
-import Electron from 'electron';
 import semver from 'semver';
 
 import { DiagnosticsCategory, DiagnosticsChecker } from './types';
@@ -26,7 +25,7 @@ const CheckLimaDarwin: DiagnosticsChecker = {
   category: DiagnosticsCategory.ContainerEngine,
   applicable() {
     const isDarwin = process.platform === 'darwin';
-    const isArm = Electron.app.runningUnderARM64Translation || process.arch.startsWith('arm');
+    const isArm = process.arch === 'arm64';
 
     return Promise.resolve(isDarwin && isArm);
   },

--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -393,7 +393,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
     const assetFilter: (asset: GitHubReleaseAsset) => boolean = (() => {
       switch (this.platform) {
       case 'darwin': {
-        const isArm64 = Electron.app.runningUnderARM64Translation || os.arch() === 'arm64';
+        const isArm64 = process.arch === 'arm64';
         const suffix = isArm64 ? '-mac.aarch64.zip' : '-mac.x86_64.zip';
 
         return (asset: GitHubReleaseAsset) => asset.name.endsWith(suffix);

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -191,7 +191,7 @@ let extPath = '';
  */
 const createView = () => {
   const hostInfo = {
-    arch:     Electron.app.runningUnderARM64Translation ? 'arm64' : process.arch,
+    arch:     process.arch,
     hostname: os.hostname(),
   };
 


### PR DESCRIPTION
Since we now ship native Electron binaries, there's no longer any point in checking for Rosetta; drop detection for it, except for the part where we check for running lima under rosetta.