### PR TITLE
More golangci-lint fixes

### DIFF
--- a/.github/workflows/config/.golangci.yaml
+++ b/.github/workflows/config/.golangci.yaml
@@ -41,8 +41,6 @@ linters-settings:
       - ^os\.Mkdir(?:All)?$
   lll:
     line-length: 140
-  misspell:
-    locale: US
   nolintlint:
     allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
@@ -60,7 +58,9 @@ linters:
     - gofmt
     - goimports
     - goprintffuncname
+    - gosimple
     - ineffassign
+    - misspell
     - typecheck
     - unconvert
     - unused

--- a/.github/workflows/config/.golangci.yaml
+++ b/.github/workflows/config/.golangci.yaml
@@ -51,9 +51,9 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - errcheck
-    - exportloopref
     - goconst
     - gofmt
     - goimports

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Ensure you have the following installed:
 
 - [yarn classic][yarn-classic]
 
-- Go 1.21 or later.
+- Go 1.22 or later.
 
 - Dependencies described in the [`node-gyp` docs][node-gyp] installation.
   This is required to install the [`ffi-napi`][ffi-napi] npm package. These docs mention

--- a/scripts/lint-go.ts
+++ b/scripts/lint-go.ts
@@ -102,9 +102,11 @@ async function goLangCILint(fix: boolean): Promise<boolean> {
   // this is necessary).  To be safe, just pass in all of the modules at once
   // and let it go at its own pace.
   const modules = await getModules();
+  const commandLine = ['go', ...args, ...modules.map(m => `${ m }/...`)];
 
   try {
-    await spawnFile('go', [...args, ...modules.map(m => `${ m }/...`)], { stdio: 'inherit' });
+    console.log(commandLine.join(' '));
+    await spawnFile(commandLine[0], commandLine.slice(1), { stdio: 'inherit' });
   } catch (ex) {
     success = false;
   }

--- a/src/go/docker-credential-none/go.mod
+++ b/src/go/docker-credential-none/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/docker-credential-none
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/cli v27.3.1+incompatible

--- a/src/go/extension-proxy/go.mod
+++ b/src/go/extension-proxy/go.mod
@@ -1,3 +1,3 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/extension-port-forwarder
 
-go 1.21
+go 1.22

--- a/src/go/github-runner-monitor/go.mod
+++ b/src/go/github-runner-monitor/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/github-runner-monitor
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/go-github/v55 v55.0.0

--- a/src/go/mock-wsl/go.mod
+++ b/src/go/mock-wsl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/e2e/assets/mock-wsl
 
-go 1.21
+go 1.22
 
 require (
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56

--- a/src/go/nerdctl-stub/generate/go.mod
+++ b/src/go/nerdctl-stub/generate/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/nerdctl-stub/generate
 
-go 1.21
+go 1.22
 
 require github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 

--- a/src/go/nerdctl-stub/go.mod
+++ b/src/go/nerdctl-stub/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/nerdctl-stub
 
-go 1.21
+go 1.22
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/src/go/rdctl/go.mod
+++ b/src/go/rdctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher-sandbox/rancher-desktop/src/go/rdctl
 
-go 1.21
+go 1.22
 
 require (
 	github.com/adrg/xdg v0.5.0

--- a/src/go/rdctl/pkg/runner/runner_test.go
+++ b/src/go/rdctl/pkg/runner/runner_test.go
@@ -14,7 +14,6 @@ func TestTaskRunner(t *testing.T) {
 		taskRunner := NewTaskRunner(ctx)
 		runOrder := make([]int, 0, 3)
 		for i := 1; i < 4; i++ {
-			i := i
 			taskRunner.Add(func() error {
 				runOrder = append(runOrder, i)
 				return nil
@@ -66,7 +65,6 @@ func TestTaskRunner(t *testing.T) {
 		expectedError := "func1 error"
 		ranSlice := make([]bool, 2)
 		for i := range ranSlice {
-			i := i
 			taskRunner.Add(func() error {
 				ranSlice[i] = true
 				t.Logf("func%d ran", i+1)

--- a/src/go/rdctl/pkg/snapshot/snapshotter_unix.go
+++ b/src/go/rdctl/pkg/snapshot/snapshotter_unix.go
@@ -95,7 +95,6 @@ func (snapshotter SnapshotterImpl) CreateFiles(ctx context.Context, appPaths pat
 	taskRunner := runner.NewTaskRunner(ctx)
 	files := snapshotter.Files(appPaths, snapshotDir)
 	for _, file := range files {
-		file := file
 		taskRunner.Add(func() error {
 			err := copyFile(file.SnapshotPath, file.WorkingPath, file.CopyOnWrite, file.FileMode)
 			if errors.Is(err, os.ErrNotExist) && file.MissingOk {
@@ -126,7 +125,6 @@ func (snapshotter SnapshotterImpl) RestoreFiles(ctx context.Context, appPaths pa
 	taskRunner := runner.NewTaskRunner(ctx)
 	files := snapshotter.Files(appPaths, snapshotDir)
 	for _, file := range files {
-		file := file
 		taskRunner.Add(func() error {
 			filename := filepath.Base(file.WorkingPath)
 			err := copyFile(file.WorkingPath, file.SnapshotPath, file.CopyOnWrite, file.FileMode)

--- a/src/go/rdctl/pkg/snapshot/snapshotter_windows.go
+++ b/src/go/rdctl/pkg/snapshot/snapshotter_windows.go
@@ -73,7 +73,6 @@ func (snapshotter SnapshotterImpl) CreateFiles(ctx context.Context, appPaths pat
 
 	// export WSL distros to snapshot directory
 	for _, distro := range snapshotter.WSLDistros(appPaths) {
-		distro := distro
 		taskRunner.Add(func() error {
 			snapshotDistroPath := filepath.Join(snapshotDir, distro.Name+".tar")
 			if err := snapshotter.ExportDistro(distro.Name, snapshotDistroPath); err != nil {
@@ -119,7 +118,6 @@ func (snapshotter SnapshotterImpl) RestoreFiles(ctx context.Context, appPaths pa
 
 	// restore WSL distros
 	for _, distro := range snapshotter.WSLDistros(appPaths) {
-		distro := distro
 		tr.Add(func() error {
 			snapshotDistroPath := filepath.Join(snapshotDir, distro.Name+".tar")
 			if err := os.MkdirAll(distro.WorkingDirPath, 0o755); err != nil {

--- a/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
+++ b/src/go/wsl-helper/pkg/wsl-utils/version_windows_test.go
@@ -103,7 +103,6 @@ func TestPackageVersion(t *testing.T) {
 			{L: "1.0.0", R: "0.0.1", expect: false},
 		}
 		for _, input := range cases {
-			input := input
 			t.Run(fmt.Sprintf("%s<%s=%v", input.L, input.R, input.expect), func(t *testing.T) {
 				var left, right PackageVersion
 				assert.NoError(t, left.UnmarshalText([]byte(input.L)))
@@ -175,8 +174,6 @@ func TestGetVersionFromCLI(t *testing.T) {
 	logger.SetOutput(io.Discard)
 
 	for name, input := range outputs {
-		name := name
-		input := input
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)


### PR DESCRIPTION
Low priority fix to add more linters.

This bumps use to golang 1.22 (current is 1.23) because that has the fix to make independent loop variables per iteration; see [release notes](https://go.dev/doc/go1.22#language).