### PR TITLE
Networking: Stop importing rancher-desktop-agent

### DIFF
--- a/docs/networking/windows/rancher-desktop-guest-agent.md
+++ b/docs/networking/windows/rancher-desktop-guest-agent.md
@@ -53,7 +53,7 @@ end
 
 ## PortMapping
 
-Is a struct object that represents an exposed container or a service. [Portmapping](https://github.com/rancher-sandbox/rancher-desktop-agent/blob/8348a5e10578f8662532eddfac73b243cfd419f4/pkg/types/portmapping.go#L22) objects consist of the following fields:
+Is a struct object that represents an exposed container or a service. [Portmapping](../../../src/go/guestagent/pkg/types/portmapping.go#L23) objects consist of the following fields:
 
 ```
 type PortMapping struct {

--- a/src/go/networking/go.mod
+++ b/src/go/networking/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/gopacket v1.1.19
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
-	github.com/rancher-sandbox/rancher-desktop-agent v0.3.19
 	github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5
+	github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
@@ -42,7 +42,6 @@ require (
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/text v0.18.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/src/go/networking/go.sum
+++ b/src/go/networking/go.sum
@@ -56,10 +56,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rancher-sandbox/rancher-desktop-agent v0.3.19 h1:29ODgwJdCPU+nbExqM9AYY7Sa+oectXHFxSKQYKhTtc=
-github.com/rancher-sandbox/rancher-desktop-agent v0.3.19/go.mod h1:Y79V+R/jlTcLemSmk8yuZVIDAQKzpU3SZcLLbZfzEtI=
 github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5 h1:F5m5WXPRjm/dNuz/cYZI+DjWwLGFyAVJglxG4ian61I=
 github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5/go.mod h1:J4GpCMQjKJNvZVNtNsSIo6PfqkC8j5woaOcAgWg7NRA=
+github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011 h1:X8nBYGrEv9MLQWSnigWUBKHc0z6ztVZ1f8NKo1ixt3Q=
+github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011/go.mod h1:b1WHkY6WX8vcR97BCWkMRXXdjaQvmJvtc42mJZrx61I=
 github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036 h1:VyDF9gpc9ILr8LT9fgat8x6KG3bom5hRQlbxecdzDqs=
 github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036/go.mod h1:ARlcfTpJPOEcGXWwYoi5f/k7zb8g35ib3MiFtIlKaUc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/src/go/networking/pkg/portproxy/server.go
+++ b/src/go/networking/pkg/portproxy/server.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/types"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/utils"
 	"github.com/sirupsen/logrus"
 )

--- a/src/go/networking/pkg/portproxy/server_test.go
+++ b/src/go/networking/pkg/portproxy/server_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/rancher-sandbox/rancher-desktop-agent/pkg/types"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/types"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/portproxy"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Use the copy in the mono-ish repo instead.

This should be looked at after #7446 is merged — that is more important.