### PR TITLE
BATS: profile: Pass Windows paths to reg.exe for export

### DIFF
--- a/bats/tests/helpers/profile.bash
+++ b/bats/tests/helpers/profile.bash
@@ -130,7 +130,8 @@ export_profile() {
             cp "$filename" "${export}.${filename##*.}"
             ;;
         windows)
-            profile_reg export "${export}.reg" /y
+            export="$(wslpath -w "${export}.reg")"
+            profile_reg export "${export}" /y
             ;;
         esac
     fi

--- a/bats/tests/profile/wasm.bats
+++ b/bats/tests/profile/wasm.bats
@@ -30,7 +30,7 @@ local_teardown_file() {
 @test 'restart application with version 11 locked profile' {
     factory_reset
     start_container_engine
-    wait_for_container_engine
+    wait_for_backend
 }
 
 @test 'WASM mode is now unlocked' {


### PR DESCRIPTION
We appear to be failing tests when exporting the profile to disk:

> ERROR: Unable to write to the file. There may be a disk or file system error.

Work around this by passing Windows paths to `reg.exe` so that it can understand it correctly; this resolves the error.

Additionally, in `wasm.bats`, wait for the backend to finish instead of just the container engine.  The next step runs `rdctl` and expects to see a message stating that we're reconfiguring.  However, if we only wait for the container engine (rather than waiting for the whole backend to settle), we can end up with the backend still busy, and end up with a different message about the backend eventually restarting.  Fix this by waiting for full completion before changing settings.
