### PR TITLE
Removed github.com/gogo/protobuf

### DIFF
--- a/src/go/guestagent/go.mod
+++ b/src/go/guestagent/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/containers/gvisor-tap-vsock v0.7.5
 	github.com/docker/docker v27.2.1+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
+	google.golang.org/protobuf v1.34.2
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
@@ -45,6 +45,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
@@ -90,7 +91,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 // indirect
 	google.golang.org/grpc v1.66.0 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/src/go/guestagent/pkg/containerd/events.go
+++ b/src/go/guestagent/pkg/containerd/events.go
@@ -31,8 +31,8 @@ import (
 	"github.com/containerd/containerd/api/events"
 	containerdNamespace "github.com/containerd/containerd/namespaces"
 	"github.com/docker/go-connections/nat"
-	"github.com/gogo/protobuf/proto"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/tracker"
+	"google.golang.org/protobuf/proto"
 )
 
 const (


### PR DESCRIPTION
This commit updates the protobuf package from `github.com/gogo/protobuf` to `google.golang.org/protobuf`. This migration appears to resolve the panic issue in guestAgent.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7491