### PR TITLE
BATS: try to auto-detect Rancher chart version

### DIFF
--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -11,7 +11,8 @@ RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.
 }
 
 @test 'run rancher' {
-    local rancher_image="rancher/rancher:$RD_RANCHER_IMAGE_TAG"
+    local rancher_image
+    rancher_image="rancher/rancher:$(rancher_image_tag)"
 
     ctrctl pull "$rancher_image"
     ctrctl run --privileged -d --restart=no -p 8080:80 -p 8443:443 --name rancher "$rancher_image"

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -18,7 +18,11 @@ using_docker() {
 : "${RD_KUBERNETES_PREV_VERSION:=1.22.7}"
 
 ########################################################################
-: "${RD_RANCHER_IMAGE_TAG:=v2.7.0}"
+: "${RD_RANCHER_IMAGE_TAG:=}"
+
+rancher_image_tag() {
+    echo "${RANCHER_IMAGE_TAG:-v2.7.0}"
+}
 
 ########################################################################
 # Defaults to true, except in the helper unit tests, which default to false

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -442,7 +442,18 @@ foreach_k3s_version() {
 
 _foreach_k3s_version() {
     local RD_KUBERNETES_PREV_VERSION=$1
+    local skip_kubernetes_version
+    skip_kubernetes_version=$(cat "$BATS_FILE_TMPDIR/skip-kubernetes-version" 2>/dev/null || echo none)
+    if [[ $skip_kubernetes_version == "$RD_KUBERNETES_PREV_VERSION" ]]; then
+        skip "All remaining tests for Kubernetes $RD_KUBERNETES_PREV_VERSION are skipped"
+    fi
     "$2"
+}
+
+# Tests can call skip_k3s_version to skip the rest of the tests within
+# foreach_k3s_version.
+skip_k3s_version() {
+    echo "$RD_KUBERNETES_PREV_VERSION" >"$BATS_FILE_TMPDIR/skip-kubernetes-version"
 }
 
 ########################################################################

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -451,7 +451,7 @@ _foreach_k3s_version() {
 }
 
 # Tests can call mark_k3s_version_skipped to skip the rest of the tests within
-# foreach_k3s_version.
+# this iteration of foreach_k3s_version.
 mark_k3s_version_skipped() {
     echo "$RD_KUBERNETES_PREV_VERSION" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
 }

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -443,17 +443,17 @@ foreach_k3s_version() {
 _foreach_k3s_version() {
     local RD_KUBERNETES_PREV_VERSION=$1
     local skip_kubernetes_version
-    skip_kubernetes_version=$(cat "$BATS_FILE_TMPDIR/skip-kubernetes-version" 2>/dev/null || echo none)
+    skip_kubernetes_version=$(cat "${BATS_FILE_TMPDIR}/skip-kubernetes-version" 2>/dev/null || echo none)
     if [[ $skip_kubernetes_version == "$RD_KUBERNETES_PREV_VERSION" ]]; then
         skip "All remaining tests for Kubernetes $RD_KUBERNETES_PREV_VERSION are skipped"
     fi
     "$2"
 }
 
-# Tests can call skip_k3s_version to skip the rest of the tests within
+# Tests can call mark_k3s_version_skipped to skip the rest of the tests within
 # foreach_k3s_version.
-skip_k3s_version() {
-    echo "$RD_KUBERNETES_PREV_VERSION" >"$BATS_FILE_TMPDIR/skip-kubernetes-version"
+mark_k3s_version_skipped() {
+    echo "$RD_KUBERNETES_PREV_VERSION" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
 }
 
 ########################################################################

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -105,7 +105,7 @@ deploy_rancher() {
     local host
     host=$(traefik_hostname) || return
 
-    trace "Installing rancher $rancher_chart_version"
+    comment "Installing rancher $rancher_chart_version"
     helm upgrade \
         --install rancher rancher-latest/rancher \
         --version "$rancher_chart_version" \

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -13,10 +13,93 @@ local_setup() {
     helm repo update
 }
 
+# Get the minimum Kubernetes version the given rancher-latest/rancher helm chart
+# does _not_ support; i.e. the chart supports < [output].
+get_chart_unsupported_version() {
+    output="" # Hack: tell shellcheck about this variable
+    local chart_version=$1
+    run helm show chart rancher-latest/rancher --version "$chart_version"
+    assert_success || return
+    run awk '/^kubeVersion:/ { $1 = ""; print }' <<<"$output"
+    assert_success || return
+    # We only support kubeVersion of form "< x.y.z"
+    assert_output --regexp '^[[:space:]]*<[[:space:]]*[^[:space:]]+$' || return
+    awk '{ print $2 }' <<<"$output"
+}
+
+# Try to determine the best chart version for the current Kubernetes version
+# (as specified in $RD_KUBERNETES_PREV_VERSION).  Saves the resulting version
+# in rancher_chart_version (and should be restored via load_var).
+determine_chart_version() {
+    if [[ -n $RD_RANCHER_IMAGE_TAG ]]; then
+        # If a version is given, check that it's compatible.
+        assert_rancher_chart_compatible "${RD_RANCHER_IMAGE_TAG#v}" || return
+        rancher_chart_version=${RD_RANCHER_IMAGE_TAG#v}
+        save_var rancher_chart_version
+        return
+    fi
+    local default_version
+    default_version=$(rancher_image_tag)
+    default_version=${default_version#v}
+    run --separate-stderr helm search repo --versions rancher-latest/rancher --output json
+    assert_success || return
+    local versions_json=$output
+    run jq_output 'map(.version).[]'
+    assert_success || return
+    run sort --version-sort <<<"$output"
+    assert_success || return
+    local versions=$output
+    local version
+    for version in $versions; do
+        if ! semver_is_valid "$version"; then
+            continue # Skip invalid / RC versions.
+        fi
+        if semver_lt "$version" "$default_version"; then
+            continue # Skip any versions older than the default version
+        fi
+        run get_chart_unsupported_version "$version"
+        assert_success || return
+        local unsupported_version=$output
+        if semver_lt "$RD_KUBERNETES_PREV_VERSION" "$unsupported_version"; then
+            # Once we find a compatible version, use it (and don't look at the
+            # rest of the chart versions).
+            trace "$(printf "Selected rancher chart version %s (wants < %s, have %s)" \
+                "$version" "$unsupported_version" "$RD_KUBERNETES_PREV_VERSION")"
+            rancher_chart_version=$version
+            save_var rancher_chart_version
+            return
+        fi
+    done
+    skip_k3s_version
+    printf "Could not find a version of rancher-latest/rancher compatible with Kubernetes %s\n" \
+        "$RD_KUBERNETES_PREV_VERSION" |
+        fail || return
+}
+
+# Check that the rancher-latest/rancher helm chart at the given version is
+# supported on the current Kubernetes version (as determined by $RD_KUBERNETES_PREV_VERSION)
+assert_rancher_chart_compatible() {
+    local chart_version=$1
+    run get_chart_unsupported_version "$chart_version"
+    assert_success || return
+    local unsupported_version=$output
+    if semver_lte "$unsupported_version" "$RD_KUBERNETES_PREV_VERSION"; then
+        skip_k3s_version
+        printf "Rancher %s wants Kubernetes < %s, have %s" \
+            "$chart_version" "$unsupported_version" "$RD_KUBERNETES_PREV_VERSION" |
+            fail || return
+    fi
+    trace "Chart $chart_version < $unsupported_version good for $RD_KUBERNETES_PREV_VERSION"
+}
+
 deploy_rancher() {
     # TODO remove `skip_unless_host_ip` once `traefik_hostname` no longer needs it
     if is_windows; then
         skip_unless_host_ip
+    fi
+
+    if ! load_var rancher_chart_version; then
+        fail "Could not restore Rancher chart version"
     fi
 
     helm upgrade \
@@ -31,7 +114,7 @@ deploy_rancher() {
 
     helm upgrade \
         --install rancher rancher-latest/rancher \
-        --version "${RD_RANCHER_IMAGE_TAG#v}" \
+        --version "${rancher_chart_version}" \
         --namespace cattle-system \
         --set hostname="$host" \
         --wait \
@@ -50,7 +133,7 @@ verify_rancher() {
 
     run try --max 9 --delay 10 curl --insecure --silent --show-error "https://${host}/dashboard/auth/login"
     assert_success
-    assert_output --partial "Rancher Dashboard"
+    assert_output --partial 'href="/dashboard/'
     run kubectl get secret --namespace cattle-system bootstrap-secret -o json
     assert_success
     assert_output --partial "bootstrapPassword"
@@ -65,6 +148,7 @@ uninstall_rancher() {
 
 foreach_k3s_version \
     factory_reset \
+    determine_chart_version \
     start_kubernetes \
     wait_for_kubelet \
     wait_for_traefik \


### PR DESCRIPTION
The Rancher Helm chart might not support the requested Kubernetes version. If a specific version was not specified, try to iterate through the available chart versions to find the minimum chart version that is compatible with the current Kubernetes version which is also at least the default version (currently 2.7.0).  Note that newer Kubernetes versions do not currently have any usable Rancher chart versions at this point.

If we determine that a chart version / Kubernetes version combination does not work, we skip all tests using that version after making sure it is marked as failed.

To support newer Rancher chart versions, also change the string we are looking for in the expected output as we no longer see the literal string "Rancher Dashboard" in the initial response.

Fixes #6947