### PR TITLE
Switch back to cgroup v1 when running k3s 1.20.2 and earlier

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -38,6 +38,19 @@ provision:
     fi
     umount /bootfs
     rmdir /bootfs
+- # make sure we booted with the right cgroup mode; k3s versions before 1.20.4 only support cgroup v1
+  mode: system
+  script: |
+    #!/bin/sh
+    set -o errexit -o nounset -o xtrace
+    [[ "${RC_CGROUP_MODE:-}" =~ "unified|hybrid|legacy" ]] || exit 0
+    if ! grep -q -E "^#?rc_cgroup_mode=\"$RC_CGROUP_MODE\"" /etc/rc.conf; then
+      sed -i -E "s/^#?rc_cgroup_mode=\".*\"/rc_cgroup_mode=\"$RC_CGROUP_MODE\"/" /etc/rc.conf
+      # avoid reboot loop if sed failed for any reason
+      if grep -q -E "^rc_cgroup_mode=\"$RC_CGROUP_MODE\"" /etc/rc.conf; then
+        reboot
+      fi
+    fi
 - # return unused space from the data volume back to the host
   mode: system
   script: |

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -142,6 +142,7 @@ export type LimaConfiguration = {
   }
   portForwards?: Array<Record<string, any>>;
   networks?: Array<Record<string, string | boolean>>;
+  env?: Record<string, string>;
 };
 
 /**
@@ -669,6 +670,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         },
       },
     });
+
+    // k3s supports cgroup v2 starting with 1.20.4
+    config.env ||= {};
+    config.env['RC_CGROUP_MODE'] = 'unified';
+    if (this.cfg?.kubernetes?.enabled && this.cfg.kubernetes.version) {
+      if (semver.lt(this.cfg.kubernetes.version, '1.20.4')) {
+        config.env['RC_CGROUP_MODE'] = 'hybrid';
+      }
+    }
 
     // Alpine can boot via UEFI now
     if (config.firmware) {


### PR DESCRIPTION
This could be slightly faster by editing `/etc/rc.conf` before the reboot, but adds complexity[^1] that would only shave off less than 15s of the reboot time when switching from k3s 1.20.4+ down to 1.20.2 and earlier, or back again (there was no 1.20.3). So I think it is not worth it to optimize this further.

[^1]: We don't have a running VM for first-boot config, so any code to edit the running config would have to be in addition to what is in this PR.

Fixes #6425