### PR TITLE
Install socket_vmnet 1.1.5 from upstream release

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -840,6 +840,7 @@ varnamelen
 vcenter
 vcpus
 vcs
+vde
 ventura
 VERSIONSTRING
 vertificate

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,5 +1,6 @@
 lima: 0.21.0.rd2
 limaAndQemu: 1.31.3
+socketVMNet: 1.1.5
 alpineLimaISO:
   isoVersion: 0.2.39.rd4
   alpineVersion: 3.20.0

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/download';
 
 import {
-  DownloadContext, Dependency, GitHubDependency, getPublishedReleaseTagNames, getPublishedVersions,
+  DownloadContext, Dependency, GitHubDependency, findChecksum, getPublishedReleaseTagNames, getPublishedVersions,
 } from 'scripts/lib/dependencies';
 import { simpleSpawn } from 'scripts/simple_process';
 
@@ -17,26 +17,6 @@ function exeName(context: DownloadContext, name: string) {
   const onWindows = context.platform === 'win32';
 
   return `${ name }${ onWindows ? '.exe' : '' }`;
-}
-
-/**
- * Download the given checksum file (which contains multiple checksums) and find
- * the correct checksum for the given executable name.
- * @param checksumURL The URL to download the checksum from.
- * @param executableName The name of the executable expected.
- * @returns The checksum.
- */
-async function findChecksum(checksumURL: string, executableName: string): Promise<string> {
-  const allChecksums = await getResource(checksumURL);
-  const desiredChecksums = allChecksums.split(/\r?\n/).filter(line => line.endsWith(executableName));
-
-  if (desiredChecksums.length < 1) {
-    throw new Error(`Couldn't find a matching SHA for [${ executableName }] in [${ allChecksums }]`);
-  }
-  if (desiredChecksums.length === 1) {
-    return desiredChecksums[0].split(/\s+/, 1)[0];
-  }
-  throw new Error(`Matched ${ desiredChecksums.length } hits, not exactly 1, for ${ executableName } in [${ allChecksums }]`);
 }
 
 export class KuberlrAndKubectl implements Dependency {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import * as goUtils from 'scripts/dependencies/go-source';
-import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, LimaAndQemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import { SudoPrompt } from 'scripts/dependencies/sudo-prompt';
 import { ExtensionProxyImage, WSLDistroImage } from 'scripts/dependencies/tar-archives';
@@ -49,6 +49,7 @@ const unixDependencies = [
 
 // Dependencies that are specific to macOS hosts.
 const macOSDependencies = [
+  new SocketVMNet(),
   new SudoPrompt(),
 ];
 

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { Octokit } from 'octokit';
 
-import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, LimaAndQemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
@@ -39,6 +39,7 @@ const dependencies: Dependency[] = [
   new tools.ECRCredHelper(),
   new Lima(),
   new LimaAndQemu(),
+  new SocketVMNet(),
   new AlpineLimaISO(),
   new WSLDistro(),
   new Wix(),


### PR DESCRIPTION
The only thing we still use from the lima-and-qemu tarball is QEMU itself.

Fixes #7572