### PR TITLE
BATS: Record number of tries

### DIFF
--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -256,6 +256,7 @@ try() {
     while true; do
         run "$@"
         if ((status == 0 || ++count >= max)); then
+            trace "$count/$max tries: $*"
             break
         fi
         sleep "$delay"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -367,8 +367,9 @@ wait_for_container_engine() {
     try --max 30 --delay 5 rdctl api /settings
 
     if using_docker; then
+        wait_for_service_status docker started
         trace "waiting for docker context to exist"
-        try --max 30 --delay 5 docker_context_exists
+        try --max 30 --delay 10 docker_context_exists
     else
         wait_for_service_status buildkitd started
     fi


### PR DESCRIPTION
Since we're occasionally hitting retry limits in CI, this adds a trace to print how many tries were required to succeed (so we can evaluate if we need to speed things up).

I'm doing this because we are sometimes hitting the limit waiting for the docker context.  I've upped the retry delay for that, and added a wait for the docker service to be up, to ensure we're at least making more forward progress (and not just dumbly waiting longer).  It's still kind of bad, though; on macOS moby, I'm seeing:

```
# (2024-04-25T23:21:19Z: wait_for_container_engine): waiting for docker context to exist
# (2024-04-25T23:24:33Z: wait_for_container_engine): 19/30 tries: docker_context_exists
```