### PR TITLE
Win32: Retry recursive deletes

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -97,7 +97,7 @@ export class MobyClient implements ContainerEngineClient {
 
       return await fs.promises.readFile(tempFile, { encoding });
     } finally {
-      await fs.promises.rm(workDir, { recursive: true });
+      await fs.promises.rm(workDir, { recursive: true, maxRetries: 3 });
     }
   }
 

--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -211,7 +211,7 @@ export class NerdctlClient implements ContainerEngineClient {
       // Copy the archive to the host
       const hostWorkDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-copy-'));
 
-      cleanups.push(() => fs.promises.rm(hostWorkDir, { recursive: true }));
+      cleanups.push(() => fs.promises.rm(hostWorkDir, { recursive: true, maxRetries: 3 }));
       const hostArchive = path.join(hostWorkDir, 'copy-file.tgz');
 
       await this.vm.copyFileOut(archive, hostArchive);
@@ -321,7 +321,7 @@ export class NerdctlClient implements ContainerEngineClient {
       const archiveName = 'nerdctl-copy-in.tar';
       const hostDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-copy-in-'));
 
-      cleanups.push(() => fs.promises.rm(hostDir, { recursive: true }));
+      cleanups.push(() => fs.promises.rm(hostDir, { recursive: true, maxRetries: 3 }));
 
       const tarStream = fs.createWriteStream(path.join(hostDir, archiveName));
       const archive = tar.pack();
@@ -407,7 +407,7 @@ export class NerdctlClient implements ContainerEngineClient {
         const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-compose-'));
         const envFile = path.join(workDir, 'env.txt');
 
-        cleanups.push(() => fs.promises.rm(workDir, { recursive: true }));
+        cleanups.push(() => fs.promises.rm(workDir, { recursive: true, maxRetries: 3 }));
         await fs.promises.writeFile(envFile, envData);
 
         return {

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -485,7 +485,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     } catch (ex) {
       console.log('Error setting up data distribution:', ex);
     } finally {
-      await fs.promises.rm(workdir, { recursive: true, force: true });
+      await fs.promises.rm(workdir, { recursive: true, maxRetries: 3 });
     }
   }
 
@@ -753,7 +753,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       await this.execCommand({ distro }, 'busybox', 'cp', wslScriptPath, filePath);
       await this.execCommand({ distro }, 'busybox', 'chmod', (options?.permissions ?? 0o644).toString(8), filePath);
     } finally {
-      await fs.promises.rm(workdir, { recursive: true });
+      await fs.promises.rm(workdir, { recursive: true, maxRetries: 3 });
     }
   }
 
@@ -797,7 +797,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       await this.execCommand('chmod', 'a+x', wslScriptPath);
       await this.execCommand(wslScriptPath, ...args);
     } finally {
-      await fs.promises.rm(workdir, { recursive: true });
+      await fs.promises.rm(workdir, { recursive: true, maxRetries: 3 });
     }
   }
 
@@ -903,9 +903,9 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   protected async handleUpgrade(files: string[]) {
     for (const file of files) {
       try {
-        await fs.promises.rm(file, { force: true });
+        await fs.promises.rm(file, { force: true, maxRetries: 3 });
       } catch {
-        // ignore the err from exception, sice we are
+        // ignore the err from exception, since we are
         // removing renamed files from previous releases
       }
     }
@@ -1650,7 +1650,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
           '-C', '/usr/local/share/ca-certificates/');
       }
     } finally {
-      await fs.promises.rm(workdir, { recursive: true, force: true });
+      await fs.promises.rm(workdir, { recursive: true, maxRetries: 3 });
     }
     await this.execCommand('/usr/sbin/update-ca-certificates');
   }

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -234,7 +234,7 @@ export class ExtensionImpl implements Extension {
       await this.markInstalled(this.dir);
     } catch (ex) {
       console.error(`Failed to install extension ${ this.id }, cleaning up:`, ex);
-      await fs.promises.rm(this.dir, { recursive: true }).catch((e) => {
+      await fs.promises.rm(this.dir, { recursive: true, maxRetries: 3 }).catch((e) => {
         console.error(`Failed to cleanup extension directory ${ this.dir }`, e);
       });
       throw ex;
@@ -479,7 +479,7 @@ export class ExtensionImpl implements Extension {
     }
 
     try {
-      await fs.promises.rm(this.dir, { recursive: true });
+      await fs.promises.rm(this.dir, { recursive: true, maxRetries: 3 });
     } catch (ex: any) {
       if ((ex as NodeJS.ErrnoException).code !== 'ENOENT') {
         throw ex;

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -322,7 +322,9 @@ export default class DockerDirManager {
    */
   async clearDockerContext(): Promise<void> {
     try {
-      await fs.promises.rm(path.dirname(this.dockerContextPath), { recursive: true, force: true });
+      await fs.promises.rm(path.dirname(this.dockerContextPath), {
+        recursive: true, force: true, maxRetries: 3,
+      });
 
       const config = await this.readDockerConfig();
 


### PR DESCRIPTION
Since virus scanners may have files held open, retry deletes.  This also drops some `force: true` parameters where we just created the directory (because they will always exist).

This should fix #6839 (but we will need to confirm that with feedback).