### PR TITLE
Scripts: Add guestagent and trivy into wsl-distro tarball instead of installing at runtime

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -8,6 +8,8 @@ extraResources:
 - resources/
 - '!resources/darwin/lima*.tgz'
 - '!resources/linux/lima*.tgz'
+- '!resources/linux/staging/'
+- '!resources/win32/staging/'
 - '!resources/host/'
 files:
 - dist/app/**/*

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -4,6 +4,7 @@ productName: Rancher Desktop
 icon: ./resources/icons/logo-square-512.png
 appId: io.rancherdesktop.app
 asar: true
+electronLanguages: [ en-US ]
 extraResources:
 - resources/
 - '!resources/darwin/lima*.tgz'
@@ -11,6 +12,7 @@ extraResources:
 - '!resources/linux/staging/'
 - '!resources/win32/staging/'
 - '!resources/host/'
+- '!resources/**/*.js.map'
 files:
 - dist/app/**/*
 - '!**/node_modules/*/prebuilds/!(${platform}*)/*.node'

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -903,21 +903,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     }
   }
 
-  /**
-   * On Windows Trivy is run via WSL as there's no native port.
-   * Ensure that all relevant files are in the wsl mount, not the windows one.
-   */
-  protected async installTrivy() {
-    // download-resources.sh installed trivy into the resources area
-    // This function moves it into /usr/local/bin/ so when trivy is
-    // invoked to run through wsl, it runs faster.
-
-    const trivyExecPath = path.join(paths.resources, 'linux', 'internal', 'trivy');
-
-    await this.execCommand('mkdir', '-p', '/var/local/bin');
-    await this.wslInstall(trivyExecPath, '/usr/local/bin');
-  }
-
   protected async installGuestAgent(kubeVersion: semver.SemVer | undefined, cfg: BackendSettings | undefined) {
     let guestAgentConfig: Record<string, any>;
     const enableKubernetes = !!kubeVersion;
@@ -1522,7 +1507,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                 this.runWslProxy().catch(console.error);
               }
             }),
-            this.progressTracker.action('Installing image scanner', 100, this.installTrivy()),
             this.progressTracker.action('Installing CA certificates', 100, this.installCACerts()),
             this.progressTracker.action('Installing helpers', 50, this.installWSLHelpers()),
           ]));

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -947,10 +947,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       };
     }
 
-    const guestAgentPath = path.join(paths.resources, 'linux', 'internal', 'guestagent');
-
     await Promise.all([
-      this.wslInstall(guestAgentPath, '/usr/local/bin/', 'rancher-desktop-guestagent'),
       this.writeFile('/etc/init.d/rancher-desktop-guestagent', SERVICE_GUEST_AGENT_INIT, 0o755),
       this.writeConf('rancher-desktop-guestagent', guestAgentConfig),
     ]);

--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -3,24 +3,50 @@ import path from 'path';
 import { AlpineLimaISOVersion, Dependency, DownloadContext } from 'scripts/lib/dependencies';
 import { simpleSpawn } from 'scripts/simple_process';
 
