### PR TITLE
docker-proxy: Recover if vsock listen fails

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/platform/vsock_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/vsock_linux.go
@@ -67,7 +67,7 @@ type vsockListener struct {
 func (v *vsockListener) Accept() (net.Conn, error) {
 	fd, sa, err := unix.Accept4(v.fd, unix.SOCK_NONBLOCK)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error accept()ing connection: %w", err)
 	}
 	return newVsockConn(uintptr(fd), &v.local, sockaddrToVsock(sa)), nil
 }


### PR DESCRIPTION
When listening on vsock, sometimes the listener falls over and does not recover.  In this case, tear down the listener and create a new one instead so the application can continue.

This seems to resolve some Windows E2E failures.