### PR TITLE
Pick Diagnostics: path management onto release-1.15

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -101,7 +101,7 @@ paths:
       summary: >-
         Return a list of the check IDs for the Diagnostics category,
         or 404 if there is no such `category`.
-        Specifying an exiting category with no checks
+        Specifying an existing category with no checks
         will return status code 200 and an empty array.
       parameters:
       - in: query

--- a/pkg/rancher-desktop/integrations/pathManager.ts
+++ b/pkg/rancher-desktop/integrations/pathManager.ts
@@ -8,8 +8,8 @@ export interface PathManager {
   /** The PathManagementStrategy that corresponds to the implementation. */
   readonly strategy: PathManagementStrategy
   /**
-   * Makes real any changes to the system. Should be idempotent, and should not
-   * throw any exceptions.
+   * Applies changes to the system. Should be idempotent, and should not throw
+   * any exceptions.
    */
   enforce(): Promise<void>
   /**

--- a/pkg/rancher-desktop/integrations/pathManager.ts
+++ b/pkg/rancher-desktop/integrations/pathManager.ts
@@ -7,9 +7,15 @@
 export interface PathManager {
   /** The PathManagementStrategy that corresponds to the implementation. */
   readonly strategy: PathManagementStrategy
-  /** Makes real any changes to the system. Should be idempotent. */
+  /**
+   * Makes real any changes to the system. Should be idempotent, and should not
+   * throw any exceptions.
+   */
   enforce(): Promise<void>
-  /** Removes any changes that the PathManager may have made. Should be idempotent. */
+  /**
+   * Removes any changes that the PathManager may have made. Should be
+   * idempotent, and should not throw any exceptions.
+   */
   remove(): Promise<void>
 }
 

--- a/pkg/rancher-desktop/integrations/pathManagerImpl.ts
+++ b/pkg/rancher-desktop/integrations/pathManagerImpl.ts
@@ -7,7 +7,10 @@ import { Mutex } from 'async-mutex';
 import manageLinesInFile from '@pkg/integrations/manageLinesInFile';
 import { ManualPathManager, PathManagementStrategy, PathManager } from '@pkg/integrations/pathManager';
 import mainEvents from '@pkg/main/mainEvents';
