### PR TITLE
BATS: Fix `refute_service_pid`

### DIFF
--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -321,8 +321,15 @@ assert_service_pid() {
     assert_output "$expected_pid"
 }
 
+# Check that the given service does not have the given PID.  It is acceptable
+# for the service to not be running.
 refute_service_pid() {
-    ! assert_service_pid "$@"
+    local service_name=$1
+    local unexpected_pid=$2
+    run get_service_pid "$service_name"
+    if [ "$status" -eq 0 ]; then
+        refute_output "$unexpected_pid"
+    fi
 }
 
 assert_service_status() {

--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -82,14 +82,14 @@ assert_traefik_on_localhost() {
     local k3s_pid
     k3s_pid=$(get_service_pid k3s)
 
-    # Disable traefik
+    trace "Disable traefik"
     rdctl set --kubernetes.options.traefik=false
 
-    # Wait until k3s has restarted
+    trace "Wait until k3s has restarted"
     try --max 30 --delay 5 refute_service_pid k3s "${k3s_pid}"
-
     wait_for_kubelet
-    # Check if the traefik pods go down
+
+    trace "Check if the traefik pods go down"
     try --max 30 --delay 10 assert_traefik_pods_are_down
 }
 
@@ -106,14 +106,14 @@ assert_traefik_on_localhost() {
     local k3s_pid
     k3s_pid=$(get_service_pid k3s)
 
-    # Enable traefik
+    trace "Enable traefik"
     rdctl set --kubernetes.options.traefik
 
-    # Wait until k3s has restarted
+    trace "Wait until k3s has restarted"
     try --max 30 --delay 5 refute_service_pid k3s "${k3s_pid}"
-
     wait_for_kubelet
-    # Check if the traefik pods come up
+
+    trace "Check if the traefik pods come up"
     try --max 30 --delay 10 assert_traefik_pods_are_up
 }
 


### PR DESCRIPTION
When checking the service pid, we should still ensure that we have successfully obtained the pid, and then check that it's different from the given value.  We should _not_ just see a failure to get the pid and accept it as passing.

I'm also adding more `trace` calls to the traefik test, as that was the test that wasn't waiting properly but the `try` commands were ambiguous.