### PR TITLE
CI: BATS: Fix installing WSL distribution

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -23,11 +23,8 @@ runs:
       do {
         wsl --update
       } while ( -not $? )
-
-  - name: "Windows: Finish setting up WSL"
-    if: runner.os == 'Windows'
-    shell: pwsh
-    run: wsl --set-default-version 2
+      # Setting the default version also lets WSL finish updating.
+      wsl --set-default-version 2
 
   - name: "Linux: Enable KVM access"
     if: runner.os == 'Linux'

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -144,10 +144,18 @@ jobs:
 
     - name: "Windows: Install WSL2 Distribution"
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: powershell # pwsh doesn't have Add-AppxPackage
       run: |
-        # Install Debian, but do not launch it
-        wsl --install Debian --no-launch
+        # `wsl --install` seems to have issues in CI since 2024-06-14; however,
+        # manually downloading the Debian installer and running it works.
+        Invoke-WebRequest https://github.com/microsoft/WSL/raw/master/distributions/DistributionInfo.json |
+          Select-Object -ExpandProperty Content |
+          ConvertFrom-JSON |
+          Select-Object -ExpandProperty Distributions |
+          Where-Object Name -EQ "Debian" |
+          Select-Object -ExpandProperty Amd64PackageUrl |
+          % { Invoke-WebRequest $_ -OutFile Debian.AppxBundle }
+        Add-AppxPackage Debian.AppxBundle
         # Initialize Debian, without going through any first-time setup
         debian.exe install --root
 


### PR DESCRIPTION
For some reason, using `wsl --install debian` started failing, but manually downloading the package and installing from there is fine; switch to doing that instead, since WSL is already manually updated.  The error is:

> Installing: Debian GNU/Linux
> There are no more endpoints available from the endpoint mapper.
> Error code: Wsl/InstallDistro/0x800706d9

Note that `--no-launch` for `wsl --install` doesn't seem to affect anything here.