### PR TITLE
WSL: Enable ipv4.ip_forward

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -740,6 +740,7 @@ subshells
 subvar
 sumologic
 suse
+svclb
 SVCNAME
 SYD
 syscalls


### PR DESCRIPTION
This needs to be enabled for traefik to work.  Also, this must be done in the default namespace; doing it in the tunnelled network namespace does not get inherited in the container namespaces.