+import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
+
+const console = Logging['path-management'];
 
 /**
  * RcFilePathManager is for when the user wants Rancher Desktop to
@@ -32,15 +35,36 @@ export class RcFilePathManager implements PathManager {
   }
 
   async enforce(): Promise<void> {
-    await this.managePosix(true);
-    await this.manageCsh(true);
-    await this.manageFish(true);
+    try {
+      await this.managePosix(true);
+      await this.manageCsh(true);
+      await this.manageFish(true);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   async remove(): Promise<void> {
-    await this.managePosix(false);
-    await this.manageCsh(false);
-    await this.manageFish(false);
+    try {
+      await this.managePosix(false);
+      await this.manageCsh(false);
+      await this.manageFish(false);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  /**
+   * Call manageFilesInLine, wrapped in calls to trigger diagnostics updates.
+   */
+  protected async manageLinesInFile(fileName: string, filePath: string, lines: string[], desiredPresent: boolean) {
+    try {
+      await manageLinesInFile(filePath, lines, desiredPresent);
+      mainEvents.emit('diagnostics-event', 'path-management', { fileName, error: undefined });
+    } catch (error) {
+      mainEvents.emit('diagnostics-event', 'path-management', { fileName, error });
+      throw error;
+    }
   }
 
   /**
@@ -51,7 +75,8 @@ export class RcFilePathManager implements PathManager {
   protected async managePosix(desiredPresent: boolean): Promise<void> {
     await this.posixMutex.runExclusive(async() => {
       const pathLine = `export PATH="${ paths.integration }:$PATH"`;
-      // Note: order is important here. Only the first one that is present is modified.
+      // Note: order is important here.  Only the first one has the PATH added;
+      // all others have it removed.
       const bashLoginShellFiles = [
         '.bash_profile',
         '.bash_login',
@@ -70,35 +95,38 @@ export class RcFilePathManager implements PathManager {
             await fs.promises.stat(filePath);
           } catch (error: any) {
             if (error.code === 'ENOENT') {
+              // If the file does not exist, it is not an error.
+              mainEvents.emit('diagnostics-event', 'path-management', { fileName, error: undefined });
               continue;
             }
+            mainEvents.emit('diagnostics-event', 'path-management', { fileName, error });
             throw error;
           }
-          await manageLinesInFile(filePath, [pathLine], desiredPresent);
+          await this.manageLinesInFile(fileName, filePath, [pathLine], !linesAdded);
           linesAdded = true;
-          break;
         }
 
         // If none of the files exist, write .bash_profile
         if (!linesAdded) {
-          const filePath = path.join(os.homedir(), bashLoginShellFiles[0]);
+          const fileName = bashLoginShellFiles[0];
+          const filePath = path.join(os.homedir(), fileName);
 
-          await manageLinesInFile(filePath, [pathLine], desiredPresent);
+          await this.manageLinesInFile(fileName, filePath, [pathLine], true);
         }
       } else {
         // Ensure lines are not present in any of the files
-        await Promise.all(bashLoginShellFiles.map((fileName) => {
+        await Promise.all(bashLoginShellFiles.map(async(fileName) => {
           const filePath = path.join(os.homedir(), fileName);
 
-          return manageLinesInFile(filePath, [], desiredPresent);
+          await this.manageLinesInFile(fileName, filePath, [], false);
         }));
       }
 
       // Handle other shells' rc files and .bashrc
-      await Promise.all(['.bashrc', '.zshrc'].map((rcName) => {
-        const rcPath = path.join(os.homedir(), rcName);
+      await Promise.all(['.bashrc', '.zshrc'].map((fileName) => {
+        const rcPath = path.join(os.homedir(), fileName);
 
-        return manageLinesInFile(rcPath, [pathLine], desiredPresent);
+        return this.manageLinesInFile(fileName, rcPath, [pathLine], desiredPresent);
       }));
 
       mainEvents.invoke('diagnostics-trigger', 'RD_BIN_IN_BASH_PATH');
@@ -110,10 +138,10 @@ export class RcFilePathManager implements PathManager {
     await this.cshMutex.runExclusive(async() => {
       const pathLine = `setenv PATH "${ paths.integration }"\\:"$PATH"`;
 
-      await Promise.all(['.cshrc', '.tcshrc'].map((rcName) => {
-        const rcPath = path.join(os.homedir(), rcName);
+      await Promise.all(['.cshrc', '.tcshrc'].map((fileName) => {
+        const rcPath = path.join(os.homedir(), fileName);
 
-        return manageLinesInFile(rcPath, [pathLine], desiredPresent);
+        return this.manageLinesInFile(fileName, rcPath, [pathLine], desiredPresent);
       }));
     });
   }
@@ -122,11 +150,12 @@ export class RcFilePathManager implements PathManager {
     await this.fishMutex.runExclusive(async() => {
       const pathLine = `set --export --prepend PATH "${ paths.integration }"`;
       const configHome = process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config');
+      const fileName = 'config.fish';
       const fishConfigDir = path.join(configHome, 'fish');
-      const fishConfigPath = path.join(fishConfigDir, 'config.fish');
+      const fishConfigPath = path.join(fishConfigDir, fileName);
 
       await fs.promises.mkdir(fishConfigDir, { recursive: true, mode: 0o700 });
-      await manageLinesInFile(fishConfigPath, [pathLine], desiredPresent);
+      await this.manageLinesInFile(fileName, fishConfigPath, [pathLine], desiredPresent);
     });
   }
 }

--- a/pkg/rancher-desktop/integrations/pathManagerImpl.ts
+++ b/pkg/rancher-desktop/integrations/pathManagerImpl.ts
@@ -61,7 +61,7 @@ export class RcFilePathManager implements PathManager {
     try {
       await manageLinesInFile(filePath, lines, desiredPresent);
       mainEvents.emit('diagnostics-event', 'path-management', { fileName, error: undefined });
-    } catch (error) {
+    } catch (error: any) {
       mainEvents.emit('diagnostics-event', 'path-management', { fileName, error });
       throw error;
     }

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -1,4 +1,4 @@
-import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './types';
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
 
 import mainEvents from '@pkg/main/mainEvents';
 import Logging from '@pkg/utils/logging';
@@ -38,7 +38,7 @@ export class DiagnosticsManager {
   lastUpdate = new Date(0);
 
   /** Last known check results, indexed by the checker id. */
