### PR TITLE
Remove Listener Creation for Containerd Events

### DIFF
--- a/src/go/guestagent/pkg/tracker/apitracker.go
+++ b/src/go/guestagent/pkg/tracker/apitracker.go
@@ -51,7 +51,6 @@ type APITracker struct {
 	tapInterfaceIP    string
 	portStorage       *portStorage
 	apiForwarder      *forwarder.APIForwarder
-	*ListenerTracker
 }
 
 // NewAPITracker creates a new instance of APITracker with the specified configuration.
@@ -75,7 +74,6 @@ func NewAPITracker(ctx context.Context, wslProxyForwarder forwarder.Forwarder, b
 		tapInterfaceIP:    tapIfaceIP,
 		portStorage:       newPortStorage(),
 		apiForwarder:      forwarder.NewAPIForwarder(baseURL),
-		ListenerTracker:   NewListenerTracker(),
 	}
 }
 

--- a/src/go/guestagent/pkg/tracker/tracker.go
+++ b/src/go/guestagent/pkg/tracker/tracker.go
@@ -15,22 +15,7 @@ limitations under the License.
 // of the ports during various container event types e.g start, stop
 package tracker
 
-import (
-	"context"
-	"net"
-
-	"github.com/docker/go-connections/nat"
-)
-
-// NetTracker is the interface that wraps the methods
-// that are used to manage Add/Remove tcp listeners.
-type NetTracker interface {
-	// AddListener creates a TCP listener for a given IP and Port.
-	AddListener(ctx context.Context, ip net.IP, port int) error
-
-	// RemoveListener removes a TCP listener for a given IP and Port.
-	RemoveListener(ctx context.Context, ip net.IP, port int) error
-}
+import "github.com/docker/go-connections/nat"
 
 // Tracker is the interface that includes all the functions that
 // are used to keep track of the port mappings plus NetTracker methods
@@ -49,6 +34,4 @@ type Tracker interface {
 
 	// RemoveAll removes all the available portMappings in the storage.
 	RemoveAll() error
-
-	NetTracker
 }


### PR DESCRIPTION
Historically, when containerd events were received, we created listeners to leverage the WSL listener forwarding feature. This was necessary because containerd, unlike Docker, didn't create listeners for running containers. Instead, it routed traffic through iptables rules in the CNI-HOSTPORT-DNAT chain, manipulating container traffic directly.

However, with the new namespaced network configuration, the WSL listener forwarding feature is no longer in use. As a result, we no longer need to manually create listeners for each running container.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7782