### PR TITLE
Revert back to symlink for kubeconfig

### DIFF
--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -37,19 +37,9 @@ type kubeConfig struct {
 		Cluster struct {
 			Server string
 			Extras map[string]interface{} `yaml:",inline"`
-		} `yaml:"cluster"`
-		Name   string                 `yaml:"name"`
+		}
 		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:"clusters"`
-	Contexts []struct {
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:"contexts"`
-	CurrentContext string `yaml:"current-context"`
-	Users          []struct {
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:"users"`
+	} `yaml:",omitempty"`
 	Extras map[string]interface{} `yaml:",inline"`
 }
 

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -37,9 +37,19 @@ type kubeConfig struct {
 		Cluster struct {
 			Server string
 			Extras map[string]interface{} `yaml:",inline"`
-		}
+		} `yaml:"cluster"`
+		Name   string                 `yaml:"name"`
 		Extras map[string]interface{} `yaml:",inline"`
-	} `yaml:",omitempty"`
+	} `yaml:"clusters"`
+	Contexts []struct {
+		Name   string                 `yaml:"name"`
+		Extras map[string]interface{} `yaml:",inline"`
+	} `yaml:"contexts"`
+	CurrentContext string `yaml:"current-context"`
+	Users          []struct {
+		Name   string                 `yaml:"name"`
+		Extras map[string]interface{} `yaml:",inline"`
+	} `yaml:"users"`
 	Extras map[string]interface{} `yaml:",inline"`
 }
 

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -22,23 +22,19 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"path/filepath"
+	"path"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 	"k8s.io/client-go/util/homedir"
 )
 
 var kubeconfigViper = viper.New()
 
-const rdCluster = "rancher-desktop"
-
-// kubeconfigCmd represents the kubeconfig command, used to set up kubeconfig
-// in WSL distributions (running on the Linux side).  Note that we must
+// kubeconfigCmd represents the kubeconfig command, used to set up a symlink on
+// the Linux side to point at the Windows-side kubeconfig.  Note that we must
 // pass the kubeconfig path in as an environment variable to take advantage of
 // the path translation capabilities of WSL2 interop.
 var kubeconfigCmd = &cobra.Command{
@@ -47,194 +43,80 @@ var kubeconfigCmd = &cobra.Command{
 	Long:  `This command configures the Kubernetes configuration inside a WSL2 distribution.`,
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		winConfigPath := kubeconfigViper.GetString("kubeconfig")
-		linuxConfigDir := filepath.Join(homedir.HomeDir(), ".kube")
-		linuxConfigPath := filepath.Join(linuxConfigDir, "config")
+		configPath := kubeconfigViper.GetString("kubeconfig")
 		enable := kubeconfigViper.GetBool("enable")
+		show := kubeconfigViper.GetBool("show")
 
-		if winConfigPath == "" {
-			//lint:ignore ST1005 The capitalization is for a proper noun.
+		if configPath == "" {
 			return errors.New("Windows kubeconfig not supplied")
 		}
 
-		// Backwards compatibility: if the Linux config is a symlink to the Windows
-		// kubeconfig, unlink it.  This avoids issues where we clobber the Windows
-		// kubeconfig by accident.
-		if _, err := os.Readlink(linuxConfigPath); err == nil {
-			linuxInfo, err1 := os.Stat(linuxConfigPath)
-			windowsInfo, err2 := os.Stat(winConfigPath)
-			if err1 == nil && err2 == nil && os.SameFile(linuxInfo, windowsInfo) {
-				if err = os.Remove(linuxConfigPath); err != nil {
-					return fmt.Errorf("failed to remove kubeconfig symlink: %w", err)
+		_, err := os.Stat(configPath)
+		if err != nil {
+			return fmt.Errorf("could not open Windows kubeconfig: %w", err)
+		}
+		cmd.SilenceUsage = true
+
+		configDir := path.Join(homedir.HomeDir(), ".kube")
+		linkPath := path.Join(configDir, "config")
+		if show {
+			// The output is "true", "false", or an error message for UI.
+			// We will only return nil in this path.
+			target, err := os.Readlink(linkPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					fmt.Println("false")
+				} else if errors.Is(err, syscall.EINVAL) {
+					fmt.Printf("File %s exists and is not a symlink\n", linkPath)
+				} else {
+					fmt.Printf("%s\n", err)
+				}
+			} else if target == configPath {
+				fmt.Println("true")
+			} else {
+				// For a symlink pointing elsewhere, we assume we can overwrite.
+				fmt.Println("false")
+			}
+			return nil
+		}
+		if enable {
+			err = os.Mkdir(configDir, 0o750)
+			if err != nil && !errors.Is(err, os.ErrExist) {
+				// The error already contains the full path, we can't do better.
+				return err
+			}
+			err = os.Symlink(configPath, linkPath)
+			if err != nil {
+				if errors.Is(err, os.ErrExist) {
+					// If it already exists, do nothing; even if it's not a symlink.
+					return nil
+				}
+				return err
+			}
+		} else {
+			// No need to create if we want to remove it
+			target, err := os.Readlink(linkPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
+			if target == configPath {
+				err = os.Remove(linkPath)
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					return err
 				}
 			}
 		}
-
-		if !enable {
-			return nil
-		}
-
-		cmd.SilenceUsage = true
-
-		winConfig, err := readKubeConfig(winConfigPath)
-		if err != nil {
-			return err
-		}
-
-		linuxConfig, err := readKubeConfig(linuxConfigPath)
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-
-		cleanConfig := removeExistingRDConfig(rdCluster, &linuxConfig)
-
-		kubeConfig, err := updateKubeConfig(winConfig, *cleanConfig, rdNetworking)
-		if err != nil {
-			return fmt.Errorf("failed to construct kubeconfig: %w", err)
-		}
-
-		var finalKubeConfigFile *os.File
-		if err := os.MkdirAll(linuxConfigDir, 0o750); err != nil {
-			return err
-		}
-		finalKubeConfigFile, err = os.Create(linuxConfigPath)
-		if err != nil {
-			return err
-		}
-		defer finalKubeConfigFile.Close()
-		encoder := yaml.NewEncoder(finalKubeConfigFile)
-		err = encoder.Encode(kubeConfig)
-		if err != nil {
-			return err
-		}
-		return encoder.Close()
+		return nil
 	},
-}
-
-func readKubeConfig(configPath string) (kubeConfig, error) {
-	var config kubeConfig
-	configFile, err := os.Open(configPath)
-	if err != nil {
-		return config, fmt.Errorf("could not open kubeconfig file %s: %w", configPath, err)
-	}
-	defer configFile.Close()
-	err = yaml.NewDecoder(configFile).Decode(&config)
-	if err != nil {
-		return config, fmt.Errorf("could not read kubeconfig %s: %w", configPath, err)
-	}
-
-	return config, nil
-}
-
-// updateKubeConfig reads the kube config from windows side it also
-// modifies the cluster's server host to an appropriate address.
-// It then merges the config with an existing configuration on
-// users distro and returns the merged config.
-func updateKubeConfig(winConfig, linuxConfig kubeConfig, rdNetworking bool) (kubeConfig, error) {
-	for clusterIdx, cluster := range winConfig.Clusters {
-		// Ignore any non rancher-desktop clusters
-		if winConfig.Clusters[clusterIdx].Name != rdCluster {
-			continue
-		}
-		server, err := url.Parse(cluster.Cluster.Server)
-		if err != nil {
-			// Ignore any clusters with invalid servers
-			continue
-		}
-		host := "gateway.rancher-desktop.internal"
-		if !rdNetworking {
-			ip, err := getClusterIP()
-			if err != nil {
-				return winConfig, err
-			}
-
-			host = ip.String()
-		}
-		if server.Port() != "" {
-			host = net.JoinHostPort(host, server.Port())
-		}
-		server.Host = host
-		winConfig.Clusters[clusterIdx].Cluster.Server = server.String()
-	}
-	return mergeKubeConfigs(winConfig, linuxConfig), nil
-}
-
-func removeExistingRDConfig(name string, config *kubeConfig) *kubeConfig {
-	// Remove clusters with the specified name
-	var filteredClusters []struct {
-		Cluster struct {
-			Server string
-			Extras map[string]interface{} `yaml:",inline"`
-		} `yaml:"cluster"`
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	}
-	for _, cluster := range config.Clusters {
-		if cluster.Name != name {
-			filteredClusters = append(filteredClusters, cluster)
-		}
-	}
-	config.Clusters = filteredClusters
-
-	// Remove contexts with the specified name
-	var filteredContexts []struct {
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	}
-	for _, context := range config.Contexts {
-		if context.Name != name {
-			filteredContexts = append(filteredContexts, context)
-		}
-	}
-	config.Contexts = filteredContexts
-
-	// Remove users with the specified name
-	var filteredUsers []struct {
-		Name   string                 `yaml:"name"`
-		Extras map[string]interface{} `yaml:",inline"`
-	}
-	for _, user := range config.Users {
-		if user.Name != name {
-			filteredUsers = append(filteredUsers, user)
-		}
-	}
-	config.Users = filteredUsers
-
-	return config
-}
-
-func mergeKubeConfigs(winConfig, linuxConfig kubeConfig) kubeConfig {
-	for _, ctx := range winConfig.Clusters {
-		if ctx.Name == rdCluster {
-			linuxConfig.Clusters = append(linuxConfig.Clusters, ctx)
-		}
-	}
-	for _, ctx := range winConfig.Contexts {
-		if ctx.Name == rdCluster {
-			linuxConfig.Contexts = append(linuxConfig.Contexts, ctx)
-		}
-	}
-
-	for _, user := range winConfig.Users {
-		if user.Name == rdCluster {
-			linuxConfig.Users = append(linuxConfig.Users, user)
-		}
-	}
-
-	if linuxConfig.CurrentContext == "" {
-		linuxConfig.CurrentContext = rdCluster
-	}
-	if len(linuxConfig.Extras) == 0 {
-		linuxConfig.Extras = winConfig.Extras
-	}
-
-	return linuxConfig
 }
 
 func init() {
 	kubeconfigCmd.PersistentFlags().Bool("enable", true, "Set up config file")
 	kubeconfigCmd.PersistentFlags().String("kubeconfig", "", "Path to Windows kubeconfig, in /mnt/... form.")
-	kubeconfigCmd.Flags().BoolVar(&rdNetworking, "rd-networking", false, "Enable the experimental Rancher Desktop Networking")
+	kubeconfigCmd.PersistentFlags().Bool("show", false, "Get the current state rather than set it")
 	kubeconfigViper.AutomaticEnv()
 	kubeconfigViper.BindPFlags(kubeconfigCmd.PersistentFlags())
 	rootCmd.AddCommand(kubeconfigCmd)


### PR DESCRIPTION
Brings back the previous symlinks mechanism that was for WSL integration to make the kubeconfig available in WSL VM. 

This PR undo some previous attempts to make the WSL integration work in our new network stack. Since we decided to change the approach and revert to the symlink, we no longer need the work that was done previously.

Related to the following epic: https://github.com/rancher-sandbox/rancher-desktop/issues/6245