### PR TITLE
CI: BATS: Install Rancher Desktop privileged

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -17,7 +17,7 @@ alibaba
 aliyun
 aliyunecs
 aliyunkubernetescontainerservice
-ALLUSERS
+allusers
 alpl
 alpline
 amazonec

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -75,7 +75,7 @@ jobs:
         BRANCH:       ${{ inputs.branch || github.ref_name }}
         ID:           ${{ inputs.package-id }}
         BATS_DIR:     ${{ github.workspace }}/bats
-        SKIP_INSTALL: true
+        INSTALL_MODE: skip
 
     - name: Calculate tests
       id: calculate
@@ -118,13 +118,15 @@ jobs:
         scripts/install-latest-ci.sh
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
-        OWNER:    ${{ inputs.owner || github.repository_owner }}
-        REPO:     ${{ inputs.repo || needs.get-tests.outputs.repo }}
-        BRANCH:   ${{ inputs.branch || github.ref_name }}
-        ID:       ${{ inputs.package-id }}
-        BATS_DIR: ${{ github.workspace }}/bats
-        ZIP_NAME: ${{ github.workspace }}/version.txt
+        GH_TOKEN:     ${{ github.token }}
+        OWNER:        ${{ inputs.owner || github.repository_owner }}
+        REPO:         ${{ inputs.repo || needs.get-tests.outputs.repo }}
+        BRANCH:       ${{ inputs.branch || github.ref_name }}
+        ID:           ${{ inputs.package-id }}
+        BATS_DIR:     ${{ github.workspace }}/bats
+        INSTALL_MODE: installer
+        ZIP_NAME:     ${{ github.workspace }}/version.txt
+        RD_LOCATION:  system
 
     - name: Set up environment
       uses: ./.github/actions/setup-environment

--- a/.github/workflows/bats/summarize.mjs
+++ b/.github/workflows/bats/summarize.mjs
@@ -52,13 +52,16 @@ class Run {
   /** Version string for this run. */
   get version() {
     let v = this.versionData;
-    for (const prefix of ['Rancher Desktop-', 'rancher-desktop-']) {
+    for (const prefix of ['Rancher Desktop-', 'rancher-desktop-', 'Rancher.Desktop.Setup.']) {
       if (v.startsWith(prefix)) {
         v = v.substring(prefix.length);
       }
     }
+    const suffixes = ['.msi'];
     for (const platform of ['linux', 'arm64-mac', 'mac', 'win']) {
-      const suffix = `-${ platform }.zip`;
+      suffixes.push(`-${ platform }.zip`);
+    }
+    for (const suffix of suffixes) {
       if (v.endsWith(suffix)) {
         v = v.substring(0, v.length - suffix.length);
       }

--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -15,7 +15,7 @@ run_container_with_published_port() {
 }
 
 verify_container_published_port() {
-    run try --max 9 --delay 10 curl --insecure --silent --show-error "$@"
+    run try --max 9 --delay 10 curl --insecure --verbose --show-error "$@"
     assert_success
     assert_output --partial 'Welcome to nginx!'
 }
@@ -27,12 +27,17 @@ verify_container_published_port() {
 
 @test 'container published port binding to localhost should not be accessible via 0.0.0.0' {
     skip_unless_host_ip
-    run curl --head "http://${HOST_IP}:8080"
+    run curl --verbose --head "http://${HOST_IP}:8080"
     assert_output --partial "curl: (7) Failed to connect"
 }
 
 @test 'container published port binding to 0.0.0.0' {
     skip_unless_host_ip
+    if is_windows && ! using_networking_tunnel; then
+        if ! (powershell.exe -Command 'Get-Service RancherDesktop*' 2>/dev/null | grep --quiet RancherDesktopPrivilegedService); then
+            skip "This test requires Rancher Desktop privileged service on Windows"
+        fi
+    fi
     run_container_with_published_port "8081:80"
     verify_container_published_port "http://${HOST_IP}:8081"
 }

--- a/scripts/lib/installer-win32.tsx
+++ b/scripts/lib/installer-win32.tsx
@@ -58,19 +58,19 @@ export async function buildCustomAction(): Promise<string> {
  * Given an unpacked build, produce a MSI installer.
  * @param workDir Directory in which we can write temporary work files.
  * @param appDir Directory containing extracted application zip file.
- * @param development True if we're in dev mode
+ * @param outFile Override for the file name to emit.
  * @returns The path of the built installer.
  */
-export default async function buildInstaller(workDir: string, appDir: string, development = false): Promise<string> {
+export default async function buildInstaller(workDir: string, appDir: string, outFile = ''): Promise<string> {
   const appVersion = getAppVersion(appDir);
-  const compressionLevel = development ? 'mszip' : 'high';
-  const outFile = path.join(process.cwd(), 'dist', `Rancher.Desktop.Setup.${ appVersion }.msi`);
+
+  outFile ||= path.join(process.cwd(), 'dist', `Rancher.Desktop.Setup.${ appVersion }.msi`);
 
   await writeUpdateConfig(appDir);
   const fileList = await generateFileList(appDir);
   const template = await fs.promises.readFile(path.join(process.cwd(), 'build', 'wix', 'main.wxs'), 'utf-8');
   const output = Mustache.render(template, {
-    appVersion, compressionLevel, fileList,
+    appVersion, fileList, compressionLevel: 'high',
   });
   const wixDir = path.join(process.cwd(), 'resources', 'host', 'wix');
 

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -156,10 +156,12 @@ class Builder {
 
   async buildInstaller(config: CliOptions) {
     const appDir = path.join(buildUtils.distDir, 'win-unpacked');
+    const { version } = (config.config as any).extraMetadata;
+    const installerPath = path.join(buildUtils.distDir, `Rancher.Desktop.Setup.${ version }.msi`);
 
     if (config.win && !process.argv.includes('--zip')) {
       // Only build installer if we're not asked not to.
-      await buildInstaller(buildUtils.distDir, appDir);
+      await buildInstaller(buildUtils.distDir, appDir, installerPath);
     }
   }
 


### PR DESCRIPTION
At least one test identified so far (`containers/published-ports.bats`), when run on Windows, requires the privileged service.  To make that work:

- When generating the installers (but not when doing the release signing), embed the version in the Windows installer file name like we do for the zip files.
- When doing BATS in CI, use the installer, and install it for all users (so we get the privileged service).
- Detect when the test is being run on Windows without the privileged service, and mark it as skipped.

The helper script still defaults to downloading the zip file without installing.