### PR TITLE
Lima: Fix starting with invalid k8s version

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1156,7 +1156,9 @@ async function handleFailure(payload: any) {
       if (noModalDialogs) {
         console.log(titlePart);
         console.log(secondaryMessage || message);
-        console.log(failureDetails);
+        // Since the log is to a file, we need to pretty-print it; otherwise the
+        // message will just be `[Object object]`.
+        console.log(JSON.stringify(failureDetails, undefined, 2));
         gone = true;
         Electron.app.quit();
       } else {

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -675,8 +675,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     config.env ||= {};
     config.env['RC_CGROUP_MODE'] = 'unified';
     if (this.cfg?.kubernetes?.enabled && this.cfg.kubernetes.version) {
-      if (semver.lt(this.cfg.kubernetes.version, '1.20.4')) {
-        config.env['RC_CGROUP_MODE'] = 'hybrid';
+      try {
+        if (semver.lt(this.cfg.kubernetes.version, '1.20.4')) {
+          config.env['RC_CGROUP_MODE'] = 'hybrid';
+        }
+      } catch {
+        // If we have an invalid version configured, ignore the error; we'll
+        // report the error later when trying to download the version.  In that
+        // case we will fall back to the latest stable version, which should be
+        // new enough to support cgroups v2.
       }
     }
 


### PR DESCRIPTION
This repairs the [`k8s/specify-invalid-k8s-version`](https://github.com/rancher-sandbox/rancher-desktop/blob/9f2a1cc5f7401f7df39c21e0bc2e8f35c3a6650e/bats/tests/k8s/specify-invalid-k8s-version.bats) BATS test, by ensuring that we don't fall over when the user specifies an invalid Kubernetes version.

Previously, we'd fall over because this `semver.lt` failed to parse, and threw an exception (which ended up causing the app to quit immediately).

Also added a change to do better error logging.