### PR TITLE
CI: Release smoke tests: Check for macOS compression

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -333,6 +333,7 @@ ifnotstart
 ifstarted
 iidfile
 iife
+imageinfo
 IMAGENAME
 IMAGEPATH
 inbox

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -88,6 +88,17 @@ install_darwin() {
     cp -a "$srcApp" "$(dirname "$destApp")"
     xattr -d -r -s -v com.apple.quarantine "$destApp"
 
+    # Check that the image is compressed
+    local compressionRatio
+    compressionRatio="$(hdiutil imageinfo "$archiveName" \
+        | plutil -convert json -o - - \
+        | jq '.["Size Information"]["Compressed Ratio"]')"
+    if jq --exit-status '. > 0.9' <<< "$compressionRatio"; then
+        printf "Archive %s appears to be uncompressed; compression ratio is %s\n" \
+            "$archiveName" "$compressionRatio" >&2
+        exit 1
+    fi
+
     if [[ "$(uname -m)" =~ arm ]]; then
         # For macOS, currently only x86_64 runners support nested virtualization
         # https://github.com/actions/runner-images/issues/9460

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -90,10 +90,10 @@ install_darwin() {
 
     # Check that the image is compressed
     local compressionRatio
-    compressionRatio="$(hdiutil imageinfo "$archiveName" \
+    compressionRatio="$(hdiutil imageinfo -plist "$archiveName" \
         | plutil -convert json -o - - \
         | jq '.["Size Information"]["Compressed Ratio"]')"
-    if jq --exit-status '. > 0.9' <<< "$compressionRatio"; then
+    if jq --exit-status '. > 0.9' <<<"$compressionRatio"; then
         printf "Archive %s appears to be uncompressed; compression ratio is %s\n" \
             "$archiveName" "$compressionRatio" >&2
         exit 1


### PR DESCRIPTION
To avoid accidentally releasing uncompressed macOS disk images, when we ingest one check to see that it's compressed.

Fixes #6966