### PR TITLE
golang: prefer `errors.Is(..., ErrNotExist)` over `errors.Is(..., ENOENT)`

### DIFF
--- a/src/go/docker-credential-none/dcnone/helpers.go
+++ b/src/go/docker-credential-none/dcnone/helpers.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
-	"syscall"
 
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -19,7 +19,7 @@ func getParsedConfig() (dockerConfigType, error) {
 	dockerConfig := make(dockerConfigType)
 	contents, err := os.ReadFile(configFile)
 	if err != nil {
-		if errors.Is(err, syscall.ENOENT) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// Time to create a new config (or return no data)
 			return dockerConfig, nil
 		}

--- a/src/go/rdctl/pkg/factoryreset/delete_data.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data.go
@@ -20,13 +20,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 
 	dockerconfig "github.com/docker/docker/cli/config"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
@@ -139,7 +139,7 @@ func removeDockerCliPlugins(altAppHomePath string) error {
 	cliPluginsDir := path.Join(dockerconfig.Dir(), "cli-plugins")
 	entries, err := os.ReadDir(cliPluginsDir)
 	if err != nil {
-		if errors.Is(err, syscall.ENOENT) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// Nothing left to do here, since there is no cli-plugins dir
 			return nil
 		}
@@ -172,7 +172,7 @@ func removePathManagement(dotFiles []string) error {
 	for _, dotFile := range dotFiles {
 		byteContents, err := os.ReadFile(dotFile)
 		if err != nil {
-			if !errors.Is(err, syscall.ENOENT) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				logrus.Errorf("Error trying to read %s: %s\n", dotFile, err)
 			}
 			continue
@@ -255,7 +255,7 @@ func clearDockerContext() error {
 	dockerConfigContents := make(dockerConfigType)
 	contents, err := os.ReadFile(configFilePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// Nothing left to do here, since the file doesn't exist
 			return nil
 		}


### PR DESCRIPTION
It seems like it sometimes makes a difference on Windows, even though the two should be equivalent.  Note that we previously used `os.IsNotExist()`, but per [documentation of that function](https://pkg.go.dev/os#IsNotExist) `errors.Is(err, fs.ErrNotExist)` is preferred.