### PR TITLE
Dependencies: docker cli: force ad-hoc signature on macOS

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -196,8 +196,9 @@ export class DockerCLI implements Dependency, GitHubDependency {
     const dockerURL = `${ baseURL }/${ executableName }`;
     const destPath = path.join(context.binDir, exeName(context, 'docker'));
     const expectedChecksum = await findChecksum(`${ baseURL }/sha256sum.txt`, executableName);
+    const codesign = process.platform === 'darwin';
 
-    await download(dockerURL, destPath, { expectedChecksum });
+    await download(dockerURL, destPath, { expectedChecksum, codesign });
   }
 
   async getAvailableVersions(includePrerelease = false): Promise<string[]> {


### PR DESCRIPTION
It looks like newer versions of docker CLI has issues launch due to an invalid signature.  Force an ad-hoc signature when we download it to fix the issue.  Note that this signature will be overwritten when we do the final signing as part of the release process.

Fixes #7021 (at least on my local machine).