### PR TITLE
Add BATS test for spinkube operator

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -83,6 +83,9 @@ rdshell() {
 rdsudo() {
     rdshell sudo "$@"
 }
+spin() {
+    "$PATH_RESOURCES/$PLATFORM/bin/spin$EXE" "$@" | no_cr
+}
 wsl() {
     wsl.exe -d "$WSL_DISTRO" "$@"
 }

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -35,6 +35,18 @@ wait_for_kubelet() {
     done
 }
 
+assert_kube_deployment_available() {
+    local jsonpath="jsonpath={.status.conditions[?(@.type=='Available')].status}"
+    run --separate-stderr kubectl get deployment "$@" --output "$jsonpath"
+    assert_success || return
+    assert_output "True"
+}
+
+wait_for_kube_deployment_available() {
+    trace "waiting for deployment $*"
+    try assert_kube_deployment_available "$@"
+}
+
 get_k3s_versions() {
     if [[ $RD_K3S_VERSIONS == "all" ]]; then
         # filter out duplicates; RD only supports the latest of +k3s1, +k3s2, etc.

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -485,6 +485,28 @@ get_json_test_data() {
 
 ########################################################################
 
+@test 'try returns stdout and stderr together' {
+    run try --max 1 sh -c 'echo foo; echo bar >&2; echo baz'
+    trace "output=$output"
+    trace "stderr=${stderr:-}"
+    assert_success
+    # output is currently re-ordered that all stderr follows all stdout
+    # this is subject to change
+    assert_line -n 0 foo
+    assert_line -n 2 bar
+    assert_line -n 1 baz
+    output=${stderr:-} assert_output ''
+}
+
+@test 'try supports --separate-stderr' {
+    run --separate-stderr try --max 1 sh -c 'echo foo; echo bar >&2; echo baz'
+    trace "output=$output"
+    trace "stderr=${stderr:-}"
+    assert_success
+    assert_output $'foo\nbaz'
+    output=$stderr assert_output bar
+}
+
 @test 'try will run command at least once' {
     run try --max 0 --delay 15 inc_counter
     assert_failure

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -1,0 +1,66 @@
+load '../helpers/load'
+
+local_setup() {
+    if using_docker; then
+        skip "this test only works on containerd right now"
+    fi
+}
+
+# Get the host name to use to reach Traefik
+get_host() {
+    if is_windows; then
+        local jsonpath='jsonpath={.status.loadBalancer.ingress[0].ip}'
+        run --separate-stderr kubectl get service traefik --namespace kube-system --output "$jsonpath"
+        assert_success || return
+        assert_output || return
+        echo "${output}.sslip.io"
+    else
+        echo "localhost"
+    fi
+}
+
+@test 'start k8s with spinkube' {
+    factory_reset
+    start_kubernetes \
+        --experimental.container-engine.web-assembly.enabled \
+        --experimental.kubernetes.options.spinkube
+    wait_for_kubelet
+}
+
+@test 'wait for spinkube operator' {
+    wait_for_kube_deployment_available --namespace spin-operator spin-operator-controller-manager
+}
+
+@test 'deploy app to kubernetes' {
+    spin kube deploy --from ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
+}
+
+# TODO replace ingress with port-forwarding
+@test 'deploy ingress' {
+    kubectl apply --filename - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spin-rust-hello
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+  - host: "$(get_host)"
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: spin-rust-hello
+              port:
+                number: 80
+EOF
+}
+
+@test 'connect to app on localhost' {
+    run --separate-stderr try curl --connect-timeout 5 --fail "http://$(get_host)/hello"
+    assert_success
+    assert_output "Hello world from Spin!"
+}

--- a/resources/setup-spin
+++ b/resources/setup-spin
@@ -6,7 +6,7 @@ set -u
 resources_dir=$(dirname "$0")
 
 # We run setup-spin in the rancher-desktop distro to setup spin on the Win32 host.
-if [ "$WSL_DISTRO_NAME" = "rancher-desktop" ]; then
+if [ "${WSL_DISTRO_NAME:-}" = "rancher-desktop" ]; then
   app_data_dir=$(/bin/wslpath "$(powershell.exe -Command "Write-Output \${Env:LOCALAPPDATA}")" | tr -d "\r")
   system_root=$(/bin/wslpath "$(powershell.exe -Command "Write-Output \${Env:SystemRoot}")" | tr -d "\r")
   spin="${resources_dir}/win32/bin/spin.exe"
@@ -36,7 +36,7 @@ spin_dir="${app_data_dir}/spin"
 assert_dir_is_empty "${spin_dir}/templates"
 assert_dir_is_empty "${spin_dir}/plugins"
 
-if [ "$WSL_DISTRO_NAME" = "rancher-desktop" ]; then
+if [ "${WSL_DISTRO_NAME:-}" = "rancher-desktop" ]; then
   echo "Waiting for github.com to become resolvable"
   for _ in $(seq 30); do
     curl --head --silent http://github.com >/dev/null
@@ -58,7 +58,7 @@ install_templates() {
 
   url="https://github.com/fermyon/${repo}/archive/refs/heads/${branch}.tar.gz"
 
-  if [ "$WSL_DISTRO_NAME" = "rancher-desktop" ]; then
+  if [ "${WSL_DISTRO_NAME:-}" = "rancher-desktop" ]; then
     # Download and extract tarball on Win32 host side to avoid 9p syncing issues
     tmpdir=$(/bin/wslpath -w "$tmpdir")
     tarball=$(/bin/wslpath -w "$tarball")


### PR DESCRIPTION
Just uses `spin kube deploy …` to deploy an existing sample app and verify that it works. Uses traefik ingress because the port_forwarding API still has some unresolved challenges.

Ref #6857

Requires #6810 to be merged first, to get a working `spin` executable.