### PR TITLE
API: add post/delete commands for port forwarding

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -842,11 +842,19 @@ ipcMainProxy.handle('service-forward', async(_, service, state) => {
   if (state) {
     const hostPort = service.listenPort ?? 0;
 
-    await k8smanager.kubeBackend.forwardPort(namespace, service.name, service.port, hostPort);
+    await doForwardPort(namespace, service.name, service.port, hostPort);
   } else {
-    await k8smanager.kubeBackend.cancelForward(namespace, service.name, service.port);
+    await doCancelForward(namespace, service.name, service.port);
   }
 });
+
+async function doForwardPort(namespace: string, service: string, k8sPort: string | number, hostPort: number) {
+  return await k8smanager.kubeBackend.forwardPort(namespace, service, k8sPort, hostPort);
+}
+
+async function doCancelForward(namespace: string, service: string, k8sPort: string | number) {
+  return await k8smanager.kubeBackend.cancelForward(namespace, service, k8sPort);
+}
 
 ipcMainProxy.on('k8s-integrations', async() => {
   mainEvents.emit('integration-update', await integrationManager.listIntegrations() ?? {});
@@ -1352,6 +1360,14 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
 
   factoryReset(keepSystemImages: boolean) {
     doFactoryReset(keepSystemImages);
+  }
+
+  async forwardPort(namespace: string, service: string, k8sPort: string | number, hostPort: number) {
+    return await doForwardPort(namespace, service, k8sPort, hostPort);
+  }
+
+  async cancelForward(namespace: string, service: string, k8sPort: string | number) {
+    return await doCancelForward(namespace, service, k8sPort);
   }
 
   /**

--- a/bats/tests/k8s/port-forwarding.bats
+++ b/bats/tests/k8s/port-forwarding.bats
@@ -6,22 +6,10 @@ local_setup() {
     fi
 }
 
-assert_traefik_crd_established() {
-    local jsonpath="{.status.conditions[?(@.type=='Established')].status}"
-    run kubectl get crd traefikservices.traefik.containo.us --output jsonpath="$jsonpath"
-    assert_success || return
-    assert_output 'True'
-}
-
 @test 'start k8s' {
     factory_reset
     start_kubernetes
     wait_for_kubelet
-
-    # The manifests in /var/lib/rancher/k3s/server/manifests are processed
-    # in alphabetical order. So when traefik.yaml has been loaded we know that
-    # rd-runtime.yaml has already been processed.
-    try assert_traefik_crd_established
 }
 
 @test 'deploy sample app' {

--- a/bats/tests/k8s/port-forwarding.bats
+++ b/bats/tests/k8s/port-forwarding.bats
@@ -1,11 +1,5 @@
 load '../helpers/load'
 
-local_setup() {
-    if is_windows; then
-        skip "this test doesn't work on Windows"
-    fi
-}
-
 @test 'start k8s' {
     factory_reset
     start_kubernetes

--- a/bats/tests/k8s/port-forwarding.bats
+++ b/bats/tests/k8s/port-forwarding.bats
@@ -85,13 +85,6 @@ spec:
 EOF
 }
 
-@test 'connect to the service' {
-    # This can take 100s with old versions of traefik, and 15s with newer ones.
-    run try curl --silent --fail "http://localhost"
-    assert_success
-    assert_output "Hello World!"
-}
-
 @test 'fail to connect to the service on localhost without port forwarding' {
     run try --max 5 curl --silent --fail "http://localhost:8080"
     assert_failure

--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -141,3 +141,21 @@ EOF
     assert_success
     assert_output "Hello world from Spin!"
 }
+
+@test 'fail to connect to the service on localhost without port forwarding' {
+    run try curl --silent --fail "http://localhost:8080/hello"
+    assert_failure
+}
+
+@test 'connect to the service on localhost with port forwarding' {
+    rdctl api -X POST -b '{ "namespace": "default", "service": "hello-spin", "k8sPort": 80, "hostPort": 8080 }' port_forwarding
+    run try curl --silent --fail "http://localhost:8080/hello"
+    assert_success
+    assert_output "Hello world from Spin!"
+}
+
+@test 'fail to connect to the service on localhost after removing port forwarding' {
+    rdctl api -X DELETE "port_forwarding?namespace=default&service=hello-spin&k8sPort=80"
+    run try curl --silent --fail "http://localhost:8080/hello"
+    assert_failure
+}

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -208,6 +208,47 @@ paths:
         '400':
           description: An error occurred
 
+  /v1/port_forwarding:
+    post:
+      operationId: createPortForward
+      summary: Create a new port forwarding
+      requestBody:
+        description: JSON block consisting of the port forwarding details
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                namespace:
+                  type: string
+                service:
+                  type: string
+                k8sPort:
+                  type: string
+                hostPort:
+                  type: integer
+        required: true
+      responses:
+        '200':
+          description: The port forwarding was created.
+        '400':
+          description: The port forwarding could not be created.
+    delete:
+      operationId: deletePortForward
+      summary: Delete a port forwarding
+      parameters:
+      - in: query
+        name: namespace
+      - in: query
+        name: service
+      - in: query
+        name: k8sPort
+      responses:
+        '200':
+          description: The port forwarding was deleted.
+        '400':
+          description: The port forwarding could not be deleted.
+
   /v1/propose_settings:
     put:
       operationId: proposeSettings

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -224,13 +224,19 @@ paths:
                 service:
                   type: string
                 k8sPort:
-                  type: string
+                  type:
+                  - string
+                  - integer
                 hostPort:
                   type: integer
         required: true
       responses:
         '200':
-          description: The port forwarding was created.
+          description: The port forwarding was created or already exists; the response contains the listening host port.
+          content:
+            text/plain:
+              schema:
+                type: integer
         '400':
           description: The port forwarding could not be created.
     delete:
@@ -245,7 +251,7 @@ paths:
         name: k8sPort
       responses:
         '200':
-          description: The port forwarding was deleted.
+          description: The port forwarding was deleted or doesn't exist.
         '400':
           description: The port forwarding could not be deleted.
 

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -599,9 +599,9 @@ export class HttpCommandServer {
           console.debug(`createPortForwarding: write back status 400, error forwarding port`);
           response.status(400).type('txt').send('Could not forward port');
         }
-      } catch (err) {
+      } catch (err: any) {
         console.error(`createPortForwarding: error forwarding port:`, err);
-        response.status(400).type('txt').send('Could not forward port');
+        response.status(400).type('txt').send(`Could not forward port; error code: ${ typeof err.code === 'string' ? err.code : 'unknown, check the logs' }`);
       }
     } else {
       console.debug(`createPortForwarding: write back status 400, error: ${ error }`);


### PR DESCRIPTION
This PR closes #4171 by adding `POST` and `DELETE` methods for the new `/v1/port_forwarding` API endpoint which ultimately call `forwardPort(...)` and `cancelForward(...)`

A sample `POST` call using rdctl looks like:

```
./rdctl api -X POST -b '{ "namespace": "director", "service": "backend", "k8sPort": 3000, "hostPort": 3421 }' port_forwarding
```

A sample `DELETE` call for the respective port looks like:

```
./rdctl api -X DELETE "port_forwarding?namespace=director&service=backend&k8sPort=3000"
```

Here is a demo of those calls:

https://github.com/rancher-sandbox/rancher-desktop/assets/549323/63311c26-81eb-46c5-b7c8-bab439a70c53

I've created additional tests under `bats/tests/k8s/wasm.bats`, but I was unable to figure out how to get the BATS tests to run (I tried on Windows, WSL, and GitHub Actions with various errors essentially not understanding how the environment should be ran).