### PR TITLE
Move initialization after subscribing to API

### DIFF
--- a/src/go/guestagent/pkg/docker/events.go
+++ b/src/go/guestagent/pkg/docker/events.go
@@ -61,10 +61,6 @@ func NewEventMonitor(portTracker tracker.Tracker) (*EventMonitor, error) {
 // MonitorPorts scans Docker's event stream API
 // for container start/stop events.
 func (e *EventMonitor) MonitorPorts(ctx context.Context) {
-	if err := e.initializeRunningContainers(ctx); err != nil {
-		log.Errorf("failed to initialize existing container port mappings: %v", err)
-	}
-
 	msgCh, errCh := e.dockerClient.Events(ctx, types.EventsOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("type", "container"),
@@ -72,6 +68,10 @@ func (e *EventMonitor) MonitorPorts(ctx context.Context) {
 			filters.Arg("event", stopEvent),
 			filters.Arg("event", dieEvent)),
 	})
+
+	if err := e.initializeRunningContainers(ctx); err != nil {
+		log.Errorf("failed to initialize existing container port mappings: %v", err)
+	}
 
 	for {
 		select {


### PR DESCRIPTION
This is to reduce the potential timing race that could occur from the time that we subscribe to the API events and the time we are extracting the ports from already running containers.