### PR TITLE
Fix: Ensure Image Name Reflects in ImagesOutputWindow During Build/Pull

### DIFF
--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -71,6 +71,7 @@
             :current-command="currentCommand"
             :image-output-culler="imageOutputCuller"
             :show-status="false"
+            :image-to-pull="imageToPull"
             @ok:process-end="resetCurrentCommand"
             @ok:show="toggleOutput"
           />
@@ -168,6 +169,7 @@ export default {
       imageOutputCuller:                null,
       mainWindowScroll:                 -1,
       selected:                         [],
+      imageToPull:                      null,
     };
   },
   computed: {

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -32,7 +32,7 @@ export default {
     },
     imageToPull: {
       type:    String,
-      default: '',
+      default: null,
     }
   },
 

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -30,6 +30,10 @@ export default {
       type:    Boolean,
       default: true,
     },
+    imageToPull: {
+      type:    String,
+      default: '',
+    }
   },
 
   data() {

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -33,7 +33,7 @@ export default {
     imageToPull: {
       type:    String,
       default: null,
-    }
+    },
   },
 
   data() {

--- a/pkg/rancher-desktop/pages/images/add.vue
+++ b/pkg/rancher-desktop/pages/images/add.vue
@@ -23,6 +23,7 @@
         :current-command="currentCommand"
         :action="activeTab"
         :image-output-culler="imageOutputCuller"
+        :image-to-pull="imageToPull"
         @ok:process-end="resetCurrentCommand"
         @ok:show="toggleOutput"
       />
@@ -89,7 +90,7 @@ export default {
       this.imageOutputCuller = getImageOutputCuller(command);
     },
     doImageAction({ action, image }) {
-      this.imageToPull = image;
+      this.imageToPull = image.trim();
       if (action === 'pull') {
         this.doPullAnImage();
       }
@@ -99,7 +100,7 @@ export default {
       }
     },
     doPullAnImage() {
-      const imageName = this.imageToPull.trim();
+      const imageName = this.imageToPull;
 
       this.currentCommand = `pull ${ imageName }`;
       this.startRunningCommand('pull');
@@ -107,7 +108,7 @@ export default {
       this.showOutput = true;
     },
     doBuildAnImage() {
-      const imageName = this.imageToPull.trim();
+      const imageName = this.imageToPull;
 
       this.currentCommand = `build ${ imageName }`;
       this.startRunningCommand('build');

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -4,6 +4,7 @@
       v-if="showOutput"
       :current-command="currentCommand"
       :image-output-culler="imageOutputCuller"
+      :image-to-pull="image"
       @ok:process-end="onProcessEnd"
     >
       <template #loading="{ isLoading }">


### PR DESCRIPTION
# Bug
Image Name is not getting reflected in the ImagesOutputWindow, while building/pulling image

## Why?
imageToPull variable was uninitialised

## More details
https://github.com/rancher-sandbox/rancher-desktop/issues/7559

# Changes
- Added imageToPull in props and modified places where ImagesOutputWindow.vue was being called


# Screenshots

## Build

<img width="1207" alt="Screenshot 2024-09-28 at 10 46 44 PM" src="https://github.com/user-attachments/assets/f9ddffe8-4b01-4ea2-b7c6-a9c1290f8e58">

---

## Pull
<img width="1210" alt="Screenshot 2024-09-28 at 10 47 43 PM" src="https://github.com/user-attachments/assets/25e13422-e72f-4048-b0ec-f40189944f7b">




closes https://github.com/rancher-sandbox/rancher-desktop/issues/7559