### PR TITLE
Windows Installer: Enforce minimum kernel version

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -335,6 +335,7 @@ Infof
 Infoln
 installable
 INSTALLMESSAGE
+INSTALLPROPERTY
 ioctl
 ipaddr
 isthebestmeshuggahalbum
@@ -467,6 +468,7 @@ msiexec
 MSIHANDLE
 MSIINSTALLPERUSER
 MSIX
+msixbundle
 msize
 msvs
 mszip
@@ -780,6 +782,7 @@ vcpus
 vcs
 vde
 ventura
+VERSIONSTRING
 vertificate
 vhdx
 vinzenz
@@ -819,9 +822,11 @@ wsl
 wslapi
 wslconfig
 WSLENV
+WSLg
 wslify
 WSLINSTALLED
 WSLIs
+WSLKERNELOUTDATED
 wslutils
 WWID
 wwn

--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -45,13 +45,16 @@
 
     <!-- Custom action to detect if WSL is installed -->
     <Binary Id="CustomActionBinary" SourceFile="wix-custom-action.dll" />
-    <CustomAction Id="DetectWSL" BinaryKey="CustomActionBinary" DllEntry="IsWSLInstalled"
+    <CustomAction Id="DetectWSL" BinaryKey="CustomActionBinary" DllEntry="DetectWSL"
       Execute="immediate" Return="check" />
     <!-- Custom action to install Windows features for WSL -->
     <CustomAction Id="InstallWindowsFeature" BinaryKey="CustomActionBinary"
       DllEntry="InstallWindowsFeature" Execute="deferred" Return="check" Impersonate="no" />
     <!-- Custom action to install WSL -->
     <CustomAction Id="InstallWSL" BinaryKey="CustomActionBinary" DllEntry="InstallWSL"
+      Execute="deferred" Return="check" Impersonate="yes" />
+    <!-- Custom action to update WSL -->
+    <CustomAction Id="UpdateWSL" BinaryKey="CustomActionBinary" DllEntry="UpdateWSL"
       Execute="deferred" Return="check" Impersonate="yes" />
 
     <!-- Disable the start app prompt if we need a reboot -->
@@ -60,6 +63,10 @@
     </SetProperty>
 
     <InstallUISequence>
+      <!--
+        - DetectWSL may set the WSLINSTALLED and WSLKERNELOUTDATED properties
+        - depending on the state of the system.
+        -->
       <Custom Action="DetectWSL" After="AppSearch">
         NOT WSLINSTALLED <!-- Skip search if user overrides -->
       </Custom>
@@ -74,7 +81,10 @@
       <Custom Action="InstallWSL" After="InstallWindowsFeature">
         NOT WSLINSTALLED AND NOT Installed
       </Custom>
-      <ScheduleReboot After="InstallWSL">
+      <Custom Action="UpdateWSL" After="InstallWSL">
+        WSLINSTALLED AND WSLKERNELOUTDATED
+      </Custom>
+      <ScheduleReboot After="UpdateWSL">
         NOT WSLINSTALLED AND NOT Installed
       </ScheduleReboot>
     </InstallExecuteSequence>

