### PR TITLE
Path management: Copy extended attributes

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
+++ b/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
@@ -1,6 +1,6 @@
 import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
 
-import { ErrorDeterminingExtendedAttributes, ErrorHasExtendedAttributes, ErrorNotRegularFile, ErrorWritingFile } from '@pkg/integrations/manageLinesInFile';
+import { ErrorDeterminingExtendedAttributes, ErrorCopyingExtendedAttributes, ErrorNotRegularFile, ErrorWritingFile } from '@pkg/integrations/manageLinesInFile';
 import mainEvents from '@pkg/main/mainEvents';
 
 const cachedResults: Record<string, DiagnosticsCheckerResult> = {};
@@ -41,7 +41,7 @@ mainEvents.on('diagnostics-event', (id, state) => {
         return { passed: true, description: `\`${ fileName }\` is managed` };
       }
 
-      if (error instanceof ErrorHasExtendedAttributes) {
+      if (error instanceof ErrorCopyingExtendedAttributes) {
         return { fixes: [{ description: `Remove extended attributes from \`${ fileName }\`` }] };
       }
 


### PR DESCRIPTION
It looks like the incidence of extended attributes on files we want to manage is higher than expected; instead of bailing on any extended attributes, try to copy them instead.

Fixes #7315

Alternatively, I'm happy to write a patch that just ignores a hard-coded set of extended attributes (depending on platform) and don't copy anything; let me know which you'd prefer.