### PR TITLE
Remove host-resolver dependency from Networking

### DIFF
--- a/src/go/networking/cmd/host/switch_windows.go
+++ b/src/go/networking/cmd/host/switch_windows.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/rancher-sandbox/rancher-desktop-host-resolver/pkg/vmsock"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/config"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/vsock"
 )
@@ -189,7 +188,7 @@ func vsockHandshake(ctx context.Context, handshakePort uint32, signature string)
 		return nil, fmt.Errorf("trying to find WSL GUID failed: %w", err)
 	}
 	logrus.Infof("successful handshake, waiting for a vsock connection from VMGUID: %v on Port: %v", vmGUID.String(), vsockListenPort)
-	ln, err := vmsock.Listen(vmGUID, vsockListenPort)
+	ln, err := vsock.Listen(vmGUID, vsockListenPort)
 	if err != nil {
 		return nil, fmt.Errorf("creating vsock listener for host-switch failed: %w", err)
 	}

--- a/src/go/networking/go.mod
+++ b/src/go/networking/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/gopacket v1.1.19
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
-	github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5
 	github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
@@ -37,7 +36,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	golang.org/x/crypto v0.28.0 // indirect

--- a/src/go/networking/go.sum
+++ b/src/go/networking/go.sum
@@ -56,12 +56,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5 h1:F5m5WXPRjm/dNuz/cYZI+DjWwLGFyAVJglxG4ian61I=
-github.com/rancher-sandbox/rancher-desktop-host-resolver v0.1.5/go.mod h1:J4GpCMQjKJNvZVNtNsSIo6PfqkC8j5woaOcAgWg7NRA=
 github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011 h1:X8nBYGrEv9MLQWSnigWUBKHc0z6ztVZ1f8NKo1ixt3Q=
 github.com/rancher-sandbox/rancher-desktop/src/go/guestagent v0.0.0-20240911164922-5443d1a11011/go.mod h1:b1WHkY6WX8vcR97BCWkMRXXdjaQvmJvtc42mJZrx61I=
-github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036 h1:VyDF9gpc9ILr8LT9fgat8x6KG3bom5hRQlbxecdzDqs=
-github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036/go.mod h1:ARlcfTpJPOEcGXWwYoi5f/k7zb8g35ib3MiFtIlKaUc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=

--- a/src/go/networking/pkg/vsock/conn_windows.go
+++ b/src/go/networking/pkg/vsock/conn_windows.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2024 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsock
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/linuxkit/virtsock/pkg/hvsock"
+)
+
+func Listen(vmGUID hvsock.GUID, vsockPort uint32) (net.Listener, error) {
+	svcPort, err := hvsock.GUIDFromString(winio.VsockServiceID(vsockPort).String())
+	if err != nil {
+		return nil, fmt.Errorf("Listen, could not parse Hyper-v service GUID: %v", err)
+	}
+
+	addr := hvsock.Addr{
+		VMID:      vmGUID,
+		ServiceID: svcPort,
+	}
+
+	return hvsock.Listen(addr)
+}


### PR DESCRIPTION
Move the AF_VSOCK Listen function to its own package in Rancher Desktop Networking.