### PR TITLE
WSL: spawn() via wsl-exec

### DIFF
--- a/pkg/rancher-desktop/backend/backend.ts
+++ b/pkg/rancher-desktop/backend/backend.ts
@@ -221,6 +221,7 @@ export interface VMExecutor {
   /**
    * spawn the given command in the virtual machine, returning the child
    * process itself.
+   * @note On Windows, this will be within the network / pid namespace.
    * @param options Execution options.
    * @param command The command to execute.
    */

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1052,7 +1052,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
   spawn(...command: string[]): childProcess.ChildProcess;
   spawn(options: execOptions, ...command: string[]): childProcess.ChildProcess;
   spawn(optionsOrCommand: execOptions | string, ...command: string[]): childProcess.ChildProcess {
-    const args = ['--distribution', INSTANCE_NAME, '--exec'];
+    const args = ['--distribution', INSTANCE_NAME, '--exec', '/usr/local/bin/wsl-exec'];
 
     if (typeof optionsOrCommand === 'string') {
       args.push(optionsOrCommand);

--- a/pkg/rancher-desktop/main/imageEvents.ts
+++ b/pkg/rancher-desktop/main/imageEvents.ts
@@ -154,6 +154,7 @@ export class ImageEventHandler {
         code = (await this.imageProcessor.scanImage(taggedImageName)).code;
         await this.imageProcessor.refreshImages();
       } catch (err) {
+        console.error(`Failed to scan image ${ imageName }: `, err);
         if (isUnixError(err)) {
           code = err.code;
         }


### PR DESCRIPTION
Executor.spawn() is currently only used by the image scanner.  That expects to be able to use the docker credential helper, so it needs to be run from within the network namespace (to be able to contact the front end).  So we can change Executor.spawn() to always run within the network namespace.

Fixes #6956 