### PR TITLE
Add "Enable Traefik" setting to the FirstRun modal

### DIFF
--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -9,6 +9,12 @@
       :is-locked="kubernetesLocked"
       @input="handleDisableKubernetesCheckbox"
     />
+    <rd-checkbox
+      label="Enable Traefik"
+      :value="settings.kubernetes.options.traefik"
+      :is-locked="kubernetesLocked"
+      @input="handleDisableTraefikCheckbox"
+    />
     <rd-fieldset
       :legend-text="t('firstRun.kubernetesVersion.legend') + offlineCheck()"
     >
@@ -171,6 +177,7 @@ export default Vue.extend({
     ipcRenderer.on('settings-update', (event, config) => {
       this.settings.containerEngine.name = config.containerEngine.name;
       this.settings.kubernetes.enabled = config.kubernetes.enabled;
+      this.settings.kubernetes.options.traefik = config.kubernetes.options.traefik;
     });
     ipcRenderer.send('k8s-versions');
     if (this.pathManagementRelevant) {
@@ -214,6 +221,16 @@ export default Vue.extend({
         ipcRenderer.invoke(
           'settings-write',
           { kubernetes: { enabled: value } },
+        );
+      } catch (err) {
+        console.log('invoke settings-write failed: ', err);
+      }
+    },
+    handleDisableTraefikCheckbox(value: boolean) {
+      try {
+        ipcRenderer.invoke(
+          'settings-write',
+          { kubernetes: { options: { traefik: value } } },
         );
       } catch (err) {
         console.log('invoke settings-write failed: ', err);


### PR DESCRIPTION
I use my own Ingress Controller, so Traefik ends up getting in the way. Due to the bug in #6315, I have frequently been needing to disable Traefik and reset K8s. Having this additional checkbox in the FirstRun modal would be helpful for me and my customers, but understandably it's opinionated. With that said, I believe it wouldn't be too much of an issue to add. I tried to add a `:legend-tooltip` to add a little more direction/description but it doesn't seem to do anything. It's fine if we don't move forward with this one.