### PR TITLE
Use highest patch release of lowest available version for forced upgrades

### DIFF
--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -439,13 +439,14 @@ describe(K3sHelper, () => {
   describe('highestStableVersion', () => {
     it('should return the highest stable version', () => {
       const versions: K8s.VersionEntry[] = [
-        new VersionEntry(new semver.SemVer('v1.0.0'), ['unstable']),
+        new VersionEntry(new semver.SemVer('v2.0.0'), ['unstable']),
         new VersionEntry(new semver.SemVer('v1.1.0'), ['stable']),
+        new VersionEntry(new semver.SemVer('v1.3.0'), ['stable']),
         new VersionEntry(new semver.SemVer('v1.2.0'), ['stable']),
       ];
-      const result = highestStableVersion(versions)?.version;
+      const result = highestStableVersion(versions)?.version.version;
 
-      expect(result).toEqual(versions[2].version);
+      expect(result).toEqual('1.3.0');
     });
 
     it('should return highest version if no stable version is found', () => {
@@ -454,9 +455,9 @@ describe(K3sHelper, () => {
         new VersionEntry(new semver.SemVer('v1.2.0'), ['beta']),
         new VersionEntry(new semver.SemVer('v1.1.0'), ['beta']),
       ];
-      const result = highestStableVersion(versions)?.version;
+      const result = highestStableVersion(versions)?.version.version;
 
-      expect(result).toEqual(versions[1].version);
+      expect(result).toEqual('1.2.0');
     });
 
     it('should return undefined if the list is empty', () => {
@@ -467,7 +468,7 @@ describe(K3sHelper, () => {
   });
 
   describe('minimumUpgradeVersion', () => {
-    it('should return the first stable version', () => {
+    it('should return the highest patch release of the lowest major.minor version', () => {
       const versions: K8s.VersionEntry[] = [
         new VersionEntry(new semver.SemVer('v1.2.1'), ['stable']),
         new VersionEntry(new semver.SemVer('v1.0.0'), ['unstable']),
@@ -475,9 +476,9 @@ describe(K3sHelper, () => {
         new VersionEntry(new semver.SemVer('v1.0.2'), ['stable']),
         new VersionEntry(new semver.SemVer('v1.2.2'), ['stable']),
       ];
-      const result = minimumUpgradeVersion(versions)?.version;
+      const result = minimumUpgradeVersion(versions)?.version.version;
 
-      expect(result).toEqual(versions[2].version);
+      expect(result).toEqual('1.0.3');
     });
 
     it('should return undefined if the list is empty', () => {

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -158,16 +158,8 @@ function sameMajorMinorVersion(version1: semver.SemVer, version2: semver.SemVer)
  */
 export function minimumUpgradeVersion(versions: K8s.VersionEntry[]): K8s.VersionEntry | undefined {
   const lowestFirst = versions.slice().sort((a, b) => a.version.compare(b.version));
-  let upgradeVersion = lowestFirst[0];
 
-  for (const version of lowestFirst) {
-    if (!sameMajorMinorVersion(version.version, lowestFirst[0].version)) {
-      break;
-    }
-    upgradeVersion = version;
-  }
-
-  return upgradeVersion;
+  return lowestFirst.findLast(v => sameMajorMinorVersion(v.version, lowestFirst[0].version));
 }
 
 /**

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -315,7 +315,11 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     return (async() => {
       const availableVersions = await this.k3sHelper.availableVersions;
 
-      return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(
+        this.cfg as BackendSettings,
+        availableVersions,
+        this.vm.noModalDialogs,
+        this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -75,7 +75,11 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     return (async() => {
       const availableVersions = await this.k3sHelper.availableVersions;
 
-      return await BackendHelper.getDesiredVersion(this.cfg as BackendSettings, availableVersions, this.vm.noModalDialogs, this.vm.writeSetting.bind(this.vm));
+      return await BackendHelper.getDesiredVersion(
+        this.cfg as BackendSettings,
+        availableVersions,
+        this.vm.noModalDialogs,
+        this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -4,7 +4,7 @@ import { Banner } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { firstStableVersion } from '@pkg/backend/k3sHelper';
+import { highestStableVersion } from '@pkg/backend/k3sHelper';
 import { VersionEntry } from '@pkg/backend/k8s';
 import RdInput from '@pkg/components/RdInput.vue';
 import RdSelect from '@pkg/components/RdSelect.vue';
@@ -40,7 +40,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters('preferences', ['isPreferenceLocked']),
     defaultVersion(): VersionEntry {
-      return firstStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
+      return highestStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
     },
     /** Versions that are the tip of a channel */
     recommendedVersions(): VersionEntry[] {

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -92,7 +92,7 @@ import _ from 'lodash';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { firstStableVersion } from '@pkg/backend/k3sHelper';
+import { highestStableVersion } from '@pkg/backend/k3sHelper';
 import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
@@ -131,7 +131,7 @@ export default Vue.extend({
     ...mapGetters('applicationSettings', { pathManagementStrategy: 'pathManagementStrategy' }),
     /** The version that should be pre-selected as the default value. */
     defaultVersion(): VersionEntry {
-      return firstStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
+      return highestStableVersion(this.recommendedVersions) ?? this.nonRecommendedVersions[0];
     },
     // This field is needed because the template-parser doesn't like `defaultVersion?.version.version`
     unwrappedDefaultVersion(): string {


### PR DESCRIPTION
Also rename `firstStableVersion` to `highestStableVersion` and force a sort on the input `versions` array. The array is supposed to be already sorted (as highest first), but the test cases didn't satisfy that requirement, and it seems fragile to trust that all call sides conform to it.

Followup to #7180