### PR TITLE
Limit the options for HostIP

### DIFF
--- a/src/go/guestagent/pkg/containerd/events.go
+++ b/src/go/guestagent/pkg/containerd/events.go
@@ -428,7 +428,7 @@ func createPortMappingFromString(portMapping string) (nat.PortMap, error) {
 		}
 
 		portBinding := nat.PortBinding{
-			HostIP:   port.HostIP,
+			HostIP:   NormalizeHostIP(port.HostIP),
 			HostPort: strconv.Itoa(port.HostPort),
 		}
 		if pb, ok := portMap[portMapKey]; ok {
@@ -473,6 +473,16 @@ func mustFormatHashWithPrefix(length int, prefix string, toHash string) string {
 	output := sha512.Sum512([]byte(toHash))
 
 	return fmt.Sprintf("%s%x", prefix, output)[:length]
+}
+
+// NormalizeHostIP checks if the provided IP address is valid.
+// The valid options are "127.0.0.1" and "0.0.0.0". If the input is "127.0.0.1",
+// it returns "127.0.0.1". Any other address will be mapped to "0.0.0.0".
+func NormalizeHostIP(ip string) string {
+	if ip == "127.0.0.1" || ip == "localhost" {
+		return ip
+	}
+	return "0.0.0.0"
 }
 
 // Port is representing nerdctl/ports entry in the

--- a/src/go/guestagent/pkg/docker/events.go
+++ b/src/go/guestagent/pkg/docker/events.go
@@ -186,7 +186,7 @@ func createPortMapping(ports []types.Port) (nat.PortMap, error) {
 		}
 
 		portBinding := nat.PortBinding{
-			HostIP:   port.IP,
+			HostIP:   containerd.NormalizeHostIP(port.IP),
 			HostPort: strconv.Itoa(int(port.PublicPort)),
 		}
 


### PR DESCRIPTION
This will restrict the options for HostIP to either "127.0.0.1" or "0.0.0.0" to validate user input for docker/nerdctl run with the "-p" option on Windows. The potential issues are as follows:

On Docker, if users provide any option for "-p" other than "127.0.0.1" or "0.0.0.0," the Docker proxy will fail to create the port mapping because those IP addresses are not visible to the Docker proxy process. However, users can still specify an IP address from the internal network that is visible to the Docker proxy, allowing Docker to create the published port; however, that port will not be accessible from the host.

On containerd, the backend containerd engine will create port mappings for published ports without any errors (silently failing); however, the published ports will not be accessible.

Therefore, to prevent the scenarios mentioned above, we need to manually validate user input to limit it to either localhost or INADDR_ANY.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7558