### PR TITLE
Avoid importing `k3sHelper` from UI

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -830,7 +830,7 @@ ipcMainProxy.on('k8s-versions', async() => {
   const versions = await k8smanager.kubeBackend.availableVersions;
   const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
 
-  window.send('k8s-versions', versions.map(e => ({ version: e.version.version, channels: e.channels })), cachedOnly);
+  window.send('k8s-versions', versions.map(v => v.versionEntry), cachedOnly);
 });
 
 ipcMainProxy.on('k8s-progress', () => {
@@ -1282,7 +1282,7 @@ function newK8sManager() {
     const versions = await mgr.kubeBackend.availableVersions;
     const cachedOnly = await mgr.kubeBackend.cachedVersionsOnly();
 
-    window.send('k8s-versions', versions.map(e => ({ version: e.version.version, channels: e.channels })), cachedOnly);
+    window.send('k8s-versions', versions.map(v => v.versionEntry), cachedOnly);
   });
 
   return mgr;

--- a/background.ts
+++ b/background.ts
@@ -1279,8 +1279,8 @@ function newK8sManager() {
   });
 
   mgr.kubeBackend.on('versions-updated', async() => {
-    const versions = await k8smanager.kubeBackend.availableVersions;
-    const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
+    const versions = await mgr.kubeBackend.availableVersions;
+    const cachedOnly = await mgr.kubeBackend.cachedVersionsOnly();
 
     window.send('k8s-versions', versions.map(e => ({ version: e.version.version, channels: e.channels })), cachedOnly);
   });

