### PR TITLE
CI: BATS: Add schedule

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -27,6 +27,8 @@ on:
         description: Package run ID override; leave empty to use latest.
         default: ''
         type: string
+  schedule:
+  - cron: '0 8 * * 1-5' # 8AM UTC weekdays as a baseline
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently the BATS runs will fail; however, having things run now provides a baseline to make it easier to see what else needs to be fixed.