### PR TITLE
Docker CLI Plugins: Use `cliPluginsExtraDirs` on Windows

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -132,12 +132,18 @@
         Type="string"
         KeyPath="yes"
       />
-      <Environment Id="PathWindowsUser" Name="PATH"
+      <Environment Id="PathWindowsUserBin" Name="PATH"
         Action="set" Part="last" System="no" Permanent="no"
         Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
-      <Environment Id="PathLinuxUser" Name="PATH"
+      <Environment Id="PathWindowsUserDockerCLIPlugins" Name="PATH"
+        Action="set" Part="last" System="no" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\win32\docker-cli-plugins\" />
+      <Environment Id="PathLinuxUserBin" Name="PATH"
         Action="set" Part="last" System="no" Permanent="no"
         Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
+      <Environment Id="PathLinuxUserDockerCLIPlugins" Name="PATH"
+        Action="set" Part="last" System="no" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\linux\docker-cli-plugins\" />
     </Component>
     <Component Id="PathSystem" Directory="APPLICATIONFOLDER">
       <Condition>
@@ -151,12 +157,18 @@
         Type="string"
         KeyPath="yes"
       />
-      <Environment Id="PathWindowsSystem" Name="PATH"
+      <Environment Id="PathWindowsSystemBin" Name="PATH"
         Action="set" Part="last" System="yes" Permanent="no"
         Value="[APPLICATIONFOLDER]resources\resources\win32\bin\" />
-      <Environment Id="PathLinuxSystem" Name="PATH"
+      <Environment Id="PathWindowsSystemDockerCLIPlugins" Name="PATH"
+        Action="set" Part="last" System="yes" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\win32\docker-cli-plugins\" />
+      <Environment Id="PathLinuxSystemBin" Name="PATH"
         Action="set" Part="last" System="yes" Permanent="no"
         Value="[APPLICATIONFOLDER]resources\resources\linux\bin\" />
+      <Environment Id="PathLinuxSystemDockerCLIPlugins" Name="PATH"
+        Action="set" Part="last" System="yes" Permanent="no"
+        Value="[APPLICATIONFOLDER]resources\resources\linux\docker-cli-plugins\" />
     </Component>
 
 

