### PR TITLE
Move macos-12 runners to macos-13

### DIFF
--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -18,7 +18,7 @@ import sys
 from typing import Iterator, List, Literal, get_args
 
 Platforms = Literal["linux", "mac", "win"]
-Hosts = Literal["ubuntu-latest", "macos-12", "windows-latest"]
+Hosts = Literal["ubuntu-latest", "macos-13", "windows-latest"]
 Engines = Literal["containerd", "moby"]
 
 @dataclasses.dataclass
@@ -56,7 +56,7 @@ def skip_test(test: Result) -> bool:
     Check if a given test should be skipped.
     We skip some tests because the CI machines can't handle them.
     """
-    if test.host == "macos-12" and test.name.startswith("k8s/"):
+    if test.host == "macos-13" and test.name.startswith("k8s/"):
         # The macOS CI runners are slow; skip some tests that can be tested on
         # other OSes.
         skipped_tests = ("verify-cached-images",)
@@ -73,7 +73,7 @@ for test in (os.environ.get("TESTS", None) or "*").split():
     for platform in platforms:
       host: Hosts = {
          "linux": "ubuntu-latest",
-         "mac": "macos-12",
+         "mac": "macos-13",
          "win": "windows-latest",
       }[platform]
       for name in resolve_test(test, platform):

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
         - platform: mac
-          runs-on: macos-12
+          runs-on: macos-13
         - platform: win
           runs-on: windows-latest
         - platform: linux


### PR DESCRIPTION
Because macos-12 will be removed early December, and have several day-long outages in November.

Fixes #7601