### PR TITLE
Windows test fixes

### DIFF
--- a/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
@@ -38,7 +38,9 @@ beforeEach(async() => {
 afterEach(async() => {
   // It is best to be careful around rm's; we don't want to remove important things.
   if (testDir) {
-    await fs.promises.rm(testDir, { recursive: true, force: true });
+    await fs.promises.rm(testDir, {
+      recursive: true, force: true, maxRetries: 5,
+    });
   }
 });
 

--- a/pkg/rancher-desktop/integrations/manageLinesInFile.ts
+++ b/pkg/rancher-desktop/integrations/manageLinesInFile.ts
@@ -165,6 +165,7 @@ async function copyFileExtendedAttributes(fromPath: string, toPath: string): Pro
   } catch (cause) {
     if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {
       // When running unit tests, assume they do not have extended attributes.
+      return;
     }
 
     if (cause && typeof cause === 'object' && 'code' in cause && cause.code === 'MODULE_NOT_FOUND') {

--- a/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/deploymentProfiles.spec.ts
@@ -34,6 +34,7 @@ describe('deployment profiles', () => {
     // We *could* write a routine that converts json to reg files, but that's not the point of this test.
     // Better to just hard-wire a few regfiles here.
 
+    const versionHex = `00${ settings.CURRENT_SETTINGS_VERSION.toString(16) }`.slice(-2);
     const defaultsUserRegFile = `Windows Registry Editor Version 5.00
 
 [${ NON_PROFILE_PATH }]
@@ -41,6 +42,7 @@ describe('deployment profiles', () => {
 [${ FULL_PROFILE_PATH }]
 
 [${ FULL_DEFAULTS_PATH }]
+"version"=dword:${ versionHex }
 
 [${ FULL_DEFAULTS_PATH }\\application]
 
@@ -91,6 +93,7 @@ describe('deployment profiles', () => {
 [${ FULL_PROFILE_PATH }]
 
 [${ FULL_PROFILE_PATH }\\Locked]
+"version"=dword:${ versionHex }
 
 [${ FULL_PROFILE_PATH }\\Locked\\containerEngine]
 
@@ -118,6 +121,7 @@ describe('deployment profiles', () => {
 [${ FULL_PROFILE_PATH }]
 
 [${ FULL_DEFAULTS_PATH }]
+"version"=dword:${ versionHex }
 
 [${ FULL_DEFAULTS_PATH }\\application]
 
@@ -160,6 +164,7 @@ describe('deployment profiles', () => {
 [${ FULL_PROFILE_PATH }]
 
 [${ FULL_DEFAULTS_PATH }]
+"version"=dword:${ versionHex }
 
 [${ FULL_DEFAULTS_PATH }\\CONTAINERENGINE]
 "name"="moby"
@@ -214,6 +219,7 @@ describe('deployment profiles', () => {
       describe('defaults', () => {
         describe('happy paths', () => {
           const defaultUserProfile: RecursivePartial<settings.Settings> = {
+            version:     settings.CURRENT_SETTINGS_VERSION,
             application: {
               debug:       true,
               adminAccess: false,
@@ -254,7 +260,8 @@ describe('deployment profiles', () => {
               },
             },
           };
-          const lockedUserProfile = {
+          const lockedUserProfile: RecursivePartial<settings.Settings> = {
+            version:         settings.CURRENT_SETTINGS_VERSION,
             containerEngine: {
               allowedImages: {
                 enabled:  false,
@@ -289,7 +296,7 @@ describe('deployment profiles', () => {
             await installInRegistry(arrayFromSingleStringDefaultsUserRegFile);
             const profile = await readDeploymentProfiles(REGISTRY_PROFILE_PATHS);
 
-            expect(profile.defaults).toEqual({
+            expect(profile.defaults).toMatchObject({
               containerEngine: { allowedImages: { patterns: ['hokey smoke!'] }, name: 'moby' },
             });
           });


### PR DESCRIPTION
This fixes two Windows unit tests.

- `manageLinesInFile`: retry deleting temporary directory if files are in use.
- `manageLinesInFile`: in code path that we never run in production, if we fail to import `fs-xattr` on Windows (which we will), assume the file doesn't have any extended attributes.
- `deploymentProfiles`: add settings version to expected output.