### PR TITLE
BATS/containers/wasm: Fix for Windows

### DIFF
--- a/bats/tests/containers/wasm.bats
+++ b/bats/tests/containers/wasm.bats
@@ -112,11 +112,13 @@ download_shim() {
 
     local base_url="https://github.com/deislabs/containerd-wasm-shims/releases/download/v${MANUAL_VERSION}"
     local filename="containerd-wasm-shims-${version}-${shim}-linux-${ARCH}.tar.gz"
+    local host_archive
+
+    # Since we end up using curl.exe on Windows, pass the host path to curl.
+    host_archive=$(host_path "${PATH_CONTAINERD_SHIMS}/${filename}")
 
     mkdir -p "$PATH_CONTAINERD_SHIMS"
-    # On Windows, use curl from the WSL distro instead of curl.exe to ensure we
-    # have no issues with PATH_CONTAINERD_SHIMS being in Linux format.
-    command curl --location --output "${PATH_CONTAINERD_SHIMS}/${filename}" "${base_url}/${filename}"
+    curl --location --output "$host_archive" "${base_url}/${filename}"
     tar xfz "${PATH_CONTAINERD_SHIMS}/${filename}" --directory "$PATH_CONTAINERD_SHIMS"
     rm "${PATH_CONTAINERD_SHIMS}/${filename}"
 }

--- a/bats/tests/containers/wasm.bats
+++ b/bats/tests/containers/wasm.bats
@@ -43,7 +43,7 @@ shim_version() {
 @test 'verify spin shim is not installed on PATH' {
     run shim_version spin v2
     assert_failure
-    assert_output --partial "containerd-shim-spin-v2: not found"
+    assert_output --regexp 'containerd-shim-spin-v2.*(not found|No such file)'
 }
 
 hello() {
@@ -114,7 +114,9 @@ download_shim() {
     local filename="containerd-wasm-shims-${version}-${shim}-linux-${ARCH}.tar.gz"
 
     mkdir -p "$PATH_CONTAINERD_SHIMS"
-    curl --silent --location --output "${PATH_CONTAINERD_SHIMS}/${filename}" "${base_url}/${filename}"
+    # On Windows, use curl from the WSL distro instead of curl.exe to ensure we
+    # have no issues with PATH_CONTAINERD_SHIMS being in Linux format.
+    command curl --location --output "${PATH_CONTAINERD_SHIMS}/${filename}" "${base_url}/${filename}"
     tar xfz "${PATH_CONTAINERD_SHIMS}/${filename}" --directory "$PATH_CONTAINERD_SHIMS"
     rm "${PATH_CONTAINERD_SHIMS}/${filename}"
 }
@@ -124,7 +126,7 @@ download_shim() {
     download_shim wws v1
 
     rdctl shutdown
-    rdctl start
+    launch_the_application
     wait_for_container_engine
 }
 


### PR DESCRIPTION
- Error message for shim not found is slightly different.
- When downloading the shim, use `curl` inside the WSL distribution (instead of `curl.exe`) because the destination path is in Linux format.
- Do not use `rdctl start` directly; instead, use `launch_the_application` wrapper because `rdctl.exe start` doesn't return.