### PR TITLE
Set default rancher image tag to lowest version compatible with k8s version

### DIFF
--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -1,6 +1,12 @@
 load '../helpers/load'
 RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.
 
+local_setup() {
+    if [[ -z $RD_RANCHER_IMAGE_TAG ]]; then
+        skip "RD_RANCHER_IMAGE_TAG is not set"
+    fi
+}
+
 @test 'factory reset' {
     factory_reset
 }

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -18,7 +18,24 @@ using_docker() {
 : "${RD_KUBERNETES_PREV_VERSION:=1.22.7}"
 
 ########################################################################
-: "${RD_RANCHER_IMAGE_TAG:=v2.7.0}"
+: "${RD_RANCHER_IMAGE_TAG:=}"
+
+# We default to the oldest Rancher version compatible with this k8s version
+if semver_lt "$RD_KUBERNETES_PREV_VERSION" 1.29.0; then
+    RD_RANCHER_IMAGE_TAG=v2.8.3
+fi
+if semver_lt "$RD_KUBERNETES_PREV_VERSION" 1.28.0; then
+    RD_RANCHER_IMAGE_TAG=v2.8.0
+fi
+if semver_lt "$RD_KUBERNETES_PREV_VERSION" 1.27.0; then
+    RD_RANCHER_IMAGE_TAG=v2.7.5
+fi
+if semver_lt "$RD_KUBERNETES_PREV_VERSION" 1.26.0; then
+    RD_RANCHER_IMAGE_TAG=v2.7.2
+fi
+if semver_lt "$RD_KUBERNETES_PREV_VERSION" 1.25.0; then
+    RD_RANCHER_IMAGE_TAG=v2.6.7
+fi
 
 ########################################################################
 # Defaults to true, except in the helper unit tests, which default to false

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -45,5 +45,8 @@ show_info() { # @test
         printf "$format" "Tracing execution:" "$(bool is_true "$RD_TRACE")"
         printf "$format" "Taking screenshots:" "$(bool taking_screenshots)"
         printf "$format" "Using ghcr.io images:" "$(bool using_ghcr_images)"
+        echo "#"
+        printf "$format" "Kubernetes version:" "$RD_KUBERNETES_PREV_VERSION"
+        printf "$format" "Rancher image tag:" "$RD_RANCHER_IMAGE_TAG"
     ) >&3
 }

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -4,6 +4,9 @@ load '../helpers/load'
 RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.
 
 local_setup() {
+    if [[ -z $RD_RANCHER_IMAGE_TAG ]]; then
+        skip "RD_RANCHER_IMAGE_TAG is not set"
+    fi
     needs_port 443
 }
 


### PR DESCRIPTION
The current hard-coded default does not work for k3s 1.25 or higher


I've looked up the max supported version for each Rancher version by parsing the helm repo index:

```bash
y2j <rancher-latest-index.yaml | jq '.entries.rancher[] | select(has("kubeVersion") and (.version | test("-rc") | not)) | "\(.version) \(.kubeVersion)"'
```