### PR TITLE
Support older WSL kernels

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -3,7 +3,7 @@ limaAndQemu: 1.31.3
 alpineLimaISO:
   isoVersion: 0.2.35.rd2
   alpineVersion: 3.19.0
-WSLDistro: "0.55"
+WSLDistro: "0.57"
 kuberlr: 0.4.5
 helm: 3.14.2
 dockerCLI: 25.0.4

--- a/src/go/wsl-helper/pkg/wsl-utils/version_windows.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/version_windows.go
@@ -98,7 +98,7 @@ var (
 	kUpgradeCodeOverride = &struct{}{}
 	// MinimumKernelVersion is the minimum WSL kernel version required to not be
 	// considered outdated.
-	MinimumKernelVersion = PackageVersion{Major: 5, Minor: 15}
+	MinimumKernelVersion = PackageVersion{Major: 5, Minor: 0}
 )
 
 // errorFromWin32 wraps a Win32 return value into an error, with a message in


### PR DESCRIPTION
This bumps the WSL distro to 0.57, and drops the required WSL kernel version to 5.0 since the new distro supports older kernels (by picking the correct iptables binary at runtime).

Note that the WSL distro bump also updates nerdctl as a side-effect; that has very few commits.

This is being created as a draft PR so that we can get a proper set of builds to test against; we should be testing harder for a patch release.

Fixes #6624