### PR TITLE
Dependencies: wix: Try harder to get bits

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -756,6 +756,7 @@ tmppath
 tmutil
 togglefullscreen
 tonistiigi
+Toolset
 topmenu
 TQF
 Tracef

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -17,7 +17,7 @@ dockerProvidedCredentialHelpers: 0.8.1
 ECRCredentialHelper: 0.7.1
 hostResolver: 0.1.5
 mobyOpenAPISpec: "1.45"
-wix: "314"
+wix: v3.14.1
 hostSwitch: 1.2.2
 moproxy: 0.5.0
 wasmShims: 0.11.1


### PR DESCRIPTION
Wix releases don't actually include the version patch number in the file name for the releases (but it _is_ included in the tag name).  Try harder to get the correct versions for it.

Obsoletes #6642