### PR TITLE
Add all-k3s.sh script to run BATS tests over multiple k3s versions

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -698,6 +698,7 @@ snakize
 softmmu
 someothername
 somepaththatshouldnevereverexist
+sourced
 splatform
 splunk
 ssd

--- a/bats/scripts/all-k3s.sh
+++ b/bats/scripts/all-k3s.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Run BATS against a list of k3s versions.
+#
+# It will factory reset, so the current VM and settings will be lost.
+# Snapshots however should be preserved.
+
+set -o errexit -o nounset -o pipefail
+
+# VERSIONS is the list of versions to test, e.g. "1.28.6 1.29.1".
+# Special value "all" will be replaced with all available tags from GitHub.
+# Special value "latest" will be replaced with versions from the release channel.
+#
+# Downloading the airgap tarballs for all k3s releases take almost 50GB, so
+# make sure you have good bandwidth and enough storage. Maybe save the cache
+# for re-use before running BATS tests that will clear the cache.
+: "${VERSIONS:=}"
+
+# TEST can specify a filename with additional test commands. It will be sourced
+# after kubelet is responsive.
+: "${TEST:=}"
+
+# The VERSIONS list can be filtered by MIN and MAX versions. The MIN and MAX
+# versions themselves will not be filtered out.
+: "${MIN_VERSION:=1.0.0}"
+: "${MAX_VERSION:=1.999.0}"
+
+# When SKIP_RUN is non-empty then the tests will not be executed, but the script
+# filename will be written to stdout. Otherwise the script will be deleted.
+: "${SKIP_RUN:=}"
+
+# By default the BATS kubelet timeout is 10 minutes. If the test is expected to
+# fail starting up k3s a lot, then reducing the timeout it highly recommended
+# (there are almost 200 k3s versions).
+: "${RD_KUBELET_TIMEOUT:=2}"
+export RD_KUBELET_TIMEOUT
+
+if [[ $VERSIONS == "all" ]]; then
+    # filter out duplicates; RD only supports the latest of +k3s1, +k3s2, etc.
+    VERSIONS=$(
+        gh api /repos/k3s-io/k3s/releases --paginate --jq '.[].tag_name' |
+            grep -E '^v1\.[0-9]+\.[0-9]+\+k3s[0-9]+$' |
+            sed -E 's/v([^+]+)\+.*/\1/' |
+            sort --unique --version-sort
+    )
+fi
+
+if [[ $VERSIONS == "latest" ]]; then
+    VERSIONS=$(
+        curl --silent https://update.k3s.io/v1-release/channels |
+            jq --raw-output '.data[] | select(.name | test("^v[0-9]+\\.[0-9]+$")).latest' |
+            sed -E 's/v([^+]+)\+.*/\1/'
+    )
+fi
+
+# PATH_BATS is the location of the bats/ directory in the rancher-desktop repo.
+# This script is in the bats/scripts/ subdirectory.
+PATH_BATS=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")/.."
+    pwd
+)
+
+SCRIPT=$(mktemp)
+
+cat >"$SCRIPT" <<EOF
+load '${PATH_BATS}/tests/helpers/load'
+
+check() {
+    RD_KUBERNETES_PREV_VERSION=\$BATS_TEST_DESCRIPTION
+    factory_reset
+    start_kubernetes
+    wait_for_kubelet
+EOF
+
+# Source $TEST as part of the test for each k3s version
+if [[ -f $TEST ]]; then
+    TEST=$(
+        cd "$(dirname "$TEST")"
+        pwd
+    )/$(basename "$TEST")
+    echo "    source \"${TEST}\"" >>"$SCRIPT"
+fi
+
+cat >>"$SCRIPT" <<'EOF'
+}
+
+EOF
+
+# Execute check() for each k3s version within the (inclusive) MIN/MAX range
+for VERSION in $VERSIONS; do
+    if printf "%s\n" "$MIN_VERSION" "$VERSION" "$MAX_VERSION" | sort --check=silent --version-sort; then
+        echo "@test '$VERSION' { check; }" >>"$SCRIPT"
+    fi
+done
+
+if [[ -z $SKIP_RUN ]]; then
+    time "${PATH_BATS}/bats-core/bin/bats" \
+        "${PATH_BATS}/tests/helpers/info.bash" \
+        "$SCRIPT"
+    rm "$SCRIPT"
+else
+    echo "$SCRIPT"
+fi

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -170,8 +170,13 @@ using_ramdisk() {
 }
 
 ########################################################################
