### PR TITLE
Remove rd-networking flag from kubeconfig command

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -408,8 +408,6 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   }
 
   protected async syncDistroKubeconfig(distro: string, kubeconfigPath: string, state: boolean) {
-    const rdNetworking = this.settings.experimental?.virtualMachine?.networkingTunnel === true;
-
     try {
       console.debug(`Syncing ${ distro } kubeconfig`);
       await this.execCommand(
@@ -424,7 +422,6 @@ export default class WindowsIntegrationManager implements IntegrationManager {
         await this.getLinuxToolPath(distro, executable('wsl-helper-linux')),
         'kubeconfig',
         `--enable=${ state && this.settings.kubernetes?.enabled }`,
-        `--rd-networking=${ rdNetworking }`,
       );
     } catch (error: any) {
       if (typeof error?.stdout === 'string') {


### PR DESCRIPTION
The kubeconfig command in wsl-helper no longer supports rd-networking flag, since there is no need to retrieve the `eth0` interface IP. This mechanism is replaced by wsl-proxy.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/6523

Related to: https://github.com/rancher-sandbox/rancher-desktop/issues/6245