### PR TITLE
BATS: containers/switch-engines: wait before switching

### DIFF
--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -6,6 +6,9 @@ RD_CONTAINER_ENGINE=moby
 switch_container_engine() {
     local name=$1
     RD_CONTAINER_ENGINE="${name}"
+    # Make sure the backend is idle, to prevent wait_for_container_engine from
+    # erroring because the wrong engine is up.
+    wait_for_backend
     rdctl set --container-engine.name="${name}"
     wait_for_container_engine
 }


### PR DESCRIPTION
If the backend is still busy (but the container engine was already up) before we request the switch, we end up waiting for the previous startup to finish rather than the new engine.  This breaks the test because it ends up getting into an unexpected state.