### PR TITLE
BATS: Paths: Fix Windows snapshot paths

### DIFF
--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -104,7 +104,7 @@ if is_windows; then
     PATH_DISTRO="$PATH_APP_HOME/distro"
     PATH_DISTRO_DATA="$PATH_APP_HOME/distro-data"
     PATH_EXTENSIONS="$PATH_APP_HOME/extensions"
-    PATH_SNAPSHOTS="$PATH_APP_HOME/rancher-desktop/snapshots"
+    PATH_SNAPSHOTS="$PATH_APP_HOME/snapshots"
 
     set_path_resources \
         "$PROGRAMFILES/Rancher Desktop" \


### PR DESCRIPTION
We do not have an extra layer of "rancher-desktop" in the snapshot path on Windows; like the other platforms, it's just directly inside PATH_APP_HOME.