### PR TITLE
Cherry-pick into release-14: Merge to main: Use separate tokens for creating a branch

### DIFF
--- a/.github/workflows/release-merge-to-main.yaml
+++ b/.github/workflows/release-merge-to-main.yaml
@@ -29,7 +29,7 @@ jobs:
     if: needs.check-for-token.outputs.has-token == 'true'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -49,4 +49,5 @@ jobs:
 
     - run: node scripts/ts-wrapper.js scripts/release-merge-to-main.ts
       env:
-        GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+        GITHUB_WRITE_TOKEN: ${{ github.token }}
+        GITHUB_PR_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}

--- a/scripts/release-merge-to-main.ts
+++ b/scripts/release-merge-to-main.ts
@@ -87,8 +87,7 @@ async function ensureBranch(owner: string, repo: string, branchName: string, tag
     if (!(ex instanceof RequestError) || ex.status !== 404) {
       throw ex;
     }
-    console.log(`Creating new branch ${ owner }/${ repo }/${ ref }` +
-      `at ${ sha }`);
+    console.log(`Creating new branch ${ owner }/${ repo }/${ ref } at ${ sha }`);
     // Branch does not exist; create it.
     await git.createRef({
       // Only this API takes a `refs/` prefix; get & update omit it.


### PR DESCRIPTION
The `RUN_WORKFLOW_FROM_WORKFLOW` secret does not allow for writing to branches; use a separate GitHub-provided token for that.

Signed-off-by: Mark Yen <mark.yen@suse.com>
(cherry picked from commit 3cd7d7de6c61afa493b78d2ee0567d44dbf7bb18)