### PR TITLE
Add diagnostic to verify kubeConfig

### DIFF
--- a/pkg/rancher-desktop/integrations/integrationManager.ts
+++ b/pkg/rancher-desktop/integrations/integrationManager.ts
@@ -51,7 +51,7 @@ export function getIntegrationManager(): IntegrationManager {
   case 'darwin':
     return new UnixIntegrationManager(resourcesBinDir, paths.integration, dockerCliPluginDir);
   case 'win32':
-    return new WindowsIntegrationManager();
+    return WindowsIntegrationManager.getInstance();
   default:
     throw new Error(`OS ${ platform } is not supported`);
   }

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -95,6 +95,9 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   /** Extra debugging arguments for wsl-helper. */
   protected wslHelperDebugArgs: string[] = [];
 
+  /** Singleton instance. */
+  private static instance: WindowsIntegrationManager;
+
   constructor() {
     mainEvents.on('settings-update', (settings) => {
       this.wslHelperDebugArgs = runInDebugMode(settings.application.debug) ? ['--verbose'] : [];
@@ -128,6 +131,15 @@ export default class WindowsIntegrationManager implements IntegrationManager {
 
     // Trigger a settings-update.
     mainEvents.emit('settings-write', {});
+  }
+
+  /** Static method to access the singleton instance. */
+  public static getInstance(): WindowsIntegrationManager {
+    if (!WindowsIntegrationManager.instance) {
+      WindowsIntegrationManager.instance = new WindowsIntegrationManager();
+    }
+
+    return WindowsIntegrationManager.instance;
   }
 
   async enforce(): Promise<void> {

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -46,14 +46,15 @@ export class DiagnosticsManager {
   constructor(diagnostics?: DiagnosticsChecker[]) {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
       const imports = (await Promise.all([
-        import('./testCheckers'),
         import('./connectedToInternet'),
         import('./dockerCliSymlinks'),
-        import('./rdBinInShell'),
+        import('./kubeConfigSymlink'),
         import('./kubeContext'),
-        import('./wslFromStore'),
-        import('./mockForScreenshots'),
         import('./limaDarwin'),
+        import('./mockForScreenshots'),
+        import('./rdBinInShell'),
+        import('./testCheckers'),
+        import('./wslFromStore'),
       ])).map(obj => obj.default);
 
       return (await Promise.all(imports)).flat();

--- a/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
@@ -1,0 +1,43 @@
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
+
+import WindowsIntegrationManager from '@pkg/integrations/windowsIntegrationManager';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.diagnostics;
+const integrationManager = new WindowsIntegrationManager();
+
+async function verifyKubeConfigSymlink(): Promise<boolean> {
+  try {
+    await integrationManager.verifyDistrosKubeConfig();
+
+    return true;
+  } catch (error: any) {
+    console.error(`Error verifying kubeconfig symlinks: ${ error }`);
+
+    return false;
+  }
+}
+
+/**
+ * CheckKubeConfigSymlink checks the symlinked kubeConfig in WSL integration
+ * enabled distro for non-rancher desktop configuration.
+ */
+const CheckKubeConfigSymlink: DiagnosticsChecker = {
+  id:       'VERIFY_WSL_INTEGRATION_KUBECONFIG',
+  category: DiagnosticsCategory.Kubernetes,
+  applicable() {
+    return Promise.resolve(true);
+  },
+  async check() {
+    return Promise.resolve({
+      description: 'Rancher Desktop cannot automatically convert the provided kubeconfig file to a symlink' +
+        ' due to existing configurations within that file. To resolve this issue, you will need to ' +
+        'manually create the symlink to ensure existing configurations are preserved and to prevent ' +
+        'any loss of configuration.',
+      passed: await verifyKubeConfigSymlink(),
+      fixes:  [],
+    });
+  },
+};
+
+export default CheckKubeConfigSymlink;

--- a/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
@@ -4,9 +4,10 @@ import WindowsIntegrationManager from '@pkg/integrations/windowsIntegrationManag
 import Logging from '@pkg/utils/logging';
 
 const console = Logging.diagnostics;
-const integrationManager = new WindowsIntegrationManager();
 
 async function verifyKubeConfigSymlink(): Promise<boolean> {
+  const integrationManager = WindowsIntegrationManager.getInstance();
+
   try {
     await integrationManager.verifyDistrosKubeConfig();
 

--- a/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
@@ -9,11 +9,11 @@ async function verifyKubeConfigSymlink(): Promise<boolean> {
   const integrationManager = WindowsIntegrationManager.getInstance();
 
   try {
-    await integrationManager.verifyDistrosKubeConfig();
+    await integrationManager.verifyAllDistrosKubeConfig();
 
     return true;
   } catch (error: any) {
-    console.error(`Error verifying kubeconfig symlinks: ${ error }`);
+    console.error(`Error verifying kubeconfig symlinks: ${ error.message }`);
 
     return false;
   }


### PR DESCRIPTION
When WSL integration is enabled we would need to check the content of the kubeConfig to see if it includes Rancher Desktop only config or not, prior to creating the symlink. Now, we can trigger a diagnostic that prompts the user to manually create the symlink if we encounter non-rancher desktop configuration.

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/7081