### PR TITLE
E2E: rdctl: Simplify accepting new settings

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -29,7 +29,7 @@ import yaml from 'yaml';
 
 import { NavPage } from './pages/nav-page';
 import {
-  getAlternateSetting, kubectl, retry, startSlowerDesktop, teardown, waitForRestartVM,
+  getAlternateSetting, kubectl, retry, startSlowerDesktop, teardown,
 } from './utils/TestUtils';
 
 import {
@@ -895,18 +895,9 @@ test.describe('Command server', () => {
           const result = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(oldSettings)]);
 
           expect(result.stderr).toEqual('');
-          // Have to do this because we don't have any other way to see the current missing progress bar
-          // and have the next  `progressBecomesReady` test pass prematurely.
+          const navPage = new NavPage(page);
 
-          // Wait until progress bar show up. It takes roughly ~60s to start in CI
-          const progressBar = page.locator('.progress');
-
-          await waitForRestartVM(progressBar);
-
-          // Since we just applied new settings, we must wait for the backend to restart.
-          while (await progressBar.count() > 0) {
-            await progressBar.waitFor({ state: 'detached', timeout: Math.round(240_000) });
-          }
+          await navPage.progressBecomesReady();
         });
       });
 

--- a/e2e/utils/TestUtils.ts
+++ b/e2e/utils/TestUtils.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 import util from 'util';
 
-import { expect, _electron, ElectronApplication, Locator } from '@playwright/test';
+import { expect, _electron, ElectronApplication } from '@playwright/test';
 import _, { GetFieldType } from 'lodash';
 import { Page } from 'playwright-core';
 import plist from 'plist';
@@ -283,37 +283,6 @@ export async function tool(tool: string, ...args: string[]): Promise<string> {
       stdout: ex.stdout, stderr: ex.stderr, message: ex.toString(),
     }).toBeUndefined();
     throw ex;
-  }
-}
-
-export async function waitForRestartVM(progressBar: Locator): Promise<void> {
-  const timeout = process.platform === 'win32' ? 20_000 : 20_000; // msec
-  const interval = 200; // msec
-  const startTime = new Date().valueOf();
-  let endTime = startTime + timeout;
-  const startingCaption = process.platform === 'win32' ? 'Starting WSL environment' : 'Starting virtual machine';
-  let currentCaption = '';
-  const timeStripPattern = /^(.*?)\s*(?:\d+[sm]\s*)?$/;
-
-  await progressBar.waitFor({ state: 'visible', timeout });
-  console.log(`Waiting for RD to restart the VM...`);
-  while (true) {
-    const caption: string = await progressBar.textContent() ?? '';
-
-    if (caption.startsWith(startingCaption)) {
-      console.log(`Restart detected.`);
-      break;
-    }
-    const captionBase = (timeStripPattern.exec(caption) ?? ['', caption])[1];
-    const nowTime = new Date().valueOf();
-
-    if (currentCaption !== captionBase) {
-      currentCaption = captionBase;
-      endTime = nowTime + timeout;
-    } else if (nowTime > endTime) {
-      throw new Error(`Failed to see the VM restart after ${ timeout / 1000 } seconds`);
-    }
-    await util.promisify(setTimeout)(interval);
   }
 }
 


### PR DESCRIPTION
Since `navPage.progressBecomesReady` is now based on the API and ensures that we transition through the `STARTING` state, we  no longer need the extra logic to do the same out-of-band.