### PR TITLE
Diagnostics: docker-cli-plugins: Update directory

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
+++ b/pkg/rancher-desktop/main/diagnostics/__tests__/dockerCliSymlinks.spec.ts
@@ -26,7 +26,7 @@ import paths from '@pkg/utils/paths';
 
 // Mock fs.promises.readdir() for the default export.
 jest.spyOn(fs.promises, 'readdir').mockImplementation((dir, encoding) => {
-  expect(dir).toEqual(path.join(appDir, 'resources', os.platform(), 'bin'));
+  expect(dir).toEqual(path.join(appDir, 'resources', os.platform(), 'docker-cli-plugins'));
   expect(encoding).toEqual('utf-8');
 
   return Promise.resolve([]);
@@ -49,7 +49,7 @@ describeUnix(CheckerDockerCLISymlink, () => {
     const resourcesDir = path.join(appDir, 'resources');
 
     await fs.promises.mkdir(resourcesDir);
-    appDirExecutable = path.join(resourcesDir, os.platform(), 'bin', executable);
+    appDirExecutable = path.join(resourcesDir, os.platform(), 'docker-cli-plugins', executable);
     replacedPathsResources = jest.replaceProperty(paths, 'resources', resourcesDir);
   });
   afterAll(async() => {

--- a/pkg/rancher-desktop/main/diagnostics/dockerCliSymlinks.ts
+++ b/pkg/rancher-desktop/main/diagnostics/dockerCliSymlinks.ts
@@ -45,7 +45,7 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
     const displayableStartingPath = replaceHome(startingPath);
     const rdBinPath = path.join(paths.integration, this.name);
     const displayableRDBinPath = replaceHome(rdBinPath);
-    const finalTarget = path.join(paths.resources, os.platform(), 'bin', this.name);
+    const finalTarget = path.join(paths.resources, os.platform(), 'docker-cli-plugins', this.name);
     const displayableFinalTarget = replaceHome(finalTarget);
     let state;
     let description = `The file \`${ displayableStartingPath }\``;
@@ -124,9 +124,8 @@ export class CheckerDockerCLISymlink implements DiagnosticsChecker {
 }
 
 const dockerCliSymlinkCheckers: Promise<DiagnosticsChecker[]> = (async() => {
-  const resourcesDir = path.join(paths.resources, os.platform(), 'bin');
-  const allNames = await fs.promises.readdir(resourcesDir, 'utf-8');
-  const names = allNames.filter(name => name.startsWith('docker-') && !name.startsWith('docker-credential-'));
+  const resourcesDir = path.join(paths.resources, os.platform(), 'docker-cli-plugins');
+  const names = await fs.promises.readdir(resourcesDir, 'utf-8');
 
   return names.map((name) => {
     return new CheckerDockerCLISymlink(name);


### PR DESCRIPTION
We changed where the docker-cli-plugins get installed, so we need to update the diagnostic to look for them.

Fixes #7500