### PR TITLE
Added rd-open-webui-docker-ext to the extensions catalog

### DIFF
--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -4,7 +4,7 @@ export const demoMarketplace = {
       id:                    '',
       name:                  'Open WebUI Extension',
       containerd_compatible: true,
-      slug:                  'ghcr.io/rancher-sandbox/rd-open-webui-docker-ext',
+      slug:                  'ghcr.io/rancher-sandbox/rancher-desktop-rdx-open-webui',
       type:                  'extension',
       publisher:             { name: 'SUSE LLC' },
       created_at:            '2024-10-03T15:43:34Z',

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -32,7 +32,7 @@ export const demoMarketplace = {
       containerd_compatible: true,
       slug:                  'ghcr.io/rancher-sandbox/epinio-desktop-extension',
       type:                  'extension',
-      publisher:             { name: 'Rancher by SUSE' },
+      publisher:             { name: 'SUSE LLC' },
       created_at:            '2022-05-06T00:44:00Z',
       updated_at:            '2023-02-24T10:40:43.666252815Z',
       short_description:     'Push from source to Kubernetes in one step',

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -316,8 +316,5 @@ export const demoMarketplace = {
       star_count:           0,
       filter_type:          'community',
     },
-
-
-
   ],
 };

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -9,7 +9,7 @@ export const demoMarketplace = {
       publisher:             { name: 'SUSE LLC' },
       created_at:            '2024-10-03T15:43:34Z',
       updated_at:            '2024-10-03T15:43:34.144218728Z',
-      short_description:     'Open WebUI and Ollama packaged into a docker extension for local GenAI development',
+      short_description:     'Open WebUI and Ollama packaged into an extension for local GenAI development',
       source:                'community',
       extension_reviewed:    true,
       popularity:            0,

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -6,7 +6,7 @@ export const demoMarketplace = {
       containerd_compatible: true,
       slug:                  'ghcr.io/rancher-sandbox/rd-open-webui-docker-ext',
       type:                  'extension',
-      publisher:             { name: 'Rancher by SUSE' },
+      publisher:             { name: 'SUSE LLC' },
       created_at:            '2024-10-03T15:43:34Z',
       updated_at:            '2024-10-03T15:43:34.144218728Z',
       short_description:     'Open WebUI and Ollama packaged into a docker extension for local GenAI development',

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -2,6 +2,32 @@ export const demoMarketplace = {
   summaries: [
     {
       id:                    '',
+      name:                  'Open WebUI Extension',
+      containerd_compatible: true,
+      slug:                  'ghcr.io/rancher-sandbox/rd-open-webui-docker-ext',
+      type:                  'extension',
+      publisher:             { name: 'Rancher by SUSE' },
+      created_at:            '2024-10-03T15:43:34Z',
+      updated_at:            '2024-10-03T15:43:34.144218728Z',
+      short_description:     'Open WebUI and Ollama packaged into a docker extension for local GenAI development',
+      source:                'community',
+      extension_reviewed:    true,
+      popularity:            0,
+      categories:            null,
+      operating_systems:     [],
+      architectures:         [],
+      logo_url:              {
+        large:
+          'https://raw.githubusercontent.com/rancher-sandbox/rd-open-webui-docker-ext/main/open-webui.svg',
+        small:
+          'https://raw.githubusercontent.com/rancher-sandbox/rd-open-webui-docker-ext/main/open-webui.svg',
+      },
+      certification_status: '',
+      star_count:           0,
+      filter_type:          'community',
+    },
+    {
+      id:                    '',
       name:                  'Epinio',
       containerd_compatible: true,
       slug:                  'ghcr.io/rancher-sandbox/epinio-desktop-extension',
@@ -290,5 +316,8 @@ export const demoMarketplace = {
       star_count:           0,
       filter_type:          'community',
     },
+
+
+
   ],
 };

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -11,7 +11,7 @@ export const demoMarketplace = {
       updated_at:            '2024-10-03T15:43:34.144218728Z',
       short_description:     'Open WebUI and Ollama packaged into an extension for local GenAI development',
       source:                'community',
-      extension_reviewed:    true,
+      extension_reviewed:    false,
       popularity:            0,
       categories:            null,
       operating_systems:     [],

--- a/pkg/rancher-desktop/utils/_demo_marketplace_items.js
+++ b/pkg/rancher-desktop/utils/_demo_marketplace_items.js
@@ -18,9 +18,9 @@ export const demoMarketplace = {
       architectures:         [],
       logo_url:              {
         large:
-          'https://raw.githubusercontent.com/rancher-sandbox/rd-open-webui-docker-ext/main/open-webui.svg',
+          'https://raw.githubusercontent.com/rancher-sandbox/rancher-desktop-rdx-open-webui/main/open-webui.svg',
         small:
-          'https://raw.githubusercontent.com/rancher-sandbox/rd-open-webui-docker-ext/main/open-webui.svg',
+          'https://raw.githubusercontent.com/rancher-sandbox/rancher-desktop-rdx-open-webui/main/open-webui.svg',
       },
       certification_status: '',
       star_count:           0,

--- a/pkg/rancher-desktop/utils/_demo_metadata.js
+++ b/pkg/rancher-desktop/utils/_demo_metadata.js
@@ -1661,4 +1661,43 @@ export default {
       },
     ],
   },
+  'ghcr.io/rancher-sandbox/rd-open-webui-docker-ext': {
+    CreatedTime: '2024-10-02T21:08:38.117591549Z',
+    Categories:  [
+      'genai',
+      'llm'
+    ],
+    LatestVersion: {
+      Tag:                'latest',
+      ManifestListDigest: 'sha256:cad83a840ba30fb1c151a0bb8d24220cd2fddcea13a1d7f13219ab01f63caf30',
+      Platforms:          [
+        {
+          OS:      'linux',
+          Arch:    'amd64',
+          Size:    29413493,
+          Created: '2024-10-02T21:08:38.117591549Z',
+        },
+        {
+          OS:      'linux',
+          Arch:    'arm64',
+          Size:    29562162,
+          Created: '2024-10-02T21:19:16.860949264Z',
+        },
+      ],
+      Labels: {
+        "com.docker.desktop.extension.api.version": "0.3.4",
+        "com.docker.desktop.extension.icon": "",
+        "com.docker.extension.additional-urls": "",
+        "com.docker.extension.categories": "",
+        "com.docker.extension.changelog": "",
+        "com.docker.extension.detailed-description": "",
+        "com.docker.extension.publisher-url": "",
+        "com.docker.extension.screenshots": "",
+        "org.opencontainers.image.description": "Open WebUI on Rancher Desktop",
+        "org.opencontainers.image.title": "Open WebUI",
+        "org.opencontainers.image.vendor": "SUSE LLC"
+      },
+    },
+    PreviousVersions: [],
+  }
 };

--- a/pkg/rancher-desktop/utils/_demo_metadata.js
+++ b/pkg/rancher-desktop/utils/_demo_metadata.js
@@ -1661,7 +1661,7 @@ export default {
       },
     ],
   },
