### PR TITLE
Fix RD_USE_NETWORKING_TUNNEL=false

### DIFF
--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -114,7 +114,7 @@ if using_windows_exe && ! is_windows; then
 fi
 
 ########################################################################
-: "${RD_USE_NETWORKING_TUNNEL:=false}"
+: "${RD_USE_NETWORKING_TUNNEL:=$(bool is_windows)}"
 
 using_networking_tunnel() {
     is_true "$RD_USE_NETWORKING_TUNNEL"

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -191,8 +191,8 @@ start_container_engine() {
             --experimental.virtual-machine.mount.9p.security-model="$RD_9P_SECURITY_MODEL"
         )
     fi
-    if using_networking_tunnel; then
-        args+=(--experimental.virtual-machine.networking-tunnel)
+    if is_windows; then
+        args+=("--experimental.virtual-machine.networking-tunnel=$(bool using_networking_tunnel)")
     fi
     if using_vz_emulation; then
         args+=(--experimental.virtual-machine.type vz)


### PR DESCRIPTION
The old code relied on the default being false, so only passed the option to the app when RD_USE_NETWORKING_TUNNEL was true. Since the app default has changed, this means we could no longer test the legacy mode.

This commit also changes the default for RD_USE_NETWORKING_TUNNEL to true to match the default app setting.