### PR TITLE
src/go: Remove old-style +build tags

### DIFF
--- a/src/go/nerdctl-stub/debugging.go
+++ b/src/go/nerdctl-stub/debugging.go
@@ -1,10 +1,27 @@
 //go:build debug
-// +build debug
+
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package main
 
 import (
 	"fmt"
+	"log"
+	"sort"
 )
 
 // describeCommands is a debugging function that prints out all commands.

--- a/src/go/nerdctl-stub/debugging_stub.go
+++ b/src/go/nerdctl-stub/debugging_stub.go
@@ -1,5 +1,4 @@
 //go:build !debug
-// +build !debug
 
 /*
 Copyright © 2024 SUSE LLC

--- a/src/go/nerdctl-stub/main_unsupported.go
+++ b/src/go/nerdctl-stub/main_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !(linux || windows)
-// +build !linux,!windows
 
 package main
 

--- a/src/go/privileged-service/cmd/root.go
+++ b/src/go/privileged-service/cmd/root.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2022 SUSE LLC

--- a/src/go/privileged-service/cmd/uninstall.go
+++ b/src/go/privileged-service/cmd/uninstall.go
@@ -1,12 +1,14 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2022 SUSE LLC
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/go/vtunnel/test/e2e/connectivity_test.go
+++ b/src/go/vtunnel/test/e2e/connectivity_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2022 SUSE LLC

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -1,9 +1,8 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © 2021 SUSE LLC
-1
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/go/wsl-helper/cmd/k3s.go
+++ b/src/go/wsl-helper/cmd/k3s.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/cmd/k3s_kubeconfig.go
+++ b/src/go/wsl-helper/cmd/k3s_kubeconfig.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/cmd/wsl_info.go
+++ b/src/go/wsl-helper/cmd/wsl_info.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2023 SUSE LLC

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/hyperv_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/pkg/dockerproxy/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve.go
@@ -1,5 +1,4 @@
 //go:build linux || windows
-// +build linux windows
 
 /*
 Copyright © 2021 SUSE LLC

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright © 2021 SUSE LLC


### PR DESCRIPTION
These are obsolete and not actually required by the linter.

See also https://github.com/rancher-sandbox/rancher-desktop/pull/7153#discussion_r1669384017