### PR TITLE
Make network tunnel default

### DIFF
--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -140,7 +140,7 @@ export const defaultSettings = {
         },
       },
       /** windows only: if set, use gvisor based network rather than host-resolver/dnsmasq. */
-      networkingTunnel: false,
+      networkingTunnel: true,
       proxy:            {
         enabled:  false,
         address:  '',


### PR DESCRIPTION
This allows the Rancher Desktop to start with the network tunnel as a default network. Some e2e tests are expected to fail since there will be a separate PR to address the failing tests. Ideally, this PR should be rebased again once the fixes for failing e2e tests are in place. 

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/6850