### PR TITLE
Path mangement: Fix macOS signing

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -4,6 +4,8 @@ productName: Rancher Desktop
 icon: ./resources/icons/logo-square-512.png
 appId: io.rancherdesktop.app
 asar: true
+asarUnpack:
+- '**/*.node'
 electronLanguages: [ en-US ]
 extraResources:
 - resources/

--- a/pkg/rancher-desktop/integrations/manageLinesInFile.ts
+++ b/pkg/rancher-desktop/integrations/manageLinesInFile.ts
@@ -2,6 +2,10 @@ import fs from 'fs';
 
 import isEqual from 'lodash/isEqual.js';
 
+import Logging from '@pkg/utils/logging';
+
+const console = Logging['path-management'];
+
 export const START_LINE = '### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)';
 export const END_LINE = '### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)';
 const DEFAULT_FILE_MODE = 0o644;
@@ -167,7 +171,7 @@ async function fileHasExtendedAttributes(filePath: string): Promise<boolean> {
       return false;
     }
 
-    console.error(`Failed to import fs-xattr, cannot check for extended attributes on ${ filePath }`);
+    console.error(`Failed to import fs-xattr, cannot check for extended attributes on ${ filePath }:`, cause);
 
     throw new ErrorDeterminingExtendedAttributes({ path: filePath }, { cause });
   }

--- a/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
+++ b/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
@@ -1,6 +1,6 @@
 import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
 
-import { ErrorHasExtendedAttributes, ErrorNotRegularFile, ErrorWritingFile } from '@pkg/integrations/manageLinesInFile';
+import { ErrorDeterminingExtendedAttributes, ErrorHasExtendedAttributes, ErrorNotRegularFile, ErrorWritingFile } from '@pkg/integrations/manageLinesInFile';
 import mainEvents from '@pkg/main/mainEvents';
 
 const cachedResults: Record<string, DiagnosticsCheckerResult> = {};
@@ -51,6 +51,10 @@ mainEvents.on('diagnostics-event', (id, state) => {
 
       if (error instanceof ErrorWritingFile) {
         return { fixes: [{ description: `Restore \`${ fileName }\` from backup file \`${ error.backupPath }\`` }] };
+      }
+
+      if (error instanceof ErrorDeterminingExtendedAttributes && error.cause) {
+        return { description: `${ error }: ${ error.cause }` };
       }
 
       return {};


### PR DESCRIPTION
On MacOS, we fail to load `fs-xattr` because the shared library was not correctly signed (because it was inside the ASAR package and we didn't see it).  Our launch constraints were set such that we ended up not being able to load it.

This also adds some extra logging to path management to correctly record any errors.

Fixes #7394