### PR TITLE
background: Don't trigger settings update actions at shutdown

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -143,6 +143,12 @@ mainEvents.on('settings-update', async(newSettings) => {
   }
   k8smanager.debug = runInDebugMode;
 
+  if (gone) {
+    console.debug('Suppressing settings-update because app is quitting');
+
+    return;
+  }
+
   await setPathManager(newSettings.application.pathManagementStrategy);
   await pathManager.enforce();
 

--- a/pkg/rancher-desktop/utils/logging.ts
+++ b/pkg/rancher-desktop/utils/logging.ts
@@ -158,7 +158,7 @@ export class Log {
   }
 
   protected logWithDate(method: consoleKey, message: any, optionalParameters: any[]) {
-    this.console[method](`%s: ${ message }`, new Date(), ...optionalParameters);
+    this.console[method](`%s: ${ message }`, new Date().toISOString(), ...optionalParameters);
   }
 
   async sync() {


### PR DESCRIPTION
When we're shutting down, don't trigger the follow-up actions from writing to settings.  This avoids an issue where we attempt to update path management on shutdown, and end up doing half a write that clobbers the user's `.bashrc` (etc.) files because that is asynchronous.

This should help with #7154, but we want to keep that open until we do reworking to make it easier to recover.