### PR TITLE
E2E: Generate unique log directories for retries

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -20,11 +20,11 @@ test.describe.serial('KubernetesBackend', () => {
   let electronApp: ElectronApplication;
   let page: Page;
 
-  test.beforeAll(async() => {
-    [electronApp, page] = await startSlowerDesktop(__filename);
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [electronApp, page] = await startSlowerDesktop(testInfo);
   });
 
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -224,9 +224,9 @@ describeWithCreds('Credentials server', () => {
 
   test.describe.configure({ mode: 'serial' });
 
-  test.beforeAll(async() => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     await tool('rdctl', 'factory-reset', '--verbose');
-    [electronApp, page] = await startSlowerDesktop(__filename, { kubernetes: { enabled: false } });
+    [electronApp, page] = await startSlowerDesktop(testInfo, { kubernetes: { enabled: false } });
   });
 
   test.afterAll(async() => {
@@ -246,7 +246,7 @@ describeWithCreds('Credentials server', () => {
     }
   });
 
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -30,7 +30,7 @@ const rdctl = getFullPathForTool('rdctl');
 // and we don't have to deal with unintended escape-sequence processing.
 const execPath = process.execPath.replace(/\\/g, '/');
 
-const console = new Log(path.basename(__filename, '.ts'), reportAsset(__filename, 'log'));
+let console: Log;
 const NAMESPACE = 'rancher-desktop-extensions';
 
 test.describe.serial('Extensions', () => {
@@ -60,14 +60,15 @@ test.describe.serial('Extensions', () => {
       });
   }
 
-  test.beforeAll(async() => {
-    [app, page] = await startSlowerDesktop(__filename, {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [app, page] = await startSlowerDesktop(testInfo, {
       containerEngine: { name: ContainerEngine.MOBY },
       kubernetes:      { enabled: false },
     });
+    console = new Log(path.basename(__filename, '.ts'), reportAsset(testInfo, 'log'));
   });
 
-  test.afterAll(() => teardown(app, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(app, testInfo));
 
   // Set things up so console messages from the UI gets logged too.
   let currentTestInfo: TestInfo;

--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -82,7 +82,7 @@ test.describe('Locked fields', () => {
     await restoreUserProfile();
   });
 
-  test.beforeAll(async() => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings({ containerEngine: { allowedImages: { enabled: true, patterns: ['a', 'b', 'c', 'e'] } } });
     await saveUserProfile();
     await setUserProfile(
@@ -93,12 +93,12 @@ test.describe('Locked fields', () => {
         kubernetes:      { version: lockedK8sVersion },
       },
     );
-    electronApp = await startRancherDesktop(__filename);
+    electronApp = await startRancherDesktop(testInfo);
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(async() => {
-    await teardown(electronApp, __filename);
+  test.afterAll(async({ colorScheme }, testInfo) => {
+    await teardown(electronApp, testInfo);
     await tool('rdctl', 'factory-reset', '--verbose');
     reopenLogs();
   });

--- a/e2e/main.e2e.spec.ts
+++ b/e2e/main.e2e.spec.ts
@@ -14,14 +14,14 @@ let page: Page;
 test.describe.serial('Main App Test', () => {
   let electronApp: ElectronApplication;
 
-  test.beforeAll(async() => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings();
 
-    electronApp = await startRancherDesktop(__filename);
+    electronApp = await startRancherDesktop(testInfo);
     page = await electronApp.firstWindow();
   });
 
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));
 
   test('should start loading the background services and hide progress bar', async() => {
     const navPage = new NavPage(page);

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -20,18 +20,18 @@ test.describe.serial('Main App Test', () => {
   let electronApp: ElectronApplication;
   let preferencesWindow: Page;
 
-  test.beforeAll(async() => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings();
 
-    electronApp = await startRancherDesktop(__filename);
+    electronApp = await startRancherDesktop(testInfo);
 
     page = await electronApp.firstWindow();
     await new NavPage(page).preferencesButton.click();
     preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
   });
 
-  test.afterAll(async() => {
-    await teardown(electronApp, __filename);
+  test.afterAll(async({ colorScheme }, testInfo) => {
+    await teardown(electronApp, testInfo);
     await tool('rdctl', 'factory-reset', '--verbose');
     reopenLogs();
   });

--- a/e2e/quit-on-close.e2e.spec.ts
+++ b/e2e/quit-on-close.e2e.spec.ts
@@ -7,31 +7,27 @@ import { createDefaultSettings, reportAsset, startRancherDesktop, teardown } fro
  * Playwright executes test in parallel by default and it will not work for our app backend loading process.
  * */
 test.describe.serial('quitOnClose setting', () => {
-  test('should quit when quitOnClose is true and window is closed', async() => {
-    const logName = `${ __filename }-quitOnCloseTrue`;
-
+  test('should quit when quitOnClose is true and window is closed', async({ colorScheme }, testInfo) => {
     createDefaultSettings({ application: { window: { quitOnClose: true } } });
-    const electronApp = await startRancherDesktop(__filename, { logName });
+    const electronApp = await startRancherDesktop(testInfo, { logVariant: 'quitOnCloseTrue' });
 
     await electronApp.firstWindow();
 
     await expect(closeWindowsAndCheckQuit(electronApp)).resolves.toBe(true);
     // Don't call teardown[App] here, because the app already exited.
-    await electronApp.context().tracing.stop({ path: reportAsset(logName, 'trace') });
+    await electronApp.context().tracing.stop({ path: reportAsset(testInfo, 'trace') });
   });
 
-  test('should not quit when quitOnClose is false and window is closed', async() => {
-    const logName = `${ __filename }-quitOnCloseFalse`;
-
+  test('should not quit when quitOnClose is false and window is closed', async({ colorScheme }, testInfo) => {
     createDefaultSettings({ application: { window: { quitOnClose: false } } });
-    const electronApp = await startRancherDesktop(__filename, { logName });
+    const electronApp = await startRancherDesktop(testInfo, { logVariant: 'quitOnCloseFalse' });
 
     try {
       await electronApp.firstWindow();
       await expect(closeWindowsAndCheckQuit(electronApp)).resolves.toBe(false);
     } finally {
       try {
-        await teardown(electronApp, __filename);
+        await teardown(electronApp, testInfo);
       } catch { }
     }
   });

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -115,11 +115,11 @@ test.describe('Command server', () => {
 
   test.describe.configure({ mode: 'serial' });
 
-  test.beforeAll(async() => {
-    [electronApp, page] = await startSlowerDesktop(__filename, { kubernetes: { enabled: true } });
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [electronApp, page] = await startSlowerDesktop(testInfo, { kubernetes: { enabled: true } });
   });
 
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));
 
   test('should load Kubernetes API', async() => {
     const navPage = new NavPage(page);

--- a/e2e/start-in-background.e2e.spec.ts
+++ b/e2e/start-in-background.e2e.spec.ts
@@ -7,23 +7,23 @@ import { createDefaultSettings, startRancherDesktop, teardown, tool } from './ut
  * Playwright executes test in parallel by default and it will not work for our app backend loading process.
  * */
 test.describe.serial('startInBackground setting', () => {
-  test('window should appear when startInBackground is false', async() => {
+  test('window should appear when startInBackground is false', async({ colorScheme }, testInfo) => {
     createDefaultSettings({ application: { startInBackground: false } });
-    const logName = `${ __filename }-startInBackgroundFalse`;
-    const electronApp = await startRancherDesktop(__filename, { logName });
+    const logVariant = `startInBackgroundFalse`;
+    const electronApp = await startRancherDesktop(testInfo, { logVariant });
 
     await expect(checkWindowOpened(electronApp)).resolves.toBe(true);
-    await teardown(electronApp, logName);
+    await teardown(electronApp, testInfo);
   });
 
-  test('window should not appear when startInBackground is true', async() => {
+  test('window should not appear when startInBackground is true', async({ colorScheme }, testInfo) => {
     createDefaultSettings({ application: { startInBackground: true } });
-    const logName = `${ __filename }-startInBackgroundTrue`;
-    const electronApp = await startRancherDesktop(__filename, { logName });
+    const logVariant = `startInBackgroundTrue`;
+    const electronApp = await startRancherDesktop(testInfo, { logVariant });
 
     await expect(checkWindowOpened(electronApp)).resolves.toBe(false);
     await tool('rdctl', 'set', '--application.start-in-background=false');
-    await teardown(electronApp, logName);
+    await teardown(electronApp, testInfo);
   });
 });
 

--- a/e2e/wsl-integrations.e2e.spec.ts
+++ b/e2e/wsl-integrations.e2e.spec.ts
@@ -164,10 +164,10 @@ test.describe('WSL Integrations', () => {
     }
   });
 
-  test.beforeAll(async() => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings();
 
-    electronApp = await startRancherDesktop(__filename, {
+    electronApp = await startRancherDesktop(testInfo, {
       env: {
         PATH:             path.join(workdir, 'system32') + path.delimiter + process.env.PATH,
         RD_TEST_WSL_EXE:  path.join(workdir, 'system32', 'wsl.exe'),
@@ -179,7 +179,7 @@ test.describe('WSL Integrations', () => {
     await new NavPage(page).preferencesButton.click();
     preferencesWindow = await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
   });
-  test.afterAll(() => teardown(electronApp, __filename));
+  test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));
 
   test('should open preferences modal', async() => {
     expect(preferencesWindow).toBeDefined();

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -21,7 +21,7 @@ import type { ElectronApplication, Page } from '@playwright/test';
 
 const isWin = os.platform() === 'win32';
 const isMac = os.platform() === 'darwin';
-const console = new Log(path.basename(__filename, '.ts'), reportAsset(__filename, 'log'));
+let console: Log;
 
 test.describe.serial('Main App Test', () => {
   let electronApp: ElectronApplication;
@@ -30,7 +30,7 @@ test.describe.serial('Main App Test', () => {
   let screenshot: MainWindowScreenshots;
   const afterCheckedTimeout = 200;
 
-  test.beforeAll(async({ colorScheme }) => {
+  test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings({
       application:     { updater: { enabled: false } },
       containerEngine: {
@@ -45,7 +45,8 @@ test.describe.serial('Main App Test', () => {
       {},
     );
 
-    electronApp = await startRancherDesktop(__filename, { mock: false });
+    electronApp = await startRancherDesktop(testInfo, { mock: false });
+    console = new Log(path.basename(__filename, '.ts'), reportAsset(testInfo, 'log'));
 
     page = await electronApp.firstWindow();
     navPage = new NavPage(page);
@@ -69,12 +70,12 @@ test.describe.serial('Main App Test', () => {
     await expect(navExtension).toBeVisible({ timeout: 30000 });
   });
 
-  test.afterAll(async({ colorScheme }) => {
+  test.afterAll(async({ colorScheme }, testInfo) => {
     await clearUserProfile();
     await tool('rdctl', 'extension', 'uninstall', 'ghcr.io/rancher-sandbox/epinio-desktop-extension');
     await tool('rdctl', 'extension', 'uninstall', 'docker/logs-explorer-extension');
 
-    return teardown(electronApp, __filename);
+    return teardown(electronApp, testInfo);
   });
 
   test.describe('Main Page', () => {


### PR DESCRIPTION
- When doing E2E tests, ensure we have a unique name for each attempt (when playwright is set to do retries) so that we can get the logs for the previous runs, instead of them being clobbered when the next attempt was started.
- As part of this, we need to pass in the `playwright.TestInfo` to `startRancherDesktop` and `teardown` instead of just the test path.  This is so it has the retry count.
- This also means updating the profile-related helpers to thread the information through.