### PR TITLE
Fix check for Wasm runtimeclasses

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -140,7 +140,7 @@ coredns
 corejs
 corepack
 coreutils
-crd
+crds
 credfwd
 credhelper
 cri
@@ -666,6 +666,7 @@ runbook
 runc
 rundir
 RUnlock
+runtimeclass
 runtimeclasses
 runtimes
 rvf

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -289,6 +289,24 @@ launch_the_application() {
     fi
 }
 
+# Write a provisioning script that will be executed during VM startup.
+# Only a single script can be defined, and scripts are deleted by factory-reset.
+# The script must be provided via STDIN and not as a parameter.
+provisioning_script() {
+    if is_windows; then
+        mkdir -p "$PATH_APP_HOME/provisioning"
+        cat >"$PATH_APP_HOME/provisioning/bats.start"
+    else
+        mkdir -p "$LIMA_HOME/_config"
+        cat <<EOF >"$LIMA_HOME/_config/override.yaml"
+provision:
+- mode: system
+  script: |
+$(sed 's/^/    /')
+EOF
+    fi
+}
+
 get_container_engine_info() {
     run ctrctl info
     echo "$output"

--- a/pkg/rancher-desktop/assets/scripts/install-k3s
+++ b/pkg/rancher-desktop/assets/scripts/install-k3s
@@ -43,10 +43,12 @@ ln -s -f "${K3S_DIR}/${K3S}" /usr/local/bin/k3s
 chmod a+x "${K3S_DIR}/${K3S}" || true
 
 # Make sure any old manifests are removed before configuring k3s again.
+# All Rancher Desktop manifest have a name like z123-foo-bar, so only delete
+# those. That way provisioning scripts can still create other manifests.
 # We need to create the directory before we run `k3s server ...` because
 # we install additional manifests that k3s will install during startup.
 MANIFESTS=/var/lib/rancher/k3s/server/manifests
-rm -rf "$MANIFESTS"
+rm -rf "$MANIFESTS/z[0-9]*"
 mkdir -p "$MANIFESTS"
 
 STATIC=/var/lib/rancher/k3s/server/static/rancher-desktop

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -23,7 +23,7 @@ const DOCKER_DAEMON_JSON = '/etc/docker/daemon.json';
 
 const MANIFEST_DIR = '/var/lib/rancher/k3s/server/manifests';
 // Manifests are applied in sort order, so use a prefix to load them last, in the required sequence.
-// Also: don't use `runtimes.yaml` because k3s may overwrite it.
+// Names should start with `z` followed by a digit, so that `install-k3s` cleans them up on restart.
 const MANIFEST_RUNTIMES_YAML = `${ MANIFEST_DIR }/z100-runtimes.yaml`;
 const MANIFEST_CERT_MANAGER = `${ MANIFEST_DIR }/z110-cert-manager.yaml`;
 const MANIFEST_SPIN_OPERATOR_CRDS = `${ MANIFEST_DIR }/z120-spin-operator.crds.yaml`;

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1510,8 +1510,12 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               await this.writeFile('/usr/local/bin/wsl-exec', WSL_EXEC, 0o755);
               await this.runInit();
               if (configureWASM) {
-                // wsl-exec is needed to correctly resolve DNS names
-                await this.execCommand('/usr/local/bin/wsl-exec', await this.wslify(executable('setup-spin')));
+                try {
+                  // wsl-exec is needed to correctly resolve DNS names
+                  await this.execCommand('/usr/local/bin/wsl-exec', await this.wslify(executable('setup-spin')));
+                } catch {
+                  // just ignore any errors; all the script does is installing spin plugins and templates
+                }
               }
               if (rdNetworking) {
                 // Do not await on this, as we don't want to wait until the proxy exits.


### PR DESCRIPTION
The old code assumed that the classes were defined in an rd-runtimes.yaml file, but that has been changed to z100-runtimes.yaml. Therefore waiting for traefik crds no longer makes sense, as their manifest is nor applied earlier.

Creating a zzzz-bats.yaml manifest with a provisioning script instead, and restrict the range of manifests being cleaned to those defined by Rancher Desktop itself.