### PR TITLE
CI: Use shared steps for setting up environment

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -1,0 +1,79 @@
+name: Setup Environment
+description: >-
+  This is a composite action that is used to set up the runner for running
+  Rancher Desktop.
+
+runs:
+  using: composite
+  steps:
+  - name: "Linux: Enable KVM access"
+    if: runner.os == 'Linux'
+    shell: bash
+    run: sudo chmod a+rwx /dev/kvm
+
+  - name: "Windows: Stop unwanted services"
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: >-
+      Get-Service -ErrorAction Continue -Name
+      @('W3SVC', 'docker')
+      | Stop-Service
+
+  - name: "Windows: Update any pre-installed WSL"
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: |
+      # Sometimes this results in a HTTP 403 for some reason; in that case, we
+      # need to retry.
+      do {
+        try {
+          wsl --update
+          break
+        } catch [Exception] {
+          Write-Host $_.Exception.Message
+        }
+      } while ($true)
+
+  - name: "Windows: Install WSL2 Distribution"
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: |
+      # Set the default WSL version (we don't work with WSL1)
+      wsl --set-default-version 2
+      # Install Debian, but do not launch it
+      wsl --install Debian --no-launch
+      # Initialize Debian, without going through any first-time setup
+      debian.exe install --root
+
+  - name: "Windows: Install prerequisites in WSL"
+    if: runner.os == 'Windows'
+    shell: pwsh
+    run: >-
+      wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
+      sh -c 'apt-get update && apt-get install --yes curl'
+
+  - name: "Linux: Initialize pass"
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      # Configure the agent to allow default passwords
+      HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
+      mkdir -p "${HOMEDIR}"
+      chmod 0700 "${HOMEDIR}"
+      echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
+
+      # Create a GPG key
+      gpg --quick-generate-key --yes --batch --passphrase '' \
+        user@rancher-desktop.test default \
+        default never
+
+      # Get info about the newly created key
+      DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
+      FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
+      GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
+
+      # Save the password
+      gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
+
+      # Initialize pass
+      pass init "${FINGERPRINT}"

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -3,12 +3,6 @@ description: >-
   This is a composite action that is used to set up the runner for running
   Rancher Desktop.
 
-inputs:
-  install-wsl-distro:
-    description: Whether to install WSL distribution
-    required: false
-    default: ''
-
 runs:
   using: composite
   steps:
@@ -44,22 +38,6 @@ runs:
     if: runner.os == 'Windows'
     shell: pwsh
     run: wsl --set-default-version 2
-
-  - name: "Windows: Install WSL2 Distribution"
-    if: runner.os == 'Windows' && inputs.install-wsl-distro != ''
-    shell: pwsh
-    run: |
-      # Install Debian, but do not launch it
-      wsl --install Debian --no-launch
-      # Initialize Debian, without going through any first-time setup
-      debian.exe install --root
-
-  - name: "Windows: Install prerequisites in WSL"
-    if: runner.os == 'Windows' && inputs.install-wsl-distro != ''
-    shell: pwsh
-    run: >-
-      wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
-      sh -c 'apt-get update && apt-get install --yes curl'
 
   - name: "Linux: Initialize pass"
     if: runner.os == 'Linux'

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -3,6 +3,12 @@ description: >-
   This is a composite action that is used to set up the runner for running
   Rancher Desktop.
 
+inputs:
+  install-wsl-distro:
+    description: Whether to install WSL distribution
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -34,19 +40,22 @@ runs:
         }
       } while ($true)
 
-  - name: "Windows: Install WSL2 Distribution"
+  - name: "Windows: Finish setting up WSL"
     if: runner.os == 'Windows'
     shell: pwsh
+    run: wsl --set-default-version 2
+
+  - name: "Windows: Install WSL2 Distribution"
+    if: runner.os == 'Windows' && inputs.install-wsl-distro != ''
+    shell: pwsh
     run: |
-      # Set the default WSL version (we don't work with WSL1)
-      wsl --set-default-version 2
       # Install Debian, but do not launch it
       wsl --install Debian --no-launch
       # Initialize Debian, without going through any first-time setup
       debian.exe install --root
 
   - name: "Windows: Install prerequisites in WSL"
-    if: runner.os == 'Windows'
+    if: runner.os == 'Windows' && inputs.install-wsl-distro != ''
     shell: pwsh
     run: >-
       wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -138,6 +138,7 @@ containo
 copypac
 coredns
 corejs
