### PR TITLE
Stop using deprecated --kubernetes-* options in rdctl

### DIFF
--- a/bats/tests/k8s/enable-disable-k8s.bats
+++ b/bats/tests/k8s/enable-disable-k8s.bats
@@ -18,13 +18,13 @@ verify_k8s_is_running() {
 }
 
 @test 'disable kubernetes' {
-    rdctl set --kubernetes-enabled=false
+    rdctl set --kubernetes.enabled=false
     wait_for_container_engine
     wait_for_service_status k3s stopped
 }
 
 @test 're-enable kubernetes' {
-    rdctl set --kubernetes-enabled=true
+    rdctl set --kubernetes.enabled=true
     wait_for_kubelet
     verify_k8s_is_running
 }

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -152,7 +152,7 @@ verify_nginx_after_change_k8s() {
 }
 
 @test 'downgrade kubernetes' {
-    rdctl set --kubernetes-version "$RD_KUBERNETES_VERSION_LOW"
+    rdctl set --kubernetes.version "$RD_KUBERNETES_VERSION_LOW"
     wait_for_kubelet "$RD_KUBERNETES_VERSION_LOW"
     wait_for_container_engine
 }


### PR DESCRIPTION
They are hidden aliases that only exist for backwards compatibility.