### PR TITLE
Use `127.0.0.1` for the host for the KubeClient port forwarding to force listening to IPv4

### DIFF
--- a/pkg/rancher-desktop/backend/kube/client.ts
+++ b/pkg/rancher-desktop/backend/kube/client.ts
@@ -506,7 +506,7 @@ export class KubeClient extends events.EventEmitter {
       });
       server.once('listening', resolveOnce);
       server.once('error', rejectOnce);
-      server.listen({ port: hostPort, host: 'localhost' });
+      server.listen({ port: hostPort, host: '127.0.0.1' });
     });
 
     return server;


### PR DESCRIPTION
This PR fixes #7248 (tested on Windows only) ~~by switching the `host` from `localhost` to `::`. The former will only listen on the interface that DNS resolves `localhost` to, causing it to sometimes only listen on IPv6. Using `::` will listen on both interfaces regardless of DNS lookup.~~

Per the discussion before, we decided to just hardcode `127.0.0.1`. I force pushed removing the original commit that tried to use `::`