### PR TITLE
UI: Prefs: Warn on spinkube

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -4891,7 +4891,8 @@ preferences:
   locked:
     tooltip: Locked due to organization's policy
   incompatibleTypeWarningPre: 'The option requires'
-  incompatibleTypeWarningPost: 'to be selected.'
+  incompatibleTypeWarningPostSelected: 'to be selected.'
+  incompatibleTypeWarningPostDisabled: 'to be unselected.'
   incompatiblePrefWarningOr: 'or'
 ##############################
 ### Integrations Page

--- a/pkg/rancher-desktop/components/IncompatiblePreferencesAlert.vue
+++ b/pkg/rancher-desktop/components/IncompatiblePreferencesAlert.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { Banner } from '@rancher/components';
 import Vue, { PropType } from 'vue';
-import { mapState } from 'vuex';
 
 import type { NavItemName } from '@pkg/config/transientSettings';
 
@@ -27,7 +26,6 @@ export default Vue.extend({
     },
   },
   computed: {
-    ...mapState('credentials', ['credentials']),
     messagePost(): string {
       switch (this.mode) {
       case 'selected':
@@ -41,14 +39,7 @@ export default Vue.extend({
   },
   methods: {
     navigate(info: CompatiblePrefs[number]) {
-      this.$store.dispatch(
-        'transientSettings/navigatePrefDialog',
-        {
-          ...this.credentials,
-          navItem: info.navItemName,
-          tab:     info.tabName,
-        },
-      );
+      (this.$root as any).navigate(info.navItemName, info.tabName);
     },
   },
 });

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -125,12 +125,16 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
         switch (mountType) {
         case MountType.NINEP:
           if (this.preferences.experimental.virtualMachine.type === VMType.VZ) {
-            compatiblePrefs.push( { prefName: VMType.QEMU, tabName: 'emulation' } );
+            compatiblePrefs.push( {
+              title: VMType.QEMU, navItemName: 'Virtual Machine', tabName: 'emulation',
+            } );
           }
           break;
         case MountType.VIRTIOFS:
           if (this.preferences.experimental.virtualMachine.type === VMType.QEMU) {
-            compatiblePrefs.push( { prefName: VMType.VZ, tabName: 'emulation' } );
+            compatiblePrefs.push( {
+              title: VMType.VZ, navItemName: 'Virtual Machine', tabName: 'emulation',
+            } );
           }
           break;
         }
@@ -183,7 +187,6 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
                     <incompatible-preferences-alert
                       v-if="option.value === preferences.experimental.virtualMachine.mount.type"
                       :compatible-prefs="option.compatiblePrefs"
-                      @update:tab="$emit('update:tab', $event)"
                     />
                   </template>
                 </radio-button>

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -187,12 +187,15 @@ export default Vue.extend({
         :is-locked="isPreferenceLocked('experimental.kubernetes.options.spinkube')"
         :is-experimental="true"
         @input="onChange('experimental.kubernetes.options.spinkube', $event)"
-      />
-      <banner v-if="spinOperatorIncompatible" color="warning">
-        Spin operator requires
-        <a href="#" @click.prevent="$root.navigate('Container Engine', 'general')">WebAssembly</a>
-        to be enabled.
-      </banner>
+      >
+        <template v-if="spinOperatorIncompatible" #below>
+          <banner color="warning">
+            Spin operator requires
+            <a href="#" @click.prevent="$root.navigate('Container Engine', 'general')">WebAssembly</a>
+            to be enabled.
+          </banner>
+        </template>
+      </rd-checkbox>
     </rd-fieldset>
   </div>
 </template>

--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -11,9 +11,7 @@ import PreferencesVirtualMachineVolumes from '@pkg/components/Preferences/Virtua
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
 import Tab from '@pkg/components/Tabbed/Tab.vue';
 import { Settings } from '@pkg/config/settings';
-import type { TransientSettings } from '@pkg/config/transientSettings';
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
-import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 import type { PropType } from 'vue';
 
@@ -47,15 +45,19 @@ export default Vue.extend({
   methods: {
     async tabSelected({ tab }: { tab: Vue.Component }) {
       if (this.activeTab !== tab.name) {
-        await this.commitPreferences(tab.name || '');
+        await this.navigateTab(tab.name || '');
       }
     },
-    async commitPreferences(tabName: string) {
+    async navigateTab(tab: string) {
+      await this.navigate('Virtual Machine', tab);
+    },
+    async navigate(navItem: string, tab: string) {
       await this.$store.dispatch(
-        'transientSettings/commitPreferences',
+        'transientSettings/navigatePrefDialog',
         {
           ...this.credentials as ServerState,
-          payload: { preferences: { navItem: { currentTabs: { 'Virtual Machine': tabName } } } } as RecursivePartial<TransientSettings>,
+          navItem,
+          tab,
         },
       );
     },
@@ -100,7 +102,6 @@ export default Vue.extend({
       <component
         :is="`preferences-virtual-machine-${ activeTab }`"
         :preferences="preferences"
-        @update:tab="commitPreferences"
         v-on="$listeners"
       />
     </div>

--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -45,11 +45,8 @@ export default Vue.extend({
   methods: {
     async tabSelected({ tab }: { tab: Vue.Component }) {
       if (this.activeTab !== tab.name) {
-        await this.navigateTab(tab.name || '');
+        await this.navigate('Virtual Machine', tab.name || '');
       }
-    },
-    async navigateTab(tab: string) {
-      await this.navigate('Virtual Machine', tab);
     },
     async navigate(navItem: string, tab: string) {
       await this.$store.dispatch(

--- a/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ContainerEngineGeneral.vue
@@ -76,12 +76,15 @@ export default Vue.extend({
         :value="preferences.experimental.containerEngine.webAssembly.enabled"
         :is-locked="isPreferenceLocked('experimental.containerEngine.webAssembly.enabled')"
         @input="onChange('experimental.containerEngine.webAssembly.enabled', $event)"
-      />
-      <banner v-if="webAssemblyIncompatible" color="warning">
-        WebAssembly must be enabled for the
-        <a href="#" @click.prevent="$root.navigate('Kubernetes')">Spin Operator</a>
-        to be installed.
-      </banner>
+      >
+        <template v-if="webAssemblyIncompatible" #below>
+          <banner color="warning">
+            WebAssembly must be enabled for the
+            <a href="#" @click.prevent="$root.navigate('Kubernetes')">Spin Operator</a>
+            to be installed.
+          </banner>
+        </template>
+      </rd-checkbox>
     </rd-fieldset>
   </div>
 </template>
@@ -91,8 +94,5 @@ export default Vue.extend({
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-.container-engine-general::v-deep .checkbox-outer-container-description {
-  font-size: 11px;
 }
 </style>

--- a/pkg/rancher-desktop/components/Preferences/ModalBody.vue
+++ b/pkg/rancher-desktop/components/Preferences/ModalBody.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 
 import Vue from 'vue';
+import { mapState } from 'vuex';
 
 import PreferencesBodyApplication from '@pkg/components/Preferences/BodyApplication.vue';
 import PreferencesBodyContainerEngine from '@pkg/components/Preferences/BodyContainerEngine.vue';
@@ -33,11 +34,28 @@ export default Vue.extend({
     },
   },
   computed: {
+    ...mapState('credentials', ['credentials']),
     normalizeNavItem(): string {
       return this.currentNavItem.toLowerCase().replaceAll(' ', '-');
     },
     componentFromNavItem(): string {
       return `preferences-body-${ this.normalizeNavItem }`;
+    },
+  },
+  mounted() {
+    (this.$root as any).navigate = this.navigate;
+  },
+  methods: {
+    navigate(navItem: string, tab: string) {
+      console.log('Navigate!', Array.from(arguments));
+      this.$store.dispatch(
+        'transientSettings/navigatePrefDialog',
+        {
+          ...this.credentials,
+          navItem,
+          tab,
+        },
+      );
     },
   },
 });

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -90,15 +90,23 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       case VMType.QEMU:
         if (this.preferences.experimental.virtualMachine.mount.type === MountType.VIRTIOFS) {
           compatiblePrefs.push(
-            { prefName: MountType.REVERSE_SSHFS, tabName: 'volumes' },
-            { prefName: MountType.NINEP, tabName: 'volumes' } );
+            {
+              title: MountType.REVERSE_SSHFS, navItemName: 'Virtual Machine', tabName: 'volumes',
+            },
+            {
+              title: MountType.NINEP, navItemName: 'Virtual Machine', tabName: 'volumes',
+            } );
         }
         break;
       case VMType.VZ:
         if (this.preferences.experimental.virtualMachine.mount.type === MountType.NINEP) {
           compatiblePrefs.push(
-            { prefName: MountType.REVERSE_SSHFS, tabName: 'volumes' },
-            { prefName: MountType.VIRTIOFS, tabName: 'volumes' } );
+            {
+              title: MountType.REVERSE_SSHFS, navItemName: 'Virtual Machine', tabName: 'volumes',
+            },
+            {
+              title: MountType.VIRTIOFS, navItemName: 'Virtual Machine', tabName: 'volumes',
+            } );
         }
         break;
       }
@@ -150,7 +158,6 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
                     <incompatible-preferences-alert
                       v-if="option.value === preferences.experimental.virtualMachine.type"
                       :compatible-prefs="option.compatiblePrefs"
-                      @update:tab="$emit('update:tab', $event)"
                     />
                   </template>
                 </radio-button>

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineVolumes.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineVolumes.vue
@@ -29,7 +29,6 @@ export default Vue.extend({
   <div class="virtual-machine-volumes">
     <mount-type-selector
       :preferences="preferences"
-      @update:tab="$emit('update:tab', $event)"
       @update="onChange"
     />
   </div>

--- a/pkg/rancher-desktop/components/form/RdCheckbox.vue
+++ b/pkg/rancher-desktop/components/form/RdCheckbox.vue
@@ -40,6 +40,7 @@ export default Vue.extend({
 <template>
   <div class="rd-checkbox-container">
     <checkbox
+      class="checkbox"
       :disabled="$attrs.disabled || isLocked"
       v-bind="$attrs"
       v-on="$listeners"
@@ -81,11 +82,25 @@ export default Vue.extend({
         </slot>
       </template>
     </checkbox>
+    <div class="checkbox-below">
+      <slot name="below" />
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
+.checkbox::v-deep .checkbox-outer-container-description {
+  font-size: 11px;
+}
 .tooltip-icon {
   margin-left: 0.25rem;
 }
+.checkbox-below {
+  margin-left: 19px;
+  font-size: 11px;
+  &:empty {
+    display: none;
+  }
+}
+
 </style>

--- a/pkg/rancher-desktop/store/transientSettings.ts
+++ b/pkg/rancher-desktop/store/transientSettings.ts
@@ -3,7 +3,7 @@ import semver from 'semver';
 
 import { ActionContext, MutationsType } from './ts-helpers';
 
-import { defaultTransientSettings, TransientSettings } from '@pkg/config/transientSettings';
+import { defaultTransientSettings, NavItemName, TransientSettings } from '@pkg/config/transientSettings';
 import type { ServerState } from '@pkg/main/commandServer/httpCommandServer';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
@@ -13,6 +13,11 @@ type Preferences = typeof defaultTransientSettings.preferences;
 
 interface CommitArgs extends ServerState {
   payload?: RecursivePartial<TransientSettings>;
+}
+
+interface NavigatePrefsDialogArgs extends ServerState {
+  navItem: NavItemName;
+  tab?: string;
 }
 
 type ExtendedTransientSettings = TransientSettings & {
@@ -80,6 +85,13 @@ export const actions = {
       'transientSettings/fetchTransientSettings',
       args,
       { root: true });
+  },
+  async navigatePrefDialog(context: TransientSettingsContext, args: NavigatePrefsDialogArgs) {
+    const commitArgs = _.omit(args, 'navItem', 'tab');
+    const { navItem, tab } = args;
+    const preferences = { navItem: { current: navItem, currentTabs: { [navItem]: tab } } };
+
+    await context.dispatch('commitPreferences', { ...commitArgs, payload: { preferences } });
   },
   setMacOsVersion({ commit }: TransientSettingsContext, macOsVersion: semver.SemVer) {
     commit('SET_MAC_OS_VERSION', macOsVersion);


### PR DESCRIPTION
If the Kubernetes Spin operator is enabled, show a warning banner if WebAssembly support is disabled. And do the same on the WebAssembly side in the same situation as well.

This entailed fixing up the incompatible preferences warning banner to make it able to navigate across pages (not just tabs).  To help with this, also expand support in the Vuex transient settings store to natively support navigation.

Fixes #6717