### PR TITLE
CI: BATS: Use inputs for summary table

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -293,7 +293,7 @@ jobs:
 
   summarize:
     name: Summarize output
-    needs: bats
+    needs: [ get-tests, bats ]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
@@ -312,3 +312,5 @@ jobs:
       with:
         pattern: "*.logs"
     - run: node .github/workflows/bats/summarize.mjs
+      env:
+        EXPECTED_TESTS: ${{ needs.get-tests.outputs.tests }}


### PR DESCRIPTION
When generating the summary table, examine the matrix directly instead of building things back from the available logs; this ensures we can insert markers for combinations that should have ran but did not have logs available (usually indicating failures).

I thought I had already PRed this, but I don't see it…

Sample run: https://github.com/mook-as/rd/actions/runs/9716555905
(containers/macos-12 moby is missing in the results)