### PR TITLE
Configure wasm shims

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -794,6 +794,7 @@ VModal
 VMs
 vmsock
 vmwarevsphere
+vmx
 vnc
 vnd
 vnode

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /resources/host/
 /resources/rancher-dashboard/*
 /resources/preload.js*
-/resources/rdx-proxy.tgz
+/resources/rdx-proxy.tar
 /coverage/
 /dist/**
 /.idea/

--- a/pkg/rancher-desktop/assets/scripts/install-containerd-shims
+++ b/pkg/rancher-desktop/assets/scripts/install-containerd-shims
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -o errexit -o nounset -o pipefail
+
+dest=/usr/local/containerd-shims
+
+# Copy all shims into the data volume so they become part of snapshots.
+# TODO Maybe use rsync to avoid copying files repeatedly?
+mkdir -p "$dest"
+for dir in "$@"; do
+  if [[ "$(uname -a)" =~ microsoft ]]; then
+    dir=$(wslpath -a -u "$dir")
+  fi
+  cp "${dir}/containerd-shim-"* "$dest" || :
+done
+
+# Make sure all shims are executable.
+chmod 755 "${dest}/"* || :
+
+# Create symlinks to each shim into /usr/local/bin.
+# In the future this will enable us putting only shims from an allow list on the PATH.
+find /usr/local/bin -type l -name 'containerd-shim-*' -delete
+find "$dest" -type f -exec ln -sf {} /usr/local/bin \;

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -128,6 +128,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     await this.progressTracker.action('Installing k3s', 50, async() => {
       await this.installK3s(desiredVersion);
       await this.writeServiceScript(config, desiredVersion, allowSudo);
+      await BackendHelper.configureRuntimeClasses(this.vm);
     });
 
     this.activeVersion = desiredVersion;

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -170,6 +170,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
   async install(config: BackendSettings, version: semver.SemVer, allowSudo: boolean) {
     await this.vm.runInstallScript(INSTALL_K3S_SCRIPT,
       'install-k3s', version.raw, await this.vm.wslify(path.join(paths.cache, 'k3s')));
+    await BackendHelper.configureRuntimeClasses(this.vm);
   }
 
   async start(config: BackendSettings, activeVersion: semver.SemVer, kubeClient?: KubeClient): Promise<string> {

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1556,7 +1556,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     return JSON.parse(stdout).SPNetworkDataType;
   }
 
-  protected async configureContainerd(): Promise<void> {
+  protected async configureContainerEngine(): Promise<void> {
     const workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-containerd-install-'));
 
     try {
@@ -1912,7 +1912,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         await Promise.all([
           this.progressTracker.action('Installing CA certificates', 50, this.installCACerts()),
           this.progressTracker.action('Configuring image proxy', 50, this.configureOpenResty(config)),
-          this.progressTracker.action('Configuring container engine', 50, this.configureContainerd()),
+          this.progressTracker.action('Configuring container engine', 50, this.configureContainerEngine()),
           this.progressTracker.action('Configuring logrotate', 50, this.configureLogrotate()),
         ]);
 

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -232,7 +232,7 @@ export class ExtensionManagerImpl implements ExtensionManager {
 
     // Import image for port forwarding
     await this.client.runClient(
-      ['image', 'load', '--input', path.join(paths.resources, 'rdx-proxy.tgz')],
+      ['image', 'load', '--input', path.join(paths.resources, 'rdx-proxy.tar')],
       console, { namespace: ExtensionImpl.extensionNamespace });
 
     // Install / uninstall extensions as needed.

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -92,6 +92,11 @@ describe('paths', () => {
       linux:  '%HOME%/.local/share/rancher-desktop/snapshots/',
       darwin: '%HOME%/Library/Application Support/rancher-desktop/snapshots/',
     },
+    containerdShims: {
+      win32:  '%LOCALAPPDATA%/rancher-desktop/containerd-shims/',
+      linux:  '%HOME%/.local/share/rancher-desktop/containerd-shims/',
+      darwin: '%HOME%/Library/Application Support/rancher-desktop/containerd-shims/',
+    },
   };
 
   const table = Object.entries(cases).flatMap(

--- a/pkg/rancher-desktop/utils/paths.ts
+++ b/pkg/rancher-desktop/utils/paths.ts
@@ -37,6 +37,8 @@ export interface Paths {
   wslDistroData: string;
   /** Directory that holds snapshots. */
   snapshots: string;
