### PR TITLE
Restore go.work.sum in rddepman workflow

### DIFF
--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -46,6 +46,9 @@ jobs:
       - run: pip install setuptools
       - run: yarn install --frozen-lockfile
 
+      # workaround for #6851
+      - run: git restore go.work.sum
+
       - run: yarn rddepman
         env:
           GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}


### PR DESCRIPTION
It looks like the go-setup action updates the file, which breaks the script:

```
go.work.sum: needs update
You have unstaged changes. Commit or stash them to manage dependencies.
```

Local testing:

```console
$ export GITHUB_TOKEN=…
$ go mod download

$ yarn rddepman
yarn run v1.22.22
$ node scripts/ts-wrapper.js scripts/rddepman.ts
go.work.sum: needs update
You have unstaged changes. Commit or stash them to manage dependencies.
✨  Done in 4.98s.

$ git restore go.work.sum

$ yarn rddepman
yarn run v1.22.22
$ node scripts/ts-wrapper.js scripts/rddepman.ts
kuberlr is up to date.
helm is up to date.
…
```

workaround for #6851 (not sure if we want to close it, or keep it open until we have a proper fix)