### PR TITLE
Factory reset: shutdown extensions

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -392,6 +392,7 @@ Kgm
 kiali
 kib
 killall
+Kinfo
 kiwano
 KNOWNFOLDERID
 kontainer
@@ -592,6 +593,7 @@ PFlags
 PGID
 pgrep
 pidfile
+pidfd
 pids
 PII
 pikachu
@@ -623,6 +625,7 @@ PQgrl
 prakhar
 prebuilds
 Privs
+PROCARGS
 progresskey
 projectroletemplatebinding
 Prometheis

--- a/src/go/rdctl/cmd/factoryReset.go
+++ b/src/go/rdctl/cmd/factoryReset.go
@@ -51,7 +51,7 @@ Use the --remove-kubernetes-cache=BOOLEAN flag to also remove the cached Kuberne
 		if err != nil {
 			return fmt.Errorf("failed to get paths: %w", err)
 		}
-		return factoryreset.DeleteData(paths, removeKubernetesCache)
+		return factoryreset.DeleteData(cmd.Context(), paths, removeKubernetesCache)
 	},
 }
 

--- a/src/go/rdctl/pkg/directories/directories.go
+++ b/src/go/rdctl/pkg/directories/directories.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directories
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// GetApplicationDirectory returns the installation directory of the application.
+func GetApplicationDirectory() (string, error) {
+	exePathWithSymlinks, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	exePath, err := filepath.EvalSymlinks(exePathWithSymlinks)
+	if err != nil {
+		return "", err
+	}
+
+	platform := runtime.GOOS
+	if runtime.GOOS == "windows" {
+		// On Windows, we use "win32" instead of "windows".
+		platform = "win32"
+	}
+
+	// Given the path to the exe, find its directory, and drop the
+	// "resources\win32\bin" suffix (possibly with another "resources" in front).
+	// On mac, we need to drop "Contents/Resources/resources/darwin/bin".
+	resultDir := filepath.Dir(exePath)
+	for _, part := range []string{"bin", platform, "resources", "Resources", "Contents"} {
+		for filepath.Base(resultDir) == part {
+			resultDir = filepath.Dir(resultDir)
+		}
+	}
+	return resultDir, nil
+}

--- a/src/go/rdctl/pkg/directories/directories_test.go
+++ b/src/go/rdctl/pkg/directories/directories_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package directories_test
+
+import (
+	"testing"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetApplicationDirectory(t *testing.T) {
+	_, err := directories.GetApplicationDirectory()
+	assert.NoError(t, err)
+	// `go test` makes a temporary directory, so we can't sensibly test the
+	// return value.
+}

--- a/src/go/rdctl/pkg/directories/directories_windows.go
+++ b/src/go/rdctl/pkg/directories/directories_windows.go
@@ -19,7 +19,6 @@ package directories
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -42,43 +41,6 @@ func InvokeWin32WithBuffer(cb func(size int) error) error {
 		}
 		size *= 2
 	}
