### PR TITLE
CI: BATS: Allow overriding run ID to download from

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -23,6 +23,10 @@ on:
         description: Container engines to run
         default: 'containerd moby'
         type: string
+      package-id:
+        description: Package run ID override; leave empty to use latest.
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -59,6 +63,7 @@ jobs:
         OWNER:        ${{ inputs.owner }}
         REPO:         ${{ inputs.repo }}
         BRANCH:       ${{ inputs.branch }}
+        ID:           ${{ inputs.package-id }}
         BATS_DIR:     ${{ github.workspace }}/bats
         SKIP_INSTALL: true
 
@@ -104,6 +109,7 @@ jobs:
         OWNER:    ${{ inputs.owner }}
         REPO:     ${{ inputs.repo }}
         BRANCH:   ${{ inputs.branch }}
+        ID:       ${{ inputs.package-id }}
         BATS_DIR: ${{ github.workspace }}/bats
         ZIP_NAME: ${{ github.workspace }}/version.txt
 


### PR DESCRIPTION
This allows an override to which GitHub Actions run id to download from, so that we can download from a build that isn't the latest completed build. This is useful to run BATS tests for packaging steps that are still in progress, as long as the relevant platforms are complete.