### PR TITLE
docker-cli-monitor: Use separate tokens

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -4,9 +4,6 @@ on:
     - cron: '55 8 * * *'
   workflow_dispatch: {}
 
-permissions:
-  issues: write
-
 jobs:
   check-for-token:
     outputs:
@@ -22,6 +19,8 @@ jobs:
     needs: check-for-token
     if: needs.check-for-token.outputs.has-token == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
 
       - uses: actions/checkout@v4
@@ -41,4 +40,5 @@ jobs:
 
       - run: yarn dcmonitor
         env:
-          GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+          GITHUB_CREATE_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/docker-cli-monitor.ts
+++ b/scripts/docker-cli-monitor.ts
@@ -1,3 +1,12 @@
+// This script creates GitHub issues when new releases of the Docker CLI are
+// found.
+
+// Environment:
+//   GITHUB_CREATE_TOKEN: GitHub authorization token for creating an issue.
+//     Must be a PAT/app token and have `issues:write` permissions.
+//   GITHUB_TOKEN: GitHub authorization token for closing an issue.
+//     Must have `issues:write` permissions.
+
 import path from 'path';
 
 import semver from 'semver';
@@ -62,7 +71,7 @@ async function checkDockerCli(): Promise<void> {
     if (issue.title.endsWith(` ${ latestTagName }`)) {
       issueFound = true;
       if (issue.state === 'closed') {
-        await mainRepo.reopenIssue(issue);
+        await mainRepo.reopenIssue(issue, process.env.GITHUB_CREATE_TOKEN);
       }
     } else if (issue.state === 'open') {
       await mainRepo.closeIssue(issue);
@@ -73,7 +82,7 @@ async function checkDockerCli(): Promise<void> {
     const body = `The Docker CLI monitor has detected a new release of docker/cli. ` +
       `Please make a corresponding release in rancher-desktop-docker-cli to keep it up to date in Rancher Desktop.`;
 
-    await mainRepo.createIssue(title, body);
+    await mainRepo.createIssue(title, body, process.env.GITHUB_CREATE_TOKEN);
   }
 }
 

--- a/scripts/docker-cli-monitor.ts
+++ b/scripts/docker-cli-monitor.ts
@@ -19,6 +19,7 @@ const DOCKER_CLI_OWNER = process.env.DOCKER_CLI_OWNER || 'docker';
 const DOCKER_CLI_REPO = process.env.DOCKER_CLI_REPO || 'cli';
 const TAG_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
 const SCRIPT_NAME = 'docker-cli-monitor';
+const TITLE_PREFIX = `${ SCRIPT_NAME }: make rancher-desktop-docker-cli release for version`;
 const mainRepo = new RancherDesktopRepository(GITHUB_OWNER, GITHUB_REPO);
 
 async function getLatestDockerCliVersion(): Promise<string> {
@@ -43,7 +44,7 @@ async function getLatestDockerCliVersion(): Promise<string> {
 }
 
 async function getDockerCliIssues(): Promise<IssueOrPullRequest[]> {
-  const query = `type:issue repo:${ GITHUB_OWNER }/${ GITHUB_REPO } sort:updated in:title ${ SCRIPT_NAME }`;
+  const query = `type:issue repo:${ GITHUB_OWNER }/${ GITHUB_REPO } sort:updated in:title "${ TITLE_PREFIX }"`;
   const result = await getOctokit().rest.search.issuesAndPullRequests({ q: query });
 
   return result.data.items;
@@ -78,7 +79,7 @@ async function checkDockerCli(): Promise<void> {
     }
   }));
   if (!issueFound) {
-    const title = `${ SCRIPT_NAME }: make rancher-desktop-docker-cli release for version ${ latestTagName }`;
+    const title = `${ TITLE_PREFIX } ${ latestTagName }`;
     const body = `The Docker CLI monitor has detected a new release of docker/cli. ` +
       `Please make a corresponding release in rancher-desktop-docker-cli to keep it up to date in Rancher Desktop.`;
 

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -166,8 +166,8 @@ export class RancherDesktopRepository {
     this.repo = repo;
   }
 
-  async createIssue(title: string, body: string): Promise<void> {
-    const result = await getOctokit().rest.issues.create({
+  async createIssue(title: string, body: string, githubToken?: string): Promise<void> {
+    const result = await getOctokit(githubToken).rest.issues.create({
       owner: this.owner, repo: this.repo, title, body,
     });
     const issue = result.data;
@@ -175,15 +175,15 @@ export class RancherDesktopRepository {
     console.log(`Created issue #${ issue.number }: "${ issue.title }"`);
   }
 
-  async reopenIssue(issue: IssueOrPullRequest): Promise<void> {
-    await getOctokit().rest.issues.update({
+  async reopenIssue(issue: IssueOrPullRequest, githubToken?: string): Promise<void> {
+    await getOctokit(githubToken).rest.issues.update({
       owner: this.owner, repo: this.repo, issue_number: issue.number, state: 'open',
     });
     console.log(`Reopened issue #${ issue.number }: "${ issue.title }"`);
   }
 
-  async closeIssue(issue: IssueOrPullRequest): Promise<void> {
-    await getOctokit().rest.issues.update({
+  async closeIssue(issue: IssueOrPullRequest, githubToken?: string): Promise<void> {
+    await getOctokit(githubToken).rest.issues.update({
       owner: this.owner, repo: this.repo, issue_number: issue.number, state: 'closed',
     });
     console.log(`Closed issue #${ issue.number }: "${ issue.title }"`);
@@ -192,8 +192,8 @@ export class RancherDesktopRepository {
 
 // For a GitHub repository, get a list of releases that are published
 // and return the tags that they were made off of.
-export async function getPublishedReleaseTagNames(owner: string, repo: string) {
-  const response = await getOctokit().rest.repos.listReleases({ owner, repo });
+export async function getPublishedReleaseTagNames(owner: string, repo: string, githubToken?: string) {
+  const response = await getOctokit(githubToken).rest.repos.listReleases({ owner, repo });
   const releases = response.data;
   const publishedReleases = releases.filter(release => release.published_at !== null);
 
@@ -205,8 +205,8 @@ export async function getPublishedReleaseTagNames(owner: string, repo: string) {
 // - The dependency is hosted at a GitHub repository.
 // - Versions are gathered from the tag that is on each GitHub release.
 // - Versions are in semver format.
-export async function getPublishedVersions(githubOwner: string, githubRepo: string, includePrerelease: boolean): Promise<string[]> {
-  const tagNames = await getPublishedReleaseTagNames(githubOwner, githubRepo);
+export async function getPublishedVersions(githubOwner: string, githubRepo: string, includePrerelease: boolean, githubToken?: string): Promise<string[]> {
+  const tagNames = await getPublishedReleaseTagNames(githubOwner, githubRepo, githubToken);
   let versions = tagNames.map((tagName: string) => tagName.replace(/^v/, ''));
 
   versions = versions.filter(version => semver.valid(version));


### PR DESCRIPTION
This adjusts docker-cli-monitor so that it uses a separate token (the Actions-supplied one) to close issues, and only uses `RUN_WORKFLOW_FROM_WORKFLOW` for opening / reopening issues.  This should hopefully resolve issues with it being unable to close issues.

This also adjusts the search so that the issue title should match more of the expected title (instead of just `docker-cli-monitor`, to avoid catching issues _about_ the script).

Fixes #7011