### PR TITLE
Adds veth-rd1 IP address to the list k3s's TLS Sans

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -782,6 +782,7 @@ vcs
 vde
 ventura
 vertificate
+veth
 vhdx
 vinzenz
 virt

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1501,6 +1501,11 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               // Make sure the apiserver can be accessed from WSL through the internal gateway
               k3sConf.ADDITIONAL_ARGS += ' --tls-san gateway.rancher-desktop.internal';
 
+              if (rdNetworking) {
+                // Add the `veth-rd1` IP address from inside the namespace
+                k3sConf.ADDITIONAL_ARGS += ' --tls-san 192.168.1.2';
+              }
+
               if (!config.kubernetes.options.flannel) {
                 console.log(`Disabling flannel and network policy`);
                 k3sConf.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';


### PR DESCRIPTION
Introducing the veth pair `veth-rd0` and `veth-rd1` is causing the following error in the k3s 
```
2024/02/28 07:47:16 http: proxy error: tls: failed to verify certificate: x509: certificate is valid for 10.43.0.1, 127.0.0.1, 172.27.186.121, 192.168.127.2, ::1, not 192.168.1.2
```

Since `192.168.1.2` is the IP address of `veth-rd1` that runs inside the network namespace, it needs to be added as a trusted SAN to the k3s API's certificate. 

Related to: https://github.com/rancher-sandbox/rancher-desktop/issues/6245