### PR TITLE
MSI: Drop dummy icon exe, use rdctl

### DIFF
--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -31,4 +31,3 @@ resources/resources/win32/internal:
 - steve.exe
 - vtunnel.exe
 - wsl-helper.exe
-- '!dummy.exe'

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -478,7 +478,6 @@ export default {
       tasks.push(() => this.buildUtility('vtunnel', 'win32', 'internal'));
       tasks.push(() => this.buildUtility('rdctl', 'linux', 'bin'));
       tasks.push(() => this.buildUtility('privileged-service', 'win32', 'internal'));
-      tasks.push(() => this.buildUtility('dummy', 'win32', 'internal'));
     }
     tasks.push(() => this.buildUtility('rdctl', os.platform(), 'bin'));
     tasks.push(() => this.buildUtility('docker-credential-none', os.platform(), 'bin'));

--- a/scripts/lib/installer-win32-gen.tsx
+++ b/scripts/lib/installer-win32-gen.tsx
@@ -206,12 +206,6 @@ export default async function generateFileList(rootPath: string): Promise<string
       return null;
     },
 
-    'resources\\resources\\win32\\internal\\dummy.exe': () => {
-      // This file is used for shortcut icons in the installer; it does not need
-      // to be installed.
-      return null;
-    },
-
     // @ts-ignore
     'resources\\resources\\win32\\internal\\privileged-service.exe': (d, f) => {
       return <Component>

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -77,7 +77,7 @@ export default async function buildInstaller(workDir: string, appDir: string, de
   console.log('Writing out WiX definition...');
   await fs.promises.writeFile(path.join(workDir, 'project.wxs'), output);
   console.log('Compiling WiX...');
-  const iconPath = path.join(appDir, 'resources', 'resources', 'win32', 'internal', 'dummy.exe');
+  const iconPath = path.join(appDir, 'resources', 'resources', 'win32', 'bin', 'rdctl.exe');
   const inputs = [
     path.join(workDir, 'project.wxs'),
     path.join(process.cwd(), 'build', 'wix', 'dialogs.wxs'),

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -176,7 +176,7 @@ class Builder {
     const iconArgs = ['icon', '--format', 'ico', '--out', workDir, '--input', imageFile];
     const iconResult = await this.executeAppBuilderAsJson(iconArgs);
     const iconFile = iconResult.icons[0].file;
-    const executable = path.join(process.cwd(), 'resources', 'win32', 'internal', 'dummy.exe');
+    const executable = path.join(process.cwd(), 'resources', 'win32', 'bin', 'rdctl.exe');
     const rceditArgs = [executable, '--set-icon', iconFile];
 
     await executeAppBuilder(['rcedit', '--args', JSON.stringify(rceditArgs)], undefined, undefined, 3);

--- a/src/go/dummy/go.mod
+++ b/src/go/dummy/go.mod
@@ -1,3 +1,0 @@
-module github.com/rancher-sandbox/rancher-desktop/src/go/dummy
-
-go 1.21.2

--- a/src/go/dummy/main.go
+++ b/src/go/dummy/main.go
@@ -1,6 +1,0 @@
-// Command dummy is an empty executable; this is used in the Windows installer
-// as an executable to hold icons.
-package main
-
-func main() {
-}


### PR DESCRIPTION
Some virus scanners are flagging the dummy exe because it doesn't do anything. Use rdctl instead, so hopefully they don't flag it (and it's a signed executable).

This hopefully helps with #6414