-  'ghcr.io/rancher-sandbox/rd-open-webui-docker-ext': {
+  'ghcr.io/rancher-sandbox/rancher-desktop-rdx-open-webui': {
     CreatedTime: '2024-10-02T21:08:38.117591549Z',
     Categories:  [
       'genai',

--- a/pkg/rancher-desktop/utils/_demo_metadata.js
+++ b/pkg/rancher-desktop/utils/_demo_metadata.js
@@ -1665,7 +1665,7 @@ export default {
     CreatedTime: '2024-10-02T21:08:38.117591549Z',
     Categories:  [
       'genai',
-      'llm'
+      'llm',
     ],
     LatestVersion: {
       Tag:                'latest',
@@ -1685,19 +1685,19 @@ export default {
         },
       ],
       Labels: {
-        "com.docker.desktop.extension.api.version": "0.3.4",
-        "com.docker.desktop.extension.icon": "",
-        "com.docker.extension.additional-urls": "",
-        "com.docker.extension.categories": "",
-        "com.docker.extension.changelog": "",
-        "com.docker.extension.detailed-description": "",
-        "com.docker.extension.publisher-url": "",
-        "com.docker.extension.screenshots": "",
-        "org.opencontainers.image.description": "Open WebUI on Rancher Desktop",
-        "org.opencontainers.image.title": "Open WebUI",
-        "org.opencontainers.image.vendor": "SUSE LLC"
+        'com.docker.desktop.extension.api.version':  '0.3.4',
+        'com.docker.desktop.extension.icon':         '',
+        'com.docker.extension.additional-urls':      '',
+        'com.docker.extension.categories':           '',
+        'com.docker.extension.changelog':            '',
+        'com.docker.extension.detailed-description': '',
+        'com.docker.extension.publisher-url':        '',
+        'com.docker.extension.screenshots':          '',
+        'org.opencontainers.image.description':      'Open WebUI on Rancher Desktop',
+        'org.opencontainers.image.title':            'Open WebUI',
+        'org.opencontainers.image.vendor':           'SUSE LLC',
       },
     },
     PreviousVersions: [],
-  }
+  },
 };

