### PR TITLE
CI: Fix skipping E2E tests

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -5,15 +5,14 @@ on:
   push:
     branches-ignore:
     - 'dependabot/**'
-  pull_request:
-    paths-ignore:
-    - '.github/actions/spelling/**'
-    - 'bats/**'
-    - 'docs/**'
-    - '**.md'
+  pull_request: {}
 
 jobs:
+  check_paths:
+    uses: ./.github/workflows/paths-ignore.yaml
   e2e-tests:
+    needs: check_paths
+    if: needs.check_paths.outputs.should_run == 'true'
     timeout-minutes: 150
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -19,7 +19,17 @@ defaults:
     shell: bash
 
 jobs:
+  check_paths:
+    uses: ./.github/workflows/paths-ignore.yaml
+    with:
+      paths_ignore: |
+        - '.github/actions/spelling/**'
+        - 'docs/**'
+        - '**.md'
+
   package:
+    needs: check_paths
+    if: needs.check_paths.outputs.should_run == 'true'
     strategy:
       matrix:
         include:

--- a/.github/workflows/paths-ignore.yaml
+++ b/.github/workflows/paths-ignore.yaml
@@ -1,0 +1,80 @@
+# This is a reusable workflow to determine if the current change requires an E2E
+# run.  This is required because using [paths-ignored] directly means the whole
+# workflow is skipped, but that means that it doesn't count as having run a
+# required workflow.
+
+# Usage:
+#   jobs:
+#     check_paths:
+#        uses: ./.github/workflows/actions/paths-ignore.yaml
+#     do_thing:
+#        if: jobs.check_paths.outputs.should_run == 'true'
+#        # Unfortunately, a string comparison is required.
+
+name: Check for ignored paths
+
+on:
+  workflow_call:
+    inputs:
+      paths_ignore:
+        description: Paths to ignore.
+        type: string
+        default: |
+          - '.github/actions/spelling/**'
+          - 'bats/**'
+          - 'docs/**'
+          - '**.md'
+    outputs:
+      should_run:
+        description: Whether other steps should run.
+        value: ${{ jobs.check.outputs.should_run }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set baseline result
+      run: echo "SHOULD_RUN=true" >> "$GITHUB_ENV"
+    - name: Determine paths to ignore
+      if: github.event_name == 'pull_request'
+      run: |
+        curl -L -o yq \
+          https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        chmod a+x yq
+        PATHS_IGNORE="PATHS_IGNORE="
+        while read -r line; do
+          PATHS_IGNORE="${PATHS_IGNORE} ':!/${line}'"
+        done <<< "$(./yq '.[]' <<< "$INPUT")"
+        echo "$PATHS_IGNORE"
+        echo "$PATHS_IGNORE" >> "$GITHUB_ENV"
+      env:
+        DEBIAN_FRONTEND: noninteractive
+        INPUT: ${{ inputs.paths_ignore }}
+    - uses: actions/checkout@v4
+      if: github.event_name == 'pull_request'
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Check for differences
+      if: github.event_name == 'pull_request'
+      run: |
+        MERGE_BASE=$(git merge-base $BASE $HEAD)
+        diff="$(git diff --name-only $MERGE_BASE $HEAD -- ${{ env.PATHS_IGNORE }})"
+        if [[ -z "$diff" ]]; then
+          echo "No modified files found.\n"
+          echo "SHOULD_RUN=false" >> "$GITHUB_ENV"
+        else
+          printf "Modified files:\n%s\n" "$diff"
+        fi
+      env:
+        BASE: ${{ github.event.pull_request.base.sha }}
+        HEAD: ${{ github.event.pull_request.head.sha }}
+        PATHS_IGNORE: ${{ env.PATHS_IGNORE }}
+    - name: Set final output
+      id: result
+      run: echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+    outputs:
+      should_run: ${{ steps.result.outputs.should_run }}

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -5,18 +5,17 @@ on:
   push:
     branches-ignore:
     - 'dependabot/**'
-  pull_request:
-    paths-ignore:
-    - '.github/actions/spelling/**'
-    - 'bats/**'
-    - 'docs/**'
-    - '**.md'
+  pull_request: {}
 
 defaults:
   run:
     shell: powershell
 jobs:
+  check_paths:
+    uses: ./.github/workflows/paths-ignore.yaml
   e2e-tests:
+    needs: check_paths
+    if: needs.check_paths.outputs.should_run == 'true'
     timeout-minutes: 90
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
If we use paths-ignore to skip a whole workflow, then it is never counted for required actions, so we can never merge without overriding.  Instead, determine whether we should skip it manually and manually skip the job.

This creates a reusable workflow that checks out the source tree, then does a `git diff` between the base and head commits, with a set of exclusions built from the `paths-ignore` input.  This would then be the empty set if only files that should be excluded are modified.

As a future improvement (not covered in this PR), we may want to do the same with `paths` too. But we don't need that right now.

As an example, https://github.com/mook-as/rd/actions/runs/7851349122 is a run from a PR where no relevant files were modified.  https://github.com/mook-as/rd/actions/runs/7851405933 is the same, but with a file that triggers E2E runs.