### PR TITLE
Add additional logging to kubeconfig --verify flag

### DIFF
--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -57,8 +57,9 @@ var kubeconfigCmd = &cobra.Command{
 		unsupportedConfig, symlinkErr := requireManualSymlink(linkPath)
 		if verify {
 			if unsupportedConfig {
-				os.Exit(1)
+				logrus.Fatalf("kubeConfig: %s contains non-rancher desktop configuration", linkPath)
 			}
+			logrus.Infof("Verified kubeConfig: %s, it only contains Rancher Desktop configuration", linkPath)
 			os.Exit(0)
 		}
 


### PR DESCRIPTION
When `--verify` flag is called it can now provide additional logging upon exit.

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/7081