### PR TITLE
Fixes the argument for wsl-proxy

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -491,7 +491,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     const debug = this.debug ? 'true' : 'false';
 
     try {
-      await this.execCommand('/usr/local/bin/wsl-proxy', '-upstream-addr', 'https://192.168.1.2:6443', '-debug', debug);
+      await this.execCommand('/usr/local/bin/wsl-proxy', '-debug', debug);
     } catch (err: any) {
       console.log('Error trying to start wsl-proxy in default namespace:', err);
     }


### PR DESCRIPTION
Since wsl-proxy is just a tcp tunnel now, it no longer requires the protocol scheme.