### PR TITLE
CI: Fix retrying `wsl --update`

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -21,13 +21,8 @@ runs:
       # Sometimes this results in a HTTP 403 for some reason; in that case, we
       # need to retry.
       do {
-        try {
-          wsl --update
-          break
-        } catch [Exception] {
-          Write-Host $_.Exception.Message
-        }
-      } while ($true)
+        wsl --update
+      } while ( -not $? )
 
   - name: "Windows: Finish setting up WSL"
     if: runner.os == 'Windows'


### PR DESCRIPTION
The previous try/catch didn't seem to actually work; fix it to use exit status instead.

See sample run (where I created a workflow just to exercise this bit and ran until failure): https://github.com/mook-as/rd/actions/runs/9008880338/job/24757521625