### PR TITLE
rdctl: factory-reset: Handle missing docker context better

### DIFF
--- a/src/go/rdctl/pkg/factoryreset/delete_data.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data.go
@@ -255,7 +255,7 @@ func clearDockerContext() error {
 	dockerConfigContents := make(dockerConfigType)
 	contents, err := os.ReadFile(configFilePath)
 	if err != nil {
-		if errors.Is(err, syscall.ENOENT) {
+		if os.IsNotExist(err) {
 			// Nothing left to do here, since the file doesn't exist
 			return nil
 		}


### PR DESCRIPTION
On Windows, for some reason `errors.Is(..., ENOENT)` doesn't work correctly and fails to catch the error.

Found when running the `factory-reset-containerd-shims.bats` test individually on a machine that didn't have a docker context.