### PR TITLE
BATS: Windows: Write files with PowerShell

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -176,7 +176,7 @@ check_directories() {
     fi
 
     for dir in "${delete_dir[@]}"; do
-        echo "$assert that $dir does not exist" 1>&3
+        echo "# $assert that $dir does not exist" 1>&3
         "${assert}_not_exists" "$dir"
     done
 }

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -307,6 +307,32 @@ EOF
     fi
 }
 
+# create_file path/to/file <<< "contents"
+# Create a new file with the provided path; the contents of standard input will
+# be written to that file.  Analogous to `cat >$1`.  Will create any parent
+# directories.
+create_file() {
+    # On Windows, avoid creating files from within WSL; this leads to issues
+    # where the WSL view of the filesystem is desynchronized from the Windows
+    # view, so we end up having ghost files that can't be deleted from Windows.
+    if ! is_windows; then
+        mkdir -p "$(dirname "$1")"
+        cat >"$1"
+        return
+    fi
+
+    local contents # Base64 encoded file contents
+    contents="$(base64)" || return
+
+    local dest
+    local parent
+    parent="$(wslpath -w "$(dirname "$1")")" || return
+    dest="$(wslpath -w "$1")" || return
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '$parent'" || true
+    local command="[IO.File]::WriteAllBytes('$dest', \$([System.Convert]::FromBase64String('$contents')))"
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "$command" || return
+}
+
 # unique_filename /tmp/image .png
 # will return /tmp/image.png, or /tmp/image_2.png, etc.
 unique_filename() {

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -312,24 +312,25 @@ EOF
 # be written to that file.  Analogous to `cat >$1`.  Will create any parent
 # directories.
 create_file() {
+    local dest=$1
     # On Windows, avoid creating files from within WSL; this leads to issues
     # where the WSL view of the filesystem is desynchronized from the Windows
     # view, so we end up having ghost files that can't be deleted from Windows.
     if ! is_windows; then
-        mkdir -p "$(dirname "$1")"
-        cat >"$1"
+        mkdir -p "$(dirname "$dest")"
+        cat >"$dest"
         return
     fi
 
     local contents # Base64 encoded file contents
     contents="$(base64)" || return
 
-    local dest
-    local parent
-    parent="$(wslpath -w "$(dirname "$1")")" || return
-    dest="$(wslpath -w "$1")" || return
-    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '$parent'" || true
-    local command="[IO.File]::WriteAllBytes('$dest', \$([System.Convert]::FromBase64String('$contents')))"
+    local winParent
+    local winDest
+    winParent="$(wslpath -w "$(dirname "$dest")")" || return
+    winDest="$(wslpath -w "$dest")" || return
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '$winParent'" || true
+    local command="[IO.File]::WriteAllBytes('$winDest', \$([System.Convert]::FromBase64String('$contents')))"
     PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "$command" || return
 }
 

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -219,12 +219,11 @@ start_container_engine() {
         # add_profile_bool containerEngine.allowedImages.enabled "$image_allow_list"
         # add_profile_list containerEngine.allowedImages.patterns "$registry"
     else
-        wsl_integrations="{}"
+        local wsl_integrations="{}"
         if is_windows; then
             wsl_integrations="{\"$WSL_DISTRO_NAME\":true}"
         fi
-        mkdir -p "$PATH_CONFIG"
-        cat <<EOF >"$PATH_CONFIG_FILE"
+        create_file "$PATH_CONFIG_FILE" <<EOF
 {
   "version": 7,
   "WSL": { "integrations": $wsl_integrations },


### PR DESCRIPTION
We are having issues with factory reset tests because we write to setting.json via redirection from the WSL distribution; this seems to result in the WSL distribution still seeing the file after it has been deleted from Windows.  Work around this by spawning PowerShell to write the file instead.

This makes the factory reset BATS test do better in CI (on Windows).