### PR TITLE
CI: go.work sync: use `pull_request_target`

### DIFF
--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -4,7 +4,7 @@
 
 name: Sync go.work
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
     paths:
     - '**/go.mod'
@@ -17,9 +17,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   update-sum:
-    if: >-
-      contains(github.ref, 'refs/pull/') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    # We only run this for pull requests from the same repository.  This is
+    # important for security reasons, as we use pull_request_target.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
     # Because the GitHub-provided token doesn't trigger further actions runs,


### PR DESCRIPTION
We seem to be having issues accessing secrets in the workflow even though we only process pull requests from the same repository (where documentation claims secrets should be available).  Switch to using `pull_request_target` to try to get access to those secrets.

Since we still only run this job if the pull request is from the same repository (with an explicit manual check), this should still be safe as it only applies to people with write access to the repository.

(Probably) fixes #7010