### PR TITLE
Main window: Force set window title.

### DIFF
--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -85,6 +85,9 @@ export default {
   },
 
   beforeMount() {
+    // The window title isn't set correctly in E2E; as a workaround, force set
+    // it here again.
+    document.title ||= 'Rancher Desktop';
     initExtensions();
     ipcRenderer.on('window/blur', (event, blur) => {
       this.blur = blur;


### PR DESCRIPTION
When running E2E tests (including the screenshots script), the window title isn't being set correctly.  However, it seems to have no issues when running otherwise (including `yarn dev`).  Try to force the window title so that it can be picked up by the screenshot script (where it tries to locate the native window ID).

Fixes #7256.