-# Use RD_PROTECTED_DOT in profile settings for WSL distro names
+# Use RD_PROTECTED_DOT in profile settings for WSL distro names.
 : "${RD_PROTECTED_DOT:=·}"
+
+########################################################################
+# RD_KUBELET_TIMEOUT specifies the number of minutes wait_for_kubelet()
+# waits before it times out.
+: "${RD_KUBELET_TIMEOUT:=10}"
 
 ########################################################################
 # RD_LOCATION specifies the location where Rancher Desktop is installed

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -1,6 +1,6 @@
 wait_for_kubelet() {
-    local desired_version="${1:-$RD_KUBERNETES_PREV_VERSION}"
-    local timeout="$(($(date +%s) + 10 * 60))"
+    local desired_version=${1:-$RD_KUBERNETES_PREV_VERSION}
+    local timeout=$(($(date +%s) + RD_KUBELET_TIMEOUT * 60))
     trace "waiting for Kubernetes ${desired_version} to be available"
     while true; do
         until kubectl get --raw /readyz &>/dev/null; do


### PR DESCRIPTION
By default `all-k3s.sh` simply checks that kubelet from each version becomes ready in Rancher Desktop, but it can be configured to run additional checks (via `TEST`).

Suggestions for a better name for this script welcome; I don't really like `all-k3s`, but am having a brain-freeze in coming up with a proper name.

Using `VERSIONS=all` runs against **all** k3s releases on GitHub, and `VERSIONS=latest` against the latest release of each minor version (from the release channel).

Checking Rancher `2.8.1` against k3s `1.22.17` and `1.24.17`:

```console
$ VERSIONS="1.22.17 1.24.17" TEST=rancher.bats ./scripts/all-k3s.sh
info.bash
 ✓ show_info
   Install location:         system
   Resources path:           /Applications/Rancher Desktop.app/Contents/Resources/resources

   Container engine:         containerd
   Mount type:               reverse-sshfs
   Using image allow list:   false
   Using socket_vmnet:       false
   Using VZ emulation:       false
   Using ramdisk:            false

   Capturing logs:           false
   Tracing execution:        false
   Taking screenshots:       false
   Using ghcr.io images:     false
/var/folders/wm/pq6w7kf54215fxz392ff3rxr0000gn/T/tmp.88I9ikgl
   ===== /var/folders/wm/pq6w7kf54215fxz392ff3rxr0000gn/T/tmp.88I9ikgl =====
 ✓ 1.22.17
 ✓ 1.24.17

3 tests, 0 failures


real	7m1.471s
user	0m24.408s
sys	0m8.508s
```

The `rancher.bats` script is:

```bash
helm repo add jetstack https://charts.jetstack.io
helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
helm repo update

helm upgrade \
     --install cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --set installCRDs=true \
     --set "extraArgs[0]=--enable-certificate-owner-ref=true" \
     --create-namespace

helm upgrade \
     --install rancher rancher-latest/rancher \
     --version "2.8.1" \
     --namespace cattle-system \
     --set hostname="localhost" \
     --wait \
     --timeout=10m \
     --create-namespace

run try --max 9 --delay 10 curl --insecure --silent --show-error "https://localhost/dashboard/auth/login"
assert_success
assert_output --partial "<title>Rancher</title>"

run kubectl get secret --namespace cattle-system bootstrap-secret -o json
assert_success
assert_output --partial "bootstrapPassword"
```

The test was writing and executing this test script:

```bash
load '/Users/jan/suse/rd/bats/tests/helpers/load'

check() {
    RD_KUBERNETES_PREV_VERSION=$BATS_TEST_DESCRIPTION
    factory_reset
    start_kubernetes
    wait_for_kubelet
    source "/Users/jan/suse/rd/bats/rancher.bats"
}

@test '1.22.17' { check; }
@test '1.24.17' { check; }
```