### PR TITLE
BATS: Lint `*.bash` too

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -30,7 +30,7 @@ bats.tar.gz: $(DEPS)
 	git submodule update --init --recursive
 	tar cvfz "$@" --exclude-vcs --exclude "*/test/*" --exclude "*/docs/*" -- *
 
-JQ_VERSION ?= 1.6
+JQ_VERSION ?= 1.7.1
 JQ_URL=https://github.com/stedolan/jq/releases/download/jq-$(JQ_VERSION)
 
 bin/darwin/jq:

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -14,7 +14,8 @@ SC_EXCLUDES ?= SC1091,SC2034,SC2154
 
 .PHONY: lint
 lint:
-	@./scripts/bats-lint.pl $(shell find tests -name '*.bats')
+	find tests -name '*.bash' | xargs ./scripts/bats-lint.pl
+	find tests -name '*.bats' | xargs ./scripts/bats-lint.pl
 	find tests -name '*.bash' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find tests -name '*.bats' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find scripts -name '*.sh' | xargs shellcheck -s bash -e $(SC_EXCLUDES)

--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -14,12 +14,14 @@ my $problems = 0;
 my $run;
 
 while (<>) {
-    # bats files should not override the global setup and teardown functions.
-    # They should define local_* variants instead, which will be called from
-    # the global versions.
-    if (/^((setup|teardown)\w*)\(/) {
-        print "$ARGV:$.: Don't define $1(); define local_$1() instead\n";
-        $problems++;
+    if ($ARGV =~ /\.bats$/) {
+      # bats files should not override the global setup and teardown functions.
+      # They should define local_* variants instead, which will be called from
+      # the global versions.
+      if (/^((setup|teardown)\w*)\(/) {
+          print "$ARGV:$.: Don't define $1(); define local_$1() instead\n";
+          $problems++;
+      }
     }
 
     # Matches:

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -108,7 +108,7 @@ teardown_file() {
         shutdown=true
     fi
     if is_true $shutdown; then
-        run rdctl shutdown
+        rdctl shutdown || :
     fi
 
     teardown_ramdisk

--- a/bats/tests/helpers/profile.bash
+++ b/bats/tests/helpers/profile.bash
@@ -93,7 +93,7 @@ create_profile() {
         ;;
     windows)
         # Make sure any old profile data at this location is removed
-        run profile_reg delete "."
+        profile_reg delete "." || :
         # Create subkey so that profile_exists returns true now
         profile_reg add "."
         ;;
@@ -105,10 +105,10 @@ delete_profile() {
     if deleting_profiles; then
         case $OS in
         darwin | linux)
-            run profile_sudo rm -f "$(profile_location)"
+            profile_sudo rm -f "$(profile_location)" || :
             ;;
         windows)
-            run profile_reg delete "."
+            profile_reg delete "." || :
             ;;
         esac
     fi
@@ -222,13 +222,13 @@ remove_profile_entry() {
 
     case $OS in
     darwin)
-        run profile_plutil -remove "${setting%.}"
+        profile_plutil -remove "${setting%.}" || return
         ;;
     linux)
-        run profile_jq "del(.${setting%.})"
+        profile_jq "del(.${setting%.})" || return
         ;;
     windows)
-        run profile_reg delete "$setting"
+        profile_reg delete "$setting" || return
         ;;
     esac
 }
@@ -273,7 +273,7 @@ profile_plutil() {
                 local keypath
                 keypath=$(echo "$setting" | cut -d . -f 1-"$index")
                 # Ignore error if dictionary already exists
-                run profile_sudo plutil -insert "$keypath" -dictionary "$(profile_location)"
+                profile_sudo plutil -insert "$keypath" -dictionary "$(profile_location)" || :
             done
         fi
     fi

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -206,6 +206,12 @@ get_json_test_data() {
     assert_output $'\n.'
 }
 
+@test 'jq must be version 1.7.1 or newer' {
+    run semver "$(jq --version)"
+    assert_success
+    semver_gte "$output" 1.7.1
+}
+
 ########################################################################
 
 @test 'semver a1b2.3c4.5.6d7.8.9.0' {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -83,7 +83,7 @@ setup_ramdisk() {
     if ((ramdisk_size < ${RD_FILE_RAMDISK_SIZE:-0})); then
         local fmt='%s requires %dGB of ramdisk; disabling ramdisk for this file'
         # shellcheck disable=SC2059 # The string is set the line above.
-        fmt="$(printf "$fmt" "$BATS_TEST_FILENAME" "$RD_FILE_RAMDISK_SIZE")"
+        printf -v fmt "$fmt" "$BATS_TEST_FILENAME" "$RD_FILE_RAMDISK_SIZE"
         printf "RD:   %s\n" "$fmt" >>"$BATS_WARNING_FILE"
         printf "# WARN: %s\n" "$fmt" >&3
         return

--- a/bats/tests/preferences/verify-settings.bats
+++ b/bats/tests/preferences/verify-settings.bats
@@ -19,7 +19,7 @@ proxy_set() {
     local field=$1
     local value=$2
 
-    payload=$(printf '{ "version": 10, "experimental": { "virtualMachine": { "proxy": { "%s": %s }}}}' "$field" "$value")
+    printf -v payload '{ "version": 10, "experimental": { "virtualMachine": { "proxy": { "%s": %s }}}}' "$field" "$value"
     run rdctl api settings -X PUT --body "$payload"
     assert_failure
     assert_output --partial "Changing field \"experimental.virtualMachine.proxy.${field}\" via the API isn't supported"
@@ -48,7 +48,7 @@ proxy_set() {
     assert_success
     run jq_output .experimental.virtualMachine.proxy
     assert_success
-    payload=$(printf '{ "version": 10, "experimental": { "virtualMachine": { "proxy": %s }}}' "$output")
+    printf -v payload '{ "version": 10, "experimental": { "virtualMachine": { "proxy": %s }}}' "$output"
     run rdctl api settings -X PUT --body "$payload"
     assert_success
 }

--- a/bats/tests/profile/create-profile-output.bats
+++ b/bats/tests/profile/create-profile-output.bats
@@ -258,7 +258,7 @@ assert_check_registry_output() {
     run rdctl create-profile --output reg --body '{"application": { "window": { "quitOnClose": true }}}'
     assert_success
     SETTINGS_VERSION=$(get_setting .version)
-    HEX_SETTINGS_VERSION=$(printf "%x" "$SETTINGS_VERSION")
+    printf -v HEX_SETTINGS_VERSION "%x" "$SETTINGS_VERSION"
     assert_output - <<EOF
 Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies]
@@ -289,7 +289,7 @@ EOF
 assert_registry_output_for_maps_and_lists() {
     assert_success
     SETTINGS_VERSION=$(get_setting .version)
-    HEX_SETTINGS_VERSION=$(printf "%x" "$SETTINGS_VERSION")
+    printf -v HEX_SETTINGS_VERSION "%x" "$SETTINGS_VERSION"
     assert_output - <<EOF
 Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\SOFTWARE\Policies]


### PR DESCRIPTION
Previously, we only linted `*.bats`, which means we missed some issues in the helpers being loaded.

I noticed that `remove_profile_entry` was never used, but I fixed it anyway.