### PR TITLE
Moby: WSL: Re-implement file copy to deal with symlinks

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import stream from 'stream';
 import util from 'util';
 
 import _ from 'lodash';
+import tar from 'tar-stream';
 
 import {
   ContainerComposeExecOptions, ReadableProcess, ContainerComposeOptions,
@@ -106,11 +108,6 @@ export class MobyClient implements ContainerEngineClient {
   async copyFile(imageID: string, sourcePath: string, destinationPath: string, options?: { silent?: boolean }): Promise<void> {
     const cleanups: (() => Promise<unknown>)[] = [];
 
-    if (sourcePath.endsWith('/')) {
-      // If we're copying a directory, add "." so we don't create an extra
-      // directory.
-      sourcePath += '.';
-    }
     if (!options?.silent) {
       console.debug(`Copying ${ imageID }:${ sourcePath } to ${ destinationPath }`);
     }
@@ -126,23 +123,160 @@ export class MobyClient implements ContainerEngineClient {
         // dereference symlinks it encounters when recursively copying a file.
         // We work around this by copying it into a tarball in the VM and then
         // extracting it from there.
-        const wslDestPath = (await this.vm.execCommand({ capture: true }, '/bin/wslpath', '-u', destinationPath)).trim();
-        const archive = (await this.vm.execCommand({ capture: true }, '/bin/mktemp', '-t', 'rd-moby-cp-XXXXXX')).trim();
+        const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-moby-cp-'));
 
-        cleanups.push(() => this.vm.execCommand('/bin/rm', '-f', archive));
+        cleanups.push(() => fs.promises.rm(workDir, {
+          recursive: true, force: true, maxRetries: 3,
+        }));
+        const archive = path.join(workDir, 'archive.tar');
+        const wslArchive = (await this.vm.execCommand({ capture: true }, '/bin/wslpath', '-u', archive)).trim();
+
         await this.vm.execCommand(
           '/bin/sh', '-c',
-          `/usr/bin/docker cp '${ container }:${ sourcePath }' - > '${ archive }'`);
-        await this.vm.execCommand(
-          '/usr/bin/tar', '--extract', '--file', archive, '--dereference',
-          '--directory', wslDestPath);
+          `/usr/bin/docker cp '${ container }:${ sourcePath }' - > '${ wslArchive }'`);
+        if (sourcePath.endsWith('/')) {
+          await this.extractArchive(archive, destinationPath, sourcePath);
+        } else {
+          // If we only archived a single file, there is no prefix in the archive.
+          await this.extractArchive(archive, destinationPath);
+        }
       } else {
+        if (sourcePath.endsWith('/')) {
+          // If we're copying a directory, add "." so we don't create an extra
+          // directory.
+          sourcePath += '.';
+        }
         await this.runClient(
           ['cp', '--follow-link', `${ container }:${ sourcePath }`, destinationPath],
           console);
       }
     } finally {
       await this.runCleanups(cleanups);
+    }
+  }
+
+  /**
+   * Extract the given archive into the given directory, dereferencing symbolic
+   * links (because they are not supported on Windows).
+   * @param archive The archive to extract, as a host path.
+   * @param destination The destination directory, as a host path.
+   * @param stripPrefix A prefix to strip from the file path.
+   */
+  protected async extractArchive(archive: string, destination: string, stripPrefix = ''): Promise<void> {
+    const stripPrefixWithoutSlash = stripPrefix.replace(/^\/+/, '');
+    // Because tar is a streaming format, we need to go over it twice: first, to
+    // extract the non-linked files, and to collect all links; then again, to
+    // extract any files that were pointed to by links.
+    const links: Record<string, string> = {};
+
+    // Convert a given path to an absolute path, ensuring that it resides
+    // within the destination.
+    const absPath = (rawPath: string): string => {
+      let mungedPath = rawPath;
+
+      if (mungedPath.startsWith(stripPrefixWithoutSlash)) {
+        mungedPath = mungedPath.substring(stripPrefixWithoutSlash.length);
+      }
+      const normalized = path.normalize(path.join(destination, mungedPath));
+
+      if (/[/\\]\.\.[/\\]/.test(path.relative(destination, normalized))) {
+        throw new Error(`Error extracting archive: ${ normalized } is not in ${ destination }`);
+      }
+
+      return normalized;
+    };
+
+    for await (const entry of fs.createReadStream(archive).pipe(tar.extract())) {
+      switch (entry.header.type) {
+      case 'link': case 'symlink': {
+        const linkName = entry.header.name;
+        const realName = entry.header.linkname;
+
+        if (!realName) {
+          throw new Error(`Error extracting archive: ${ linkName } has no destination`);
+        }
+        if (realName.startsWith('/')) {
+          links[linkName] = realName;
+        } else {
+          links[linkName] = path.posix.join(path.posix.dirname(entry.header.name), realName);
+        }
+        break;
+      }
+      case 'directory': {
+        const dirName = absPath(entry.header.name);
+
+        await fs.promises.mkdir(dirName, { recursive: true });
+        console.debug(`Created directory ${ dirName }`);
+
+        break;
+      }
+      case 'file': case 'contiguous-file': {
+        const fileName = absPath(entry.header.name);
+
+        await fs.promises.mkdir(path.dirname(fileName), { recursive: true });
+        await stream.promises.finished(entry.pipe(fs.createWriteStream(fileName)));
+        console.debug(`Wrote ${ fileName }`);
+
+        break;
+      }
+      default:
+        console.info(`Ignoring unsupported file type ${ entry.header.name } (${ entry.header.type })`);
+      }
+    }
+
+    /**
+     * Mapping from link destination to the link name.
+     * @note There can be multiple links pointing to the same file.
+     */
+    const reverseLinks: Record<string, string[]> = {};
+
+    for (const linkName in links) {
+      while (links[links[linkName]]) {
+        // The link points to another link; flatten it.
+        links[linkName] = links[links[linkName]];
+      }
+
+      reverseLinks[links[linkName]] ||= [];
+      reverseLinks[links[linkName]].push(linkName);
+    }
+
+    for await (const entry of fs.createReadStream(archive).pipe(tar.extract())) {
+      const linkNames = reverseLinks[entry.header.name] ?? [];
+
+      if (linkNames.length === 0) {
+        // This entry isn't a link target
+        continue;
+      }
+      switch (entry.header.type) {
+      case 'directory':
+        await Promise.all(linkNames.map(async(linkName) => {
+          const dirName = absPath(linkName);
+
+          await fs.promises.mkdir(dirName, { recursive: true });
+          delete links[linkName];
+          console.debug(`Created directory ${ dirName }`);
+        }));
+        break;
+      case 'file': case 'contiguous-file': {
+        await Promise.all(linkNames.map(async(linkName) => {
+          const fileName = absPath(linkName);
+
+          await fs.promises.mkdir(path.dirname(fileName), { recursive: true });
+          await stream.promises.finished(entry.pipe(fs.createWriteStream(fileName)));
+          delete links[linkName];
+          console.debug(`Wrote ${ fileName } from ${ entry.header.name }`);
+        }));
+
+        break;
+      }
+      default:
+        console.info(`Ignoring unsupported file type ${ entry.header.name } (${ entry.header.type })`);
+      }
+    }
+
+    // Handle symlinks that were not found
+    for (const [linkName, linkTarget] of Object.entries(links)) {
+      console.warn(`Skipping missing link ${ linkName } -> ${ linkTarget }`);
     }
   }
 


### PR DESCRIPTION
Windows doesn't deal with symlinks; re-implement file copy manually to ensure we dereference them correctly.  We previously used `tar --dereference` but that flag only works when _creating_ the archive; it was still failing to handle dangling symlinks.  Reimplement the logic ourselves so we have better control.

This fixes the BATS test extensions/containers.