### PR TITLE
rddepman: Only consider PRs from the same repo

### DIFF
--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -105,18 +105,7 @@ type PRSearchFn = ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>
 
 async function getPulls(name: string): Promise<Awaited<PRSearchFn>['data']['items']> {
   const queryString = `type:pr repo:${ GITHUB_OWNER }/${ GITHUB_REPO } head:rddepman/${ name } sort:updated`;
-  let response: Awaited<PRSearchFn>;
-  let retries = 0;
-
-  while (true) {
-    try {
-      response = await getOctokit().rest.search.issuesAndPullRequests({ q: queryString });
-      break;
-    } catch (error: any) {
-      retries += 1;
-      if (retries > 2) {
-        throw error;
-      }
+  const response = await getOctokit().rest.search.issuesAndPullRequests({ q: queryString });
 
   const results: typeof response.data.items = [];
 


### PR DESCRIPTION
When doing automated dependency updates, only consider pull requests from the same repository as possibly obsolete; other PRs that happen to match the search criteria are manually created and therefore cannot be considered to be pull requests for the same dependency.

Additionally, adjust our octokit usage to use native retries instead of hacking retries on top; this ensures we wait appropriately (based on the `retry-after` headers, as appropriate).