### PR TITLE
Various BATS fixes

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -10,7 +10,6 @@ RD_USE_IMAGE_ALLOW_LIST=true
 
 @test 'update the list of patterns first time' {
     update_allowed_patterns true "$IMAGE_NGINX" "$IMAGE_BUSYBOX" "$IMAGE_PYTHON"
-    wait_for_container_engine
 }
 
 @test 'verify pull nginx succeeds' {
@@ -54,7 +53,6 @@ RD_USE_IMAGE_ALLOW_LIST=true
 }
 
 @test 'can run kubectl' {
-    wait_for_kubelet
     kubectl run nginx --image="${IMAGE_NGINX}:latest" --port=8080
 }
 
@@ -70,9 +68,6 @@ verify_no_nginx() {
 
 @test 'set patterns with the allowed list disabled' {
     update_allowed_patterns false "$IMAGE_NGINX" "$IMAGE_BUSYBOX" "$IMAGE_RUBY"
-    # containerEngine.allowedImages.enabled changed, so wait for a restart
-    wait_for_container_engine
-    wait_for_kubelet "$RD_KUBERNETES_PREV_VERSION"
 }
 
 @test 'verify pull python succeeds because allowedImages filter is disabled' {

--- a/bats/tests/extensions/allow-list.bats
+++ b/bats/tests/extensions/allow-list.bats
@@ -15,15 +15,8 @@ write_allow_list() { # list
 
     # Note that the list preference is not writable using `rdctl set`, and we
     # need to do a direct API call instead.
-
-    # TODO TODO TODO
-    # Once https://github.com/rancher-sandbox/rancher-desktop/issues/4939 has been
-    # implemented, the `version` field  should be made a constant. Putting in the
-    # current version here doesn't guarantee that the structure conforms to the latest
-    # schema; we should rely on migrations instead.
-    # TODO TODO TODO
     rdctl api /v1/settings --input - <<<'{
-        "version": '"$(get_setting .version)"',
+        "version": 8,
         "application": {
             "extensions": {
                 "allowed": {

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -3,27 +3,35 @@ wait_for_kubelet() {
     local timeout=$(($(date +%s) + RD_KUBELET_TIMEOUT * 60))
     trace "waiting for Kubernetes ${desired_version} to be available"
     while true; do
-        until kubectl get --raw /readyz &>/dev/null; do
-            assert [ "$(date +%s)" -lt "$timeout" ]
-            sleep 1
-        done
+        sleep 1
         assert [ "$(date +%s)" -lt "$timeout" ]
+        if ! kubectl get --raw /readyz &>/dev/null; then
+            continue
+        fi
 
         # Check that kubelet is Ready
         run kubectl get node -o jsonpath="{.items[0].status.conditions[?(@.type=='Ready')].status}"
-        if ((status == 0)) && [[ $output == "True" ]]; then
-            # Verify kubelet version
-            run kubectl get node -o jsonpath="{.items[0].status.nodeInfo.kubeletVersion}"
-            if ((status == 0)); then
-                # Turn "v1.23.4+k3s1" into "1.23.4"
-                local version=${output#v}
-                version=${version%+*}
-                if [ "$version" == "$desired_version" ]; then
-                    return 0
-                fi
-            fi
+        if ((status != 0)) || [[ $output != "True" ]]; then
+            continue
         fi
-        sleep 1
+
+        # Make sure the "default" serviceaccount exists
+        if ! kubectl get --namespace default serviceaccount default; then
+            continue
+        fi
+
+        # Get kubelet version
+        run kubectl get node -o jsonpath="{.items[0].status.nodeInfo.kubeletVersion}"
+        if ((status != 0)); then
+            continue
+        fi
+
+        # Turn "v1.23.4+k3s1" into "1.23.4"
+        local version=${output#v}
+        version=${version%+*}
+        if [ "$version" == "$desired_version" ]; then
+            return 0
+        fi
     done
 }
 

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -213,6 +213,7 @@ trace() {
         return
     fi
     local caller="${CALLER:-$(calling_function)}"
+    caller="$(date -u +"%FT%TZ"): $caller"
     local line
     while IFS= read -r line; do
         if [[ -e /dev/fd/3 ]]; then

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -278,15 +278,9 @@ update_allowed_patterns() {
     local patterns
     patterns=$(join_map ", " image_without_tag_as_json_string "$@")
 
-    # TODO TODO TODO
-    # Once https://github.com/rancher-sandbox/rancher-desktop/issues/4939 has been
-    # implemented, the `version` field  should be made a constant. Putting in the
-    # current version here doesn't guarantee that the structure conforms to the latest
-    # schema; we should rely on migrations instead.
-    # TODO TODO TODO
     rdctl api settings -X PUT --input - <<EOF
 {
-  "version": $(get_setting .version),
+  "version": 8,
   "containerEngine": {
     "allowedImages": {
       "enabled": $enabled,

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -279,7 +279,14 @@ update_allowed_patterns() {
     local patterns
     patterns=$(join_map ", " image_without_tag_as_json_string "$@")
 
-    rdctl api settings -X PUT --input - <<EOF
+    # If the enabled state changes, then the container engine will be restarted.
+    # Record PID of the current daemon process so we can wait for it to be ready again.
+    local pid
+    if [ "$enabled" != "$(get_setting .containerEngine.allowedImages.enabled)" ]; then
+        pid=$(get_service_pid "$CONTAINER_ENGINE_SERVICE")
+    fi
+
+    rdctl api settings -X PUT --input - <<EOF || return
 {
   "version": 8,
   "containerEngine": {
@@ -290,6 +297,14 @@ update_allowed_patterns() {
   }
 }
 EOF
+    # Wait for container engine (and Kubernetes) to be ready again
+    if [[ -n ${pid:-} ]]; then
+        try --max 15 --delay 5 refute_service_pid "$CONTAINER_ENGINE_SERVICE" "$pid" || return
+        wait_for_container_engine || return
+        if [[ $(get_setting .kubernetes.enabled) == "true" ]]; then
+            wait_for_kubelet || return
+        fi
+    fi
 }
 
 # unique_filename /tmp/image .png

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -352,14 +352,6 @@ wait_for_container_engine() {
     trace "waiting for api /settings to be callable"
     try --max 30 --delay 5 rdctl api /settings
 
-    run jq_output .containerEngine.allowedImages.enabled
-    assert_success
-    if [[ $output == true ]]; then
-        wait_for_service_status rd-openresty started
-    else
-        wait_for_service_status rd-openresty stopped
-    fi
-
     if using_docker; then
         trace "waiting for docker context to exist"
         try --max 30 --delay 5 docker_context_exists

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -294,6 +294,10 @@ get_container_engine_info() {
 }
 
 docker_context_exists() {
+    # We don't use docker contexts on Windows
+    if is_windows; then
+        return
+    fi
     run docker_exe context ls -q
     assert_success || return
     assert_line "$RD_DOCKER_CONTEXT"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -327,7 +327,7 @@ assert_service_status() {
     local expect=$2
 
     run rdsudo rc-service "$service_name" status
-    # Some services (e.g. k3s) report non-zero status when not running
+    # rc-service report non-zero status (3) when the service is stopped
     if [[ $expect == started ]]; then
         assert_success || return
     fi

--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -170,8 +170,7 @@ install_extensions() {
 
 api_set() {
     local body version
-    version=$(get_setting .version)
-    body=$(jq ".version=$version" <<<"{$1}")
+    body=$(jq ".version=10" <<<"{$1}")
     rdctl api /v1/settings -X PUT --body "$body"
 }
 

--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -107,9 +107,7 @@ install_extensions() {
 }
 
 @test 'verify all extensions can be installed' {
-    #WORKAROUND `rdctl` tries to install extensions before app is ready.
-    wait_for_container_engine
-    sleep 30
+    wait_for_kubelet
     before install_extensions
 }
 


### PR DESCRIPTION
These commits fix various BATS flakiness on macOS. With these fixes I get all tests to pass for `containerd` and `moby`, using both QEMU and VZ, with the exception of `tests/containers/allowed-images.bats`, which often fails for VZ with a timeout.

Example failures:

```
  time="2024-02-18T23:30:00Z" level=fatal msg="failed to copy: httpReadSeeker: failed open: failed to do request: Get \"https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:46362cb2d76cba4bd94e65a730f6ff60f9bc735c60f68a32765e8f86e3bb07b0?se=2024-02-18T23%3A35%3A00Z&sig=GAJrSOL%2BmR9UZ8R17KikGp%2FMCMCfhA3fw3SDduih2Uk%3D&sp=r&spr=https&sr=b&sv=2019-12-12\": dial tcp 185.199.111.154:443: i/o timeout"
```

or

```
Error response from daemon: Get "https://ghcr.io/v2/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

I think these timeouts are a real issue with the networking stack under `VZ` emulation and not an issue with the BATS tests.

Without this PR the test previously often failed for `moby` and VZ because the `rancher-desktop` docker context was not yet recreated.

Fixes #6282
