### PR TITLE
Bumps guestAgent from v0.4.0 -> v0.4.1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerBuildx: 0.14.0
 dockerCompose: 2.27.0
 trivy: 0.51.1
 steve: 0.1.0-beta9
-guestAgent: 0.4.0
+guestAgent: 0.4.1
 rancherDashboard: desktop-v2.7.0.beta.1
 dockerProvidedCredentialHelpers: 0.8.1
 ECRCredentialHelper: 0.7.1


### PR DESCRIPTION
Update Guest Agent to [v0.4.1](https://github.com/rancher-sandbox/rancher-desktop-agent/releases/tag/v0.4.1).