### PR TITLE
CI: BATS: Also test newer version of k3s

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -76,6 +76,7 @@ bpf
 bpffs
 brucebean
 bsd
+bsdextrautils
 bsdtar
 btime
 bugtracker

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -164,7 +164,8 @@ jobs:
       shell: pwsh
       run: >-
         wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
-        sh -c 'apt-get update && apt-get install --yes coreutils curl'
+        sh -c 'apt-get update && apt-get install --yes
+        bsdextrautils coreutils curl' # spellcheck-ignore-line
 
     - name: Set log directory
       shell: bash
@@ -229,6 +230,7 @@ jobs:
         LOGS_DIR:                 ${{ env.LOGS_DIR }}
         RD_CAPTURE_LOGS:          "true"
         RD_CONTAINER_ENGINE:      ${{ matrix.engine }}
+        RD_K3S_VERSIONS:          ${{ matrix.k3sVersion }}
         RD_TAKE_SCREENSHOTS:      "true"
         RD_TRACE:                 "true"
         RD_USE_GHCR_IMAGES:       "true"
@@ -239,6 +241,7 @@ jobs:
           GITHUB_TOKEN:\
           RD_CAPTURE_LOGS:\
           RD_CONTAINER_ENGINE:\
+          RD_K3S_VERSIONS:\
           RD_TAKE_SCREENSHOTS:\
           RD_TRACE:\
           RD_USE_GHCR_IMAGES:\

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -225,23 +225,25 @@ jobs:
         --report-formatter tap
         'tests/${{ steps.normalize.outputs.test }}'
       env:
-        BATS_COMMAND:             ${{ env.BATS_COMMAND }}
-        GITHUB_TOKEN:             ${{ github.token }}
-        LOGS_DIR:                 ${{ env.LOGS_DIR }}
-        RD_CAPTURE_LOGS:          "true"
-        RD_CONTAINER_ENGINE:      ${{ matrix.engine }}
-        RD_K3S_VERSIONS:          ${{ matrix.k3sVersion }}
-        RD_TAKE_SCREENSHOTS:      "true"
-        RD_TRACE:                 "true"
-        RD_USE_GHCR_IMAGES:       "true"
-        RD_USE_RAMDISK:           "true"
-        RD_USE_WINDOWS_EXE:       "${{ runner.os == 'Windows' }}"
-        RD_USE_NETWORKING_TUNNEL: "${{ runner.os == 'Windows' && format('{0}', inputs.rd-use-networking-tunnel) != 'false' }}"
+        BATS_COMMAND:              ${{ env.BATS_COMMAND }}
+        GITHUB_TOKEN:              ${{ github.token }}
+        LOGS_DIR:                  ${{ env.LOGS_DIR }}
+        RD_CAPTURE_LOGS:           "true"
+        RD_CONTAINER_ENGINE:       ${{ matrix.engine }}
+        RD_KUBERNETES_VERSION:     ${{ matrix.k3sVersion }}
+        RD_KUBERNETES_ALT_VERSION: ${{ matrix.k3sAltVersion }}
+        RD_TAKE_SCREENSHOTS:       "true"
+        RD_TRACE:                  "true"
+        RD_USE_GHCR_IMAGES:        "true"
+        RD_USE_RAMDISK:            "true"
+        RD_USE_WINDOWS_EXE:        "${{ runner.os == 'Windows' }}"
+        RD_USE_NETWORKING_TUNNEL:  "${{ runner.os == 'Windows' && format('{0}', inputs.rd-use-networking-tunnel) != 'false' }}"
         WSLENV: "\
           GITHUB_TOKEN:\
           RD_CAPTURE_LOGS:\
           RD_CONTAINER_ENGINE:\
-          RD_K3S_VERSIONS:\
+          RD_KUBERNETES_VERSION:\
+          RD_KUBERNETES_ALT_VERSION:\
           RD_TAKE_SCREENSHOTS:\
           RD_TRACE:\
           RD_USE_GHCR_IMAGES:\

--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -23,6 +23,14 @@ on:
         description: Container engines to run
         default: 'containerd moby'
         type: string
