### PR TITLE
BATS: k8s/spinkube-npm: Fix expected text

### DIFF
--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -87,5 +87,5 @@ EOF
 
     run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}"
     assert_success
-    assert_output "Hello from JS-SDK"
+    assert_output --regexp '^(Hello|hello)'
 }


### PR DESCRIPTION
The spin-js-sdk template was updated at some point to print different text which caused tests to fail.  Update the expression to match both the old and new outputs (and hopefully whatever else they change it to).

Old text: "Hello from JS-SDK"
Intermediate text: "Hello, Universe!"
New text: "hello universe"