### PR TITLE
ui: prefs: remove lima networking

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyVirtualMachine.vue
@@ -77,12 +77,6 @@ export default Vue.extend({
         :weight="1"
       />
       <tab
-        v-if="isPlatformDarwin"
-        label="Network"
-        name="network"
-        :weight="2"
-      />
-      <tab
         label="Volumes"
         name="volumes"
         :weight="3"


### PR DESCRIPTION
The contents of the prefs dialog was removed in #6975 but the tab was accidentally not removed.

Fixes #7225