+      kubernetes-version:
+        description: Primary Kubernetes version to test
+        default: '1.22.7'
+        type: string
+      kubernetes-alt-version:
+        description: Secondary Kubernetes version to test (e.g. for upgrades)
+        default: '1.28.11' # Rancher/rancher chart 2.8.5 maximum supported version
+        type: string
       package-id:
         description: Package run ID override; leave empty to use latest.
         default: ''
@@ -82,9 +90,11 @@ jobs:
       # This script is not inline to make local testing easier
       run: python3 ${{ github.workspace }}/.github/workflows/bats/get-tests.py
       env:
-        TESTS: ${{ inputs.tests }}
-        PLATFORMS: ${{ inputs.platforms }}
-        ENGINES: ${{ inputs.engines }}
+        TESTS:                  ${{ inputs.tests }}
+        PLATFORMS:              ${{ inputs.platforms }}
+        ENGINES:                ${{ inputs.engines }}
+        KUBERNETES_VERSION:     ${{ inputs.kubernetes-version }}
+        KUBERNETES_ALT_VERSION: ${{ inputs.kubernetes-alt-version }}
       working-directory: bats/tests
     outputs:
       repo: ${{ steps.repo.outputs.repo }}
@@ -164,8 +174,7 @@ jobs:
       shell: pwsh
       run: >-
         wsl.exe -d Debian --exec /usr/bin/env DEBIAN_FRONTEND=noninteractive
-        sh -c 'apt-get update && apt-get install --yes
-        bsdextrautils coreutils curl' # spellcheck-ignore-line
+        sh -c 'apt-get update && apt-get install --yes bsdextrautils coreutils curl'
 
     - name: Set log directory
       shell: bash

--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -28,8 +28,10 @@ class Result:
     name: str
     host: Hosts
     engine: Engines
-    # The version of k3s to test; may be empty.
+    # The version of k3s to test
     k3sVersion: str
+    # A different Kubernetes version, for testing upgrades.
+    k3sAltVersion: str
 
     key = staticmethod(attrgetter("name", "host", "engine"))
 
@@ -74,17 +76,26 @@ for test in (os.environ.get("TESTS", None) or "*").split():
       }[platform]
       for name in resolve_test(test, platform):
           for engine in engines:
-            # If using containerd, use the maximum version of k3s that is
-            # supported by the Rancher helm chart; as of 2.8.5, that's 1.28.x.
-            k3sVersion = "1.28.11" if engine == "containerd" else ""
             if os.access(name, os.R_OK):
-              result = Result(name=name, host=host, engine=engine, k3sVersion=k3sVersion)
+              pass
             elif os.access(f"{name}.bats", os.R_OK):
-              result = Result(name=name, host=host, engine=engine, k3sVersion=k3sVersion)
+              name = f"{name}.bats"
             else:
               errors = True
               print(f"Failed to find test {name}", file=sys.stderr)
               continue
+
+            # To get some coverage of different Kubernetes versions, pick the
+            # version depending on the container engine; one gets the old version
+            # we previously tested (1.22.7), the other gets the maximum version
+            # of k3s that is supported by the Rancher helm chart.  As of chart
+            # version 2.8.5, that is Kubernetes 1.28.x.
+            k3sVersion, k3sAltVersion = ("1.22.7", "1.28.11")
+            if engine == "containerd":
+              (k3sAltVersion, k3sVersion) = (k3sVersion, k3sAltVersion)
+
+            result = Result(name=name, host=host, engine=engine,
+                            k3sVersion=k3sVersion, k3sAltVersion=k3sAltVersion)
             if not skip_test(result):
                 results.append(result)
 

--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -5,6 +5,8 @@
 # TESTS The set of tests to run (e.g. "*", "containers k8s")
 # PLATFORMS The set of platforms (e.g. "linux mac")
 # ENGINES The set of engines (e.g. "containerd moby")
+# KUBERNETES_VERSION The default Kubernetes version to use
+# KUBERNETES_ALT_VERSION Alternative Kubernetes version for coverage
 # The working directory must be the "bats/tests/" folder
 
 import dataclasses
@@ -87,10 +89,13 @@ for test in (os.environ.get("TESTS", None) or "*").split():
 
             # To get some coverage of different Kubernetes versions, pick the
             # version depending on the container engine; one gets the old version
