### PR TITLE
BATS: containers/auto-start: don't check Windows path

### DIFF
--- a/bats/tests/containers/auto-start.bats
+++ b/bats/tests/containers/auto-start.bats
@@ -45,7 +45,7 @@ load '../helpers/load'
     if is_windows; then
         run powershell.exe -c "reg query HKCU\Software\Microsoft\Windows\CurrentVersion\Run /v RancherDesktop"
         assert_success
-        assert_line --index 2 --partial "\Rancher Desktop\Rancher Desktop.exe"
+        assert_line --index 2 --partial "\Rancher Desktop.exe"
     fi
 }
 


### PR DESCRIPTION
On Windows, when running BATS out of dist/, the path to the exe file ends with `.../win-unpacked/Rancher Desktop.exe`; this means that we will not match `\Rancher Desktop\Rancher Desktop.exe`. Change the test so that it only matches the leaf name (which is still correct).