### PR TITLE
CI: E2E: Always upload e2e logs

### DIFF
--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -61,7 +61,7 @@ jobs:
         timeout-minutes: 150
       - name: Upload failure reports
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: failure-reports.zip
           path: ./e2e/reports/*

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -50,7 +50,7 @@ jobs:
           RD_DEBUG_ENABLED: '1'
       - name: Upload failure reports
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: e2etest-artifacts
           path: ./e2e/reports/*


### PR DESCRIPTION
In order to debug issues where the E2E tests only pass on retries, we need to always upload the logs (so that we can see the logs from the earlier runs).