### PR TITLE
Default kubeconfig --verify flag to false

### DIFF
--- a/src/go/wsl-helper/cmd/kubeconfig.go
+++ b/src/go/wsl-helper/cmd/kubeconfig.go
@@ -158,7 +158,7 @@ func readKubeConfig(configPath string) (kubeConfig, error) {
 }
 
 func init() {
-	kubeconfigCmd.PersistentFlags().Bool("verify", true, "Checks whether the symlinked config contains non-Rancher Desktop configuration.")
+	kubeconfigCmd.PersistentFlags().Bool("verify", false, "Checks whether the symlinked config contains non-Rancher Desktop configuration.")
 	kubeconfigCmd.PersistentFlags().Bool("enable", true, "Set up config file")
 	kubeconfigCmd.PersistentFlags().String("kubeconfig", "", "Path to Windows kubeconfig, in /mnt/... form.")
 	kubeconfigViper.AutomaticEnv()


### PR DESCRIPTION
The default setting for the --verify flag was previously set to true, which caused the process always to follow the exit branch.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7273