### PR TITLE
Lima: Drop Kubernetes endpoint from docker context

### DIFF
--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -103,7 +103,7 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
   /**
    * Start running a pre-installed version of Kubernetes.
    */
-  start(config: BackendSettings, kubernetesVersion: semver.SemVer): Promise<string>;
+  start(config: BackendSettings, kubernetesVersion: semver.SemVer): Promise<void>;
 
   /**
    * Stop the Kubernetes backend.

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -6,7 +6,6 @@ import timers from 'timers';
 import util from 'util';
 
 import semver from 'semver';
-import yaml from 'yaml';
 
 import { Architecture, BackendSettings, RestartReasons } from '../backend';
 import BackendHelper from '../backendHelper';
@@ -148,9 +147,8 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
    * Start Kubernetes.
    * @returns The Kubernetes endpoint
    */
-  async start(config_: BackendSettings, kubernetesVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<string> {
+  async start(config_: BackendSettings, kubernetesVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<void> {
     const config = this.cfg = clone(config_);
-    let k3sEndpoint = '';
 
     // Remove flannel config if necessary, before starting k3s
     if (!config.kubernetes.options.flannel) {
@@ -163,7 +161,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
       await this.vm.execCommand({ root: true }, '/sbin/rc-service', '--ifnotstarted', 'k3s', 'start');
     });
 
-    await this.progressTracker.action(
+    const aborted = await this.progressTracker.action(
       'Waiting for Kubernetes API',
       100,
       async() => {
@@ -171,7 +169,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
         while (true) {
           if (this.vm.currentAction !== Action.STARTING) {
             // User aborted
-            return;
+            return true;
           }
           try {
             await this.vm.execCommand({ expectFailure: true }, 'ls', '/etc/rancher/k3s/k3s.yaml');
@@ -182,20 +180,20 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
           }
         }
         console.debug('/etc/rancher/k3s/k3s.yaml is ready.');
+
+        return false;
       },
     );
+
+    if (aborted) {
+      return;
+    }
     await this.progressTracker.action(
       'Updating kubeconfig',
       50,
       this.k3sHelper.updateKubeconfig(
-        async() => {
-          const k3sConfigString = await this.vm.execCommand({ capture: true, root: true }, 'cat', '/etc/rancher/k3s/k3s.yaml');
-          const k3sConfig = yaml.parse(k3sConfigString);
-
-          k3sEndpoint = k3sConfig?.clusters?.[0]?.cluster?.server;
-
-          return k3sConfigString;
-        }));
+        () => this.vm.execCommand({ capture: true, root: true }, 'cat', '/etc/rancher/k3s/k3s.yaml'),
+      ));
 
     this.client = kubeClient?.() || new KubeClient();
 
@@ -245,8 +243,6 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
           await new Promise(resolve => setTimeout(resolve, 5000));
         });
     }
-
-    return k3sEndpoint;
   }
 
   async stop() {

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -182,7 +182,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     }
   }
 
-  async start(config: BackendSettings, activeVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<string> {
+  async start(config: BackendSettings, activeVersion: semver.SemVer, kubeClient?: () => KubeClient): Promise<void> {
     if (!config) {
       throw new Error('no config!');
     }
@@ -200,7 +200,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
 
     if (this.vm.currentAction !== Action.STARTING) {
       // User aborted
-      return '';
+      return;
     }
 
     await this.progressTracker.action(
@@ -270,8 +270,6 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
         'Skipping node checks, flannel is disabled',
         100, Promise.resolve({}));
     }
-
-    return '';
   }
 
   async stop() {

--- a/pkg/rancher-desktop/backend/mock.ts
+++ b/pkg/rancher-desktop/backend/mock.ts
@@ -221,7 +221,7 @@ class MockKubernetesBackend extends events.EventEmitter implements KubernetesBac
   }
 
   start() {
-    return Promise.resolve('');
+    return Promise.resolve();
   }
 
   stop() {

--- a/pkg/rancher-desktop/backend/mock_screenshots.ts
+++ b/pkg/rancher-desktop/backend/mock_screenshots.ts
@@ -6,13 +6,13 @@ import LimaKubernetesBackend from '@pkg/backend/kube/lima';
 import WSLKubernetesBackend from '@pkg/backend/kube/wsl';
 
 export class LimaKubernetesBackendMock extends LimaKubernetesBackend {
-  start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<string> {
+  start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<void> {
     return super.start(config_, kubernetesVersion, () => new KubeClientMock());
   }
 }
 
 export class WSLKubernetesBackendMock extends WSLKubernetesBackend {
-  start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<string> {
+  start(config_: BackendSettings, kubernetesVersion: semver.SemVer): Promise<void> {
     return super.start(config_, kubernetesVersion, () => new KubeClientMock());
   }
 }

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -295,9 +295,8 @@ export default class DockerDirManager {
   /**
    * Ensures that the rancher-desktop docker context exists.
    * @param socketPath Path to the rancher-desktop specific docker socket.
-   * @param kubernetesEndpoint Path to rancher-desktop Kubernetes endpoint.
    */
-  protected async ensureDockerContextFile(socketPath: string, kubernetesEndpoint?: string): Promise<void> {
+  protected async ensureDockerContextFile(socketPath: string): Promise<void> {
     if (os.platform().startsWith('win')) {
       throw new Error('ensureDockerContextFile is not on Windows');
     }
@@ -309,16 +308,8 @@ export default class DockerDirManager {
           Host:          `unix://${ socketPath }`,
           SkipTLSVerify: false,
         },
-      } as Record<string, {Host: string, SkipTLSVerify: boolean, DefaultNamespace?: string}>,
+      },
     };
-
-    if (kubernetesEndpoint) {
-      contextContents.Endpoints.kubernetes = {
-        Host:             kubernetesEndpoint,
-        SkipTLSVerify:    true,
-        DefaultNamespace: 'default',
-      };
-    }
 
     console.debug(`Updating docker context: writing to ${ this.dockerContextPath }`, contextContents);
 
@@ -351,9 +342,8 @@ export default class DockerDirManager {
    * is set in the config file according to our rules.
    * @param weOwnDefaultSocket Whether Rancher Desktop has control over the default socket.
    * @param socketPath Path to the rancher-desktop specific docker socket. Darwin/Linux only.
-   * @param kubernetesEndpoint Path to rancher-desktop Kubernetes endpoint.
    */
-  async ensureDockerContextConfigured(weOwnDefaultSocket: boolean, socketPath?: string, kubernetesEndpoint?: string): Promise<void> {
+  async ensureDockerContextConfigured(weOwnDefaultSocket: boolean, socketPath?: string): Promise<void> {
     // read current config
     const currentConfig = await this.readDockerConfig();
 
@@ -364,7 +354,7 @@ export default class DockerDirManager {
     const platform = os.platform();
 
     if ((platform === 'darwin' || platform === 'linux') && socketPath) {
-      await this.ensureDockerContextFile(socketPath, kubernetesEndpoint);
+      await this.ensureDockerContextFile(socketPath);
     }
     newConfig.currentContext = await this.getDesiredDockerContext(weOwnDefaultSocket, currentConfig.currentContext);
 


### PR DESCRIPTION
This appears to have been dropped in docker CLI v23.0 and doesn't appear to be used for anything.  Dropping this lets us write out the docker context faster (because we don't need to wait for Kubernetes to be up before writing the context out).  This should help with BATS because we can continue with testing faster.

Fixes #4548