### PR TITLE
Upgrade go.work to go 1.22

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -34,7 +34,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version-file: go.work
           cache-dependency-path: src/go/**/go.sum
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/github-runner-monitor-build.yaml
+++ b/.github/workflows/github-runner-monitor-build.yaml
@@ -24,7 +24,7 @@ jobs:
           .github/workflows/config
     - uses: actions/setup-go@v5
       with:
-        go-version-file: src/go/github-runner-monitor/go.mod
+        go-version-file: go.work
         cache-dependency-path: src/go/github-runner-monitor/go.sum
     - run: go build .
       working-directory: src/go/github-runner-monitor

--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -31,7 +31,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version-file: go.work
           cache-dependency-path: src/go/**/go.sum
       # For now, we don't need to `pip install setuptools` because we're not on
       # Python 3.12; we will need that later, however.

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: go.work
           cache-dependency-path: src/go/**/go.sum
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -64,7 +64,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
@@ -170,7 +170,7 @@ jobs:
       run: .\scripts\windows-setup.ps1 -SkipVisualStudio -SkipTools
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - uses: actions/setup-node@v4
       with:
@@ -232,7 +232,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version-file: go.work
           cache-dependency-path: src/go/**/go.sum
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/release-merge-to-main.yaml
+++ b/.github/workflows/release-merge-to-main.yaml
@@ -42,7 +42,7 @@ jobs:
         cache: yarn
     - uses: actions/setup-go@v5
       with:
-        go-version-file: src/go/rdctl/go.mod
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
 
     - run: yarn install --frozen-lockfile

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -81,7 +81,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - uses: ./.github/actions/setup-environment
     - run: pip install setuptools

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         cache: yarn
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - run: pip install setuptools
     - run: yarn install --frozen-lockfile

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version-file: go.work
           cache-dependency-path: src/go/**/go.sum
 
       - run: pip install setuptools

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
@@ -88,7 +88,7 @@ jobs:
         cache: yarn
     - uses: actions/setup-go@v5
       with:
-        go-version: '^1.21'
+        go-version-file: go.work
         cache-dependency-path: src/go/**/go.sum
     - run: yarn install --frozen-lockfile
     - name: Download installer (msi)

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -35,7 +35,7 @@ jobs:
           cache: yarn
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version-file: go.work
           cache: 'true'
           cache-dependency-path: src/go/**/go.sum
       - uses: actions/setup-python@v5

--- a/.github/workflows/wsl-helper-build.yaml
+++ b/.github/workflows/wsl-helper-build.yaml
@@ -25,7 +25,7 @@ jobs:
         cache: yarn
     - uses: actions/setup-go@v5
       with:
-        go-version-file: src/go/wsl-helper/go.mod
+        go-version-file: go.work
         cache-dependency-path: src/go/wsl-helper/go.sum
     - run: yarn install --frozen-lockfile
     - name: Build Windows

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.22
 
 use (
 	./src/go/docker-credential-none


### PR DESCRIPTION
Upgrades go version to 1.22 since go: module [k8s.io/client-go@v0.30.1](http://k8s.io/client-go@v0.30.1) requires go >= 1.22.0 (running go 1.21.9) in [here](https://github.com/rancher-sandbox/rancher-desktop/actions/runs/9099696436/job/25012848376?pr=6892#step:10:518).