### PR TITLE
Use local rancher-desktop-networking

### DIFF
--- a/docs/networking/windows/rancher-desktop-networking.md
+++ b/docs/networking/windows/rancher-desktop-networking.md
@@ -1,5 +1,5 @@
 
-# [Rancher Desktop Networking](https://github.com/rancher-sandbox/rancher-desktop-networking)
+# [Rancher Desktop Networking](../../../src/go/networking/)
 
 Rancher Desktop Networking primarily acts as a layer 2 switch between the host (currently Windows only) and the VM (WSL) using the `AF_VSOCK` protocol. It facilitates the transmission of Ethernet frames from the VM to the host. Additionally, it provides `DNS`, `DHCP`, and dynamic port forwarding functionalities. The Rancher Desktop Networking comprises several key services: `host-switch`, `vm-switch`, `network-setup`, and `wsl-proxy`. It utilizes [gvisor's](https://github.com/google/gvisor) network stack and draws inspiration from the [gvisor-tap-vsock](https://github.com/google/gvisor) project.
 
@@ -54,14 +54,14 @@ The host-switch runs on the Windows host and acts as a receiver for all traffic 
 ## Supported Flags:
 
 - **debug**: Enables debug logging.
-- **subnet**: This flag defines a subnet range with a CIDR suffix for a virtual network. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/vm/switch_linux.go#L59) flag in the vm-switch.
+- **subnet**: This flag defines a subnet range with a CIDR suffix for a virtual network. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/vm/switch_linux.go#L59) flag in the vm-switch.
 - **port-forward**: This is a list of static ports that need to be pre-forwarded to the WSL VM. These ports are not dynamically retrieved from any of the APIs that the Rancher Desktop guest agent interacts with.
 
 ## network-setup:
 
 The reason for its creation was that the `AF_VSOCK` connection could not be established between the host and a process residing inside the network namespace within the VM, as such capability is not currently supported by `AF_VSOCK`. As a result, the network setup was created. Its main responsibility is to respond to the handshake request from the `host-switch.exe`. Once the handshake process is successful with the `host-switch`, the `network-setup` process creates a new network namespace and attempts to start its subprocess, `vm-switch`, in the newly created network namespace. It also hands over the `AF_VSOCK` connection to the `vm-switch` as a file descriptor in the new namespace.
 
-Additionally, it calls unshare with provided arguments through [---unshare-args](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272). The process also establishes a Virtual Ethernet pair consisting of two endpoints: `veth-rd0` and `veth-rd1`. `veth-rd0` resides within the default namespace and is configured to listen on the IP address `192.168.1.1`. Conversely, `veth-rd1` is located within a network namespace and is assigned the IP address `192.168.1.2`. The virtual Ethernet pair allows accessibility from the default network into the network namespace, which is particularly useful when WSL integration is enabled.
+Additionally, it calls unshare with provided arguments through [---unshare-args](https://github.com/rancher-sandbox/rancher-desktop/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272). The process also establishes a Virtual Ethernet pair consisting of two endpoints: `veth-rd0` and `veth-rd1`. `veth-rd0` resides within the default namespace and is configured to listen on the IP address `192.168.1.1`. Conversely, `veth-rd1` is located within a network namespace and is assigned the IP address `192.168.1.2`. The virtual Ethernet pair allows accessibility from the default network into the network namespace, which is particularly useful when WSL integration is enabled.
 
 ## Supported Flags:
 
@@ -69,7 +69,7 @@ Additionally, it calls unshare with provided arguments through [---unshare-args]
 
 - **tap-interface**: The name of the tap interface that is created by the vm-switch upon startup, e.g., `eth0`, `eth1`. This value is passed to the `vm-switch` process when the `network-setup` attempts to start it. If no value is provided, the default name of `eth0` is used.
 
-- **subnet**: A subnet range with a CIDR suffix that is associated with the tap interface in the network namespace. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/host/switch_windows.go#L54) flag in the `host-switch`.
+- **subnet**: A subnet range with a CIDR suffix that is associated with the tap interface in the network namespace. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/host/switch_windows.go#L54) flag in the `host-switch`.
 
 - **tap-mac-address**: MAC address associated with the tap interface created by the vm-switch in the network namespace. If no address is provided, the default address of `5a:94:ef:e4:0c:ee`is used.
 
@@ -77,7 +77,7 @@ Additionally, it calls unshare with provided arguments through [---unshare-args]
 
 - **vm-switch-logfile**: The path to the logfile for the vm-switch process.
 
-- **unshare-arg**: The command argument to pass to the unshare program in addition to the following [arguments](https://github.com/rancher-sandbox/rancher-desktop-networking/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272).
+- **unshare-arg**: The command argument to pass to the unshare program in addition to the following [arguments](https://github.com/rancher-sandbox/rancher-desktop/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/network/setup_linux.go#L272).
 
 - **logfile**: Path to the logfile for the `network-setup` process.
 

--- a/scripts/dependencies/wsl.ts
+++ b/scripts/dependencies/wsl.ts
@@ -10,50 +10,6 @@ import {
   DownloadContext, Dependency, GitHubDependency, getPublishedReleaseTagNames, getPublishedVersions,
 } from 'scripts/lib/dependencies';
 
-async function extract(resourcesPath: string, file: string, expectedFile: string): Promise<void> {
-  const systemRoot = process.env.SystemRoot;
-
-  if (!systemRoot) {
-    throw new Error('Could not find system root');
-  }
-  const bsdTar = path.join(systemRoot, 'system32', 'tar.exe');
-
-  await simpleSpawn(bsdTar, ['-xzf', file, expectedFile], { cwd: resourcesPath });
-  await fs.promises.rm(file, { maxRetries: 10 });
-}
-
-export class HostSwitch implements Dependency, GitHubDependency {
-  name = 'hostSwitch';
-  githubOwner = 'rancher-sandbox';
-  githubRepo = 'rancher-desktop-networking';
-
-  async download(context: DownloadContext): Promise<void> {
-    const baseURL = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
-    const tarName = `rancher-desktop-networking-v${ context.versions.hostSwitch }.tar.gz`;
-    const hostSwitchURL = `${ baseURL }/v${ context.versions.hostSwitch }/${ tarName }`;
-    const hostSwitchPath = path.join(context.internalDir, tarName);
-
-    await download(
-      hostSwitchURL,
-      hostSwitchPath,
-      { access: fs.constants.W_OK });
-
-    await extract(context.internalDir, hostSwitchPath, 'host-switch.exe');
-  }
-
-  async getAvailableVersions(includePrerelease = false): Promise<string[]> {
-    return await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
-  }
-
-  versionToTagName(version: string): string {
-    return `v${ version }`;
-  }
-
-  rcompareVersions(version1: string, version2: string): -1 | 0 | 1 {
-    return semver.rcompare(version1, version2);
-  }
-}
-
 export class Moproxy implements Dependency, GitHubDependency {
   name = 'moproxy';
   githubOwner = 'sorz';

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -50,7 +50,6 @@ export type DependencyVersions = {
   ECRCredentialHelper: string;
   mobyOpenAPISpec: string;
   wix: string;
-  hostSwitch: string;
   moproxy: string;
   spinShim: string;
   certManager: string;

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -61,6 +61,9 @@ const wslDependencies = [
   new Moproxy(),
   new goUtils.RDCtl(),
   new goUtils.GoDependency('guestagent', 'staging'),
+  new goUtils.GoDependency('networking/cmd/vm', 'staging/vm-switch'),
+  new goUtils.GoDependency('networking/cmd/network', 'staging/network-setup'),
+  new goUtils.GoDependency('networking/cmd/proxy', 'staging/wsl-proxy'),
   new goUtils.WSLHelper(),
   new goUtils.NerdctlStub(),
 ];

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -8,7 +8,7 @@ import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import { ExtensionProxyImage, WSLDistroImage } from 'scripts/dependencies/tar-archives';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
-import { WSLDistro, HostSwitch, Moproxy } from 'scripts/dependencies/wsl';
+import { WSLDistro, Moproxy } from 'scripts/dependencies/wsl';
 import {
   DependencyPlatform, DependencyVersions, readDependencyVersions, DownloadContext, Dependency,
 } from 'scripts/lib/dependencies';
@@ -51,7 +51,7 @@ const windowsDependencies = [
   new WSLDistro(),
   new WSLDistroImage(),
   new Wix(),
-  new HostSwitch(),
+  new goUtils.GoDependency('networking/cmd/host', 'internal/host-switch'),
   new goUtils.WSLHelper(),
   new goUtils.NerdctlStub(),
 ];

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -9,7 +9,7 @@ import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
-import { WSLDistro, HostSwitch, Moproxy } from 'scripts/dependencies/wsl';
+import { WSLDistro, Moproxy } from 'scripts/dependencies/wsl';
 import {
   DependencyVersions, readDependencyVersions, writeDependencyVersions, Dependency, AlpineLimaISOVersion, getOctokit,
 } from 'scripts/lib/dependencies';
@@ -43,7 +43,6 @@ const dependencies: Dependency[] = [
   new WSLDistro(),
   new Wix(),
   new MobyOpenAPISpec(),
-  new HostSwitch(),
   new Moproxy(),
   new tools.WasmShims(),
   new tools.CertManager(),

--- a/scripts/unreleased-change-monitor.ts
+++ b/scripts/unreleased-change-monitor.ts
@@ -2,7 +2,7 @@ import { Octokit } from 'octokit';
 
 import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import * as tools from 'scripts/dependencies/tools';
-import { WSLDistro, HostSwitch } from 'scripts/dependencies/wsl';
+import { WSLDistro } from 'scripts/dependencies/wsl';
 import {
   Dependency, GitHubDependency, HasUnreleasedChangesResult, getOctokit, RancherDesktopRepository,
 } from 'scripts/lib/dependencies';
@@ -26,7 +26,6 @@ const dependencies: UnreleasedChangeMonitoringDependency[] = [
   new tools.Steve(),
   new tools.RancherDashboard(),
   new AlpineLimaISO(),
-  new HostSwitch(),
 ];
 
 type Issue = Awaited<ReturnType<Octokit['rest']['search']['issuesAndPullRequests']>>['data']['items'][0];

--- a/src/go/guestagent/pkg/forwarder/wslproxy.go
+++ b/src/go/guestagent/pkg/forwarder/wslproxy.go
@@ -25,7 +25,7 @@ import (
 // WSLProxyForwarder forwards the PortMappings to Rancher Desktop WSLProxy process in
 // the default namespace over the unix socket.
 // For more information on Rancher Desktop WSL Proxy, refer to the source code at:
-// https://github.com/rancher-sandbox/rancher-desktop-networking/blob/main/cmd/proxy/wsl_integration_linux.go
+// https://github.com/rancher-sandbox/rancher-desktop/blob/main/src/go/networking/cmd/proxy/wsl_integration_linux.go
 type WSLProxyForwarder struct {
 	proxySocket string
 }

--- a/src/go/networking/cmd/host/config_windows.go
+++ b/src/go/networking/cmd/host/config_windows.go
@@ -17,7 +17,7 @@ import (
 	"net"
 
 	"github.com/containers/gvisor-tap-vsock/pkg/types"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/config"
 )
 
 const (

--- a/src/go/networking/cmd/host/switch_windows.go
+++ b/src/go/networking/cmd/host/switch_windows.go
@@ -33,8 +33,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/rancher-sandbox/rancher-desktop-host-resolver/pkg/vmsock"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/config"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/vsock"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/vsock"
 )
 
 var (

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -31,9 +31,9 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/config"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/log"
-	rdvsock "github.com/rancher-sandbox/rancher-desktop-networking/pkg/vsock"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/log"
+	rdvsock "github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/vsock"
 )
 
 var (

--- a/src/go/networking/cmd/proxy/wsl_integration_linux.go
+++ b/src/go/networking/cmd/proxy/wsl_integration_linux.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/log"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/portproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/log"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/portproxy"
 )
 
 var (

--- a/src/go/networking/cmd/vm/switch_linux.go
+++ b/src/go/networking/cmd/vm/switch_linux.go
@@ -34,8 +34,8 @@ import (
 	"github.com/vishvananda/netlink"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/config"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/log"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/log"
 )
 
 var (

--- a/src/go/networking/go.mod
+++ b/src/go/networking/go.mod
@@ -1,4 +1,4 @@
-module github.com/rancher-sandbox/rancher-desktop-networking
+module github.com/rancher-sandbox/rancher-desktop/src/go/networking
 
 go 1.22.0
 

--- a/src/go/networking/pkg/portproxy/server.go
+++ b/src/go/networking/pkg/portproxy/server.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/docker/go-connections/nat"
 	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/utils"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 

--- a/src/go/networking/pkg/portproxy/server_test.go
+++ b/src/go/networking/pkg/portproxy/server_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/docker/go-connections/nat"
 	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
-	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/portproxy"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/portproxy"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/nettest"

--- a/src/go/networking/pkg/vsock/constants.go
+++ b/src/go/networking/pkg/vsock/constants.go
@@ -14,6 +14,6 @@ limitations under the License.
 package vsock
 
 const (
-	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop-networking"
+	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop/src/go/networking"
 	ReadySignal     = "READY"
 )


### PR DESCRIPTION
This replaces the use of https://github.com/rancher-sandbox/rancher-desktop-networking/ with the local version.  Note that this just overrides the WSL executables; the old versions are still in the tar archive (but will be overwritten on extraction).

This also renames the go module path for the networking code to match where it now lives.