--- a/src/go/wsl-helper/pkg/wsl-utils/install_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/install_windows.go
@@ -2,8 +2,11 @@ package wslutils
 
 import (
 	"context"
+	"errors"
+	"os/exec"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 // InstallWSL runs wsl.exe to install WSL.
@@ -24,6 +27,41 @@ func InstallWSL(ctx context.Context, log *logrus.Entry) error {
 		Run(ctx, "--install", "--no-distribution")
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// UpdateWSL runs wsl.exe to update the WSL kernel.  This assumes that WSL had
+// already been installed.  This may request elevation.
+func UpdateWSL(ctx context.Context, log *logrus.Entry) error {
+	// Similar to InstallWSL, the best we have so far is just to spawn wsl.exe and
+	// hope it does the right thing.  We can technically fetch the .msixbundle
+	// from https://api.github.com/repos/Microsoft/WSL/releases/latest and install
+	// it with PackageManager.AddPackageAsync but that isn't really useful.
+	newRunnerFunc := NewWSLRunner
+	if f := ctx.Value(&kWSLExeOverride); f != nil {
+		newRunnerFunc = f.(func() WSLRunner)
+	}
+	// WSL install hangs if we set stdout; don't set that here.
+	runner := newRunnerFunc().WithStderr(log.WriterLevel(logrus.InfoLevel))
+	err := runner.Run(ctx, "--update")
+	if err != nil {
+		// Since we're running from Windows Installer, `wsl --update` will fail
+		// because the Windows Installer database is locked (by us).  It will,
+		// however, succeed the next time we use WSL.  It seems to return
+		// STATUS_CONTROL_C_EXIT in this case, so catch that error code and
+		// ignore it.  Unfortunately, this means we can't check that the update
+		// has succeeded (because it hasn't, yet).
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			if exitError.ExitCode() == int(windows.STATUS_CONTROL_C_EXIT) {
+				log.WithError(err).Trace("wsl --update exited with error as expected (ignoring)")
+			} else {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/utf16writer_windows.go
@@ -2,9 +2,8 @@ package wslutils
 
 import (
 	"io"
+	"unicode/utf16"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 // utf16Writer is a writer that attempts to convert writes in UTF-16 to UTF-8.
@@ -13,11 +12,14 @@ type utf16Writer struct {
 }
 
 func (w *utf16Writer) Write(p []byte) (int, error) {
-	output := windows.UTF16PtrToString(
-		(*uint16)(unsafe.Pointer(unsafe.SliceData(append(p, 0, 0)))),
-	)
-	n, err := w.Writer.Write(
-		unsafe.Slice(unsafe.StringData(output), len(output)),
-	)
-	return n * 2, err
+	// Manually decode the data; don't use windows.UTF16PtrToString because we
+	// don't assume the input is zero-terminated (but we have a valid length).
+	runes := utf16.Decode(unsafe.Slice((*uint16)(unsafe.Pointer(unsafe.SliceData(p))), len(p)/2))
+	str := string(runes)
+	_, err := w.Writer.Write(unsafe.Slice(unsafe.StringData(str), len(str)))
+	// Even though we may not have written all of the bytes, report that we
+	// consumed it all; this beats figuring out how many bytes we have _actually_
+	// written.  To do this correctly, we'd need to decode the runes one at a time
+	// and feed it to the writer without buffering, but that seems terrible.
+	return len(p), err
 }

--- a/src/go/wsl-helper/pkg/wsl-utils/version_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/version_windows.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -32,22 +34,50 @@ import (
 
 // WSLInfo describes the current (online) WSL installation.
 type WSLInfo struct {
-	Installed bool           `json:"installed"`  // Whether WSL is considered to be installed.
-	Inbox     bool           `json:"inbox"`      // Whether WSL was shipped in-box or from the MS Store/MSIX
-	HasKernel bool           `json:"has_kernel"` // Whether WSL has a kernel installed
-	Version   PackageVersion `json:"version"`    // Installed WSL version (only for store version)
+	Installed      bool           `json:"installed"`       // Whether WSL is considered to be installed.
+	Inbox          bool           `json:"inbox"`           // Whether WSL was shipped in-box or from the MS Store/MSIX
+	Version        PackageVersion `json:"version"`         // Installed WSL version (only for store version)
+	KernelVersion  PackageVersion `json:"kernel_version"`  // Installed WSL kernel version
+	HasKernel      bool           `json:"has_kernel"`      // Whether WSL has a kernel installed
+	OutdatedKernel bool           `json:"outdated_kernel"` // Whether the WSL kernel is too old
+}
+
+func (i WSLInfo) String() string {
+	var parts []string
+	if i.Installed {
+		parts = append(parts, "installed")
+	}
+	if i.Inbox {
+		parts = append(parts, "inbox")
+	}
+	if i.HasKernel {
+		parts = append(parts, "has-kernel")
+	}
+	if i.OutdatedKernel {
+		parts = append(parts, "outdated-kernel")
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "not-installed")
+	}
+	return fmt.Sprintf("Version=%s (%s)", i.Version, strings.Join(parts, ", "))
 }
 
 const (
 	// kPackageFamily is the package family for the WSL app (MSIX).
 	kPackageFamily = "MicrosoftCorporationII.WindowsSubsystemForLinux_8wekyb3d8bbwe" // spellcheck-ignore-line
 	// kMsiUpgradeCode is the upgrade code for the WSL kernel (for in-box WSL2)
-	kMsiUpgradeCode           = "{1C3DB5B6-65A5-4EBC-A5B9-2F2D6F665F48}"
-	PACKAGE_INFORMATION_BASIC = 0x00000000
-	PACKAGE_INFORMATION_FULL  = 0x00000100
+	kMsiUpgradeCode               = "{1C3DB5B6-65A5-4EBC-A5B9-2F2D6F665F48}"
+	INSTALLPROPERTY_VERSIONSTRING = "VersionString"
+	PACKAGE_INFORMATION_BASIC     = 0x00000000
+	PACKAGE_INFORMATION_FULL      = 0x00000100
+	PACKAGE_FILTER_STATIC         = 0x00080000
+	PACKAGE_FILTER_DYNAMIC        = 0x00100000
+	PackagePathType_Effective     = 2
 	// wslExitNotInstalled is the exit code from `wsl --status` when WSL is not
 	// installed.
 	wslExitNotInstalled = 50
+	// wslExitVersion is the expected exit code from `wsl --version`.
+	wslExitVersion = 128
 )
 
 var (
@@ -59,12 +89,16 @@ var (
 
 	dllMsi                 = windows.NewLazySystemDLL("msi.dll")
 	msiEnumRelatedProducts = dllMsi.NewProc("MsiEnumRelatedProductsW")
+	msiGetProductInfo      = dllMsi.NewProc("MsiGetProductInfoW")
 
 	// kWSLExeOverride is a context key to override how we run wsl.exe for
 	// testing.
 	kWSLExeOverride = &struct{}{}
 	// kUpgradeCodeOverride is a context key to override the MSI file to look for.
 	kUpgradeCodeOverride = &struct{}{}
+	// MinimumKernelVersion is the minimum WSL kernel version required to not be
+	// considered outdated.
+	MinimumKernelVersion = PackageVersion{Major: 5, Minor: 15}
 )
 
 // errorFromWin32 wraps a Win32 return value into an error, with a message in
@@ -135,6 +169,63 @@ func (v PackageVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d.%d", v.Major, v.Minor, v.Build, v.Revision)
 }
 
+func (v *PackageVersion) UnmarshalText(text []byte) error {
+	expr, err := regexp.Compile(`\s*(\d+)[.,](\d+)[.,](\d+)(?:[.,](\d+))?`)
+	if err != nil {
+		return err
+	}
+	groups := expr.FindStringSubmatch(string(text))
+	if groups == nil {
+		return fmt.Errorf("could not parse version %q", string(text))
+	}
+	var allErrors []error
+	if part, err := strconv.ParseInt(groups[1], 10, 16); err == nil {
+		v.Major = uint16(part)
+	} else {
+		err = fmt.Errorf("version %q has invalid major part: %w", string(text), err)
+		allErrors = append(allErrors, err)
+	}
+	if part, err := strconv.ParseInt(groups[2], 10, 16); err == nil {
+		v.Minor = uint16(part)
+	} else {
+		err = fmt.Errorf("version %q has invalid minor part: %w", string(text), err)
+		allErrors = append(allErrors, err)
+	}
+	if part, err := strconv.ParseInt(groups[3], 10, 16); err == nil {
+		v.Build = uint16(part)
+	} else {
+		err = fmt.Errorf("version %q has invalid build part: %w", string(text), err)
+		allErrors = append(allErrors, err)
+	}
+	if groups[4] != "" {
+		if part, err := strconv.ParseInt(groups[4], 10, 16); err == nil {
+			v.Revision = uint16(part)
+		} else {
+			err = fmt.Errorf("version %q has invalid revision part: %w", string(text), err)
+			allErrors = append(allErrors, err)
+		}
+	}
+	if len(allErrors) > 0 {
+		return errors.Join(allErrors...)
+	}
+	return nil
+}
+
+// Less returns true if this version is lower (i.e. older) than the other.
+func (v PackageVersion) Less(other PackageVersion) bool {
+	switch {
+	case v.Major != other.Major:
+		return v.Major < other.Major
+	case v.Minor != other.Minor:
+		return v.Minor < other.Minor
+	case v.Build != other.Build:
+		return v.Build < other.Build
+	case v.Revision != other.Revision:
+		return v.Revision < other.Revision
+	}
+	return false
+}
+
 // packageInfo corresponds to the PACKAGE_INFO structure.
 type packageInfo struct {
 	reserved          uint32
@@ -174,7 +265,7 @@ func getPackageVersion(fullName string) (*PackageVersion, error) {
 	var bufferLength, count uint32
 	rv, _, err = getPackageInfo.Call(
 		packageInfoReference,
-		uintptr(PACKAGE_INFORMATION_BASIC),
+		uintptr(PACKAGE_INFORMATION_BASIC|PACKAGE_FILTER_STATIC|PACKAGE_FILTER_DYNAMIC),
 		uintptr(unsafe.Pointer(&bufferLength)),
 		uintptr(unsafe.Pointer(nil)),
 		uintptr(unsafe.Pointer(nil)),
@@ -192,7 +283,7 @@ func getPackageVersion(fullName string) (*PackageVersion, error) {
 	buf := make([]byte, bufferLength)
 	rv, _, err = getPackageInfo.Call(
 		packageInfoReference,
-		uintptr(PACKAGE_INFORMATION_BASIC),
+		uintptr(PACKAGE_INFORMATION_BASIC|PACKAGE_FILTER_STATIC|PACKAGE_FILTER_DYNAMIC),
 		uintptr(unsafe.Pointer(&bufferLength)),
 		uintptr(unsafe.Pointer(unsafe.SliceData(buf))),
 		uintptr(unsafe.Pointer(&count)),
@@ -211,9 +302,62 @@ func getPackageVersion(fullName string) (*PackageVersion, error) {
 	return nil, fmt.Errorf("no info found for %s", fullName)
 }
 
+// Get the component versions for an AppX-based installation.  Returns the WSL
+// version, followed by the kernel version.
+func getAppxVersion(ctx context.Context, log *logrus.Entry) (*PackageVersion, *PackageVersion, error) {
+	newRunnerFunc := NewWSLRunner
+	if f := ctx.Value(&kWSLExeOverride); f != nil {
+		newRunnerFunc = f.(func() WSLRunner)
+	}
+	output := &bytes.Buffer{}
+	err := newRunnerFunc().WithStdout(output).WithStderr(os.Stderr).Run(ctx, "--version")
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == wslExitVersion {
+		// wsl --version is expected to return non-nil
+	} else if err != nil {
+		return nil, nil, fmt.Errorf("error running wsl --version: %w", err)
+	}
+	log.WithField("raw", output.String()).Trace("wsl --version output")
+	expr, err := regexp.Compile(`\s+\d+[.,]\d+[.,]\d+(?:[.,]\d+)?`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to compile version regular expression: %w", err)
+	}
+	var errorList []error
+	var version, wslVersion, kernelVersion PackageVersion
+	i := 0
+	for _, line := range strings.Split(output.String(), "\n") {
+		line = strings.TrimSpace(line)
+		matchedString := expr.FindString(line)
+		if matchedString == "" {
+			log.WithField("line", line).Trace("line does not contain version string")
+			continue
+		}
+		log.WithField("line", line).WithField("version", matchedString).Trace("found version string")
+		if err = version.UnmarshalText([]byte(matchedString)); err != nil {
+			errorList = append(errorList, err)
+		} else {
+			switch i {
+			case 0:
+				wslVersion = version
+			case 1:
+				kernelVersion = version
+			}
+			i++
+			if i > 1 {
+				break
+			}
+		}
+	}
+	if len(errorList) > 0 {
+		return nil, nil, fmt.Errorf("error getting AppX version: %w", errors.Join(errorList...))
+	}
+	log.WithFields(logrus.Fields{"wsl": wslVersion, "kernel": kernelVersion}).Trace("got AppX version")
+	return &wslVersion, &kernelVersion, nil
+}
+
 // isInboxWSLInstalled checks if the "in-box" version of WSL is installed,
-// returning whether it's installed, and whether the kernel is installed
-func isInboxWSLInstalled(ctx context.Context, log *logrus.Entry) (bool, bool, error) {
+// returning whether it's installed, the version of the kernel installed (if any)
+func isInboxWSLInstalled(ctx context.Context, log *logrus.Entry) (bool, *PackageVersion, error) {
 	var allErrors []error
 
 	// Check if the core is installed
@@ -240,7 +384,7 @@ func isInboxWSLInstalled(ctx context.Context, log *logrus.Entry) (bool, bool, er
 	}
 
 	// Check if the kernel is installed.
-	kernelInstalled := false
+	var kernelVersion *PackageVersion
 	upgradeCodeString := kMsiUpgradeCode
 	if v := ctx.Value(&kUpgradeCodeOverride); v != nil {
 		upgradeCodeString = v.(string)
@@ -259,7 +403,10 @@ func isInboxWSLInstalled(ctx context.Context, log *logrus.Entry) (bool, bool, er
 		)
 		switch rv {
 		case uintptr(windows.ERROR_SUCCESS):
-			kernelInstalled = true
+			kernelVersion, err = getMSIVersion(productCode)
+			if err != nil {
+				allErrors = append(allErrors, fmt.Errorf("error getting kernel version: %w", err))
+			}
 		case uintptr(windows.ERROR_NO_MORE_ITEMS):
 			// kernel is not installed
 		default:
@@ -268,8 +415,42 @@ func isInboxWSLInstalled(ctx context.Context, log *logrus.Entry) (bool, bool, er
 		}
 	}
 
-	err = errors.Join(allErrors...)
-	return coreInstalled, kernelInstalled, err
+	return coreInstalled, kernelVersion, errors.Join(allErrors...)
+}
+
+// Get the version of an installed MSI package, given its product code.
+func getMSIVersion(productCode []uint16) (*PackageVersion, error) {
+	version := PackageVersion{}
+	versionStringWide, err := windows.UTF16PtrFromString(INSTALLPROPERTY_VERSIONSTRING)
+	if err != nil {
+		return nil, err
+	}
+	bufSize := uint32(64)
+	wideBuf := make([]uint16, bufSize)
+	for {
+		rv, _, _ := msiGetProductInfo.Call(
+			uintptr(unsafe.Pointer(unsafe.SliceData(productCode))),
+			uintptr(unsafe.Pointer(versionStringWide)),
+			uintptr(unsafe.Pointer(unsafe.SliceData(wideBuf))),
+			uintptr(unsafe.Pointer(&bufSize)),
+		)
+		switch rv {
+		case uintptr(windows.ERROR_SUCCESS):
+			versionString := windows.UTF16ToString(wideBuf[:bufSize])
+			if err = version.UnmarshalText([]byte(versionString)); err != nil {
+				return nil, err
+			}
+			return &version, nil
+		case uintptr(windows.ERROR_MORE_DATA):
+			bufSize = uint32(len(wideBuf) * 2)
+			wideBuf = make([]uint16, bufSize)
+		case uintptr(windows.ERROR_BAD_CONFIGURATION):
+			err = errorFromWin32("Windows Installer configuration data is corrupt", rv, nil)
+			return nil, err
+		default:
+			return nil, errorFromWin32("failed to get WSL kernel MSI version", rv, nil)
+		}
+	}
 }
 
 func GetWSLInfo(ctx context.Context, log *logrus.Entry) (*WSLInfo, error) {
@@ -282,26 +463,38 @@ func GetWSLInfo(ctx context.Context, log *logrus.Entry) (*WSLInfo, error) {
 	log.Tracef("Got %d appx packages", len(names))
 	for _, name := range names {
 		if version, err := getPackageVersion(name); err == nil {
-			// It seems like the store version _always_ has the kernel,
-			// somewhere; it doesn't seem possible to uninstall it.
 			log.Tracef("Got appx package %s with version %s", name, version)
+			wslVersion, kernelVersion, err := getAppxVersion(ctx, log)
+			if err != nil {
+				return nil, err
+			}
 			return &WSLInfo{
-				Installed: true,
-				Inbox:     false,
-				HasKernel: true,
-				Version:   *version,
+				Installed:      true,
+				Inbox:          false,
+				Version:        *wslVersion,
+				KernelVersion:  *kernelVersion,
+				HasKernel:      PackageVersion{}.Less(*kernelVersion),
+				OutdatedKernel: kernelVersion.Less(MinimumKernelVersion),
 			}, nil
+		} else {
+			log.WithError(err).Trace("Failed to get package version")
 		}
 	}
 
 	log.Trace("Failed to get WSL appx package, trying inbox versions...")
-	hasWSL, hasKernel, err := isInboxWSLInstalled(ctx, log)
+	hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, log)
 	if err != nil {
 		return nil, err
 	}
+	if kernelVersion == nil {
+		kernelVersion = &PackageVersion{}
+	}
+	hasKernel := PackageVersion{}.Less(*kernelVersion)
 	return &WSLInfo{
-		Installed: hasWSL && hasKernel,
-		Inbox:     hasWSL,
-		HasKernel: hasKernel,
+		Installed:      hasWSL && hasKernel,
+		Inbox:          hasWSL,
+		HasKernel:      hasKernel,
+		KernelVersion:  *kernelVersion,
+		OutdatedKernel: kernelVersion.Less(MinimumKernelVersion),
 	}, nil
 }

--- a/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
@@ -270,7 +270,7 @@ func TestGetAppxVersion(t *testing.T) {
 	}
 }
 
-func TestIsInboxWSLInstalled(t *testing.T) {
+func TestGetInboxWSLInfo(t *testing.T) {
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
 
@@ -287,7 +287,7 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		})
 		// Use a random GUID here
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{60486CC7-CD7A-4514-9E88-7F21E8A81679}")
-		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := getInboxWSLInfo(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.False(t, hasWSL, "WSL should not be installed")
 		if !assert.Nil(t, kernelVersion, "kernel should not be installed") {
@@ -315,7 +315,7 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		})
 		// Use a random GUID here
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{0C32EDDD-2674-4F32-B415-B715AF90BE74}")
-		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := getInboxWSLInfo(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.True(t, hasWSL, "WSL should be installed")
 		if !assert.Nil(t, kernelVersion, "kernel should not be installed") {
@@ -333,7 +333,7 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		// Use the upgrade code for "Microsoft Update Health Tools", which is
 		// automatically installed from Windows Update.
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{2E5106FD-42A1-4BBE-9C29-7E1D34CB79A1}")
-		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := getInboxWSLInfo(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.True(t, hasWSL, "WSL should be installed")
 		if assert.NotNil(t, kernelVersion, "kernel should be installed") {

--- a/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package wslutils
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -29,36 +31,157 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	// Test with a package that's more likely to exist across all machines
-	testPackageFamily     = "Microsoft.LockApp_cw5n1h2txyewy" // spellcheck-ignore-line
-	testPackageNamePrefix = "Microsoft.LockApp_"
+	"golang.org/x/sys/windows"
 )
 
 func TestGetPackageNames(t *testing.T) {
-	names, err := getPackageNames(testPackageFamily)
-	require.NoError(t, err, "Error getting package names")
-	require.NotEmpty(t, names, "Failed to get any packages")
-	for _, name := range names {
-		assert.True(
-			t,
-			strings.HasPrefix(name, testPackageNamePrefix),
-			fmt.Sprintf("Unexpected package name %s", name))
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("valid package family", func(t *testing.T) {
+		// Get a random package family
+		command := `Get-AppxPackage | Select-Object -First 1 -ExpandProperty PackageFamilyName`
+		output, err := runPowerShell(ctx, command)
+		if err != nil {
+			t.Skipf("Failed to get sample family, skipping test: %s", err)
+		}
+		family := strings.TrimSpace(output.String())
+
+		// Get all packages in that family; not that we can't pipe single element
+		// arrays (they get flattened to just the element), so we need to pass the
+		// list as an argument to ConvertTo-JSON
+		command = fmt.Sprintf(strings.NewReplacer("\r", " ", "\n", " ", "\t", " ").Replace(`
+		ConvertTo-JSON -InputObject @(
+			Get-AppxPackage
+			| Where-Object { $_.PackageFamilyName -eq "%s" }
+			| Select-Object -ExpandProperty PackageFullName
+		)
+	`), family)
+		output, err = runPowerShell(ctx, command)
+		if err != nil {
+			t.Skipf("Failed to get packages in family %s, skipping test: %s", family, err)
+		}
+		var expected []string
+		assert.NoErrorf(t, json.Unmarshal(output.Bytes(), &expected), "failed to read package names: %s", output.String())
+
+		names, err := getPackageNames(family)
+		require.NoError(t, err, "Error getting package names")
+		assert.ElementsMatch(t, expected, names, "Failed to get packages")
+	})
+
+	t.Run("invalid package family", func(t *testing.T) {
+		_, err := getPackageNames("invalid package family")
+		assert.Error(t, err, "should not get packages for invalid family")
+	})
+}
+
+func TestPackageVersion(t *testing.T) {
+	t.Run("UnmarshalText", func(t *testing.T) {
+		t.Parallel()
+		t.Run("three-part", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("1.2.3"))
+			assert.NoError(t, err, "failed to unmarshal 1.2.3")
+			assert.Equal(t, PackageVersion{Major: 1, Minor: 2, Build: 3}, v)
+		})
+		t.Run("four-part", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("1234.5678.8765.4321"))
+			assert.NoError(t, err, "failed to unmarshal 1234.5678.8765.4321")
+			assert.Equal(t, PackageVersion{Major: 1234, Minor: 5678, Build: 8765, Revision: 4321}, v)
+		})
+		t.Run("comma", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("1,2,3"))
+			assert.NoError(t, err, "failed to unmarshal 1,2,3")
+			assert.Equal(t, PackageVersion{Major: 1, Minor: 2, Build: 3}, v)
+		})
+		t.Run("space", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte(" 4.5.6"))
+			assert.NoError(t, err, "failed to unmarshal <space>4.5.6")
+			assert.Equal(t, PackageVersion{Major: 4, Minor: 5, Build: 6}, v)
+		})
+		t.Run("invalid", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("12345"))
+			assert.ErrorContains(t, err, `could not parse version "12345"`)
+		})
+		t.Run("negative", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("-1.-2.-3.-4"))
+			assert.ErrorContains(t, err, `could not parse version "-1.-2.-3.-4"`)
+		})
+		t.Run("too-large", func(t *testing.T) {
+			v := PackageVersion{}
+			err := v.UnmarshalText([]byte("65537.65537.65537.65537"))
+			if assert.Error(t, err) {
+				assert.ErrorContains(t, err, `version "65537.65537.65537.65537" has invalid major part`)
+				assert.ErrorContains(t, err, `version "65537.65537.65537.65537" has invalid minor part`)
+				assert.ErrorContains(t, err, `version "65537.65537.65537.65537" has invalid build part`)
+				assert.ErrorContains(t, err, `version "65537.65537.65537.65537" has invalid revision part`)
+			}
+		})
+	})
+	t.Run("Less", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			L      string
+			R      string
+			expect bool
+		}{
+			{L: "0.0.0", R: "0.0.0", expect: false},
+			{L: "0.0.0", R: "0.0.1", expect: true},
+			{L: "0.0.2", R: "0.0.1", expect: false},
+			{L: "0.0.0", R: "0.1.0", expect: true},
+			{L: "0.2.0", R: "0.1.0", expect: false},
+			{L: "0.0.0", R: "1.0.0", expect: true},
+			{L: "2.0.0", R: "1.0.0", expect: false},
+			{L: "0.0.1", R: "0.1.0", expect: true},
+			{L: "0.0.1", R: "1.0.0", expect: true},
+			{L: "0.1.0", R: "0.0.1", expect: false},
+			{L: "1.0.0", R: "0.0.1", expect: false},
+		}
+		for _, input := range cases {
+			input := input
+			t.Run(fmt.Sprintf("%s<%s=%v", input.L, input.R, input.expect), func(t *testing.T) {
+				var left, right PackageVersion
+				assert.NoError(t, left.UnmarshalText([]byte(input.L)))
+				assert.NoError(t, right.UnmarshalText([]byte(input.R)))
+				assert.Equal(t, input.expect, left.Less(right))
+			})
+		}
+	})
 }
 
 func TestGetPackageVersion(t *testing.T) {
-	packageNames, err := getPackageNames(testPackageFamily)
-	require.NoError(t, err, "could not get package names")
-	require.NotEmpty(t, packageNames)
-	packageName := packageNames[0]
-	version, err := getPackageVersion(packageName)
-	require.NoError(t, err)
-	require.NotNil(t, version)
-	// The package major version is always at least 10 (for Windows 10)
-	assert.GreaterOrEqual(t, version.Major, uint16(10), "Unexpected version %s", version)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("valid package", func(t *testing.T) {
+		// Get a random package and version
+		info := struct {
+			PackageFullName string
+			Version         *PackageVersion
+		}{}
+		command := `Get-AppxPackage | Select-Object -First 1 -Property PackageFullName, Version | ConvertTo-JSON`
+		output, err := runPowerShell(ctx, command)
+		if err != nil {
+			t.Skipf("Failed to get sample package, skipping test: %s", err)
+		}
+		require.NoError(t, json.Unmarshal(output.Bytes(), &info), "failed to get package")
+		require.NotNil(t, info.Version, "failed to get package version")
+
+		version, err := getPackageVersion(info.PackageFullName)
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, info.Version, version, "unexpected version")
+	})
+
+	t.Run("invalid package", func(t *testing.T) {
+		_, err := getPackageVersion("not a valid package name")
+		assert.Error(t, err, "should error with invalid package name")
+	})
 }
 
 // TestWithExitCode is a dummy test function to let us exit with a given exit
@@ -82,6 +205,71 @@ func mockRun(ctx context.Context, fn func(context.Context, ...string) error) (co
 	return context.WithValue(ctx, &kWSLExeOverride, func() WSLRunner { return runner }), runner
 }
 
+// runPowerShell runs the given command with PowerShell, returning standard output.
+func runPowerShell(ctx context.Context, command string) (*bytes.Buffer, error) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := exec.CommandContext(ctx, "powershell.exe",
+		"-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("Failed to run command %q: stdout=%s stderr=%s", command, stdout, stderr)
+	}
+	return stdout, nil
+}
+
+func TestGetAppxVersion(t *testing.T) {
+	outputs := map[string]struct {
+		lines  []string
+		wsl    string
+		kernel string
+	}{
+		"english": {
+			lines:  []string{"WSL Version: 2.0.9.0", "Kernel version: 5.15.133.1-1", "WSLg version: 1.0.59", "... stuff"},
+			wsl:    "2.0.9.0",
+			kernel: "5.15.133.1-1",
+		},
+		"commas": {
+			lines:  []string{"Text 2,0,9,0", "Ignored 5,15,133,1-1", "more,ignored,text"},
+			wsl:    "2.0.9.0",
+			kernel: "5.15.133.1-1",
+		},
+		"incomplete": {
+			lines:  []string{"W 2.0.9.0", "no kernel version listed"},
+			wsl:    "2.0.9.0",
+			kernel: "0.0.0",
+		},
+	}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	for name, input := range outputs {
+		name := name
+		input := input
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			var runner *wslRunnerImpl
+			ctx, runner = mockRun(ctx, func(ctx context.Context, s ...string) error {
+				assert.ElementsMatch(t, []string{"--version"}, s)
+				for _, line := range input.lines {
+					_, err := io.WriteString(runner.stdout, line+"\r\n")
+					assert.NoError(t, err)
+				}
+				return nil
+			})
+			var expectedWSL, expectedKernel PackageVersion
+			wsl, kernel, err := getAppxVersion(ctx, logrus.NewEntry(logger))
+			assert.NoError(t, err)
+			assert.NoError(t, expectedWSL.UnmarshalText([]byte(input.wsl)))
+			assert.NoError(t, expectedKernel.UnmarshalText([]byte(input.kernel)))
+			assert.Equal(t, &expectedWSL, wsl)
+			assert.Equal(t, &expectedKernel, kernel)
+		})
+	}
+}
+
 func TestIsInboxWSLInstalled(t *testing.T) {
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
@@ -99,10 +287,12 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		})
 		// Use a random GUID here
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{60486CC7-CD7A-4514-9E88-7F21E8A81679}")
-		hasWSL, hasKernel, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.False(t, hasWSL, "WSL should not be installed")
-		assert.False(t, hasKernel, "kernel should not be installed")
+		if !assert.Nil(t, kernelVersion, "kernel should not be installed") {
+			assert.False(t, PackageVersion{}.Less(*kernelVersion), "kernel should not be installed")
+		}
 	})
 	t.Run("installed without kernel", func(t *testing.T) {
 		var ctx context.Context
@@ -125,10 +315,12 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		})
 		// Use a random GUID here
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{0C32EDDD-2674-4F32-B415-B715AF90BE74}")
-		hasWSL, hasKernel, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.True(t, hasWSL, "WSL should be installed")
-		assert.False(t, hasKernel, "kernel should not be installed")
+		if !assert.Nil(t, kernelVersion, "kernel should not be installed") {
+			assert.False(t, PackageVersion{}.Less(*kernelVersion), "kernel should not be installed")
+		}
 	})
 	t.Run("installed with kernel", func(t *testing.T) {
 		var ctx context.Context
@@ -141,9 +333,40 @@ func TestIsInboxWSLInstalled(t *testing.T) {
 		// Use the upgrade code for "Microsoft Update Health Tools", which is
 		// automatically installed from Windows Update.
 		ctx = context.WithValue(ctx, &kUpgradeCodeOverride, "{2E5106FD-42A1-4BBE-9C29-7E1D34CB79A1}")
-		hasWSL, hasKernel, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
+		hasWSL, kernelVersion, err := isInboxWSLInstalled(ctx, logrus.NewEntry(logger))
 		assert.NoError(t, err)
 		assert.True(t, hasWSL, "WSL should be installed")
-		assert.True(t, hasKernel, "kernel should be installed")
+		if assert.NotNil(t, kernelVersion, "kernel should be installed") {
+			assert.True(t, PackageVersion{}.Less(*kernelVersion), "kernel should be installed")
+		}
 	})
+}
+
+func TestGetMSIVersion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	// Find a random installed MSI (via PowerShell), then check that we can get
+	// the same version number.
+	commandLine := strings.NewReplacer("\r", " ", "\n", " ", "\t", " ").Replace(`
+		Get-CimInstance -ClassName Win32_Product -Property IdentifyingNumber, Version
+		| Select-Object -First 1
+		| ConvertTo-JSON
+	`)
+	stdout, err := runPowerShell(ctx, commandLine)
+	if err != nil {
+		t.Skipf("Skipping test, failed to get any installed product: %s", err)
+	}
+	result := struct {
+		IdentifyingNumber string
+		Version           *PackageVersion
+	}{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "Failed to get product info")
+	require.NotNil(t, result.Version, "Failed to get product version")
+
+	// Now we have a product code to test again; actually run the function under test.
+	productCode, err := windows.UTF16FromString(result.IdentifyingNumber)
+	require.NoError(t, err, "Failed to convert product code")
+	actualVersion, err := getMSIVersion(productCode)
+	require.NoError(t, err, "Failed to get product version")
+	assert.Equal(t, result.Version, actualVersion, "Unexpected version")
 }

