### PR TITLE
BATS: Time out if rdctl gets stuck

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -129,10 +129,16 @@ jobs:
     - name: Set up environment
       uses: ./.github/actions/setup-environment
 
-    - name: "macOS: Install bash 5"
+    - name: "Linux: Install prerequisites"
+      if: runner.os == 'Linux'
+      run: >-
+        sudo DEBIAN_FRONTEND=noninteractive
+        apt-get install coreutils
+
+    - name: "macOS: Install prerequisites"
       if: runner.os == 'macOS'
       shell: bash
-      run: brew install --force bash
+      run: brew install --force bash coreutils
 
     - name: "Windows: Install WSL2 Distribution"
       if: runner.os == 'Windows'
@@ -148,7 +154,7 @@ jobs:
       shell: pwsh
       run: >-
         wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
-        sh -c 'apt-get update && apt-get install --yes curl'
+        sh -c 'apt-get update && apt-get install --yes coreutils curl'
 
     - name: Set log directory
       shell: bash

--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -68,11 +68,13 @@ limactl() {
 nerdctl() {
     "$PATH_RESOURCES/$PLATFORM/bin/nerdctl$EXE" --namespace "$CONTAINERD_NAMESPACE" "$@" | no_cr
 }
+# Run `rdctl`; if $RD_TIMEOUT is set, the value is used as the first argument to
+# the `timeout` command.
 rdctl() {
     if is_windows; then
-        "$PATH_RESOURCES/win32/bin/rdctl.exe" "$@" | no_cr
+        timeout "${RD_TIMEOUT:-0}" "$PATH_RESOURCES/win32/bin/rdctl.exe" "$@" | no_cr
     else
-        "$PATH_RESOURCES/$PLATFORM/bin/rdctl$EXE" "$@"
+        timeout "${RD_TIMEOUT:-0}" "$PATH_RESOURCES/$PLATFORM/bin/rdctl$EXE" "$@"
     fi
 }
 rdshell() {

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -82,6 +82,16 @@ using_image_allow_list() {
 : "${RD_USE_PROFILE:=false}"
 
 ########################################################################
+# RD_TIMEOUT is for internal use. It is used to configure timeouts for
+# the `rdctl` command, and should not be set outside of specific
+# commands.
+: "${RD_TIMEOUT:=}"
+
+if [[ -n $RD_TIMEOUT ]]; then
+    fatal "RD_TIMEOUT should not be set"
+fi
+
+########################################################################
 : "${RD_USE_VZ_EMULATION:=false}"
 
 using_vz_emulation() {

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -312,9 +312,9 @@ docker_context_exists() {
 
 get_service_pid() {
     local service_name=$1
-    run rdshell sh -c "RC_SVCNAME=$service_name /lib/rc/bin/service_get_value pidfile"
+    RD_TIMEOUT=10s run rdshell sh -c "RC_SVCNAME=$service_name /lib/rc/bin/service_get_value pidfile"
     assert_success || return
-    rdshell cat "$output"
+    RD_TIMEOUT=10s rdshell cat "$output"
 }
 
 assert_service_pid() {
@@ -340,7 +340,7 @@ assert_service_status() {
     local service_name=$1
     local expect=$2
 
-    run rdsudo rc-service "$service_name" status
+    RD_TIMEOUT=10s run rdsudo rc-service "$service_name" status
     # rc-service report non-zero status (3) when the service is stopped
     if [[ $expect == started ]]; then
         assert_success || return
@@ -364,7 +364,7 @@ wait_for_container_engine() {
     CALLER=$(this_function)
 
     trace "waiting for api /settings to be callable"
-    try --max 30 --delay 5 rdctl api /settings
+    RD_TIMEOUT=10s try --max 30 --delay 5 rdctl api /settings
 
     if using_docker; then
         wait_for_service_status docker started
@@ -398,7 +398,7 @@ wait_for_extension_manager() {
 # See definition of `State` in
 # pkg/rancher-desktop/backend/backend.ts for an explanation of each state.
 assert_backend_available() {
-    run rdctl api /v1/backend_state
+    RD_TIMEOUT=10s run rdctl api /v1/backend_state
     if ((status == 0)); then
         run jq_output .vmState
         case "$output" in

--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -81,13 +81,13 @@ install_extensions() {
     # Extension install doesn't work until startup is fully complete.
     wait_for_backend
 
-    run rdctl extension install "$FORBIDDEN_EXTENSION"
+    RD_TIMEOUT=120s run rdctl extension install "$FORBIDDEN_EXTENSION"
     "${refute}_success"
 
-    run rdctl extension install "$ALLOWED_EXTENSION_NAME:$FORBIDDEN_EXTENSION_TAG"
+    RD_TIMEOUT=120s run rdctl extension install "$ALLOWED_EXTENSION_NAME:$FORBIDDEN_EXTENSION_TAG"
     "${refute}_success"
 
-    run rdctl extension install "${LOCKED_EXTENSIONS_ALLOWED_LIST[0]}"
+    RD_TIMEOUT=120s run rdctl extension install "${LOCKED_EXTENSIONS_ALLOWED_LIST[0]}"
     assert_success
 }
 


### PR DESCRIPTION
In CI, it seems like BATS can get stuck waiting for the backend to be ready; that is, we end up waiting for the backend to be started, and all output ceases until the two hour global timeout.  Try setting a timeout on the `rdctl` command to see if this will un-jam the tests enough to at least fail it so we can get more useful logs.