### PR TITLE
BATS: When we create an initial profile, set a version

### DIFF
--- a/bats/tests/helpers/profile.bash
+++ b/bats/tests/helpers/profile.bash
@@ -256,14 +256,19 @@ count_setting_segments() {
 
 # Usage: profile_jq $expr
 #
-# Applies $expr against the profile and updates it in-places.
+# Applies $expr against the profile and update it in-place.
 profile_jq() {
     local expr=$1
     local filename
     filename=$(profile_location)
-    # Need to use a temp file to avoid truncating the file before it has been read.
-    jq "$expr" "$filename" | profile_cat "${filename}.tmp"
-    profile_sudo mv "${filename}.tmp" "$filename"
+    if [ -f "$filename" ]; then
+        # Need to use a temp file to avoid truncating the file before it has been read.
+        jq "$expr" "$filename" | profile_cat "${filename}.tmp"
+        profile_sudo mv "${filename}.tmp" "$filename"
+    else
+        # The profile doesn't exist yet; create a new file.
+        echo '{}' | jq "$expr" | profile_cat "$filename"
+    fi
 }
 
 # Usage: profile_plutil $action $options

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -209,6 +209,9 @@ start_container_engine() {
         registry="ghcr.io"
     fi
     if is_true "${RD_USE_PROFILE:-}"; then
+        if ! profile_exists; then
+            create_profile
+        fi
         add_profile_int "version" 7
         if is_windows; then
             # Translate any dots in the distro name into $RD_PROTECTED_DOT (e.g. "Ubuntu-22.04")

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -209,6 +209,7 @@ start_container_engine() {
         registry="ghcr.io"
     fi
     if is_true "${RD_USE_PROFILE:-}"; then
+        add_profile_int "version" 7
         if is_windows; then
             # Translate any dots in the distro name into $RD_PROTECTED_DOT (e.g. "Ubuntu-22.04")
             # so that they are not treated as setting separator characters.

--- a/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
+++ b/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
@@ -45,7 +45,9 @@ local_setup() {
     # don't provide a --container-engine.name argument to `rdctl start`
     RD_CONTAINER_ENGINE=""
     # don't create settings.json file
-    RD_USE_PROFILE=true start_kubernetes
+    RD_USE_PROFILE=true
+    start_kubernetes
+    unset RD_USE_PROFILE
     # make sure we are not waiting for the docker context to be created
     RD_CONTAINER_ENGINE="containerd"
     wait_for_container_engine

--- a/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
+++ b/bats/tests/snapshots/restore-snapshot-after-factory-reset.bats
@@ -45,8 +45,7 @@ local_setup() {
     # don't provide a --container-engine.name argument to `rdctl start`
     RD_CONTAINER_ENGINE=""
     # don't create settings.json file
-    RD_USE_PROFILE=true
-    start_kubernetes
+    RD_USE_PROFILE=true start_kubernetes
     # make sure we are not waiting for the docker context to be created
     RD_CONTAINER_ENGINE="containerd"
     wait_for_container_engine


### PR DESCRIPTION
We no longer allow profiles with no version set; so we need to set a version when we create a profile.