### PR TITLE
Use custom SPIN_DATA_DIR for spin plugins and templates

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -900,7 +900,7 @@ Wrapf
 wsl
 wslapi
 wslconfig
-WSLENV
+wslenv
 WSLg
 wslify
 wslinfo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -131,6 +131,14 @@ updates:
     reviewers: [ "jandubois" ]
 
   - package-ecosystem: "gomod"
+    directory: "/src/go/spin-stub"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 12
+    labels: ["component/dependencies"]
+    reviewers: [ "jandubois" ]
+
+  - package-ecosystem: "gomod"
     directory: "/src/go/wsl-helper"
     schedule:
       interval: "daily"

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -21,6 +21,8 @@ local_setup() {
 }
 
 @test 'deploy app to kubernetes' {
+    # Newer versions of the sample app have moved from "deislabs" to "spinkube":
+    # ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.13.0
     spin kube deploy --from ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
 }
 

--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -98,6 +98,8 @@ spec:
       runtimeClassName: spin
       containers:
       - name: hello-spin
+        # Newer versions of the sample app have moved from "deislabs" to "spinkube":
+        # ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.13.0
         image: ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
         command: ["/"]
 EOF

--- a/bats/tests/utils/spin.bats
+++ b/bats/tests/utils/spin.bats
@@ -3,20 +3,7 @@ load '../helpers/load'
 # Verify that enabling Wasm support will install spin plugins and templates
 
 local_setup() {
-    if is_windows; then
-        if using_windows_exe; then
-            SPIN_DATA_DIR=$LOCALAPPDATA
-        else
-            SPIN_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
-        fi
-    elif is_macos; then
-        SPIN_DATA_DIR="${HOME}/Library/Application Support"
-    elif is_linux; then
-        SPIN_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
-    else
-        skip "Unknown OS: $OS"
-    fi
-    SPIN_DATA_DIR="${SPIN_DATA_DIR}/spin"
+    SPIN_DATA_DIR="${PATH_APP_HOME}/spin"
 }
 
 cmd_exe() {

--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -17,12 +17,12 @@ resources/resources/win32/bin:
 - docker-credential-none.exe
 - nerdctl.exe
 - rdctl.exe
+- spin.exe
 - '!docker-credential-ecr-login.exe'
 - '!docker-credential-wincred.exe'
 - '!helm.exe'
 - '!kubectl.exe'
 - '!kuberlr.exe'
-- '!spin.exe'
 resources/resources/win32/docker-cli-plugins:
 - '!docker-buildx.exe'
 - '!docker-compose.exe'
@@ -30,3 +30,4 @@ resources/resources/win32/internal:
 - host-switch.exe
 - steve.exe
 - wsl-helper.exe
+- '!spin.exe'

--- a/go.work
+++ b/go.work
@@ -12,5 +12,6 @@ use (
 	./src/go/nerdctl-stub/generate
 	./src/go/networking
 	./src/go/rdctl
+	./src/go/spin-stub
 	./src/go/wsl-helper
 )

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -24,3 +24,5 @@ spinShim: 0.17.0
 spinOperator: 0.4.0
 certManager: 1.16.2
 spinCLI: 3.0.0
+spinKubePlugin: 0.3.1
+js2wasmPlugin: 0.6.1

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1485,7 +1485,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
       promises.push(BackendHelper.configureContainerEngine(this, configureWASM));
       if (configureWASM) {
-        promises.push(this.spawnWithCapture(executable('setup-spin')));
+        const version = semver.parse(DEPENDENCY_VERSIONS.spinCLI);
+        const env = {
+          ...process.env,
+          KUBE_PLUGIN_VERSION:    DEPENDENCY_VERSIONS.spinKubePlugin,
+          JS2WASM_PLUGIN_VERSION: DEPENDENCY_VERSIONS.js2wasmPlugin,
+          SPIN_TEMPLATE_BRANCH:   (version ? `v${ version.major }.${ version.minor }` : 'main'),
+        };
+
+        promises.push(this.spawnWithCapture(executable('setup-spin'), { env }));
       }
       await Promise.all(promises);
     } catch (err) {

--- a/resources/darwin/bin/spin
+++ b/resources/darwin/bin/spin
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu -o pipefail
+
+scriptname="${BASH_SOURCE[0]}"
+while [ -L "${scriptname}" ]; do
+    scriptname=$(readlink "${scriptname}")
+done
+scriptdir=$(cd "$(dirname "${scriptname}")" && pwd)
+internal=$(cd "${scriptdir}/../internal" && pwd)
+
+export SPIN_DATA_DIR="$HOME/Library/Application Support/rancher-desktop/spin"
+mkdir -p "$SPIN_DATA_DIR"
+exec "${internal}/spin" "$@"

--- a/resources/linux/bin/spin
+++ b/resources/linux/bin/spin
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu -o pipefail
+
+scriptname="${BASH_SOURCE[0]}"
+while [ -L "${scriptname}" ]; do
+    scriptname=$(readlink "${scriptname}")
+done
+scriptdir=$(cd "$(dirname "${scriptname}")" && pwd)
+internal=$(cd "${scriptdir}/../internal" && pwd)
+
+export SPIN_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/rancher-desktop/spin"
+mkdir -p "$SPIN_DATA_DIR"
+exec "${internal}/spin" "$@"

--- a/resources/setup-spin
+++ b/resources/setup-spin
@@ -23,18 +23,9 @@ if [ ! -x "$spin" ]; then
   exit 1
 fi
 
-assert_dir_is_empty() {
-  # shellcheck disable=SC2012 # Using `ls` is fine
-  if [ -d "$1" ] && [ "$(ls -1 "$1" | wc -l)" -gt 0 ]; then
-    echo "'$1' already exists and is not empty"
-    exit 0
-  fi
-}
-
-spin_dir="${app_data_dir}/spin"
-
-assert_dir_is_empty "${spin_dir}/templates"
-assert_dir_is_empty "${spin_dir}/plugins"
+# This is the WSL path, not the Win32 path, so we can't use it to set SPIN_DATA_DIR.
+# We rely on the spin/spin.exe wrapper to setup SPIN_DATA_DIR and use spin_dir only for temp files.
+spin_dir="${app_data_dir}/rancher-desktop/spin"
 
 if [ "${WSL_DISTRO_NAME:-}" = "rancher-desktop" ]; then
   echo "Waiting for github.com to become resolvable"
@@ -52,7 +43,7 @@ fi
 # We do need either curl or wget to be on the PATH though.
 install_templates() {
   repo=$1
-  branch=main
+  branch=$2
   tmpdir="${spin_dir}/rancher-desktop.$$"
   tarball="${tmpdir}/${repo}.tar.gz"
 
@@ -71,12 +62,11 @@ install_templates() {
 
     if [ $rc -eq 0 ]; then
       echo "Unpacking '${tarball}'"
-      "${system_root}/system32/tar.exe" xfz "$tarball" -C "$tmpdir"
+      "${system_root}/system32/tar.exe" xfz "$tarball" -C "$tmpdir" --strip-components 1
       rc=$?; test $rc -ne 0 && echo "tar.exe exit status is $rc"
 
-      dir="${tmpdir}\\${repo}-${branch}"
-      echo "Installing templates from '${dir}'"
-      "$spin" templates install --update --dir "$dir"
+      echo "Installing templates from '${tmpdir}'"
+      "$spin" templates install --update --dir "$tmpdir"
       rc=$?; test $rc -ne 0 && echo "Exit status is $rc"
     else
       echo "Could not download '${url}'"
@@ -97,12 +87,11 @@ install_templates() {
   fi
   if [ -f "$tarball" ]; then
     echo "Unpacking '${tarball}'"
-    tar xfz "$tarball" -C "$tmpdir"
+    tar xfz "$tarball" -C "$tmpdir" --strip-components 1
     rc=$?; test $rc -ne 0 && echo "tar exit status is $rc"
 
-    dir="${tmpdir}/${repo}-${branch}"
-    echo "Installing templates from '${dir}'"
-    "$spin" templates install --update --dir "$dir"
+    echo "Installing templates from '${tmpdir}'"
+    "$spin" templates install --update --dir "$tmpdir"
     rc=$?; test $rc -ne 0 && echo "Exit status is $rc"
   else
     echo "Could not download '${url}' (maybe no curl/wget)"
@@ -112,17 +101,18 @@ install_templates() {
 
 install_plugin() {
   plugin=$1
-  url="https://raw.githubusercontent.com/fermyon/spin-plugins/main/manifests/${plugin}/${plugin}.json"
-  echo "Installing plugin from '${url}'"
-  "$spin" plugins install --yes --url "$url"
+  version=$2
+  echo "Installing plugin ${plugin} version ${version}"
+  "$spin" plugins uninstall "$plugin" || true
+  "$spin" plugins install --yes --version "${version}" "$plugin"
   rc=$?; test $rc -ne 0 && echo "Exit status is $rc"
 }
 
-install_templates spin
-install_templates spin-python-sdk
-install_templates spin-js-sdk
+install_templates spin "${SPIN_TEMPLATE_BRANCH:-main}"
+install_templates spin-python-sdk main
+install_templates spin-js-sdk main
 
-install_plugin js2wasm
-install_plugin kube
+install_plugin js2wasm "${JS2WASM_PLUGIN_VERSION:-0.6.1}"
+install_plugin kube "${KUBE_PLUGIN_VERSION:-0.3.1}"
 
 echo "'${spin}' setup complete"

--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -135,3 +135,14 @@ export class NerdctlStub extends GoDependency {
     return path.join(context.resourcesDir, context.platform, 'bin', leafName);
   }
 }
+
+export class SpinStub extends GoDependency {
+  constructor() {
+    super('spin-stub');
+  }
+
+  override outFile(context: DownloadContext) {
+    // spin-stub is only used on Windows
+    return path.join(context.resourcesDir, context.platform, 'bin', 'spin.exe');
+  }
+}

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -587,7 +587,7 @@ export class SpinCLI implements Dependency, GitHubDependency {
     const options: ArchiveDownloadOptions = { expectedChecksum, entryName };
     const downloadFunc = context.platform.startsWith('win') ? downloadZip : downloadTarGZ;
 
-    await downloadFunc(`${ baseURL }/${ archiveName }`, path.join(context.binDir, entryName), options);
+    await downloadFunc(`${ baseURL }/${ archiveName }`, path.join(context.internalDir, entryName), options);
   }
 
   async getAvailableVersions(includePrerelease = false): Promise<string[]> {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -61,6 +61,7 @@ const windowsDependencies = [
   new goUtils.GoDependency('networking/cmd/host', 'internal/host-switch'),
   new goUtils.WSLHelper(),
   new goUtils.NerdctlStub(),
+  new goUtils.SpinStub(),
 ];
 
 // Dependencies that are specific to WSL.

--- a/src/go/spin-stub/README.md
+++ b/src/go/spin-stub/README.md
@@ -4,4 +4,4 @@ This is a stub executable used to launch spin on Windows.
 
 ## Usage
 
-Use like normal spin. It just sets up `SPIN_DATA_DIR` to point to the `spin` subdirectory in the Rancher Desktop application data directory and then invokes `../internal/spin.exe` (relative to the location of the `spin-stub` binary).
+Use it as you would with a normal `spin` command. It simply configures the `SPIN_DATA_DIR` environment variable to point to the spin subdirectory within the Rancher Desktop application data directory, and then runs `../internal/spin.exe` (relative to the location of the `spin-stub` binary).

--- a/src/go/spin-stub/README.md
+++ b/src/go/spin-stub/README.md
@@ -1,0 +1,7 @@
+# spin-stub
+
+This is a stub executable used to launch spin on Windows.
+
+## Usage
+
+Use like normal spin. It just sets up `SPIN_DATA_DIR` to point to the `spin` subdirectory in the Rancher Desktop application data directory and then invokes `../internal/spin.exe` (relative to the location of the `spin-stub` binary).

--- a/src/go/spin-stub/go.mod
+++ b/src/go/spin-stub/go.mod
@@ -1,0 +1,3 @@
+module github.com/rancher-sandbox/rancher-desktop/src/go/spin-stub
+
+go 1.22.0

--- a/src/go/spin-stub/main.go
+++ b/src/go/spin-stub/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const appName = "rancher-desktop"
+
+func main() {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Sprintf("failed to get user home directory: %s", err))
+	}
+	localAppData := os.Getenv("LOCALAPPDATA")
+	if localAppData == "" {
+		localAppData = filepath.Join(homeDir, "AppData", "Local")
+	}
+	err = os.Setenv("SPIN_DATA_DIR", filepath.Join(localAppData, appName, "spin"))
+	if err != nil {
+		panic(fmt.Sprintf("failed to set SPIN_DATA_DIR: %s", err))
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		panic(fmt.Sprintf("failed to get executable path: %s", err))
+	}
+	spin := filepath.Join(filepath.Dir(filepath.Dir(exe)), "internal", "spin.exe")
+	command := exec.Command(spin, os.Args[1:]...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	err = command.Run()
+	if err != nil {
+		panic(fmt.Sprintf("failed to execute command: %s", err))
+	}
+}

--- a/src/go/spin-stub/main.go
+++ b/src/go/spin-stub/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,7 +13,7 @@ const appName = "rancher-desktop"
 func main() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		panic(fmt.Sprintf("failed to get user home directory: %s", err))
+		panic(fmt.Errorf("failed to retrieve the user's home directory: %w", err))
 	}
 	localAppData := os.Getenv("LOCALAPPDATA")
 	if localAppData == "" {
@@ -20,11 +21,11 @@ func main() {
 	}
 	err = os.Setenv("SPIN_DATA_DIR", filepath.Join(localAppData, appName, "spin"))
 	if err != nil {
-		panic(fmt.Sprintf("failed to set SPIN_DATA_DIR: %s", err))
+		panic(fmt.Errorf("failed to set SPIN_DATA_DIR: %w", err))
 	}
 	exe, err := os.Executable()
 	if err != nil {
-		panic(fmt.Sprintf("failed to get executable path: %s", err))
+		panic(fmt.Errorf("failed to get executable path: %w", err))
 	}
 	spin := filepath.Join(filepath.Dir(filepath.Dir(exe)), "internal", "spin.exe")
 	command := exec.Command(spin, os.Args[1:]...)
@@ -32,7 +33,11 @@ func main() {
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
 	err = command.Run()
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		os.Exit(exitError.ExitCode())
+	}
 	if err != nil {
-		panic(fmt.Sprintf("failed to execute command: %s", err))
+		panic(fmt.Errorf("failed to execute command: %w", err))
 	}
 }


### PR DESCRIPTION
Pin bundled spin version incl plugins and templates

Due to recent backwards incompatible changes in the `spinkube` operator ecosystem we need to tightly control the version of the `spin` executable and `kube` plugin to ensure they are compatible with the `spinkube` operator.

We use a shim script (or executable on Windows) to set `SPIN_DATA_DIR` to `$APPDATA/rancher-desktop/spin` and reinstall plugins and templates to the pinned versions on each start of the application (if Wasm support is enabled).

As usual, users can put a `spin` version managed by themselves on the front of the `PATH` if they want to use a different version.