### PR TITLE
Bump shfmt 3.7.0 → latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,6 @@ jobs:
     - run: yarn build
     - run: yarn lint:nofix
     - name: Install shfmt
-      run: go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
+      run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
     - run: make -C bats lint
     - run: yarn test


### PR DESCRIPTION
Because shfmt isn't covered by any of our automated dependency trackers.