--- a/pkg/rancher-desktop/utils/_demo_metadata.js
+++ b/pkg/rancher-desktop/utils/_demo_metadata.js
@@ -1,4 +1,43 @@
 export default {
+  'ghcr.io/rancher-sandbox/rancher-desktop-rdx-open-webui': {
+    CreatedTime: '2024-10-02T21:08:38.117591549Z',
+    Categories:  [
+      'genai',
+      'llm',
+    ],
+    LatestVersion: {
+      Tag:                'latest',
+      ManifestListDigest: 'sha256:cad83a840ba30fb1c151a0bb8d24220cd2fddcea13a1d7f13219ab01f63caf30',
+      Platforms:          [
+        {
+          OS:      'linux',
+          Arch:    'amd64',
+          Size:    29413493,
+          Created: '2024-10-02T21:08:38.117591549Z',
+        },
+        {
+          OS:      'linux',
+          Arch:    'arm64',
+          Size:    29562162,
+          Created: '2024-10-02T21:19:16.860949264Z',
+        },
+      ],
+      Labels: {
+        'com.docker.desktop.extension.api.version':  '0.3.4',
+        'com.docker.desktop.extension.icon':         '',
+        'com.docker.extension.additional-urls':      '',
+        'com.docker.extension.categories':           '',
+        'com.docker.extension.changelog':            '',
+        'com.docker.extension.detailed-description': '',
+        'com.docker.extension.publisher-url':        '',
+        'com.docker.extension.screenshots':          '',
+        'org.opencontainers.image.description':      'Open WebUI on Rancher Desktop',
+        'org.opencontainers.image.title':            'Open WebUI',
+        'org.opencontainers.image.vendor':           'SUSE LLC',
+      },
+    },
+    PreviousVersions: [],
+  },
   'ghcr.io/rancher-sandbox/epinio-desktop-extension': {
     CreatedTime:   '2022-05-06T00:44:00Z',
     UpdatedAt:     '2023-02-24T10:40:43.666252815Z',
@@ -1660,44 +1699,5 @@ export default {
         },
       },
     ],
-  },
-  'ghcr.io/rancher-sandbox/rancher-desktop-rdx-open-webui': {
-    CreatedTime: '2024-10-02T21:08:38.117591549Z',
-    Categories:  [
-      'genai',
-      'llm',
-    ],
-    LatestVersion: {
-      Tag:                'latest',
-      ManifestListDigest: 'sha256:cad83a840ba30fb1c151a0bb8d24220cd2fddcea13a1d7f13219ab01f63caf30',
-      Platforms:          [
-        {
-          OS:      'linux',
-          Arch:    'amd64',
-          Size:    29413493,
-          Created: '2024-10-02T21:08:38.117591549Z',
-        },
-        {
-          OS:      'linux',
-          Arch:    'arm64',
-          Size:    29562162,
-          Created: '2024-10-02T21:19:16.860949264Z',
-        },
-      ],
-      Labels: {
-        'com.docker.desktop.extension.api.version':  '0.3.4',
-        'com.docker.desktop.extension.icon':         '',
-        'com.docker.extension.additional-urls':      '',
-        'com.docker.extension.categories':           '',
-        'com.docker.extension.changelog':            '',
-        'com.docker.extension.detailed-description': '',
-        'com.docker.extension.publisher-url':        '',
-        'com.docker.extension.screenshots':          '',
-        'org.opencontainers.image.description':      'Open WebUI on Rancher Desktop',
-        'org.opencontainers.image.title':            'Open WebUI',
-        'org.opencontainers.image.vendor':           'SUSE LLC',
-      },
-    },
-    PreviousVersions: [],
   },
 };


### PR DESCRIPTION
Fixes https://github.com/rancher-sandbox/rd-open-webui-docker-ext/issues/3

Note: At this time, the icon doesn't show up on the catalog tile as `rancher-sandbox/rd-open-webui-docker-ext` is not public yet.