### PR TITLE
Disable wasm feature when an older locked profile exist

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1372,7 +1372,7 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     let newSettings: RecursivePartial<settings.Settings> = {};
 
     try {
-      newSettings = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(specifiedNewSettings);
+      newSettings = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(specifiedNewSettings, false);
       [needToUpdate, errors] = await this.validateSettings(cfg, newSettings);
     } catch (ex: any) {
       errors.push(ex.message);

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -139,13 +139,13 @@ describe('settings', () => {
   const jsonProfile = JSON.stringify(fullDefaults);
   const plistProfile = plist.build(fullDefaults);
   const unlockedProfile = {
-    version:         10,
+    version:         11,
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
     containerEngine: { name: 'moby' },
     kubernetes:      { version: '1.25.9' },
   };
   const lockedProfile = {
-    version:         10,
+    version:         11,
     ignoreThis:      { soups: ['beautiful', 'vichyssoise'] },
     containerEngine: {
       allowedImages: {
@@ -759,7 +759,7 @@ describe('settings', () => {
 
         fromSettings.version = existingVersion;
         toSettings.version = targetVersion;
-        expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(fromSettings, targetVersion)).toEqual(toSettings);
+        expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(fromSettings, false, targetVersion)).toEqual(toSettings);
       });
     });
   });

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -432,7 +432,7 @@ describe('settings', () => {
       const s: RecursivePartial<settings.Settings> = {};
 
       expect(() => {
-        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s);
+        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false);
       }).toThrow('updating settings requires specifying an API version, but no version was specified');
     });
 
@@ -440,7 +440,7 @@ describe('settings', () => {
       const s: RecursivePartial<settings.Settings> = { version: 'no way' as unknown as typeof settings.CURRENT_SETTINGS_VERSION };
 
       expect(() => {
-        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s);
+        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false);
       }).toThrow('updating settings requires specifying an API version, but "no way" is not a proper config version');
     });
 
@@ -448,7 +448,7 @@ describe('settings', () => {
       const s: RecursivePartial<settings.Settings> = { version: -7 as unknown as typeof settings.CURRENT_SETTINGS_VERSION };
 
       expect(() => {
-        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s);
+        settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false);
       }).toThrow('updating settings requires specifying an API version, but "-7" is not a positive number');
     });
 
