### PR TITLE
CI: Drop yarn cache restoring

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -5,17 +5,11 @@ description: >-
 runs:
   using: composite
   steps:
-  # In case we're running on a self-hosted runner without `yarn` installed,
-  # set up NodeJS, enable `yarn`, and then handle the caching.
   - uses: actions/setup-node@v4
     with:
       node-version-file: package.json
   - run: corepack enable yarn
     shell: bash
-  - uses: actions/setup-node@v4
-    with:
-      node-version-file: package.json
-      cache: yarn
 
   - uses: actions/setup-go@v5
     with:


### PR DESCRIPTION
Trying to see if this helps with issues in CI where Rancher Desktop no longer starts.  Hopefully this is due to a poisoned cache.