### PR TITLE
Delete kubernetes cache when testing factory-reset

### DIFF
--- a/bats/tests/containers/factory-reset-containerd-shims.bats
+++ b/bats/tests/containers/factory-reset-containerd-shims.bats
@@ -14,7 +14,8 @@ local_teardown_file() {
 }
 
 @test 'factory reset' {
-    factory_reset
+    # On Windows the cache directory is under PATH_APP_HOME.
+    factory_reset --remove-kubernetes-cache=true
     assert_not_exists "$PATH_APP_HOME"
 }
 

--- a/bats/tests/containers/factory-reset-snapshots.bats
+++ b/bats/tests/containers/factory-reset-snapshots.bats
@@ -7,7 +7,8 @@ local_setup_file() {
 @test 'factory reset' {
     delete_all_snapshots
     rm -rf "$PATH_CONTAINERD_SHIMS"
-    factory_reset
+    # On Windows the cache directory is under PATH_APP_HOME.
+    factory_reset --remove-kubernetes-cache=true
 }
 
 @test 'Start up Rancher Desktop with a snapshots subdirectory' {
@@ -19,16 +20,15 @@ local_setup_file() {
 @test "Verify the snapshot dir isn't deleted on factory-reset" {
     rdctl shutdown
     rdctl snapshot create shortlived-snapshot
-    rdctl factory-reset
+    factory_reset --remove-kubernetes-cache=true
     assert_not_exists "$PATH_APP_HOME/rd-engine.json"
     assert_exists "$PATH_SNAPSHOTS"
     run ls -A "$PATH_SNAPSHOTS"
     assert_output
-    test -n "$output"
 }
 
 @test 'Verify factory-reset deletes an empty snapshots directory' {
     rdctl snapshot delete shortlived-snapshot
-    rdctl factory-reset
+    factory_reset --remove-kubernetes-cache=true
     assert_not_exists "$PATH_APP_HOME"
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -136,7 +136,7 @@ factory_reset() {
         clear_iptables_chain "CNI"
         clear_iptables_chain "KUBE"
     fi
-    rdctl factory-reset
+    rdctl factory-reset "$@"
     setup_ramdisk
 }
 


### PR DESCRIPTION
On windows the cache is stored inside the AppHome directory, so the AppHome will not get deleted when the cache exists.