### PR TITLE
Kubernetes: Support starting with no versions

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -827,10 +827,15 @@ ipcMainProxy.on('k8s-restart', async() => {
 });
 
 ipcMainProxy.on('k8s-versions', async() => {
-  const versions = await k8smanager.kubeBackend.availableVersions;
-  const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
+  try {
+    const versions = await k8smanager.kubeBackend.availableVersions;
+    const cachedOnly = await k8smanager.kubeBackend.cachedVersionsOnly();
 
-  window.send('k8s-versions', versions.map(v => v.versionEntry), cachedOnly);
+    window.send('k8s-versions', versions.map(v => v.versionEntry), cachedOnly);
+  } catch (ex) {
+    console.error(`Error handling k8s-versions: ${ ex }`);
+    window.send('k8s-versions', [], true);
+  }
 });
 
 ipcMainProxy.on('k8s-progress', () => {

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -201,7 +201,9 @@ describe(K3sHelper, () => {
 
         return Promise.resolve(new FetchResponse(
           JSON.stringify({
-            data: [{
+            resourceType: 'channels',
+            data:         [{
+              type:   'channel',
               name:   'stable',
               latest: 'v1.99.3+k3s3',
             }],
@@ -314,12 +316,23 @@ describe(K3sHelper, () => {
 
         return Promise.resolve(new FetchResponse(
           JSON.stringify({
-            data: [
-              { name: 'v1.96', latest: '1.96.9+k3s1' },
-              { name: 'v1.97', latest: '1.97.7+k3s1' },
-              { name: 'stable', latest: '1.97.7+k3s1' },
-              { name: 'latest', latest: '1.98.3+k3s1' },
-              { name: 'v1.98', latest: '1.98.3+k3s1' },
+            resourceType: 'channels',
+            data:         [
+              {
+                type: 'channel', name: 'v1.96', latest: '1.96.9+k3s1',
+              },
+              {
+                type: 'channel', name: 'v1.97', latest: '1.97.7+k3s1',
+              },
+              {
+                type: 'channel', name: 'stable', latest: '1.97.7+k3s1',
+              },
+              {
+                type: 'channel', name: 'latest', latest: '1.98.3+k3s1',
+              },
+              {
+                type: 'channel', name: 'v1.98', latest: '1.98.3+k3s1',
+              },
             ],
           }),
         ));

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -360,12 +360,8 @@ export default class K3sHelper extends events.EventEmitter {
       let channelResponse: Response;
 
       try {
-        const headers: HeadersInit = { Accept: this.channelApiAccept };
-
-        if (process.env.GITHUB_TOKEN) {
-          headers.Authorization = `Bearer ${ process.env.GITHUB_TOKEN }`;
-        }
-        channelResponse = await fetch(this.channelApiUrl, { headers });
+        channelResponse = await fetch(this.channelApiUrl,
+          { headers: { Accept: this.channelApiAccept } });
       } catch (ex: any) {
         console.log(`updateCache: error: ${ ex }`);
         if (!(await checkConnectivity('k3s.io'))) {

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -376,9 +376,22 @@ export default class K3sHelper extends events.EventEmitter {
       }
 
       if (channelResponse.ok) {
-        const channels = (await channelResponse.json()) as { data?: { name: string, latest: string }[] };
+        const ResourceTypeChannels = 'channels';
+
+        type ChannelResponse = {
+          resourceType?: string;
+          data?: {
+            name: string;
+            latest: string;
+          }[];
+        };
+        const channels: ChannelResponse = await channelResponse.json();
 
         console.debug(`Got K3s update channel data: ${ channels.data?.map(ch => ch.name) }`);
+        if (channels.resourceType !== ResourceTypeChannels) {
+          throw new Error(`Channel response does not have correct resource type: ${ channels.resourceType }`);
+        }
+
         for (const channel of channels.data ?? []) {
           const version = semver.parse(channel.latest);
 


### PR DESCRIPTION
If we had no internet access on first start and fail to download the list of k3s versions, force disable Kubernetes instead of failing.

This also checks the k3s channel response harder, so that if we got a success code but some JSON that didn't include the correct contents, we'll reject it correctly.

Fixes #7412

On macOS, this is easier to test with `echo nameserver 0.0.0.0 | sudo tee /etc/resolver/update.k3s.io` before factory resetting.