### PR TITLE
BATS: vm.bash: allow more time for initial WSL start

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -1,6 +1,6 @@
 wait_for_shell() {
     if is_windows; then
-        try --max 24 --delay 5 rdctl shell true
+        try --max 48 --delay 5 rdctl shell true
     else
         # Be at the root directory to avoid issues with limactl automatic
         # changing to the current directory, which might not exist.


### PR DESCRIPTION
WSL can take a while to start our distribution, especially on CI; double the number of tries to allow for this.

This actually fixes quite a few BATS failures for Windows :(