### PR TITLE
k3sHelper: Use events to check online state

### DIFF
--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -75,6 +75,12 @@ interface MainEventNames {
   'network-ready'(): void;
 
   /**
+   * Emitted when the network comes online or goes offline.
+   * @param connected The new network state.
+   */
+  'update-network-status'(connected: boolean): void;
+
+  /**
    * Emitted when the integration state has changed.
    *
    * @param state A mapping of WSL distributions to the current state, or a

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -284,6 +284,7 @@ export class Tray {
     } else {
       this.currentNetworkStatus = await checkConnectivity('k3s.io') ? networkStatus.CONNECTED : networkStatus.OFFLINE;
     }
+    mainEvents.emit('update-network-status', this.currentNetworkStatus === networkStatus.CONNECTED);
     send('update-network-status', this.currentNetworkStatus === networkStatus.CONNECTED);
     this.updateMenu();
   }


### PR DESCRIPTION
Instead of manually checking connectivity to determine if we're online, rely events to trigger the state change.  This is useful because on some systems (e.g. Linux) `checkConnectivity()` can take a long time to fail, which breaks fetching the list of Kubernetes versions in the front end.

This should fix #7501; however, I'm not confident enough in it (mostly around initial state) to want it in 1.16.