### PR TITLE
Dashboard: Fix websocket requests

### DIFF
--- a/pkg/rancher-desktop/main/dashboardServer/proxyUtils.ts
+++ b/pkg/rancher-desktop/main/dashboardServer/proxyUtils.ts
@@ -1,50 +1,74 @@
+import { ClientRequest } from 'http';
+import { Socket } from 'net';
+
 import { Options } from 'http-proxy-middleware';
 
 import Logging from '@pkg/utils/logging';
 
+import type { ErrorCallback, ProxyReqCallback, ProxyReqWsCallback } from 'http-proxy';
+
 const console = Logging.dashboardServer;
 
-export const proxyOpts = (): Omit<Options, 'target'> => {
-  return {
-    followRedirects: true,
-    secure:          false,
-    logger:          console,
-    on:              {
-      proxyReq:   onProxyReq,
-      proxyReqWs: onProxyReqWs,
-      error:      onError,
-    },
-  };
-};
+const onProxyReq: ProxyReqCallback = (clientReq, req) => {
+  const actualClientReq: ClientRequest | undefined = (clientReq as any)._currentRequest;
 
-export const proxyWsOpts = (): Omit<Options, 'target'> => {
-  return {
-    ...proxyOpts(),
-    ws:           false,
-    changeOrigin: true,
-  };
-};
-
-const onProxyReq = (proxyReq: any, req: any) => {
-  if (!(proxyReq._currentRequest && proxyReq._currentRequest._headerSent)) {
-    proxyReq.setHeader('x-api-host', req.headers['host']);
-    proxyReq.setHeader('x-forwarded-proto', 'https');
+  if (!actualClientReq || !actualClientReq.headersSent) {
+    if (req.headers.host) {
+      clientReq.setHeader('x-api-host', req.headers.host);
+    }
+    clientReq.setHeader('x-forwarded-proto', 'https');
   }
 };
 
-const onProxyReqWs = (proxyReq: any, req: any, socket: any, options: any, _head: any) => {
-  req.headers.origin = options.target.href;
-  proxyReq.setHeader('origin', options.target.href);
-  proxyReq.setHeader('x-api-host', req.headers['host']);
-  proxyReq.setHeader('x-forwarded-proto', 'https');
+const onProxyReqWs: ProxyReqWsCallback = (clientReq, req, socket, options) => {
+  const target = options?.target as Partial<URL> | undefined;
 
-  socket.on('error', (err: any) => {
-    console.error('Proxy WS Error:', err);
-  });
+  if (!target?.href) {
+    console.error(`onProxyReqWs: No target href, aborting`);
+    req.destroy(new Error(`onProxyReqWs: no target href`));
+
+    return;
+  }
+  if (target.pathname && clientReq.path.startsWith(target.pathname)) {
+    // `options.prependPath` is required for non-websocket requests to be routed
+    // correctly; this means that we end up with the prepended path here, but
+    // that does not work in this case.  Therefore we need to manually strip off
+    // the prepended path here before passing it to the backend.
+    clientReq.path = clientReq.path.substring(target.pathname.length);
+  }
+  req.headers.origin = target.href;
+  clientReq.setHeader('origin', target.href);
+  if (req.headers.host) {
+    clientReq.setHeader('x-api-host', req.headers.host);
+  }
+  clientReq.setHeader('x-forwarded-proto', 'https');
+
+  socket.on('error', err => console.error('Proxy WS Error:', err));
 };
 
-const onError = (err: any, req: any, res: any) => {
-  res.statusCode = 598;
+const onError: ErrorCallback = (err, req, res) => {
   console.error('Proxy Error:', err);
-  res.write(JSON.stringify(err));
+  if (res instanceof Socket) {
+    res.destroy(err);
+  } else {
+    res.statusCode = 598; // (Informal) Network read timeout error
+    res.write(JSON.stringify(err));
+  }
+};
+
+export const proxyOpts: Omit<Options, 'target'> = {
+  followRedirects: true,
+  secure:          false,
+  logger:          console,
+  on:              {
+    proxyReq:   onProxyReq,
+    proxyReqWs: onProxyReqWs,
+    error:      onError,
+  },
+};
+
+export const proxyWsOpts: Omit<Options, 'target'> = {
+  ...proxyOpts,
+  ws:           false,
+  changeOrigin: true,
 };


### PR DESCRIPTION
The http-proxy-middleware bump missed the fact that now websocket requests end up with the proxied path in front of the client path, resulting in the server seeing requests like `/k8s/k8s/clusters/local/v1/subscribe`.  This breaks the request.  However, we can't just set `prependPath` to `false` in the options, as that breaks non-websocket requests instead.  So we need to manually strip the duplicate prefix instead.

Fixes #6968