### PR TITLE
BATS: profile/deployment: wait for backend before installing extension

### DIFF
--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -78,6 +78,9 @@ verify_settings() {
 }
 
 install_extensions() {
+    # Extension install doesn't work until startup is fully complete.
+    wait_for_backend
+
     run rdctl extension install "$FORBIDDEN_EXTENSION"
     "${refute}_success"
 


### PR DESCRIPTION
Extension installation doesn't work until the backend is fully started (instead of just waiting for the container engine to be running), because the extension manager isn't initialized that early.