### PR TITLE
Bump rancher-desktop-lima to v0.19.0.rd6

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-lima: 0.19.0.rd5
+lima: 0.19.0.rd6
 limaAndQemu: 1.31.3
 alpineLimaISO:
   isoVersion: 0.2.35.rd2


### PR DESCRIPTION
Unmount directories before moving to persistent storage

This prevents host directories from being wiped if they happen to be below one of /etc /home /root /tmp /usr/local /var/lib.

Fixes #6582
Fixes #4943