--- a/src/go/wsl-helper/wix/check_windows.go
+++ b/src/go/wsl-helper/wix/check_windows.go
@@ -24,12 +24,15 @@ import (
 )
 
 const (
-	PROP_WSL_INSTALLED = "WSLINSTALLED"
+	// Windows Installer property that is set if WSL was detected to be installed.
+	PropWslInstalled = "WSLINSTALLED"
+	// Windows Installer property that is set if the WSL kernel needs to be upgraded.
+	PropWslKernelOutdated = "WSLKERNELOUTDATED"
 )
 
-// IsWSLInstalledImpl checks if WSL is installed; it outputs results by setting
-// the `WSLINSTALLED` Windows Installer property.
-func IsWSLInstalledImpl(hInstall MSIHANDLE) uint32 {
+// DetectWSLImpl checks if WSL is installed; it outputs results by setting
+// Windows Installer properties.
+func DetectWSLImpl(hInstall MSIHANDLE) uint32 {
 	ctx := context.Background()
 
 	writer := &msiWriter{hInstall: hInstall}
@@ -43,14 +46,19 @@ func IsWSLInstalledImpl(hInstall MSIHANDLE) uint32 {
 	log.Info("Checking if WSL is installed...")
 	info, err := wslutils.GetWSLInfo(ctx, log)
 	if err != nil {
-		log.Errorf("Failed to get WSL info: %s", err)
+		log.WithError(err).Error("Failed to get WSL info")
 		return 1
 	}
 	log.Infof("WSL install state: %+v", info)
 
 	if info.Installed {
-		if err = setProperty(hInstall, PROP_WSL_INSTALLED, "1"); err != nil {
-			log.WithError(err).Error("failed to set property")
+		if err = setProperty(hInstall, PropWslInstalled, "1"); err != nil {
+			log.WithError(err).Errorf("failed to set property %s", PropWslInstalled)
+		}
+		if info.OutdatedKernel {
+			if err = setProperty(hInstall, PropWslKernelOutdated, "1"); err != nil {
+				log.WithError(err).Errorf("failed to set property %s", PropWslKernelOutdated)
+			}
 		}
 	}
 	return 0

--- a/src/go/wsl-helper/wix/check_windows.go
+++ b/src/go/wsl-helper/wix/check_windows.go
@@ -25,9 +25,9 @@ import (
 
 const (
 	// Windows Installer property that is set if WSL was detected to be installed.
-	PropWslInstalled = "WSLINSTALLED"
+	PropWSLInstalled = "WSLINSTALLED"
 	// Windows Installer property that is set if the WSL kernel needs to be upgraded.
-	PropWslKernelOutdated = "WSLKERNELOUTDATED"
+	PropWSLKernelOutdated = "WSLKERNELOUTDATED"
 )
 
 // DetectWSLImpl checks if WSL is installed; it outputs results by setting
@@ -52,12 +52,12 @@ func DetectWSLImpl(hInstall MSIHANDLE) uint32 {
 	log.Infof("WSL install state: %+v", info)
 
 	if info.Installed {
-		if err = setProperty(hInstall, PropWslInstalled, "1"); err != nil {
-			log.WithError(err).Errorf("failed to set property %s", PropWslInstalled)
+		if err = setProperty(hInstall, PropWSLInstalled, "1"); err != nil {
+			log.WithError(err).Errorf("failed to set property %s", PropWSLInstalled)
 		}
 		if info.OutdatedKernel {
-			if err = setProperty(hInstall, PropWslKernelOutdated, "1"); err != nil {
-				log.WithError(err).Errorf("failed to set property %s", PropWslKernelOutdated)
+			if err = setProperty(hInstall, PropWSLKernelOutdated, "1"); err != nil {
+				log.WithError(err).Errorf("failed to set property %s", PropWSLKernelOutdated)
 			}
 		}
 	}

--- a/src/go/wsl-helper/wix/install_windows.go
+++ b/src/go/wsl-helper/wix/install_windows.go
@@ -74,3 +74,29 @@ func InstallWSLImpl(hInstall MSIHANDLE) uint32 {
 	log.Info("WSL successfully installed.")
 	return 0
 }
+
+// UpdateWSLImpl updates the previously installed WSL.
+// This needs to be run as the user, and may request elevation.
+func UpdateWSLImpl(hInstall MSIHANDLE) uint32 {
+	ctx := context.Background()
+
+	writer := &msiWriter{hInstall: hInstall}
+	log := logrus.NewEntry(&logrus.Logger{
+		Out:       writer,
+		Formatter: &logrus.TextFormatter{},
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.TraceLevel,
+	})
+
+	log.Info("Updating WSL...")
+	submitMessage(hInstall, INSTALLMESSAGE_ACTIONSTART, []string{
+		"", "UpdateWSL", "Updating Windows Subsystem for Linux...", "<unused>",
+	})
+	if err := wslutils.UpdateWSL(ctx, log); err != nil {
+		log.WithError(err).Error("Updating WSL failed")
+		return 1
+	}
+
+	log.Info("WSL successfully updated.")
+	return 0
+}

--- a/src/go/wsl-helper/wix/main_windows.go
+++ b/src/go/wsl-helper/wix/main_windows.go
@@ -23,8 +23,9 @@ func main() {
 }
 
 // DetectWSL is a wrapper around DetectWSLImpl; this is the stub to be exported
-// in the DLL.  This only exists because code analysis doesn't work as well in
-// cgo files.
+// in the DLL.  This only exists to limit cgo to this file so that editing on a
+// machine that requires cross compilation can avoid needing a cross cgo
+// toolchain.
 //
 //export DetectWSL
 func DetectWSL(hInstall C.ulong) C.ulong {
@@ -32,8 +33,9 @@ func DetectWSL(hInstall C.ulong) C.ulong {
 }
 
 // InstallWindowsFeature is a wrapper around InstallWindowsFeature; this is the
-// stub to be exported in the DLL.  This only exists because code analysis
-// doesn't work as well in cgo files.
+// stub to be exported in the DLL.  This only exists to limit cgo to this file
+// so that editing on a machine that requires cross compilation can avoid
+// needing a cross cgo toolchain.
 //
 //export InstallWindowsFeature
 func InstallWindowsFeature(hInstall C.ulong) C.ulong {
@@ -41,8 +43,9 @@ func InstallWindowsFeature(hInstall C.ulong) C.ulong {
 }
 
 // InstallWSL is a wrapper around InstallWSLImpl; this is the stub to be
-// exported in the DLL.  This only exists because code analysis doesn't work as
-// well in cgo files.
+// exported in the DLL.  This only exists to limit cgo to this file so that
+// editing on a machine that requires cross compilation can avoid needing a
+// cross cgo toolchain.
 //
 //export InstallWSL
 func InstallWSL(hInstall C.ulong) C.ulong {
@@ -50,8 +53,9 @@ func InstallWSL(hInstall C.ulong) C.ulong {
 }
 
 // UpdateWSL is a wrapper around UpdateWSLImpl; this is the stub to be exported
-// in the DLL.  This only exists because code analysis doesn't work as well in
-// cgo files.
+// in the DLL.  This only exists to limit cgo to this file so that editing on a
+// machine that requires cross compilation can avoid needing a cross cgo
+// toolchain.
 //
 //export UpdateWSL
 func UpdateWSL(hInstall C.ulong) C.ulong {

--- a/src/go/wsl-helper/wix/main_windows.go
+++ b/src/go/wsl-helper/wix/main_windows.go
@@ -22,13 +22,13 @@ func main() {
 	// DllMain is not used
 }
 
-// IsWSLInstalled is a wrapper around IsWSLInstalledImpl; this is the stub to
-// be exported in the DLL.  This only exists because code analysis doesn't work
-// as well in cgo files.
+// DetectWSL is a wrapper around DetectWSLImpl; this is the stub to be exported
+// in the DLL.  This only exists because code analysis doesn't work as well in
+// cgo files.
 //
-//export IsWSLInstalled
-func IsWSLInstalled(hInstall C.ulong) C.ulong {
-	return C.ulong(IsWSLInstalledImpl(MSIHANDLE(hInstall)))
+//export DetectWSL
+func DetectWSL(hInstall C.ulong) C.ulong {
+	return C.ulong(DetectWSLImpl(MSIHANDLE(hInstall)))
 }
 
 // InstallWindowsFeature is a wrapper around InstallWindowsFeature; this is the
@@ -47,4 +47,13 @@ func InstallWindowsFeature(hInstall C.ulong) C.ulong {
 //export InstallWSL
 func InstallWSL(hInstall C.ulong) C.ulong {
 	return C.ulong(InstallWSLImpl(MSIHANDLE(hInstall)))
+}
+
+// UpdateWSL is a wrapper around UpdateWSLImpl; this is the stub to be exported
+// in the DLL.  This only exists because code analysis doesn't work as well in
+// cgo files.
+//
+//export UpdateWSL
+func UpdateWSL(hInstall C.ulong) C.ulong {
+	return C.ulong(UpdateWSLImpl(MSIHANDLE(hInstall)))
 }


### PR DESCRIPTION
This adds detection for the kernel version into the install process (instead of just checking if WSL is installed), and spawns `wsl --update` if it's too old (currently defined as older than 5.15).

Note that because we're doing this from within the installer, `wsl --update` will exit with an error; however, it triggers the process and it will get updated _after_ our install is complete.

Fixes #6482 (because we will attempt to update WSL, and fail the install if we can't start it).  Note that this doesn't quite fix things the whole way, because we're unable to check if the update has succeeded.  That will need to be resolved with #6481.

Should also fix #6471 (but I'm unable to confirm as I was unable to reproduce the error).