@@ -474,7 +474,7 @@ describe('settings', () => {
         },
       };
 
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
+      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false)).toEqual(expected);
     });
 
     it('correctly migrates earlier no-proxy settings', () => {
@@ -507,7 +507,7 @@ describe('settings', () => {
         },
       };
 
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
+      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false)).toEqual(expected);
     });
 
     it('leaves unrecognized settings unchanged', () => {
@@ -535,7 +535,7 @@ describe('settings', () => {
       };
       const expected = _.merge({}, s, { version: settings.CURRENT_SETTINGS_VERSION });
 
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
+      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false)).toEqual(expected);
     });
 
     it('updates all old settings going back to version 1', () => {
@@ -594,7 +594,7 @@ describe('settings', () => {
         },
       };
 
-      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s)).toEqual(expected);
+      expect(settingsImpl.migrateSpecifiedSettingsToCurrentVersion(s, false)).toEqual(expected);
     });
 
     describe('migrates from step to step', () => {

--- a/pkg/rancher-desktop/config/__tests__/settingsMigrations.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settingsMigrations.spec.ts
@@ -13,7 +13,7 @@ describe('settings migrations', () => {
       const testSettings = _.cloneDeep(settings);
 
       testSettings.experimental.virtualMachine.proxy.noproxy = [];
-      updateTable[9](testSettings);
+      updateTable[9](testSettings, false);
 
       expect(testSettings.experimental.virtualMachine.proxy.noproxy).toStrictEqual([]);
     });
@@ -24,7 +24,7 @@ describe('settings migrations', () => {
       testSettings.experimental.virtualMachine.proxy.noproxy = [
         '0.0.0.0/8', ' 10.0.0.0/8', '127.0.0.0/8  ', '  169.254.0.0/16', '172.16.0.0/12',
         '192.168.0.0/16 '];
-      updateTable[9](testSettings);
+      updateTable[9](testSettings, false);
 
       expect(testSettings.experimental.virtualMachine.proxy.noproxy).toStrictEqual([
         '0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16', '172.16.0.0/12',
@@ -36,7 +36,7 @@ describe('settings migrations', () => {
 
       testSettings.experimental.virtualMachine.proxy.noproxy = [
         '0.0.0.0/8\t', '\t10.0.0.0/8', '\t 127.0.0.0/8', '169.254.0.0/16 \t'];
-      updateTable[9](testSettings);
+      updateTable[9](testSettings, false);
 
       expect(testSettings.experimental.virtualMachine.proxy.noproxy).toStrictEqual([
         '0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16']);
@@ -47,7 +47,7 @@ describe('settings migrations', () => {
 
       testSettings.experimental.virtualMachine.proxy.noproxy = [
         '0.0.0.0/8\n', '\n10.0.0.0/8', '\n 127.0.0.0/8', '169.254.0.0/16 \n'];
-      updateTable[9](testSettings);
+      updateTable[9](testSettings, false);
 
       expect(testSettings.experimental.virtualMachine.proxy.noproxy).toStrictEqual([
         '0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16']);
@@ -58,10 +58,26 @@ describe('settings migrations', () => {
 
       testSettings.experimental.virtualMachine.proxy.noproxy = [
         '0.0.0.0/8', '', '\n', '10.0.0.0/8', ' ', '127.0.0.0/8', '    ', '\t'];
-      updateTable[9](testSettings);
+      updateTable[9](testSettings, false);
 
       expect(testSettings.experimental.virtualMachine.proxy.noproxy).toStrictEqual([
         '0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8']);
+    });
+  });
+
+  describe('step 10', () => {
+    it('should not disable wasm in normal settings', () => {
+      const testSettings = {};
+
+      updateTable[10](testSettings, false);
+      expect(!_.has(testSettings, 'experimental.containerEngine.webAssembly.enabled'));
+    });
+
+    it('should disable wasm in locked profiles', () => {
+      const testSettings = {};
+
+      updateTable[10](testSettings, true);
+      expect(_.has(testSettings, 'experimental.containerEngine.webAssembly.enabled'));
     });
   });
 });

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -481,7 +481,7 @@ function migrateSettingsToCurrentVersion(settings: Record<string, any>): Setting
   if (Object.keys(settings).length === 0) {
     return defaultSettings;
   }
-  const newSettings = migrateSpecifiedSettingsToCurrentVersion(settings);
+  const newSettings = migrateSpecifiedSettingsToCurrentVersion(settings, false);
 
   return _.defaultsDeep(newSettings, defaultSettings);
 }
@@ -497,7 +497,7 @@ function migrateSettingsToCurrentVersion(settings: Record<string, any>): Setting
  * @param locked - perform special migrations for locked profiles.
  * @param targetVersion - used for unit testing, to run a specific step from version n to n + 1, and not the full migration
  */
-export function migrateSpecifiedSettingsToCurrentVersion(settings: Record<string, any>, locked = false, targetVersion:number = CURRENT_SETTINGS_VERSION): RecursivePartial<Settings> {
+export function migrateSpecifiedSettingsToCurrentVersion(settings: Record<string, any>, locked: boolean, targetVersion:number = CURRENT_SETTINGS_VERSION): RecursivePartial<Settings> {
   const firstPart = 'updating settings requires specifying an API version';
   let loadedVersion = settings.version;
 

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -89,7 +89,7 @@ export async function readDeploymentProfiles(registryProfilePath = REGISTRY_PROF
     if (!('version' in defaults)) {
       throw new DeploymentProfileError(`Invalid deployment file ${ fullDefaultPath }: no version specified. You'll need to add a version field to make it valid (current version is ${ settings.CURRENT_SETTINGS_VERSION }).`);
     }
-    defaults = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(defaults);
+    defaults = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(defaults, false);
   }
   if (locked) {
     if (!('version' in locked)) {
@@ -236,7 +236,7 @@ class Win32DeploymentReader {
 
               throw new DeploymentProfileError(`Invalid default-deployment: no version specified at ${ registryPath }. You'll need to add a version field to make it valid (current version is ${ settings.CURRENT_SETTINGS_VERSION }).`);
             }
-            defaults = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(defaults);
+            defaults = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(defaults, false);
           }
           if (!_.isEmpty(locked)) {
             if (!('version' in locked)) {

--- a/pkg/rancher-desktop/main/deploymentProfiles.ts
+++ b/pkg/rancher-desktop/main/deploymentProfiles.ts
@@ -95,7 +95,7 @@ export async function readDeploymentProfiles(registryProfilePath = REGISTRY_PROF
     if (!('version' in locked)) {
       throw new DeploymentProfileError(`Invalid deployment file ${ fullLockedPath }: no version specified. You'll need to add a version field to make it valid (current version is ${ settings.CURRENT_SETTINGS_VERSION }).`);
     }
-    locked = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(locked);
+    locked = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(locked, true);
   }
 
   profiles.defaults = validateDeploymentProfile(fullDefaultPath, defaults, settings.defaultSettings, []) ?? {};
@@ -244,7 +244,7 @@ class Win32DeploymentReader {
 
               throw new DeploymentProfileError(`Invalid locked-deployment: no version specified at ${ registryPath }. You'll need to add a version field to make it valid (current version is ${ settings.CURRENT_SETTINGS_VERSION }).`);
             }
-            locked = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(locked);
+            locked = settingsImpl.migrateSpecifiedSettingsToCurrentVersion(locked, true);
           }
 
           return { defaults, locked };
@@ -590,7 +590,7 @@ const userDefinedKeys = [
  *
  * @param pathParts - On Windows, the parts of the registry path below KEY\Software\Rancher Desktop\Profile\{defaults|locked|}
  *                    The first field is always either 'defaults' or 'locked' and can be ignored
- *                    On other platforms its the path-parts up to but not including the root (which is unnamed anyway).
+ *                    On other platforms it is the path-parts up to but not including the root (which is unnamed anyway).
  * @returns boolean
  */
 function haveUserDefinedObject(pathParts: string[]): boolean {


### PR DESCRIPTION
If an admin deploys a version 10 (or earlier) locked profile, and the user upgrades to Rancher Desktop 1.13+, then WASM will automatically be locked to the disabled position until the admin updates the profile.

A version 11 profile that doesn't lock the wasm settings let's the user enable/disable the wasm feature at will.

Fixes #6512