### PR TITLE
Disable the virtiofs mount type

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -370,7 +370,7 @@ virtualMachine:
                 none: none
         virtiofs:
           label: virtiofs
-          description: Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: This option is unavailable in this release.
   proxy:
     legend: WSL Proxy
     label: Enable the proxy used by rancher-desktop
@@ -2673,8 +2673,7 @@ prefs:
   experimental: Experimental
   onlyFromVentura_x64: This setting requires macOS 13.0 (Ventura) or later.
   onlyFromVentura_arm64: This setting requires macOS 13.3 (Ventura) or later.
-  onlyWithVZ_x64: This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
-  onlyWithVZ_arm64: This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  virtiofsDisabled: This setting has been temporarily removed to investigate a potential bug that could lead to data loss on the host.
 
 principal:
   loading: Loading&hellip;

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -68,10 +68,8 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       return this.preferences.experimental.virtualMachine.mount.type === MountType.NINEP;
     },
     virtIoFsDisabled(): boolean {
-      // virtiofs should only be disabled on macOS WITHOUT the possibility to select the VM type VZ. VZ doesn't need to
-      // be selected, yet. We're going to show a warning banner in that case.
-      return os.platform() === 'darwin' &&
-        (semver.lt(this.macOsVersion.version, '13.0.0') || (this.isArm && semver.lt(this.macOsVersion.version, '13.3.0')));
+      // virtiofs is unavailable in the 1.13 release of Rancher Desktop
+      return true;
     },
     arch(): string {
       return this.isArm ? 'arm64' : 'x64';
@@ -110,13 +108,7 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       this.$emit('update', property, value);
     },
     disabledVirtIoFsTooltip(disabled: boolean): { content: string } | Record<string, never> {
-      let tooltip = {};
-
-      if (disabled) {
-        tooltip = { content: this.t(`prefs.onlyWithVZ_${ this.arch }`) };
-      }
-
-      return tooltip;
+      return { content: this.t('prefs.virtiofsDisabled') };
     },
     getCompatiblePrefs(mountType: MountType): CompatiblePrefs | [] {
       const compatiblePrefs: CompatiblePrefs = [];

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 import {
   CURRENT_SETTINGS_VERSION, defaultSettings, DeploymentProfileType,
-  LockedSettingsType, Settings, SettingsError,
+  LockedSettingsType, MountType, Settings, SettingsError,
 } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import clone from '@pkg/utils/clone';
@@ -470,6 +470,12 @@ export const updateTable: Record<number, (settings: any, locked : boolean) => vo
     }
   },
   10: (settings, locked) => {
+    // virtiofs is not supported in Rancher Desktop 1.13.0
+    if (!_.isEmpty(_.get(settings, 'experimental.virtualMachine.mount.type'))) {
+      if (settings.experimental.virtualMachine.mount.type === MountType.VIRTIOFS) {
+        settings.experimental.virtualMachine.mount.type = MountType.REVERSE_SSHFS;
+      }
+    }
     // Migrating from an older locked profile automatically locks newer features (wasm support).
     if (locked && !_.has(settings, 'experimental.containerEngine.webAssembly.enabled')) {
       _.set(settings, 'experimental.containerEngine.webAssembly.enabled', false);

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -879,18 +879,7 @@ describe(SettingsValidator, () => {
       checkForError(
         needToUpdate, errors,
         'Setting experimental.virtualMachine.type to \"vz\" requires that ' +
-        'experimental.virtual-machine.mount.type is \"reverse-sshfs\" or \"virtiofs\".',
-      );
-    });
-
-    it('should reject QEMU if mount type is virtiofs on macOS', () => {
-      const [needToUpdate, errors] = subject.validateSettings(
-        _.merge({}, cfg, getMountTypeSetting(MountType.VIRTIOFS)), getVMTypeSetting(VMType.QEMU));
-
-      checkForError(
-        needToUpdate, errors,
-        'Setting experimental.virtualMachine.type to \"qemu\" requires that ' +
-        'experimental.virtual-machine.mount.type is \"reverse-sshfs\" or \"9p\".',
+        'experimental.virtual-machine.mount.type is \"reverse-sshfs\".',
       );
     });
   });

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -331,16 +331,7 @@ export default class SettingsValidator {
       if (mergedSettings.experimental.virtualMachine.mount.type === MountType.NINEP) {
         errors.push(
           `Setting ${ fqname } to "${ VMType.VZ }" requires that experimental.virtual-machine.mount.type is ` +
-          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.VIRTIOFS }".`);
-
-        return false;
-      }
-    }
-    if (desiredValue === VMType.QEMU) {
-      if (mergedSettings.experimental.virtualMachine.mount.type === MountType.VIRTIOFS && os.platform() === 'darwin') {
-        errors.push(
-          `Setting ${ fqname } to "${ VMType.QEMU }" requires that experimental.virtual-machine.mount.type is ` +
-          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.NINEP }".`);
+          `"${ MountType.REVERSE_SSHFS }".`);
 
         return false;
       }
@@ -350,14 +341,8 @@ export default class SettingsValidator {
   }
 
   protected checkMountType(mergedSettings: Settings, currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
-    if (desiredValue === MountType.VIRTIOFS && mergedSettings.experimental.virtualMachine.type !== VMType.VZ && os.platform() === 'darwin') {
-      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that experimental.virtual-machine.type is "${ VMType.VZ }".`);
-      this.isFatal = true;
-
-      return false;
-    }
-    if (desiredValue === MountType.VIRTIOFS && mergedSettings.experimental.virtualMachine.type !== VMType.QEMU && os.platform() === 'linux') {
-      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that experimental.virtual-machine.type is "${ VMType.QEMU }".`);
+    if (desiredValue === MountType.VIRTIOFS) {
+      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" is not supported in this version of Rancher Desktop.`);
       this.isFatal = true;
 
       return false;


### PR DESCRIPTION
Testing with virtiofs on Linux has wiped out the HOME directory on the host, and a recent Lima issue claims that they experienced data loss with virtiofs on macOS as well.

Ref https://github.com/rancher-sandbox/rancher-desktop/issues/6582 and https://github.com/lima-vm/lima/issues/2221

With this PR the option is still shown in the Preferences dialog, but permanently disabled:

<img width="455" alt="CleanShot 2024-03-07 at 11 12 00@2x" src="https://github.com/rancher-sandbox/rancher-desktop/assets/78947/9eb090d9-48af-4db4-9ee4-344bfe4950c3">

A settings migration will automatically change `virtiofs` to `reverse-sshfs`.

And the settings validator will reject the setting:

```console
$ rdctl set --experimental.virtual-machine.mount.type virtiofs
Error: errors in attempt to update settings:
Setting experimental.virtualMachine.mount.type to "virtiofs" is not supported in this version of Rancher Desktop.
```