### PR TITLE
BATS test for spin cli and spinkube operator

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -34,6 +34,11 @@ runs:
     shell: bash
     run: sudo chmod a+rwx /dev/kvm
 
+  - name: "Linux: Set unprivileged port start to 80"
+    if: runner.os == 'Linux'
+    shell: bash
+    run: sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80
+
   - name: "Linux: Initialize pass"
     if: runner.os == 'Linux'
     shell: bash

--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -84,7 +84,8 @@ rdsudo() {
     rdshell sudo "$@"
 }
 spin() {
-    "$PATH_RESOURCES/$PLATFORM/bin/spin$EXE" "$@" | no_cr
+    # spin may call itself recursively, so make sure it calls the correct binary
+    PATH="$PATH_RESOURCES/$PLATFORM/bin:$PATH" "$PATH_RESOURCES/$PLATFORM/bin/spin$EXE" "$@" | no_cr
 }
 wsl() {
     wsl.exe -d "$WSL_DISTRO" "$@"

--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -1,0 +1,85 @@
+load '../helpers/load'
+
+local_setup_file() {
+    echo "$RANDOM" >"${BATS_FILE_TMPDIR}/random"
+}
+
+local_setup() {
+    if using_docker; then
+        skip "this test only works on containerd right now"
+    fi
+    if ! command -v "npm${EXE}" >/dev/null; then
+        skip "this test requires npm${EXE} to be installed and on the PATH"
+    fi
+    MY_APP=my-app
+    MY_APP_NAME="${MY_APP}-$(cat "${BATS_FILE_TMPDIR}/random")"
+    MY_APP_IMAGE="ttl.sh/${MY_APP_NAME}:15m"
+}
+
+# Get the host name to use to reach Traefik
+get_host() {
+    if is_windows; then
+        local jsonpath='jsonpath={.status.loadBalancer.ingress[0].ip}'
+        run --separate-stderr kubectl get service traefik --namespace kube-system --output "$jsonpath"
+        assert_success || return
+        assert_output || return
+        echo "${output}.sslip.io"
+    else
+        echo "localhost"
+    fi
+}
+
+@test 'start k8s with spinkube' {
+    factory_reset
+    start_kubernetes \
+        --experimental.container-engine.web-assembly.enabled \
+        --experimental.kubernetes.options.spinkube
+    wait_for_kubelet
+}
+
+@test 'create sample application' {
+    cd "$BATS_FILE_TMPDIR"
+    spin new --accept-defaults --template http-js "$MY_APP"
+    cd "$MY_APP"
+    "npm${EXE}" install
+    spin build
+    spin registry push "$MY_APP_IMAGE"
+}
+
+@test 'wait for spinkube operator' {
+    wait_for_kube_deployment_available --namespace spin-operator spin-operator-controller-manager
+}
+
+@test 'deploy app to kubernetes' {
+    spin kube deploy --from "$MY_APP_IMAGE"
+}
+
+# TODO replace ingress with port-forwarding
+@test 'deploy ingress' {
+    kubectl apply --filename - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "${MY_APP_NAME}"
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+  - host: "$(get_host)"
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: "${MY_APP_NAME}"
+              port:
+                number: 80
+EOF
+}
+
+@test 'connect to app on localhost' {
+    run --separate-stderr try curl --connect-timeout 5 --fail "http://$(get_host)"
+    assert_success
+    assert_output "Hello from JS-SDK"
+}

--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -11,6 +11,8 @@ local_setup() {
     if ! command -v "npm${EXE}" >/dev/null; then
         skip "this test requires npm${EXE} to be installed and on the PATH"
     fi
+    needs_port 80
+
     MY_APP=my-app
     MY_APP_NAME="${MY_APP}-$(cat "${BATS_FILE_TMPDIR}/random")"
     MY_APP_IMAGE="ttl.sh/${MY_APP_NAME}:15m"

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -4,6 +4,7 @@ local_setup() {
     if using_docker; then
         skip "this test only works on containerd right now"
     fi
+    needs_port 80
 }
 
 # Get the host name to use to reach Traefik


### PR DESCRIPTION
It extends on the scope of spinkube.bats by also building the app, using `spin new`, `spin build`, and `spin registry push` commands. However, it depends on a local installation of `npm`, so doesn't replace the former test.

Uses ttl.sh as a temporary registry.

Ref #6857

Requires #6810 to be merged first, to get a working `spin` executable.
Also needs #6869 to get the `spin()` function in `commands.bash` for Windows.