### PR TITLE
CI: Use macos-latest instead of macos-11 runners

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,10 +40,10 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-11
+          runs-on: macos-latest
         - platform: mac
           arch: aarch64
-          runs-on: macos-11
+          runs-on: macos-latest
         - platform: win
           runs-on: windows-2019
         - platform: linux
@@ -218,7 +218,7 @@ jobs:
         include:
         - arch: aarch64
         # skip x86_64, we don't need to duplicate the testing for now.
-    runs-on: macos-12
+    runs-on: macos-latest
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,7 +40,7 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-latest
+          runs-on: macos-13
         - platform: mac
           arch: aarch64
           runs-on: macos-latest

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -10,10 +10,10 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-11
+          runs-on: macos-latest
         - platform: mac
           arch: aarch64
-          runs-on: macos-11
+          runs-on: macos-latest
         - platform: win
           runs-on: windows-latest
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -10,7 +10,7 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-latest
+          runs-on: macos-13
         - platform: mac
           arch: aarch64
           runs-on: macos-latest


### PR DESCRIPTION
GitHub-hosted `macos-11` runners have been deprecated and will start failing soon; change them ahead of the brownouts.

Note that the `macos-latest` runners are aarch64 and do not yet support virtualization.

Fixes #6923