### PR TITLE
Fix runtimeclass definitions

### DIFF
--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -264,10 +264,8 @@ export default class BackendHelper {
       runtimes.push({
         apiVersion: 'node.k8s.io/v1',
         kind:       'RuntimeClass',
-        metaData:   {
-          name:    shim,
-          handler: shim,
-        },
+        metaData:   { name: shim },
+        handler:    shim,
       });
     }
 


### PR DESCRIPTION
The handler field is not part of the metadata, but of the runtimeclass itself.