+type GoDependencyOptions = {
+  /**
+   * The output file name, relative to the platform-specific resources directory.
+   * If this does not contain any directory separators ('/'), it is assumed to
+   * be a directory name (defaults to `bin`) and the leaf name of the source
+   * path is appended as the executable name.
+   */
+  outputPath: string;
+  /**
+   * Additional environment for the go compiler; e.g. for GOARCH overrides.
+   */
+  env?: NodeJS.ProcessEnv;
+};
+
 /**
  * GoDependency represents a golang binary that is built from the local source
  * code.
  */
 export class GoDependency implements Dependency {
-  constructor(path: string | string[], dir: 'bin' | 'internal' | 'host' | 'staging' = 'bin') {
-    this.name = Array.isArray(path) ? path[path.length - 1] : path;
-    this.path = Array.isArray(path) ? path : [path];
-    this.dir = dir;
+  /**
+   * Construct a new GoDependency.
+   * @param sourcePath The path to be compiled, relative to .../src/go
+   * @param options Additional configuration option; if a string is given, this
+   * is the outputPath option, defaulting to `bin`.
+   */
+  constructor(sourcePath: string, options: string | GoDependencyOptions = 'bin') {
+    this.sourcePath = sourcePath;
+    this.options = typeof options === 'string' ? { outputPath: options } : options;
   }
 
-  name: string;
-  path: string[];
-  dir: 'bin' | 'internal' | 'host' | 'staging';
+  get name(): string {
+    if (this.options.outputPath.includes('/')) {
+      return path.basename(this.options.outputPath);
+    }
+
+    return path.basename(this.sourcePath);
+  }
+
+  sourcePath: string;
+  options: GoDependencyOptions;
 
   async download(context: DownloadContext): Promise<void> {
     // Rather than actually downloading anything, this builds the source code.
-    const sourceDir = path.join(process.cwd(), 'src', 'go', ...this.path);
+    const sourceDir = path.join(process.cwd(), 'src', 'go', this.sourcePath);
     const outFile = this.outFile(context);
 
     console.log(`Building go utility \x1B[1;33;40m${ this.name }\x1B[0m from ${ sourceDir } to ${ outFile }...`);
@@ -35,17 +61,19 @@ export class GoDependency implements Dependency {
       ...process.env,
       GOOS:   context.goPlatform,
       GOARCH: context.isM1 ? 'arm64' : 'amd64',
+      ...this.options.env ?? {},
     };
   }
 
   outFile(context: DownloadContext): string {
-    const target = context.platform === 'win32' ? `${ this.name }.exe` : this.name;
+    const suffix = context.platform === 'win32' ? '.exe' : '';
+    let outputPath = `${ this.options.outputPath }${ suffix }`;
 
-    if (this.dir === 'host') {
-      return path.join(context.resourcesDir, this.dir, target);
+    if (!this.options.outputPath.includes('/')) {
+      outputPath = `${ this.options.outputPath }/${ this.name }${ suffix }`;
     }
 
-    return path.join(context.resourcesDir, context.platform, this.dir, target);
+    return path.join(context.resourcesDir, context.platform, outputPath);
   }
 
   getAvailableVersions(includePrerelease?: boolean | undefined): Promise<string[]> {
@@ -83,33 +111,13 @@ export class RDCtl extends GoDependency {
   }
 }
 
-export class ExtensionProxy extends GoDependency {
-  constructor() {
-    super('extension-proxy', 'staging');
-  }
-
-  override environment(context: DownloadContext): NodeJS.ProcessEnv {
-    return {
-      ...super.environment(context),
-      CGO_ENABLED: '0',
-    };
-  }
-}
-
 export class WSLHelper extends GoDependency {
   constructor() {
-    super('wsl-helper', 'internal');
+    super('wsl-helper', { outputPath: 'internal', env: { CGO_ENABLED: '0' } });
   }
 
   dependencies(context: DownloadContext): string[] {
     return ['mobyOpenAPISpec:win32'];
-  }
-
-  override environment(context: DownloadContext) {
-    return {
-      ...super.environment(context),
-      CGO_ENABLED: '0',
-    };
   }
 }
 
@@ -124,6 +132,6 @@ export class NerdctlStub extends GoDependency {
     // easier to handle permissions for Linux-in-WSL.
     const leafName = context.platform === 'win32' ? 'nerdctl.exe' : 'nerdctl-stub';
 
-    return path.join(context.resourcesDir, context.platform, this.dir, leafName);
+    return path.join(context.resourcesDir, context.platform, 'bin', leafName);
   }
 }

--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -1,0 +1,129 @@
+import path from 'path';
+
+import { AlpineLimaISOVersion, Dependency, DownloadContext } from 'scripts/lib/dependencies';
+import { simpleSpawn } from 'scripts/simple_process';
+
+/**
+ * GoDependency represents a golang binary that is built from the local source
+ * code.
+ */
+export class GoDependency implements Dependency {
+  constructor(path: string | string[], dir: 'bin' | 'internal' | 'host' | 'staging' = 'bin') {
+    this.name = Array.isArray(path) ? path[path.length - 1] : path;
+    this.path = Array.isArray(path) ? path : [path];
+    this.dir = dir;
+  }
+
+  name: string;
+  path: string[];
+  dir: 'bin' | 'internal' | 'host' | 'staging';
+
+  async download(context: DownloadContext): Promise<void> {
+    // Rather than actually downloading anything, this builds the source code.
+    const sourceDir = path.join(process.cwd(), 'src', 'go', ...this.path);
+    const outFile = this.outFile(context);
+
+    console.log(`Building go utility \x1B[1;33;40m${ this.name }\x1B[0m from ${ sourceDir } to ${ outFile }...`);
+    await simpleSpawn('go', ['build', '-ldflags', '-s -w', '-o', outFile, '.'], {
+      cwd: sourceDir,
+      env: this.environment(context),
+    });
+  }
+
+  environment(context: DownloadContext): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      GOOS:   context.goPlatform,
+      GOARCH: context.isM1 ? 'arm64' : 'amd64',
+    };
+  }
+
+  outFile(context: DownloadContext): string {
+    const target = context.platform === 'win32' ? `${ this.name }.exe` : this.name;
+
+    if (this.dir === 'host') {
+      return path.join(context.resourcesDir, this.dir, target);
+    }
+
+    return path.join(context.resourcesDir, context.platform, this.dir, target);
+  }
+
+  getAvailableVersions(includePrerelease?: boolean | undefined): Promise<string[]> {
+    throw new Error('Go dependencies do not have available versions.');
+  }
+
+  rcompareVersions(version1: string | AlpineLimaISOVersion, version2: string): 0 | 1 | -1 {
+    throw new Error('Go dependencies do not have available versions.');
+  }
+}
+
+export class RDCtl extends GoDependency {
+  constructor() {
+    super('rdctl');
+  }
+
+  dependencies(context: DownloadContext): string[] {
+    if (context.dependencyPlatform === 'wsl') {
+      // For the WSL copy depend on the Windows one to generate code
+      return ['rdctl:win32'];
+    }
+
+    return [];
+  }
+
+  override async download(context: DownloadContext): Promise<void> {
+    // For WSL, don't re-generate the code; the win32 copy did it.
+    if (context.dependencyPlatform !== 'wsl') {
+      await simpleSpawn('node', ['scripts/ts-wrapper.js',
+        'scripts/generateCliCode.ts',
+        'pkg/rancher-desktop/assets/specs/command-api.yaml',
+        'src/go/rdctl/pkg/options/generated/options.go']);
+    }
+    await super.download(context);
+  }
+}
+
+export class ExtensionProxy extends GoDependency {
+  constructor() {
+    super('extension-proxy', 'staging');
+  }
+
+  override environment(context: DownloadContext): NodeJS.ProcessEnv {
+    return {
+      ...super.environment(context),
+      CGO_ENABLED: '0',
+    };
+  }
+}
+
+export class WSLHelper extends GoDependency {
+  constructor() {
+    super('wsl-helper', 'internal');
+  }
+
+  dependencies(context: DownloadContext): string[] {
+    return ['mobyOpenAPISpec:win32'];
+  }
+
+  override environment(context: DownloadContext) {
+    return {
+      ...super.environment(context),
+      CGO_ENABLED: '0',
+    };
+  }
+}
+
+export class NerdctlStub extends GoDependency {
+  constructor() {
+    super('nerdctl-stub');
+  }
+
+  override outFile(context: DownloadContext) {
+    // nerdctl-stub is the actual nerdctl binary to be run on linux;
+    // there is also a `nerdctl` wrapper in the same directory to make it
+    // easier to handle permissions for Linux-in-WSL.
+    const leafName = context.platform === 'win32' ? 'nerdctl.exe' : 'nerdctl-stub';
+
+    return path.join(context.resourcesDir, context.platform, this.dir, leafName);
+  }
+}

