### PR TITLE
Bump rancher-desktop-lima to v0.19.0.rd7

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-lima: 0.19.0.rd6
+lima: 0.19.0.rd7
 limaAndQemu: 1.31.3
 alpineLimaISO:
   isoVersion: 0.2.35.rd2


### PR DESCRIPTION
To fix deleting mount data under /home with 9p and virtiofs.