### PR TITLE
Show dialog on startup if WSL kernel is too old

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -61,6 +61,12 @@ Electron.app.setAppLogsPath(paths.logs);
 
 const console = Logging.background;
 
+// Do an early check for debugging enabled via the environment variable so that
+// we can turn on extra logging to troubleshoot startup issues.
+if (settingsImpl.runInDebugMode(false)) {
+  setLogLevel('debug');
+}
+
 if (!Electron.app.requestSingleInstanceLock()) {
   process.exit(201);
 }

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -4,22 +4,29 @@ import { queryUpgradeResponder, UpgradeResponderRequestPayload } from '../Longho
 
 import { spawnFile } from '@pkg/utils/childProcess';
 import fetch from '@pkg/utils/fetch';
-import getWSLVersion from '@pkg/utils/wslVersion';
+import getWSLVersion, { WSLVersionInfo } from '@pkg/utils/wslVersion';
 
 const itWindows = process.platform === 'win32' ? it : it.skip;
 const itUnix = process.platform !== 'win32' ? it : it.skip;
 const describeWindows = process.platform === 'win32' ? describe : describe.skip;
-const standardMockedVersion = {
-  installed:  true,
-  inbox:      false,
-  has_kernel: true,
-  version:    {
+const standardMockedVersion: WSLVersionInfo = {
+  installed:       true,
+  inbox:           false,
+  has_kernel:      true,
+  outdated_kernel: false,
+  version:         {
     major:    1,
     minor:    2,
     revision: 5,
     build:    0,
   },
-} as const;
+  kernel_version: {
+    major:    5,
+    minor:    0,
+    revision: 13,
+    build:    0,
+  },
+};
 
 jest.mock('@pkg/utils/fetch', () => {
   return {

--- a/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
+++ b/pkg/rancher-desktop/pages/UnmetPrerequisites.vue
@@ -19,9 +19,36 @@
 </template>
 
 <script lang="ts">
+/* eslint-disable no-redeclare -- Conflicts with TypeScript overloading */
 import Vue from 'vue';
 
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import type { WSLVersionInfo } from '@pkg/utils/wslVersion';
+import type { reqMessageId } from '@pkg/window';
+
+function describeReason(reasonId: Exclude<reqMessageId, 'win32-kernel'>): string;
+function describeReason(reasonId: 'win32-kernel', version: WSLVersionInfo): string;
+function describeReason(reasonId: reqMessageId, ...extras: any[]): string {
+  switch (reasonId) {
+  case 'win32-release':
+    return 'Requires Windows version 10-1909 or newer';
+  case 'win32-kernel': {
+    const version: WSLVersionInfo = extras[0];
+    const {
+      major, minor, build, revision,
+    } = version.kernel_version;
+    const kernelString = [major, minor, build, revision].join('.');
+
+    return `Requires WSL with kernel 5.15 or newer (have ${ kernelString })`;
+  }
+  case 'macOS-release':
+    return 'Requires macOS version 10.15 or newer';
+  case 'linux-nested':
+    return 'Nested virtualization not enabled on this host';
+  }
+
+  return `Reason ${ reasonId } is unknown`;
+}
 
 export default Vue.extend({
   layout: 'dialog',
@@ -32,18 +59,8 @@ export default Vue.extend({
     };
   },
   mounted() {
-    ipcRenderer.on('dialog/populate', (event, reasonId) => {
-      switch (reasonId) {
-      case 'win32-release':
-        this.$data.reason = 'Requires Windows version 10-1909 or newer';
-        break;
-      case 'macOS-release':
-        this.$data.reason = 'Requires macOS version 10.15 or newer';
-        break;
-      case 'linux-nested':
-        this.$data.reason = 'Nested virtualization not enabled on this host';
-        break;
-      }
+    ipcRenderer.on('dialog/populate', (event, ...args: Parameters<typeof describeReason>) => {
+      this.$data.reason = describeReason(...args);
     });
   },
   methods: {

--- a/pkg/rancher-desktop/utils/wslVersion.ts
+++ b/pkg/rancher-desktop/utils/wslVersion.ts
@@ -7,17 +7,24 @@ import { spawnFile } from '@pkg/utils/childProcess';
 import logging from '@pkg/utils/logging';
 import { executable } from '@pkg/utils/resources';
 
-type WSLVersionInfo = {
+export type WSLVersionInfo = {
     installed: boolean;
     inbox: boolean;
 
     has_kernel: boolean;
+    outdated_kernel: boolean;
     version: {
         major: number;
         minor: number;
         build: number;
         revision: number;
     };
+    kernel_version: {
+      major: number;
+      minor: number;
+      build: number;
+      revision: number;
+    }
 };
 
 const console = logging['wsl-version'];

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -508,18 +508,18 @@ export async function openDenyRootDialog() {
   }));
 }
 
-export type reqMessageId = 'ok' | 'linux-nested' | 'win32-release' | 'macOS-release';
+export type reqMessageId = 'ok' | 'linux-nested' | 'win32-release' | 'win32-kernel' | 'macOS-release';
 
 /**
  * Open a dialog to show reason Desktop will not start
  * @param reasonId Specifies which message to show in dialog
  */
-export async function openUnmetPrerequisitesDialog(reasonId: reqMessageId) {
+export async function openUnmetPrerequisitesDialog(reasonId: reqMessageId, ...args: any[]) {
   const window = openDialog('UnmetPrerequisites', { frame: true });
 
   window.webContents.on('ipc-message', (event, channel) => {
     if (channel === 'dialog/load') {
-      window.webContents.send('dialog/populate', reasonId);
+      window.webContents.send('dialog/populate', reasonId, ...args);
     }
   });
   await (new Promise<void>((resolve) => {


### PR DESCRIPTION
This PR depends on #6524 as that provides information about the installed WSL version and whether it's outdated.

The actual version we want is determined by `wsl-helper wsl info` (which is shared with the installer); we don't try to calculate it from JavaScript to ensure there is only a single source of truth.

![screenshot of dialog when WSL version is too old](https://github.com/rancher-sandbox/rancher-desktop/assets/3977982/142c05b6-48a6-41cc-bdb6-b93d799c5e50)

Fixes #6481