### PR TITLE
BATS: Print location error to stderr if &3 unavailable

### DIFF
--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -11,6 +11,11 @@ set_path_resources() {
     local user=$2
     local dist=$3
     local subdir=$4
+    local fd=3
+
+    if [[ ! -e /dev/fd/3 ]]; then
+        fd=2
+    fi
 
     if [ -z "${RD_LOCATION:-}" ]; then
         if [ -d "$system" ]; then
@@ -28,7 +33,7 @@ set_path_resources() {
                 echo "- \"$user\""
                 echo "- \"$dist\""
                 echo "and 'yarn dev' is unavailable outside repo clone"
-            ) >&3
+            ) >&$fd
             exit 1
         fi
     fi


### PR DESCRIPTION
If BATS isn't running correctly yet, fd 3 would not be available; use standard error for complaining about failing to find a Rancher Desktop install instead.