### PR TITLE
CI: go.work sync: Force use GitHub-provided token

### DIFF
--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -28,7 +28,10 @@ jobs:
       id: has-token
       run: echo "has-token=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
       env:
-        HAS_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
+        # Temporarily disable use of token; we don't have a correct token set up
+        # (so we fail to push), so using the GitHub-provided token that doesn't
+        # trigger subsequent checks is better than failing to push.
+        HAS_TOKEN: ${{ false && secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
     - name: Checkout with token
       if: steps.has-token.outputs.has-token == 'true'
       uses: actions/checkout@v4


### PR DESCRIPTION
We're having issues with the secret token in our repo; it's not allowing pushes for some reason.  Switch to the GitHub provided one, which doesn't trigger CI but should at least pass (and we can manually re-trigger CI).

Sample run: https://github.com/mook-as/rd/actions/runs/9862372231/job/27232830143?pr=287
Sample commit from that run: https://github.com/mook-as/rd/pull/287/commits/b8cb8f35ca7dedf7831128a9b0ef2f8a57be5b9f