### PR TITLE
CI: Add workflow to merge published releases back to main

### DIFF
--- a/.github/workflows/release-merge-to-main.yaml
+++ b/.github/workflows/release-merge-to-main.yaml
@@ -1,0 +1,52 @@
+name: "Release: Merge to main"
+
+on:
+  release:
+    types:
+    - created
+    - published
+    - released
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-for-token:
+    outputs:
+      has-token: ${{ steps.calc.outputs.HAS_SECRET }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: calc
+      run: echo "HAS_SECRET=${HAS_SECRET}" >> "${GITHUB_OUTPUT}"
+      env:
+        HAS_SECRET: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+
+  create-pr:
+    needs: check-for-token
+    if: needs.check-for-token.outputs.has-token == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: package.json
+    - run: corepack enable yarn # spellcheck-ignore-line
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: package.json
+        cache: yarn
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: src/go/rdctl/go.mod
+        cache-dependency-path: src/go/**/go.sum
+
+    - run: yarn install --frozen-lockfile
+
+    - run: node scripts/ts-wrapper.js scripts/release-merge-to-main.ts
+      env:
+        GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}

--- a/scripts/release-merge-to-main.ts
+++ b/scripts/release-merge-to-main.ts
@@ -71,7 +71,8 @@ async function ensureBranch(owner: string, repo: string, branchName: string, tag
     });
 
     if (existingBranch.object.sha !== sha) {
-    // Branch exists, but points at the wrong hash; update it.
+      // Branch exists, but points at the wrong hash; update it.
+      console.log(`Updating existing branch ${ owner }/${ repo }/${ ref } to new commit ${ sha }`);
       await git.updateRef({
         owner, repo, ref, sha,
       });
@@ -111,22 +112,22 @@ async function findExisting(owner: string, repo: string, branch: string) {
 
     // PR target must be the expected repository.
     if (pr.base.repo.full_name !== fullRepo) {
-      console.log(`Skipping ${ item.number }: incorrect base repo ${ pr.base.repo.full_name }`);
+      console.log(`Skipping ${ item.number }: incorrect base repo ${ pr.base.repo.full_name } (expected ${ fullRepo })`);
       continue;
     }
     // PR target must merge into the default branch.
     if (pr.base.ref !== base) {
-      console.log(`Skipping ${ item.number }: incorrect base ref ${ pr.base.ref }`);
+      console.log(`Skipping ${ item.number }: incorrect base ref ${ pr.base.ref } (expected ${ base })`);
       continue;
     }
     // Must not be a cross-repository (fork) pull request.
     if (pr.head.repo && pr.head.repo.full_name !== fullRepo) {
-      console.log(`Skipping ${ item.number }: incorrect head repo ${ pr.head.repo.full_name }`);
+      console.log(`Skipping ${ item.number }: incorrect head repo ${ pr.head.repo.full_name } (expected ${ fullRepo })`);
       continue;
     }
     // Must be a pull request from the expected branch.
     if (pr.head.ref !== branch) {
-      console.log(`Skipping ${ item.number }: incorrect head ref ${ pr.head.ref }`);
+      console.log(`Skipping ${ item.number }: incorrect head ref ${ pr.head.ref } (expected ${ branch })`);
       continue;
     }
 
@@ -143,7 +144,7 @@ async function findExisting(owner: string, repo: string, branch: string) {
   const [, owner, repo] = /([^/]+)\/(.*)/.exec(fullRepo) ?? [];
 
   if (!owner || !repo) {
-    throw new TypeError(`Could not determine owner from ${ fullRepo }`);
+    throw new TypeError(`Could not determine owner or repo from ${ fullRepo }`);
   }
   if (!tagName) {
     throw new TypeError(`Could not detect tag from ${ rawPayload }`);

--- a/scripts/release-merge-to-main.ts
+++ b/scripts/release-merge-to-main.ts
@@ -72,7 +72,8 @@ async function ensureBranch(owner: string, repo: string, branchName: string, tag
 
     if (existingBranch.object.sha !== sha) {
       // Branch exists, but points at the wrong hash; update it.
-      console.log(`Updating existing branch ${ owner }/${ repo }/${ ref } to new commit ${ sha }`);
+      console.log(`Updating existing branch ${ owner }/${ repo }/${ ref } ` +
+        `from ${ existingBranch.object.sha } to new commit ${ sha }`);
       await git.updateRef({
         owner, repo, ref, sha,
       });

--- a/scripts/release-merge-to-main.ts
+++ b/scripts/release-merge-to-main.ts
@@ -1,0 +1,155 @@
+// This file creates PRs when releases are published to merge back to the main
+// branch.
+
+// Environment:
+//   GITHUB_REPOSITORY, GITHUB_EVENT_PATH, and others
+//     See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+//   GITHUB_TOKEN: GitHub authorization token.
+
+import fs from 'fs';
+
+import { getOctokit } from './lib/dependencies';
+
+/**
+ * Valid value for an environment variable.
+ */
+type EnvironmentVariableName =
+  'GITHUB_REPOSITORY' |
+  'GITHUB_EVENT_PATH' |
+  'GITHUB_TOKEN';
+
+/**
+ * Partial contents of the event payload, for a release event.
+ */
+interface GitHubReleasePayload {
+  release: {
+    tag_name: string;
+  }
+}
+
+/**
+ * The name of the branch to merge into.
+ */
+const base = 'main';
+
+/**
+ * Read the environment variable, or throw an error.
+ * @param variable The environment variable to look up.
+ * @returns The environment variable value.
+ */
+function getEnv(variable: EnvironmentVariableName): string {
+  const result = process.env[variable];
+
+  if (typeof result !== 'string') {
+    throw new ReferenceError(`Environment variable ${ variable } is not set`);
+  }
+
+  return result;
+}
+
+/**
+ * Determine the branch name from the tag.
+ * @param owner The repository owner.
+ * @param repo The repository name, excluding owner.
+ * @param tagName The tag of the release event.
+ * @returns The name of the branch to merge into the base branch.
+ */
+async function getBranch(owner: string, repo: string, tagName: string): Promise<string> {
+  const [, release] = /^v(\d+\.\d+)\.\d+/.exec(tagName) ?? [];
+
+  if (!release) {
+    throw new TypeError(`Failed to guess branch name from tag "${ tagName }"`);
+  }
+  const branch = `release-${ release }`;
+  const { data: ref } = await getOctokit().rest.git.getRef({
+    owner, repo, ref: `heads/${ branch }`,
+  });
+
+  if (!ref.object.sha) {
+    throw new TypeError(`Failed to get commit hash of branch "${ branch }"`);
+  }
+
+  return branch;
+}
+
+/**
+ * Locate an existing pull request.
+ * @param owner The repository owner.
+ * @param repo The repository name (without the owner).
+ * @param branch The branch to merge from (i.e. the release branch).
+ * @returns The found pull request, or undefined.
+ */
+async function findExisting(owner: string, repo: string, branch: string) {
+  const fullRepo = `${ owner }/${ repo }`;
+  const query = `type:pr is:open repo:${ fullRepo } base:${ base } head:${ branch } sort:updated`;
+  const result = await getOctokit().rest.search.issuesAndPullRequests({ q: query });
+
+  for (const item of result.data.items) {
+    // Must be an open item, and that item must be a pull request.
+    if (item.state !== 'open' || !item.pull_request) {
+      continue;
+    }
+    const { data: pr } = await getOctokit().rest.pulls.get({
+      owner, repo, pull_number: item.number,
+    });
+
+    // PR target must be the expected repository.
+    if (pr.base.repo.full_name !== fullRepo) {
+      console.log(`Skipping ${ item.number }: incorrect base repo ${ pr.base.repo.full_name }`);
+      continue;
+    }
+    // PR target must merge into the default branch.
+    if (pr.base.ref !== base) {
+      console.log(`Skipping ${ item.number }: incorrect base ref ${ pr.base.ref }`);
+      continue;
+    }
+    // Must not be a cross-repository (fork) pull request.
+    if (pr.head.repo && pr.head.repo.full_name !== fullRepo) {
+      console.log(`Skipping ${ item.number }: incorrect head repo ${ pr.head.repo.full_name }`);
+      continue;
+    }
+    // Must be a pull request from the expected branch.
+    if (pr.head.ref !== branch) {
+      console.log(`Skipping ${ item.number }: incorrect head ref ${ pr.head.ref }`);
+      continue;
+    }
+
+    return item;
+  }
+}
+
+(async() => {
+  const rawPayload = await fs.promises.readFile(getEnv('GITHUB_EVENT_PATH'), 'utf-8');
+  const payload: GitHubReleasePayload = JSON.parse(rawPayload);
+  const tagName = payload.release.tag_name;
+  const fullRepo = getEnv('GITHUB_REPOSITORY');
+  const [, owner, repo] = /([^/]+)\/(.*)/.exec(fullRepo) ?? [];
+
+  if (!owner || !repo) {
+    throw new TypeError(`Could not determine owner from ${ fullRepo }`);
+  }
+  if (!tagName) {
+    throw new TypeError(`Could not detect tag from ${ rawPayload }`);
+  }
+  console.log(`Processing release event on ${ owner }/${ repo } for tag ${ tagName }...`);
+
+  const branch = await getBranch(owner, repo, tagName);
+  const existing = await findExisting(owner, repo, branch);
+
+  if (existing) {
+    console.log(`Found existing PR ${ existing.number }: ${ existing.html_url }`);
+
+    return;
+  }
+
+  console.log(`Creating new PR on ${ owner }/${ repo }: ${ base } <- ${ branch }`);
+  const title = `Merge release ${ tagName } back into ${ base }`;
+  const { data: item } = await getOctokit().rest.pulls.create({
+    owner, repo, title, head: branch, base, maintainer_can_modify: true,
+  });
+
+  console.log(`Created PR #${ item.number }: ${ item.html_url }`);
+})().catch((ex) => {
+  console.error(ex);
+  process.exit(1);
+});


### PR DESCRIPTION
This creates a PR every time we create/publish a release (filtering for open PRs from the same branches).  This ensures we don't forget to merge things back after a release.

Note that this will only apply if the release itself contains the change (so it will only be active on the _next_ release).

Since this only creates the PR, we will need to manually resolve any merge conflicts; but that's okay, since it's more useful as a reminder to handle the process.

---
Edit: Sample runs
- [Created a PR](https://github.com/mook-as/rd/actions/runs/8269822694)
- [Found existing PR](https://github.com/mook-as/rd/actions/runs/8269871415)