+corepack
 coreutils
 crd
 credfwd

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -101,6 +101,7 @@ jobs:
         sparse-checkout-cone-mode: false
         sparse-checkout: |
           scripts/install-latest-ci.sh
+          .github/actions/setup-environment/action.yaml
           .github/workflows/bats/sanitize-artifact-name.sh
 
     - name: Install latest CI build
@@ -121,63 +122,8 @@ jobs:
         BATS_DIR: ${{ github.workspace }}/bats
         ZIP_NAME: ${{ github.workspace }}/version.txt
 
-    - name: "Linux: Enable KVM access"
-      if: runner.os == 'Linux'
-      run: sudo chmod a+rwx /dev/kvm
-
-    - name: "Windows: Stop unwanted services"
-      if: runner.os == 'Windows'
-      run: >-
-        Get-Service -ErrorAction Continue -Name
-        @('W3SVC', 'docker')
-        | Stop-Service
-
-    - name: "Windows: Update any pre-installed WSL"
-      if: runner.os == 'Windows'
-      run: wsl --update
-      continue-on-error: true
-
-    - name: "Windows: Install WSL2 Distribution"
-      if: runner.os == 'Windows'
-      run: |
-        # Set the default WSL version (we don't work with WSL1)
-        wsl --set-default-version 2
-        # Install Debian, but do not launch it
-        wsl --install Debian --no-launch
-        # Initialize Debian, without going through any first-time setup
-        debian.exe install --root
-      shell: pwsh
-
-    - name: "Windows: Install prerequisites in WSL"
-      if: runner.os == 'Windows'
-      run: >-
-        wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
-        sh -c 'apt-get update && apt-get install --yes curl'
-
-    - name: "Linux: Initialize pass"
-      if: runner.os == 'Linux'
-      run: |
-        # Configure the agent to allow default passwords
-        HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
-        mkdir -p "${HOMEDIR}"
-        chmod 0700 "${HOMEDIR}"
-        echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
-
-        # Create a GPG key
-        gpg --quick-generate-key --yes --batch --passphrase '' \
-          user@rancher-desktop.test default \
-          default never
-
-        # Get info about the newly created key
-        DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
-        FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
-        GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
-
-        # Save the password
-        gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
-
-        # Initialize pass
-        pass init "${FINGERPRINT}"
+    - name: Set up environment
+      uses: ./.github/actions/setup-environment
 
     - name: Set log directory
       shell: bash

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -124,8 +124,22 @@ jobs:
 
     - name: Set up environment
       uses: ./.github/actions/setup-environment
-      with:
-        install-wsl-distro: true
+
+    - name: "Windows: Install WSL2 Distribution"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # Install Debian, but do not launch it
+        wsl --install Debian --no-launch
+        # Initialize Debian, without going through any first-time setup
+        debian.exe install --root
+
+    - name: "Windows: Install prerequisites in WSL"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: >-
+        wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
+        sh -c 'apt-get update && apt-get install --yes curl'
 
     - name: Set log directory
       shell: bash

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -124,6 +124,8 @@ jobs:
 
     - name: Set up environment
       uses: ./.github/actions/setup-environment
+      with:
+        install-wsl-distro: true
 
     - name: Set log directory
       shell: bash

--- a/.github/workflows/release-merge-to-main.yaml
+++ b/.github/workflows/release-merge-to-main.yaml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: package.json
-    - run: corepack enable yarn # spellcheck-ignore-line
+    - run: corepack enable yarn
     - uses: actions/setup-node@v4
       with:
         node-version-file: package.json

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -34,54 +34,11 @@ jobs:
         brew update
         brew install smokris/getwindowid/getwindowid
 
-    - name: "Linux: Enable KVM access"
-      if: runner.os == 'Linux'
-      run: sudo chmod a+rwx /dev/kvm
     - name: "Linux: Install Tools"
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install graphicsmagick x11-utils mutter # spellcheck-ignore-line
-    - name: "Linux: Initialize pass"
-      if: runner.os == 'Linux'
-      run: |
-        # Configure the agent to allow default passwords
-        HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
-        mkdir -p "${HOMEDIR}"
-        chmod 0700 "${HOMEDIR}"
-        echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
-
-        # Create a GPG key
-        gpg --quick-generate-key --yes --batch --passphrase '' \
-          user@rancher-desktop.test default \
-          default never
-
-        # Get info about the newly created key
-        DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
-        FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
-        GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
-
-        # Save the password
-        gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
-
-        # Initialize pass
-        pass init "${FINGERPRINT}"
-
-    - name: "Windows: Stop unwanted services"
-      if: runner.os == 'Windows'
-      run: >-
-        Get-Service -ErrorAction Continue -Name
-        @('W3SVC', 'docker')
-        | Stop-Service
-    - name: "Windows: Update any pre-installed WSL"
-      if: runner.os == 'Windows'
-      run: wsl --update
-      continue-on-error: true
-    - name: "Windows: Install WSL2 from the Store as necessary"
-      if: runner.os == 'Windows'
-      run: wsl --install --no-distribution
-    - run: wsl --version
-      if: runner.os == 'Windows'
 
     - name: "macOS: Set startup command"
       if: runner.os == 'macOS'
