### PR TITLE
K3sHelper: Retry uninstalling traefik if server not ready

### DIFF
--- a/bats/tests/k8s/traefik.bats
+++ b/bats/tests/k8s/traefik.bats
@@ -1,8 +1,3 @@
-# shellcheck disable=SC2030,SC2031
-# See https://github.com/koalaman/shellcheck/issues/2431
-# https://www.shellcheck.net/wiki/SC2030 -- Modification of output is local (to subshell caused by @bats test)
-# https://www.shellcheck.net/wiki/SC2031 -- output was modified in a subshell. That change might be lost
-
 load '../helpers/load'
 
 local_setup() {

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -7,7 +7,9 @@ import stream from 'stream';
 import tls from 'tls';
 import util from 'util';
 
-import { CustomObjectsApi, KubeConfig, V1ObjectMeta, findHomeDir } from '@kubernetes/client-node';
+import {
+  CustomObjectsApi, KubeConfig, V1ObjectMeta, findHomeDir, HttpError,
+} from '@kubernetes/client-node';
 import { ActionOnInvalid } from '@kubernetes/client-node/dist/config_types';
 import _ from 'lodash';
 import { Response } from 'node-fetch';
@@ -1049,26 +1051,41 @@ export default class K3sHelper extends events.EventEmitter {
    * This exists to work around https://github.com/k3s-io/k3s/issues/5103
    */
   async uninstallTraefik(client: KubeClient) {
-    try {
-      const customApi = client.k8sClient.makeApiClient(CustomObjectsApi);
-      const { body: response } = await customApi.listNamespacedCustomObject('helm.cattle.io', 'v1', 'kube-system', 'helmcharts');
-      const charts: V1HelmChart[] = (response as any)?.items ?? [];
+    const deadline = Date.now() + 10 * 60 * 1_000;
 
-      await Promise.all(charts.filter((chart) => {
-        const annotations = chart.metadata?.annotations ?? {};
+    // If the Kubernetes server is not ready yet, we need to retry until it is.
+    // However, don't attempt that forever; only loop until we hit a deadline.
+    while (Date.now() < deadline) {
+      try {
+        const customApi = client.k8sClient.makeApiClient(CustomObjectsApi);
+        const { body: response } = await customApi.listNamespacedCustomObject('helm.cattle.io', 'v1', 'kube-system', 'helmcharts');
+        const charts: V1HelmChart[] = (response as any)?.items ?? [];
 
-        return chart.metadata?.name && (annotations['objectset.rio.cattle.io/owner-name'] === 'traefik');
-      }).map((chart) => {
-        const name = chart.metadata?.name;
+        await Promise.all(charts.filter((chart) => {
+          const annotations = chart.metadata?.annotations ?? {};
 
-        if (name) {
-          console.debug(`Will delete helm chart ${ name }`);
+          return chart.metadata?.name && (annotations['objectset.rio.cattle.io/owner-name'] === 'traefik');
+        }).map((chart) => {
+          const name = chart.metadata?.name;
 
-          return customApi.deleteNamespacedCustomObject('helm.cattle.io', 'v1', 'kube-system', 'helmcharts', name);
+          if (name) {
+            console.debug(`Will delete helm chart ${ name }`);
+
+            return customApi.deleteNamespacedCustomObject('helm.cattle.io', 'v1', 'kube-system', 'helmcharts', name);
+          }
+        }));
+
+        return;
+      } catch (ex) {
+        if (ex instanceof HttpError && ex.statusCode === 503) {
+          console.debug(`Got Service Unavailable (${ ex.body.message }), retrying...`);
+          await util.promisify(setTimeout)(1_000);
+          continue;
         }
-      }));
-    } catch (ex) {
-      console.error('Error uninstalling Traefik', ex);
+        console.error('Error uninstalling Traefik', ex);
+
+        return;
+      }
     }
   }
 

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -1087,6 +1087,8 @@ export default class K3sHelper extends events.EventEmitter {
         return;
       }
     }
+
+    console.error('Timed out uninstalling Traefik, giving up');
   }
 
   /**


### PR DESCRIPTION
The Kubernetes API might not be ready enough to handle uninstalling traefik by the time we try it; if we hit a HTTP 503, retry until it succeeds (or returns a different error code).

Since this was found while debugging BATS, it also rewrites the BATS test to try to be clearer about what we're filtering (instead of doing many uncommented greps).  Also, the shellcheck directives at the top of the file are not needed anymore.