### PR TITLE
Escaped Html character in the snapshot creation dialog box

### DIFF
--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -5,10 +5,9 @@ import dayjs from 'dayjs';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
-import { escapeHtml } from '../../utils/string';
-
 import { Snapshot, SnapshotEvent } from '@pkg/main/snapshots/types';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { escapeHtml } from '@pkg/utils/string';
 
 const defaultName = () => {
   const dateString = dayjs().format('YYYY-MM-DD_HH_mm_ss');

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -5,6 +5,8 @@ import dayjs from 'dayjs';
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
 
+import { escapeHtml } from '../../utils/string';
+
 import { Snapshot, SnapshotEvent } from '@pkg/main/snapshots/types';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -109,7 +111,7 @@ export default Vue.extend({
           format: {
             header:            this.t('snapshots.dialog.creating.header', { snapshot: name }),
             showProgressBar:   true,
-            message:           this.t('snapshots.dialog.creating.message', { snapshot: name }, true),
+            message:           this.t('snapshots.dialog.creating.message', { snapshot: escapeHtml(name) }, true),
             snapshotEventType: 'create',
           },
         },


### PR DESCRIPTION
## Changes
Escape the snapshot name in create snapshot dialog

## Why?
Causing unintended interaction with the UI elements.

## How
Escape the name of the created snapshot in the dialog displayed to avoid interpreting it as HTML.

### Details
Referring to this comment -
Issue: https://github.com/rancher-sandbox/rancher-desktop/pull/7542#issuecomment-2375338228

### Changes
- reused the escapeHtml function in utils/string file

## Screenshots
<img width="999" alt="Screenshot 2024-09-26 at 9 45 51 AM" src="https://github.com/user-attachments/assets/7a96744c-a89b-4102-9481-9c975ddfcd5a">
