### PR TITLE
Bump to Lima 1.0.0-beta.0

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -15,7 +15,7 @@ entitlements:
     entitlements:
     - com.apple.security.cs.allow-jit
   - paths:
-    - Contents/Resources/resources/darwin/lima/bin/limactl.ventura
+    - Contents/Resources/resources/darwin/lima/bin/limactl
     entitlements:
     - com.apple.security.virtualization
   - paths:
@@ -45,7 +45,6 @@ entitlements:
 constraints:
 - paths:
   - Contents/Resources/resources/darwin/lima/bin/limactl
-  - Contents/Resources/resources/darwin/lima/bin/limactl.ventura
   self:
     team-identifier: '${AC_TEAMID}'
 

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,4 +1,4 @@
-lima: 0.21.0.rd2
+lima: 1.0.0.rd0
 limaAndQemu: 1.31.3
 socketVMNet: 1.1.7
 alpineLimaISO:

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -250,29 +250,6 @@ const LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/zzzzz-rancher-desktop-lima
 // Filename used in versions 1.0.0 and earlier:
 const PREVIOUS_LIMA_SUDOERS_LOCATION = '/private/etc/sudoers.d/rancher-desktop-lima';
 
-/** Forward compatible limactl binary allows for support of lima built for newer
- * versions of Darwin/macOS.
- *
- * When the xcode version used to build the forward compatible limactl binary
- * changes, update fwdCompatLimactlDarwinVer with the Darwin version
- * that xcode version is usually installed on.
- *
- * Xcode version used to build forward compatible limactl can be found here:
- * https://github.com/rancher-sandbox/lima-and-qemu/blob/main/.github/workflows/release.yml#L105
- *
- * Find which macOS the xcode version is installed on by default in the Xcode table:
- * https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)
- *
- * Then match the macOS version to the Darwin version.
- *
- * For Ventura see the Release History table:
- * https://en.wikipedia.org/wiki/MacOS_Ventura#Release_history
- */
-// Name of the forward compatible limactl binary installed by the lima dependencies script.
-const fwdCompatLimactlBin = 'limactl.ventura';
-// Version of Darwin the forward compatible limactl binary was built for.
-const fwdCompatLimactlDarwinVer = '22.1.0';
-
 /**
  * LimaBackend implements all the Lima-specific functionality for Rancher
  * Desktop.  This is used on macOS and Linux.
@@ -763,13 +740,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   protected static get limactl() {
-    let limactlBin = 'limactl';
-
-    if (os.platform() === 'darwin' && semver.gte(os.release(), fwdCompatLimactlDarwinVer)) {
-      limactlBin = fwdCompatLimactlBin;
-    }
-
-    return path.join(paths.resources, os.platform(), 'lima', 'bin', limactlBin);
+    return path.join(paths.resources, os.platform(), 'lima', 'bin', 'limactl');
   }
 
   protected static get qemuImg() {


### PR DESCRIPTION
Get rid of `limactl.ventura`, we are going to use the macOS-13 binaries everywhere. Testing by the Lima project itself indicates that releases build on latest XCode still work on older macOS versions.

Fixes #7463
Closes #7669