### PR TITLE
Take screenshots from CI

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -853,6 +853,7 @@ XPOST
 Xrandr
 XVar
 xvfb
+xwininfo
 xzf
 yac
 yarker

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -168,3 +168,9 @@ regexp?\.MustCompile\(`[^`]*`\)
 
 # GitHub owner names should not be checked (dependency scripts)
 \bgithubOwner\s*=\s*'.*?'
+
+# Win32 constants
+\bGWL_EXSTYLE\b
+\bHWND_NOTOPMOST\b
+\bSWP_NOMOVE\b
+\bSWP_NOSIZE\b

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -1,0 +1,156 @@
+name: Screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      mock_version:
+        description: Mock Version
+        type: string
+        required: true
+        default: '1.0.0'
+
+jobs:
+  screenshot:
+    name: Take screenshot
+    concurrency:
+      group: "${{ github.workflow_ref }} (${{ matrix.platform }})"
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - platform: mac
+          runs-on: macos-12
+        - platform: win
+          runs-on: windows-latest
+        - platform: linux
+          runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+
+    - name: "macOS: Install GetWindowID"
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install smokris/getwindowid/getwindowid
+
+    - name: "Linux: Enable KVM access"
+      if: runner.os == 'Linux'
+      run: sudo chmod a+rwx /dev/kvm
+    - name: "Linux: Install Tools"
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install graphicsmagick x11-utils mutter # spellcheck-ignore-line
+    - name: "Linux: Initialize pass"
+      if: runner.os == 'Linux'
+      run: |
+        # Configure the agent to allow default passwords
+        HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
+        mkdir -p "${HOMEDIR}"
+        chmod 0700 "${HOMEDIR}"
+        echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
+
+        # Create a GPG key
+        gpg --quick-generate-key --yes --batch --passphrase '' \
+          user@rancher-desktop.test default \
+          default never
+
+        # Get info about the newly created key
+        DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
+        FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
+        GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
+
+        # Save the password
+        gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
+
+        # Initialize pass
+        pass init "${FINGERPRINT}"
+
+    - name: "Windows: Stop unwanted services"
+      if: runner.os == 'Windows'
+      run: >-
+        Get-Service -ErrorAction Continue -Name
+        @('W3SVC', 'docker')
+        | Stop-Service
+    - name: "Windows: Update any pre-installed WSL"
+      if: runner.os == 'Windows'
+      run: wsl --update
+      continue-on-error: true
+    - name: "Windows: Install WSL2 from the Store as necessary"
+      if: runner.os == 'Windows'
+      run: wsl --install --no-distribution
+    - run: wsl --version
+      if: runner.os == 'Windows'
+
+    - name: "macOS: Set startup command"
+      if: runner.os == 'macOS'
+      run: echo "EXEC_COMMAND=$EXEC_COMMAND" >> "$GITHUB_ENV"
+      env:
+        EXEC_COMMAND: exec
+    - name: "Linux: Set startup command"
+      if: runner.os == 'Linux'
+      run: |
+        # Write a wrapper script to start mutter (so we get window decorations).
+        echo '#!/bin/sh' > /usr/local/bin/exec-command
+        echo 'mutter --replace --sm-disable --x11 &>/dev/null &' >> /usr/local/bin/exec-command
+        echo 'exec "$@"' >> /usr/local/bin/exec-command
+        chmod a+x /usr/local/bin/exec-command
+        echo "EXEC_COMMAND=$EXEC_COMMAND /usr/local/bin/exec-command" >> "$GITHUB_ENV"
+      env:
+        EXEC_COMMAND: >-
+          exec xvfb-run --auto-servernum
+          --server-args='-screen 0 1280x960x24'
+    - name: "Windows: Set startup command"
+      if: runner.os == 'Windows'
+      shell: bash
+      run: echo "EXEC_COMMAND=$EXEC_COMMAND" >> "$GITHUB_ENV"
+      env:
+        EXEC_COMMAND: # On Windows, we don't need any commands.
+
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18.16.x'
+    - run: npm install --global yarn
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18.16.x'
+        cache: yarn
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '^1.21'
+        cache-dependency-path: src/go/**/go.sum
+    - run: pip install setuptools
+    - # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
+      run: yarn install --frozen-lockfile --network-timeout 1000000
+    - name: Override version
+      if: inputs.mock_version
+      run: echo "RD_MOCK_VERSION=${{ inputs.mock_version }}" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - run: ${{ env.EXEC_COMMAND }} yarn screenshots
+      env:
+        EXEC_COMMAND: ${{ env.EXEC_COMMAND }}
+        RD_ENV_SCREENSHOT_SLEEP: 5000
+        RD_LOGS_DIR: logs
+    - name: Upload screenshots
+      uses: actions/upload-artifact@v4
+      with:
+        name: screenshots-${{ matrix.platform }}.zip
+        path: screenshots/output/
+        if-no-files-found: error
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: logs-${{ matrix.platform }}.zip
+        path: |
+          logs/
+          e2e/reports/
+          screenshots/output/

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -138,7 +138,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
    * Start Kubernetes.
    * @returns The Kubernetes endpoint
    */
-  async start(config_: BackendSettings, kubernetesVersion: semver.SemVer, kubeClient?: KubeClient): Promise<string> {
+  async start(config_: BackendSettings, kubernetesVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<string> {
     const config = this.cfg = clone(config_);
     let k3sEndpoint = '';
 
@@ -187,7 +187,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
           return k3sConfigString;
         }));
 
-    this.client = kubeClient || new KubeClient();
+    this.client = kubeClient?.() || new KubeClient();
 
     await this.progressTracker.action(
       'Waiting for services',

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -173,7 +173,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     await BackendHelper.configureRuntimeClasses(this.vm);
   }
 
-  async start(config: BackendSettings, activeVersion: semver.SemVer, kubeClient?: KubeClient): Promise<string> {
+  async start(config: BackendSettings, activeVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<string> {
     if (!config) {
       throw new Error('no config!');
     }
@@ -219,7 +219,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
           async() => await this.vm.execCommand({ capture: true }, await this.vm.getWSLHelperPath(), 'k3s', 'kubeconfig', rdNetworking));
       });
 
-    const client = this.client = kubeClient || new KubeClient();
+    const client = this.client = kubeClient?.() || new KubeClient();
 
     await this.progressTracker.action(
       'Waiting for services',

--- a/pkg/rancher-desktop/backend/mock_screenshots.ts
+++ b/pkg/rancher-desktop/backend/mock_screenshots.ts
@@ -7,13 +7,13 @@ import WSLKubernetesBackend from '@pkg/backend/kube/wsl';
 
 export class LimaKubernetesBackendMock extends LimaKubernetesBackend {
   start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<string> {
-    return super.start(config_, kubernetesVersion, new KubeClientMock());
+    return super.start(config_, kubernetesVersion, () => new KubeClientMock());
   }
 }
 
 export class WSLKubernetesBackendMock extends WSLKubernetesBackend {
   start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<string> {
-    return super.start(config_, kubernetesVersion, new KubeClientMock());
+    return super.start(config_, kubernetesVersion, () => new KubeClientMock());
   }
 }
 

--- a/pkg/rancher-desktop/main/diagnostics/kubeContext.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeContext.ts
@@ -22,7 +22,9 @@ const KubeContextDefaultChecker: DiagnosticsChecker = {
   async check(): Promise<DiagnosticsCheckerResult> {
     const kubectl = path.join(paths.resources, process.platform, 'bin', 'kubectl');
     const { stdout } = await spawnFile(kubectl, ['config', 'view', '--minify', '--output=json'], {
-      stdio:    ['ignore', 'pipe', 'ignore'],
+      // While we only need stdout here, capture stderr so if we encounter errors
+      // the message shows up in the logs.
+      stdio:    ['ignore', 'pipe', 'pipe'],
       encoding: 'utf-8',
     });
     const config = JSON.parse(stdout);

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -35,7 +35,7 @@ will be visible.
 
 ### Linux
 
-`gnome-screenshot` is required. See https://github.com/GNOME/gnome-screenshot
+`xwininfo` and `GraphicsMagick` are required.  The former may be in the `x11-utils` package.
 
 ## Running
 

--- a/screenshots/screenshot.ps1
+++ b/screenshots/screenshot.ps1
@@ -5,11 +5,14 @@
   Take a screenshot of the active window and output it to a PNG file.
 .PARAMETER FilePath
   The name of the file to write to.  The file will be a PNG.
+.PARAMETER Title
+  The title of the window to capture; defaults to the active window.
 #>
 Param(
   [Parameter(
     Mandatory = $true
-  )][string]$FilePath
+  )][string]$FilePath,
+  [string]$Title
 )
 
 # We need to call Win32 APIs; PowerShell natively understands .NET only, so we
@@ -21,13 +24,35 @@ using System.Runtime.InteropServices;
 
 namespace Screenshot {
   public class Screenshot {
-    public void Take(string filePath) {
-      Image img = CaptureActiveWindow();
+    public void Take(string filePath, string title) {
+      Image img;
+      if (title != "") {
+        img = CaptureWindowWithTitle(title);
+      } else {
+        img = CaptureActiveWindow();
+      }
       img.Save(filePath, System.Drawing.Imaging.ImageFormat.Png);
     }
 
     public Image CaptureActiveWindow() {
       return CaptureWindow(User32.GetForegroundWindow());
+    }
+
+    public Image CaptureWindowWithTitle(string title) {
+      IntPtr hwnd = User32.FindWindow(null, title);
+      if (User32.SetForegroundWindow(hwnd) != 0) {
+        return CaptureWindow(hwnd);
+      }
+      // Failed to set the window as foreground; make it topmost instead.
+      Int32 styles = User32.GetWindowLong(hwnd, User32.GWL_EXSTYLE);
+      User32.SetWindowPos(hwnd, (IntPtr)(User32.HWND_TOPMOST), 0, 0, 0, 0,
+        User32.SWP_NOSIZE | User32.SWP_NOMOVE);
+      Image image = CaptureWindow(hwnd);
+      if ((styles & User32.WS_EX_TOPMOST) == 0) {
+        User32.SetWindowPos(hwnd, (IntPtr)(User32.HWND_NOTOPMOST), 0, 0, 0, 0,
+          User32.SWP_NOSIZE | User32.SWP_NOMOVE);
+      }
+      return image;
     }
 
     public Image CaptureWindow(IntPtr hwnd) {
@@ -63,8 +88,30 @@ namespace Screenshot {
     }
 
     private class User32 {
+      public const Int32 GWL_EXSTYLE = -20;
+      public const Int32 HWND_TOPMOST = -1;
+      public const Int32 HWND_NOTOPMOST = -2;
+      public const UInt32 SWP_NOSIZE = 0x0001;
+      public const UInt32 SWP_NOMOVE = 0x0002;
+      public const Int32 WS_EX_TOPMOST = 0x00000008;
+
+      [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+      public static extern IntPtr FindWindow(
+        String windowClass,
+        String windowTitle);
       [DllImport("user32.dll")]
       public static extern IntPtr GetForegroundWindow();
+      [DllImport("user32.dll")]
+      public static extern Int32 GetWindowLong(IntPtr hwnd, Int32 index);
+      [DllImport("user32.dll")]
+      public static extern Int32 SetForegroundWindow(IntPtr hwnd);
+      [DllImport("user32.dll")]
+      public static extern Int32 SetWindowPos(
+        IntPtr hwnd,
+        IntPtr hwndInsertAfter,
+        Int32 x, Int32 y,
+        Int32 cx, Int32 cy,
+        UInt32 flags);
     }
 
     private class DWMAPI {
@@ -92,4 +139,4 @@ namespace Screenshot {
 
 Add-Type $cSharpSource -ReferencedAssemblies 'System.Drawing'
 
-(New-Object Screenshot.Screenshot).Take($FilePath)
+(New-Object Screenshot.Screenshot).Take($FilePath, $Title)


### PR DESCRIPTION
This implements taking screenshots via a CI workflow (instead of doing so as a manual workflow by running `yarn screenshots`).  This ensures we don't have to track down people with the correct platforms (and making sure their environment is clean enough).

This fixes #2430 (which was prematurely closed because the issues asks for CI but we never did that…)

See also #6645, #6646 which are PRs spawned while working on this.