### PR TITLE
Raise minimum supported Kubernetes version from 1.15.0 → 1.21.0

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -43,7 +43,7 @@ provision:
   script: |
     #!/bin/sh
     set -o errexit -o nounset -o xtrace
-    [[ "${RC_CGROUP_MODE:-}" =~ "unified|hybrid|legacy" ]] || exit 0
+    RC_CGROUP_MODE=unified
     if ! grep -q -E "^#?rc_cgroup_mode=\"$RC_CGROUP_MODE\"" /etc/rc.conf; then
       sed -i -E "s/^#?rc_cgroup_mode=\".*\"/rc_cgroup_mode=\"$RC_CGROUP_MODE\"/" /etc/rc.conf
       # avoid reboot loop if sed failed for any reason

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -47,11 +47,11 @@ beforeEach(() => {
 
 describe(buildVersion, () => {
   test('parses the build number', () => {
-    expect(buildVersion(new semver.SemVer('v1.2.3+k3s4'))).toEqual(4);
+    expect(buildVersion(new semver.SemVer('v1.99.3+k3s4'))).toEqual(4);
   });
 
   test('handles non-conforming versions', () => {
-    expect(buildVersion(new semver.SemVer('v1.2.3'))).toEqual(-1);
+    expect(buildVersion(new semver.SemVer('v1.99.3'))).toEqual(-1);
   });
 });
 
@@ -91,31 +91,31 @@ describe(K3sHelper, () => {
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should skip prereleases', async() => {
-      expect(process('1.2.3-beta1')).toEqual(true);
+      expect(process('1.99.3-beta1')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should skip valid but erroneous versions', async() => {
-      expect(process('1.2.3+rk3s1')).toEqual(true);
+      expect(process('1.99.3+rk3s1')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should ignore old versions', async() => {
-      expect(process('0.2.0')).toEqual(true);
+      expect(process('1.2.0')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should ignore obsolete builds', async() => {
-      expect(process('1.2.3_k3s4', ['1.2.3+k3s5'])).toEqual(true);
+      expect(process('1.99.3+k3s4', ['1.99.3+k3s5'])).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(1);
     });
     it('should ignore existing builds', async() => {
-      expect(process('1.2.3+k3s4', ['1.2.3+k3s4'])).toEqual(false);
+      expect(process('1.99.3+k3s4', ['1.99.3+k3s4'])).toEqual(false);
       expect(await subject.availableVersions).toHaveLength(1);
     });
     it('should ignore versions with missing assets', async() => {
-      expect(process('1.2.3+k3s4')).toEqual(true);
+      expect(process('1.99.3+k3s4')).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(0);
     });
     it('should add versions', async() => {
-      expect(process('1.2.3+k3s4', [], true)).toEqual(true);
+      expect(process('1.99.3+k3s4', [], true)).toEqual(true);
       expect(await subject.availableVersions).toHaveLength(1);
     });
   });
@@ -124,8 +124,8 @@ describe(K3sHelper, () => {
     const subject = new K3sHelper('x86_64');
     const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
     const versions: Record<string, VersionEntry> = {
-      '1.2.3': new VersionEntry(semver.parse('1.2.3+k3s1') as semver.SemVer, ['stable']),
-      '2.3.4': new VersionEntry(semver.parse('2.3.4+k3s3') as semver.SemVer),
+      '1.99.3': new VersionEntry(semver.parse('1.99.3+k3s1') as semver.SemVer, ['stable']),
+      '2.3.4':  new VersionEntry(semver.parse('2.3.4+k3s3') as semver.SemVer),
     };
     const versionStrings = Object.values(versions)
       .map(v => v.version)
@@ -143,7 +143,7 @@ describe(K3sHelper, () => {
 
       expect(actual).toHaveProperty('cacheVersion');
       expect(semver.sort(actualStrings)).toEqual(versionStrings);
-      expect(channels).toEqual({ stable: '1.2.3' });
+      expect(channels).toEqual({ stable: '1.99.3' });
 
       // Check that we can load the values back properly
       subject['versions'] = {};
@@ -173,8 +173,8 @@ describe(K3sHelper, () => {
         const result = new ChannelMapping();
 
         for (const [version, tags] of Object.entries({
-          'v1.2.1+k3s1': ['stale-tag'],
-          'v1.2.3+k3s1': ['stable'],
+          'v1.99.1+k3s1': ['stale-tag'],
+          'v1.99.3+k3s1': ['stable'],
         })) {
           const parsedVersion = new semver.SemVer(version);
 
@@ -199,7 +199,7 @@ describe(K3sHelper, () => {
           JSON.stringify({
             data: [{
               name:   'stable',
-              latest: 'v1.2.3+k3s3',
+              latest: 'v1.99.3+k3s3',
             }],
           }),
         ));
@@ -209,12 +209,12 @@ describe(K3sHelper, () => {
 
         return Promise.resolve(new FetchResponse(
           JSON.stringify([
-            { tag_name: 'v1.2.3+k3s2', assets: validAssets },
-            { tag_name: 'v1.2.3+k3s3', assets: validAssets },
+            { tag_name: 'v1.99.3+k3s2', assets: validAssets },
+            { tag_name: 'v1.99.3+k3s3', assets: validAssets },
             // The next one is skipped because there's a newer build
-            { tag_name: 'v1.2.3+k3s1', assets: validAssets },
-            { tag_name: 'v1.2.4+k3s1', assets: [] },
-            { tag_name: 'v1.2.1+k3s2', assets: validAssets },
+            { tag_name: 'v1.99.3+k3s1', assets: validAssets },
+            { tag_name: 'v1.99.4+k3s1', assets: [] },
+            { tag_name: 'v1.99.1+k3s2', assets: validAssets },
           ]),
           { headers: { link: '<url>; rel="next"' } },
         ));
@@ -233,7 +233,7 @@ describe(K3sHelper, () => {
         return Promise.resolve(new FetchResponse(
           JSON.stringify([
             { tag_name: 'Invalid tag name', assets: validAssets },
-            { tag_name: 'v1.2.0+k3s5', assets: validAssets },
+            { tag_name: 'v1.99.0+k3s5', assets: validAssets },
           ]),
           { headers: { link: '<url>; rel="first"' } },
         ));
@@ -249,9 +249,9 @@ describe(K3sHelper, () => {
     expect(fetch).toHaveBeenCalledTimes(4);
     expect(subject['delayForWaitLimiting']).toHaveBeenCalledTimes(1);
     expect(await subject.availableVersions).toEqual([
-      new VersionEntry(new semver.SemVer('v1.2.3+k3s3'), ['stable']),
-      new VersionEntry(new semver.SemVer('v1.2.1+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.2.0+k3s5')),
+      new VersionEntry(new semver.SemVer('v1.99.3+k3s3'), ['stable']),
+      new VersionEntry(new semver.SemVer('v1.99.1+k3s2')),
+      new VersionEntry(new semver.SemVer('v1.99.0+k3s5')),
     ]);
   });
 
@@ -274,15 +274,15 @@ describe(K3sHelper, () => {
         const result = new ChannelMapping();
 
         for (const [version, tags] of Object.entries({
-          'v1.26.0+k3s2': [],
-          'v1.26.1+k3s1': [],
-          'v1.26.2+k3s1': [],
-          'v1.26.3+k3s1': ['v1.26', 'stable'],
-          'v1.27.1+k3s1': [],
-          'v1.27.2+k3s1': [],
-          'v1.27.3+k3s1': [],
-          'v1.27.4+k3s1': [],
-          'v1.27.5+k3s1': ['v1.27', 'latest'],
+          'v1.96.0+k3s2': [],
+          'v1.96.1+k3s1': [],
+          'v1.96.2+k3s1': [],
+          'v1.96.3+k3s1': ['v1.96', 'stable'],
+          'v1.97.1+k3s1': [],
+          'v1.97.2+k3s1': [],
+          'v1.97.3+k3s1': [],
+          'v1.97.4+k3s1': [],
+          'v1.97.5+k3s1': ['v1.97', 'latest'],
         })) {
           const parsedVersion = new semver.SemVer(version);
 
@@ -293,10 +293,10 @@ describe(K3sHelper, () => {
         }
 
         subject['versionFromChannel'] = {
-          stable:  '1.26.3',
-          latest:  '1.27.5',
-          'v1.26': '1.26.3',
-          'v1.27': '1.27.5',
+          stable:  '1.96.3',
+          latest:  '1.97.5',
+          'v1.96': '1.96.3',
+          'v1.97': '1.97.5',
         };
 
         return Promise.resolve(result);
@@ -311,11 +311,11 @@ describe(K3sHelper, () => {
         return Promise.resolve(new FetchResponse(
           JSON.stringify({
             data: [
-              { name: 'v1.26', latest: '1.26.9+k3s1' },
-              { name: 'v1.27', latest: '1.27.7+k3s1' },
-              { name: 'stable', latest: '1.27.7+k3s1' },
-              { name: 'latest', latest: '1.28.3+k3s1' },
-              { name: 'v1.28', latest: '1.28.3+k3s1' },
+              { name: 'v1.96', latest: '1.96.9+k3s1' },
+              { name: 'v1.97', latest: '1.97.7+k3s1' },
+              { name: 'stable', latest: '1.97.7+k3s1' },
+              { name: 'latest', latest: '1.98.3+k3s1' },
+              { name: 'v1.98', latest: '1.98.3+k3s1' },
             ],
           }),
         ));
@@ -325,11 +325,11 @@ describe(K3sHelper, () => {
 
         return Promise.resolve(new FetchResponse(
           JSON.stringify([
-            { tag_name: 'v1.28.3+k3s2', assets: validAssets },
-            { tag_name: 'v1.28.2+k3s2', assets: validAssets },
-            { tag_name: 'v1.28.1+k3s2', assets: validAssets },
-            { tag_name: 'v1.27.7+k3s2', assets: validAssets },
-            { tag_name: 'v1.27.6+k3s1', assets: validAssets },
+            { tag_name: 'v1.98.3+k3s2', assets: validAssets },
+            { tag_name: 'v1.98.2+k3s2', assets: validAssets },
+            { tag_name: 'v1.98.1+k3s2', assets: validAssets },
+            { tag_name: 'v1.97.7+k3s2', assets: validAssets },
+            { tag_name: 'v1.97.6+k3s1', assets: validAssets },
           ]),
           { headers: { link: '<url>; rel="first"' } },
         ));
@@ -346,20 +346,20 @@ describe(K3sHelper, () => {
     const availableVersions = await subject.availableVersions;
 
     expect(availableVersions).toEqual([
-      new VersionEntry(new semver.SemVer('v1.28.3+k3s2'), ['latest', 'v1.28']),
-      new VersionEntry(new semver.SemVer('v1.28.2+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.28.1+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.27.7+k3s2'), ['stable', 'v1.27']),
-      new VersionEntry(new semver.SemVer('v1.27.6+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.27.5+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.27.4+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.27.3+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.27.2+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.27.1+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.26.3+k3s1'), ['v1.26']),
-      new VersionEntry(new semver.SemVer('v1.26.2+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.26.1+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.26.0+k3s2')),
+      new VersionEntry(new semver.SemVer('v1.98.3+k3s2'), ['latest', 'v1.98']),
+      new VersionEntry(new semver.SemVer('v1.98.2+k3s2')),
+      new VersionEntry(new semver.SemVer('v1.98.1+k3s2')),
+      new VersionEntry(new semver.SemVer('v1.97.7+k3s2'), ['stable', 'v1.97']),
+      new VersionEntry(new semver.SemVer('v1.97.6+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.97.5+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.97.4+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.97.3+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.97.2+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.97.1+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.96.3+k3s1'), ['v1.96']),
+      new VersionEntry(new semver.SemVer('v1.96.2+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.96.1+k3s1')),
+      new VersionEntry(new semver.SemVer('v1.96.0+k3s2')),
     ]);
   });
 
@@ -367,7 +367,7 @@ describe(K3sHelper, () => {
     it('should finish initialize without network if cache is available', async() => {
       const writer = new K3sHelper('x86_64');
 
-      writer['versions'] = { 'v1.0.0': new VersionEntry(new semver.SemVer('v1.0.0')) };
+      writer['versions'] = { 'v1.99.0': new VersionEntry(new semver.SemVer('v1.99.0')) };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.
@@ -385,7 +385,7 @@ describe(K3sHelper, () => {
       });
 
       expect(await subject.availableVersions).toContainEqual({
-        version:  semver.parse('v1.0.0'),
+        version:  semver.parse('v1.99.0'),
         channels: undefined,
       });
       await pendingInit;
@@ -423,7 +423,7 @@ describe(K3sHelper, () => {
     });
 
     test('can handle zero choices', () => {
-      const desiredSemver = new semver.SemVer('v1.2.3+k3s4');
+      const desiredSemver = new semver.SemVer('v1.99.3+k3s4');
 
       expect(() => subject['selectClosestSemVer'](desiredSemver, [])).toThrow(NoCachedK3sVersionsError);
     });

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -172,7 +172,7 @@ export default class BackendHelper {
     const currentConfigVersionString = cfg?.kubernetes?.version;
     let storedVersion: semver.SemVer | null;
     let matchedVersion: semver.SemVer | undefined;
-    const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a valid version.`;
+    const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a supported version.`;
     const sv = new SettingsValidator();
     const lockedSettings = settingsImpl.getLockedSettings();
     const versionIsLocked = lockedSettings.kubernetes?.version ?? false;

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -10,6 +10,8 @@ import INSTALL_CONTAINERD_SHIMS_SCRIPT from '@pkg/assets/scripts/install-contain
 import CONTAINERD_CONFIG from '@pkg/assets/scripts/k3s-containerd-config.toml';
 import SPIN_OPERATOR from '@pkg/assets/scripts/spin-operator.yaml';
 import { BackendSettings, VMExecutor } from '@pkg/backend/backend';
+import { firstStableVersion } from '@pkg/backend/k3sHelper';
+import * as K8s from '@pkg/backend/k8s';
 import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine, Settings } from '@pkg/config/settings';
 import * as settingsImpl from '@pkg/config/settingsImpl';
@@ -168,10 +170,10 @@ export default class BackendHelper {
    * If it's valid and available, use it.
    * Otherwise fall back to the first (recommended) available version.
    */
-  static async getDesiredVersion(cfg: BackendSettings, availableVersions: semver.SemVer[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
+  static async getDesiredVersion(cfg: BackendSettings, availableVersions: K8s.VersionEntry[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
     const currentConfigVersionString = cfg?.kubernetes?.version;
     let storedVersion: semver.SemVer | null;
-    let matchedVersion: semver.SemVer | undefined;
+    let matchedVersion: K8s.VersionEntry | undefined;
     const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a supported version.`;
     const sv = new SettingsValidator();
     const lockedSettings = settingsImpl.getLockedSettings();
@@ -187,13 +189,13 @@ export default class BackendHelper {
       throw new Error('No kubernetes version available.');
     }
 
-    sv.k8sVersions = availableVersions.map(v => v.version);
+    sv.k8sVersions = availableVersions.map(v => v.version.version);
     if (currentConfigVersionString) {
       storedVersion = semver.parse(currentConfigVersionString);
       if (storedVersion) {
         matchedVersion = availableVersions.find((v) => {
           try {
-            return v.compare(storedVersion as semver.SemVer) === 0;
+            return v.version.compare(storedVersion as semver.SemVer) === 0;
           } catch (err: any) {
             console.error(`Can't compare versions ${ storedVersion } and ${ v }: `, err);
             if (!(err instanceof TypeError)) {
@@ -206,9 +208,9 @@ export default class BackendHelper {
         });
         if (matchedVersion) {
           // This throws a LockedFieldError if it fails.
-          this.checkForLockedVersion(matchedVersion, cfg, sv);
+          this.checkForLockedVersion(matchedVersion.version, cfg, sv);
 
-          return matchedVersion;
+          return matchedVersion.version;
         } else if (versionIsLocked) {
           // This is a bit subtle. If we're here, the user specified a nonexistent version in the locked manifest.
           // We can't switch to the default version, so throw a fatal error.
@@ -220,7 +222,8 @@ export default class BackendHelper {
         throw new LockedFieldError(`Locked kubernetes version '${ currentConfigVersionString }' isn't a valid version.`);
       }
       const message = invalidK8sVersionMainMessage;
-      const detail = `Falling back to the most recent stable version of ${ availableVersions[0] }`;
+      // firstStableVersion is guaranteed to return a version because availableVersions is not empty.
+      const detail = `Falling back to the most recent stable version of ${ firstStableVersion(availableVersions)!.version.version }`;
 
       if (noModalDialogs) {
         console.log(`${ message } ${ detail }`);
@@ -237,10 +240,12 @@ export default class BackendHelper {
       }
     }
     // No (valid) stored version; save the default one.
-    // Because no version was specified, there can't be a locked version field, so no need to call checkForLockedVersion
-    settingsWriter({ kubernetes: { version: availableVersions[0].version } });
+    // Because no version was specified, there can't be a locked version field, so no need to call checkForLockedVersion.
+    const stableVersion = firstStableVersion(availableVersions)!.version;
 
-    return availableVersions[0];
+    settingsWriter({ kubernetes: { version: stableVersion.version } });
+
+    return stableVersion;
   }
 
   /**

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -137,6 +137,21 @@ export class VersionEntry implements K8s.VersionEntry {
 }
 
 /**
+ * Get the first stable version from a list of K8s.VersionEntry objects.
+ * @param versions The list of K8s.VersionEntry objects.
+ * @returns The first stable version, or first version if no stable version is found.
+ */
+export function firstStableVersion(versions: K8s.VersionEntry[]): K8s.VersionEntry | undefined {
+  let stableVersion = versions.find(v => (v.channels ?? []).includes('stable'));
+
+  if (!stableVersion && versions.length > 0) {
+    stableVersion = versions[0];
+  }
+
+  return stableVersion;
+}
+
+/**
  * Given a version, return the K3s build version.
  *
  * Note that this is only exported for testing.
@@ -629,8 +644,8 @@ export default class K3sHelper extends events.EventEmitter {
    * that is considered closest to the desired version:
    *
    * @precondition the desired version wasn't found
-   * @param desiredVersion: a semver for the version currently specified in the config
-   * @param k3sNames: typically a list of names like 'v1.2.3+k3s4'
+   * @param desiredVersion a semver for the version currently specified in the config
+   * @param k3sNames typically a list of names like 'v1.2.3+k3s4'
    * @returns {semver.SemVer} the oldest version newer than the desired version
    *      If there is more than one such version, favor the one with the highest '+k3s' build version
    *      If there are none, the newest version older than the desired version

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -155,7 +155,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected readonly releaseApiUrl = 'https://api.github.com/repos/k3s-io/k3s/releases?per_page=100';
   protected readonly releaseApiAccept = 'application/vnd.github.v3+json';
   protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
-  protected readonly minimumVersion = new semver.SemVer('1.15.0');
+  protected readonly minimumVersion = new semver.SemVer('1.21.0');
   protected versionFromChannel: Record<string, string> = {};
 
   constructor(arch: Architecture) {
@@ -195,7 +195,7 @@ export default class K3sHelper extends events.EventEmitter {
       for (const versionString of cacheData.versions) {
         const version = semver.parse(versionString);
 
-        if (version) {
+        if (version && version.compare(this.minimumVersion) >= 0) {
           this.versions[version.version] = new VersionEntry(version);
         }
       }
@@ -287,7 +287,7 @@ export default class K3sHelper extends events.EventEmitter {
 
       return true;
     }
-    if (version < this.minimumVersion) {
+    if (version.compare(this.minimumVersion) < 0) {
       console.log(`Version ${ version } is less than the minimum ${ this.minimumVersion }, skipping.`);
 
       // We may have new patch versions for really old releases; fetch more.

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -142,13 +142,7 @@ export class VersionEntry implements K8s.VersionEntry {
  * @returns The first stable version, or first version if no stable version is found.
  */
 export function firstStableVersion(versions: K8s.VersionEntry[]): K8s.VersionEntry | undefined {
-  let stableVersion = versions.find(v => (v.channels ?? []).includes('stable'));
-
-  if (!stableVersion && versions.length > 0) {
-    stableVersion = versions[0];
-  }
-
-  return stableVersion;
+  return versions.find(v => (v.channels ?? []).includes('stable')) ?? versions[0];
 }
 
 /**
@@ -210,7 +204,7 @@ export default class K3sHelper extends events.EventEmitter {
       for (const versionString of cacheData.versions) {
         const version = semver.parse(versionString);
 
-        if (version && version.compare(this.minimumVersion) >= 0) {
+        if (version && semver.gte(version, this.minimumVersion)) {
           this.versions[version.version] = new VersionEntry(version);
         }
       }

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -313,7 +313,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
 
   protected get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
-      const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
+      const availableVersions = (await this.k3sHelper.availableVersions);
 
       return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -313,7 +313,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
 
   protected get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
-      const availableVersions = (await this.k3sHelper.availableVersions);
+      const availableVersions = await this.k3sHelper.availableVersions;
 
       return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -73,7 +73,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
 
   protected get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
-      const availableVersions = (await this.k3sHelper.availableVersions).map(v => v.version);
+      const availableVersions = (await this.k3sHelper.availableVersions);
 
       return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -73,7 +73,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
 
   protected get desiredVersion(): Promise<semver.SemVer> {
     return (async() => {
-      const availableVersions = (await this.k3sHelper.availableVersions);
+      const availableVersions = await this.k3sHelper.availableVersions;
 
       return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
     })();

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -661,22 +661,6 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       },
     });
 
-    // k3s supports cgroup v2 starting with 1.20.4
-    config.env ||= {};
-    config.env['RC_CGROUP_MODE'] = 'unified';
-    if (this.cfg?.kubernetes?.enabled && this.cfg.kubernetes.version) {
-      try {
-        if (semver.lt(this.cfg.kubernetes.version, '1.20.4')) {
-          config.env['RC_CGROUP_MODE'] = 'hybrid';
-        }
-      } catch {
-        // If we have an invalid version configured, ignore the error; we'll
-        // report the error later when trying to download the version.  In that
-        // case we will fall back to the latest stable version, which should be
-        // new enough to support cgroups v2.
-      }
-    }
-
     // Alpine can boot via UEFI now
     if (config.firmware) {
       config.firmware.legacyBIOS = false;

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -4,6 +4,7 @@ import { Banner } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
+import { firstStableVersion } from '@pkg/backend/k3sHelper';
 import { VersionEntry } from '@pkg/backend/k8s';
 import RdInput from '@pkg/components/RdInput.vue';
 import RdSelect from '@pkg/components/RdSelect.vue';
@@ -39,9 +40,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters('preferences', ['isPreferenceLocked']),
     defaultVersion(): VersionEntry {
-      const version = this.recommendedVersions.find(v => (v.channels ?? []).includes('stable'));
-
-      return version ?? this.recommendedVersions[0] ?? this.nonRecommendedVersions[0];
+      return firstStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
     },
     /** Versions that are the tip of a channel */
     recommendedVersions(): VersionEntry[] {

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -92,6 +92,7 @@ import _ from 'lodash';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
+import { firstStableVersion } from '@pkg/backend/k3sHelper';
 import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
@@ -130,9 +131,7 @@ export default Vue.extend({
     ...mapGetters('applicationSettings', { pathManagementStrategy: 'pathManagementStrategy' }),
     /** The version that should be pre-selected as the default value. */
     defaultVersion(): VersionEntry {
-      const version = this.recommendedVersions.find(v => (v.channels ?? []).includes('stable'));
-
-      return version ?? this.recommendedVersions[0] ?? this.nonRecommendedVersions[0];
+      return firstStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
     },
     // This field is needed because the template-parser doesn't like `defaultVersion?.version.version`
     unwrappedDefaultVersion(): string {

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -50,18 +50,6 @@ export class KuberlrAndKubectl implements Dependency {
     const arch = context.isM1 ? 'arm64' : 'amd64';
 
     await this.bindKubectlToKuberlr(kuberlrPath, path.join(context.binDir, exeName(context, 'kubectl')));
-
-    if (context.platform === os.platform()) {
-      // Download Kubectl into kuberlr's directory of versioned kubectl's
-      const kubeVersion = (await getResource('https://dl.k8s.io/release/stable.txt')).trim();
-      const kubectlURL = `https://dl.k8s.io/${ kubeVersion }/bin/${ context.goPlatform }/${ arch }/${ exeName(context, 'kubectl') }`;
-      const kubectlSHA = await getResource(`${ kubectlURL }.sha256`);
-      const homeDir = await this.findHome(context.platform === 'win32');
-      const kuberlrDir = path.join(homeDir, '.kuberlr', `${ context.goPlatform }-${ arch }`);
-      const managedKubectlPath = path.join(kuberlrDir, exeName(context, `kubectl${ kubeVersion.replace(/^v/, '') }`));
-
-      await download(kubectlURL, managedKubectlPath, { expectedChecksum: kubectlSHA });
-    }
   }
 
   async downloadKuberlr(context: DownloadContext, version: string, arch: 'amd64' | 'arm64'): Promise<string> {

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -45,9 +45,8 @@ export class KuberlrAndKubectl implements Dependency {
   githubRepo = 'kuberlr';
 
   async download(context: DownloadContext): Promise<void> {
-    // We use the x86_64 version even on aarch64 because kubectl binaries before v1.21.0 are unavailable
-    const kuberlrPath = await this.downloadKuberlr(context, context.versions.kuberlr, 'amd64');
     const arch = context.isM1 ? 'arm64' : 'amd64';
+    const kuberlrPath = await this.downloadKuberlr(context, context.versions.kuberlr, arch);
 
     await this.bindKubectlToKuberlr(kuberlrPath, path.join(context.binDir, exeName(context, 'kubectl')));
   }


### PR DESCRIPTION
This allows us to switch to arm64-native versions of `kuberlr`.

Version filtering is applied not only to newly received versions from the channels, but also to cached versions from `k3s-versions.json`.

If after an upgrade the currently selected version is no longer supported, then we will automatically switch to the recommended (stable) version (previously it would switch to the latest version).

Closes #980

This PR also stops downloading the latest `kubectl` into the `~/.kuberlr` cache. I have no idea why that code exists and think `kuberlr` will download the binary by itself if it is needed.

Also fixes k3s minimum version comparisons, which used numeric comparisons instead of semver before.