### PR TITLE
Spinkube followup

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/install-k3s
+++ b/pkg/rancher-desktop/assets/scripts/install-k3s
@@ -42,7 +42,7 @@ ln -s -f "${K3S_DIR}/${K3S}" /usr/local/bin/k3s
 # The file system may be readonly (on macOS)
 chmod a+x "${K3S_DIR}/${K3S}" || true
 
-# Make sure any old manifests are removed before configuring k3s again
+# Make sure any old manifests are removed before configuring k3s again.
 # We need to create the directory before we run `k3s server ...` because
 # we install additional manifests that k3s will install during startup.
 MANIFESTS=/var/lib/rancher/k3s/server/manifests

--- a/pkg/rancher-desktop/assets/scripts/spin-operator.helm-chart.yaml
+++ b/pkg/rancher-desktop/assets/scripts/spin-operator.helm-chart.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   chart: "https://%{KUBERNETES_API}%/static/rancher-desktop/spin-operator.tgz"
   targetNamespace: spin-operator
-  createNamespace: true
+  # Old versions of the helm-controller don't support createNamespace, so we
+  # create the namespace separately via spin-operator.namespace.yaml.
+  createNamespace: false

--- a/pkg/rancher-desktop/assets/scripts/spin-operator.namespace.yaml
+++ b/pkg/rancher-desktop/assets/scripts/spin-operator.namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spin-operator

--- a/pkg/rancher-desktop/assets/scripts/spin-operator.namespace.yaml
+++ b/pkg/rancher-desktop/assets/scripts/spin-operator.namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: spin-operator

--- a/pkg/rancher-desktop/assets/scripts/spin-operator.shim-executor.yaml
+++ b/pkg/rancher-desktop/assets/scripts/spin-operator.shim-executor.yaml
@@ -1,8 +1,0 @@
-apiVersion: core.spinoperator.dev/v1alpha1
-kind: SpinAppExecutor
-metadata:
-  name: containerd-shim-spin
-spec:
-  createDeployment: true
-  deploymentConfig:
-    runtimeClassName: spin

--- a/pkg/rancher-desktop/assets/scripts/spin-operator.yaml
+++ b/pkg/rancher-desktop/assets/scripts/spin-operator.yaml
@@ -1,3 +1,18 @@
+---
+apiVersion: core.spinoperator.dev/v1alpha1
+kind: SpinAppExecutor
+metadata:
+  name: containerd-shim-spin
+spec:
+  createDeployment: true
+  deploymentConfig:
+    runtimeClassName: spin
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spin-operator
+---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:
@@ -7,5 +22,5 @@ spec:
   chart: "https://%{KUBERNETES_API}%/static/rancher-desktop/spin-operator.tgz"
   targetNamespace: spin-operator
   # Old versions of the helm-controller don't support createNamespace, so we
-  # create the namespace separately via spin-operator.namespace.yaml.
+  # created the namespace ourselves.
   createNamespace: false

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -7,9 +7,7 @@ import yaml from 'yaml';
 
 import INSTALL_CONTAINERD_SHIMS_SCRIPT from '@pkg/assets/scripts/install-containerd-shims';
 import CONTAINERD_CONFIG from '@pkg/assets/scripts/k3s-containerd-config.toml';
-import SPIN_OPERATOR_HELM_CHART from '@pkg/assets/scripts/spin-operator.helm-chart.yaml';
-import SPIN_OPERATOR_NAMESPACE from '@pkg/assets/scripts/spin-operator.namespace.yaml';
-import SPIN_OPERATOR_SHIM_EXECUTOR from '@pkg/assets/scripts/spin-operator.shim-executor.yaml';
+import SPIN_OPERATOR from '@pkg/assets/scripts/spin-operator.yaml';
 import { BackendSettings, VMExecutor } from '@pkg/backend/backend';
 import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine, Settings } from '@pkg/config/settings';
