### PR TITLE
BATS: use `run --separate-stderr` with `jq_output`

### DIFF
--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -105,6 +105,9 @@ join_map() {
     echo "$result"
 }
 
+# Run jq on the current $output
+# Note that when capturing $output, you may need to use `run --separate-stderr`
+# to avoid also capturing stderr and ending up with invalid JSON.
 jq_output() {
     local json=$output
     run jq --raw-output "$@" <<<"${json}"


### PR DESCRIPTION
Because `jq_output` acts on `$output`, when we execute the previous command we should be using `--separate-stderr` to avoid trying to parse stderr as JSON.

This shows up in `k8s/wasm.bats` where the initial run fails because running `kubectl get runtimeclasses` in some versions can produce a warning about the `v1beta1` API being deprecated.  This is triggered because `k8s/verify-cached-images` that runs immediately before left the settings at a version that produces these warnings.

When the test fails, `$output` is:
```json
Warning: node.k8s.io/v1beta1 RuntimeClass is deprecated in v1.22+, unavailable in v1.25+
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
```