### PR TITLE
Wait for traefik before calling get_host()

### DIFF
--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -7,25 +7,13 @@ local_setup() {
     needs_port 80
 }
 
-# Get the host name to use to reach Traefik
-get_host() {
-    if is_windows; then
-        local jsonpath='jsonpath={.status.loadBalancer.ingress[0].ip}'
-        run --separate-stderr kubectl get service traefik --namespace kube-system --output "$jsonpath"
-        assert_success || return
-        assert_output || return
-        echo "${output}.sslip.io"
-    else
-        echo "localhost"
-    fi
-}
-
 @test 'start k8s with spinkube' {
     factory_reset
     start_kubernetes \
         --experimental.container-engine.web-assembly.enabled \
         --experimental.kubernetes.options.spinkube
     wait_for_kubelet
+    wait_for_traefik
 }
 
 @test 'wait for spinkube operator' {
@@ -38,6 +26,9 @@ get_host() {
 
 # TODO replace ingress with port-forwarding
 @test 'deploy ingress' {
+    local host
+    host=$(traefik_hostname)
+
     kubectl apply --filename - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -47,7 +38,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
 spec:
   rules:
-  - host: "$(get_host)"
+  - host: "${host}"
     http:
       paths:
         - path: /
@@ -61,7 +52,10 @@ EOF
 }
 
 @test 'connect to app on localhost' {
-    run --separate-stderr try curl --connect-timeout 5 --fail "http://$(get_host)/hello"
+    local host
+    host=$(traefik_hostname)
+
+    run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}/hello"
     assert_success
     assert_output "Hello world from Spin!"
 }


### PR DESCRIPTION
On Windows get_host() gets the IP address from the traefik service, and will fail with an empty return value if the service is not yet ready.

The assert failures in get_host() don't cause a direct test failure if $(get_host) is just interpolated into a string, so it needs to be called once by itself.

Sample failure that should be fixed by this: https://github.com/rancher-sandbox/rancher-desktop/actions/runs/9104774312/job/25029228803

Note that the `wasm.bats` test already had this check: https://github.com/rancher-sandbox/rancher-desktop/blob/7bffdd78a78f664ac9565025a552e68d43a4f2de/bats/tests/k8s/wasm.bats#L105-L107