--- a/scripts/dependencies/tar-archives.ts
+++ b/scripts/dependencies/tar-archives.ts
@@ -54,10 +54,10 @@ export class ExtensionProxyImage implements Dependency {
       // Build the image tarball
       const layerHash = layerHasher.digest().toString('hex');
       const image = tar.pack();
-      const imageWritten =
-        stream.promises.finished(
-          image
-            .pipe(fs.createWriteStream(imagePath)));
+      const imageStream = fs.createWriteStream(imagePath);
+      const imageWritten = stream.promises.finished(imageStream);
+
+      image.pipe(imageStream);
       const addEntry = (name: string, input: Buffer | stream.Readable, size?: number) => {
         if (Buffer.isBuffer(input)) {
           size = input.length;
@@ -118,5 +118,65 @@ export class ExtensionProxyImage implements Dependency {
 
   rcompareVersions(version1: string | AlpineLimaISOVersion, version2: string | AlpineLimaISOVersion): 0 | 1 | -1 {
     throw new Error('extension-proxy does not have versions.');
+  }
+}
+
+export class WSLDistroImage implements Dependency {
+  name = 'WSLDistroImage';
+  dependencies(context: DownloadContext): string[] {
+    return ['WSLDistro:win32', 'guestagent:linux'];
+  }
+
+  async download(context: DownloadContext): Promise<void> {
+    const tarName = `distro-${ context.versions.WSLDistro }.tar`;
+    const pristinePath = path.join(context.resourcesDir, context.platform, 'staging', tarName);
+    const pristineFile = fs.createReadStream(pristinePath);
+    const extractor = tar.extract();
+    const destPath = path.join(context.resourcesDir, context.platform, tarName);
+    const destFile = fs.createWriteStream(destPath);
+    const packer = tar.pack();
+
+    console.log('Building WSLDistro image...');
+
+    // Copy the pristine tar file to the destination.
+    packer.pipe(destFile);
+    extractor.on('entry', (header, stream, callback) => {
+      stream.pipe(packer.entry(header, callback));
+    });
+    await stream.promises.finished(pristineFile.pipe(extractor));
+
+    async function addFile(fromPath: string, name: string, options: Omit<tar.Headers, 'name' | 'size'> = {}) {
+      const { size } = await fs.promises.stat(fromPath);
+      const inputFile = fs.createReadStream(fromPath);
+
+      console.log(`WSL Distro: Adding ${ fromPath } to ${ name }...`);
+      await stream.promises.finished(inputFile.pipe(packer.entry({
+        name,
+        size,
+        mode:  0o755,
+        type:  'file',
+        mtime: new Date(0),
+        ...options,
+      })));
+    }
+
+    // Add extra files.
+    await addFile(path.join(context.resourcesDir, 'linux', 'staging', 'guestagent'),
+      'usr/local/bin/rancher-desktop-guestagent');
+    await addFile(path.join(context.resourcesDir, 'linux', 'staging', 'trivy'),
+      'usr/local/bin/trivy');
+
+    // Finish the archive.
+    packer.finalize();
+    await stream.promises.finished(packer);
+    console.log('Built WSLDistro image.');
+  }
+
+  getAvailableVersions(includePrerelease?: boolean | undefined): Promise<string[] | AlpineLimaISOVersion[]> {
+    throw new Error('WSLDistroImage does not have versions.');
+  }
+
+  rcompareVersions(version1: string | AlpineLimaISOVersion, version2: string | AlpineLimaISOVersion): 0 | 1 | -1 {
+    throw new Error('WSLDistroImage does not have versions.');
   }
 }

--- a/scripts/dependencies/tar-archives.ts
+++ b/scripts/dependencies/tar-archives.ts
@@ -1,0 +1,122 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import stream from 'stream';
+
+import tar from 'tar-stream';
+
+import { AlpineLimaISOVersion, Dependency, DownloadContext } from 'scripts/lib/dependencies';
+
+export class ExtensionProxyImage implements Dependency {
+  name = 'rdx-proxy.tar';
+  dependencies(context: DownloadContext) {
+    return [`extension-proxy:linux`];
+  }
+
+  async download(context: DownloadContext): Promise<void> {
+    // Build the extension proxy image.
+    const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-build-rdx-pf-'));
+
+    try {
+      const executablePath = path.join(context.resourcesDir, 'linux', 'staging', 'extension-proxy');
+      const layerPath = path.join(workDir, 'layer.tar');
+      const imagePath = path.join(context.resourcesDir, 'rdx-proxy.tar');
+
+      console.log('Building RDX proxying image...');
+
+      // Build the layer tarball
+      // tar streams don't implement piping to multiple writers, and stream.Duplex
+      // can't deal with it either; so we need to fully write out the file, then
+      // calculate the hash as a separate step.
+      const layer = tar.pack();
+      const layerOutput = layer.pipe(fs.createWriteStream(layerPath));
+      const executableStats = await fs.promises.stat(executablePath);
+
+      await stream.promises.finished(
+        fs.createReadStream(executablePath)
+          .pipe(layer.entry({
+            name:  path.basename(executablePath),
+            mode:  0o755,
+            type:  'file',
+            mtime: new Date(0),
+            size:  executableStats.size,
+          })));
+      layer.finalize();
+      await stream.promises.finished(layerOutput);
+
+      // calculate the hash
+      const layerReader = fs.createReadStream(layerPath);
+      const layerHasher = layerReader.pipe(crypto.createHash('sha256'));
+
+      await stream.promises.finished(layerReader);
+
+      // Build the image tarball
+      const layerHash = layerHasher.digest().toString('hex');
+      const image = tar.pack();
+      const imageWritten =
+        stream.promises.finished(
+          image
+            .pipe(fs.createWriteStream(imagePath)));
+      const addEntry = (name: string, input: Buffer | stream.Readable, size?: number) => {
+        if (Buffer.isBuffer(input)) {
+          size = input.length;
+          input = stream.Readable.from(input);
+        }
+
+        return stream.promises.finished((input as stream.Readable).pipe(image.entry({
+          name,
+          size,
+          type:  'file',
+          mtime: new Date(0),
+        })));
+      };
+
+      image.entry({ name: layerHash, type: 'directory' });
+      await addEntry(`${ layerHash }/VERSION`, Buffer.from('1.0'));
+      await addEntry(`${ layerHash }/layer.tar`, fs.createReadStream(layerPath), layerOutput.bytesWritten);
+      await addEntry(`${ layerHash }/json`, Buffer.from(JSON.stringify({
+        id:     layerHash,
+        config: {
+          ExposedPorts: { '80/tcp': {} },
+          WorkingDir:   '/',
+          Entrypoint:   [`/${ path.basename(executablePath) }`],
+        },
+      })));
+      await addEntry(`${ layerHash }.json`, Buffer.from(JSON.stringify({
+        architecture: context.isM1 ? 'arm64' : 'amd64',
+        config:       {
+          ExposedPorts: { '80/tcp': {} },
+          Entrypoint:   [`/${ path.basename(executablePath) }`],
+          WorkingDir:   '/',
+        },
+        history: [],
+        os:      'linux',
+        rootfs:  {
+          type:     'layers',
+          diff_ids: [`sha256:${ layerHash }`],
+        },
+      })));
+      await addEntry('manifest.json', Buffer.from(JSON.stringify([
+        {
+          Config:   `${ layerHash }.json`,
+          RepoTags: ['ghcr.io/rancher-sandbox/rancher-desktop/rdx-proxy:latest'],
+          Layers:   [`${ layerHash }/layer.tar`],
+        },
+      ])));
+      image.finalize();
+      await imageWritten;
+      console.log('Built RDX port proxy image');
+    } finally {
+      await fs.promises.rm(workDir, { recursive: true });
+    }
+  }
+
+  getAvailableVersions(includePrerelease?: boolean | undefined): Promise<string[] | AlpineLimaISOVersion[]> {
+    throw new Error('extension-proxy does not have versions.');
+  }
+
+  rcompareVersions(version1: string | AlpineLimaISOVersion, version2: string | AlpineLimaISOVersion): 0 | 1 | -1 {
+    throw new Error('extension-proxy does not have versions.');
+  }
+}

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -298,7 +298,8 @@ export class Trivy implements Dependency, GitHubDependency {
     const trivyURL = `${ trivyURLBase }/download/${ versionWithV }/${ trivyBasename }.tar.gz`;
     const checksumURL = `${ trivyURLBase }/download/${ versionWithV }/trivy_${ context.versions.trivy }_checksums.txt`;
     const trivySHA = await findChecksum(checksumURL, `${ trivyBasename }.tar.gz`);
-    const trivyPath = path.join(context.resourcesDir, 'linux', 'internal', 'trivy');
+    const trivyDir = context.dependencyPlatform === 'wsl' ? 'staging' : 'internal';
+    const trivyPath = path.join(context.resourcesDir, 'linux', trivyDir, 'trivy');
 
     // trivy.tgz files are top-level tarballs - not wrapped in a labelled directory :(
     await downloadTarGZ(trivyURL, trivyPath, { expectedChecksum: trivySHA });

--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -164,7 +164,7 @@ export class WSLDistro implements Dependency, GitHubDependency {
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
     const tarName = `distro-${ context.versions.WSLDistro }.tar`;
     const url = `${ baseUrl }/v${ context.versions.WSLDistro }/${ tarName }`;
-    const destPath = path.join(context.resourcesDir, context.platform, tarName);
+    const destPath = path.join(context.resourcesDir, context.platform, 'staging', tarName);
 
     await download(url, destPath, { access: fs.constants.W_OK });
   }

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -72,6 +72,11 @@ export async function writeDependencyVersions(path: string, depVersions: Depende
 
 export interface Dependency {
   name: string,
+  /**
+   * Other dependencies this one requires.
+   * This must be in the form <name>:<platform>, e.g. "kuberlr:linux"
+   */
+  dependencies?: (context: DownloadContext) => string[],
   download(context: DownloadContext): Promise<void>
   // Returns the available versions of the Dependency.
   // Includes prerelease versions if includePrerelease is true.

--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -10,6 +10,8 @@ import path from 'path';
 
 import fetch from 'node-fetch';
 
+import { simpleSpawn } from 'scripts/simple_process';
+
 type ChecksumAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 export type DownloadOptions = {
@@ -193,9 +195,10 @@ export async function downloadTarGZ(url: string, destPath: string, options: Arch
       }
       args[0] = path.join(systemRoot, 'system32', 'tar.exe');
     }
-    execFileSync(args[0], args.slice(1), { stdio: 'inherit' });
-    fs.copyFileSync(path.join(workDir, fileToExtract), destPath);
-    fs.chmodSync(destPath, mode);
+    await simpleSpawn(args[0], args.slice(1));
+    await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+    await fs.promises.copyFile(path.join(workDir, fileToExtract), destPath);
+    await fs.promises.chmod(destPath, mode);
   } finally {
     fs.rmSync(workDir, { recursive: true, maxRetries: 10 });
   }

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -131,11 +131,11 @@ class Builder {
       break;
     }
 
-    // If we have files (resp. extraFiles / extraResources) both at the top
-    // level as well as at the platform-specific level, merge the two and move
-    // it to the top level.  This allows us to have platform-specific exclusions
-    // (as otherwise the two lists are calculated separately _then_ merged
-    // together).
+    // When there are files (e.g., extraFiles or extraResources) specified at both
+    // the top-level and platform-specific levels, we need to combine them
+    // and place the combined list at the top level. This approach enables us to have
+    // platform-specific exclusions, since the two lists are initially processed
+    // separately and then merged together afterward.
     for (const key of ['files', 'extraFiles', 'extraResources'] as const) {
       const section = config[electronPlatform];
       const items = config[key];

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -73,7 +73,7 @@ const vmDependencies = [
   new tools.WasmShims(),
   new tools.CertManager(),
   new tools.SpinOperator(),
-  new goUtils.ExtensionProxy(),
+  new goUtils.GoDependency('extension-proxy', { outputPath: 'staging', env: { CGO_ENABLED: '0' } }),
   new ExtensionProxyImage(),
 ];
 

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import * as goUtils from 'scripts/dependencies/go-source';
 import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
-import { ExtensionProxyImage } from 'scripts/dependencies/tar-archives';
+import { ExtensionProxyImage, WSLDistroImage } from 'scripts/dependencies/tar-archives';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
 import {
@@ -46,6 +46,7 @@ const unixDependencies = [
 // Dependencies that are specific to windows hosts.
 const windowsDependencies = [
   new WSLDistro(),
+  new WSLDistroImage(),
   new HostResolverHost(),
   new Wix(),
   new HostSwitch(),

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -16,6 +16,11 @@ import {
 } from 'scripts/lib/dependencies';
 import { simpleSpawn } from 'scripts/simple_process';
 
+type DependencyWithContext = {
+  dependency: Dependency;
+  context: DownloadContext;
+};
+
 // Dependencies that should be installed into places that users touch
 // (so users' WSL distros and hosts as of the time of writing).
 const userTouchedDependencies = [
@@ -65,38 +70,106 @@ const hostDependencies = [
   new MobyOpenAPISpec(),
 ];
 
-function downloadDependencies(context: DownloadContext, dependencies: Dependency[]): Promise<void[]> {
-  return Promise.all(
-    dependencies.map(dependency => dependency.download(context)),
-  );
+async function downloadDependencies(items: DependencyWithContext[]): Promise<void[]> {
+  function specialize(item: DependencyWithContext) {
+    return `${ item.dependency.name }:${ item.context.platform }`;
+  }
+  // Dependencies might depend on other dependencies.  Note that we may have
+  // multiple dependencies of the same name, but different platforms; therefore,
+  // all dependencies are keyed by <name>:<platform>.
+  const dependenciesByName = Object.fromEntries(items.map(item => [specialize(item), item]));
+  const forwardDependencies = Object.fromEntries(items.map(item => [specialize(item), [] as string[]] as const));
+  const reverseDependencies = Object.fromEntries(items.map(item => [specialize(item), [] as string[]] as const));
+  const all = new Set(Object.keys(dependenciesByName));
+  const running = new Set<string>();
+  const done = new Set<string>();
+  const promises: Promise<void>[] = [];
+
+  for (const item of items) {
+    const dependencies = item.dependency.dependencies?.(item.context) ?? [];
+
+    forwardDependencies[specialize(item)].push(...dependencies);
+    for (const dependency of dependencies) {
+      if (dependency in reverseDependencies) {
+        reverseDependencies[dependency].push(specialize(item));
+      } else {
+        throw new Error(`Dependency ${ item.dependency.name } depends on unknown dependency ${ dependency }`);
+      }
+    }
+  }
+  async function process(name: string) {
+    running.add(name);
+    const item = dependenciesByName[name];
+
+    await item.dependency.download(item.context);
+    done.add(name);
+    for (const dependent of reverseDependencies[name]) {
+      if (!running.has(dependent)) {
+        if (forwardDependencies[dependent].every(d => done.has(d))) {
+          promises.push(process(dependent));
+        }
+      }
+    }
+  }
+
+  for (const item of items.filter(d => (d.dependency.dependencies?.(d.context) ?? []).length === 0)) {
+    promises.push(process(specialize(item)));
+  }
+
+  while (running.size > done.size) {
+    await Promise.all(promises);
+  }
+
+  if (all.size > done.size) {
+    const remaining = Array.from(all).filter(d => !done.has(d)).sort();
+    const message = [`${ remaining.length } dependencies are stuck:`];
+
+    for (const key of remaining) {
+      const deps = forwardDependencies[key].filter(d => !done.has(d));
+
+      message.push(`    ${ key } depends on ${ deps }`);
+    }
+    throw new Error(message.join('\n'));
+  }
+
+  return await Promise.all(promises);
 }
 
 async function runScripts(): Promise<void> {
   // load desired versions of dependencies
   const depVersions = await readDependencyVersions(path.join('pkg', 'rancher-desktop', 'assets', 'dependencies.yaml'));
   const platform = os.platform();
+  const dependencies: DependencyWithContext[] = [];
 
   if (platform === 'linux' || platform === 'darwin') {
     // download things that go on unix host
     const hostDownloadContext = buildDownloadContextFor(platform, depVersions);
 
-    await downloadDependencies(hostDownloadContext, [...userTouchedDependencies, ...unixDependencies, ...hostDependencies]);
+    for (const dependency of [...userTouchedDependencies, ...unixDependencies, ...hostDependencies]) {
+      dependencies.push({ dependency, context: hostDownloadContext });
+    }
 
     // download things that go inside Lima VM
     const vmDownloadContext = buildDownloadContextFor('linux', depVersions);
 
-    await downloadDependencies(vmDownloadContext, vmDependencies);
+    dependencies.push(...vmDependencies.map(dependency => ({ dependency, context: vmDownloadContext })));
   } else if (platform === 'win32') {
     // download things for windows
     const hostDownloadContext = buildDownloadContextFor('win32', depVersions);
 
-    await downloadDependencies(hostDownloadContext, [...userTouchedDependencies, ...windowsDependencies, ...hostDependencies]);
+    for (const dependency of [...userTouchedDependencies, ...windowsDependencies, ...hostDependencies]) {
+      dependencies.push({ dependency, context: hostDownloadContext });
+    }
 
     // download things that go inside WSL distro
     const vmDownloadContext = buildDownloadContextFor('wsl', depVersions);
 
-    await downloadDependencies(vmDownloadContext, [...userTouchedDependencies, ...wslDependencies, ...vmDependencies]);
+    for (const dependency of [...userTouchedDependencies, ...wslDependencies, ...vmDependencies]) {
+      dependencies.push({ dependency, context: vmDownloadContext });
+    }
   }
+
+  await downloadDependencies(dependencies);
 }
 
 function buildDownloadContextFor(rawPlatform: DependencyPlatform, depVersions: DependencyVersions): DownloadContext {


### PR DESCRIPTION
Fixes #7137.

- Convert the go utility building to `Dependency`s, and implement crude dependency tracking so that they can depend on each other.
  - Note that `GoDependency` can take an array as the first argument, so `new GoDependency(['networking', 'cmd', 'network'])` is valid.
- Embed the guest agent and trivy into the WSL distro.  Note that we do not change trivy for Lima-based platforms for now.
- Mark some files as not needing to be installed (this was from when I was ignoring specific files; I've changed to put the files in a new `staging` directory instead so not packaging them is easier).