### PR TITLE
BATS: Check use of semver comparision with invalid semver

### DIFF
--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -22,6 +22,20 @@ while (<>) {
         $problems++;
     }
 
+    # The semver comparison functions take arguments that are valid semver;
+    # catch uses of it with invalid versions, like '1.2' instead of '1.2.3'.
+    if (/
+      (semver_(?:n?eq|[lg]te?)) # Semver comparison function
+      [^#\n]*                   # Eat any number of characters before new line or comment
+      (?<!\d)                   # Was not preceded by digit (or we'd check that instead)
+      (?<!\d\.)                 # Was not preceded by digit-dot (or we'd check that instead)
+      (?!\d+\.\d+\.\d+)         # Is not a valid version string
+      (\b\d[\d.]*)              # But starts a version string
+    /x) {
+      print qq'$ARGV:$.: $1 must be called with a valid semver, got "$2"\n';
+      $problems++;
+    }
+
     # Matches:
     # - assert_success
     # - $assert_success


### PR DESCRIPTION
This catches uses like:
  smever_neq $foo 1.2
  semver_gt 3 $bar
The issue being version numbers that don't correctly have three parts.