@@ -29,9 +27,7 @@ const MANIFEST_DIR = '/var/lib/rancher/k3s/server/manifests';
 const MANIFEST_RUNTIMES_YAML = `${ MANIFEST_DIR }/z100-runtimes.yaml`;
 const MANIFEST_CERT_MANAGER = `${ MANIFEST_DIR }/z110-cert-manager.yaml`;
 const MANIFEST_SPIN_OPERATOR_CRDS = `${ MANIFEST_DIR }/z120-spin-operator.crds.yaml`;
-const MANIFEST_SPIN_OPERATOR_SHIM_EXECUTOR = `${ MANIFEST_DIR }/z121-spin-operator.shim-executor.yaml`;
-const MANIFEST_SPIN_OPERATOR_NAMESPACE = `${ MANIFEST_DIR }/z122-spin-operator.namespace.yaml`;
-const MANIFEST_SPIN_OPERATOR_CHART = `${ MANIFEST_DIR }/z123-spin-operator.chart.yaml`;
+const MANIFEST_SPIN_OPERATOR = `${ MANIFEST_DIR }/z125-spin-operator.yaml`;
 
 const STATIC_DIR = '/var/lib/rancher/k3s/server/static/rancher-desktop';
 const STATIC_SPIN_OPERATOR_CHART = `${ STATIC_DIR }/spin-operator.tgz`;
@@ -301,9 +297,7 @@ export default class BackendHelper {
       vmx.copyFileIn(path.join(paths.resources, 'cert-manager.yaml'), MANIFEST_CERT_MANAGER),
       vmx.copyFileIn(path.join(paths.resources, 'spin-operator.crds.yaml'), MANIFEST_SPIN_OPERATOR_CRDS),
       vmx.copyFileIn(path.join(paths.resources, 'spin-operator.tgz'), STATIC_SPIN_OPERATOR_CHART),
-      vmx.writeFile(MANIFEST_SPIN_OPERATOR_SHIM_EXECUTOR, SPIN_OPERATOR_SHIM_EXECUTOR, 0o644),
-      vmx.writeFile(MANIFEST_SPIN_OPERATOR_NAMESPACE, SPIN_OPERATOR_NAMESPACE, 0o644),
-      vmx.writeFile(MANIFEST_SPIN_OPERATOR_CHART, SPIN_OPERATOR_HELM_CHART, 0o644),
+      vmx.writeFile(MANIFEST_SPIN_OPERATOR, SPIN_OPERATOR, 0o644),
     ]);
   }
 

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -8,6 +8,7 @@ import yaml from 'yaml';
 import INSTALL_CONTAINERD_SHIMS_SCRIPT from '@pkg/assets/scripts/install-containerd-shims';
 import CONTAINERD_CONFIG from '@pkg/assets/scripts/k3s-containerd-config.toml';
 import SPIN_OPERATOR_HELM_CHART from '@pkg/assets/scripts/spin-operator.helm-chart.yaml';
+import SPIN_OPERATOR_NAMESPACE from '@pkg/assets/scripts/spin-operator.namespace.yaml';
 import SPIN_OPERATOR_SHIM_EXECUTOR from '@pkg/assets/scripts/spin-operator.shim-executor.yaml';
 import { BackendSettings, VMExecutor } from '@pkg/backend/backend';
 import { LockedFieldError } from '@pkg/config/commandLineOptions';
@@ -25,11 +26,12 @@ const DOCKER_DAEMON_JSON = '/etc/docker/daemon.json';
 const MANIFEST_DIR = '/var/lib/rancher/k3s/server/manifests';
 // Manifests are applied in sort order, so use a prefix to load them last, in the required sequence.
 // Also: don't use `runtimes.yaml` because k3s may overwrite it.