--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -471,7 +471,8 @@ export class MobyClient implements ContainerEngineClient {
   runClient(args: string[], stdio: 'stream', options?: runClientOptions): ReadableProcess;
   runClient(args: string[], stdio?: 'ignore' | 'pipe' | 'stream' | Log, options?: runClientOptions) {
     const executableName = options?.executable ?? this.executable;
-    const binType = executableName.startsWith('docker-') ? 'docker-cli-plugins' : 'bin';
+    const isCLIPlugin = /^docker-(?!credential-)/.test(executableName);
+    const binType = isCLIPlugin ? 'docker-cli-plugins' : 'bin';
     const binDir = path.join(paths.resources, process.platform, binType);
     const executable = path.resolve(binDir, executableName);
     const opts = _.merge({}, options ?? {}, {

--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -470,8 +470,10 @@ export class MobyClient implements ContainerEngineClient {
   runClient(args: string[], stdio: 'pipe', options?: runClientOptions): Promise<{ stdout: string; stderr: string; }>;
   runClient(args: string[], stdio: 'stream', options?: runClientOptions): ReadableProcess;
   runClient(args: string[], stdio?: 'ignore' | 'pipe' | 'stream' | Log, options?: runClientOptions) {
-    const binDir = path.join(paths.resources, process.platform, 'bin');
-    const executable = path.resolve(binDir, options?.executable ?? this.executable);
+    const executableName = options?.executable ?? this.executable;
+    const binType = executableName.startsWith('docker-') ? 'docker-cli-plugins' : 'bin';
+    const binDir = path.join(paths.resources, process.platform, binType);
+    const executable = path.resolve(binDir, executableName);
     const opts = _.merge({}, options ?? {}, {
       env: {
         DOCKER_HOST: this.endpoint,

--- a/pkg/rancher-desktop/integrations/__tests__/unixIntegrationManager.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/unixIntegrationManager.spec.ts
@@ -15,9 +15,9 @@ let testDir: string;
 // Creates integration directory and docker CLI plugin directory with
 // relevant symlinks in them. Useful for testing removal parts
 // of UnixIntegrationManager.
-async function createTestSymlinks(integrationDirectory: string, dockerCliPluginDirectory: string): Promise<void> {
+async function createTestSymlinks(integrationDirectory: string, dockerCLIPluginDest: string): Promise<void> {
   await fs.promises.mkdir(integrationDirectory, { recursive: true, mode: 0o755 });
-  await fs.promises.mkdir(dockerCliPluginDirectory, { recursive: true, mode: 0o755 });
+  await fs.promises.mkdir(dockerCLIPluginDest, { recursive: true, mode: 0o755 });
 
   const kubectlSrcPath = path.join(binDir, 'kubectl');
   const kubectlDstPath = path.join(integrationDirectory, 'kubectl');
@@ -25,7 +25,7 @@ async function createTestSymlinks(integrationDirectory: string, dockerCliPluginD
   await fs.promises.symlink(kubectlSrcPath, kubectlDstPath);
 
   const composeSrcPath = path.join(dockerCLIPluginSource, 'docker-compose');
-  const composeDstPath = path.join(dockerCliPluginDirectory, 'docker-compose');
+  const composeDstPath = path.join(dockerCLIPluginDest, 'docker-compose');
 
   await fs.promises.symlink(composeSrcPath, composeDstPath);
 }

--- a/pkg/rancher-desktop/integrations/integrationManager.ts
+++ b/pkg/rancher-desktop/integrations/integrationManager.ts
@@ -48,9 +48,6 @@ export function getIntegrationManager(): IntegrationManager {
 
   switch (platform) {
   case 'linux':
-    return new UnixIntegrationManager({
-      binDir, integrationDir: paths.integration, dockerCLIPluginSource, dockerCLIPluginDest,
-    });
   case 'darwin':
     return new UnixIntegrationManager({
       binDir, integrationDir: paths.integration, dockerCLIPluginSource, dockerCLIPluginDest,

--- a/pkg/rancher-desktop/integrations/integrationManager.ts
+++ b/pkg/rancher-desktop/integrations/integrationManager.ts
@@ -42,14 +42,19 @@ export interface IntegrationManager {
 
 export function getIntegrationManager(): IntegrationManager {
   const platform = os.platform();
-  const resourcesBinDir = path.join(paths.resources, platform, 'bin');
-  const dockerCliPluginDir = path.join(os.homedir(), '.docker', 'cli-plugins');
+  const binDir = path.join(paths.resources, platform, 'bin');
+  const dockerCLIPluginSource = path.join(paths.resources, platform, 'docker-cli-plugins');
+  const dockerCLIPluginDest = path.join(os.homedir(), '.docker', 'cli-plugins');
 
   switch (platform) {
   case 'linux':
-    return new UnixIntegrationManager(resourcesBinDir, paths.integration, dockerCliPluginDir);
+    return new UnixIntegrationManager({
+      binDir, integrationDir: paths.integration, dockerCLIPluginSource, dockerCLIPluginDest,
+    });
   case 'darwin':
-    return new UnixIntegrationManager(resourcesBinDir, paths.integration, dockerCliPluginDir);
+    return new UnixIntegrationManager({
+      binDir, integrationDir: paths.integration, dockerCLIPluginSource, dockerCLIPluginDest,
+    });
   case 'win32':
     return WindowsIntegrationManager.getInstance();
   default:

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -212,7 +212,7 @@ export class DockerBuildx implements Dependency, GitHubDependency {
     const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download/v${ context.versions.dockerBuildx }`;
     const executableName = exeName(context, `buildx-v${ context.versions.dockerBuildx }.${ context.goPlatform }-${ arch }`);
     const dockerBuildxURL = `${ baseURL }/${ executableName }`;
-    const dockerBuildxPath = path.join(context.binDir, exeName(context, 'docker-buildx'));
+    const dockerBuildxPath = path.join(context.dockerPluginsDir, exeName(context, 'docker-buildx'));
     const options: DownloadOptions = {};
 
     // No checksums available on the docker/buildx site for darwin builds
@@ -246,7 +246,7 @@ export class DockerCompose implements Dependency, GitHubDependency {
     const arch = context.isM1 ? 'aarch64' : 'x86_64';
     const executableName = exeName(context, `docker-compose-${ context.goPlatform }-${ arch }`);
     const url = `${ baseUrl }/${ executableName }`;
-    const destPath = path.join(context.binDir, exeName(context, 'docker-compose'));
+    const destPath = path.join(context.dockerPluginsDir, exeName(context, 'docker-compose'));
     const expectedChecksum = await findChecksum(`${ url }.sha256`, executableName);
 
     await download(url, destPath, { expectedChecksum });

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -22,6 +22,8 @@ export type DownloadContext = {
   binDir: string;
   // internalDir is for binaries that RD will execute behind the scenes
   internalDir: string;
+  // dockerPluginsDir is for docker CLI plugins.
+  dockerPluginsDir: string;
 };
 
 export type AlpineLimaISOVersion = {

--- a/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/integration"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,9 +36,18 @@ var wslIntegrationDockerPluginCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		state := wslIntegrationDockerPluginViper.GetBool("state")
-		pluginPath := wslIntegrationDockerPluginViper.GetString("plugin")
+		pluginPath := wslIntegrationDockerPluginViper.GetString("plugin-dir")
+		binDir := wslIntegrationDockerPluginViper.GetString("bin-dir")
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to locate home directory: %w", err)
+		}
 
-		if err := integration.DockerPlugin(pluginPath, state); err != nil {
+		if err := integration.SetupPluginDirConfig(homeDir, pluginPath, state); err != nil {
+			return err
+		}
+
+		if err := integration.RemoveObsoletePluginSymlinks(homeDir, binDir); err != nil {
 			return err
 		}
 
@@ -44,9 +56,10 @@ var wslIntegrationDockerPluginCmd = &cobra.Command{
 }
 
 func init() {
-	wslIntegrationDockerPluginCmd.Flags().String("plugin", "", "Full path to plugin")
+	wslIntegrationDockerPluginCmd.Flags().String("plugin-dir", "", "Full path to plugin directory")
+	wslIntegrationDockerPluginCmd.Flags().String("bin-dir", "", "Full path to bin directory to clean up deprecated links")
 	wslIntegrationDockerPluginCmd.Flags().Bool("state", false, "Desired state")
-	if err := wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin"); err != nil {
+	if err := wslIntegrationDockerPluginCmd.MarkFlagRequired("plugin-dir"); err != nil {
 		logrus.WithError(err).Fatal("Failed to set up flags")
 	}
 	wslIntegrationDockerPluginViper.AutomaticEnv()

--- a/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
+++ b/src/go/wsl-helper/cmd/wsl_integration_docker_plugin_linux.go
@@ -36,14 +36,14 @@ var wslIntegrationDockerPluginCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		state := wslIntegrationDockerPluginViper.GetBool("state")
-		pluginPath := wslIntegrationDockerPluginViper.GetString("plugin-dir")
+		pluginDir := wslIntegrationDockerPluginViper.GetString("plugin-dir")
 		binDir := wslIntegrationDockerPluginViper.GetString("bin-dir")
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to locate home directory: %w", err)
 		}
 
-		if err := integration.SetupPluginDirConfig(homeDir, pluginPath, state); err != nil {
+		if err := integration.SetupPluginDirConfig(homeDir, pluginDir, state); err != nil {
 			return err
 		}
 

--- a/src/go/wsl-helper/pkg/integration/docker_plugin_linux.go
+++ b/src/go/wsl-helper/pkg/integration/docker_plugin_linux.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	dirsKey = "cliPluginsExtraDirs"
+	pluginDirsKey = "cliPluginsExtraDirs"
 )
 
 // SetupPluginDirConfig configures docker CLI to load plugins from the directory
@@ -54,17 +54,17 @@ func SetupPluginDirConfig(homeDir, pluginPath string, enabled bool) error {
 
 	var dirs []string
 
-	if dirsRaw, ok := config[dirsKey]; ok {
+	if dirsRaw, ok := config[pluginDirsKey]; ok {
 		if dirsAny, ok := dirsRaw.([]any); ok {
 			for _, item := range dirsAny {
 				if dir, ok := item.(string); ok {
 					dirs = append(dirs, dir)
 				} else {
-					return fmt.Errorf("failed to update docker CLI configuration: %q has non-string item %v", dirsKey, item)
+					return fmt.Errorf("failed to update docker CLI configuration: %q has non-string item %v", pluginDirsKey, item)
 				}
 			}
 		} else {
-			return fmt.Errorf("failed to update docker CLI configuration: %q is not a string array", dirsKey)
+			return fmt.Errorf("failed to update docker CLI configuration: %q is not a string array", pluginDirsKey)
 		}
 		index := slices.Index(dirs, pluginPath)
 		if enabled {
@@ -72,7 +72,7 @@ func SetupPluginDirConfig(homeDir, pluginPath string, enabled bool) error {
 				// Config file already contains the plugin path; nothing to do.
 				return nil
 			}
-			dirs = append(dirs, pluginPath)
+			dirs = append([]string{pluginPath}, dirs...)
 		} else {
 			if index < 0 {
 				// Config does not contain the plugin path; nothing to do.
@@ -89,9 +89,9 @@ func SetupPluginDirConfig(homeDir, pluginPath string, enabled bool) error {
 		dirs = []string{pluginPath}
 	}
 	if len(dirs) > 0 {
-		config[dirsKey] = dirs
+		config[pluginDirsKey] = dirs
 	} else {
-		delete(config, dirsKey)
+		delete(config, pluginDirsKey)
 	}
 
 	if configBytes, err = json.Marshal(config); err != nil {

--- a/src/go/wsl-helper/pkg/integration/docker_plugin_linux.go
+++ b/src/go/wsl-helper/pkg/integration/docker_plugin_linux.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 SUSE LLC
+Copyright © 2024 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,47 +17,126 @@ limitations under the License.
 package integration
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"slices"
+
+	"github.com/sirupsen/logrus"
 )
 
-// DockerPlugin manages a specific docker plugin (given in pluginPath), either
-// enabling it or disabling it in the WSL distribution the process is running in.
-func DockerPlugin(pluginPath string, enabled bool) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("could not get home directory: %w", err)
-	}
-	pluginDir := filepath.Join(homeDir, ".docker", "cli-plugins")
-	if err = os.MkdirAll(pluginDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create docker plugins directory: %w", err)
-	}
-	destPath := filepath.Join(pluginDir, filepath.Base(pluginPath))
+const (
+	dirsKey = "cliPluginsExtraDirs"
+)
 
-	if enabled {
-		if _, err := os.Readlink(destPath); err == nil {
-			if _, err := os.Stat(destPath); errors.Is(err, os.ErrNotExist) {
-				// The destination is a dangling symlink
-				if err = os.Remove(destPath); err != nil {
-					return fmt.Errorf("could not remove dangling symlink %q: %w", destPath, err)
+// SetupPluginDirConfig configures docker CLI to load plugins from the directory
+// given.
+func SetupPluginDirConfig(homeDir, pluginPath string, enabled bool) error {
+	configPath := filepath.Join(homeDir, ".docker", "config.json")
+	config := make(map[string]any)
+
+	configBytes, err := os.ReadFile(configPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// If the config file does not exist, start with empty map.
+		if !enabled {
+			return nil
+		}
+	} else if err != nil {
+		return fmt.Errorf("could not read docker CLI configuration: %w", err)
+	} else {
+		if err = json.Unmarshal(configBytes, &config); err != nil {
+			return fmt.Errorf("could not parse docker CLI configuration: %w", err)
+		}
+	}
+
+	var dirs []string
+
+	if dirsRaw, ok := config[dirsKey]; ok {
+		if dirsAny, ok := dirsRaw.([]any); ok {
+			for _, item := range dirsAny {
+				if dir, ok := item.(string); ok {
+					dirs = append(dirs, dir)
+				} else {
+					return fmt.Errorf("failed to update docker CLI configuration: %q has non-string item %v", dirsKey, item)
 				}
 			}
+		} else {
+			return fmt.Errorf("failed to update docker CLI configuration: %q is not a string array", dirsKey)
 		}
-
-		if err = os.Symlink(pluginPath, destPath); err != nil {
-			// ErrExist is fine, that means there's a user-created file there.
-			if !errors.Is(err, os.ErrExist) {
-				return fmt.Errorf("failed to create symlink %q: %w", destPath, err)
+		index := slices.Index(dirs, pluginPath)
+		if enabled {
+			if index >= 0 {
+				// Config file already contains the plugin path; nothing to do.
+				return nil
 			}
+			dirs = append(dirs, pluginPath)
+		} else {
+			if index < 0 {
+				// Config does not contain the plugin path; nothing to do.
+				return nil
+			}
+			dirs = slices.Delete(dirs, index, index+1)
 		}
 	} else {
-		link, err := os.Readlink(destPath)
-		if err == nil && link == pluginPath {
-			if err = os.Remove(destPath); err != nil {
-				return fmt.Errorf("failed to remove link %q: %w", destPath, err)
-			}
+		if !enabled {
+			// The key does not exist, and we don't want it; nothing to do.
+			return nil
+		}
+		// The key does not exist; add it.
+		dirs = []string{pluginPath}
+	}
+	if len(dirs) > 0 {
+		config[dirsKey] = dirs
+	} else {
+		delete(config, dirsKey)
+	}
+
+	if configBytes, err = json.Marshal(config); err != nil {
+		return fmt.Errorf("failed to serialize updated docker CLI configuration: %w", err)
+	}
+
+	if err = os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("failed to update docker CLI configuration: could not create parent: %w", err)
+	}
+
+	if err = os.WriteFile(configPath, configBytes, 0o644); err != nil {
+		return fmt.Errorf("failed to update docker CLI configuration: %w", err)
+	}
+
+	return nil
+}
+
+// RemoveObsoletePluginSymlinks removes symlinks in the docker CLI plugin
+// directory which are children of the given directory.
+func RemoveObsoletePluginSymlinks(homeDir, binPath string) error {
+	pluginDir := path.Join(homeDir, ".docker", "cli-plugins")
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// If the plugin directory does not exist, there is nothing to do.
+			logrus.Debugf("Docker CLI plugins directory %q does not exist", pluginDir)
+			return nil
+		}
+		return fmt.Errorf("failed to enumerate docker CLI plugins: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != os.ModeSymlink {
+			// entry is not a symlink; ignore it.
+			logrus.Debugf("Plugin %q is not a symlink", entry.Name())
+			continue
+		}
+		entryPath := path.Join(pluginDir, entry.Name())
+		target, err := os.Readlink(entryPath)
+		if err != nil {
+			logrus.Debugf("Error reading plugin symlink %q: %v", entryPath, err)
+		} else if filepath.Dir(target) == binPath {
+			// Remove the symlink, ignoring any errors.
+			_ = os.Remove(entryPath)
+		} else {
+			logrus.Debugf("Plugin symlink %q does not start with %q", target, binPath)
 		}
 	}
 

--- a/src/go/wsl-helper/pkg/integration/docker_plugin_linux_test.go
+++ b/src/go/wsl-helper/pkg/integration/docker_plugin_linux_test.go
@@ -79,7 +79,7 @@ func TestSetupPluginDirConfig(t *testing.T) {
 
 		require.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
 
-		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		bytes, err := os.ReadFile(configPath)
 		require.NoError(t, err, "error reading docker CLI config")
 		require.NoError(t, json.Unmarshal(bytes, &config))
 
@@ -99,7 +99,7 @@ func TestSetupPluginDirConfig(t *testing.T) {
 
 		require.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
 
-		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		bytes, err := os.ReadFile(configPath)
 		require.NoError(t, err, "error reading docker CLI config")
 		require.NoError(t, json.Unmarshal(bytes, &config))
 
@@ -117,7 +117,7 @@ func TestSetupPluginDirConfig(t *testing.T) {
 
 			assert.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
 
-			bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+			bytes, err := os.ReadFile(configPath)
 			require.NoError(t, err, "error reading docker CLI config")
 			assert.Equal(t, existingContents, bytes, "docker CLI config was changed")
 		})
@@ -134,7 +134,7 @@ func TestSetupPluginDirConfig(t *testing.T) {
 
 			require.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
 
-			bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+			bytes, err := os.ReadFile(configPath)
 			require.NoError(t, err, "error reading docker CLI config")
 			// Since we should not have modified the file at all, the file should
 			// still be byte-identical.
@@ -154,7 +154,7 @@ func TestSetupPluginDirConfig(t *testing.T) {
 
 		require.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
 
-		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		bytes, err := os.ReadFile(configPath)
 		require.NoError(t, err, "error reading docker CLI config")
 		// Since we should not have modified the file at all, the file should
 		// still be byte-identical.

--- a/src/go/wsl-helper/pkg/integration/docker_plugin_linux_test.go
+++ b/src/go/wsl-helper/pkg/integration/docker_plugin_linux_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2023 SUSE LLC
+Copyright © 2024 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ limitations under the License.
 package integration_test
 
 import (
+	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -27,93 +29,191 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/integration"
 )
 
-func TestDockerPlugin(t *testing.T) {
-	t.Run("create symlink", func(t *testing.T) {
+func TestSetupPluginDirConfig(t *testing.T) {
+	t.Parallel()
+	t.Run("create config file", func(t *testing.T) {
 		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+		pluginPath := t.TempDir()
 
-		require.NoError(t, integration.DockerPlugin(pluginPath, true))
-		link, err := os.Readlink(destPath)
-		if assert.NoError(t, err, "error reading created symlink") {
-			assert.Equal(t, pluginPath, link)
-		}
+		assert.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
+
+		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		require.NoError(t, err, "error reading docker CLI config")
+		var config map[string]any
+		require.NoError(t, json.Unmarshal(bytes, &config))
+
+		value := config["cliPluginsExtraDirs"]
+		require.Contains(t, config, "cliPluginsExtraDirs")
+		require.Contains(t, value, pluginPath, "did not contain plugin path")
 	})
-	t.Run("remove dangling symlink", func(t *testing.T) {
+	t.Run("update config file", func(t *testing.T) {
 		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+		pluginPath := t.TempDir()
+		configPath := path.Join(homeDir, ".docker", "config.json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+		existingContents := []byte(`{"credsStore": "nothing"}`)
+		require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
 
-		require.NoError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
-		require.NoError(t, os.Symlink(filepath.Join(pluginDir, "missing"), destPath))
-		require.NoError(t, integration.DockerPlugin(pluginPath, true))
-		link, err := os.Readlink(destPath)
-		if assert.NoError(t, err, "error reading created symlink") {
-			assert.Equal(t, pluginPath, link)
-		}
+		require.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
+
+		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		require.NoError(t, err, "error reading docker CLI config")
+		var config map[string]any
+		require.NoError(t, json.Unmarshal(bytes, &config))
+
+		assert.Subset(t, config, map[string]any{"credsStore": "nothing"})
+		assert.Subset(t, config, map[string]any{"cliPluginsExtraDirs": []any{pluginPath}})
 	})
-	t.Run("leave existing symlink", func(t *testing.T) {
-		executable, err := os.Executable()
-		require.NoError(t, err, "failed to locate executable")
+	t.Run("do not add multiple instances", func(t *testing.T) {
 		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+		pluginPath := t.TempDir()
+		configPath := path.Join(homeDir, ".docker", "config.json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
 
-		require.NoError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
-		require.NoError(t, os.Symlink(executable, destPath))
-		require.NoError(t, integration.DockerPlugin(pluginPath, true))
-		link, err := os.Readlink(destPath)
-		if assert.NoError(t, err, "error reading created symlink") {
-			assert.Equal(t, executable, link)
-		}
+		expected := []any{"1", pluginPath, "2"}
+		config := map[string]any{"cliPluginsExtraDirs": expected}
+		existingContents, err := json.Marshal(config)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
+		config = make(map[string]any)
+
+		require.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
+
+		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		require.NoError(t, err, "error reading docker CLI config")
+		require.NoError(t, json.Unmarshal(bytes, &config))
+
+		assert.Subset(t, config, map[string]any{"cliPluginsExtraDirs": expected})
 	})
-	t.Run("leave existing file", func(t *testing.T) {
+	t.Run("remove existing instances", func(t *testing.T) {
 		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+		pluginPath := t.TempDir()
+		configPath := path.Join(homeDir, ".docker", "config.json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
 
-		require.NoError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
-		require.NoError(t, os.WriteFile(destPath, []byte("hello"), 0o644))
-		require.NoError(t, integration.DockerPlugin(pluginPath, true))
-		buf, err := os.ReadFile(destPath)
-		if assert.NoError(t, err, "failed to read destination file") {
-			assert.Equal(t, []byte("hello"), buf)
-		}
+		config := map[string]any{"cliPluginsExtraDirs": []any{"1", pluginPath, "2"}}
+		existingContents, err := json.Marshal(config)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
+		config = make(map[string]any)
+
+		require.NoError(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
+
+		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		require.NoError(t, err, "error reading docker CLI config")
+		require.NoError(t, json.Unmarshal(bytes, &config))
+
+		assert.Subset(t, config, map[string]any{"cliPluginsExtraDirs": []any{"1", "2"}})
 	})
-	t.Run("remove correct symlink", func(t *testing.T) {
-		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+	t.Run("do not modify invalid file", func(t *testing.T) {
+		t.Parallel()
+		t.Run("file is not JSON", func(t *testing.T) {
+			homeDir := t.TempDir()
+			pluginPath := t.TempDir()
+			configPath := path.Join(homeDir, ".docker", "config.json")
+			require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+			existingContents := []byte(`this is not JSON`)
+			require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
 
-		require.NoError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
-		require.NoError(t, os.Symlink(pluginPath, destPath))
-		require.NoError(t, integration.DockerPlugin(pluginPath, false))
-		_, err := os.Lstat(destPath)
-		assert.ErrorIs(t, err, os.ErrNotExist, "symlink was not removed")
+			assert.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, true))
+
+			bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+			require.NoError(t, err, "error reading docker CLI config")
+			assert.Equal(t, existingContents, bytes, "docker CLI config was changed")
+		})
+		t.Run("file contains invalid plugin dirs", func(t *testing.T) {
+			homeDir := t.TempDir()
+			pluginPath := t.TempDir()
+			configPath := path.Join(homeDir, ".docker", "config.json")
+			require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+
+			config := map[string]any{"cliPluginsExtraDirs": 500}
+			existingContents, err := json.MarshalIndent(config, " \t ", "  \n\r  ")
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
+
+			require.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
+
+			bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+			require.NoError(t, err, "error reading docker CLI config")
+			// Since we should not have modified the file at all, the file should
+			// still be byte-identical.
+			assert.Equal(t, existingContents, bytes, "docker CLI config was modified")
+		})
+		t.Run("file contains non-string plugin dirs items", func(t *testing.T) {})
+		homeDir := t.TempDir()
+		pluginPath := t.TempDir()
+		configPath := path.Join(homeDir, ".docker", "config.json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+
+		items := []any{1, true, map[string]any{"hello": "world"}}
+		config := map[string]any{"cliPluginsExtraDirs": items}
+		existingContents, err := json.MarshalIndent(config, " \t ", "  \n\r  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(configPath, existingContents, 0o644))
+
+		require.Error(t, integration.SetupPluginDirConfig(homeDir, pluginPath, false))
+
+		bytes, err := os.ReadFile(path.Join(homeDir, ".docker", "config.json"))
+		require.NoError(t, err, "error reading docker CLI config")
+		// Since we should not have modified the file at all, the file should
+		// still be byte-identical.
+		assert.Equal(t, existingContents, bytes, "docker CLI config was modified")
 	})
-	t.Run("do not remove incorrect symlink", func(t *testing.T) {
-		homeDir := t.TempDir()
-		pluginDir := t.TempDir()
-		pluginPath := filepath.Join(pluginDir, "docker-something")
-		destPath := filepath.Join(homeDir, ".docker", "cli-plugins", "docker-something")
-		t.Setenv("HOME", homeDir)
+}
 
-		require.NoError(t, os.MkdirAll(filepath.Dir(destPath), 0o755))
-		require.NoError(t, os.Symlink(destPath, destPath))
-		require.NoError(t, integration.DockerPlugin(pluginPath, false))
-		result, err := os.Readlink(destPath)
-		if assert.NoError(t, err, "error reading symlink") {
-			assert.Equal(t, destPath, result, "unexpected symlink contents")
-		}
+func TestRemoveObsoletePluginSymlinks(t *testing.T) {
+	t.Run("plugin directory does not exist", func(t *testing.T) {
+		homeDir := t.TempDir()
+		binPath := t.TempDir()
+		assert.NoError(t, integration.RemoveObsoletePluginSymlinks(homeDir, binPath))
+	})
+	t.Run("leaves non-symlink plugins", func(t *testing.T) {
+		homeDir := t.TempDir()
+		binPath := t.TempDir()
+		pluginDir := path.Join(homeDir, ".docker", "cli-plugins")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		pluginPath := path.Join(pluginDir, "docker-plugin")
+		assert.NoError(t, os.WriteFile(pluginPath, []byte{}, 0o755))
+		assert.NoError(t, integration.RemoveObsoletePluginSymlinks(homeDir, binPath))
+		contents, err := os.ReadFile(pluginPath)
+		assert.NoError(t, err)
+		assert.Empty(t, contents)
+	})
+	t.Run("leaves foreign symlinks", func(t *testing.T) {
+		homeDir := t.TempDir()
+		binPath := t.TempDir()
+		pluginDir := path.Join(homeDir, ".docker", "cli-plugins")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		pluginPath := path.Join(pluginDir, "docker-plugin")
+		assert.NoError(t, os.Symlink("/usr/bin/true", pluginPath))
+		assert.NoError(t, integration.RemoveObsoletePluginSymlinks(homeDir, binPath))
+		symlinkTarget, err := os.Readlink(pluginPath)
+		assert.NoError(t, err)
+		assert.Equal(t, "/usr/bin/true", symlinkTarget)
+	})
+	t.Run("leaves self-referential symlinks", func(t *testing.T) {
+		homeDir := t.TempDir()
+		binPath := t.TempDir()
+		pluginDir := path.Join(homeDir, ".docker", "cli-plugins")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		pluginPath := path.Join(pluginDir, "docker-plugin")
+		assert.NoError(t, os.Symlink(pluginPath, pluginPath))
+		assert.NoError(t, integration.RemoveObsoletePluginSymlinks(homeDir, binPath))
+		symlinkTarget, err := os.Readlink(pluginPath)
+		assert.NoError(t, err)
+		assert.Equal(t, pluginPath, symlinkTarget)
+	})
+	t.Run("removes symlinks", func(t *testing.T) {
+		homeDir := t.TempDir()
+		binPath := t.TempDir()
+		pluginDir := path.Join(homeDir, ".docker", "cli-plugins")
+		assert.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		pluginPath := path.Join(pluginDir, "docker-plugin")
+		targetPath := path.Join(binPath, "does-not-exist")
+		assert.NoError(t, os.Symlink(targetPath, pluginPath))
+		assert.NoError(t, integration.RemoveObsoletePluginSymlinks(homeDir, binPath))
+		_, err := os.Readlink(pluginPath)
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 }


### PR DESCRIPTION
On Windows, we don't have symlinks available.  So instead of copying the plugins to `~/.docker/cli-plugins/`, add a `cliPluginsExtraDirs` config entry instead so we look for them there.

On Windows it appears to prefer that (so leaving the old plugins in `~/.docker/cli-plugins` is harmless; on Linux/mac it seems to prefer `~/.docker/cli-plugins` (which makes no sense to me, but ¯\\\_(ツ)_/¯)

Note that this PR also moves all the plugins to their own directory (instead of `resources/platform/bin`), because we don't want to add everything else to the search path.

Fixes #7308