### PR TITLE
Unix integration: Symlink docker CLI plugins to bin

### DIFF
--- a/pkg/rancher-desktop/integrations/__tests__/unixIntegrationManager.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/unixIntegrationManager.spec.ts
@@ -67,7 +67,7 @@ describeUnix('UnixIntegrationManager', () => {
         const pluginPath = path.join(dockerCLIPluginDest, name);
         const expectedValue = path.join(dockerCLIPluginSource, name);
 
-        await expect(fs.promises.readlink(pluginPath, 'utf8')).resolves.toEqual(expectedValue);
+        await expect(fs.promises.readlink(pluginPath, 'utf8')).resolves.toEqual(binPath);
         await expect(fs.promises.readlink(binPath, 'utf8')).resolves.toEqual(expectedValue);
       }
     });
@@ -90,7 +90,7 @@ describeUnix('UnixIntegrationManager', () => {
     test('should update an existing docker CLI plugin that is a dangling symlink', async() => {
       const existingPluginPath = path.join(dockerCLIPluginDest, 'docker-compose');
       const nonExistentPath = '/somepaththatshouldnevereverexist';
-      const expectedTarget = path.join(dockerCLIPluginSource, 'docker-compose');
+      const expectedTarget = path.join(integrationDir, 'docker-compose');
 
       await fs.promises.mkdir(dockerCLIPluginDest, { mode: 0o755 });
       await fs.promises.symlink(nonExistentPath, existingPluginPath);
@@ -102,13 +102,13 @@ describeUnix('UnixIntegrationManager', () => {
       expect(newTarget).toEqual(expectedTarget);
     });
 
-    test('should update an existing docker CLI plugin whose target is integrations directory', async() => {
+    test('should update an existing docker CLI plugin whose target is resources directory', async() => {
       const existingPluginPath = path.join(dockerCLIPluginDest, 'docker-compose');
-      const integrationsPath = path.join(integrationDir, 'docker-compose');
-      const expectedTarget = path.join(dockerCLIPluginSource, 'docker-compose');
+      const sourceDir = path.join(dockerCLIPluginSource, 'docker-compose');
+      const expectedTarget = path.join(integrationDir, 'docker-compose');
 
       await fs.promises.mkdir(dockerCLIPluginDest, { mode: 0o755 });
-      await fs.promises.symlink(integrationsPath, existingPluginPath);
+      await fs.promises.symlink(sourceDir, existingPluginPath);
 
       await integrationManager.enforce();
 

--- a/pkg/rancher-desktop/integrations/unixIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/unixIntegrationManager.ts
@@ -134,7 +134,9 @@ export default class UnixIntegrationManager implements IntegrationManager {
 
     // create or remove the plugin links
     for (const name of pluginNames) {
-      const sourcePath = path.join(this.dockerCLIPluginSource, name);
+      // We create symlinks to the integration directory instead of the file
+      // directly, to avoid factory reset having to deal with it.
+      const sourcePath = path.join(this.integrationDir, name);
       const destPath = path.join(this.dockerCLIPluginDest, name);
 
       if (!await this.weOwnDockerCliFile(destPath)) {


### PR DESCRIPTION
To make it easier for `rdctl factory-reset`, point the docker CLI plugins to the integrations directory (`~/.rd/bin/`), and in from there into the executables we ship, rather than pointing at the executables directly.