### PR TITLE
Fetch spin-shim from new repo on spinkube organization

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -20,6 +20,6 @@ mobyOpenAPISpec: "1.45"
 wix: v3.14.1
 hostSwitch: 1.2.3
 moproxy: 0.5.0
-wasmShims: 0.11.1
+spinShim: 0.14.0
 spinOperator: 0.1.0
 certManager: 1.14.5

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -560,14 +560,14 @@ export class ECRCredHelper implements Dependency, GitHubDependency {
 }
 
 export class WasmShims implements Dependency, GitHubDependency {
-  name = 'wasmShims';
-  githubOwner = 'deislabs';
-  githubRepo = 'containerd-wasm-shims';
+  name = 'spinShim';
+  githubOwner = 'spinkube';
+  githubRepo = 'containerd-shim-spin';
 
   async download(context: DownloadContext): Promise<void> {
     const arch = context.isM1 ? 'aarch64' : 'x86_64';
-    const base = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.versions.wasmShims }`;
-    const url = `${ base }/containerd-wasm-shims-v2-spin-linux-${ arch }.tar.gz`;
+    const base = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.versions.spinShim }`;
+    const url = `${ base }/containerd-shim-spin-v2-linux-${ arch }.tar.gz`;
     const destPath = path.join(context.resourcesDir, 'linux', 'internal', 'containerd-shim-spin-v2');
 
     await downloadTarGZ(url, destPath);

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -52,7 +52,7 @@ export type DependencyVersions = {
   wix: string;
   hostSwitch: string;
   moproxy: string;
-  wasmShims: string;
+  spinShim: string;
   certManager: string;
   spinOperator: string;
 };


### PR DESCRIPTION
This PR intentionally bumps the version to 0.4.0, so we can test if `rddepman` correctly detects the 0.4.1 patch release from earlier today.