### PR TITLE
Escapes Html

### DIFF
--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -5,6 +5,8 @@ import isEmpty from 'lodash/isEmpty';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
+import { escapeHtml } from '../utils/string';
+
 import EmptyState from '@pkg/components/EmptyState.vue';
 import SnapshotCard from '@pkg/components/SnapshotCard.vue';
 import { Snapshot, SnapshotEvent } from '@pkg/main/snapshots/types';
@@ -19,6 +21,7 @@ interface Data {
 interface Methods {
   pollingStart: () => void,
   currentTime: () => string,
+  escapeSnapshotName: (name: string|undefined) => string,
 }
 
 interface Computed {
@@ -85,6 +88,9 @@ export default Vue.extend<Data, Methods, Computed, never>({
 
       return date.format('YYYY-MM-DD HH:mm');
     },
+    escapeSnapshotName(value: string|undefined) {
+      return escapeHtml(value);
+    },
   },
 });
 </script>
@@ -102,7 +108,8 @@ export default Vue.extend<Data, Methods, Computed, never>({
         @close="snapshotEvent=null"
       >
         <span
-          v-clean-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`, { snapshot: snapshotEvent.snapshotName, error: snapshotEvent.error }, true)"
+          v-clean-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`,
+                          { snapshot: escapeSnapshotName(snapshotEvent.snapshotName), error: snapshotEvent.error }, true)"
           class="event-message"
         />
         <span

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -5,12 +5,11 @@ import isEmpty from 'lodash/isEmpty';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { escapeHtml } from '../utils/string';
-
 import EmptyState from '@pkg/components/EmptyState.vue';
 import SnapshotCard from '@pkg/components/SnapshotCard.vue';
 import { Snapshot, SnapshotEvent } from '@pkg/main/snapshots/types';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { escapeHtml } from '@pkg/utils/string';
 
 interface Data {
   snapshotEvent: SnapshotEvent | null;
@@ -21,7 +20,7 @@ interface Data {
 interface Methods {
   pollingStart: () => void,
   currentTime: () => string,
-  escapeSnapshotName: (name: string|undefined) => string,
+  escapeHtml: (name: string|undefined) => string,
 }
 
 interface Computed {
@@ -88,9 +87,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
 
       return date.format('YYYY-MM-DD HH:mm');
     },
-    escapeSnapshotName(value: string|undefined) {
-      return escapeHtml(value);
-    },
+    escapeHtml,
   },
 });
 </script>
@@ -109,7 +106,7 @@ export default Vue.extend<Data, Methods, Computed, never>({
       >
         <span
           v-clean-html="t(`snapshots.info.${ snapshotEvent.type }.${ snapshotEvent.result }`,
-                          { snapshot: escapeSnapshotName(snapshotEvent.snapshotName), error: snapshotEvent.error }, true)"
+                          { snapshot: escapeHtml(snapshotEvent.snapshotName), error: snapshotEvent.error }, true)"
           class="event-message"
         />
         <span


### PR DESCRIPTION
## Changes
Escape the snapshot name in result banner

### Why?
Causing unintended interaction with the UI elements. 

## How
Escape the name of the created snapshot in the banner displayed in the snapshot list to avoid interpreting it as HTML.

### Details
Referring to this comment -
https://github.com/rancher-sandbox/rancher-desktop/issues/7508#issuecomment-2361742964

### Changes
- reused the escapeHtml function in utils/string file


## Screenshots
<img width="940" alt="Screenshot 2024-09-26 at 1 09 20 AM" src="https://github.com/user-attachments/assets/a302736f-3dea-4c6d-a6b0-a6642ace92e7">
<img width="955" alt="Screenshot 2024-09-26 at 1 09 27 AM" src="https://github.com/user-attachments/assets/db52c1e5-53b5-4ca1-b629-670c3c6dec06">


