### PR TITLE
BATS: Require bash 5

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -6,11 +6,6 @@ description: >-
 runs:
   using: composite
   steps:
-  - name: "Linux: Enable KVM access"
-    if: runner.os == 'Linux'
-    shell: bash
-    run: sudo chmod a+rwx /dev/kvm
-
   - name: "Windows: Stop unwanted services"
     if: runner.os == 'Windows'
     shell: pwsh
@@ -38,6 +33,11 @@ runs:
     if: runner.os == 'Windows'
     shell: pwsh
     run: wsl --set-default-version 2
+
+  - name: "Linux: Enable KVM access"
+    if: runner.os == 'Linux'
+    shell: bash
+    run: sudo chmod a+rwx /dev/kvm
 
   - name: "Linux: Initialize pass"
     if: runner.os == 'Linux'

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -125,6 +125,11 @@ jobs:
     - name: Set up environment
       uses: ./.github/actions/setup-environment
 
+    - name: "macOS: Install bash 5"
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install --force bash
+
     - name: "Windows: Install WSL2 Distribution"
       if: runner.os == 'Windows'
       shell: pwsh

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -84,6 +84,11 @@ call_local_function() {
 }
 
 setup_file() {
+    # We require bash 5; bash 3.2 (as shipped by macOS) seems to have
+    # compatibility issues.
+    if semver_gt 5.0.0 "$(semver "$BASH_VERSION")"; then
+        fail "Bash 5.0.0 is required; you have $BASH_VERSION"
+    fi
     # Ideally this should be printed only when using the tap formatter,
     # but I don't see a way to check for this.
     echo "# ===== $RD_TEST_FILENAME =====" >&3


### PR DESCRIPTION
This is an alternative to #6790 where we require bash 5 instead.  This also modifies the CI job to install bash 5 first.

Sample run to demonstrate that it works: https://github.com/mook-as/rd/actions/runs/8886697265/job/24400642362