### PR TITLE
CI: BATS: Don't depend on input defaults

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -52,6 +52,10 @@ jobs:
           scripts/install-latest-ci.sh
           .github/workflows/bats/get-tests.py
 
+    - id: repo
+      name: Calculate short repository
+      run: echo "repo=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
+
     - name: Fetch tests
       run: |
         : ${OWNER:=$GH_OWNER}
@@ -62,9 +66,9 @@ jobs:
         "scripts/install-latest-ci.sh"
       env:
         GH_TOKEN:     ${{ github.token }}
-        OWNER:        ${{ inputs.owner }}
-        REPO:         ${{ inputs.repo }}
-        BRANCH:       ${{ inputs.branch }}
+        OWNER:        ${{ inputs.owner || github.repository_owner }}
+        REPO:         ${{ inputs.repo || steps.repo.outputs.repo }}
+        BRANCH:       ${{ inputs.branch || github.ref_name }}
         ID:           ${{ inputs.package-id }}
         BATS_DIR:     ${{ github.workspace }}/bats
         SKIP_INSTALL: true
@@ -79,6 +83,7 @@ jobs:
         ENGINES: ${{ inputs.engines }}
       working-directory: bats/tests
     outputs:
+      repo: ${{ steps.repo.outputs.repo }}
       tests: ${{ steps.calculate.outputs.tests }}
 
   bats:
@@ -109,9 +114,9 @@ jobs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        OWNER:    ${{ inputs.owner }}
-        REPO:     ${{ inputs.repo }}
-        BRANCH:   ${{ inputs.branch }}
+        OWNER:    ${{ inputs.owner || github.repository_owner }}
+        REPO:     ${{ inputs.repo || needs.get-tests.outputs.repo }}
+        BRANCH:   ${{ inputs.branch || github.ref_name }}
         ID:       ${{ inputs.package-id }}
         BATS_DIR: ${{ github.workspace }}/bats
         ZIP_NAME: ${{ github.workspace }}/version.txt

--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -13,10 +13,11 @@ import json
 from operator import attrgetter
 import os
 import sys
-from typing import Iterator, List, Literal, Protocol, Union
+from typing import Iterator, List, Literal, get_args
 
 Platforms = Literal["linux", "mac", "win"]
 Hosts = Literal["ubuntu-latest", "macos-12", "windows-latest"]
+Engines = Literal["containerd", "moby"]
 
 @dataclasses.dataclass
 class Result:
@@ -26,7 +27,7 @@ class Result:
     # The name of the test; either a directory or a file name (without extension)
     name: str
     host: Hosts
-    engine: Literal["containerd", "moby"]
+    engine: Engines
 
     key = staticmethod(attrgetter("name", "host", "engine"))
 
@@ -60,9 +61,9 @@ def skip_test(test: Result) -> bool:
 results: List[Result] = list()
 errors: bool = False
 
-for test in os.environ.get("TESTS", "*").split():
-    platforms: List[Platforms] = os.environ.get("PLATFORMS", "linux mac").split()
-    engines: List[Literal["containerd", "moby"]] = os.environ.get("ENGINES", "contained moby").split()
+for test in (os.environ.get("TESTS", None) or "*").split():
+    platforms: List[Platforms] = os.environ.get("PLATFORMS", "").split() or get_args(Platforms)
+    engines: List[Engines] = os.environ.get("ENGINES", "").split() or get_args(Engines)
     for platform in platforms:
       host: Hosts = {
          "linux": "ubuntu-latest",


### PR DESCRIPTION
When running BATS on a schedule, none of the inputs are available, so we need to use fallbacks for that case.

This fixes issues where we end up with no tests to run on schedule, e.g. https://github.com/rancher-sandbox/rancher-desktop/actions/runs/8277352224/job/22647544188

Fixed run (also via a schedule run): https://github.com/mook-as/rd/actions/runs/8285317275/job/22672787929