### PR TITLE
WSL: Terminate network-setup on stop

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -371,6 +371,7 @@ keyout
 Kgm
 kiali
 kib
+killall
 kiwano
 KNOWNFOLDERID
 kontainer

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1742,7 +1742,10 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         const initProcess = this.process;
 
         this.process = null;
-        initProcess?.kill('SIGTERM');
+        if (initProcess) {
+          initProcess.kill('SIGTERM');
+          await this.execCommand('/usr/bin/killall', '-q', '/usr/local/bin/network-setup');
+        }
         await this.hostSwitchProcess.stop();
         if (await this.isDistroRegistered({ runningOnly: true })) {
           await this.execWSL('--terminate', INSTANCE_NAME);


### PR DESCRIPTION
This is needed to ensure that network-setup has the chance to gracefully shut down.  Note that we suppress errors if the process was not found, so it is safe to run even when network tunnel is not in use.

Note that this isn't all that useful until we pick up https://github.com/rancher-sandbox/rancher-desktop-networking/pull/24 but that can happen independently — there's no ill effect from merging this first.