### PR TITLE
postinstall: Set timeout for downloading dependenices

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -12,6 +11,7 @@ import {
 import {
   DownloadContext, Dependency, GitHubDependency, getPublishedReleaseTagNames, getPublishedVersions,
 } from 'scripts/lib/dependencies';
+import { simpleSpawn } from 'scripts/simple_process';
 
 function exeName(context: DownloadContext, name: string) {
   const onWindows = context.platform === 'win32';
@@ -413,15 +413,13 @@ export class RancherDashboard implements Dependency, GitHubDependency {
       args[0] = path.join(systemRoot, 'system32', 'tar.exe');
     }
 
-    spawnSync(
-      args[0],
-      args.slice(1),
-      {
-        cwd:   rancherDashboardDir,
-        stdio: 'inherit',
-      });
+    console.log('Extracting rancher dashboard...');
+    await simpleSpawn(args[0], args.slice(1), {
+      cwd:   rancherDashboardDir,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
 
-    fs.rmSync(destPath, { maxRetries: 10 });
+    await fs.promises.rm(destPath, { recursive: true, maxRetries: 10 });
   }
 
   async getAvailableVersions(): Promise<string[]> {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -21,6 +21,11 @@ type DependencyWithContext = {
   context: DownloadContext;
 };
 
+/**
+ * The amount of time we allow the post-install script to run, in milliseconds.
+ */
+const InstallTimeout = 10 * 60 * 1_000; // Ten minutes.
+
 // Dependencies that should be installed into places that users touch
 // (so users' WSL distros and hosts as of the time of writing).
 const userTouchedDependencies = [
@@ -130,7 +135,7 @@ async function downloadDependencies(items: DependencyWithContext[]): Promise<voi
     promises[specialize(item)] = process(specialize(item));
   }
 
-  const abortSignal = AbortSignal.timeout(10 * 60 * 1_000);
+  const abortSignal = AbortSignal.timeout(InstallTimeout);
 
   while (!abortSignal.aborted && running.size > done.size) {
     const timeout = new Promise((resolve) => {


### PR DESCRIPTION
We seem to have issues in CI where postinstall ends up hanging.  Try to add a timeout for the whole process to see what is failing.

~This also seems to make it harder to reproduce the hang, so maybe that's good enough to solve the issue? See the reruns on https://github.com/mook-as/rd/actions/runs/10115895877.~

Of course the PR run hits the issue (and actually still hung). Fixed a probable bug that broke the timeout.