### PR TITLE
Upgrade Electron to v30

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "cross-env": "7.0.3",
     "css-loader": "7.1.1",
     "ejs": "3.1.10",
-    "electron": "26.6.10",
+    "electron": "30.0.9",
     "electron-builder": "24.13.3",
     "eslint": "8.57.0",
     "eslint-plugin-deprecation": "3.0.0",

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -16,6 +16,8 @@
     <main ref="body" class="body">
       <Nuxt />
     </main>
+    <!-- The extension area is used for sizing the extension view. -->
+    <div id="extension-spacer" class="extension" />
     <status-bar class="status-bar"></status-bar>
     <!-- The ActionMenu is used by SortableTable for per-row actions. -->
     <ActionMenu />
@@ -209,12 +211,21 @@ export default {
     border-right: var(--nav-border-size) solid var(--nav-border);
   }
 
+  .title {
+    grid-area: title;
+  }
+
   .body {
     display: grid;
     grid-area: body;
     grid-template-rows: auto 1fr;
     padding: 0 20px 20px 20px;
     overflow: auto;
+  }
+
+  .extension {
+    grid-area: title / title / body / body;
+    z-index: -1000;
   }
 
   .status-bar {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -230,6 +230,7 @@ export interface IpcRendererEvents {
   // #region extensions
   // The list of installed extensions may have changed.
   'extensions/changed': () => void;
+  'extensions/getContentArea': () => void;
   'extensions/open': (id: string, path: string) => void;
   'err:extensions/open': () => void;
   'extensions/close': () => void;

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -58,6 +58,7 @@ class Builder {
     const exeName = `${ context.packager.appInfo.productFilename }${ extension }`;
     const exePath = path.join(context.appOutDir, exeName);
     const resetAdHocDarwinSignature = context.arch === Arch.arm64;
+    const integrityEnabled = context.electronPlatformName === 'darwin';
 
     await flipFuses(
       exePath,
@@ -68,7 +69,7 @@ class Builder {
         [FuseV1Options.EnableCookieEncryption]:                false,
         [FuseV1Options.EnableNodeOptionsEnvironmentVariable]:  false,
         [FuseV1Options.EnableNodeCliInspectArguments]:         false,
-        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+        [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: integrityEnabled,
         [FuseV1Options.OnlyLoadAppFromAsar]:                   true,
       },
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,7 +2899,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.3.tgz#329842940042d2b280897150e023e604d11657d6"
   integrity sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==
 
-"@types/node@18.18.9", "@types/node@^18.11.17", "@types/node@^18.11.18":
+"@types/node@18.18.9", "@types/node@^18.11.17":
   version "18.18.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.9.tgz#5527ea1832db3bba8eb8023ce8497b7d3f299592"
   integrity sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==
@@ -2910,6 +2910,13 @@
   version "16.18.65"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.65.tgz#b07eb49a14a808777b82879288a7e6f5a296ccfa"
   integrity sha512-5E9WgTy95B7i90oISjui9U5Zu7iExUPfU4ygtv4yXEy6zJFE3oQYHCnh5H1jZRPkjphJt2Ml3oQW6M0qtK534A==
+
+"@types/node@^20.9.0":
+  version "20.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.0.tgz#49ceec7b34f8621470cff44677fa9d461a477f17"
+  integrity sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -5998,13 +6005,13 @@ electron-updater@6.1.8:
     semver "^7.3.8"
     tiny-typed-emitter "^2.1.0"
 
-electron@26.6.10:
-  version "26.6.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.6.10.tgz#01ca7610bd662033ed3ceb70804cbf940c7e6756"
-  integrity sha512-pV2SD0RXzAiNRb/2yZrsVmVkBOMrf+DVsPulIgRjlL0+My9BL5spFuhHVMQO9yHl9tFpWtuRpQv0ofM/i9P8xg==
+electron@30.0.9:
+  version "30.0.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-30.0.9.tgz#b11400e4642a4b635e79244ba365f1d401ee60b5"
+  integrity sha512-ArxgdGHVu3o5uaP+Tqj8cJDvU03R6vrGrOqiMs7JXLnvQHMqXJIIxmFKQAIdJW8VoT3ac3hD21tA7cPO10RLow==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^18.11.18"
+    "@types/node" "^20.9.0"
     extract-zip "^2.0.1"
 
 element-matches@^0.1.2:


### PR DESCRIPTION
This upgrades Electron; fixes #6744 

There were surprisingly few issues this round.  I recommend reviewing commit-by-commit.

Filed #6999 to re-enable Windows ASAR integrity (because it's not supported on current electron-builder).
