### PR TITLE
E2E: screenshots: fix access to checkbox

### DIFF
--- a/e2e/pages/preferences/containerEngine.ts
+++ b/e2e/pages/preferences/containerEngine.ts
@@ -17,7 +17,7 @@ export class ContainerEngineNav {
     this.tabAllowedImages = page.locator('.tab >> text=Allowed Images');
     this.containerEngine = page.locator('[data-test="containerEngine"]');
     this.allowedImages = page.locator('[data-test="allowedImages"]');
-    this.allowedImagesCheckbox = page.locator('[data-test="allowedImagesCheckbox"]');
-    this.enabledLockedField = page.locator('[data-test="allowedImages"] > .rd-checkbox-container > .icon-lock');
+    this.allowedImagesCheckbox = page.getByTestId('allowedImagesCheckbox');
+    this.enabledLockedField = this.allowedImagesCheckbox.locator('.icon-lock');
   }
 }

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineAllowedImages.vue
@@ -65,16 +65,10 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
 </script>
 
 <template>
-  <div
-    class="container-engine-allowed-images"
-  >
-    <rd-fieldset
-      data-test="allowedImages"
-      :legend-text="t('allowedImages.label')"
-      :is-experimental="true"
-    >
+  <div class="container-engine-allowed-images">
+    <rd-fieldset data-test="allowedImages" :legend-text="t('allowedImages.label')" :is-experimental="true">
       <rd-checkbox
-        data-test="allowedImagesCheckbox"
+        data-testid="allowedImagesCheckbox"
         :label="t('allowedImages.enable')"
         :value="isAllowedImagesEnabled"
         :is-locked="isPreferenceLocked('containerEngine.allowedImages.enabled')"

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -40,7 +40,7 @@ test.describe.serial('Main App Test', () => {
     });
 
     await setUserProfile(
-      { version: 10 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true, patterns: [] } } },
+      { version: 11 as typeof CURRENT_SETTINGS_VERSION, containerEngine: { allowedImages: { enabled: true, patterns: [] } } },
       {},
     );
 


### PR DESCRIPTION
We changed how the checkbox lock icon worked in f262f26d7ec7; update the E2E tests to use the new layout.  Or rather, update it to be more tolerant of changes in the checkbox layout.

Sorry about the formatting changes; my editor hates me and forces it :(