### PR TITLE
[Do Not Merge] Do not update /etc/hosts when integration is enabled

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -128,7 +128,6 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       await Promise.all([
         this.syncHostSocketProxy(),
         this.syncHostDockerPlugins(),
-        this.syncHostFile(),
         ...(await this.supportedDistros).map(distro => this.syncDistro(distro.name, kubeconfigPath)),
       ]);
     } catch (ex) {
@@ -405,39 +404,6 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       await this.execCommand({ distro }, wslHelper, 'wsl', 'integration', 'docker-plugin', `--plugin=${ srcPath }`, `--state=${ state }`);
     } catch (error) {
       console.error(`Failed to sync ${ distro } docker plugin ${ pluginName }: ${ error }`.trim());
-    }
-  }
-
-  protected async syncHostFile() {
-    await Promise.all(
-      (await this.supportedDistros).map((distro) => {
-        return this.updateHostsFile(distro.name);
-      }),
-    );
-  }
-
-  protected async updateHostsFile(distro: string) {
-    const entry = '192.168.1.2 gateway.rancher-desktop.internal';
-
-    try {
-      console.debug(`Update ${ distro } host file`);
-      if (this.settings.experimental?.virtualMachine?.networkingTunnel) {
-        await this.execCommand(
-          { distro, root: true },
-          await this.getLinuxToolPath(distro, executable('wsl-helper-linux')),
-          'update-host',
-          `--entries=${ entry }`,
-        );
-      } else {
-        await this.execCommand(
-          { distro, root: true },
-          await this.getLinuxToolPath(distro, executable('wsl-helper-linux')),
-          'update-host',
-          `--remove`,
-        );
-      }
-    } catch (error: any) {
-      console.error(`Could not update ${ distro } host file`, error);
     }
   }
 


### PR DESCRIPTION
This PR undo some previous attempts to make the WSL integration work in our new network stack. Since we decided to change the approach and revert to the symlink, we no longer need the work that was done previously.

Related to: https://github.com/rancher-sandbox/rancher-desktop/issues/6245