### PR TITLE
Add BATS test to verify spin plugins and templates are installed

### DIFF
--- a/bats/scripts/bats-lint.pl
+++ b/bats/scripts/bats-lint.pl
@@ -52,9 +52,9 @@ while (<>) {
         undef $run;
     }
     # Doesn't match on:
-    # - "empty lines (just whitespace)"
+    # - "empty lines (just whitespace or comment)"
     # - if ...
-    if ($run && !/^\s*(if.*)?$/) {
+    if ($run && !/^\s*(#.*|if.*)?$/) {
         print "$ARGV:$.: Expected assert or refute after\n$run\n";
         undef $run;
         $problems++;

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -16,7 +16,7 @@ wait_for_kubelet() {
         fi
 
         # Make sure the "default" serviceaccount exists
-        if ! kubectl get --namespace default serviceaccount default; then
+        if ! kubectl get --namespace default serviceaccount default &>/dev/null; then
             continue
         fi
 

--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -98,6 +98,7 @@ wslpath_from_win32_env() {
 if is_windows; then
     LOCALAPPDATA="$(wslpath_from_win32_env LOCALAPPDATA)"
     PROGRAMFILES="$(wslpath_from_win32_env ProgramFiles)"
+    SYSTEMROOT="$(wslpath_from_win32_env SystemRoot)"
 
     PATH_APP_HOME="$LOCALAPPDATA/rancher-desktop"
     PATH_CONFIG="$LOCALAPPDATA/rancher-desktop"

--- a/bats/tests/utils/spin.bats
+++ b/bats/tests/utils/spin.bats
@@ -1,0 +1,74 @@
+load '../helpers/load'
+
+# Verify that enabling Wasm support will install spin plugins and templates
+
+local_setup() {
+    if is_windows; then
+        if using_windows_exe; then
+            SPIN_DATA_DIR=$LOCALAPPDATA
+        else
+            SPIN_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+        fi
+    elif is_macos; then
+        SPIN_DATA_DIR="${HOME}/Library/Application Support"
+    elif is_linux; then
+        SPIN_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+    else
+        skip "Unknown OS: $OS"
+    fi
+    SPIN_DATA_DIR="${SPIN_DATA_DIR}/spin"
+}
+
+cmd_exe() {
+    "${SYSTEMROOT}/system32/cmd.exe" /c "$@"
+}
+
+dir_exists() {
+    if using_windows_exe; then
+        run --separate-stderr cmd_exe if exist "$(host_path "$1")" echo True
+        # Output may have trailing \r
+        [[ $output =~ ^True ]]
+    else
+        [[ -d $1 ]]
+    fi
+}
+
+@test 'delete spin plugins and templates' {
+    if using_windows_exe; then
+        run cmd_exe rmdir /s /q "$(host_path "${SPIN_DATA_DIR:?}")"
+        assert_nothing
+    else
+        rm -rf "${SPIN_DATA_DIR:?}"
+    fi
+}
+
+@test 'confirm the spin directory is gone' {
+    run dir_exists "$SPIN_DATA_DIR"
+    assert_failure
+}
+
+@test 'start container engine with wasm support enabled' {
+    factory_reset
+    start_container_engine --experimental.container-engine.web-assembly.enabled
+    wait_for_container_engine
+}
+
+@test 'plugins are installed' {
+    run dir_exists "${SPIN_DATA_DIR}/plugins/js2wasm"
+    assert_success
+    run dir_exists "${SPIN_DATA_DIR}/plugins/kube"
+    assert_success
+}
+
+@test 'templates are installed' {
+    if using_windows_exe; then
+        run --separate-stderr cmd_exe dir /b "$(host_path "${SPIN_DATA_DIR}/templates")"
+        assert_success
+    else
+        run ls -1 "${SPIN_DATA_DIR}/templates"
+        assert_success
+    fi
+    assert_line --regexp "^http-go_" # from spin
+    assert_line --regexp "^http-js_" # from spin-js-sdk
+    assert_line --regexp "^http-py_" # from spin-python-sdk
+}

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1503,7 +1503,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               await this.writeFile('/usr/local/bin/wsl-exec', WSL_EXEC, 0o755);
               await this.runInit();
               if (configureWASM) {
-                await this.execCommand(await this.wslify(executable('setup-spin')));
+                // wsl-exec is needed to correctly resolve DNS names
+                await this.execCommand('/usr/local/bin/wsl-exec', await this.wslify(executable('setup-spin')));
               }
               if (rdNetworking) {
                 // Do not await on this, as we don't want to wait until the proxy exits.


### PR DESCRIPTION
Passes BATS on CI: https://github.com/rancher-sandbox/rancher-desktop/actions/runs/9102407767


Additional manual BATS runs on Windows (with tunneling network, without using windows exes):

```console
$ RD_USE_WINDOWS_EXE=1 RD_USE_NETWORKING_TUNNEL=1 ./bats-core/bin/bats -T tests/utils/*
spin.bats
   ===== utils/spin =====
 ✓ delete spin plugins and templates [336]                                                                     Install location:         system
   Resources path:           /mnt/c/Program Files/Rancher Desktop/resources/resources

   Container engine:         containerd
   Mount type:
   Using image allow list:   false
   Using Windows executables: true
   Using networking tunnel:  true

   Capturing logs:           false
   Tracing execution:        false
   Taking screenshots:       false
   Using ghcr.io images:     false
 ✓ confirm the spin directory is gone [134]
 ✓ start container engine with wasm support enabled [55349]
 ✓ plugins are installed [254]
 ✓ templates are installed [203]

5 tests, 0 failures in 81 seconds

$ RD_USE_NETWORKING_TUNNEL=1 ./bats-core/bin/bats -T tests/utils/*
spin.bats
   ===== utils/spin =====
 ✓ delete spin plugins and templates [246]                                                                     Install location:         system
   Resources path:           /mnt/c/Program Files/Rancher Desktop/resources/resources

   Container engine:         containerd
   Mount type:
   Using image allow list:   false
   Using Windows executables: false
   Using networking tunnel:  true

   Capturing logs:           false
   Tracing execution:        false
   Taking screenshots:       false
   Using ghcr.io images:     false
 ✓ confirm the spin directory is gone [81]
 ✓ start container engine with wasm support enabled [44931]
 ✓ plugins are installed [132]
 ✓ templates are installed [200]

5 tests, 0 failures in 65 seconds
```