-const MANIFEST_RUNTIMES_YAML = `${ MANIFEST_DIR }/z100-rd-runtimes.yaml`;
+const MANIFEST_RUNTIMES_YAML = `${ MANIFEST_DIR }/z100-runtimes.yaml`;
 const MANIFEST_CERT_MANAGER = `${ MANIFEST_DIR }/z110-cert-manager.yaml`;
 const MANIFEST_SPIN_OPERATOR_CRDS = `${ MANIFEST_DIR }/z120-spin-operator.crds.yaml`;
 const MANIFEST_SPIN_OPERATOR_SHIM_EXECUTOR = `${ MANIFEST_DIR }/z121-spin-operator.shim-executor.yaml`;
-const MANIFEST_SPIN_OPERATOR_CHART = `${ MANIFEST_DIR }/z122-spin-operator.chart.yaml`;
+const MANIFEST_SPIN_OPERATOR_NAMESPACE = `${ MANIFEST_DIR }/z122-spin-operator.namespace.yaml`;
+const MANIFEST_SPIN_OPERATOR_CHART = `${ MANIFEST_DIR }/z123-spin-operator.chart.yaml`;
 
 const STATIC_DIR = '/var/lib/rancher/k3s/server/static/rancher-desktop';
 const STATIC_SPIN_OPERATOR_CHART = `${ STATIC_DIR }/spin-operator.tgz`;
@@ -300,6 +302,7 @@ export default class BackendHelper {
       vmx.copyFileIn(path.join(paths.resources, 'spin-operator.crds.yaml'), MANIFEST_SPIN_OPERATOR_CRDS),
       vmx.copyFileIn(path.join(paths.resources, 'spin-operator.tgz'), STATIC_SPIN_OPERATOR_CHART),
       vmx.writeFile(MANIFEST_SPIN_OPERATOR_SHIM_EXECUTOR, SPIN_OPERATOR_SHIM_EXECUTOR, 0o644),
+      vmx.writeFile(MANIFEST_SPIN_OPERATOR_NAMESPACE, SPIN_OPERATOR_NAMESPACE, 0o644),
       vmx.writeFile(MANIFEST_SPIN_OPERATOR_CHART, SPIN_OPERATOR_HELM_CHART, 0o644),
     ]);
   }

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -374,12 +374,19 @@ export default class SettingsValidator {
   }
 
   protected checkSpinkube(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
-    // only validate the Spinkube option when Kubernetes is enabled
-    if (desiredValue && mergedSettings.kubernetes.enabled && !mergedSettings.experimental.containerEngine.webAssembly.enabled) {
-      errors.push(`Setting ${ fqname } can only be set when experimental.container-engine.web-assembly.enabled is set as well.`);
-      this.isFatal = true;
+    if (mergedSettings.kubernetes.enabled && desiredValue) {
+      if (!mergedSettings.experimental.containerEngine.webAssembly.enabled) {
+        errors.push(`Setting ${ fqname } can only be set when experimental.container-engine.web-assembly.enabled is set as well.`);
+        this.isFatal = true;
 
-      return false;
+        return false;
+      }
+      if (mergedSettings.kubernetes.version === '' || semver.gt('1.22.0', mergedSettings.kubernetes.version) ) {
+        errors.push(`Setting ${ fqname } requires Kubernetes 1.22 or later`);
+        this.isFatal = true;
+
+        return false;
+      }
     }
 
     return currentValue !== desiredValue;

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -381,7 +381,7 @@ export default class SettingsValidator {
 
         return false;
       }
-      if (mergedSettings.kubernetes.version === '' || semver.gt('1.22.0', mergedSettings.kubernetes.version) ) {
+      if (mergedSettings.kubernetes.version === '' || semver.gt('1.22.0', mergedSettings.kubernetes.version)) {
         errors.push(`Setting ${ fqname } requires Kubernetes 1.22 or later`);
         this.isFatal = true;
 


### PR DESCRIPTION
Create `spin-operator` namespace explicitly because older versions of `helm-controller` don't have support for creating it.

Also require Kubernetes 1.22 or later because earlier versions of k3s bundle a version of the `helm-controller` that fails to parse the `spin-operator` chart templates correctly.