### PR TITLE
foreach_k3s_version support in BATS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -701,6 +701,7 @@ snakize
 softmmu
 someothername
 somepaththatshouldnevereverexist
+sourced
 splatform
 splunk
 ssd

--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -22,6 +22,11 @@ while (<>) {
           print "$ARGV:$.: Don't define $1(); define local_$1() instead\n";
           $problems++;
       }
+
+      if (/\b run \b .* \b load_var/x) {
+          print "$ARGV:$.: Running load_var in a subshell (via run) does not work\n";
+          $problems++;
+      }
     }
 
     # The semver comparison functions take arguments that are valid semver;

--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -23,7 +23,7 @@ while (<>) {
           $problems++;
       }
 
-      if (/\b run \b .* \b load_var/x) {
+      if (/\b run \b .* \b load_var \b/x) {
           print "$ARGV:$.: Running load_var in a subshell (via run) does not work\n";
           $problems++;
       }

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -21,7 +21,8 @@ using_docker() {
 : "${RD_RANCHER_IMAGE_TAG:=v2.7.0}"
 
 ########################################################################
-: "${RD_INFO:=true}"
+# Defaults to true, except in the helper unit tests, which default to false
+: "${RD_INFO:=}"
 
 ########################################################################
 : "${RD_CAPTURE_LOGS:=false}"

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -209,7 +209,7 @@ using_dev_mode() {
 
 : "${RD_K3S_MIN:=1.0.0}"
 : "${RD_K3S_MAX:=1.99.0}"
-: "${RD_K3S_VERSIONS:=RD_KUBERNETES_PREV_VERSION}"
+: "${RD_K3S_VERSIONS:=$RD_KUBERNETES_PREV_VERSION}"
 
 validate_semver RD_K3S_MIN
 validate_semver RD_K3S_MAX

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -170,8 +170,13 @@ using_ramdisk() {
 }
 
 ########################################################################
-# Use RD_PROTECTED_DOT in profile settings for WSL distro names
+# Use RD_PROTECTED_DOT in profile settings for WSL distro names.
 : "${RD_PROTECTED_DOT:=·}"
+
+########################################################################
+# RD_KUBELET_TIMEOUT specifies the number of minutes wait_for_kubelet()
+# waits before it times out.
+: "${RD_KUBELET_TIMEOUT:=10}"
 
 ########################################################################
 # RD_LOCATION specifies the location where Rancher Desktop is installed
@@ -188,3 +193,47 @@ validate_enum RD_LOCATION system user dist dev ""
 using_dev_mode() {
     [ "$RD_LOCATION" = "dev" ]
 }
+
+########################################################################
+# RD_K3S_VERSIONS specifies a list of k3s versions. foreach_k3s_version()
+# can dynamically register a test to run once for each version in the
+# list. Only versions between RD_K3S_MIN and RD_K3S_MAX (inclusively)
+# will be used.
+#
+# Special values:
+# "all" will fetch the list of all k3s releases from GitHub
+# "latest" will fetch the list of latest versions from the release channel
+
+: "${RD_K3S_MIN:=1.0.0}"
+: "${RD_K3S_MAX:=1.99.0}"
+: "${RD_K3S_VERSIONS:=}"
+
+validate_semver RD_K3S_MIN
+validate_semver RD_K3S_MAX
+
+# Cache expansion of RD_K3S_VERSIONS special versions because they are slow to compute
+if ! load_var RD_K3S_VERSIONS; then
+    if [[ $RD_K3S_VERSIONS == "all" ]]; then
+        # filter out duplicates; RD only supports the latest of +k3s1, +k3s2, etc.
+        RD_K3S_VERSIONS=$(
+            gh api /repos/k3s-io/k3s/releases --paginate --jq '.[].tag_name' |
+                grep -E '^v1\.[0-9]+\.[0-9]+\+k3s[0-9]+$' |
+                sed -E 's/v([^+]+)\+.*/\1/' |
+                sort --unique --version-sort
+        )
+    fi
+
+    if [[ $RD_K3S_VERSIONS == "latest" ]]; then
+        RD_K3S_VERSIONS=$(
+            curl --silent --fail https://update.k3s.io/v1-release/channels |
+                jq --raw-output '.data[] | select(.name | test("^v[0-9]+\\.[0-9]+$")).latest' |
+                sed -E 's/v([^+]+)\+.*/\1/'
+        )
+    fi
+
+    for k3s_version in ${RD_K3S_VERSIONS}; do
+        validate_semver k3s_version
+    done
+
+    save_var RD_K3S_VERSIONS
+fi

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -209,7 +209,7 @@ using_dev_mode() {
 
 : "${RD_K3S_MIN:=1.0.0}"
 : "${RD_K3S_MAX:=1.99.0}"
-: "${RD_K3S_VERSIONS:=}"
+: "${RD_K3S_VERSIONS:=RD_KUBERNETES_PREV_VERSION}"
 
 validate_semver RD_K3S_MIN
 validate_semver RD_K3S_MAX

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -12,7 +12,7 @@ show_info() { # @test
         rm -rf "$PATH_BATS_LOGS"
     fi
 
-    if is_false "$RD_INFO"; then
+    if is_false "${RD_INFO:-true}"; then
         return
     fi
 

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -12,6 +12,10 @@ show_info() { # @test
         rm -rf "$PATH_BATS_LOGS"
     fi
 
+    if is_false "$RD_INFO"; then
+        return
+    fi
+
     (
         local format="# %-25s %s\n"
 

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -26,3 +26,23 @@ wait_for_kubelet() {
         sleep 1
     done
 }
+
+get_k3s_versions() {
+    if [[ $RD_K3S_VERSIONS == "all" ]]; then
+        # filter out duplicates; RD only supports the latest of +k3s1, +k3s2, etc.
+        RD_K3S_VERSIONS=$(
+            gh api /repos/k3s-io/k3s/releases --paginate --jq '.[].tag_name' |
+                grep -E '^v1\.[0-9]+\.[0-9]+\+k3s[0-9]+$' |
+                sed -E 's/v([^+]+)\+.*/\1/' |
+                sort --unique --version-sort
+        )
+    fi
+
+    if [[ $RD_K3S_VERSIONS == "latest" ]]; then
+        RD_K3S_VERSIONS=$(
+            curl --silent --fail https://update.k3s.io/v1-release/channels |
+                jq --raw-output '.data[] | select(.name | test("^v[0-9]+\\.[0-9]+$")).latest' |
+                sed -E 's/v([^+]+)\+.*/\1/'
+        )
+    fi
+}

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -1,6 +1,6 @@
 wait_for_kubelet() {
-    local desired_version="${1:-$RD_KUBERNETES_PREV_VERSION}"
-    local timeout="$(($(date +%s) + 10 * 60))"
+    local desired_version=${1:-$RD_KUBERNETES_PREV_VERSION}
+    local timeout=$(($(date +%s) + RD_KUBELET_TIMEOUT * 60))
     trace "waiting for Kubernetes ${desired_version} to be available"
     while true; do
         until kubectl get --raw /readyz &>/dev/null; do

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -45,8 +45,12 @@ source "$PATH_BATS_HELPERS/os.bash"
 source "$PATH_BATS_HELPERS/utils.bash"
 source "$PATH_BATS_HELPERS/snapshots.bash"
 
+# kubernetes.bash has no load-time dependencies
+source "$PATH_BATS_HELPERS/kubernetes.bash"
+
 # defaults.bash uses is_windows() from os.bash and
 # validate_enum() and is_true() from utils.bash.
+# get_k3s_versions from kubernetes.bash.
 source "$PATH_BATS_HELPERS/defaults.bash"
 
 # images.bash uses using_ghcr_images() from defaults.bash
@@ -66,9 +70,6 @@ source "$PATH_BATS_HELPERS/profile.bash"
 # vm.bash uses various PATH_* variables from paths.bash,
 # rdctl from commands.bash, and jq_output from utils.bash
 source "$PATH_BATS_HELPERS/vm.bash"
-
-# kubernetes.bash has no load-time dependencies
-source "$PATH_BATS_HELPERS/kubernetes.bash"
 
 # Use Linux utilities (like jq) on WSL
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -392,11 +392,19 @@ _var_filename() {
 
 # Save env variables on disk, so they can be reloaded in different tests.
 # This is mostly useful if calculating the setting takes a long time.
+# Returns false if any variable was unbound, but will continue saving remaining variables.
 # `save_var VAR1 VAR2`
 save_var() {
+    local res=0
     for var in "$@"; do
-        printf "%s=%q\n" "$var" "${!var}" >"$(_var_filename "$var")"
+        # Using [[ -v $var ]] requires bash 4.2 but macOS only ships with 3.2
+        if [ -n "${!var+exists}" ]; then
+            printf "%s=%q\n" "$var" "${!var}" >"$(_var_filename "$var")"
+        else
+            res=1
+        fi
     done
+    return $res
 }
 
 # Load env variables saved by `save_var`. Returns an error if any of the variables

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -396,6 +396,7 @@ _var_filename() {
 # `save_var VAR1 VAR2`
 save_var() {
     local res=0
+    local var
     for var in "$@"; do
         # Using [[ -v $var ]] requires bash 4.2 but macOS only ships with 3.2
         if [ -n "${!var+exists}" ]; then
@@ -412,6 +413,7 @@ save_var() {
 # `load_var VAR1 VAR2`
 load_var() {
     local res=0
+    local var
     for var in "$@"; do
         local file
         file=$(_var_filename "$var")

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -530,3 +530,28 @@ get_json_test_data() {
     assert_success
     assert_output "${COUNTER}_3.png"
 }
+
+########################################################################
+
+@test 'save_var FOO=baz' {
+    FOO=baz
+    save_var FOO
+}
+
+@test 'load_var FOO' {
+    FOO=bar
+    load_var FOO
+    [[ $FOO == baz ]]
+}
+
+@test 'save_var non-existing var' {
+    run save_var DOES_NOT_EXIST
+    assert_failure
+}
+
+@test 'load_var non-existing var' {
+    DOES_NOT_EXIST=false
+    # Can't use `run` because variable would be sourced in a subshell
+    load_var DOES_NOT_EXIST || DOES_NOT_EXIST=true
+    [[ $DOES_NOT_EXIST == true ]]
+}

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -1,7 +1,6 @@
 load '../helpers/load'
 
-# Don't display the info.bash output if this is the only test running
-RD_INFO=false
+: "${RD_INFO:=false}"
 
 ########################################################################
 

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -621,8 +621,7 @@ get_json_test_data() {
 ########################################################################
 
 @test 'save_var existing variables' {
-    FOO=baz
-    BAR=foo
+    FOO=baz BAR=foo
     save_var FOO BAR
 }
 
@@ -634,9 +633,14 @@ get_json_test_data() {
     [[ $BAR == foo ]]
 }
 
-@test 'save_var of non-existing variable' {
-    run save_var DOES_NOT_EXIST
-    assert_failure
+@test 'save_var mix of existing and non-existing variables' {
+    ONE=one TWO=two
+    FAILED=false
+    # Don't use run because it may mask errexit failures
+    save_var ONE DOES_NOT_EXIST TWO || FAILED=true
+    [[ $FAILED == true ]]
+    [[ $ONE == one ]]
+    [[ $TWO == two ]]
 }
 
 @test 'load_var mix of existing and non-existing variables' {

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -1,5 +1,8 @@
 load '../helpers/load'
 
+# Don't display the info.bash output if this is the only test running
+RD_INFO=false
+
 ########################################################################
 
 local_setup() {
@@ -302,22 +305,60 @@ get_json_test_data() {
 
 ########################################################################
 
+@test 'semver_eq' {
+    fails
+}
+@test 'semver_eq 1.2.3' {
+    succeeds
+}
 @test 'semver_eq 1.2.3 1.2.3' {
     succeeds
 }
 @test 'semver_eq 1.2.3 4.5.6' {
     fails
 }
+@test 'semver_eq 1.2.3 1.2.3 1.2.3' {
+    succeeds
+}
+@test 'semver_eq 1.2.3 1.2.3 4.5.6' {
+    fails
+}
 
+########################################################################
+
+@test 'semver_neq' {
+    fails
+}
+@test 'semver_neq 1.2.3' {
+    succeeds
+}
 @test 'semver_neq 1.2.3 1.2.3' {
     fails
 }
 @test 'semver_neq 1.2.3 4.5.6' {
     succeeds
 }
+@test 'semver_neq 4.5.6 1.2.3' {
+    succeeds
+}
+@test 'semver_neq 1.2.3 4.5.6 1.2.3' {
+    fails
+}
+@test 'semver_neq 1.2.3 4.5.6 7.8.9' {
+    succeeds
+}
+@test 'semver_neq 4.5.6 7.8.9 1.2.3' {
+    succeeds
+}
 
 ########################################################################
 
+@test 'semver_lt' {
+    fails
+}
+@test 'semver_lt 1.2.3' {
+    succeeds
+}
 @test 'semver_lt 1.2.3 1.2.3' {
     fails
 }
@@ -327,7 +368,21 @@ get_json_test_data() {
 @test 'semver_lt 4.5.6 1.2.3' {
     fails
 }
+@test 'semver_lt 1.2.3 4.5.6 7.8.9' {
+    succeeds
+}
+@test 'semver_lt 1.2.3 4.5.6 4.5.6' {
+    fails
+}
 
+########################################################################
+
+@test 'semver_lte' {
+    fails
+}
+@test 'semver_lte 1.2.3' {
+    succeeds
+}
 @test 'semver_lte 1.2.3 1.2.3' {
     succeeds
 }
@@ -337,9 +392,21 @@ get_json_test_data() {
 @test 'semver_lte 4.5.6 1.2.3' {
     fails
 }
+@test 'semver_lte 1.2.3 4.5.6 4.5.6' {
+    succeeds
+}
+@test 'semver_lte 1.2.3 4.5.6 1.2.3' {
+    fails
+}
 
 ########################################################################
 
+@test 'semver_gt' {
+    fails
+}
+@test 'semver_gt 1.2.3' {
+    succeeds
+}
 @test 'semver_gt 1.2.3 1.2.3' {
     fails
 }
@@ -349,7 +416,21 @@ get_json_test_data() {
 @test 'semver_gt 4.5.6 1.2.3' {
     succeeds
 }
+@test 'semver_gt 7.8.9 4.5.6 1.2.3' {
+    succeeds
+}
+@test 'semver_gt 7.8.9 4.5.6 4.5.6' {
+    fails
+}
 
+########################################################################
+
+@test 'semver_gte' {
+    fails
+}
+@test 'semver_gte 1.2.3' {
+    succeeds
+}
 @test 'semver_gte 1.2.3 1.2.3' {
     succeeds
 }
@@ -358,6 +439,12 @@ get_json_test_data() {
 }
 @test 'semver_gte 4.5.6 1.2.3' {
     succeeds
+}
+@test 'semver_gte 7.8.9 4.5.6 4.5.6' {
+    succeeds
+}
+@test 'semver_gte 7.8.9 4.5.6 7.8.9' {
+    fails
 }
 
 ########################################################################
@@ -533,25 +620,32 @@ get_json_test_data() {
 
 ########################################################################
 
-@test 'save_var FOO=baz' {
+@test 'save_var existing variables' {
     FOO=baz
-    save_var FOO
+    BAR=foo
+    save_var FOO BAR
 }
 
-@test 'load_var FOO' {
-    FOO=bar
-    load_var FOO
+@test 'load_var existing variables' {
+    # shellcheck disable=SC2030
+    FOO=bar BAR=bar
+    load_var FOO BAR
     [[ $FOO == baz ]]
+    [[ $BAR == foo ]]
 }
 
-@test 'save_var non-existing var' {
+@test 'save_var of non-existing variable' {
     run save_var DOES_NOT_EXIST
     assert_failure
 }
 
-@test 'load_var non-existing var' {
+@test 'load_var mix of existing and non-existing variables' {
     DOES_NOT_EXIST=false
     # Can't use `run` because variable would be sourced in a subshell
-    load_var DOES_NOT_EXIST || DOES_NOT_EXIST=true
+    load_var FOO DOES_NOT_EXIST BAR || DOES_NOT_EXIST=true
     [[ $DOES_NOT_EXIST == true ]]
+    # shellcheck disable=SC2031
+    [[ $FOO == baz ]]
+    # shellcheck disable=SC2031
+    [[ $BAR == foo ]]
 }

--- a/bats/tests/k8s/foreach-k3s-version.bats
+++ b/bats/tests/k8s/foreach-k3s-version.bats
@@ -1,11 +1,6 @@
 load '../helpers/load'
 
-# This file will not run **any** test unless RD_K3S_VERSIONS is set
-
-start_and_wait_for_kubelet() {
-    factory_reset
-    start_kubernetes
+foreach_k3s_version \
+    factory_reset \
+    start_kubernetes \
     wait_for_kubelet
-}
-
-foreach_k3s_version start_and_wait_for_kubelet

--- a/bats/tests/k8s/foreach-k3s-version.bats
+++ b/bats/tests/k8s/foreach-k3s-version.bats
@@ -1,0 +1,11 @@
+load '../helpers/load'
+
+# This file will not run **any** test unless RD_K3S_VERSIONS is set
+
+start_and_wait_for_kubelet() {
+    factory_reset
+    start_kubernetes
+    wait_for_kubelet
+}
+
+foreach_k3s_version start_and_wait_for_kubelet


### PR DESCRIPTION
Uses dynamic test registration to run the same test for each version in `RD_K3S_VERSIONS`. Can fetch "all" versions from GitHub or "latest" versions from the release channel.

Replaces #6454

Testing latest release of each minor version (not setting `RD_KUBELET_TIMEOUT` because I know they will all pass):

```console
$ time RD_K3S_VERSIONS=latest ./bats-core/bin/bats tests/helpers/info.bash tests/k8s/foreach-k3s-version.bats
info.bash
 ✓ show_info
   Install location:         system
   Resources path:           /Applications/Rancher Desktop.app/Contents/Resources/resources

   Container engine:         containerd
   Mount type:               reverse-sshfs
   Using image allow list:   false
   Using socket_vmnet:       false
   Using VZ emulation:       false
   Using ramdisk:            false

   Capturing logs:           false
   Tracing execution:        false
   Taking screenshots:       false
   Using ghcr.io images:     false
/Users/jan/suse/rd/bats/tests/k8s/foreach-k3s-version.bats
   ===== k8s/foreach-k3s-version =====
 ✓ start_and_wait_for_kubelet 1.16.15
 ✓ start_and_wait_for_kubelet 1.17.17
 ✓ start_and_wait_for_kubelet 1.18.20
 ✓ start_and_wait_for_kubelet 1.19.16
 ✓ start_and_wait_for_kubelet 1.20.15
 ✓ start_and_wait_for_kubelet 1.21.14
 ✓ start_and_wait_for_kubelet 1.22.17
 ✓ start_and_wait_for_kubelet 1.23.17
 ✓ start_and_wait_for_kubelet 1.24.17
 ✓ start_and_wait_for_kubelet 1.25.16
 ✓ start_and_wait_for_kubelet 1.26.13
 ✓ start_and_wait_for_kubelet 1.27.10
 ✓ start_and_wait_for_kubelet 1.28.6
 ✓ start_and_wait_for_kubelet 1.29.1

15 tests, 0 failures


real	19m37.345s
user	1m25.697s
sys	0m42.142s
```