### PR TITLE
Use cri-docker from RD when k3s version doesn't support docker API 1.44

### DIFF
--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -210,7 +210,7 @@ using_dev_mode() {
 # "all" will fetch the list of all k3s releases from GitHub
 # "latest" will fetch the list of latest versions from the release channel
 
-: "${RD_K3S_MIN:=1.0.0}"
+: "${RD_K3S_MIN:=1.21.0}"
 : "${RD_K3S_MAX:=1.99.0}"
 : "${RD_K3S_VERSIONS:=$RD_KUBERNETES_PREV_VERSION}"
 

--- a/bats/tests/helpers/kubernetes.bats
+++ b/bats/tests/helpers/kubernetes.bats
@@ -1,0 +1,51 @@
+load '../helpers/load'
+
+: "${RD_INFO:=false}"
+
+@test 'unwrap_kube_list: no list' {
+    run echo '{"kind": "Pod"}'
+    assert_success
+
+    run unwrap_kube_list
+    assert_success
+
+    run jq_output .kind
+    assert_success
+    assert_output Pod
+}
+
+@test 'unwrap_kube_list: no items' {
+    run echo '{"kind": "List"}'
+    assert_success
+
+    run unwrap_kube_list
+    assert_failure
+}
+
+@test 'unwrap_kube_list: one item' {
+    run echo '{"kind": "List", "items": [{"kind": "Pod"}]}'
+    assert_success
+
+    run unwrap_kube_list
+    assert_success
+
+    run jq_output .kind
+    assert_success
+    assert_output Pod
+}
+
+@test 'unwrap_kube_list: two items' {
+    run echo '{"kind": "List", "items": [{"kind": "Pod"},{"kind": "Pod"}]}'
+    assert_success
+
+    run unwrap_kube_list
+    assert_failure
+}
+
+@test 'unwrap_kube_list: not JSON' {
+    run echo 'Some random error message'
+    assert_success
+
+    run unwrap_kube_list
+    assert_failure
+}

--- a/bats/tests/k8s/foreach-k3s-version.bats
+++ b/bats/tests/k8s/foreach-k3s-version.bats
@@ -1,6 +1,13 @@
 load '../helpers/load'
 
+wait_for_dns() {
+    try assert_pod_containers_are_running \
+        --namespace kube-system \
+        --selector k8s-app=kube-dns
+}
+
 foreach_k3s_version \
     factory_reset \
     start_kubernetes \
-    wait_for_kubelet
+    wait_for_kubelet \
+    wait_for_dns

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -147,26 +147,18 @@ export default class BackendHelper {
     if (engineName !== ContainerEngine.MOBY) {
       return false;
     }
-    // versions 1.24.1 to 1.24.3 don't support the --docker option
-    if (semver.gte(kubeVersion, '1.24.1') && semver.lte(kubeVersion, '1.24.3')) {
-      return true;
-    }
-    // cri-dockerd bundled with k3s is not compatible with docker 25.x (using API 1.44)
-    // see https://github.com/k3s-io/k3s/issues/9279
-    if (semver.gte(kubeVersion, '1.26.8') && semver.lte(kubeVersion, '1.26.13')) {
-      return true;
-    }
-    if (semver.gte(kubeVersion, '1.27.5') && semver.lte(kubeVersion, '1.27.10')) {
-      return true;
-    }
-    if (semver.gte(kubeVersion, '1.28.0') && semver.lte(kubeVersion, '1.28.6')) {
-      return true;
-    }
-    if (semver.gte(kubeVersion, '1.29.0') && semver.lte(kubeVersion, '1.29.1')) {
-      return true;
-    }
+    const ranges = [
+      // versions 1.24.1 to 1.24.3 don't support the --docker option
+      '1.24.1 - 1.24.3',
+      // cri-dockerd bundled with k3s is not compatible with docker 25.x (using API 1.44)
+      // see https://github.com/k3s-io/k3s/issues/9279
+      '1.26.8 - 1.26.13',
+      '1.27.5 - 1.27.10',
+      '1.28.0 - 1.28.6',
+      '1.29.0 - 1.29.1',
+    ];
 
-    return false;
+    return semver.satisfies(kubeVersion, ranges.join('||'));
   }
 
   static checkForLockedVersion(newVersion: semver.SemVer, cfg: BackendSettings, sv: SettingsValidator): void {

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -143,12 +143,30 @@ export default class BackendHelper {
     return patterns;
   }
 
-  /**
-   * k3s versions 1.24.1 to 1.24.3 don't support the --docker option and need to talk to
-   * a cri_dockerd endpoint when using the moby engine.
-   */
   static requiresCRIDockerd(engineName: string, kubeVersion: string | semver.SemVer): boolean {
-    return engineName === ContainerEngine.MOBY && semver.gte(kubeVersion, '1.24.1') && semver.lte(kubeVersion, '1.24.3');
+    if (engineName !== ContainerEngine.MOBY) {
+      return false;
+    }
+    // versions 1.24.1 to 1.24.3 don't support the --docker option
+    if (semver.gte(kubeVersion, '1.24.1') && semver.lte(kubeVersion, '1.24.3')) {
+      return true;
+    }
+    // cri-dockerd bundled with k3s is not compatible with docker 25.x (using API 1.44)
+    // see https://github.com/k3s-io/k3s/issues/9279
+    if (semver.gte(kubeVersion, '1.26.8') && semver.lte(kubeVersion, '1.26.13')) {
+      return true;
+    }
+    if (semver.gte(kubeVersion, '1.27.5') && semver.lte(kubeVersion, '1.27.10')) {
+      return true;
+    }
+    if (semver.gte(kubeVersion, '1.28.0') && semver.lte(kubeVersion, '1.28.6')) {
+      return true;
+    }
+    if (semver.gte(kubeVersion, '1.29.0') && semver.lte(kubeVersion, '1.29.1')) {
+      return true;
+    }
+
+    return false;
   }
 
   static checkForLockedVersion(newVersion: semver.SemVer, cfg: BackendSettings, sv: SettingsValidator): void {


### PR DESCRIPTION
Updated tests can be used to verify:

```shell
RD_K3S_VERSIONS=all RD_CONTAINER_ENGINE=moby bats tests/k8s/foreach-k3s-version.bats
```

Fixes #7160