+  /** Directory that holds user-managed containerd-shims. */
+  containerdShims: string;
 }
 
 export class UnixPaths implements Paths {
@@ -52,6 +54,7 @@ export class UnixPaths implements Paths {
   deploymentProfileUser = '';
   extensionRoot = '';
   snapshots = '';
+  containerdShims = '';
 
   constructor(pathsData: Record<string, unknown>) {
     Object.assign(this, pathsData);
@@ -77,6 +80,7 @@ export class WindowsPaths implements Paths {
   wslDistro = '';
   wslDistroData = '';
   snapshots = '';
+  containerdShims = '';
 
   constructor(pathsData: Record<string, unknown>) {
     Object.assign(this, pathsData);

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -9,7 +9,6 @@ import os from 'os';
 import path from 'path';
 import stream from 'stream';
 import util from 'util';
-import zlib from 'zlib';
 
 import spawn from 'cross-spawn';
 import _ from 'lodash';
@@ -326,7 +325,7 @@ export default {
     try {
       const executablePath = path.join(workDir, 'extension-proxy');
       const layerPath = path.join(workDir, 'layer.tar');
-      const imagePath = path.join(this.rootDir, 'resources', 'rdx-proxy.tgz');
+      const imagePath = path.join(this.rootDir, 'resources', 'rdx-proxy.tar');
 
       console.log('Building RDX proxying image...');
 
@@ -373,7 +372,6 @@ export default {
       const imageWritten =
         stream.promises.finished(
           image
-            .pipe(zlib.createGzip())
             .pipe(fs.createWriteStream(imagePath)));
       const addEntry = (name: string, input: Buffer | stream.Readable, size?: number) => {
         if (Buffer.isBuffer(input)) {

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -9,19 +9,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
+func DeleteData(appPaths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
 
 	pathList := []string{
-		paths.AltAppHome,
-		paths.Config,
-		paths.Logs,
-		paths.ExtensionRoot,
+		appPaths.AltAppHome,
+		appPaths.Config,
+		appPaths.Logs,
+		appPaths.ExtensionRoot,
 	}
-	appHomeDirs := addAppHomeWithoutSnapshots(paths.AppHome)
-	pathList = append(pathList, appHomeDirs...)
+	pathList = append(pathList, appHomeDirectories(appPaths)...)
 
 	// Get path that electron-updater stores cache data in. Technically this
 	// is the wrong directory to use for cache data, but it is set by electron-updater.
@@ -34,9 +33,9 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	}
 
 	if removeKubernetesCache {
-		pathList = append(pathList, paths.Cache)
+		pathList = append(pathList, appPaths.Cache)
 	} else {
-		pathList = append(pathList, filepath.Join(paths.Cache, "updater-longhorn.json"))
+		pathList = append(pathList, filepath.Join(appPaths.Cache, "updater-longhorn.json"))
 	}
-	return deleteUnixLikeData(paths, pathList)
+	return deleteUnixLikeData(appPaths, pathList)
 }

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
+func DeleteData(appPaths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
@@ -20,9 +20,9 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	}
 
 	pathList := []string{
-		paths.AltAppHome,
-		paths.Config,
-		paths.Logs,
+		appPaths.AltAppHome,
+		appPaths.Config,
+		appPaths.Logs,
 		filepath.Join(homeDir, ".local", "state", "rancher-desktop"),
 	}
 
@@ -36,11 +36,10 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	}
 
 	if removeKubernetesCache {
-		pathList = append(pathList, paths.Cache)
+		pathList = append(pathList, appPaths.Cache)
 	} else {
-		pathList = append(pathList, filepath.Join(paths.Cache, "updater-longhorn.json"))
+		pathList = append(pathList, filepath.Join(appPaths.Cache, "updater-longhorn.json"))
 	}
-	appHomeDirs := addAppHomeWithoutSnapshots(paths.AppHome)
-	pathList = append(pathList, appHomeDirs...)
-	return deleteUnixLikeData(paths, pathList)
+	pathList = append(pathList, appHomeDirectories(appPaths)...)
+	return deleteUnixLikeData(appPaths, pathList)
 }

--- a/src/go/rdctl/pkg/paths/paths.go
+++ b/src/go/rdctl/pkg/paths/paths.go
@@ -38,6 +38,8 @@ type Paths struct {
 	ExtensionRoot string `json:"extensionRoot"`
 	// Directory that holds snapshots
 	Snapshots string `json:"snapshots,omitempty"`
+	// Directory containing user-managed containerd-shims
+	ContainerdShims string `json:"containerdShims,omitempty"`
 }
 
 func getResourcesPath() (string, error) {

--- a/src/go/rdctl/pkg/paths/paths_darwin.go
+++ b/src/go/rdctl/pkg/paths/paths_darwin.go
@@ -35,6 +35,7 @@ func GetPaths(getResourcesPathFuncs ...func() (string, error)) (Paths, error) {
 		DeploymentProfileUser:   filepath.Join(homeDir, "Library", "Preferences"),
 		ExtensionRoot:           filepath.Join(appHome, "extensions"),
 		Snapshots:               filepath.Join(appHome, "snapshots"),
+		ContainerdShims:         filepath.Join(appHome, "containerd-shims"),
 	}
 	paths.Logs = os.Getenv("RD_LOGS_DIR")
 	if paths.Logs == "" {

--- a/src/go/rdctl/pkg/paths/paths_darwin_test.go
+++ b/src/go/rdctl/pkg/paths/paths_darwin_test.go
@@ -26,6 +26,7 @@ func TestGetPaths(t *testing.T) {
 			DeploymentProfileUser:   filepath.Join(homeDir, "Library", "Preferences"),
 			ExtensionRoot:           filepath.Join(homeDir, "Library", "Application Support", appName, "extensions"),
 			Snapshots:               filepath.Join(homeDir, "Library", "Application Support", appName, "snapshots"),
+			ContainerdShims:         filepath.Join(homeDir, "Library", "Application Support", appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {
@@ -56,6 +57,7 @@ func TestGetPaths(t *testing.T) {
 			DeploymentProfileUser:   filepath.Join(homeDir, "Library", "Preferences"),
 			ExtensionRoot:           filepath.Join(homeDir, "Library", "Application Support", appName, "extensions"),
 			Snapshots:               filepath.Join(homeDir, "Library", "Application Support", appName, "snapshots"),
+			ContainerdShims:         filepath.Join(homeDir, "Library", "Application Support", appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {

--- a/src/go/rdctl/pkg/paths/paths_linux.go
+++ b/src/go/rdctl/pkg/paths/paths_linux.go
@@ -46,6 +46,7 @@ func GetPaths(getResourcesPathFuncs ...func() (string, error)) (Paths, error) {
 		DeploymentProfileUser:   configHome,
 		ExtensionRoot:           filepath.Join(dataHome, appName, "extensions"),
 		Snapshots:               filepath.Join(dataHome, appName, "snapshots"),
+		ContainerdShims:         filepath.Join(dataHome, appName, "containerd-shims"),
 	}
 	paths.Logs = os.Getenv("RD_LOGS_DIR")
 	if paths.Logs == "" {

--- a/src/go/rdctl/pkg/paths/paths_linux_test.go
+++ b/src/go/rdctl/pkg/paths/paths_linux_test.go
@@ -36,6 +36,7 @@ func TestGetPaths(t *testing.T) {
 			DeploymentProfileUser:   filepath.Join(homeDir, ".config"),
 			ExtensionRoot:           filepath.Join(homeDir, ".local/share", appName, "extensions"),
 			Snapshots:               filepath.Join(homeDir, ".local/share", appName, "snapshots"),
+			ContainerdShims:         filepath.Join(homeDir, ".local/share", appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {
@@ -74,6 +75,7 @@ func TestGetPaths(t *testing.T) {
 			DeploymentProfileUser:   environment["XDG_CONFIG_HOME"],
 			ExtensionRoot:           filepath.Join(environment["XDG_DATA_HOME"], appName, "extensions"),
 			Snapshots:               filepath.Join(environment["XDG_DATA_HOME"], appName, "snapshots"),
+			ContainerdShims:         filepath.Join(environment["XDG_DATA_HOME"], appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {

--- a/src/go/rdctl/pkg/paths/paths_windows.go
+++ b/src/go/rdctl/pkg/paths/paths_windows.go
@@ -28,14 +28,15 @@ func GetPaths(getResourcesPathFuncs ...func() (string, error)) (Paths, error) {
 	}
 	appHome := filepath.Join(localAppData, appName)
 	paths := Paths{
-		AppHome:       appHome,
-		AltAppHome:    appHome,
-		Config:        appHome,
-		Cache:         filepath.Join(localAppData, appName, "cache"),
-		WslDistro:     filepath.Join(localAppData, appName, "distro"),
-		WslDistroData: filepath.Join(localAppData, appName, "distro-data"),
-		ExtensionRoot: filepath.Join(localAppData, appName, "extensions"),
-		Snapshots:     filepath.Join(localAppData, appName, "snapshots"),
+		AppHome:         appHome,
+		AltAppHome:      appHome,
+		Config:          appHome,
+		Cache:           filepath.Join(localAppData, appName, "cache"),
+		WslDistro:       filepath.Join(localAppData, appName, "distro"),
+		WslDistroData:   filepath.Join(localAppData, appName, "distro-data"),
+		ExtensionRoot:   filepath.Join(localAppData, appName, "extensions"),
+		Snapshots:       filepath.Join(localAppData, appName, "snapshots"),
+		ContainerdShims: filepath.Join(localAppData, appName, "containerd-shims"),
 	}
 	paths.Logs = os.Getenv("RD_LOGS_DIR")
 	if paths.Logs == "" {

--- a/src/go/rdctl/pkg/paths/paths_windows_test.go
+++ b/src/go/rdctl/pkg/paths/paths_windows_test.go
@@ -23,16 +23,17 @@ func TestGetPaths(t *testing.T) {
 			t.Errorf("Unexpected error getting user home directory: %s", err)
 		}
 		expectedPaths := Paths{
-			AppHome:       filepath.Join(homeDir, "AppData", "Local", appName),
-			AltAppHome:    filepath.Join(homeDir, "AppData", "Local", appName),
-			Config:        filepath.Join(homeDir, "AppData", "Local", appName),
-			Logs:          filepath.Join(homeDir, "AppData", "Local", appName, "logs"),
-			Cache:         filepath.Join(homeDir, "AppData", "Local", appName, "cache"),
-			WslDistro:     filepath.Join(homeDir, "AppData", "Local", appName, "distro"),
-			WslDistroData: filepath.Join(homeDir, "AppData", "Local", appName, "distro-data"),
-			Resources:     fakeResourcesPath,
-			ExtensionRoot: filepath.Join(homeDir, "AppData", "Local", appName, "extensions"),
-			Snapshots:     filepath.Join(homeDir, "AppData", "Local", appName, "snapshots"),
+			AppHome:         filepath.Join(homeDir, "AppData", "Local", appName),
+			AltAppHome:      filepath.Join(homeDir, "AppData", "Local", appName),
+			Config:          filepath.Join(homeDir, "AppData", "Local", appName),
+			Logs:            filepath.Join(homeDir, "AppData", "Local", appName, "logs"),
+			Cache:           filepath.Join(homeDir, "AppData", "Local", appName, "cache"),
+			WslDistro:       filepath.Join(homeDir, "AppData", "Local", appName, "distro"),
+			WslDistroData:   filepath.Join(homeDir, "AppData", "Local", appName, "distro-data"),
+			Resources:       fakeResourcesPath,
+			ExtensionRoot:   filepath.Join(homeDir, "AppData", "Local", appName, "extensions"),
+			Snapshots:       filepath.Join(homeDir, "AppData", "Local", appName, "snapshots"),
+			ContainerdShims: filepath.Join(homeDir, "AppData", "Local", appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {
@@ -58,16 +59,17 @@ func TestGetPaths(t *testing.T) {
 		}
 
 		expectedPaths := Paths{
-			AppHome:       filepath.Join(environment["LOCALAPPDATA"], appName),
-			AltAppHome:    filepath.Join(environment["LOCALAPPDATA"], appName),
-			Config:        filepath.Join(environment["LOCALAPPDATA"], appName),
-			Logs:          environment["RD_LOGS_DIR"],
-			Cache:         filepath.Join(environment["LOCALAPPDATA"], appName, "cache"),
-			WslDistro:     filepath.Join(environment["LOCALAPPDATA"], appName, "distro"),
-			WslDistroData: filepath.Join(environment["LOCALAPPDATA"], appName, "distro-data"),
-			Resources:     fakeResourcesPath,
-			ExtensionRoot: filepath.Join(environment["LOCALAPPDATA"], appName, "extensions"),
-			Snapshots:     filepath.Join(environment["LOCALAPPDATA"], appName, "snapshots"),
+			AppHome:         filepath.Join(environment["LOCALAPPDATA"], appName),
+			AltAppHome:      filepath.Join(environment["LOCALAPPDATA"], appName),
+			Config:          filepath.Join(environment["LOCALAPPDATA"], appName),
+			Logs:            environment["RD_LOGS_DIR"],
+			Cache:           filepath.Join(environment["LOCALAPPDATA"], appName, "cache"),
+			WslDistro:       filepath.Join(environment["LOCALAPPDATA"], appName, "distro"),
+			WslDistroData:   filepath.Join(environment["LOCALAPPDATA"], appName, "distro-data"),
+			Resources:       fakeResourcesPath,
+			ExtensionRoot:   filepath.Join(environment["LOCALAPPDATA"], appName, "extensions"),
+			Snapshots:       filepath.Join(environment["LOCALAPPDATA"], appName, "snapshots"),
+			ContainerdShims: filepath.Join(environment["LOCALAPPDATA"], appName, "containerd-shims"),
 		}
 		actualPaths, err := GetPaths(mockGetResourcesPath)
 		if err != nil {


### PR DESCRIPTION
* shims are copied into the data volume to become part of snapshots
* user-managed shims can be installed into $APPHOME/containerd-shims
* shims are symlinked into /usr/local/bin, so can be filtered in the future by removing the symlink
* containerd gets a config for each runtime shim
* dockerd uses the containerd-snapshotter when wasm support is enabled
* k3s runtime classes are defined for each shim