### PR TITLE
Postinstall: Try harder to retry

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -820,6 +820,7 @@ udhcpc
 UEFI
 Unauthed
 UNCONFIGURED
+Undici
 unexpose
 unexposing
 unfetch

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -141,12 +141,12 @@ async function downloadDependencies(items: DependencyWithContext[]): Promise<voi
 
   while (!abortSignal.aborted && running.size > done.size) {
     const timeout = new Promise((resolve) => {
-      setTimeout(resolve, 60_000);
+      setTimeout(resolve, 5_000);
       abortSignal.onabort = resolve;
     });
     const pending = Array.from(running).filter(v => !done.has(v));
 
-    await Promise.any([timeout, ...pending.map(v => promises[v])]);
+    await Promise.race([timeout, ...pending.map(v => promises[v])]);
   }
   abortSignal.onabort = null;
 


### PR DESCRIPTION
This re-implements the download retry logic for post-install downloads (lima-alpine images, etc.) so that we can attempt to retry harder when things go wrong (in particular, if we end up going 5 seconds without getting any data).  Hopefully this will reduce the chance of us hitting the ten minute timeout.