### PR TITLE
BATS: Bump submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "bats/bats-core"]
 	path = bats/bats-core
 	url = https://github.com/rancher-sandbox/bats-core.git
+	branch = master
 [submodule "bats/bats-assert"]
 	path = bats/bats-assert
 	url = https://github.com/rancher-sandbox/bats-assert.git
+	branch = master
 [submodule "bats/bats-support"]
 	path = bats/bats-support
 	url = https://github.com/rancher-sandbox/bats-support.git
+	branch = master
 [submodule "bats/bats-file"]
 	path = bats/bats-file
 	url = https://github.com/rancher-sandbox/bats-file.git
+	branch = master

--- a/bats/README.md
+++ b/bats/README.md
@@ -66,7 +66,7 @@ To test the Windows-based tools, set `RD_USE_WINDOWS_EXE` to `true` before runni
 By default bats will use Rancher Desktop installed in a "system" location. If
 that doesn't exists, it will try a "user" location, followed by the local "dist"
 directory inside the local git directory. The final option if none of the above
-apply is to use "dev", which uses `npm run dev`. On Linux there is no "user"
+apply is to use "dev", which uses `yarn dev`. On Linux there is no "user"
 location.
 
 You can explicitly request a specific install location by setting `RD_LOCATION` to `system`, `user`, `dist`, or `dev`:

--- a/bats/README.md
+++ b/bats/README.md
@@ -63,9 +63,13 @@ To test the Windows-based tools, set `RD_USE_WINDOWS_EXE` to `true` before runni
 
 ### RD_LOCATION
 
-By default bats will use Rancher Desktop installed in a "system" location. If that doesn't exists, it will try a "user" location, followed by the local "dist" directory inside the local git directory. The final option if is to use "npm". On Linux there is no "user" location.
+By default bats will use Rancher Desktop installed in a "system" location. If
+that doesn't exists, it will try a "user" location, followed by the local "dist"
+directory inside the local git directory. The final option if none of the above
+apply is to use "dev", which uses `npm run dev`. On Linux there is no "user"
+location.
 
-You can explicitly request a specific install location by setting `RD_LOCATION` to `system`, `user`, `dist`, or `npm`:
+You can explicitly request a specific install location by setting `RD_LOCATION` to `system`, `user`, `dist`, or `dev`:
 
 ```
 cd bats

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -21,7 +21,12 @@ RD_TEST_FILENAME=${RD_TEST_FILENAME%.bats}
 
 # Use fatal() to abort loading helpers; don't run any tests
 fatal() {
-    echo "   $1" >&3
+    # fd 3 might not be open if we're not fully under bats yet; detect that.
+    if [[ -e /dev/fd/3 ]]; then
+        echo "   $1" >&3
+    else
+        echo "   $1" >&2
+    fi
     exit 1
 }
 
@@ -88,7 +93,7 @@ teardown_file() {
     if is_linux || is_windows; then
         # On Linux & Windows if we don't shutdown Rancher Desktop bats tests don't terminate.
         shutdown=true
-    elif [[ $RD_LOCATION == dev ]]; then
+    elif using_dev_mode; then
         # In dev mode, we also need to shut down.
         shutdown=true
     elif using_ramdisk; then

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -12,7 +12,7 @@ set_path_resources() {
     local dist=$3
     local subdir=$4
 
-    if [ -z "$RD_LOCATION" ]; then
+    if [ -z "${RD_LOCATION:-}" ]; then
         if [ -d "$system" ]; then
             RD_LOCATION=system
         elif [ -d "$user" ]; then
@@ -20,7 +20,7 @@ set_path_resources() {
         elif [ -d "$dist" ]; then
             RD_LOCATION=dist
         elif inside_repo_clone; then
-            RD_LOCATION=npm
+            RD_LOCATION=dev
         else
             (
                 echo "Couldn't locate Rancher Desktop in"


### PR DESCRIPTION
Only bats-core has changed; the relevant change is the fix for multiple slashes in the test name for `--gather-test-output-in`.  However, the bump also exposed issues where we had unset variables (BAT previous broke usage of `-o nounset`).