-            # we previously tested (1.22.7), the other gets the maximum version
-            # of k3s that is supported by the Rancher helm chart.  As of chart
-            # version 2.8.5, that is Kubernetes 1.28.x.
-            k3sVersion, k3sAltVersion = ("1.22.7", "1.28.11")
+            # we previously tested, the other gets the maximum version
+            # of k3s that is supported by the Rancher helm chart.  These values
+            # come from the environment.
+            k3sVersion = os.environ.get("KUBERNETES_VERSION", "")
+            k3sAltVersion = os.environ.get("KUBERNETES_ALT_VERSION", "")
+            if k3sVersion == "" or k3sAltVersion == "":
+               raise "Either KUBERNETES_VERSION or KUBERNETES_ALT_VERSION is unset"
             if engine == "containerd":
               (k3sAltVersion, k3sVersion) = (k3sVersion, k3sAltVersion)
 

--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -28,6 +28,8 @@ class Result:
     name: str
     host: Hosts
     engine: Engines
+    # The version of k3s to test; may be empty.
+    k3sVersion: str
 
     key = staticmethod(attrgetter("name", "host", "engine"))
 
@@ -72,10 +74,13 @@ for test in (os.environ.get("TESTS", None) or "*").split():
       }[platform]
       for name in resolve_test(test, platform):
           for engine in engines:
+            # If using containerd, use the maximum version of k3s that is
+            # supported by the Rancher helm chart; as of 2.8.5, that's 1.28.x.
+            k3sVersion = "1.28.11" if engine == "containerd" else ""
             if os.access(name, os.R_OK):
-              result = Result(name=name, host=host, engine=engine)
+              result = Result(name=name, host=host, engine=engine, k3sVersion=k3sVersion)
             elif os.access(f"{name}.bats", os.R_OK):
-              result = Result(name=name, host=host, engine=engine)
+              result = Result(name=name, host=host, engine=engine, k3sVersion=k3sVersion)
             else:
               errors = True
               print(f"Failed to find test {name}", file=sys.stderr)

--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -12,12 +12,6 @@ using_docker() {
 }
 
 ########################################################################