@@ -114,7 +71,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: '18.16.x'
-    - run: npm install --global yarn
+    - run: corepack enable yarn
     - uses: actions/setup-node@v4
       with:
         node-version: '18.16.x'
@@ -126,6 +83,7 @@ jobs:
       with:
         go-version: '^1.21'
         cache-dependency-path: src/go/**/go.sum
+    - uses: ./.github/actions/setup-environment
     - run: pip install setuptools
     - # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
       run: yarn install --frozen-lockfile --network-timeout 1000000

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -101,34 +101,8 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: "Linux: Enable KVM access"
-      if: runner.os == 'Linux'
-      run: sudo chmod a+rwx /dev/kvm
-
-    - name: "Linux: Initialize pass"
-      if: runner.os == 'Linux'
-      run: |
-        # Configure the agent to allow default passwords
-        HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
-        mkdir -p "${HOMEDIR}"
-        chmod 0700 "${HOMEDIR}"
-        echo "allow-preset-passphrase" >> "${HOMEDIR}/gpg-agent.conf"
-
-        # Create a GPG key
-        gpg --quick-generate-key --yes --batch --passphrase '' \
-          user@rancher-desktop.test default \
-          default never
-
-        # Get info about the newly created key
-        DATA="$(gpg --batch --with-colons --with-keygrip --list-secret-keys)"
-        FINGERPRINT="$(awk -F: '/^fpr:/ { print $10 ; exit }' <<< "${DATA}")" # spellcheck-ignore-line
-        GRIP="$(awk -F: '/^grp:/ { print $10 ; exit }' <<< "${DATA}")"
-
-        # Save the password
-        gpg-connect-agent --verbose "PRESET_PASSPHRASE ${GRIP} -1 00" /bye
-
-        # Initialize pass
-        pass init "${FINGERPRINT}"
+    - name: Set up environment
+      uses: ./.github/actions/setup-environment
 
     - name: "Linux: Set startup command"
       if: runner.os == 'Linux'
@@ -137,24 +111,6 @@ jobs:
         EXEC_COMMAND: >-
           exec xvfb-run --auto-servernum
           --server-args='-screen 0 1280x960x24'
-
-    - name: "Windows: Stop unwanted services"
-      if: runner.os == 'Windows'
-      run: >-
-        Get-Service -ErrorAction Continue -Name
-        @('W3SVC', 'docker')
-        | Stop-Service
-
-    - name: "Windows: Update any pre-installed WSL"
-      if: runner.os == 'Windows'
-      run: wsl --update
-      continue-on-error: true
-
-    - name: "Windows: Set default WSL version"
-      if: runner.os == 'Windows'
-      run: |
-        wsl --set-default-version 2
-        wsl --version
 
     - name: "Windows: Install yq"
       if: runner.os == 'Windows'

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -19,23 +19,16 @@ jobs:
     timeout-minutes: 90
     runs-on: windows-latest
     steps:
-      - name: Update any pre-installed WSL
-        run: wsl --update
-        continue-on-error: true
-      - name: Install WSL2 from the Store as necessary
-        run: wsl --install --no-distribution
-      - run: wsl --version
-      - name: Stop Docker daemon
-        run: Stop-Service -Name docker
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-environment
       # For compatibility with runners without yarn, we need to install node
       # once, install yarn, then install node again to get caching.
       - uses: actions/setup-node@v4
         with:
           node-version: '18.16.x'
-      - run: npm install --global yarn
+      - run: corepack enable yarn
       - uses: actions/setup-node@v4
         with:
           node-version: '18.16.x'


### PR DESCRIPTION
This uses a local composite action to set up some shared steps needed for running Rancher Desktop in CI:

- On Linux, set up kvm permissions
- On Linux, set up `pass`
- On Windows, set up WSL (bonus fix: retry, because this sometimes gets a HTTP 403)
- On Windows, (optionally) set up Debian for running BATS &c

Fixes #6692