### PR TITLE
Add com.apple.security.cs.allow-unsigned-executable-memory entitlement for spin

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -25,6 +25,10 @@ entitlements:
     - com.apple.security.cs.allow-jit
     - com.apple.security.hypervisor
   - paths:
+    - Contents/Resources/resources/darwin/bin/spin
+    entitlements:
+    - com.apple.security.cs.allow-unsigned-executable-memory
+  - paths:
     - Contents/Frameworks/Rancher Desktop Helper (GPU).app
     - Contents/Frameworks/Rancher Desktop Helper (Renderer).app
     entitlements:


### PR DESCRIPTION
* In order to notarize the executable it needs to be configured to use the [hardened runtime](https://developer.apple.com/documentation/security/hardened_runtime). I've confirmed that requesting the hardened runtime while codesigning is sufficient to trigger the broken `spin up` behaviour.

* I've confirmed that signing the binary without the hardened runtime does not break the `spin up` functionality.

* I've further confirmed that when signing the binary with the hardened runtime, but adding the [com.apple.security.cs.allow-unsigned-executable-memory](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-unsigned-executable-memory) entitlement also allows `spin up` to work normally.

* I tried to use the [com.apple.security.cs.allow-jit](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-jit) entitlement, but it alone did not work, so I assume that Spin is not using the "passing `MAP_JIT` flag to the `mmap` system function" mechanism to allocate its executable memory area.

Fixes #7041