--- a/background.ts
+++ b/background.ts
@@ -827,7 +827,10 @@ ipcMainProxy.on('k8s-restart', async() => {
 });
 
 ipcMainProxy.on('k8s-versions', async() => {
-  window.send('k8s-versions', await k8smanager.kubeBackend.availableVersions, await k8smanager.kubeBackend.cachedVersionsOnly());
+  const versions = await k8smanager.kubeBackend.availableVersions;
+  const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
+
+  window.send('k8s-versions', versions.map(e => ({ version: e.version.version, channels: e.channels })), cachedOnly);
 });
 
 ipcMainProxy.on('k8s-progress', () => {
@@ -1276,7 +1279,10 @@ function newK8sManager() {
   });
 
   mgr.kubeBackend.on('versions-updated', async() => {
-    window.send('k8s-versions', await mgr.kubeBackend.availableVersions, await mgr.kubeBackend.cachedVersionsOnly());
+    const versions = await k8smanager.kubeBackend.availableVersions;
+    const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
+
+    window.send('k8s-versions', versions.map(e => ({ version: e.version.version, channels: e.channels })), cachedOnly);
   });
 
   return mgr;

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -11,14 +11,11 @@ import semver from 'semver';
 import K3sHelper, {
   buildVersion,
   ChannelMapping,
-  highestStableVersion,
-  minimumUpgradeVersion,
   NoCachedK3sVersionsError,
   ReleaseAPIEntry,
   VersionEntry,
 } from '../k3sHelper';
 
-import * as K8s from '@pkg/backend/k8s';
 import paths from '@pkg/utils/paths';
 
 const cachePath = path.join(paths.cache, 'k3s-versions.json');
@@ -433,58 +430,6 @@ describe(K3sHelper, () => {
       const desiredSemver = new semver.SemVer('v1.99.3+k3s4');
 
       expect(() => subject['selectClosestSemVer'](desiredSemver, [])).toThrow(NoCachedK3sVersionsError);
-    });
-  });
-
-  describe('highestStableVersion', () => {
-    it('should return the highest stable version', () => {
-      const versions: K8s.VersionEntry[] = [
-        new VersionEntry(new semver.SemVer('v2.0.0'), ['unstable']),
-        new VersionEntry(new semver.SemVer('v1.1.0'), ['stable']),
-        new VersionEntry(new semver.SemVer('v1.3.0'), ['stable']),
-        new VersionEntry(new semver.SemVer('v1.2.0'), ['stable']),
-      ];
-      const result = highestStableVersion(versions)?.version.version;
-
-      expect(result).toEqual('1.3.0');
-    });
-
-    it('should return highest version if no stable version is found', () => {
-      const versions: K8s.VersionEntry[] = [
-        new VersionEntry(new semver.SemVer('v1.0.0'), ['unstable']),
-        new VersionEntry(new semver.SemVer('v1.2.0'), ['beta']),
-        new VersionEntry(new semver.SemVer('v1.1.0'), ['beta']),
-      ];
-      const result = highestStableVersion(versions)?.version.version;
-
-      expect(result).toEqual('1.2.0');
-    });
-
-    it('should return undefined if the list is empty', () => {
-      const result = highestStableVersion([]);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('minimumUpgradeVersion', () => {
-    it('should return the highest patch release of the lowest major.minor version', () => {
-      const versions: K8s.VersionEntry[] = [
-        new VersionEntry(new semver.SemVer('v1.2.1'), ['stable']),
-        new VersionEntry(new semver.SemVer('v1.0.0'), ['unstable']),
-        new VersionEntry(new semver.SemVer('v1.0.3'), ['unstable']),
-        new VersionEntry(new semver.SemVer('v1.0.2'), ['stable']),
-        new VersionEntry(new semver.SemVer('v1.2.2'), ['stable']),
-      ];
-      const result = minimumUpgradeVersion(versions)?.version.version;
-
-      expect(result).toEqual('1.0.3');
-    });
-
-    it('should return undefined if the list is empty', () => {
-      const result = minimumUpgradeVersion([]);
-
-      expect(result).toBeUndefined();
     });
   });
 });

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -13,7 +13,7 @@ import K3sHelper, {
   ChannelMapping,
   NoCachedK3sVersionsError,
   ReleaseAPIEntry,
-  VersionEntry,
+  SemanticVersionEntry,
 } from '../k3sHelper';
 
 import paths from '@pkg/utils/paths';
@@ -78,7 +78,7 @@ describe(K3sHelper, () => {
       for (const version of existing) {
         const parsed = new semver.SemVer(version);
 
-        subject['versions'][parsed.version] = new VersionEntry(parsed);
+        subject['versions'][parsed.version] = new SemanticVersionEntry(parsed);
       }
 
       return subject['processVersion']({ tag_name: name, assets });
@@ -127,9 +127,9 @@ describe(K3sHelper, () => {
   test('cache read/write', async() => {
     const subject = new K3sHelper('x86_64');
     const workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-test-cache-'));
-    const versions: Record<string, VersionEntry> = {
-      '1.99.3': new VersionEntry(semver.parse('1.99.3+k3s1') as semver.SemVer, ['stable']),
-      '2.3.4':  new VersionEntry(semver.parse('2.3.4+k3s3') as semver.SemVer),
+    const versions: Record<string, SemanticVersionEntry> = {
+      '1.99.3': new SemanticVersionEntry(semver.parse('1.99.3+k3s1') as semver.SemVer, ['stable']),
+      '2.3.4':  new SemanticVersionEntry(semver.parse('2.3.4+k3s3') as semver.SemVer),
     };
     const versionStrings = Object.values(versions)
       .map(v => v.version)
@@ -182,7 +182,7 @@ describe(K3sHelper, () => {
         })) {
           const parsedVersion = new semver.SemVer(version);
 
-          this.versions[parsedVersion.version] = new VersionEntry(parsedVersion, tags);
+          this.versions[parsedVersion.version] = new SemanticVersionEntry(parsedVersion, tags);
           for (const tag of tags) {
             result[tag] = parsedVersion;
           }
@@ -253,9 +253,9 @@ describe(K3sHelper, () => {
     expect(fetch).toHaveBeenCalledTimes(4);
     expect(subject['delayForWaitLimiting']).toHaveBeenCalledTimes(1);
     expect(await subject.availableVersions).toEqual([
-      new VersionEntry(new semver.SemVer('v1.99.3+k3s3'), ['stable']),
-      new VersionEntry(new semver.SemVer('v1.99.1+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.99.0+k3s5')),
+      new SemanticVersionEntry(new semver.SemVer('v1.99.3+k3s3'), ['stable']),
+      new SemanticVersionEntry(new semver.SemVer('v1.99.1+k3s2')),
+      new SemanticVersionEntry(new semver.SemVer('v1.99.0+k3s5')),
     ]);
   });
 
@@ -290,7 +290,7 @@ describe(K3sHelper, () => {
         })) {
           const parsedVersion = new semver.SemVer(version);
 
-          this.versions[parsedVersion.version] = new VersionEntry(parsedVersion, tags);
+          this.versions[parsedVersion.version] = new SemanticVersionEntry(parsedVersion, tags);
           for (const tag of tags) {
             result[tag] = parsedVersion;
           }
@@ -350,20 +350,20 @@ describe(K3sHelper, () => {
     const availableVersions = await subject.availableVersions;
 
     expect(availableVersions).toEqual([
-      new VersionEntry(new semver.SemVer('v1.98.3+k3s2'), ['latest', 'v1.98']),
-      new VersionEntry(new semver.SemVer('v1.98.2+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.98.1+k3s2')),
-      new VersionEntry(new semver.SemVer('v1.97.7+k3s2'), ['stable', 'v1.97']),
-      new VersionEntry(new semver.SemVer('v1.97.6+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.97.5+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.97.4+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.97.3+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.97.2+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.97.1+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.96.3+k3s1'), ['v1.96']),
-      new VersionEntry(new semver.SemVer('v1.96.2+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.96.1+k3s1')),
-      new VersionEntry(new semver.SemVer('v1.96.0+k3s2')),
+      new SemanticVersionEntry(new semver.SemVer('v1.98.3+k3s2'), ['latest', 'v1.98']),
+      new SemanticVersionEntry(new semver.SemVer('v1.98.2+k3s2')),
+      new SemanticVersionEntry(new semver.SemVer('v1.98.1+k3s2')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.7+k3s2'), ['stable', 'v1.97']),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.6+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.5+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.4+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.3+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.2+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.97.1+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.96.3+k3s1'), ['v1.96']),
+      new SemanticVersionEntry(new semver.SemVer('v1.96.2+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.96.1+k3s1')),
+      new SemanticVersionEntry(new semver.SemVer('v1.96.0+k3s2')),
     ]);
   });
 
@@ -371,7 +371,7 @@ describe(K3sHelper, () => {
     it('should finish initialize without network if cache is available', async() => {
       const writer = new K3sHelper('x86_64');
 
-      writer['versions'] = { 'v1.99.0': new VersionEntry(new semver.SemVer('v1.99.0')) };
+      writer['versions'] = { 'v1.99.0': new SemanticVersionEntry(new semver.SemVer('v1.99.0')) };
       await writer['writeCache']();
 
       // We want to check that initialize() returns before updateCache() does.

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -13,9 +13,9 @@ import K3sHelper, {
   ChannelMapping,
   NoCachedK3sVersionsError,
   ReleaseAPIEntry,
-  SemanticVersionEntry,
 } from '../k3sHelper';
 
+import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import paths from '@pkg/utils/paths';
 
 const cachePath = path.join(paths.cache, 'k3s-versions.json');

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -10,12 +10,11 @@ import INSTALL_CONTAINERD_SHIMS_SCRIPT from '@pkg/assets/scripts/install-contain
 import CONTAINERD_CONFIG from '@pkg/assets/scripts/k3s-containerd-config.toml';
 import SPIN_OPERATOR from '@pkg/assets/scripts/spin-operator.yaml';
 import { BackendSettings, VMExecutor } from '@pkg/backend/backend';
-import * as K8s from '@pkg/backend/k8s';
 import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine, Settings } from '@pkg/config/settings';
 import * as settingsImpl from '@pkg/config/settingsImpl';
 import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
-import { minimumUpgradeVersion } from '@pkg/utils/kubeVersions';
+import { minimumUpgradeVersion, SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';
@@ -180,10 +179,10 @@ export default class BackendHelper {
    * If it's valid and available, use it.
    * Otherwise fall back to the minimum upgrade version (highest patch release of lowest available version).
    */
-  static async getDesiredVersion(cfg: BackendSettings, availableVersions: K8s.VersionEntry[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
+  static async getDesiredVersion(cfg: BackendSettings, availableVersions: SemanticVersionEntry[], noModalDialogs: boolean, settingsWriter: (_: any) => void): Promise<semver.SemVer> {
     const currentConfigVersionString = cfg?.kubernetes?.version;
     let storedVersion: semver.SemVer | null;
-    let matchedVersion: K8s.VersionEntry | undefined;
+    let matchedVersion: SemanticVersionEntry | undefined;
     const invalidK8sVersionMainMessage = `Requested kubernetes version '${ currentConfigVersionString }' is not a supported version.`;
     const sv = new SettingsValidator();
     const lockedSettings = settingsImpl.getLockedSettings();

--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -10,12 +10,12 @@ import INSTALL_CONTAINERD_SHIMS_SCRIPT from '@pkg/assets/scripts/install-contain
 import CONTAINERD_CONFIG from '@pkg/assets/scripts/k3s-containerd-config.toml';
 import SPIN_OPERATOR from '@pkg/assets/scripts/spin-operator.yaml';
 import { BackendSettings, VMExecutor } from '@pkg/backend/backend';
-import { minimumUpgradeVersion } from '@pkg/backend/k3sHelper';
 import * as K8s from '@pkg/backend/k8s';
 import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine, Settings } from '@pkg/config/settings';
 import * as settingsImpl from '@pkg/config/settingsImpl';
 import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
+import { minimumUpgradeVersion } from '@pkg/utils/kubeVersions';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { jsonStringifyWithWhiteSpace } from '@pkg/utils/stringify';

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -137,35 +137,6 @@ export class VersionEntry implements K8s.VersionEntry {
 }
 
 /**
- * Get the highest stable version from a list of K8s.VersionEntry objects.
- * @param versions The list of K8s.VersionEntry objects.
- * @returns The highest stable version, or highest version if no stable version is found.
- */
-export function highestStableVersion(versions: K8s.VersionEntry[]): K8s.VersionEntry | undefined {
-  // The versions object may have been received via IPC from the k8s-versions message, so it may be just a structured clone without any prototypes.
-  // That means versions[].version may not actually be a semver.SemVer object. Therefore, we re-create it from the versions[].version.version property.
-  const highestFirst = versions.slice().sort((a, b) => semver.compare(b.version.version, a.version.version));
-
-  return highestFirst.find(v => (v.channels ?? []).includes('stable')) ?? highestFirst[0];
-}
-
-function sameMajorMinorVersion(version1: semver.SemVer, version2: semver.SemVer): boolean {
-  return version1.major === version2.major && version1.minor === version2.minor;
-}
-
-/**
- * Get the highest patch release of the lowest available versions
- * @param versions The list of K8s.VersionEntry objects.
- * @returns The highest patch version.
- */
-export function minimumUpgradeVersion(versions: K8s.VersionEntry[]): K8s.VersionEntry | undefined {
-  // See comment on highestStableVersion about versions[].version potentially not being a semver.SemVer object.
-  const lowestFirst = versions.slice().sort((a, b) => semver.compare(a.version.version, b.version.version));
-
-  return lowestFirst.findLast(v => sameMajorMinorVersion(v.version, lowestFirst[0].version));
-}
-
-/**
  * Given a version, return the K3s build version.
  *
  * Note that this is only exported for testing.

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -112,12 +112,12 @@ export class ChannelMapping {
 }
 
 /**
- * VersionEntry implements K8s.VersionEntry.
+ * SemanticVersionEntry implements K8s.SemanticVersionEntry.
  *
  * This only exists to aid in debugging (by implementing util.debug.custom).
  * This is only exported for tests.
  */
-export class VersionEntry implements K8s.VersionEntry {
+export class SemanticVersionEntry implements K8s.SemanticVersionEntry {
   version: semver.SemVer;
   channels?: string[];
 
@@ -168,7 +168,7 @@ export default class K3sHelper extends events.EventEmitter {
    * without any build information (since we only ever take the latest build).
    * Note that the key is in the form `1.0.0` (i.e. without the `v` prefix).
    */
-  protected versions: Record<ShortVersion, VersionEntry> = {};
+  protected versions: Record<ShortVersion, SemanticVersionEntry> = {};
 
   protected pendingNetworkSetup = Latch();
   protected pendingInitialize: Promise<void> | undefined;
@@ -196,7 +196,7 @@ export default class K3sHelper extends events.EventEmitter {
         const version = semver.parse(versionString);
 
         if (version && semver.gte(version, this.minimumVersion)) {
-          this.versions[version.version] = new VersionEntry(version);
+          this.versions[version.version] = new SemanticVersionEntry(version);
         }
       }
 
@@ -329,7 +329,7 @@ export default class K3sHelper extends events.EventEmitter {
       const foundImage = this.filenames.images.find(name => entry.assets.some(v => v.name === name));
 
       if (foundImage) {
-        this.versions[version.version] = new VersionEntry(version);
+        this.versions[version.version] = new SemanticVersionEntry(version);
         console.log(`Adding version ${ version.raw } - ${ foundImage }`);
       } else {
         console.debug(`Skipping version ${ version.raw } due to missing image`);
@@ -562,7 +562,7 @@ export default class K3sHelper extends events.EventEmitter {
   /**
    * The versions that are available to install.
    */
-  get availableVersions(): Promise<K8s.VersionEntry[]> {
+  get availableVersions(): Promise<K8s.SemanticVersionEntry[]> {
     return (async() => {
       await this.initialize();
       const upstreamSeemsReachable = await checkConnectivity('k3s.io');
@@ -577,7 +577,7 @@ export default class K3sHelper extends events.EventEmitter {
     return !(await checkConnectivity('k3s.io'));
   }
 
-  static async filterVersionsAgainstCache(fullVersionList: K8s.VersionEntry[]): Promise<K8s.VersionEntry[]> {
+  static async filterVersionsAgainstCache(fullVersionList: K8s.SemanticVersionEntry[]): Promise<K8s.SemanticVersionEntry[]> {
     try {
       const cacheDir = path.join(paths.cache, 'k3s');
       const k3sFilenames = (await fs.promises.readdir(cacheDir))

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -4,6 +4,7 @@ import { BackendSettings, RestartReasons } from './backend';
 import K3sHelper, { ExtraRequiresReasons } from './k3sHelper';
 
 import EventEmitter from '@pkg/utils/eventEmitter';
+import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
 import type { ServiceEntry } from './kube/client';
@@ -14,15 +15,7 @@ export type {
 } from './backend';
 export type { ServiceEntry } from './kube/client';
 
-/**
- * VersionEntry describes a version of K3s.
- */
-export interface VersionEntry {
-  /** The version being described. This includes any build-specific data. */
-  version: semver.SemVer;
-  /** A string describing the channels that include this version, if any. */
-  channels?: string[];
-}
+export type { SemanticVersionEntry as VersionEntry } from '@pkg/utils/kubeVersions';
 
 /**
  * KubernetesBackendEvents describes the events that may be emitted by a
@@ -57,7 +50,7 @@ export interface KubernetesBackend extends EventEmitter<KubernetesBackendEvents>
    * The versions that are available to install, sorted as would be displayed to
    * the user.
    */
-  availableVersions: Promise<VersionEntry[]>;
+  availableVersions: Promise<SemanticVersionEntry[]>;
 
   /**
    * Used to let the UI know whether it was sent all potentially supported k8s versions.

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -15,8 +15,6 @@ export type {
 } from './backend';
 export type { ServiceEntry } from './kube/client';
 
-export type { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
-
 /**
  * KubernetesBackendEvents describes the events that may be emitted by a
  * Kubernetes backend (as an EventEmitter).  Each property name is the name of

--- a/pkg/rancher-desktop/backend/k8s.ts
+++ b/pkg/rancher-desktop/backend/k8s.ts
@@ -15,7 +15,7 @@ export type {
 } from './backend';
 export type { ServiceEntry } from './kube/client';
 
-export type { SemanticVersionEntry as VersionEntry } from '@pkg/utils/kubeVersions';
+export type { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 
 /**
  * KubernetesBackendEvents describes the events that may be emitted by a

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -299,7 +299,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     return this.activeVersion?.version ?? '';
   }
 
-  get availableVersions(): Promise<K8s.VersionEntry[]> {
+  get availableVersions(): Promise<K8s.SemanticVersionEntry[]> {
     return this.k3sHelper.availableVersions;
   }
 

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -22,6 +22,7 @@ import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 import { checkConnectivity } from '@pkg/main/networking';
 import clone from '@pkg/utils/clone';
+import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
@@ -299,7 +300,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     return this.activeVersion?.version ?? '';
   }
 
-  get availableVersions(): Promise<K8s.SemanticVersionEntry[]> {
+  get availableVersions(): Promise<SemanticVersionEntry[]> {
     return this.k3sHelper.availableVersions;
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -16,6 +16,7 @@ import * as K8s from '@pkg/backend/k8s';
 import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 import { checkConnectivity } from '@pkg/main/networking';
+import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
@@ -63,7 +64,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     return this.currentPort;
   }
 
-  get availableVersions(): Promise<K8s.SemanticVersionEntry[]> {
+  get availableVersions(): Promise<SemanticVersionEntry[]> {
     return this.k3sHelper.availableVersions;
   }
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -63,7 +63,7 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     return this.currentPort;
   }
 
-  get availableVersions(): Promise<K8s.VersionEntry[]> {
+  get availableVersions(): Promise<K8s.SemanticVersionEntry[]> {
     return this.k3sHelper.availableVersions;
   }
 

--- a/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyKubernetes.vue
@@ -4,14 +4,13 @@ import { Banner } from '@rancher/components';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { highestStableVersion } from '@pkg/backend/k3sHelper';
-import { VersionEntry } from '@pkg/backend/k8s';
 import RdInput from '@pkg/components/RdInput.vue';
 import RdSelect from '@pkg/components/RdSelect.vue';
 import RdCheckbox from '@pkg/components/form/RdCheckbox.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { highestStableVersion, VersionEntry } from '@pkg/utils/kubeVersions';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
 import type { PropType } from 'vue';
@@ -82,10 +81,10 @@ export default Vue.extend({
       const names = (version.channels ?? []).filter(ch => !/^v?\d+/.test(ch));
 
       if (names.length > 0) {
-        return `v${ version.version.version } (${ names.join(', ') })`;
+        return `v${ version.version } (${ names.join(', ') })`;
       }
 
-      return `v${ version.version.version }`;
+      return `v${ version.version }`;
     },
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
@@ -132,9 +131,9 @@ export default Vue.extend({
         >
           <option
             v-for="item in recommendedVersions"
-            :key="item.version.version"
-            :value="item.version.version"
-            :selected="item.version.version === defaultVersion.version.version"
+            :key="item.version"
+            :value="item.version"
+            :selected="item.version === defaultVersion.version"
           >
             {{ versionName(item) }}
           </option>
@@ -145,11 +144,11 @@ export default Vue.extend({
         >
           <option
             v-for="item in nonRecommendedVersions"
-            :key="item.version.version"
-            :value="item.version.version"
-            :selected="item.version.version === defaultVersion.version.version"
+            :key="item.version"
+            :value="item.version"
+            :selected="item.version === defaultVersion.version"
           >
-            v{{ item.version.version }}
+            v{{ item.version }}
           </option>
         </optgroup>
       </rd-select>

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -28,9 +28,9 @@
         >
           <option
             v-for="item in recommendedVersions"
-            :key="item.version.version"
-            :value="item.version.version"
-            :selected="item.version.version === unwrappedDefaultVersion"
+            :key="item.version"
+            :value="item.version"
+            :selected="item.version === unwrappedDefaultVersion"
           >
             {{ versionName(item) }}
           </option>
@@ -41,11 +41,11 @@
         >
           <option
             v-for="item in nonRecommendedVersions"
-            :key="item.version.version"
-            :value="item.version.version"
-            :selected="item.version.version === unwrappedDefaultVersion"
+            :key="item.version"
+            :value="item.version"
+            :selected="item.version === unwrappedDefaultVersion"
           >
-            v{{ item.version.version }}
+            v{{ item.version }}
           </option>
         </optgroup>
       </rd-select>
@@ -92,8 +92,6 @@ import _ from 'lodash';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { highestStableVersion } from '@pkg/backend/k3sHelper';
-import { VersionEntry } from '@pkg/backend/k8s';
 import EngineSelector from '@pkg/components/EngineSelector.vue';
 import PathManagementSelector from '@pkg/components/PathManagementSelector.vue';
 import RdSelect from '@pkg/components/RdSelect.vue';
@@ -103,6 +101,7 @@ import { defaultSettings } from '@pkg/config/settings';
 import type { ContainerEngine } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { highestStableVersion, VersionEntry } from '@pkg/utils/kubeVersions';
 
 export default Vue.extend({
   components: {
@@ -137,7 +136,7 @@ export default Vue.extend({
     unwrappedDefaultVersion(): string {
       const wrappedSemver = this.defaultVersion;
 
-      return wrappedSemver ? wrappedSemver.version.version : '';
+      return wrappedSemver ? wrappedSemver.version : '';
     },
     /** Versions that are the tip of a channel */
     recommendedVersions(): VersionEntry[] {
@@ -227,10 +226,10 @@ export default Vue.extend({
       const names = (version.channels ?? []).filter(ch => !/^v?\d+/.test(ch));
 
       if (names.length > 0) {
-        return `v${ version.version.version } (${ names.join(', ') })`;
+        return `v${ version.version } (${ names.join(', ') })`;
       }
 
-      return `v${ version.version.version }`;
+      return `v${ version.version }`;
     },
     setPathManagementStrategy(val: PathManagementStrategy) {
       this.$store.dispatch('applicationSettings/setPathManagementStrategy', val);

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -182,7 +182,7 @@ export interface IpcRendererEvents {
   ) => void;
   'k8s-current-port': (port: number) => void;
   'k8s-versions': (
-    versions: import('@pkg/backend/k8s').VersionEntry[],
+    versions: import('@pkg/utils/kubeVersions').VersionEntry[],
     cachedOnly: boolean
   ) => void;
   'k8s-integrations': (integrations: Record<string, boolean | string>) => void;

--- a/pkg/rancher-desktop/utils/__tests__/kubeVersions.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/kubeVersions.spec.ts
@@ -36,11 +36,11 @@ describe('highestStableVersion', () => {
 describe('minimumUpgradeVersion', () => {
   it('should return the highest patch release of the lowest major.minor version', () => {
     const versions: SemanticVersionEntry[] = [
-      { version: new semver.SemVer('v1.2.1'), channels: ['stable'] },
-      { version: new semver.SemVer('v1.0.0'), channels: ['unstable'] },
-      { version: new semver.SemVer('v1.0.3'), channels: ['unstable'] },
-      { version: new semver.SemVer('v1.0.2'), channels: ['stable'] },
-      { version: new semver.SemVer('v1.2.2'), channels: ['stable'] },
+      new SemanticVersionEntry(new semver.SemVer('v1.2.1'), ['stable']),
+      new SemanticVersionEntry(new semver.SemVer('v1.0.0'), ['unstable']),
+      new SemanticVersionEntry(new semver.SemVer('v1.0.3'), ['unstable']),
+      new SemanticVersionEntry(new semver.SemVer('v1.0.2'), ['stable']),
+      new SemanticVersionEntry(new semver.SemVer('v1.2.2'), ['stable']),
     ];
     const result = minimumUpgradeVersion(versions)?.version.version;
 

--- a/pkg/rancher-desktop/utils/__tests__/kubeVersions.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/kubeVersions.spec.ts
@@ -1,0 +1,55 @@
+import semver from 'semver';
+
+import { highestStableVersion, minimumUpgradeVersion, SemanticVersionEntry, VersionEntry } from '@pkg/utils/kubeVersions';
+
+describe('highestStableVersion', () => {
+  it('should return the highest stable version', () => {
+    const versions: VersionEntry[] = [
+      { version: '2.0.0', channels: ['unstable'] },
+      { version: '1.1.0', channels: ['stable'] },
+      { version: '1.3.0', channels: ['stable'] },
+      { version: '1.2.0', channels: ['stable'] },
+    ];
+    const result = highestStableVersion(versions)?.version;
+
+    expect(result).toEqual('1.3.0');
+  });
+
+  it('should return highest version if no stable version is found', () => {
+    const versions: VersionEntry[] = [
+      { version: '1.0.0', channels: ['unstable'] },
+      { version: '1.2.0', channels: ['beta'] },
+      { version: '1.1.0', channels: ['beta'] },
+    ];
+    const result = highestStableVersion(versions)?.version;
+
+    expect(result).toEqual('1.2.0');
+  });
+
+  it('should return undefined if the list is empty', () => {
+    const result = highestStableVersion([]);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('minimumUpgradeVersion', () => {
+  it('should return the highest patch release of the lowest major.minor version', () => {
+    const versions: SemanticVersionEntry[] = [
+      { version: new semver.SemVer('v1.2.1'), channels: ['stable'] },
+      { version: new semver.SemVer('v1.0.0'), channels: ['unstable'] },
+      { version: new semver.SemVer('v1.0.3'), channels: ['unstable'] },
+      { version: new semver.SemVer('v1.0.2'), channels: ['stable'] },
+      { version: new semver.SemVer('v1.2.2'), channels: ['stable'] },
+    ];
+    const result = minimumUpgradeVersion(versions)?.version.version;
+
+    expect(result).toEqual('1.0.3');
+  });
+
+  it('should return undefined if the list is empty', () => {
+    const result = minimumUpgradeVersion([]);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/pkg/rancher-desktop/utils/kubeVersions.ts
+++ b/pkg/rancher-desktop/utils/kubeVersions.ts
@@ -1,0 +1,50 @@
+import semver from 'semver';
+
+export interface VersionEntry {
+  /**
+   * The version being described. This includes any build-specific data.
+   * This must be a valid semver-parsable string, without any pre-release
+   * versions or build metadata.
+   */
+  version: string;
+  /** A string describing the channels that include this version, if any. */
+  channels?: string[];
+}
+
+/**
+ * SemanticVersionEntry is a VersionEntry that contains semver.SemVer objects.
+ * This should not be passed over IPC.
+ */
+export interface SemanticVersionEntry extends Omit<VersionEntry, 'version'> {
+  /**
+   * The version being described. This includes any build-specific data.
+   */
+  version: semver.SemVer;
+}
+
+/**
+ * Get the highest stable version from a list of K8s.VersionEntry objects.
+ * @param versions The list of K8s.VersionEntry objects.
+ * @returns The highest stable version, or highest version if no stable version is found.
+ */
+export function highestStableVersion(versions: VersionEntry[]): VersionEntry | undefined {
+  const highestFirst = versions.slice().sort((a, b) => semver.compare(b.version, a.version));
+
+  return highestFirst.find(v => (v.channels ?? []).includes('stable')) ?? highestFirst[0];
+}
+
+function sameMajorMinorVersion(version1: semver.SemVer, version2: semver.SemVer): boolean {
+  return version1.major === version2.major && version1.minor === version2.minor;
+}
+
+/**
+ * Get the highest patch release of the lowest available versions
+ * @param versions The list of K8s.VersionEntry objects.
+ * @returns The highest patch version.
+ */
+export function minimumUpgradeVersion(versions: SemanticVersionEntry[]): SemanticVersionEntry | undefined {
+  // See comment on highestStableVersion about versions[].version potentially not being a semver.SemVer object.
+  const lowestFirst = versions.slice().sort((a, b) => semver.compare(a.version, b.version));
+
+  return lowestFirst.findLast(v => sameMajorMinorVersion(v.version, lowestFirst[0].version));
+}

--- a/pkg/rancher-desktop/utils/kubeVersions.ts
+++ b/pkg/rancher-desktop/utils/kubeVersions.ts
@@ -7,7 +7,10 @@ export interface VersionEntry {
    * versions or build metadata.
    */
   version: string;
-  /** A string describing the channels that include this version, if any. */
+  /**
+   * An array of strings describing the channels that include this version,
+   * if any.
+   */
   channels?: string[];
 }
 


### PR DESCRIPTION
Because `k3sHelper.ts` pulls in `@pkg/utils/paths` (which is main-process only and spawns `rdctl`), we must not use it from the renderer process as that will cause an error when the relevant window opens.  Instead, move the Kubernetes version helpers into a new file that does not import it.

While we're at it, avoid sending `semver.SemVer` objects across processes because that does not work anyway.  See #7208 (though we still need to do an audit to make sure there are no other non-cloneable objects being passed).