### PR TITLE
WSL: Wait for container engine setup before starting K3s setup

### DIFF
--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -95,10 +95,15 @@ get_host() {
         local LB_IP
         local output='jsonpath={.status.loadBalancer.ingress[0].ip}'
         LB_IP=$(kubectl get service traefik --namespace kube-system --output "$output")
+        assert_not_equal "$LB_IP" "" || return
         echo "$LB_IP.sslip.io"
     else
         echo "localhost"
     fi
+}
+
+@test 'wait for traefik to get IP' {
+    try get_host >/dev/null
 }
 
 @test 'deploy ingress' {

--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -27,6 +27,19 @@ get_runtime_classes() {
     fi
 }
 
+# Get the host name to use to reach Traefik
+get_host() {
+    if is_windows; then
+        local jsonpath='jsonpath={.status.loadBalancer.ingress[0].ip}'
+        run --separate-stderr kubectl get service traefik --namespace kube-system --output "$jsonpath"
+        assert_success || return
+        assert_output || return
+        echo "$output.sslip.io"
+    else
+        echo "localhost"
+    fi
+}
+
 @test 'start k8s without wasm support' {
     factory_reset
     start_kubernetes
@@ -90,20 +103,8 @@ spec:
 EOF
 }
 
-get_host() {
-    if is_windows; then
-        local LB_IP
-        local output='jsonpath={.status.loadBalancer.ingress[0].ip}'
-        LB_IP=$(kubectl get service traefik --namespace kube-system --output "$output")
-        assert_not_equal "$LB_IP" "" || return
-        echo "$LB_IP.sslip.io"
-    else
-        echo "localhost"
-    fi
-}
-
 @test 'wait for traefik to get IP' {
-    try get_host >/dev/null
+    try get_host
 }
 
 @test 'deploy ingress' {

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1523,6 +1523,10 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           if (kubernetesVersion) {
             const version = kubernetesVersion;
 
+            // We install containerd-shims as part of the container engine installation (see
+            // BackendHelper#installContainerdShims); and we need that to finish first so that when
+            // we install Kubernetes, we can look up the set of shims in order to create
+            // RuntimeClasses for them.  (See BackendHelper#configureRuntimeClasses.)
             await this.progressTracker.action('Installing Kubernetes', 0, Promise.all([
               this.progressTracker.action('Writing K3s configuration', 50, async() => {
                 const k3sConf = {


### PR DESCRIPTION
We now install containerd shims (for e.g. wasm) as part of the container engine setup.  However, the Kubernetes setup needs to wait for that to complete first so that it can find those shims so that we can build runtime classes for them.

Explicitly wait for the container engine setup to finish before starting Kubernetes setup to account for this.  This already happens in the Lima code path (where fewer things happen in parallel).

Also adjust the WASM BATS test to wait for a valid traefik load balancer IP address before continuing, since we use it later.

It's recommended to review this PR commit-by-commit (there's only two), and to ignore whitespace at least for the first one.
