### PR TITLE
Bind WSL-Proxy Process to Specified IP Address

### DIFF
--- a/src/go/networking/pkg/portproxy/server.go
+++ b/src/go/networking/pkg/portproxy/server.go
@@ -97,7 +97,7 @@ func (p *PortProxy) execListener(pm types.PortMapping) {
 				p.mutex.Unlock()
 				continue
 			}
-			addr := net.JoinHostPort("localhost", portBinding.HostPort)
+			addr := net.JoinHostPort(portBinding.HostIP, portBinding.HostPort)
 			l, err := net.Listen("tcp", addr)
 			if err != nil {
 				logrus.Errorf("failed creating listener for published port [%s]: %s", portBinding.HostPort, err)
@@ -106,6 +106,7 @@ func (p *PortProxy) execListener(pm types.PortMapping) {
 			p.mutex.Lock()
 			p.activeListeners[port] = l
 			p.mutex.Unlock()
+			logrus.Debugf("created listener for: %s", addr)
 			go p.acceptTraffic(l, portBinding.HostPort)
 		}
 	}


### PR DESCRIPTION
This changes the binding of the WSL-Proxy process from always using localhost to utilizing the specified host IP address for port bindings.

Previously, binding exclusively to localhost caused issues for users who needed to define port bindings that extended beyond this address. The new approach ensures that the proxy listens on the provided hostIP.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7550