### PR TITLE
deps: Use upstream moproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can now clone the repository and run `yarn`.
 1. Install [Windows Subsystem for Linux (WSL)] on your machine. Skip this step, if WSL is already installed.
 2. Open a PowerShell prompt (hit Windows Key + `X` and open `Windows PowerShell`).
 3. Install [Scoop] via `iwr -useb get.scoop.sh | iex`.
-4. Install git, go, mingw, nvm, and unzip via `scoop install git go mingw nvm python unzip`.
+4. Install 7zip, git, go, mingw, nvm, and unzip via `scoop install 7zip git go mingw nvm python unzip`.
    Check node version with `nvm list`. If node v18 is not installed or set as the current version, then install using `nvm install 18` and set as current using `nvm use 18.xx.xx`.
 5. Install the yarn package manager via `npm install --global yarn`
 6. Install Visual Studio 2017 or higher. As of this writing the latest version is available at [https://visualstudio.microsoft.com/downloads/]; if that's changed, a good search engine should find it.

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -19,7 +19,7 @@ hostResolver: 0.1.5
 mobyOpenAPISpec: "1.45"
 wix: v3.14.1
 hostSwitch: 1.2.6
-moproxy: 0.5.0
+moproxy: 0.5.1
 spinShim: 0.14.1
 spinOperator: 0.2.0
 certManager: 1.15.0

--- a/scripts/windows-setup.ps1
+++ b/scripts/windows-setup.ps1
@@ -48,7 +48,7 @@ if (!$SkipTools) {
 
         Invoke-WebRequest -UseBasicParsing -Uri 'https://get.scoop.sh' `
             | Invoke-Expression
-        scoop install git go mingw nvm python unzip
+        scoop install 7zip git go mingw nvm python unzip
         # Install and use latest node 18* version
         nvm install 18
         nvm use $(nvm list | Select-String '[18\.[0-9.]+]' | Select-Object -First 1 | ForEach-Object { $_.Matches.Value })


### PR DESCRIPTION
We had a fork _just_ so we can change the packaging to use gzip instead of xz.  Long term, it would be a lot less maintenance if we just taught our build system to extract the xz archive instead.

Fixes #4680