### PR TITLE
CI: go.work sync: Use vault secrets

### DIFF
--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -1,0 +1,40 @@
+name: Get Token
+description: >-
+  This action attempts to get a token with the requested permissions; if this is
+  not running from the upstream repository, it attempts to get the token from a
+  secret.  Otherwise, it uses the vault actions.
+  This requires permissions set described in
+  https://github.com/rancher-eio/read-vault-secrets
+inputs:
+  token-secret:
+    description: Secret to fall back to
+    required: false
+outputs:
+  token:
+    description: The GitHub token retrieved
+    value: ${{ github.repository == 'rancher-sandbox/rancher-desktop' && steps.gen-token.outputs.token || steps.get-secret.outputs.token }}
+runs:
+  using: composite
+  steps:
+  - id: vault
+    name: Read vault secrets
+    if: github.repository == 'rancher-sandbox/rancher-desktop'
+    uses: rancher-eio/read-vault-secrets@main
+    with:
+      secrets: |
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+        secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+  - id: gen-token
+    name: Generate token
+    if: github.repository == 'rancher-sandbox/rancher-desktop'
+    uses: actions/create-github-app-token@v1
+    with:
+      app-id: ${{ env.APP_ID }}
+      private-key: ${{ env.PRIVATE_KEY }}
+  - id: get-secret
+    name: Fetch secret.
+    if: github.repository != 'rancher-sandbox/rancher-desktop'
+    run: echo "token=$SECRET" >> "$GITHUB_OUTPUT"
+    shell: bash
+    env:
+      SECRET: ${{ inputs.token-secret }}

--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -1,6 +1,6 @@
 # Sync go.work on PRs
-# Uses the RUN_WORKFLOW_FROM_WORKFLOW secret if available.  Otherwise it is
-# necessary to reopen a PR to run more workflows.
+# If not running upstream (where it uses the vault action), requires the
+# RUN_WORKFLOW_FROM_WORKFLOW secret to be set.
 
 name: Sync go.work
 on:
@@ -20,33 +20,25 @@ jobs:
     # We only run this for pull requests from the same repository.  This is
     # important for security reasons, as we use pull_request_target.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write # Required for ./.github/actions/get-token
     runs-on: ubuntu-latest
     steps:
-    # Because the GitHub-provided token doesn't trigger further actions runs,
-    # try to use a secret if available.
-    - name: Determine checkout token
-      id: has-token
-      run: echo "has-token=$HAS_TOKEN" >> "$GITHUB_OUTPUT"
-      env:
-        # Temporarily disable use of token; we don't have a correct token set up
-        # (so we fail to push), so using the GitHub-provided token that doesn't
-        # trigger subsequent checks is better than failing to push.
-        HAS_TOKEN: ${{ false && secrets.RUN_WORKFLOW_FROM_WORKFLOW != '' }}
-    - name: Checkout with token
-      if: steps.has-token.outputs.has-token == 'true'
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.base_ref }}
+    - id: get-token
+      uses: ./.github/actions/get-token
+      with:
+        token-secret: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+    - name: Checkout
       uses: actions/checkout@v4
       with:
         persist-credentials: true
         ref: ${{ github.head_ref }}
         fetch-depth: 3
-        token: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
-    - name: Checkout without token
-      if: steps.has-token.outputs.has-token != 'true'
-      uses: actions/checkout@v4
-      with:
-        persist-credentials: true
-        ref: ${{ github.head_ref }}
-        fetch-depth: 3
+        token: ${{ steps.get-token.outputs.token }}
     - uses: actions/setup-node@v4
       with:
         node-version-file: package.json


### PR DESCRIPTION
Since our current token seems to have issues, switch to using the token from vault to see if that makes a difference.  This requires forks to have a `RUN_WORKFLOW_FROM_WORKFLOW` secret.

Fixes #7351 

Sample run: https://github.com/rancher-sandbox/rancher-desktop/actions/runs/10479481840/job/29025163697?pr=7367 (Post-run caching was skipped, but it did cause CI runs on the new commit in #7367)