### PR TITLE
docs(readme): updating nvm version for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ you'll need to `source` that file.
 Currently we build Rancher Desktop with Node 18. To install it, run:
 
 ```
-nvm install 18.16
+nvm install 18.18
 ```
 
 Next, you'll need to install the yarn package manager:


### PR DESCRIPTION
Updating the `README.md` to correctly set the node version for local mac development. 