### PR TITLE
Win32 Installer: Correct name

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -107,7 +107,7 @@ jobs:
       if: matrix.platform == 'win'
       with:
         name: Rancher Desktop Setup.msi
-        path: dist/Rancher Desktop*.msi
+        path: dist/Rancher.Desktop*.msi
         if-no-files-found: error
     - name: Upload Windows zip
       uses: actions/upload-artifact@v4
@@ -209,7 +209,7 @@ jobs:
     - name: Verify installer signature
       shell: powershell
       run: |
-        $usedCert = (Get-AuthenticodeSignature -FilePath 'dist\Rancher Desktop Setup*.msi').SignerCertificate
+        $usedCert = (Get-AuthenticodeSignature -FilePath 'dist\Rancher*Desktop*.msi').SignerCertificate
         Write-Output $usedCert
         if ($usedCert.Thumbprint -ne $env:CSC_FINGERPRINT) {
           Throw "Installer signed with wrong certificate"

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Rancher Desktop Setup.msi
-        path: dist/Rancher Desktop*.msi
+        path: dist/Rancher.Desktop*.msi
         if-no-files-found: error
     - if: runner.os == 'Windows'
       run: cat dist/electron-builder.yaml

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -64,7 +64,7 @@ export async function buildCustomAction(): Promise<string> {
 export default async function buildInstaller(workDir: string, appDir: string, development = false): Promise<string> {
   const appVersion = getAppVersion(appDir);
   const compressionLevel = development ? 'mszip' : 'high';
-  const outFile = path.join(process.cwd(), 'dist', `Rancher Desktop Setup ${ appVersion }.msi`);
+  const outFile = path.join(process.cwd(), 'dist', `Rancher.Desktop.Setup.${ appVersion }.msi`);
 
   await writeUpdateConfig(appDir);
   const fileList = await generateFileList(appDir);


### PR DESCRIPTION
The name that our installer generates does not actually match the convention we use when we publish releases. Fix this so that we don't have to manually rename the file every release.