### PR TITLE
Don't package the qemu.*.tgz tarballs

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -10,7 +10,9 @@ electronLanguages: [ en-US ]
 extraResources:
 - resources/
 - '!resources/darwin/lima*.tgz'
+- '!resources/darwin/qemu*.tgz'
 - '!resources/linux/lima*.tgz'
+- '!resources/linux/qemu*.tgz'
 - '!resources/linux/staging/'
 - '!resources/win32/staging/'
 - '!resources/host/'


### PR DESCRIPTION
QEMU used to be included in the lima-and-qemu* tarballs, which are already excluded from packaging, but now we have separate qemu.* releases.