### PR TITLE
RDX: Support hooks to run native code on install/uninstall

### DIFF
--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -6,6 +6,8 @@ import type { ContainerEngineClient } from '@pkg/backend/containerClient';
 import type { Settings } from '@pkg/config/settings';
 import type { RecursiveReadonly } from '@pkg/utils/typeUtils';
 
+type PlatformSpecific<T> = Record<'darwin' | 'windows' | 'linux', T>;
+
 export type ExtensionMetadata = {
   /** Icon for the extension, as a path in the image. */
   icon: string;
@@ -33,8 +35,22 @@ export type ExtensionMetadata = {
       socket: string;
     }
   };
-  /** Files to copy to the host. */
-  host?: { binaries: Record<'darwin' | 'windows' | 'linux', { path: string }[]>[] };
+  host?: {
+    /** Files to copy to the host. */
+    binaries: PlatformSpecific<{ path: string }[]>[],
+    /**
+     * Rancher Desktop extension: this will be run after the extension is
+     * installed (possibly as an upgrade).  This file should be listed in
+     * `binaries`.  Errors will be ignored.
+     */
+    'x-rd-install'?: PlatformSpecific<string|string[]>,
+    /**
+     * Rancher Desktop extension: this will be run before the extension is
+     * uninstalled (possibly as an upgrade).  This file should be listed in
+     * `binaries`.  Errors will be ignored.
+     */
+    'x-rd-uninstall'?: PlatformSpecific<string|string[]>,
+ };
 };
 
 /**


### PR DESCRIPTION
This lets extensions define hooks to be run on install or uninstall.  Each extension can run one command on install (after everything else is up), and one command on uninstall (before anything is torn down).  Any errors are logged but otherwise ignored.  Note that extensions get re-installed on startup, so both scripts should be idempotent.