### PR TITLE
BATS: When saving logs, handle dangling symlinks

### DIFF
--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -360,6 +360,12 @@ capture_logs() {
         local logdir
         logdir=$(unique_filename "${PATH_BATS_LOGS}/${RD_TEST_FILENAME}")
         mkdir -p "$logdir"
+        # On Linux/macOS, the symlinks to the lima logs might be dangling.
+        # Remove any dangling ones before doing the copy.
+        find -L "${PATH_LOGS}/" -type l \
+            -exec rm -f '{}' ';' \
+            -exec touch '{}' ';' \
+            -exec echo 'Removed dangling symlink' '{}' ';'
         cp -LR "${PATH_LOGS}/" "$logdir"
         echo "${BATS_TEST_DESCRIPTION:-teardown}" >"${logdir}/test_description"
         # Capture settings.json


### PR DESCRIPTION
On Linux/macOS, `lima.*.log` may be dangling; delete them before running `cp` to ensure it doesn't error out.

This has been tested to _not_ remove non-dangling symlinks (that is, the lima logs are sometimes not empty).