### PR TITLE
BATS: preferences/roaming: avoid creating files from Linux

### DIFF
--- a/bats/tests/preferences/move-from-roaming-to-local.bats
+++ b/bats/tests/preferences/move-from-roaming-to-local.bats
@@ -7,6 +7,8 @@ local_setup() {
 
 @test 'factory reset' {
     factory_reset
+    # WSL sometimes ends up not seeing deletes from Windows; force it here.
+    rm -rf "$PATH_CONFIG" "$ROAMING_HOME"
 }
 
 @test 'start app, create a setting, and move settings to roaming' {
@@ -15,8 +17,8 @@ local_setup() {
 
     rdctl api -X PUT /settings --body '{ "version": 9, "WSL": {"integrations": { "beaker" : true }}}'
     rdctl shutdown
-    mkdir -p "$ROAMING_HOME"
-    mv "$PATH_CONFIG_FILE" "$ROAMING_HOME/settings.json"
+    create_file "$ROAMING_HOME/settings.json" <"$PATH_CONFIG_FILE"
+    rm -f "$PATH_CONFIG_FILE"
 }
 
 @test 'restart app, verify settings has been migrated' {


### PR DESCRIPTION
WSL seems to be having issues where files deleted from Windows are still showing up on the Linux side if they were created from there.  Work around this by creating the roaming settings from the Windows side (and deleting the file from local settings from Linux).