### PR TITLE
[POC] Use the Ace Editor for Writing Snapshot Descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "vue-eslint-parser": "9.4.2",
     "vue-jest": "3.0.7",
     "vue-template-compiler": "2.7.16",
+    "vue2-ace-editor": "^0.0.15",
     "webpack": "5.88.2"
   },
   "resolutions": {

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
 
-import { Banner, LabeledInput, TextAreaAutoGrow } from '@rancher/components';
+import { Banner, LabeledInput } from '@rancher/components';
 import dayjs from 'dayjs';
 import Vue from 'vue';
+import editor from 'vue2-ace-editor';
 import { mapGetters } from 'vuex';
 
 import { Snapshot, SnapshotEvent } from '@pkg/main/snapshots/types';
@@ -18,7 +19,7 @@ export default Vue.extend({
   components: {
     Banner,
     LabeledInput,
-    TextAreaAutoGrow,
+    editor,
   },
 
   data() {
@@ -45,6 +46,12 @@ export default Vue.extend({
   },
 
   methods: {
+    editorInit() {
+      require('brace/ext/language_tools');
+      require('brace/mode/markdown');
+      require('brace/theme/solarized_dark');
+    },
+
     goBack(event: SnapshotEvent | null) {
       this.$router.push({
         name:   'Snapshots',
@@ -142,12 +149,12 @@ export default Vue.extend({
       </div>
       <div class="field description-field">
         <label>{{ t('snapshots.create.description.label') }}</label>
-        <TextAreaAutoGrow
-          ref="descriptionInput"
+        <editor
           v-model="description"
-          data-test="createSnapshotDescInput"
+          lang="markdown"
+          theme="solarized_dark"
           class="input"
-          :disabled="creating"
+          @init="editorInit"
         />
       </div>
       <div class="actions">

--- a/pkg/rancher-desktop/typings/vue2-ace-editor.d.ts
+++ b/pkg/rancher-desktop/typings/vue2-ace-editor.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue2-ace-editor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4630,6 +4630,11 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
+brace@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
+  integrity sha512-Fc8Ne62jJlKHiG/ajlonC4Sd66Pq68fFwK4ihJGNZpGqboc324SQk+lRvMzpPRuJOmfrJefdG8/7JdWX4bzJ2Q==
+
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -13267,6 +13272,13 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue2-ace-editor@^0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/vue2-ace-editor/-/vue2-ace-editor-0.0.15.tgz#569b208e54ae771ae1edd3b8902ac42f0edc74e3"
+  integrity sha512-e3TR9OGXc71cGpvYcW068lNpRcFt3+OONCC81oxHL/0vwl/V3OgqnNMw2/RRolgQkO/CA5AjqVHWmANWKOtNnQ==
+  dependencies:
+    brace "^0.11.0"
 
 vue@2.7.16:
   version "2.7.16"


### PR DESCRIPTION
This is a proof of concept to demonstrate how Rancher Desktop can utilize the Ace editor to get syntax highlighting for fields that might require it. This example demonstrates writing markdown for a snapshot description.

https://github.com/rancher-sandbox/rancher-desktop/assets/835961/ffdbddc4-9f1b-4220-9de2-fd84f0f41fa3

