### PR TITLE
postinstall: use new qemu packaging

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 lima: 1.0.0.rd3
-limaAndQemu: 1.31.3
+qemu: 9.1.0-rd0
 socketVMNet: 1.1.7
 alpineLimaISO:
   isoVersion: 0.2.41.rd1

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 lima: 1.0.0.rd3
-qemu: 9.1.0-rd0
+qemu: 9.1.0.rd3
 socketVMNet: 1.1.7
 alpineLimaISO:
   isoVersion: 0.2.41.rd1

--- a/scripts/dependencies/lima.ts
+++ b/scripts/dependencies/lima.ts
@@ -12,6 +12,7 @@ import { download, downloadTarGZ, getResource } from '../lib/download';
 import {
   DownloadContext, Dependency, AlpineLimaISOVersion, findChecksum, getOctokit, GitHubDependency, getPublishedReleaseTagNames, GitHubRelease,
 } from 'scripts/lib/dependencies';
+import { simpleSpawn } from 'scripts/simple_process';
 
 /**
  * rcompareVersions implementation for version strings that look like 0.1.2.rd3????.
@@ -103,44 +104,26 @@ export class Lima implements Dependency, GitHubDependency {
   }
 }
 
-export class LimaAndQemu implements Dependency, GitHubDependency {
-  name = 'limaAndQemu';
-  githubOwner = 'rancher-sandbox';
-  githubRepo = 'lima-and-qemu';
+export class Qemu implements Dependency, GitHubDependency {
+  name = 'qemu';
+  githubOwner = 'mook-as';
+  githubRepo = 'qemu-packaging';
 
   async download(context: DownloadContext): Promise<void> {
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
-    let platform: string = context.platform;
+    const arch = context.isM1 ? 'aarch64' : 'x86_64';
 
-    if (platform === 'darwin') {
-      platform = 'macos';
-      if (process.env.M1) {
-        platform = `macos-aarch64`;
-      }
-    }
-    const url = `${ baseUrl }/v${ context.versions.limaAndQemu }/lima-and-qemu.${ platform }.tar.gz`;
+    const url = `${ baseUrl }/v${ context.versions.qemu }/qemu-${ context.platform }-${ arch }.tar.gz`;
     const expectedChecksum = (await getResource(`${ url }.sha512sum`)).split(/\s+/)[0];
     const limaDir = path.join(context.resourcesDir, context.platform, 'lima');
-    const tarPath = path.join(context.resourcesDir, context.platform, `lima-and-qemu.v${ context.versions.limaAndQemu }.tgz`);
+    const tarPath = path.join(context.resourcesDir, context.platform, `qemu.v${ context.versions.qemu }.tgz`);
 
     await download(url, tarPath, {
       expectedChecksum, checksumAlgorithm: 'sha512', access: fs.constants.W_OK,
     });
     await fs.promises.mkdir(limaDir, { recursive: true });
 
-    const child = childProcess.spawn('/usr/bin/tar',
-      ['-xf', tarPath, '--exclude', 'lima*', '--exclude', 'vde/bin', '--exclude', 'vde/lib', '--exclude', 'socket_vmnet'],
-      { cwd: limaDir, stdio: 'inherit' });
-
-    await new Promise<void>((resolve, reject) => {
-      child.on('exit', (code, signal) => {
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(new Error(`Lima-and-QEMU extract failed with ${ code || signal }`));
-        }
-      });
-    });
+    await simpleSpawn('/usr/bin/tar', ['-xf', tarPath], { cwd: limaDir });
   }
 
   async getAvailableVersions(): Promise<string[]> {

--- a/scripts/dependencies/lima.ts
+++ b/scripts/dependencies/lima.ts
@@ -106,14 +106,14 @@ export class Lima implements Dependency, GitHubDependency {
 
 export class Qemu implements Dependency, GitHubDependency {
   name = 'qemu';
-  githubOwner = 'mook-as';
-  githubRepo = 'qemu-packaging';
+  githubOwner = 'rancher-sandbox';
+  githubRepo = 'rancher-desktop-qemu';
 
   async download(context: DownloadContext): Promise<void> {
     const baseUrl = `https://github.com/${ this.githubOwner }/${ this.githubRepo }/releases/download`;
     const arch = context.isM1 ? 'aarch64' : 'x86_64';
 
-    const url = `${ baseUrl }/v${ context.versions.qemu }/qemu-${ context.platform }-${ arch }.tar.gz`;
+    const url = `${ baseUrl }/v${ context.versions.qemu }/qemu-${ context.versions.qemu }-${ context.platform }-${ arch }.tar.gz`;
     const expectedChecksum = (await getResource(`${ url }.sha512sum`)).split(/\s+/)[0];
     const limaDir = path.join(context.resourcesDir, context.platform, 'lima');
     const tarPath = path.join(context.resourcesDir, context.platform, `qemu.v${ context.versions.qemu }.tgz`);

--- a/scripts/lib/dependencies.ts
+++ b/scripts/lib/dependencies.ts
@@ -37,7 +37,7 @@ export type AlpineLimaISOVersion = {
 
 export type DependencyVersions = {
   lima: string;
-  limaAndQemu: string;
+  qemu: string;
   socketVMNet: string;
   alpineLimaISO: AlpineLimaISOVersion;
   WSLDistro: string;

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import * as goUtils from 'scripts/dependencies/go-source';
-import { Lima, LimaAndQemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, Qemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import { SudoPrompt } from 'scripts/dependencies/sudo-prompt';
 import { ExtensionProxyImage, WSLDistroImage } from 'scripts/dependencies/tar-archives';
@@ -43,7 +43,7 @@ const userTouchedDependencies = [
 // Dependencies that are specific to unix hosts.
 const unixDependencies = [
   new Lima(),
-  new LimaAndQemu(),
+  new Qemu(),
   new AlpineLimaISO(),
 ];
 
@@ -147,7 +147,7 @@ async function downloadDependencies(items: DependencyWithContext[]): Promise<voi
     });
     const pending = Array.from(running).filter(v => !done.has(v));
 
-    await Promise.any([timeout, ...pending.map(v => promises[v])]);
+    await Promise.race([timeout, ...pending.map(v => promises[v])]);
   }
   abortSignal.onabort = null;
 

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { Octokit } from 'octokit';
 
-import { Lima, LimaAndQemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, Qemu, SocketVMNet, AlpineLimaISO } from 'scripts/dependencies/lima';
 import { MobyOpenAPISpec } from 'scripts/dependencies/moby-openapi';
 import * as tools from 'scripts/dependencies/tools';
 import { Wix } from 'scripts/dependencies/wix';
@@ -38,7 +38,7 @@ const dependencies: Dependency[] = [
   new tools.RancherDashboard(),
   new tools.ECRCredHelper(),
   new Lima(),
-  new LimaAndQemu(),
+  new Qemu(),
   new SocketVMNet(),
   new AlpineLimaISO(),
   new WSLDistro(),

--- a/scripts/unreleased-change-monitor.ts
+++ b/scripts/unreleased-change-monitor.ts
@@ -1,6 +1,6 @@
 import { Octokit } from 'octokit';
 
-import { Lima, LimaAndQemu, AlpineLimaISO } from 'scripts/dependencies/lima';
+import { Lima, Qemu, AlpineLimaISO } from 'scripts/dependencies/lima';
 import * as tools from 'scripts/dependencies/tools';
 import { WSLDistro } from 'scripts/dependencies/wsl';
 import {
@@ -20,7 +20,7 @@ type DependencyState = { dependency: UnreleasedChangeMonitoringDependency } & Ha
 
 const dependencies: UnreleasedChangeMonitoringDependency[] = [
   new Lima(),
-  new LimaAndQemu(),
+  new Qemu(),
   new WSLDistro(),
   new tools.DockerCLI(),
   new tools.Steve(),


### PR DESCRIPTION
Switch to the new qemu packaging method which doesn't include lima, since we now use separate lima releases.

Note that this is currently pulling from my fork, hence this is still draft. Also, I might need to handle Linux as well?

See also https://github.com/rancher-sandbox/rancher-desktop-qemu/pull/1