### PR TITLE
window: log console messages

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -70,6 +70,12 @@ export function createWindow(name: string, url: string, options: Electron.Browse
   };
 
   window = new BrowserWindow(options);
+  window.webContents.on('console-message', (event, level, message, line, sourceId) => {
+    const levelNum = level === 0 ? 0 : level === 1 ? 1 : level === 2 ? 2 : level === 3 ? 3 : 0;
+    const key = ['debug', 'info', 'warn', 'error'] as const;
+
+    console[key[levelNum]](`${ name }@${ line }: ${ message }`);
+  });
   window.webContents.on('will-navigate', (event, input) => {
     if (isInternalURL(input)) {
       return;


### PR DESCRIPTION
This logs the console messages (from the top-level webview only) from windows into `window_browser.log`.  This may be useful to troubleshoot issues when the window does not get shown correctly (e.g. during first run dialog initialization).