### PR TITLE
CI: Add workflow to do a simple smoke test from a release

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -150,6 +150,7 @@ cshrc
 Ctl
 ctrctl
 cxt
+cygpath
 DACL
 daemonset
 dapp
@@ -474,6 +475,7 @@ MSIX
 msixbundle
 msize
 msvs
+msys
 mszip
 multierror
 multiport

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -167,7 +167,7 @@ jobs:
         if ! command -v yq; then
           mkdir -p "$bindir"
           curl --location --output "$bindir/yq.exe" \
-            https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe
+            https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_windows_amd64.exe
           chmod a+x "$bindir/yq.exe"
         fi
       shell: bash

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -26,7 +26,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.tag }}
     steps:
     - name: Find release
-      if : inputs.tag == ''
+      if: inputs.tag == ''
       run: >-
         set -o xtrace;
         printf "RELEASE_TAG=%s\n" >>"$GITHUB_ENV"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,194 @@
+# This workflow downloads artifacts from a (by default, draft) release and runs
+# a short smoke test where the application is installed and run and immediately
+# shut down.
+# Since we need contents-write permissions to look at draft releases, we
+# actually download the artifacts in a smaller job, then upload them into the
+# run and download it _again_ in the second (per-platform) job where no
+# permissions are required.
+name: Release smoke test
+permissions: {}
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >
+          Download artifacts from release with this tag, rather than picking the
+          first draft release.
+        type: string
+
+jobs:
+  download-artifacts:
+    name: Find release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to list draft releases
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+    - name: Find release
+      if : inputs.tag == ''
+      run: >-
+        set -o xtrace;
+        printf "RELEASE_TAG=%s\n" >>"$GITHUB_ENV"
+        "$(gh api repos/${{ github.repository }}/releases
+        --jq 'map(select(.draft))[0].tag_name')"
+      env:
+        GH_TOKEN: ${{ github.token }}
+    - name: Download artifacts
+      run: |
+        if [[ -z "$RELEASE_TAG" ]]; then
+          echo "Failed to find release tag" >&2
+          exit 1
+        fi
+        gh release download "$RELEASE_TAG" \
+          --repo ${{ github.repository }} \
+          --pattern '*.dmg' \
+          --pattern '*.dmg.sha512sum' \
+          --pattern '*.msi' \
+          --pattern '*.msi.sha512sum' \
+          --pattern 'rancher-desktop-linux-*.zip' \
+          --pattern 'rancher-desktop-linux-*.zip.sha512sum'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Upload macOS aarch-64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: application-macos-aarch64.zip
+        if-no-files-found: error
+        path: |
+          *.aarch64.dmg
+          *.aarch64.dmg.sha512sum
+    - name: Upload macOS x86_64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: application-macos-x86_64.zip
+        if-no-files-found: error
+        path: |
+          *.x86_64.dmg
+          *.x86_64.dmg.sha512sum
+    - name: Upload Windows artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: application-win32.zip
+        if-no-files-found: error
+        path: |
+          *.msi
+          *.msi.sha512sum
+    - name: Upload Linux artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: application-linux.zip
+        if-no-files-found: error
+        path: |
+          rancher-desktop-linux-*.zip
+          rancher-desktop-linux-*.zip.sha512sum
+
+  smoke-test:
+    name: Smoke test
+    needs: download-artifacts
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { platform: macos-aarch64, runs-on: macos-14 }
+        - { platform: macos-x86_64, runs-on: macos-13 }
+        - { platform: win32, runs-on: windows-latest }
+        - { platform: linux, runs-on: ubuntu-latest }
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: "Linux: Enable KVM access"
+      if: runner.os == 'Linux'
+      run: sudo chmod a+rwx /dev/kvm
+
+    - name: "Linux: Initialize pass"
+      if: runner.os == 'Linux'
+      run: |
+        # Configure the agent to allow default passwords
+        HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
+        mkdir -p "${HOMEDIR}"
+        chmod 0700 "${HOMEDIR}"
+        echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
+
+        # Create a GPG key
+        gpg --quick-generate-key --yes --batch --passphrase '' \
+          user@rancher-desktop.test default \
+          default never
+
+        # Get info about the newly created key
+        DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
+        FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
+        GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
+
+        # Save the password
+        gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
+
+        # Initialize pass
+        pass init "${FINGERPRINT}"
+
+    - name: "Linux: Set startup command"
+      if: runner.os == 'Linux'
+      run: echo "EXEC_COMMAND=$EXEC_COMMAND" >> "$GITHUB_ENV"
+      env:
+        EXEC_COMMAND: >-
+          exec xvfb-run --auto-servernum
+          --server-args='-screen 0 1280x960x24'
+
+    - name: "Windows: Stop unwanted services"
+      if: runner.os == 'Windows'
+      run: >-
+        Get-Service -ErrorAction Continue -Name
+        @('W3SVC', 'docker')
+        | Stop-Service
+
+    - name: "Windows: Update any pre-installed WSL"
+      if: runner.os == 'Windows'
+      run: wsl --update
+      continue-on-error: true
+
+    - name: "Windows: Set default WSL version"
+      if: runner.os == 'Windows'
+      run: |
+        wsl --set-default-version 2
+        wsl --version
+
+    - name: "Windows: Install yq"
+      if: runner.os == 'Windows'
+      run: |
+        set -o xtrace
+        bindir="$HOME/bin"
+        if [[ ! "$PATH" =~ "$bindir" ]]; then
+          bindir=/usr/bin
+        fi
+        if ! command -v yq; then
+          mkdir -p "$bindir"
+          curl --location --output "$bindir/yq.exe" \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe
+          chmod a+x "$bindir/yq.exe"
+        fi
+      shell: bash
+
+    - name: Set log directory
+      shell: bash
+      # Use node here to do path manipulation to get correct Windows paths.
+      run: >-
+        node --eval='console.log("RD_LOGS_DIR=" + require("path").join(process.cwd(), "logs"));'
+        >> "$GITHUB_ENV"
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: application-${{ matrix.platform }}.zip
+    - run: ${{ env.EXEC_COMMAND }} .github/workflows/smoke-test/smoke-test.sh
+      shell: bash
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: logs-${{ matrix.platform }}.zip
+        path: ${{ github.workspace }}/logs
+        if-no-files-found: warn

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+# This script is expected to run from CI, and does a final smoke test.
+# There should be an installer in the current directory (or, in the case of
+# Linux, a zip file), along with its accompanying sha512sum file.
+# On Windows, build/signing-config-win.yaml is also required.
+
+# Required tools:
+# - jq
+# - yq (Windows only)
+
+# Note that, on Windows, this is run via msys bash (installed wit git).
+
+set -o errexit -o nounset
+
+# All commands in the cleanups array will be run on exit.  They must be plain
+# strings that will be passed to eval
+cleanups=()
+
+# Run the cleanups.
+do_cleanup() {
+    # In case the array has holes (it shouldn't), make an array of indices.
+    local indices=("${!cleanups[@]}")
+    local i
+    for (( i=${#indices[@]} - 1; i >= 0; i-- )); do
+        # shellcheck disable=2086 # We expect to glob and word split
+        eval ${cleanups[$i]}
+    done
+}
+
+trap do_cleanup EXIT
+
+# Locate the archive, check its checksum, and echo the file name.
+get_archive() {
+    local checksum archiveName
+    for checksum in *.sha512sum; do
+        archiveName=${checksum%.sha512sum}
+        if command -v sha512sum &>/dev/null; then
+            sha512sum --check --quiet --strict "$checksum"
+        else
+            shasum --check --quiet --algorithm 512 "$checksum"
+        fi
+        grep --quiet "$archiveName" "$checksum"
+        readlink -f "$archiveName"
+        return
+    done
+    echo "Failed to find archive." >&2
+    exit 1
+}
+
+# Return the current platform; one of "darwin", "linux", "win32"
+get_platform() {
+    case "$(uname -s)" in
+    Darwin)
+        echo "darwin";;
+    Linux)
+        echo "linux";;
+    MINGW*)
+        echo "win32";;
+    *)
+        printf "Unsupported platform %s\n" "$(uname -s)" >&2
+        exit 1;;
+    esac
+}
+
+# Assume the first argument given is a path to the Rancher Desktop .dmg disk
+# image; install it, and set the global variable RDCTL to the path of the rdctl
+# executable.
+install_darwin() {
+    local archiveName=$1
+    local mountpoint
+    mountpoint=$(mktemp -d -t rd-dmg-)
+    cleanups+=("rm -rf '$mountpoint'")
+
+    local srcApp="${mountpoint}/Rancher Desktop.app"
+    local destApp="/Applications/Rancher Desktop.app"
+
+    codesign --verify --deep --strict --verbose=2 --check-notarization "$archiveName"
+    hdiutil attach "$archiveName" -mountpoint "$mountpoint"
+    cleanups+=("hdiutil detach '$mountpoint'")
+
+    codesign --verify --deep --strict --verbose=2 --check-notarization "$srcApp"
+    mkdir -p "$destApp"
+    cleanups+=("rm -rf '$destApp'")
+
+    tar -cC "$srcApp" . | tar -xC "$destApp"
+    xattr -d -r -s -v com.apple.quarantine "$destApp"
+
+    if [[ "$(uname -m)" =~ arm ]]; then
+        # For macOS, currently only x86_64 supports nested virtualization
+        # https://github.com/actions/runner-images/issues/9460
+        # Abort the script (gracefully) instead of trying to run RD.
+        exit 0
+    fi
+
+    RDCTL="$destApp/Contents/Resources/resources/darwin/bin/rdctl"
+}
+
+# Assume the first argument given is a path to the Rancher Desktop zip file;
+# install it, and set the global variable RDCTL to the path of the rdctl
+# executable.
+install_linux() {
+    local archiveName=$1
+
+    sudo mkdir -p /opt/rancher-desktop
+    sudo unzip -d /opt/rancher-desktop "$archiveName"
+
+    RDCTL="/opt/rancher-desktop/resources/resources/linux/bin/rdctl"
+}
+
+# Helper function on Windows to verify the signature of a file (provided as the
+# first argument).
+win32_verify() {
+    local path
+    path="$(cygpath --windows "$1")"
+    # When running GitHub actions, using `powershell.exe` here causes issues
+    # with loading the `Microsoft.PowerShell.Security` module; using `pwsh.exe`
+    # seems to be fine.  This is probably because the default shell is pwsh, and
+    # the environment has paths to the PowerShell 7 version of the module, so it
+    # tries to load that instead of the version appropriate for PowerShell.exe.
+    local pwsh=(pwsh.exe -NoLogo -NoProfile -NonInteractive -Command)
+    local stdout
+    stdout=$("${pwsh[@]}" "\$(Get-AuthenticodeSignature '$path').Status")
+
+    if [[ "$stdout" != "Valid" ]]; then
+        printf "%s is not correctly signed:\n" "$path"
+        "${pwsh[@]}" "Get-AuthenticodeSignature '$path' | Format-List"
+        exit 1
+    fi
+}
+
+# Assume the first argument given is a path to the Rancher Desktop installer;
+# install it, and set the global variable RDCTL to the path of the rdctl
+# executable.
+install_win32() {
+    local archiveName=$1
+
+    win32_verify "$archiveName"
+    mkdir -p "$(cygpath --unix "${RD_LOGS_DIR}")"
+    MSYS2_ARG_CONV_EXCL='*' msiexec.exe '/lv*x' "${RD_LOGS_DIR}\\install.log" \
+        /i "$(cygpath --windows "$archiveName")" /passive ALLUSERS=1
+    # msiexec returns immediately and runs in the background; wait for that
+    # process to exit before continuing.
+    local deadline
+    deadline=$(( $(date +%s) + 10 * 60 ))
+    while [[ $(date +%s) -lt $deadline ]]; do
+        if MSYS2_ARG_CONV_EXCL='*' tasklist.exe /FI "ImageName eq msiexec.exe" | grep msiexec; then
+            break
+        fi
+        printf "Waiting for msiexec: %s/%s\n" "$(date)" "$(date --date="@$deadline")"
+        sleep 10
+    done
+    local installDirectory
+    installDirectory=$(cygpath --unix 'C:\Program Files\Rancher Desktop')
+    local rdctl="$installDirectory/resources/resources/win32/bin/rdctl.exe"
+
+    local -a keys
+    mapfile -t keys < <(yq.exe 'keys | .[]' < build/signing-config-win.yaml)
+    local key
+    for key in "${keys[@]}"; do
+        local expr='.[env(key)][] | select(. != "!*")'
+        local -a values
+        mapfile -t values < <(key=$key yq.exe "$expr" < build/signing-config-win.yaml)
+        for value in "${values[@]}"; do
+            if [[ "$value" == "wix-custom-action.dll" ]]; then
+                # This file is not installed
+                continue
+            fi
+            win32_verify "$installDirectory/$key/$value"
+        done
+    done
+
+    # Verify that rdctl exists
+    win32_verify "$rdctl"
+    RDCTL=$rdctl
+}
+
+# Wait for the backend to be alive.  $RDCTL must be set (from the install_*
+# functions).
+wait_for_backend() {
+    local deadline state
+    deadline=$(( $(date +%s) + 10 * 60 ))
+
+    while [[ $(date +%s) -lt $deadline ]]; do
+        state=$(MSYS2_ARG_CONV_EXCL='*' "$RDCTL" api /v1/backend_state || echo '{"vmState": "UNREADY"}')
+        state=$(jq --raw-output .vmState <<< "$state")
+        case "$state" in
+            ERROR)
+                echo "Backend reached error state." >&2
+                exit 1 ;;
+            STARTED|DISABLED)
+                return ;;
+            *)
+                printf "Backend state: %s\n" "$state";;
+        esac
+
+        # if we get here, either we failed to get state or it's starting.
+        printf "Waiting for backend: %s/%s\n" "$(date)" \
+            "$({ date --date="@$deadline" || date -j -f %s "$deadline"; } 2>/dev/null)"
+        sleep 10
+    done
+
+    echo "Timed out waiting for backend to stabilize." >&2
+    printf "Current time: %s\n" "$(date)" >&2
+    printf "Deadline: %s\n" >&2 \
+        "$({ date --date="@$deadline" || date -j -f %s "$deadline"; } 2>/dev/null)"
+    exit 1
+}
+
+main() {
+    local archive platform
+    platform=$(get_platform)
+    archive=$(get_archive)
+
+    eval "install_${platform}" "$archive"
+    "$RDCTL" start --no-modal-dialogs \
+        --kubernetes.enabled --application.updater.enabled=false
+    cleanups+=("'$RDCTL' shutdown")
+    wait_for_backend
+    echo "Smoke test passed."
+}
+
+main


### PR DESCRIPTION
This is used to verify that our artifacts in a release are correct (and we can ship them).  It checks that signatures look sane.

This currently just starts the application then quits.