### PR TITLE
CI: Fix electron sandbox on Linux

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -41,3 +41,10 @@ runs:
 
   - run: yarn install --frozen-lockfile
     shell: bash
+
+  - name: Fix electron sandbox
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      sudo chown root node_modules/electron/dist/chrome-sandbox
+      sudo chmod 04755 node_modules/electron/dist/chrome-sandbox


### PR DESCRIPTION
As of Ubuntu 24.04, electron sandbox needs to be properly SUID to run; previously we were able to limp along.