-}
-
-// GetApplicationDirectory returns the installation directory of the application.
-func GetApplicationDirectory() (string, error) {
-	var exePath string
-	err := InvokeWin32WithBuffer(func(bufSize int) error {
-		buf := make([]uint16, bufSize)
-		n, err := windows.GetModuleFileName(windows.Handle(0), &buf[0], uint32(bufSize))
-		if err != nil {
-			return err
-		}
-		if n == uint32(bufSize) {
-			// If the buffer is too small, GetModuleFileName returns the buffer size,
-			// and the result includes the null character. If the buffer is large
-			// enough, GetModuleFileName returns the string length, _excluding_ the
-			// null character.
-			if buf[bufSize-1] == 0 {
-				// The buffer contains a null character
-				return windows.ERROR_INSUFFICIENT_BUFFER
-			}
-		}
-		exePath = windows.UTF16ToString(buf[:n])
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	// Given the path to the exe, find its directory, and drop the
-	// "resources\win32\bin" suffix (possibly with another "resources" in front).
-	resultDir := filepath.Dir(exePath)
-	for _, part := range []string{"bin", "win32", "resources"} {
-		for filepath.Base(resultDir) == part {
-			resultDir = filepath.Dir(resultDir)
-		}
-	}
-	return resultDir, nil
 }
 
 func GetLocalAppDataDirectory() (string, error) {

--- a/src/go/rdctl/pkg/directories/directories_windows_test.go
+++ b/src/go/rdctl/pkg/directories/directories_windows_test.go
@@ -23,13 +23,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestGetApplicationDirectory(t *testing.T) {
-	_, err := GetApplicationDirectory()
-	assert.NoError(t, err)
-	// `go test` makes a temporary directory, so we can't sensibly test the
-	// return value.
-}
-
 func TestGetKnownFolder(t *testing.T) {
 	t.Run("AppData", func(t *testing.T) {
 		expected := os.Getenv("APPDATA")

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -16,7 +16,7 @@ func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
 
-	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+	if err := process.TerminateProcessInDirectory(appPaths.ExtensionRoot, false); err != nil {
 		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -1,17 +1,23 @@
 package factoryreset
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(appPaths paths.Paths, removeKubernetesCache bool) error {
+func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
+	}
+
+	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 
 	pathList := []string{

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -21,7 +21,7 @@ func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache
 		logrus.Errorf("Error getting home directory: %s", err)
 	}
 
-	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+	if err := process.TerminateProcessInDirectory(appPaths.ExtensionRoot, false); err != nil {
 		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -1,15 +1,17 @@
 package factoryreset
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(appPaths paths.Paths, removeKubernetesCache bool) error {
+func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
@@ -17,6 +19,10 @@ func DeleteData(appPaths paths.Paths, removeKubernetesCache bool) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		logrus.Errorf("Error getting home directory: %s", err)
+	}
+
+	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 
 	pathList := []string{

--- a/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
@@ -1,13 +1,16 @@
 package factoryreset
 
 import (
+	"context"
+
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/autostart"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
 	"github.com/sirupsen/logrus"
 )
 
-func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
+func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache bool) error {
 	if err := autostart.EnsureAutostart(false); err != nil {
 		logrus.Errorf("Failed to remove autostart configuration: %s", err)
 	}
@@ -15,6 +18,9 @@ func DeleteData(paths paths.Paths, removeKubernetesCache bool) error {
 	if err := w.UnregisterDistros(); err != nil {
 		logrus.Errorf("could not unregister WSL: %s", err)
 		return err
+	}
+	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 	if err := deleteWindowsData(!removeKubernetesCache, "rancher-desktop"); err != nil {
 		logrus.Errorf("could not delete data: %s", err)

--- a/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_windows.go
@@ -19,7 +19,7 @@ func DeleteData(ctx context.Context, appPaths paths.Paths, removeKubernetesCache
 		logrus.Errorf("could not unregister WSL: %s", err)
 		return err
 	}
-	if err := process.TerminateProcessInDirectory(ctx, appPaths.ExtensionRoot); err != nil {
+	if err := process.TerminateProcessInDirectory(appPaths.ExtensionRoot, false); err != nil {
 		logrus.Errorf("Failed to stop extension processes, ignoring: %s", err)
 	}
 	if err := deleteWindowsData(!removeKubernetesCache, "rancher-desktop"); err != nil {

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -25,18 +25,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
-	"strings"
-	"unsafe"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
-)
-
-var (
-	pKernel32      = windows.NewLazySystemDLL("kernel32.dll")
-	pEnumProcesses = pKernel32.NewProc("K32EnumProcesses")
 )
 
 // CheckProcessWindows - returns true if Rancher Desktop is still running, false if it isn't
@@ -75,106 +68,9 @@ func KillRancherDesktop() error {
 		return fmt.Errorf("could not find application directory: %w", err)
 	}
 
-	var processes []uint32
-	err = directories.InvokeWin32WithBuffer(func(size int) error {
-		processes = make([]uint32, size)
-		var bytesReturned uint32
-		// We can't use `windows.EnumProcesses`, because it passes in an incorrect
-		// value for the second argument (`cb`).
-		elementSize := unsafe.Sizeof(uint32(0))
-		bufferSize := uintptr(len(processes)) * elementSize
-		n, _, err := pEnumProcesses.Call(
-			uintptr(unsafe.Pointer(&processes[0])),
-			bufferSize,
-			uintptr(unsafe.Pointer(&bytesReturned)),
-		)
-		if n == 0 {
-			return err
-		}
-		if uintptr(bytesReturned) >= bufferSize {
-			return windows.ERROR_INSUFFICIENT_BUFFER
-		}
-		processesFound := uintptr(bytesReturned) / elementSize
-		logrus.Tracef("got %d processes", processesFound)
-		processes = processes[:processesFound]
-		return nil
-	})
+	err = process.TerminateProcessInDirectory(appDir, true)
 	if err != nil {
-		return fmt.Errorf("could not get process list: %w", err)
-	}
-
-	sort.Slice(processes, func(i, j int) bool {
-		return processes[i] < processes[j]
-	})
-	var processesToKill []uint32
-	for _, pid := range processes {
-		// Add a scope to help with defer
-		(func(pid uint32) {
-			if pid == uint32(os.Getpid()) {
-				// Skip the current process.
-				return
-			}
-
-			hProc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
-			if err != nil {
-				// We can't open privileged processes, processes that have exited since,
-				// idle process, etc.; so we log this at trace level instead.
-				logrus.Tracef("failed to open pid %d: %s (skipping)", pid, err)
-				return
-			}
-			defer func() { _ = windows.CloseHandle(hProc) }()
-
-			var imageName string
-			err = directories.InvokeWin32WithBuffer(func(size int) error {
-				nameBuf := make([]uint16, size)
-				charsWritten := uint32(size)
-				err := windows.QueryFullProcessImageName(hProc, 0, &nameBuf[0], &charsWritten)
-				if err != nil {
-					logrus.Tracef("failed to get image name for pid %d: %s", pid, err)
-					return err
-				}
-				if charsWritten >= uint32(size)-1 {
-					logrus.Tracef("buffer too small for pid %d image name", pid)
-					return windows.ERROR_INSUFFICIENT_BUFFER
-				}
-				imageName = windows.UTF16ToString(nameBuf)
-				return nil
-			})
-			if err != nil {
-				logrus.Debugf("failed to get process name of pid %d: %s (skipping)", pid, err)
-				return
-			}
-
-			relPath, err := filepath.Rel(appDir, imageName)
-			if err != nil {
-				// This may be because they're on different drives, network shares, etc.
-				logrus.Tracef("failed to make pid %d image %s relative to %s: %s", pid, imageName, appDir, err)
-				return
-			}
-			if strings.HasPrefix(relPath, "..") {
-				// Relative path includes "../" prefix, not a child of appDir
-				logrus.Tracef("skipping pid %d (%s), not in app %s", pid, imageName, appDir)
-				return
-			}
-
-			logrus.Tracef("will terminate pid %d image %s", pid, imageName)
-			processesToKill = append(processesToKill, pid)
-		})(pid)
-	}
-
-	for _, pid := range processesToKill {
-		(func() {
-			hProc, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, pid)
-			if err != nil {
-				logrus.Infof("failed to open process %d for termination, skipping", pid)
-				return
-			}
-			defer func() { _ = windows.CloseHandle(hProc) }()
-
-			if err = windows.TerminateProcess(hProc, 0); err != nil {
-				logrus.Infof("failed to terminate process %d: %s", pid, err)
-			}
-		})()
+		return err
 	}
 
 	return nil

--- a/src/go/rdctl/pkg/process/process_linux.go
+++ b/src/go/rdctl/pkg/process/process_linux.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// TerminateProcessInDirectory terminates all processes where the executable
+// resides within the given directory, as gracefully as possible.
+func TerminateProcessInDirectory(ctx context.Context, directory string) error {
+	// Check /proc/<pid>/exe to see if they're the correct file.
+	pidfds, err := os.ReadDir("/proc")
+	if err != nil {
+		return fmt.Errorf("error listing processes: %w", err)
+	}
+	for _, pidfd := range pidfds {
+		if !pidfd.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(pidfd.Name())
+		if err != nil {
+			continue
+		}
+		procPath, err := os.Readlink(filepath.Join("/proc", pidfd.Name(), "exe"))
+		if err != nil {
+			continue
+		}
+		relPath, err := filepath.Rel(directory, procPath)
+		if err != nil || strings.HasPrefix(relPath, "../") {
+			continue
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			continue
+		}
+		err = proc.Signal(unix.SIGTERM)
+		if err == nil {
+			logrus.Infof("Terminated process %d (%s)", pid, procPath)
+		} else if !errors.Is(err, unix.EINVAL) {
+			logrus.Infof("Ignoring failure to terminate pid %d (%s): %s", pid, procPath, err)
+		}
+	}
+
+	return nil
+}

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -1,0 +1,97 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+// TerminateProcessInDirectory terminates all processes where the executable
+// resides within the given directory, as gracefully as possible.
+func TerminateProcessInDirectory(ctx context.Context, directory string) error {
+	pids := make([]uint32, 4096)
+	// Try EnumProcesses until the number of pids returned is less than the
+	// buffer size.
+	for {
+		var bytesReturned uint32
+		err := windows.EnumProcesses(pids, &bytesReturned)
+		if err != nil || len(pids) < 1 {
+			return fmt.Errorf("failed to enumerate processes: %w", err)
+		}
+		pidsReturned := uintptr(bytesReturned) / unsafe.Sizeof(pids[0])
+		if pidsReturned < uintptr(len(pids)) {
+			// Remember to truncate the pids to only the valid set.
+			pids = pids[:pidsReturned]
+			break
+		}
+		pids = make([]uint32, len(pids)*2)
+	}
+
+	for _, pid := range pids {
+		// Do each iteration in a function so defer statements run faster.
+		err := (func() error {
+			hProc, err := windows.OpenProcess(
+				windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_TERMINATE,
+				false,
+				pid)
+			if err != nil {
+				logrus.Infof("Ignoring error opening process %d: %s", pid, err)
+				return nil
+			}
+			defer func() {
+				_ = windows.CloseHandle(hProc)
+			}()
+
+			nameBuf := make([]uint16, 1024)
+			for {
+				bufSize := uint32(len(nameBuf))
+				err = windows.QueryFullProcessImageName(hProc, 0, &nameBuf[0], &bufSize)
+				if err != nil {
+					return fmt.Errorf("error getting process %d executable: %w", pid, err)
+				}
+				if int(bufSize) < len(nameBuf) {
+					break
+				}
+				nameBuf = make([]uint16, len(nameBuf)*2)
+			}
+			executablePath := windows.UTF16ToString(nameBuf)
+
+			relPath, err := filepath.Rel(directory, executablePath)
+			if err != nil || strings.HasPrefix(relPath, "../") {
+				return nil
+			}
+
+			if err = windows.TerminateProcess(hProc, 0); err != nil {
+				return fmt.Errorf("failed to terminate pid %d (%s): %w", pid, executablePath, err)
+			}
+
+			return nil
+		})()
+		if err != nil {
+			logrus.Errorf("%s", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This makes us force terminate processes from extensions on factory reset, where that is defined as processes whose main executable is in the extension directory.

This also makes factory reset use some of the same code (removing shelling out to `pkill` for darwin and Linux).

Fixes #7587