### PR TITLE
CI: linux-release: Drop use of prewk/s3-cp-action

### DIFF
--- a/.github/workflows/linux-release.yaml
+++ b/.github/workflows/linux-release.yaml
@@ -30,25 +30,31 @@ jobs:
         echo "release_zip_name=$release_zip_name" >> $GITHUB_ENV
         echo "major_minor=$major_minor" >> $GITHUB_ENV
         echo "s3_zip_name=$s3_zip_name" >> $GITHUB_ENV
+    - run: mkdir -p dist
     - name: Fetch the .zip file from release
-      run: |
-        mkdir -p dist
-        curl -L -o "dist/${release_zip_name}" "https://github.com/rancher-sandbox/rancher-desktop/releases/download/${version_with_v}/${release_zip_name}"
+      run: >-
+        curl -L -o "dist/${release_zip_name}"
+        "https://github.com/${repository}/releases/download/${version_with_v}/${release_zip_name}"
       env:
+        repository: ${{ github.repository }}
         version_with_v: ${{ env.version_with_v }}
         release_zip_name: ${{ env.release_zip_name }}
-    - name: Copy .zip file to s3
-      uses: prewk/s3-cp-action@v2
-      with:
-        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        source: ${{ format('./dist/{0}', env.release_zip_name) }}
-        dest: ${{ format('s3://rancher-desktop-assets-for-obs/{0}', env.s3_zip_name) }}
+    - name: Upload zip file to S3
+      run: >-
+        aws s3 cp
+        "dist/${release_zip_name}"
+        "s3://rancher-desktop-assets-for-obs/${s3_zip_name}"
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: us-east-1
+        release_zip_name: ${{ env.release_zip_name }}
+        s3_zip_name: ${{ env.s3_zip_name }}
     - name: Trigger OBS services for relevant package in stable channel
-      run: |
-        curl -X POST \
-          -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}" \
-          "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-${MAJOR_MINOR}"
+      run: >-
+        curl -X POST
+        -H "Authorization: Token ${OBS_WEBHOOK_TOKEN}"
+        "https://build.opensuse.org/trigger/runservice?project=isv:Rancher:stable&package=rancher-desktop-${MAJOR_MINOR}"
       env:
         MAJOR_MINOR: ${{ env.major_minor }}
         OBS_WEBHOOK_TOKEN: ${{ secrets.OBS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
We can use the S3 CLI to accomplish the same, without the need for pulling in a new dependency we need to trust (since we already need to trust GitHub provided runners).

Fixes #7036

Note that this is untested (because I don't have the correct credentials for this), but it's mostly copied from `package.yaml`.