### PR TITLE
Fix spawn sometimes omitting output

### DIFF
--- a/pkg/rancher-desktop/utils/__tests__/childProcess.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/childProcess.spec.ts
@@ -19,6 +19,17 @@ describe(childProcess.spawnFile, () => {
     expect(result).not.toHaveProperty('stderr');
   });
 
+  test('returns output under stress', async() => {
+    const args = ['--version'];
+
+    await Promise.all(Array.from(Array(1000).keys()).map(async() => {
+      const result = await childProcess.spawnFile(process.execPath, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+
+      expect(result.stdout.trim()).toEqual(process.version);
+      expect(result).not.toHaveProperty('stderr');
+    }));
+  }, 180_000);
+
   test('returns error', async() => {
     const args = [makeArg(() => console.error('hello'))];
     const result = await childProcess.spawnFile(process.execPath, args, { stdio: 'pipe' });


### PR DESCRIPTION
We never actually waited for the streams to be complete before returning from the spawn helper; under stress (e.g. when running a thousand processes in parallel), we can end up with truncated output.

While the test timeout is large (3 minutes), that's only because it's significantly slower on GitHub runners; it finishes in 2 seconds for me locally.

Hopefully this will help with issues with `wslpath` sometimes failing in the same way on Windows too?