### PR TITLE
Added a button to the main page nav area to invoke the cluster dashboard

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -734,6 +734,7 @@ tencenttke
 termch
 testbuild
 testfilethatdoesntexist
+testid
 testreleasedate
 testurl
 tgz

--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -36,7 +36,8 @@ export class NavPage {
     this.page = page;
     this.mainTitle = page.locator('[data-test="mainTitle"]');
     this.progressBar = page.locator('.progress');
-    this.preferencesButton = page.locator('[data-test="preferencesButton"]');
+    // this.preferencesButton = page.locator('[data-test="preferencesButton"]');
+    this.preferencesButton = page.getByTestId('preferences-button');
   }
 
   protected async getBackendState(): Promise<string> {

--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -36,7 +36,7 @@ export class NavPage {
     this.page = page;
     this.mainTitle = page.locator('[data-test="mainTitle"]');
     this.progressBar = page.locator('.progress');
-    this.preferencesButton = page.locator('.preferences-button-nav button');
+    this.preferencesButton = page.locator('[data-test="preferencesButton"]');
   }
 
   protected async getBackendState(): Promise<string> {

--- a/e2e/pages/nav-page.ts
+++ b/e2e/pages/nav-page.ts
@@ -36,7 +36,6 @@ export class NavPage {
     this.page = page;
     this.mainTitle = page.locator('[data-test="mainTitle"]');
     this.progressBar = page.locator('.progress');
-    // this.preferencesButton = page.locator('[data-test="preferencesButton"]');
     this.preferencesButton = page.getByTestId('preferences-button');
   }
 

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -114,6 +114,7 @@ nav:
     setLoginPage: Set as login page
     restoreCards: Restore hidden cards
   userMenu:
+    clusterDashboard: Cluster Dashboard
     preferences: Preferences
     accountAndKeys: Account & API Keys
     logOut: Log Out

--- a/pkg/rancher-desktop/components/DashboardOpen.vue
+++ b/pkg/rancher-desktop/components/DashboardOpen.vue
@@ -1,0 +1,38 @@
+<script lang="ts">
+import Vue from 'vue';
+import { mapGetters } from 'vuex';
+
+import { State as K8sState } from '@pkg/backend/backend';
+
+export default Vue.extend({
+  name:     'dashboard-button',
+  computed: {
+    ...mapGetters('preferences', ['getPreferences']),
+    ...mapGetters('k8sManager', { k8sState: 'getK8sState' }),
+    kubernetesEnabled(): boolean {
+      return this.getPreferences.kubernetes.enabled;
+    },
+    kubernetesStarted(): boolean {
+      return this.k8sState === K8sState.STARTED;
+    },
+  },
+  methods: {
+    openDashboard() {
+      this.$emit('open-dashboard');
+    },
+  },
+});
+</script>
+
+<template>
+  <button
+    class="btn role-secondary btn-icon-text"
+    :disabled="!kubernetesEnabled || !kubernetesStarted"
+    @click="openDashboard"
+  >
+    <span
+      class="icon icon-dashboard"
+    />
+    {{ t('nav.userMenu.clusterDashboard') }}
+  </button>
+</template>

--- a/pkg/rancher-desktop/components/DashboardOpen.vue
+++ b/pkg/rancher-desktop/components/DashboardOpen.vue
@@ -26,7 +26,8 @@ export default Vue.extend({
 
 <template>
   <button
-    v-if="kubernetesEnabled && kubernetesStarted"
+    v-if="kubernetesEnabled"
+    :disabled="!kubernetesStarted"
     class="btn role-secondary btn-icon-text"
     @click="openDashboard"
   >

--- a/pkg/rancher-desktop/components/DashboardOpen.vue
+++ b/pkg/rancher-desktop/components/DashboardOpen.vue
@@ -26,13 +26,10 @@ export default Vue.extend({
 
 <template>
   <button
+    v-if="kubernetesEnabled && kubernetesStarted"
     class="btn role-secondary btn-icon-text"
-    :disabled="!kubernetesEnabled || !kubernetesStarted"
     @click="openDashboard"
   >
-    <span
-      class="icon icon-dashboard"
-    />
     {{ t('nav.userMenu.clusterDashboard') }}
   </button>
 </template>

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -47,9 +47,15 @@
         </template>
       </div>
     </template>
-    <div class="preferences-button-nav">
+    <div class="nav-button-container">
+      <dashboard-button
+        class="nav-button"
+        @open-dashboard="openDashboard"
+      />
+    </div>
+    <div class="nav-button-container">
       <preferences-button
-        class="preferences-button"
+        class="nav-button"
         @open-preferences="openPreferences"
       />
     </div>
@@ -67,6 +73,7 @@ import { RouteRecordPublic } from 'vue-router';
 import NavIconExtension from './NavIconExtension.vue';
 import NavItem from './NavItem.vue';
 
+import DashboardButton from '@pkg/components/DashboardOpen.vue';
 import PreferencesButton from '@pkg/components/Preferences/ButtonOpen.vue';
 import type { ExtensionMetadata } from '@pkg/main/extensions/types';
 import { hexEncode } from '@pkg/utils/string-encode';
@@ -80,6 +87,7 @@ export default Vue.extend({
     BadgeState,
     NavItem,
     NavIconExtension,
+    DashboardButton,
     PreferencesButton,
   },
   props: {
@@ -166,6 +174,9 @@ export default Vue.extend({
     openPreferences(): void {
       this.$emit('open-preferences');
     },
+    openDashboard(): void {
+      this.$emit('open-dashboard');
+    },
   },
 });
 </script>
@@ -232,13 +243,13 @@ a {
   font-size: 0.75rem;
 }
 
-.preferences-button-nav {
+.nav-button-container {
   display: flex;
   justify-content: center;
 
-  .preferences-button {
+  .nav-button {
     flex: 1;
-    margin: 0 10px;
+    margin: 5px 10px 0px 10px;
     justify-content: center;
   }
 }

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -47,14 +47,14 @@
         </template>
       </div>
     </template>
-    <div class="nav-button-container" data-test="dashboardButton">
+    <div class="nav-button-container">
       <dashboard-button
+        data-testid="dashboard-button"
         class="nav-button"
         @open-dashboard="openDashboard"
       />
-    </div>
-    <div class="nav-button-container" data-test="preferencesButton">
       <preferences-button
+        data-testid="preferences-button"
         class="nav-button"
         @open-preferences="openPreferences"
       />
@@ -245,6 +245,7 @@ a {
 
 .nav-button-container {
   display: flex;
+  flex-direction: column;
   justify-content: center;
 
   .nav-button {

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -47,13 +47,13 @@
         </template>
       </div>
     </template>
-    <div class="nav-button-container">
+    <div class="nav-button-container" data-test="dashboardButton">
       <dashboard-button
         class="nav-button"
         @open-dashboard="openDashboard"
       />
     </div>
-    <div class="nav-button-container">
+    <div class="nav-button-container" data-test="preferencesButton">
       <preferences-button
         class="nav-button"
         @open-preferences="openPreferences"

--- a/pkg/rancher-desktop/components/Preferences/ButtonOpen.vue
+++ b/pkg/rancher-desktop/components/Preferences/ButtonOpen.vue
@@ -15,9 +15,6 @@ export default Vue.extend({
     class="btn role-secondary btn-icon-text"
     @click="openPreferences"
   >
-    <span
-      class="icon icon-gear"
-    />
     {{ t('nav.userMenu.preferences') }}
   </button>
 </template>

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -9,6 +9,7 @@
       class="nav"
       :items="routes"
       :extensions="extensions"
+      @open-dashboard="openDashboard"
       @open-preferences="openPreferences"
     />
     <the-title ref="title" />
@@ -136,6 +137,9 @@ export default {
   },
 
   methods: {
+    openDashboard() {
+      ipcRenderer.send('dashboard-open');
+    },
     openPreferences() {
       ipcRenderer.send('preferences-open');
     },


### PR DESCRIPTION
Addresses https://github.com/rancher-sandbox/rancher-desktop/issues/6232 by adding a button to the main page nav area to invoke the cluster dashboard. The implementation follows the same pattern as that of the Preferences button.

- Clicking on the button invokes the cluster dashboard
- The button is disabled when Kubernetes is disabled
- The button is disabled during the app launch to prevent the user from clicking it while the Kubernetes is still starting.

![image](https://github.com/rancher-sandbox/rancher-desktop/assets/59538726/5b5ed7f9-5989-4923-8208-089766c33e20)
