### PR TITLE
RDX: Allow hooks on shutdown

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -609,13 +609,8 @@ Electron.app.on('before-quit', async(event) => {
 
   try {
     await k8smanager?.stop();
-    try {
-      await mainEvents.invoke('shutdown-integrations');
-    } catch (ex) {
-      if (!`${ ex }`.includes('No handlers registered')) {
-        throw ex;
-      }
-    }
+    await mainEvents.tryInvoke('shutdown-integrations');
+    await mainEvents.tryInvoke('extensions/shutdown');
 
     console.log(`2: Child exited cleanly.`);
   } catch (ex: any) {

--- a/background.ts
+++ b/background.ts
@@ -608,9 +608,9 @@ Electron.app.on('before-quit', async(event) => {
   httpCredentialHelperServer.closeServer();
 
   try {
+    await mainEvents.tryInvoke('extensions/shutdown');
     await k8smanager?.stop();
     await mainEvents.tryInvoke('shutdown-integrations');
-    await mainEvents.tryInvoke('extensions/shutdown');
 
     console.log(`2: Child exited cleanly.`);
   } catch (ex: any) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "containers@suse.com"
   },
   "engines": {
-    "node": "^20.17"
+    "node": "20.16.0"
   },
   "packageManager": "yarn@1.22.21",
   "repository": {

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -269,7 +269,7 @@ export class ExtensionManagerImpl implements ExtensionManager {
     await Promise.all(tasks);
 
     // Register a listener to shut down extensions on quit
-    mainEvents.on('quit', this.triggerExtensionShutdown);
+    mainEvents.handle('extensions/shutdown', this.triggerExtensionShutdown);
   }
 
   /**
@@ -577,7 +577,7 @@ export class ExtensionManagerImpl implements ExtensionManager {
       proc.deref()?.kill();
     }));
 
-    mainEvents.off('quit', this.triggerExtensionShutdown);
+    mainEvents.handle('extensions/shutdown', undefined);
   }
 
   triggerExtensionShutdown = async() => {

--- a/pkg/rancher-desktop/main/extensions/types.ts
+++ b/pkg/rancher-desktop/main/extensions/types.ts
@@ -50,6 +50,13 @@ export type ExtensionMetadata = {
      * `binaries`.  Errors will be ignored.
      */
     'x-rd-uninstall'?: PlatformSpecific<string|string[]>,
+    /**
+     * Rancher Desktop extension: this will be executed when the application
+     * quits.  The application may exit before the process completes.  It is not
+     * defined what the container engine / Kubernetes cluster may be doing at
+     * the time this is called.
+     */
+    'x-rd-shutdown'?: PlatformSpecific<string|string[]>,
  };
 };
 


### PR DESCRIPTION
This adds a `x-rd-shutdown` extension hook that is executed on application shutdown.  We do not attempt to check the exit code.

Fixes #7588