### PR TITLE
Use vEthernet IP address instead of traefik service IP address

### DIFF
--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -57,9 +57,18 @@ traefik_ip() {
 
 traefik_hostname() {
     if is_windows; then
-        local ip
-        ip=$(traefik_ip) || return
-        echo "${ip}.sslip.io"
+        # BUG BUG BUG
+        # Currently the service ip address is not routable from the host
+        # https://github.com/rancher-sandbox/rancher-desktop/issues/6934
+        # BUG BUG BUG
+
+        # local ip
+        # ip=$(traefik_ip) || return
+        # echo "${ip}.sslip.io"
+
+        # caller must have called `skip_unless_host_ip`
+        output=$HOST_IP assert_output
+        echo "${HOST_IP}.sslip.io"
     else
         echo "localhost"
     fi

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -14,6 +14,11 @@ local_setup() {
 }
 
 deploy_rancher() {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     helm upgrade \
         --install cert-manager jetstack/cert-manager \
         --namespace cert-manager \
@@ -35,6 +40,11 @@ deploy_rancher() {
 }
 
 verify_rancher() {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname) || return
 

--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -46,6 +46,11 @@ local_setup() {
 
 # TODO replace ingress with port-forwarding
 @test 'deploy ingress' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 
@@ -72,6 +77,11 @@ EOF
 }
 
 @test 'connect to app on localhost' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -26,6 +26,11 @@ local_setup() {
 
 # TODO replace ingress with port-forwarding
 @test 'deploy ingress' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 
@@ -52,6 +57,11 @@ EOF
 }
 
 @test 'connect to app on localhost' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 

--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -104,6 +104,11 @@ EOF
 }
 
 @test 'deploy ingress' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 
@@ -141,6 +146,11 @@ EOF
 }
 
 @test 'connect to the service' {
+    # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
+    if is_windows; then
+        skip_unless_host_ip
+    fi
+
     local host
     host=$(traefik_hostname)
 


### PR DESCRIPTION
The external node ip address on Windows is not routable from the host, so does not work for BATS. Explicitly look up the vEthernet address until this is fixed.

See https://github.com/rancher-sandbox/rancher-desktop/issues/6934