### PR TITLE
Networking docs

### DIFF
--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -1,0 +1,7 @@
+
+# Rancher Desktop Network Documentation
+
+The table of contents below provides references to all the projects that comprise the Rancher Desktop network.
+
+- [Rancher Desktop Guest Agent](rancher-desktop-guest-agent.md)
+- [Rancher Desktop Networking](rancher-desktop-networking.md)

--- a/docs/networking/rancher-desktop-guest-agent.md
+++ b/docs/networking/rancher-desktop-guest-agent.md
@@ -1,0 +1,149 @@
+# **[Rancher Desktop Guest Agent](https://github.com/rancher-sandbox/rancher-desktop-agent)**
+
+The Rancher Desktop Guest Agent runs in the Rancher Desktop WSL distro, it runs inside the isolated namespace (when network tunnel is enabled). It is currently responsible for interaction between various APIs for container engines such as Moby, containerd, and Kubernetes. It listens for container creation events from those APIs if it detects any ports that require exposing from those containers it forwards the corresponding port mappings to the internal services.
+
+The Rancher Desktop Guest Agent operates within the Rancher Desktop WSL distribution, particularly in an isolated namespace when the network tunnel is enabled. It facilitates interactions between various container engine APIs like Moby, containerd, and Kubernetes. The agent monitors container/service creation events from these APIs and, upon detecting ports needing exposure, forwards the port mappings to internal services accordingly. This ensures efficient and automated port forwarding management within the Rancher Desktop environment.
+
+```mermaid
+flowchart  LR;
+subgraph Host["HOST"]
+host-switch["host-switch\n/services/forwarder/all\n /services/forwarder/expose\n /services/forwarder/unexpose"]
+end
+ subgraph VM["WSL"]
+  subgraph netNs["Isolated Network Namespace"]
+   guest-agent["Guest Agent"]
+   docker(("Docker API"))
+   containerd(("Containerd API"))
+   kubernetes(("K8s API"))
+   iptables(("iptable scanning"))
+   guest-agent <----> docker
+   guest-agent <----> containerd
+   guest-agent <----> kubernetes
+   guest-agent <----> iptables
+   guest-agent ----> host-switch
+  end
+  subgraph defaultNs["Default Namespace"]
+  wsl-proxy["wsl-proxy"]
+  end
+  guest-agent ----> |UNIX socket| wsl-proxy
+ end
+```
+
+### Supported Flags
+
+-   **debug**: Enables debug logging.
+
+-   **docker**: When this flag is enabled, the guest agent monitors Docker API container events via the Docker socket (`/var/run/docker.sock`). On container creation or deletion, if there are exposed ports, the agent creates corresponding port mappings. These mappings are forwarded to the Rancher Desktop Networking's `host-switch`, which hosts an API for exposing ports from the host into the network namespace. If WSL integration is enabled in Rancher Desktop, the port mapping is also forwarded to Rancher Desktop Networking’s `wsl-proxy`, allowing access to the container's ports from other WSL distributions.
+
+-   **kubernetes**: Enables Kubernetes service port forwarding. When enabled, the Rancher Desktop Guest Agent creates a watcher for the Kubernetes API, monitoring NodePort and LoadBalancer services needing port forwarding. For services with exposed ports, the agent creates corresponding port mappings, forwarding them to Rancher Desktop Networking’s `host-switch`, which hosts an API for exposing ports from the host into the network namespace. If WSL integration is enabled, the port mapping is also forwarded to Rancher Desktop Networking’s `wsl-proxy`, allowing access from other WSL distributions.
+
+-   **kubeconfig**: Specifies the path to `kubeconfig` for locating the Kubernetes API endpoint. By default, it looks in `/etc/rancher/k3s/k3s.yaml`.
+
+-   **iptables**: This flag enables the scanning of iptables. In newer versions of Kubernetes, kubelet no longer creates listeners for NodePort and LoadBalancer services. To rectify this, we manually create those listeners so the port forwarding functions correctly. The guest agent creates a corresponding port mapping that represents the service’s exposed port. The port mapping is then forwarded to Rancher Desktop Networking’s `host-switch`, which hosts an API for exposing ports from the host into the network namespace. If WSL integration options are enabled within Rancher Desktop, a copy of that port mapping is also forwarded to Rancher Desktop Networking’s `wsl-proxy`. The `wsl-proxy` exposes the service port to enable users to access it from other WSL distros.
+
+-   **containerd**: When this flag is enabled, the guest agent monitors container events from the containerd API. It connects to the Containerd API via the containerd socket (/run/k3s/containerd/containerd.sock). Whenever a container is created or deleted, if there are exposed ports associated with that container, the guest agent creates a corresponding port mapping. This port mapping is then forwarded to Rancher Desktop Networking's `host-switch`, which hosts an API for exposing ports from the host into the network namespace. If WSL integration options are enabled within Rancher Desktop, a copy of this port mapping is also forwarded to Rancher Desktop Networking's `wsl-proxy`. The `wsl-proxy` exposes the container's port to enable users to access it from other WSL distros.
+
+-   **containerdSock**: File path for the containerd socket address. If no argument is provided, it defaults to `/run/k3s/containerd/containerd.sock`.
+
+-   **vtunnelAddr**: Peer address for the Vtunnel process that forwards port mappings to the Vtunnel Host process over `AF_VSOCK`. This feature will soon be deprecated.
+
+-   **privilegedService**: This flag enables privileged service mode. When enabled, the Rancher Desktop guest agent communicates over `AF_VSOCK` to a privileged service process running on the host. This functionality is primarily designed for Windows and will soon be deprecated.
+
+-   **k8sServiceListenerAddr**: Specifies an IP address (`0.0.0.0` or `127.0.0.1`) to bind Kubernetes services on the host.
+
+-   **adminInstall**: This flag indicates whether Rancher Desktop is installed with administrator privileges. It is used to enable Network Tunnel mode, where port mappings are forwarded to Rancher Desktop Networking's `host-switch`. The `host-switch` hosts an API that exposes ports from the host into the network namespace.
+
+-   **k8sAPIPort**: Specifies the Kubernetes API port, which is forwarded to `wsl-proxy` to allow other distros that are part of WSL integrations to  interact via `kubectl`.
+
+## PortMapping
+
+Is a struct object that represents an exposed container or a service. [Portmapping](https://github.com/rancher-sandbox/rancher-desktop-agent/blob/8348a5e10578f8662532eddfac73b243cfd419f4/pkg/types/portmapping.go#L22) objects consist of the following fields:
+
+```
+type PortMapping struct {
+	// Remvoe indicates wherethere to remove or add the entry
+	Remove bool `json:"remove"`
+	// Ports are the port mappings for both IPV4 and IPV6
+	Ports nat.PortMap `json:"ports"`
+	// ConnectAddrs are the backend addresses to connect to
+	ConnectAddrs []ConnectAddrs `json:"connectAddrs"`
+}
+```
+## Networking Mode
+
+The Rancher Desktop Guest Agent currently supports two networking modes. In the first mode, if the privileged service flag mentioned above is enabled, it utilizes the vtunnel peer process to forward all port mappings to privileged services running on the host, thereby creating port proxies. However, this mode lacks network namespace isolation and shares iptables with other WSL distros, and it will soon be deprecated.
+
+Alternatively, the Network Tunnel mode allows the Guest Agent to operate in an isolated network namespace with a dedicated iptables. This mode is enabled through Rancher Desktop Networking.
+
+It's also important to note that when neither of the networking modes mentioned above are selected, the Rancher Desktop Guest Agent operates in non-admin user mode. In this mode, all port mappings are bound to localhost, and the use of privileged ports is restricted.
+
+## Containerd
+
+When containerd mode is enabled, the guest agent monitors the containerd API for the following container events:
+```
+/tasks/start
+/containers/update
+/tasks/exit
+```
+If it detects any exposed ports associated with a container, it creates a port mapping object. Depending on the selected network mode, the port mapping object is then forwarded to the host. If the privileged service is enabled, it utilizes the vtunnel peer process to communicate the port mappings with privileged services. Alternatively, if network tunnel mode is enabled, it sends the port mappings to the API offered in the host switch process.
+
+If network tunnel mode is enabled along with the WSL integration option, a copy of the port mapping is also forwarded to the WSL proxy process, enabling access to the exposed port from other distributions.
+
+## Docker
+
+Similar to containerd mode, when Docker mode is enabled, the guest agent watches Docker API with the following container events filter:
+```
+Filters: filters.NewArgs(
+    filters.Arg("type", "container"),
+    filters.Arg("event", startEvent),
+    filters.Arg("event", stopEvent),
+    filters.Arg("event", dieEvent)
+),
+```
+If it detects any exposed ports associated with a container, it creates a port mapping object. Depending on the selected network mode, the port mapping object is then forwarded to the host. If the privileged service is enabled, it uses the vtunnel peer process to communicate the port mappings with privileged services. Otherwise, if network tunnel mode is enabled, it sends the port mappings to the API offered in the host switch process.
+
+If network tunnel mode is enabled along with the WSL integration option, a copy of the port mapping is also forwarded to the `wsl-proxy` process, allowing access to the exposed port from other distributions.
+
+Additionally, Docker mode creates a series of iptables rules associated with the `PREROUTING` and `POSTROUTING` chains.
+
+The `PREROUTING` rule rewrites the destination IP address of any packets received by the local system and destined for `192.168.127.2` to `127.0.0.1`. Meanwhile, the `POSTROUTING` chain rule rewrites the source IP address of any packets being sent out through the eth0 network interface to the IP address of that interface (eth0). These rules are necessary because when the port binding is set to `127.0.0.1`, an additional `DNAT` rule is added in the main `DOCKER` chain after the existing rule using `--append`.
+
+This adjustment is essential because the initial `DOCKER DNAT` rule created by Docker only allows traffic to be routed to `localhost` from `localhost`. Therefore, an additional rule is added to permit traffic to any destination IP address, enabling the service to be discoverable through the namespaced network's subnet.
+
+These changes are necessary as the traffic is routed via the vm-switch over the tap network. The existing `DNAT` rule is as follows:
+
+```
+DNAT tcp -- anywhere localhost tcp dpt:9119 to:10.4.0.22:80
+```
+The following rule is added after the existing rule:
+```
+DNAT tcp -- anywhere anywhere tcp dpt:9119 to:10.4.0.22:80
+```
+## Kubernetes
+
+When this option is enabled, the Rancher Desktop guest agent uses the Kubernetes service watcher to subscribe to the Kubernetes API for any services of type NodePort and LoadBalancer that require port exposure. If the service watcher detects such services, it creates a port mapping object representing each service. The port mapping object is then forwarded to the host based on the selected network mode. If the privileged service is enabled, it uses the vtunnel peer process to communicate the port mappings with privileged services. Otherwise, if network tunnel mode is enabled, it sends the port mappings to the API provided in the host switch process.
+
+It is important to note that if the `k8sServiceListenerAddr` flag is provided, the specified IP address (either `0.0.0.0` or `127.0.0.1`) is used to bind the Kubernetes services on the host.
+
+Additionally, if network tunnel mode is enabled along with the WSL integration option, a copy of the port mapping is also forwarded to the `wsl-proxy` process to allow access to the exposed port from other distributions. However, when the Kubernetes option is enabled, the guest agent statically emits a port mapping to the `wsl-proxy` process in the default network. This port mapping represents the Kubernetes API port (`6443`) to allow access to the Kubernetes API from other distributions.
+
+Below port mapping is an example of what is emitted to `wsl-proxy`:
+```
+types.PortMapping {
+    Remove: false,
+    Ports: nat.PortMap {
+        port: [] nat.PortBinding {
+            {
+                HostIP: "127.0.0.1",
+                HostPort: 6443,
+            },
+        },
+    },
+}
+```
+
+## iptables
+
+In [newer versions](https://github.com/rancher-sandbox/rancher-desktop/blob/bb7f71f18828c45b711d6d4982a2dcaf19f8f3fa/pkg/rancher-desktop/backend/k3sHelper.ts#L1152) of Kubernetes, kubelet no longer automatically creates listeners for NodePort and LoadBalancer services. To address this, we manually create these listeners to ensure proper port forwarding functionality. Service ports requiring forwarding are identified in iptables DNAT. When iptables identifies such ports, it creates a port mapping object representing that service. Depending on the selected network mode, the port mapping object is then forwarded to the host. If the privileged service is enabled, it uses the vtunnel peer process to communicate the port mappings with privileged services. Otherwise, if network tunnel mode is enabled, it sends the port mappings to the API provided by the host switch process.
+
+If network tunnel mode is enabled along with the WSL integration option, a copy of the port mapping is also forwarded to the `wsl-proxy` process, allowing access to the exposed port from other distributions.

--- a/docs/networking/rancher-desktop-networking.md
+++ b/docs/networking/rancher-desktop-networking.md
@@ -1,0 +1,147 @@
+
+# [Rancher Desktop Networking](https://github.com/rancher-sandbox/rancher-desktop-networking)
+
+Rancher Desktop Networking primarily acts as a layer 2 switch between the host (currently Windows only) and the VM (WSL) using the `AF_VSOCK` protocol. It facilitates the transmission of Ethernet frames from the VM to the host. Additionally, it provides `DNS`, `DHCP`, and dynamic port forwarding functionalities. The Rancher Desktop Networking comprises several key services: `host-switch`, `vm-switch`, `network-setup`, and `wsl-proxy`. It utilizes [gvisor's](https://github.com/google/gvisor) network stack and draws inspiration from the [gvisor-tap-vsock](https://github.com/google/gvisor) project.
+
+The diagram below demonstrates the overall architecture of Rancher Desktop Networking:
+
+```mermaid
+flowchart  LR
+subgraph  hostSwitch["host-switch.exe"]
+vsockHost{"main loop"}
+eth(("reconstruct ETH frames"))
+portForwarding["Port Forwarding API"]
+end
+subgraph  Host["HOST"]
+dns["DNS"]
+syscall(("OS syscall"))
+hostSwitch
+end
+subgraph  netNs["Isolated Network Namespace"]
+vsockVM{"VM Switch"}
+tapDevice("eth0")
+veth-rd1("veth-rd1")
+containers["containers"]
+services["services"]
+end
+subgraph  WSL["WSL"]
+netNs
+other-distro(("Other Distros"))
+veth-rd0("veth-rd0")
+wsl-proxy{"wsl-proxy"}
+end
+vsockHost  <---->  eth  &  dns
+eth  <---->  syscall
+vsockHost  ---->  portForwarding
+tapDevice  -- ethernet frames -->  vsockVM
+veth-rd1  -- ethernet frames -->  vsockVM
+veth-rd0  <---->  veth-rd1
+other-distro  <---->  wsl-proxy
+wsl-proxy  <---->  veth-rd0
+containers  <---->  tapDevice
+services  <---->  tapDevice
+vsockVM <-- AF_VSOCK ---> vsockHost
+```
+
+## host-switch:
+
+The host-switch runs on the Windows host and acts as a receiver for all traffic originating from the network namespace within the WSL VM. It performs a handshake to identify the correct VM to communicate with over `AF_VSOCK`. This process retrieves the GUID for the appropriate Hyper-V VM (most likely WSL). It then performs a handshake with the network-setup process running in the WSL distribution to ensure the `AF_VSOCK` connection is established with the correct VM. Once the ready signal is received from the vm-switch, an `AF_VSOCK` connection is established to listen for incoming traffic from that VM. Additionally, the host-switch provides a DNS resolver that runs in the user space network and an API for dynamic port forwarding. The port forwarding API offers the following endpoints:
+
+- `/services/forwarder/all`: Lists all the currently forwarded ports.
+- `/services/forwarder/expose`: Exposes a port.
+- `/services/forwarder/unexpose`: Unexposes a port.
+
+## Supported Flags:
+
+-   **debug**: Enables debug logging.
+-   **subnet**: This flag defines a subnet range with a CIDR suffix for a virtual network. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/vm/switch_linux.go#L59) flag in the vm-switch.
+- **port-forward**: This is a list of static ports that need to be pre-forwarded to the WSL VM. These ports are not dynamically retrieved from any of the APIs that the Rancher Desktop guest agent interacts with.
+
+## network-setup:
+
+The reason for its creation was that the `AF_VSOCK` connection could not be established between the host and a process residing inside the network namespace within the VM, as such capability is not currently supported by `AF_VSOCK`. As a result, the network setup was created. Its main responsibility is to respond to the handshake request from the `host-switch.exe`. Once the handshake process is successful with the `host-switch`, the `network-setup` process creates a new network namespace and attempts to start its subprocess, `vm-switch`, in the newly created network namespace. It also hands over the `AF_VSOCK` connection to the `vm-switch` as a file descriptor in the new namespace.
+
+Additionally, it calls unshare with provided arguments through [---unshare-args](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272). The process also establishes a Virtual Ethernet pair consisting of two endpoints: `veth-rd0` and `veth-rd1`. `veth-rd0` resides within the default namespace and is configured to listen on the IP address `192.168.1.1`. Conversely, `veth-rd1` is located within a network namespace and is assigned the IP address `192.168.1.2`. The virtual Ethernet pair allows accessibility from the default network into the network namespace, which is particularly useful when WSL integration is enabled.
+
+## Supported Flags:
+
+- **debug**: enable the debug logging
+
+- **tap-interface**: The name of the tap interface that is created by the vm-switch upon startup, e.g., `eth0`, `eth1`. This value is passed to the `vm-switch` process when the `network-setup` attempts to start it. If no value is provided, the default name of `eth0` is used.
+
+- **subnet**: A subnet range with a CIDR suffix that is associated with the tap interface in the network namespace. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/host/switch_windows.go#L54) flag in the `host-switch`.
+
+- **tap-mac-address**: MAC address associated with the tap interface created by the vm-switch in the network namespace. If no address is provided, the default address of `5a:94:ef:e4:0c:ee`is used.
+
+- **vm-switch-path**: The path to the `vm-switch` binary that will run in a new namespace. This value is used with `nsenter` to switch the namespace and start the `vm-switch` in the network namespace.
+
+- **vm-switch-logfile**: The path to the logfile for the vm-switch process.
+
+- **unshare-arg**: The command argument to pass to the unshare program in addition to the following [arguments](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272).
+
+- **logfile**: Path to the logfile for the `network-setup` process.
+
+## vm-switch:
+
+Once the network-setup starts the `vm-switch` process in the new namespace, the `vm-switch` creates a tap device (`eth0`) and a loopback device (`lo`). When the `eth0` tap device is successfully created, it uses the `DHCP` client to acquire an IP address within the defined range from the `DHCP` server. Once the `eth0` tap device is up and running, the kernel forwards all raw Ethernet frames originating from the network namespace to the tap device. In addition to the traffic from the network namespace, the kernel also forwards all the traffic that arrives at `veth-rd1` from its pair, `veth-rd0`, in the default namespace.
+
+The tap device forwards the Ethernet frames over [vsock](https://wiki.qemu.org/Features/VirtioVsock) to the host. The process on the host (`host-switch.exe`) decapsulates the frames. Since host-switch maintains both internal (`vm-switch` to `host-switch.exe`) and external (`host-switch.exe` to the internet) connections, it connects to the external endpoints via syscalls.
+
+## Supported Flags:
+
+- **debug**: Enable the debug logging
+
+- **tap-interface**: Tap interface name to create, eg. eth0, eth1
+
+- **tap-mac-address** : MAC address that is associated with the tap interface
+
+- **subnet**: The subnet range with CIDR suffix associated with the tap interface. Although this value is passed from network-setup, it must match the subnet flag in `host-switch` and `network-setup`.
+
+- **logfile**: Path to `vm-switch` process logfile
+
+## wsl-proxy:
+
+Its primary function comes into play when WSL integration is activated alongside the network tunnel. Running within the default network namespace, it establishes a Unix socket listener (`/run/wsl-proxy.sock`) for the guest agent process to connect to from inside the network namespace. The guest agent forwards port mappings from various APIs (docker, containerd, and K8s) over the Unix socket to the `wsl-proxy`. Upon receiving the port mappings, the wsl-proxy sets up listeners bound to localhost for those ports. When traffic arrives at these listeners, it forwards the traffic to the bridge interface connecting the default namespace to the namespaced network, facilitating bidirectional traffic flow.
+
+## Supported Flags:
+
+- **debug**: Enable the debug logging
+
+- **logfile**: Path to the logfile for `wsl-proxy` process
+
+- **socketFile**: This is the path to the `.sock` file for the UNIX socket connection established between the Rancher Desktop guest agent and the `wsl-proxy`. If not provided, the default value of `/run/wsl-proxy.sock` is used.
+
+- **upstreamAddress**: This is the IP address associated with the upstream server to use. It corresponds to the address of the veth pair connecting the default namespace to the network namespace, specifically `veth-rd1`. The default value is `192.168.1.2`.
+
+
+## Process Timelines:
+
+Below is a flow chart that demonstrates the process start up orders.
+
+```mermaid
+sequenceDiagram
+    participant wsl-init (pid n)
+    participant network-setup
+    participant vm-switch
+    participant wsl-init (pid 1)
+    participant host-switch.exe
+    Note over wsl-init (pid n),wsl-init (pid 1): WSL distro (Network Namespace)
+    Note over host-switch.exe: windows host
+    wsl-init (pid n)->>network-setup: spawn process
+    host-switch.exe->>network-setup: handshake request
+    network-setup->>host-switch.exe: handshake response (READY signal)
+    host-switch.exe->>network-setup: vsock listener ready
+    network-setup->>network-setup: open vsock
+    network-setup->>network-setup: create namespace
+    network-setup->>network-setup: create veth pair (veth-rd)
+    network-setup->>vm-switch: spawn
+    Note over network-setup,vm-switch: spawn in network namespace
+    Note over network-setup,vm-switch: pass in vsock connection as fd
+    network-setup->>wsl-init (pid 1): spawn
+    Note over network-setup,wsl-init (pid 1): spawns in netns, new mnt/pid ns
+    vm-switch->>vm-switch: create lo/eth0
+    vm-switch->>vm-switch: DHCP eth0
+    vm-switch->>vm-switch: listen for ethernet frames
+    vm-switch->>host-switch.exe: forward ethernet
+    wsl-init (pid 1)-->>wsl-init (pid 1): Spawn /sbin/init
+```


### PR DESCRIPTION
The intention here is to provide low-level documentation for engineering purposes, along with the architecture of all the components that comprise the Rancher Desktop network.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/4904