### PR TITLE
CI: BATS: Better summary table

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -231,7 +231,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-    - name: Fetch install script
+    - name: Fetch summarizer script
       uses: actions/checkout@v4
       with:
         persist-credentials: false

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -167,8 +167,10 @@ jobs:
         ${{ env.BATS_COMMAND }}
         ./bats-core/bin/bats
         --gather-test-outputs-in "${LOGS_DIR}"
-        --formatter tap
-        --report-formatter tap
+        --print-output-on-failure
+        --filter-tags '!ci-skip'
+        --formatter cat
+        --report-formatter tap13
         'tests/${{ steps.normalize.outputs.test }}'
       env:
         RD_CONTAINER_ENGINE:     ${{ matrix.engine }}
@@ -183,22 +185,6 @@ jobs:
       working-directory: bats
       timeout-minutes: 120
 
-    - name: Consolidate logs
-      if: ${{ !cancelled() }}
-      run: |
-        # bats/logs may not exist if the workflow is being tested with e.g. tests/helpers/utils.bats
-        if [ -d "bats/logs" ]; then
-            cp -R "bats/logs/" logs
-        fi
-        cp "bats/report.tap" logs
-        .github/workflows/bats/sanitize-artifact-name.sh logs
-        echo "\`${NAME}\` (${OS} ${ENGINE})" > logs/test-name.txt
-        mv version.txt logs/
-      env:
-        NAME: ${{ matrix.name }}
-        OS: ${{ matrix.host }}
-        ENGINE: ${{ matrix.engine }}
-
     - name: Calculate log name
       id: log_name
       if: ${{ !cancelled() }}
@@ -211,6 +197,26 @@ jobs:
       env:
         name: ${{ matrix.host }}-${{ matrix.engine }}-${{ matrix.name }}.logs
 
+    - name: Consolidate logs
+      if: ${{ !cancelled() }}
+      run: |
+        # bats/logs may not exist if the workflow is being tested with e.g. tests/helpers/utils.bats
+        if [ -d "bats/logs" ]; then
+            cp -R "bats/logs/" logs
+        fi
+        cp "bats/report.tap" logs
+        .github/workflows/bats/sanitize-artifact-name.sh logs
+        echo "$NAME" > logs/name.txt
+        echo "$OS" > logs/os.txt
+        echo "$ENGINE" > logs/engine.txt
+        echo "$LOG_NAME" > logs/log-name.txt
+        mv version.txt logs/
+      env:
+        NAME: ${{ matrix.name }}
+        OS: ${{ matrix.host }}
+        ENGINE: ${{ matrix.engine }}
+        LOG_NAME: ${{ steps.log_name.outputs.name }}
+
     - name: Upload logs
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
@@ -221,36 +227,22 @@ jobs:
 
   summarize:
     name: Summarize output
-    permissions: {}
     needs: bats
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch install script
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          package.json
+          .github/workflows/bats/summarize.mjs
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: package.json
     - uses: actions/download-artifact@v4
       with:
         pattern: "*.logs"
-    - run: |
-        set -o xtrace
-        shopt -s nullglob
-
-        echo Versions
-        echo ---
-        cat */version.txt | sort --unique
-
-        echo "Result | Passed | Failed | Skipped | Total | Test" >> "$GITHUB_STEP_SUMMARY"
-        echo ":--- | ---: | ---: | ---: | ---: | :---" >> "$GITHUB_STEP_SUMMARY"
-        for i in */*.tap ; do
-          name="$(cat "${i%/*}/test-name.txt")"
-          count="$(grep -E '^1\.\.' "$i" | cut -d. -f3)"
-          ok="$(grep -c -E '^ok' "$i" ||:)"
-          fail="$(grep -c -E '^not ok' "$i" ||:)"
-          skip="$(grep -c -E '^ok.* # skip' "$i" ||:)"
-          if (( ok == count && count > 1 )) ; then
-            summary=":white_check_mark:"
-          else
-            summary=":x:"
-          fi
-          printf '%s | %d | %d | %d | %d | %s\n' \
-            "${summary}" "$((ok - skip))" "${fail}" "${skip}" "${count}" "${name}" \
-            >> "$GITHUB_STEP_SUMMARY"
-        done
+    - run: node .github/workflows/bats/summarize.mjs

--- a/.github/workflows/bats/summarize.mjs
+++ b/.github/workflows/bats/summarize.mjs
@@ -198,8 +198,8 @@ async function getRunMetadata(infoType) {
   /** @type Record<string, string> */
   const headers = {};
 
-  if ('GITHUB_TOKEN' in process.env) {
-    headers.Authorization = `Bearer ${ process.env.GITHUB_TOKEN }`;
+  if ('GITHUB_TOKEN' in env) {
+    headers.Authorization = `Bearer ${ env.GITHUB_TOKEN }`;
   }
   const response = await fetch(url, { headers })
 

--- a/.github/workflows/bats/summarize.mjs
+++ b/.github/workflows/bats/summarize.mjs
@@ -300,16 +300,17 @@ async function printResults(runs, output) {
       tooltip += run.skipped ? `${ run.skipped } skipped ` : '';
       tooltip += `out of ${ run.total }`;
       const { env } = process;
-      let result = `<a title="${ tooltip }"`;
+      let result = '';
+      if (run.logId) {
+        const url = `${ env.GITHUB_SERVER_URL }/${ env.GITHUB_REPOSITORY }/actions/runs/${ env.GITHUB_RUN_ID}/artifacts/${ run.logId }`;
+        result += `<a href="${ url }" title="Download logs">:file_folder:</a> `;
+      }
+      result += `<a title="${ tooltip }"`;
       if (run.id) {
         const url = `${ env.GITHUB_SERVER_URL }/${ env.GITHUB_REPOSITORY }/actions/runs/${ env.GITHUB_RUN_ID }/job/${ run.id }`;
         result += ` href="${ url }"`;
       }
       result += `>${ emoji } ${ count }</a>`;
-      if (run.logId) {
-        const url = `${ env.GITHUB_SERVER_URL }/${ env.GITHUB_REPOSITORY }/actions/runs/${ env.GITHUB_RUN_ID}/artifacts/${ run.logId }`;
-        result += ` <a href="${ url }" title="Download logs">:scroll:</a>`;
-      }
       // Because we may have missing jobs (where it failed so completely there
       // was no uploaded logs), we need to use the column map rather than just
       // append to the row.


### PR DESCRIPTION
This writes the summary table as an actual table, with multiple jobs per row.  This makes it easier to spot what combination failed, and provides links so we can jump to the relevant run faster.

It looks like the bottom of this run:
https://github.com/mook-as/rd/actions/runs/7920944696