### PR TITLE
rddepman: Support golangci-lint

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -9,6 +9,7 @@ helm: 3.15.2
 dockerCLI: 27.0.3
 dockerBuildx: 0.15.1
 dockerCompose: 2.28.1
+golangci-lint: 1.59.1
 trivy: 0.53.0
 steve: 0.1.0-beta9
 rancherDashboard: desktop-v2.7.0.beta.1

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -278,6 +278,30 @@ export class DockerCompose implements Dependency, GitHubDependency {
   }
 }
 
+export class GoLangCILint implements Dependency, GitHubDependency {
+  name = 'golangci-lint';
+  githubOwner = 'golangci';
+  githubRepo = 'golangci-lint';
+
+  download(context: DownloadContext): Promise<void> {
+    // We don't actually download anything; when we invoke the linter, we just
+    // use `go run` with the appropriate package.
+    return Promise.resolve();
+  }
+
+  async getAvailableVersions(includePrerelease = false): Promise<string[]> {
+    return await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
+  }
+
+  versionToTagName(version: string): string {
+    return `v${ version }`;
+  }
+
+  rcompareVersions(version1: string, version2: string): -1 | 0 | 1 {
+    return semver.rcompare(version1, version2);
+  }
+}
+
 export class Trivy implements Dependency, GitHubDependency {
   name = 'trivy';
   githubOwner = 'aquasecurity';

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -41,6 +41,7 @@ export type DependencyVersions = {
   dockerCLI: string;
   dockerBuildx: string;
   dockerCompose: string;
+  'golangci-lint': string;
   trivy: string;
   steve: string;
   guestAgent: string;

--- a/scripts/lint-go.ts
+++ b/scripts/lint-go.ts
@@ -5,6 +5,8 @@
  */
 import path from 'path';
 
+import { readDependencyVersions } from './lib/dependencies';
+
 import { spawnFile } from '@pkg/utils/childProcess';
 
 const fix = process.argv.includes('--fix');
@@ -77,10 +79,11 @@ async function syncModules(fix: boolean): Promise<boolean> {
 }
 
 async function goLangCILint(fix: boolean): Promise<boolean> {
-  const version = '1.59.1';
+  const depVersionsPath = path.join('pkg', 'rancher-desktop', 'assets', 'dependencies.yaml');
+  const dependencyVersions = await readDependencyVersions(depVersionsPath);
 
   const args = [
-    'run', `github.com/golangci/golangci-lint/cmd/golangci-lint@v${ version }`,
+    'run', `github.com/golangci/golangci-lint/cmd/golangci-lint@v${ dependencyVersions['golangci-lint'] }`,
     'run', '--config=.github/workflows/config/.golangci.yaml',
     '--timeout=10m', '--verbose',
   ];

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -32,6 +32,7 @@ const dependencies: Dependency[] = [
   new tools.DockerBuildx(),
   new tools.DockerCompose(),
   new tools.DockerProvidedCredHelpers(),
+  new tools.GoLangCILint(),
   new tools.Trivy(),
   new tools.Steve(),
   new tools.RancherDashboard(),

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -179,6 +179,15 @@ async function checkDependencies(): Promise<void> {
 
   const updatesAvailable = await determineUpdatesAvailable();
 
+  if (!process.env.CI) {
+    // When not running in CI, don't try to make pull requests.
+    if (updatesAvailable.length) {
+      console.log(`Not running in CI, skipping creation of ${ updatesAvailable.length } pull requests.`);
+    }
+
+    return;
+  }
+
   // reconcile dependencies that need an update with state of repo's PRs
   const needToCreatePR: VersionComparison[] = [];
 


### PR DESCRIPTION
This adds support for rddepman to manage golangci-lint versions.

This also changes rddepman to not attempt to create PRs when not running in CI (which can always be overridden by setting the `CI` environment variable).  This makes it easier to test changes without worrying about making accidental PRs.