### PR TITLE
CI: go-work-sync: Use head ref if available

### DIFF
--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -13,7 +13,7 @@ on:
 permissions:
   contents: write
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:
   update-sum:


### PR DESCRIPTION
When multiple PRs exist, `github.ref_name` for every one is `main`, which prevents the jobs from running in parallel.  Use `github.head_ref` if available, so that for PRs we still limit it to one per PR.

It is unclear why this is the case, because `github.ref_name` is documented to be `<pr_number>/merge` instead of `main`.  However, actually running the workflow shows this to be the case.