### PR TITLE
CI: BATS: Fix defaulting to tunneled networking on Windows

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -234,7 +234,7 @@ jobs:
         RD_USE_GHCR_IMAGES:       "true"
         RD_USE_RAMDISK:           "true"
         RD_USE_WINDOWS_EXE:       "${{ runner.os == 'Windows' }}"
-        RD_USE_NETWORKING_TUNNEL: "${{ runner.os == 'Windows' && inputs.rd-use-networking-tunnel == true }}"
+        RD_USE_NETWORKING_TUNNEL: "${{ runner.os == 'Windows' && format('{0}', inputs.rd-use-networking-tunnel) != 'false' }}"
         WSLENV: "\
           GITHUB_TOKEN:\
           RD_CAPTURE_LOGS:\


### PR DESCRIPTION
When the workflow is run on a schedule, none of the inputs are set; in that case, `inputs.rd-use-networking-tunnel` is blank rather than `true` or `false`.  In order to make the comparison, we need to convert the input to a string first, then check if it equals the literal string `false` in order to correctly default to true.

Sample run with a simplified workflow:
Unset (triggered on push): https://github.com/mook-as/junk/actions/runs/9620374504/job/26538446414
Manually triggered, set to false: https://github.com/mook-as/junk/actions/runs/9620382948/job/26538469579
Manually triggered, set to true: https://github.com/mook-as/junk/actions/runs/9620391657/job/26538493274