### PR TITLE
CI: Package: Allow skipping signing

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,7 +12,12 @@ on:
     - release-*
     tags:
     - '*'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      sign:
+        type: boolean
+        default: true
+        description: Whether to check signing result
 
 defaults:
   run:
@@ -159,7 +164,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
     permissions:
       contents: read
     steps:
@@ -224,7 +229,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
When doing a manually-triggered run of packaging, sometimes we don't need to check signing (and just want the output for some other purpose).  Allow the signing check steps to be skipped in that case.

Note that this will still be triggered by default, and also it will be run when it's _not_ manually triggered (e.g. due to a push).