### PR TITLE
install-containerd-shims: Silence chmod errors

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/install-containerd-shims
+++ b/pkg/rancher-desktop/assets/scripts/install-containerd-shims
@@ -15,7 +15,11 @@ for dir in "$@"; do
 done
 
 # Make sure all shims are executable.
-chmod 755 "${dest}/"* || :
+for file in "${dest}/"*; do
+  if [ -e "$file" ]; then
+    chmod 755 "$file"
+  fi
+done
 
 # Create symlinks to each shim into /usr/local/bin.
 # In the future this will enable us putting only shims from an allow list on the PATH.


### PR DESCRIPTION
If the files do not exist, running `chmod` on them will result in error messages that we ignore.  These end up as red herrings when chasing down issues; it is better to ensure they do not show up at all.