### PR TITLE
Fix separator for KUBECONFIG env var

### DIFF
--- a/pkg/rancher-desktop/backend/kubeconfig.ts
+++ b/pkg/rancher-desktop/backend/kubeconfig.ts
@@ -125,7 +125,8 @@ export async function getKubeConfigPaths(): Promise<string[]> {
   if (process.env.KUBECONFIG && process.env.KUBECONFIG.length > 0) {
     const results: string[] = [];
 
-    for (const filePath of process.env.KUBECONFIG.split(path.delimiter)) {
+    const delimiter = os.platform() === 'win32' ? ';' : ':';
+    for (const filePath of process.env.KUBECONFIG.split(delimiter)) {
       if (await hasAccess(filePath)) {
         results.push(filePath);
       }


### PR DESCRIPTION
While looking through the code, I was confused by the code here. Looking at https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable, it seems the delimiter between the paths should be the proposed changes, not `path.delimiter` (which would be `/` or `\\`)