### PR TITLE
CI: BATS: fix log directory

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -175,7 +175,7 @@ jobs:
     - name: Set log directory
       shell: bash
       run: |
-        echo 'LOGS_DIR=$(pwd)/logs' >> "$GITHUB_ENV"
+        echo "LOGS_DIR=$(pwd)/logs" >> "$GITHUB_ENV"
         mkdir logs
     - name: "Windows: Override log directory"
       if: runner.os == 'Windows'


### PR DESCRIPTION
We should be expanding `$(pwd)` instead of leaving it as a literal.