### PR TITLE
Allow changing networkingTunnel option on all platforms

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -124,7 +124,13 @@ export default class SettingsValidator {
             },
           },
           socketVMNet:      this.checkPlatform('darwin', this.checkBoolean),
-          networkingTunnel: this.checkPlatform('win32', this.checkBoolean),
+          // networkingTunnel only applies to Win32, but deployment profiles on macOS/Linux may still include
+          // the setting. Since we changed the default value, this would now throw a validation error.
+          // see https://github.com/rancher-sandbox/rancher-desktop/issues/6953
+          // The setting will be removed once the legacy Windows networking mode is disabled, so until
+          // then we will allow changing the setting on all platforms to avoid the profile error.
+          // Changing the setting will have no effect on macOS/Linux anyways.
+          networkingTunnel: this.checkBoolean,
           useRosetta:       this.checkPlatform('darwin', this.checkRosetta),
           type:             this.checkPlatform('darwin', this.checkMulti(
             this.checkEnum(...Object.values(VMType)),


### PR DESCRIPTION
This avoids old deployment profiles on macOS/Linux throwing an error because they include this setting, that does not apply to those platforms. But since we changed the default value for this value it would cause a validation error.

Fixes #6953