### PR TITLE
Fix fallback when Kubernetes versions list is unavailable

### DIFF
--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -516,7 +516,12 @@ export default class K3sHelper extends events.EventEmitter {
 
           return;
         }
-        await this.updateCache();
+        try {
+          await this.updateCache();
+        } catch (ex) {
+          console.log(`Ignoring failure to get initial versions list: ${ ex }`);
+          // At this point this.versions is still empty.
+        }
       })();
     }
     this.versionFromChannel = {};
@@ -561,6 +566,8 @@ export default class K3sHelper extends events.EventEmitter {
 
   /**
    * The versions that are available to install.
+   * @note The list will be empty if the machine is offline and we have no
+   * cached versions.
    */
   get availableVersions(): Promise<SemanticVersionEntry[]> {
     return (async() => {

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -77,20 +77,24 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
   protected get desiredVersion(): Promise<semver.SemVer | undefined> {
     return (async() => {
       let availableVersions: SemanticVersionEntry[];
+      let available = true;
 
       try {
         availableVersions = await this.k3sHelper.availableVersions;
+
+        return await BackendHelper.getDesiredVersion(
+          this.cfg as BackendSettings,
+          availableVersions,
+          this.vm.noModalDialogs,
+          this.vm.writeSetting.bind(this.vm));
       } catch (ex) {
         console.error(`Could not get desired version: ${ ex }`);
+        available = false;
 
         return undefined;
+      } finally {
+        mainEvents.emit('diagnostics-event', { id: 'kube-versions-available', available });
       }
-
-      return await BackendHelper.getDesiredVersion(
-        this.cfg as BackendSettings,
-        availableVersions,
-        this.vm.noModalDialogs,
-        this.vm.writeSetting.bind(this.vm));
     })();
   }
 

--- a/pkg/rancher-desktop/integrations/pathManagerImpl.ts
+++ b/pkg/rancher-desktop/integrations/pathManagerImpl.ts
@@ -60,9 +60,13 @@ export class RcFilePathManager implements PathManager {
   protected async manageLinesInFile(fileName: string, filePath: string, lines: string[], desiredPresent: boolean) {
     try {
       await manageLinesInFile(filePath, lines, desiredPresent);
-      mainEvents.emit('diagnostics-event', 'path-management', { fileName, error: undefined });
+      mainEvents.emit('diagnostics-event', {
+        id: 'path-management', fileName, error: undefined,
+      });
     } catch (error: any) {
-      mainEvents.emit('diagnostics-event', 'path-management', { fileName, error });
+      mainEvents.emit('diagnostics-event', {
+        id: 'path-management', fileName, error,
+      });
       throw error;
     }
   }
@@ -96,10 +100,14 @@ export class RcFilePathManager implements PathManager {
           } catch (error: any) {
             if (error.code === 'ENOENT') {
               // If the file does not exist, it is not an error.
-              mainEvents.emit('diagnostics-event', 'path-management', { fileName, error: undefined });
+              mainEvents.emit('diagnostics-event', {
+                id: 'path-management', fileName, error: undefined,
+              });
               continue;
             }
-            mainEvents.emit('diagnostics-event', 'path-management', { fileName, error });
+            mainEvents.emit('diagnostics-event', {
+              id: 'path-management', fileName, error,
+            });
             throw error;
           }
           await this.manageLinesInFile(fileName, filePath, [pathLine], !linesAdded);

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -50,6 +50,7 @@ export class DiagnosticsManager {
         import('./dockerCliSymlinks'),
         import('./kubeConfigSymlink'),
         import('./kubeContext'),
+        import('./kubeVersionsAvailable'),
         import('./limaDarwin'),
         import('./mockForScreenshots'),
         import('./pathManagement'),

--- a/pkg/rancher-desktop/main/diagnostics/kubeVersionsAvailable.ts
+++ b/pkg/rancher-desktop/main/diagnostics/kubeVersionsAvailable.ts
@@ -1,0 +1,44 @@
+import mainEvents from '../mainEvents';
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult } from './types';
+
+let kubeVersionsAvailable = true;
+
+mainEvents.on('diagnostics-event', (payload) => {
+  if (payload.id !== 'kube-versions-available') {
+    return;
+  }
+  kubeVersionsAvailable = payload.available;
+  mainEvents.invoke('diagnostics-trigger', instance.id);
+});
+
+/**
+ * KubeVersionsAvailable is a diagnostic that will be emitted when all of the
+ * following are met:
+ * - Kubernetes was configured to be enabled
+ * - The selected Kubernetes version is unavailable (e.g. user is offline)
+ * Once the diagnostic is triggered, it stays on until the backend is restarted.
+ */
+class KubeVersionsAvailable implements DiagnosticsChecker {
+  readonly id = 'KUBE_VERSIONS_AVAILABLE';
+  readonly category = DiagnosticsCategory.Kubernetes;
+  applicable(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  check(): Promise<DiagnosticsCheckerResult> {
+    const description = [
+      'There are no issues with Kubernetes versions',
+      'Kubernetes has been disabled due to issues with fetching Kubernetes versions',
+    ][kubeVersionsAvailable ? 0 : 1];
+
+    return Promise.resolve({
+      passed: kubeVersionsAvailable,
+      description,
+      fixes:  [{ description: 'Check your network connection to update.k3s.io' }],
+    });
+  }
+}
+
+const instance = new KubeVersionsAvailable();
+
+export default instance;

--- a/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
+++ b/pkg/rancher-desktop/main/diagnostics/pathManagement.ts
@@ -25,12 +25,11 @@ const CheckPathManagement: DiagnosticsChecker = {
   },
 };
 
-mainEvents.on('diagnostics-event', (id, state) => {
-  if (id !== 'path-management') {
+mainEvents.on('diagnostics-event', (payload) => {
+  if (payload.id !== 'path-management') {
     return;
   }
-  const typedState: { fileName: string, error: Error | undefined } = state;
-  const { fileName, error } = typedState;
+  const { fileName, error } = payload;
 
   cachedResults[fileName] = {
     description: error?.message ?? error?.toString() ?? `Unknown error managing ${ fileName }`,

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -149,6 +149,7 @@ interface MainEventNames {
  * 'diagnostics-event' event.
  */
 type DiagnosticsEventPayload =
+  { id: 'kube-versions-available', available: boolean } |
   { id: 'path-management', fileName: string; error: Error | undefined };
 
 /**

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -105,7 +105,7 @@ interface MainEventNames {
    * @param id The diagnostic identifier.
    * @param state The new state for the diagnostic.
    */
-  'diagnostics-event'<K extends keyof DiagnosticsEventPayload>(id: K, state: DiagnosticsEventPayload[K]): void;
+  'diagnostics-event'(payload: DiagnosticsEventPayload): void;
 
   /**
    * Emitted when an extension is uninstalled via the extension manager.
@@ -148,9 +148,8 @@ interface MainEventNames {
  * DiagnosticsEventPayload defines the data that will be passed on a
  * 'diagnostics-event' event.
  */
-type DiagnosticsEventPayload = {
-  'path-management': { fileName: string; error: Error | undefined };
-};
+type DiagnosticsEventPayload =
+  { id: 'path-management', fileName: string; error: Error | undefined };
 
 /**
  * Helper type definition to check if the given event name is a handler (i.e.


### PR DESCRIPTION
If we previously had Kubernetes enabled, then the user deletes the `k3s-versions.json` cache _and_ we fail to download a new one, we would previously fall over hard.  This makes it so we automatically disable Kubernetes in that situation (and add a diagnostic so the user has a chance of figuring out what was wrong).

Fixes #7484