### PR TITLE
BATS: snapshot: ensure rdctl doesn't eat input

### DIFF
--- a/bats/tests/helpers/snapshots.bash
+++ b/bats/tests/helpers/snapshots.bash
@@ -1,8 +1,17 @@
 delete_all_snapshots() {
     run rdctl snapshot list --json
     assert_success
-    jq_output .name | while IFS= read -r name; do
-        run rdctl snapshot delete "$name"
-        assert_success
+    # On Windows, executing native Windows executables consumes stdin.
+    # https://github.com/microsoft/WSL/issues/10429
+    # Work around the issue by using `run` to populate `${lines[@]}` ahead of
+    # time, so that we don't need the buffer during the loop.
+    run jq_output .name
+    assert_success
+    local name
+    for name in "${lines[@]}"; do
+        rdctl snapshot delete "$name"
     done
+    run rdctl snapshot list
+    assert_success
+    assert_output --partial 'No snapshots'
 }


### PR DESCRIPTION
On Windows, it appears that running `rdctl` ended up draining standard input; however, we needed that standard input to iterate over all snapshots so we can delete them.  Work around the issue by explicitly redirecting standard input from `/dev/null` so that the original standard input is left alone.

Additionally, when deleting all snapshots, check that the snapshots have actually been cleared afterwards.  This catches the above problem where we do not delete all snapshots.