-: "${RD_KUBERNETES_VERSION:=1.23.6}"
-
-########################################################################
-: "${RD_KUBERNETES_PREV_VERSION:=1.22.7}"
-
-########################################################################
 : "${RD_RANCHER_IMAGE_TAG:=}"
 
 rancher_image_tag() {
@@ -201,6 +195,14 @@ using_dev_mode() {
 }
 
 ########################################################################
+# Kubernetes versions
+
+# The main Kubernetes version to test.
+: "${RD_KUBERNETES_VERSION:=1.23.6}"
+
+# A secondary Kubernetes version; this is used for testing upgrades.
+: "${RD_KUBERNETES_ALT_VERSION:=1.22.7}"
+
 # RD_K3S_VERSIONS specifies a list of k3s versions. foreach_k3s_version()
 # can dynamically register a test to run once for each version in the
 # list. Only versions between RD_K3S_MIN and RD_K3S_MAX (inclusively)
@@ -212,7 +214,7 @@ using_dev_mode() {
 
 : "${RD_K3S_MIN:=1.21.0}"
 : "${RD_K3S_MAX:=1.99.0}"
-: "${RD_K3S_VERSIONS:=$RD_KUBERNETES_PREV_VERSION}"
+: "${RD_K3S_VERSIONS:=$RD_KUBERNETES_VERSION}"
 
 validate_semver RD_K3S_MIN
 validate_semver RD_K3S_MAX

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -17,12 +17,13 @@ show_info() { # @test
     fi
 
     (
-        local format="# %-25s %s\n"
+        local format="# %s | %s\n"
 
         printf "$format" "Install location:" "$RD_LOCATION"
         printf "$format" "Resources path:" "$PATH_RESOURCES"
         echo "#"
         printf "$format" "Container engine:" "$RD_CONTAINER_ENGINE"
+        printf "$format" "Kubernetes versions:" "$RD_K3S_VERSIONS"
         printf "$format" "Mount type:" "$RD_MOUNT_TYPE"
         if [ "$RD_MOUNT_TYPE" = "9p" ]; then
             printf "$format" "  9p cache mode:" "$RD_9P_CACHE_MODE"
@@ -44,5 +45,5 @@ show_info() { # @test
         printf "$format" "Tracing execution:" "$(bool is_true "$RD_TRACE")"
         printf "$format" "Taking screenshots:" "$(bool taking_screenshots)"
         printf "$format" "Using ghcr.io images:" "$(bool using_ghcr_images)"
-    ) >&3
+    ) | column -t -s '|' >&3
 }

--- a/bats/tests/helpers/info.bash
+++ b/bats/tests/helpers/info.bash
@@ -23,7 +23,7 @@ show_info() { # @test
         printf "$format" "Resources path:" "$PATH_RESOURCES"
         echo "#"
         printf "$format" "Container engine:" "$RD_CONTAINER_ENGINE"
-        printf "$format" "Kubernetes versions:" "$RD_K3S_VERSIONS"
+        printf "$format" "Kubernetes version:" "$RD_KUBERNETES_VERSION ($RD_K3S_VERSIONS)"
         printf "$format" "Mount type:" "$RD_MOUNT_TYPE"
         if [ "$RD_MOUNT_TYPE" = "9p" ]; then
             printf "$format" "  9p cache mode:" "$RD_9P_CACHE_MODE"

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -1,5 +1,5 @@
 wait_for_kubelet() {
-    local desired_version=${1:-$RD_KUBERNETES_PREV_VERSION}
+    local desired_version=${1:-$RD_KUBERNETES_VERSION}
     local timeout=$(($(date +%s) + RD_KUBELET_TIMEOUT * 60))
     trace "waiting for Kubernetes ${desired_version} to be available"
     while true; do

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -449,11 +449,11 @@ foreach_k3s_version() {
 }
 
 _foreach_k3s_version() {
-    local RD_KUBERNETES_PREV_VERSION=$1
+    local RD_KUBERNETES_VERSION=$1
     local skip_kubernetes_version
     skip_kubernetes_version=$(cat "${BATS_FILE_TMPDIR}/skip-kubernetes-version" 2>/dev/null || echo none)
-    if [[ $skip_kubernetes_version == "$RD_KUBERNETES_PREV_VERSION" ]]; then
-        skip "All remaining tests for Kubernetes $RD_KUBERNETES_PREV_VERSION are skipped"
+    if [[ $skip_kubernetes_version == "$RD_KUBERNETES_VERSION" ]]; then
+        skip "All remaining tests for Kubernetes $RD_KUBERNETES_VERSION are skipped"
     fi
     "$2"
 }
@@ -461,7 +461,7 @@ _foreach_k3s_version() {
 # Tests can call mark_k3s_version_skipped to skip the rest of the tests within
 # this iteration of foreach_k3s_version.
 mark_k3s_version_skipped() {
-    echo "$RD_KUBERNETES_PREV_VERSION" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
+    echo "$RD_KUBERNETES_VERSION" >"${BATS_FILE_TMPDIR}/skip-kubernetes-version"
 }
 
 ########################################################################

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -243,7 +243,7 @@ EOF
 start_kubernetes() {
     start_container_engine \
         --kubernetes.enabled \
-        --kubernetes.version "$RD_KUBERNETES_PREV_VERSION" \
+        --kubernetes.version "$RD_KUBERNETES_VERSION" \
         "$@"
 }
 

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -9,7 +9,7 @@ local_setup() {
 
 # Check that the rancher-latest/rancher helm chart at the given version is
 # supported on the current Kubernetes version (as determined by
-# $RD_KUBERNETES_PREV_VERSION)
+# $RD_KUBERNETES_VERSION)
 is_rancher_chart_compatible() {
     local chart_version=$1
 
@@ -25,12 +25,12 @@ is_rancher_chart_compatible() {
     assert_success || return
 
     local unsupported_version=$output
-    semver_gt "$unsupported_version" "$RD_KUBERNETES_PREV_VERSION" || return
+    semver_gt "$unsupported_version" "$RD_KUBERNETES_VERSION" || return
 }
 
 # Set (and save) $rancher_chart_version to $RD_RANCHER_IMAGE_TAG if it is set
 # (and compatible), or otherwise the oldest chart version that supports
-# $RD_KUBERNETES_PREV_VERSION.
+# $RD_KUBERNETES_VERSION.
 # If no compatible chart version could be found, calls mark_k3s_version_skipped
 # and fails the test.
 determine_chart_version() {
@@ -41,7 +41,7 @@ determine_chart_version() {
         if ! is_rancher_chart_compatible "$rancher_chart_version"; then
             mark_k3s_version_skipped
             printf "Rancher %s is not compatible with Kubernetes %s" \
-                "$rancher_chart_version" "$RD_KUBERNETES_PREV_VERSION" |
+                "$rancher_chart_version" "$RD_KUBERNETES_VERSION" |
                 fail
             return
         fi
@@ -73,14 +73,14 @@ determine_chart_version() {
             # Once we find a compatible version, use it (and don't look at the
             # rest of the chart versions).
             trace "$(printf "Selected rancher chart version %s for Kubernetes %s" \
-                "$rancher_chart_version" "$RD_KUBERNETES_PREV_VERSION")"
+                "$rancher_chart_version" "$RD_KUBERNETES_VERSION")"
             save_var rancher_chart_version
             return
         fi
     done
     mark_k3s_version_skipped
     printf "Could not find a version of rancher-latest/rancher compatible with Kubernetes %s\n" \
-        "$RD_KUBERNETES_PREV_VERSION" |
+        "$RD_KUBERNETES_VERSION" |
         fail || return
 }
 

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -9,6 +9,9 @@ local_setup_file() {
             "$RD_KUBERNETES_VERSION" "$RD_KUBERNETES_ALT_VERSION" |
             fail
     fi
+    # It is undefined whether RD_KUBERNETES_VERSION is greater or less than
+    # RD_KUBERNETES_ALT_VERSION (and it's expected to flip in CI); actually
+    # compare them so we can expect to wipe data on the downgrade.
     if semver_gt "$RD_KUBERNETES_VERSION" "$RD_KUBERNETES_ALT_VERSION"; then
         export RD_KUBERNETES_VERSION_LOW=$RD_KUBERNETES_ALT_VERSION
         export RD_KUBERNETES_VERSION_HIGH=$RD_KUBERNETES_VERSION

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -3,13 +3,29 @@
 load '../helpers/load'
 ARCH_FOR_KUBERLR=amd64
 
+local_setup_file() {
+    if semver_eq "$RD_KUBERNETES_VERSION" "$RD_KUBERNETES_ALT_VERSION"; then
+        printf "Cannot upgrade from %s to %s\n" \
+            "$RD_KUBERNETES_VERSION" "$RD_KUBERNETES_ALT_VERSION" |
+            fail
+    fi
+    if semver_gt "$RD_KUBERNETES_VERSION" "$RD_KUBERNETES_ALT_VERSION"; then
+        export RD_KUBERNETES_VERSION_LOW=$RD_KUBERNETES_ALT_VERSION
+        export RD_KUBERNETES_VERSION_HIGH=$RD_KUBERNETES_VERSION
+    else
+        export RD_KUBERNETES_VERSION_LOW=$RD_KUBERNETES_VERSION
+        export RD_KUBERNETES_VERSION_HIGH=$RD_KUBERNETES_ALT_VERSION
+    fi
+}
+
 @test 'factory reset' {
     factory_reset
 }
 
 @test 'start rancher desktop' {
-    start_kubernetes
-    wait_for_kubelet
+    # Force use the pre-upgrade version
+    RD_KUBERNETES_VERSION=$RD_KUBERNETES_VERSION_LOW start_kubernetes
+    wait_for_kubelet "$RD_KUBERNETES_VERSION_LOW"
     # the docker context "rancher-desktop" may not have been written
     # even though the apiserver is already running
     wait_for_container_engine
@@ -77,18 +93,18 @@ verify_kuberlr_for_version() {
 
     rm -f "${KUBERLR_DIR}/kubectl"*
     run kubectl version
-    assert_output --regexp "Client Version.*GitVersion:.v${K8S_VERSION}"
+    assert_output --regexp "Client Version.*:.v${K8S_VERSION}"
     assert_exists "${KUBERLR_DIR}/kubectl${K8S_VERSION}$EXE"
 }
 
 @test 'upgrade kubernetes' {
-    rdctl set --kubernetes.version "$RD_KUBERNETES_VERSION"
-    wait_for_kubelet "$RD_KUBERNETES_VERSION"
+    rdctl set --kubernetes.version "$RD_KUBERNETES_VERSION_HIGH"
+    wait_for_kubelet "$RD_KUBERNETES_VERSION_HIGH"
     wait_for_container_engine
 }
 
 @test 'kuberlr pulls in kubectl for new k8s version' {
-    verify_kuberlr_for_version "$RD_KUBERNETES_VERSION"
+    verify_kuberlr_for_version "$RD_KUBERNETES_VERSION_HIGH"
 }
 
 verify_nginx_after_change_k8s() {
@@ -129,13 +145,13 @@ verify_nginx_after_change_k8s() {
 }
 
 @test 'downgrade kubernetes' {
-    rdctl set --kubernetes-version "$RD_KUBERNETES_PREV_VERSION"
-    wait_for_kubelet
+    rdctl set --kubernetes-version "$RD_KUBERNETES_VERSION_LOW"
+    wait_for_kubelet "$RD_KUBERNETES_VERSION_LOW"
     wait_for_container_engine
 }
 
 @test 'kuberlr pulls in kubectl for previous k8s version' {
-    verify_kuberlr_for_version "$RD_KUBERNETES_PREV_VERSION"
+    verify_kuberlr_for_version "$RD_KUBERNETES_VERSION_LOW"
 }
 
 @test 'verify nginx after downgrade' {

--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -74,7 +74,7 @@ verify_settings() {
 
     run get_setting .kubernetes.version
     "${assert}_output" "$LOCKED_KUBERNETES_VERSION"
-    refute_output "$DEFAULTS_KUBERNETES_VERSION"
+    "${refute}_output" "$DEFAULTS_KUBERNETES_VERSION"
 }
 
 install_extensions() {
@@ -96,6 +96,8 @@ install_extensions() {
 }
 
 @test 'start up with NO profiles' {
+    assert_not_equal "$DEFAULTS_KUBERNETES_VERSION" "$LOCKED_KUBERNETES_VERSION"
+    assert_not_equal "$KUBERNETES_RANDOM_VERSION" "$LOCKED_KUBERNETES_VERSION"
     RD_USE_PROFILE=false
     RD_USE_IMAGE_ALLOW_LIST=false
     start_application

--- a/bats/tests/profile/invalid-locked-k8s-version.bats
+++ b/bats/tests/profile/invalid-locked-k8s-version.bats
@@ -21,7 +21,7 @@ local_teardown_file() {
 
 @test 'fails to start app with an invalid locked k8s version' {
     # Have to set the version field or RD will think we're trying to change a locked field.
-    RD_KUBERNETES_PREV_VERSION=NattyBo
+    RD_KUBERNETES_VERSION=NattyBo
     start_kubernetes
     # Don't do wait_for_container_engine because RD will shut down in the middle
     # and the function will take a long time to time out making futile queries.
@@ -38,7 +38,7 @@ local_teardown_file() {
 @test 'fails to start app with a specified k8s version != locked k8s version' {
     factory_reset
     # Have to set the version field or RD will think we're trying to change a locked field.
-    RD_KUBERNETES_PREV_VERSION=v1.27.2
+    RD_KUBERNETES_VERSION=v1.27.2
     start_kubernetes
     # The app should exit gracefully; after that we can check for contents.
     try --max 60 --delay 5 assert_file_contains "$PATH_LOGS/background.log" "Child exited"


### PR DESCRIPTION
This changes CI so that we can test a newer version of K3s (not just 1.22.7) in CI.  As part of that, change how we pick versions so we don't end up using `RD_KUBERNETES_PREV_VERSION` for the bulk of the tests (because that makes no sense).

As usual, consider reviewing per-commit instead of as a PR (but there's nothing wrong with that either way).

Fixes #7141