### PR TITLE
BATS: Fix compatibility with bash 3.2

### DIFF
--- a/bats/tests/helpers/snapshots.bash
+++ b/bats/tests/helpers/snapshots.bash
@@ -3,12 +3,13 @@ delete_all_snapshots() {
     assert_success
     # On Windows, executing native Windows executables consumes stdin.
     # https://github.com/microsoft/WSL/issues/10429
-    # Work around the issue by using `run` to populate `${lines[@]}` ahead of
-    # time, so that we don't need the buffer during the loop.
+    # Therefore, we have to collect all of the names before running any `rdctl`
+    # commands.  However, on macOS (bash 3.2), we seem to have issues with array
+    # variables; as a workaround, do an unquoted iteration.
     run jq_output .name
     assert_success
-    local name
-    for name in "${lines[@]}"; do
+    local name names=$output
+    for name in $names; do
         rdctl snapshot delete "$name"
     done
     run rdctl snapshot list


### PR DESCRIPTION
It appears that on bash 3.2 (as shipped with macOS), the `${lines[@]}` array isn't being correctly populated.  As a workaround, use `$output` directly and rely on word splitting, which should still work here.

While using `run --separate-stderr` would be good here, _that_ doesn't seem to work here either (because it calls `bats_require_minimum_version` which internally fails to find `BATS_TEST_TMPDIR` on this setup).