-  results: Record<DiagnosticsChecker['id'], DiagnosticsCheckerResult> = {};
+  results: Record<DiagnosticsChecker['id'], DiagnosticsCheckerResult|DiagnosticsCheckerSingleResult[]> = {};
 
   /** Mapping of category name to diagnostic ids */
   readonly checkerIdByCategory: Partial<Record<DiagnosticsCategory, string[]>> = {};
@@ -92,9 +92,10 @@ export class DiagnosticsManager {
   }
 
   protected async applicableCheckers(categoryName: string | null, id: string | null): Promise<DiagnosticsChecker[]> {
+    const checkerId = id?.split(':', 1)[0];
     const checkers = (await this.checkers)
       .filter(checker => categoryName ? checker.category === categoryName : true)
-      .filter(checker => id ? checker.id === id : true);
+      .filter(checker => checkerId ? checker.id === checkerId : true);
 
     return (await Promise.all(checkers.map(async(checker) => {
       try {
@@ -124,12 +125,25 @@ export class DiagnosticsManager {
     return {
       last_update: this.lastUpdate.toISOString(),
       checks:      checkers
-        .map(checker => ({
-          ...this.results[checker.id],
-          id:       checker.id,
-          category: checker.category,
-          mute:     false,
-        })),
+        .flatMap((checker) => {
+          const result = this.results[checker.id];
+
+          if (Array.isArray(result)) {
+            return result.map(result => ({
+              ...result,
+              id:       `${ checker.id }:${ result.id }`,
+              category: checker.category,
+              mute:     false,
+            }));
+          } else {
+            return {
+              ...result,
+              id:       checker.id,
+              category: checker.category,
+              mute:     false,
+            };
+          }
+        }),
     };
   }
 
@@ -139,8 +153,16 @@ export class DiagnosticsManager {
   protected async runChecker(checker: DiagnosticsChecker) {
     console.debug(`Running check ${ checker.id }`);
     try {
-      this.results[checker.id] = await checker.check();
-      console.debug(`Check ${ checker.id } result: ${ JSON.stringify(this.results[checker.id]) }`);
+      const result = await checker.check();
+
+      this.results[checker.id] = result;
+      if (Array.isArray(result)) {
+        for (const singleResult of result) {
+          console.debug(`Check ${ checker.id }:${ singleResult.id } result: ${ JSON.stringify(singleResult) }`);
+        }
+      } else {
+        console.debug(`Check ${ checker.id } result: ${ JSON.stringify(result) }`);
+      }
     } catch (e) {
       console.error(`ERROR checking ${ checker.id }`, { e });
     }

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -47,12 +47,12 @@ export class DiagnosticsManager {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
       const imports = (await Promise.all([
         import('./connectedToInternet'),
-        import('./pathManagement'),
         import('./dockerCliSymlinks'),
         import('./kubeConfigSymlink'),
         import('./kubeContext'),
         import('./limaDarwin'),
         import('./mockForScreenshots'),
+        import('./pathManagement'),
         import('./rdBinInShell'),
         import('./testCheckers'),
         import('./wslFromStore'),

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -47,6 +47,7 @@ export class DiagnosticsManager {
     this.checkers = diagnostics ? Promise.resolve(diagnostics) : (async() => {
       const imports = (await Promise.all([
         import('./connectedToInternet'),
+        import('./pathManagement'),
         import('./dockerCliSymlinks'),
         import('./kubeConfigSymlink'),
         import('./kubeContext'),

--- a/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeConfigSymlink.ts
@@ -27,7 +27,7 @@ const CheckKubeConfigSymlink: DiagnosticsChecker = {
   id:       'VERIFY_WSL_INTEGRATION_KUBECONFIG',
   category: DiagnosticsCategory.Kubernetes,
   applicable() {
-    return Promise.resolve(true);
+    return Promise.resolve(process.platform === 'win32');
   },
   async check() {
     return Promise.resolve({

--- a/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
+++ b/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
@@ -2,11 +2,13 @@ import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, Diag
 
 import { ErrorHasExtendedAttributes, ErrorNotRegularFile, ErrorWritingFile } from '@pkg/integrations/manageLinesInFile';
 import mainEvents from '@pkg/main/mainEvents';
-import Logging from '@pkg/utils/logging';
 
-const console = Logging.diagnostics;
 const cachedResults: Record<string, DiagnosticsCheckerResult> = {};
 
+/**
+ * Check for any errors raised from handling path management (i.e. handling of
+ * ~/.bashrc and related files) and report them to the user.
+ */
 const CheckPathManagement: DiagnosticsChecker = {
   id:       'PATH_MANAGEMENT',
   category: DiagnosticsCategory.Utilities,
@@ -24,7 +26,6 @@ const CheckPathManagement: DiagnosticsChecker = {
 };
 
 mainEvents.on('diagnostics-event', (id, state) => {
-  console.log('diagnostics-event', id, state);
   if (id !== 'path-management') {
     return;
   }

--- a/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
+++ b/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
@@ -1,0 +1,40 @@
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
+
+import mainEvents from '@pkg/main/mainEvents';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.diagnostics;
+const cachedResults: Record<string, DiagnosticsCheckerResult> = {};
+
+const CheckPathManagement: DiagnosticsChecker = {
+  id:       'PATH_MANAGEMENT',
+  category: DiagnosticsCategory.Utilities,
+  applicable() {
+    return Promise.resolve(['darwin', 'linux'].includes(process.platform));
+  },
+  check(): Promise<DiagnosticsCheckerSingleResult[]> {
+    return Promise.resolve(Object.entries(cachedResults).map(([id, result]) => {
+      return ({
+        ...result,
+        id,
+      });
+    }));
+  },
+};
+
+mainEvents.on('diagnostics-event', (id, state) => {
+  console.log('diagnostics-event', id, state);
+  if (id !== 'path-management') {
+    return;
+  }
+  const typedState: { fileName: string, error: Error | undefined } = state;
+  const { fileName, error } = typedState;
+
+  cachedResults[fileName] = {
+    passed:      !error,
+    description: error?.toString() ?? 'Passed',
+    fixes:       [],
+  };
+});
+
+export default CheckPathManagement;

--- a/pkg/rancher-desktop/main/diagnostics/types.ts
+++ b/pkg/rancher-desktop/main/diagnostics/types.ts
@@ -16,9 +16,9 @@ type DiagnosticsFix = {
  * checker.
  */
 export type DiagnosticsCheckerResult = {
-  /* Link to documentation about this check. */
+  /** Link to documentation about this check. */
   documentation?: string,
-  /* User-visible markdown description about this check. */
+  /** User-visible markdown description about this check. */
   description: string,
   /** If true, the check succeeded (no fixes need to be applied). */
   passed: boolean,
@@ -26,17 +26,31 @@ export type DiagnosticsCheckerResult = {
   fixes: DiagnosticsFix[],
 };
 
+export type DiagnosticsCheckerSingleResult = DiagnosticsCheckerResult & {
+  /**
+   * For checkers returning multiple results, each result must have its own
+   * identifier that is consistent over checker runs.
+   */
+  id: string;
+};
+
 /**
- * DiagnosticsChecker describes an implementation of a single diagnostics check.
+ * DiagnosticsChecker describes an implementation of a diagnostics checker.
+ * The checker may return one or more results.
  */
 export interface DiagnosticsChecker {
   /** Unique identifier for this check. */
   id: string;
   category: DiagnosticsCategory,
-  /** Whether this checker should be used on this system. */
+  /**
+   * Whether any of the checks this checker supports should be used on this
+   * system.
+   */
   applicable(): Promise<boolean>,
   /**
-   * Perform the check.
+   * Perform the check.  If this checker does multiple checks, any checks that
+   * are not applicable on this system should be skipped (rather than returning
+   * a failing result).
    */
-  check(): Promise<DiagnosticsCheckerResult>;
+  check(): Promise<DiagnosticsCheckerResult | DiagnosticsCheckerSingleResult[]>;
 }

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -98,7 +98,7 @@ interface MainEventNames {
    * @note This does not update the last run time (since it only runs a single
    * checker).
    */
-  'diagnostics-trigger'(id: string): DiagnosticsCheckerResult | undefined;
+  'diagnostics-trigger'(id: string): DiagnosticsCheckerResult|DiagnosticsCheckerResult[] | undefined;
 
   /**
    * Emitted when an extension is uninstalled via the extension manager.

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -105,7 +105,7 @@ interface MainEventNames {
    * @param id The diagnostic identifier.
    * @param state The new state for the diagnostic.
    */
-  'diagnostics-event'(id: string, state: any): void;
+  'diagnostics-event'<K extends keyof DiagnosticsEventPayload>(id: K, state: DiagnosticsEventPayload[K]): void;
 
   /**
    * Emitted when an extension is uninstalled via the extension manager.
@@ -143,6 +143,14 @@ interface MainEventNames {
 
   'dialog-info'(args: Record<string, string>): void;
 }
+
+/**
+ * DiagnosticsEventPayload defines the data that will be passed on a
+ * 'diagnostics-event' event.
+ */
+type DiagnosticsEventPayload = {
+  'path-management': { fileName: string; error: Error | undefined };
+};
 
 /**
  * Helper type definition to check if the given event name is a handler (i.e.

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -101,6 +101,13 @@ interface MainEventNames {
   'diagnostics-trigger'(id: string): DiagnosticsCheckerResult|DiagnosticsCheckerResult[] | undefined;
 
   /**
+   * Generically signify that a diagnostic should be updated.
+   * @param id The diagnostic identifier.
+   * @param state The new state for the diagnostic.
+   */
+  'diagnostics-event'(id: string, state: any): void;
+
+  /**
    * Emitted when an extension is uninstalled via the extension manager.
    * @param id The ID of the extension that was uninstalled.
    */

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -203,8 +203,11 @@ export class Tray {
     // updates the network status in the tray if there's a change in the network
     // state.
     this.networkInterval = setInterval(async() => {
-      const networkDiagnostic = await mainEvents.invoke('diagnostics-trigger', 'CONNECTED_TO_INTERNET');
+      let networkDiagnostic = await mainEvents.invoke('diagnostics-trigger', 'CONNECTED_TO_INTERNET');
 
+      if (Array.isArray(networkDiagnostic)) {
+        networkDiagnostic = networkDiagnostic.shift();
+      }
       if (this.networkState === networkDiagnostic?.passed) {
         return; // network state hasn't changed since last check
       }


### PR DESCRIPTION
This merges #7297 ("Diagnostics: path management") onto the release-1.15 branch.

From the original pull request description:

> This implements diagnostics for path management so people can see the errors that occur.
>
> This also adds the ability for diagnostics to return multiple results, because there are too many files under management to list just one.
>
> Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/7262