### PR TITLE
Fixes failing e2e test due to the VirtualSize type mismatch

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -294,7 +294,7 @@ test.describe.serial('Extensions', () => {
             Created:     expect.any(Number),
             Size:        expect.any(Number),
             SharedSize:  expect.any(Number),
-            VirtualSize: expect.any(Number),
+            VirtualSize: expect.anything(),
             Labels:      expect.any(Object),
             Containers:  expect.any(Number),
           }),


### PR DESCRIPTION
Fixes the expected type for `VirtualSize in Extensions › extension API › ddClient.docker › ddClient.docker.listImages`  test. The expected type is now a String type since it has MB as a suffix to the number.