### PR TITLE
Merge rancher-desktop-networking v1.2.7

### DIFF
--- a/src/go/networking/pkg/utils/pipe.go
+++ b/src/go/networking/pkg/utils/pipe.go
@@ -27,15 +27,19 @@ func Pipe(conn net.Conn, upstreamAddr string) {
 		logrus.Errorf("Failed to dial upstream %s: %s", upstreamAddr, err)
 		return
 	}
-	defer upstream.Close()
-
 	go func() {
 		if _, err := io.Copy(upstream, conn); err != nil {
 			logrus.Debugf("Error copying to upstream: %s", err)
+		}
+		if err = upstream.Close(); err != nil {
+			logrus.Debugf("error closing connection while writing to upstream: %s", err)
 		}
 	}()
 
 	if _, err := io.Copy(conn, upstream); err != nil {
 		logrus.Debugf("Error copying from upstream: %s", err)
+	}
+	if err = upstream.Close(); err != nil {
+		logrus.Debugf("error closing connection: %s", err)
 	}
 }


### PR DESCRIPTION
This picks up a change in rancher-desktop-networking that landed in Rancher Desktop 1.15.1 that needed to be merged back into the copy of the code that was merged into the main repo.