### PR TITLE
Win32: Spawn extension processes in job

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -378,6 +378,7 @@ iwr
 jan
 jetstack
 jitconfig
+JOBOBJECT
 joycelin
 jpe
 jsmith
@@ -770,6 +771,7 @@ ssd
 sshfs
 sslip
 Ssr
+STARTUPINFO
 statefulset
 stoinks
 storageclass

--- a/pkg/rancher-desktop/main/snapshots/snapshots.ts
+++ b/pkg/rancher-desktop/main/snapshots/snapshots.ts
@@ -116,7 +116,7 @@ class SnapshotsImpl {
 
           if (pid) {
             console.log(`Found process ${ command } with PID ${ pid }`);
-            await spawnFile(exe, ['kill-process', `--pid=${ pid }`], { stdio: console });
+            await spawnFile(exe, ['process', 'kill', `--pid=${ pid }`], { stdio: console });
           }
         }
       } else {

--- a/src/go/rdctl/pkg/directories/directories_windows.go
+++ b/src/go/rdctl/pkg/directories/directories_windows.go
@@ -26,8 +26,8 @@ import (
 
 // InvokeWin32WithBuffer calls the given function with increasing buffer sizes
 // until it does not return ERROR_INSUFFICIENT_BUFFER.
-func InvokeWin32WithBuffer(cb func(size int) error) error {
-	size := 256
+func InvokeWin32WithBuffer(initialSize int, cb func(size int) error) error {
+	size := initialSize
 	for {
 		err := cb(size)
 		if err == nil {

--- a/src/go/rdctl/pkg/directories/directories_windows.go
+++ b/src/go/rdctl/pkg/directories/directories_windows.go
@@ -26,8 +26,8 @@ import (
 
 // InvokeWin32WithBuffer calls the given function with increasing buffer sizes
 // until it does not return ERROR_INSUFFICIENT_BUFFER.
-func InvokeWin32WithBuffer(initialSize int, cb func(size int) error) error {
-	size := initialSize
+func InvokeWin32WithBuffer(cb func(size int) error) error {
+	size := 256
 	for {
 		err := cb(size)
 		if err == nil {

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -40,16 +40,17 @@ type JOBOBJECT_BASIC_LIMIT_INFORMATION struct {
 	PriorityClass           uint32
 	SchedulingClass         uint32
 }
+type IO_COUNTERS struct {
+	ReadOperationCount  uint64
+	WriteOperationCount uint64
+	OtherOperationCount uint64
+	ReadTransferCount   uint64
+	WriteTransferCount  uint64
+	OtherTransferCount  uint64
+}
 type JOBOBJECT_EXTENDED_LIMIT_INFORMATION struct {
 	BasicLimitInformation JOBOBJECT_BASIC_LIMIT_INFORMATION
-	IoInfo                struct {
-		ReadOperationCount  uint64
-		WriteOperationCount uint64
-		OtherOperationCount uint64
-		ReadTransferCount   uint64
-		WriteTransferCount  uint64
-		OtherTransferCount  uint64
-	}
+	IoInfo                IO_COUNTERS
 	ProcessMemoryLimit    uintptr
 	JobMemoryLimit        uintptr
 	PeakProcessMemoryUsed uintptr
@@ -76,26 +77,43 @@ var (
 	heapFree                  = hKernel32.NewProc("HeapFree")
 )
 
-// Convert a list of arguments into a command line for use with CreateProcess.
-// This is the reverse of `windows.DecomposeCommandLine()`.
+// buildCommandLine convert a slice of arguments into a properly formatted
+// command line string suitable for use with [windows.CreateProcess].  This
+// function is the reverse of [windows.DecomposeCommandLine], which parses a
+// command line string into individual arguments.
+//
+// The function follows the parsing rules for command-line arguments as outlined in
+// https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments
+//
+// Key behaviors include:
+//
+//  1. The first argument (typically the executable name) is treated specially and
+//     enclosed in double quotes without applying backslash escape rules,
+//     including for embedded quotes.
+//
+//  2. Each subsequent argument is wrapped in double quotes, and any internal
+//     quotes or backslashes are escaped appropriately according to the rules for
+//     Windows command-line parsing:
+//
+//     - Backslashes preceding a quote are doubled (e.g., \ becomes \\), and the
+//     quote itself is escaped.
+//
+//     - Backslashes followed by non-quote characters are preserved as-is.
 func buildCommandLine(args []string) string {
-	// See https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments
-	// for details on how it must be parsed.
-	var result []byte
+	var builder strings.Builder
 
 	// argv[0], i.e. the executable name, must be treated specially.  It is quoted
 	// without any of the backslash escape rules.  This includes not being able to
 	// escape quotes.
-	if len(args) > 1 {
-		result = append(result, '"')
-		result = append(result, args[0]...)
-		result = append(result, '"')
+	if len(args) > 0 {
+		_, _ = builder.WriteString("\"")
+		_, _ = builder.WriteString(args[0])
+		_, _ = builder.WriteString("\"")
 	}
 
 	for _, word := range args[1:] {
-		result = append(result, ' ')
 		slashes := 0
-		result = append(result, '"')
+		_, _ = builder.WriteString(" \"")
 		for _, ch := range []byte(word) {
 			if ch == '\\' {
 				slashes += 1
@@ -104,29 +122,29 @@ func buildCommandLine(args []string) string {
 				// to be escaped by another backslash, and then the quote must be
 				// itself escaped.
 				for i := 0; i < slashes; i++ {
-					result = append(result, '\\', '\\')
+					_, _ = builder.WriteString("\\\\")
 				}
-				result = append(result, '\\', '"')
+				_, _ = builder.WriteString("\\\"")
 				slashes = 0
 			} else {
 				// If a run of backslashes is followed by a non-quote character, all of
 				// the backslashes are treated literally.
 				for i := 0; i < slashes; i++ {
-					result = append(result, '\\')
+					_, _ = builder.WriteString("\\")
 				}
-				result = append(result, ch)
+				_ = builder.WriteByte(ch)
 				slashes = 0
 			}
 		}
 		// If the word ends in slashes, because we're adding a quote we must escape
 		// all of the slashes.
 		for i := 0; i < slashes; i++ {
-			result = append(result, '\\', '\\')
+			_, _ = builder.WriteString("\\\\")
 		}
-		result = append(result, '"')
+		_, _ = builder.WriteString("\"")
 	}
 
-	return string(result)
+	return builder.String()
 }
 
 // Given a job handle, spawn a process in the given job.  The function does not
@@ -136,27 +154,30 @@ func spawnProcessInJob(job windows.Handle, commandLine *uint16) (*os.ProcessStat
 	// We need the handle to have a stable address for the jobs list; we
 	// do this by allocating memory in C to avoid the golang GC moving
 	// things around.
-	heap, _, err := getProcessHeap.Call(0, 0, 0)
+	heap, _, err := getProcessHeap.Call()
 	if heap == 0 {
 		return nil, fmt.Errorf("failed to get process heap: %w", err)
 	}
 
 	jobList, _, err := heapAlloc.Call(heap, 0, unsafe.Sizeof(job))
 	if jobList == 0 {
-		return nil, fmt.Errorf("failed to allocate memory: %s", err)
+		return nil, fmt.Errorf("failed to allocate memory: %w", err)
 	}
 	defer func() {
-		_, _, _ = heapFree.Call(heap, 0, jobList)
+		if ok, _, err := heapFree.Call(heap, 0, jobList); ok == 0 {
+			logrus.Tracef("Ignoring error %s freeing job list", err)
+		}
 	}()
 	*(*windows.Handle)(unsafe.Pointer(jobList)) = job
 
-	attrList, err := windows.NewProcThreadAttributeList(1)
+	maxAttrCount := uint32(1) // We only have PROC_THREAD_ATTRIBUTE_JOB_LIST
+	attrList, err := windows.NewProcThreadAttributeList(maxAttrCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate process attributes: %s", err)
+		return nil, fmt.Errorf("failed to allocate process attributes: %w", err)
 	}
 	err = attrList.Update(PROC_THREAD_ATTRIBUTE_JOB_LIST, unsafe.Pointer(jobList), unsafe.Sizeof(job))
 	if err != nil {
-		return nil, fmt.Errorf("failed to update process attributes: %s", err)
+		return nil, fmt.Errorf("failed to update process attributes: %w", err)
 	}
 	startupInfo := windows.StartupInfoEx{
 		StartupInfo: windows.StartupInfo{
@@ -186,6 +207,54 @@ func spawnProcessInJob(job windows.Handle, commandLine *uint16) (*os.ProcessStat
 	return state, nil
 }
 
+// configureJobLimits configures the given job to prevent processes in the job
+// from breaking away, and flags the job to terminate when the last handle to
+// the job is closed.
+func configureJobLimits(job windows.Handle) error {
+	var limits JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	ok, _, err := queryInformationJobObject.Call(
+		uintptr(job),
+		JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)),
+		unsafe.Sizeof(limits),
+		uintptr(unsafe.Pointer(nil)))
+	if ok == 0 {
+		return fmt.Errorf("error looking up job limits: %w", err)
+	}
+
+	// Prevent processes from breaking away from the job.
+	breakAwayFlags := JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
+	limits.BasicLimitInformation.LimitFlags &= ^breakAwayFlags
+	// Flag the job to terminate when the last handle to the job is closed.
+	limits.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+	ok, _, err = setInformationJobObject.Call(
+		uintptr(job),
+		JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)),
+		unsafe.Sizeof(limits))
+	if ok == 0 {
+		return fmt.Errorf("error setting job limits: %w", err)
+	}
+
+	return nil
+}
+
+// injectHandleInProcess creates a copy of the provided handle into the
+// specified process.  As nothing refers to the handle otherwise, the duplicated
+// handle will only be closed when the specified process exits.
+func injectHandleInProcess(pid uint32, handle windows.Handle) error {
+	process, err := windows.OpenProcess(windows.PROCESS_DUP_HANDLE, false, pid)
+	if err != nil {
+		return fmt.Errorf("failed to open parent process %d: %w", pid, err)
+	}
+	err = windows.DuplicateHandle(windows.CurrentProcess(), handle, process, nil, 0, false, 0)
+	if err != nil {
+		return fmt.Errorf("failed to inject job into parent process %d: %w", pid, err)
+	}
+	return nil
+}
+
 // Spawn a process in the Rancher Desktop job.  If the job doesn't exist, ensure
 // that the given process has a handle to the new job.  Returns the resulting
 // process state after the process exits; the caller may get the process exit
@@ -209,41 +278,18 @@ func SpawnProcessInRDJob(pid uint32, command []string) (*os.ProcessState, error)
 	defer func() {
 		_ = windows.CloseHandle(job)
 	}()
+	// Check whether a new job was created, or an existing one was found.
 	if !errors.Is(err, os.ErrExist) {
 		// The job was newly created.
 
-		// Set the job so processes can't break away, and it terminates when the
-		// last handle is closed.
-		var limits JOBOBJECT_EXTENDED_LIMIT_INFORMATION
-		ok, _, err := queryInformationJobObject.Call(
-			uintptr(job),
-			JobObjectExtendedLimitInformation,
-			uintptr(unsafe.Pointer(&limits)),
-			unsafe.Sizeof(limits),
-			uintptr(unsafe.Pointer(nil)))
-		if ok == 0 {
-			return nil, fmt.Errorf("error looking up job limits: %w", err)
-		}
-		limits.BasicLimitInformation.LimitFlags &= ^(JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)
-		limits.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
-		ok, _, err = setInformationJobObject.Call(
-			uintptr(job),
-			JobObjectExtendedLimitInformation,
-			uintptr(unsafe.Pointer(&limits)),
-			unsafe.Sizeof(limits))
-		if ok == 0 {
-			return nil, fmt.Errorf("error setting job limits: %w", err)
+		if err = configureJobLimits(job); err != nil {
+			return nil, err
 		}
 
 		// Duplicate the job into the given process (but leaking it).  This way when
 		// the target process exits, it will shut down the job.
-		hProc, err := windows.OpenProcess(windows.PROCESS_DUP_HANDLE, false, pid)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open parent process %d: %w", pid, err)
-		}
-		err = windows.DuplicateHandle(windows.CurrentProcess(), job, hProc, nil, 0, false, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to inject job into parent process %d: %w", pid, err)
+		if err = injectHandleInProcess(pid, job); err != nil {
+			return nil, err
 		}
 	}
 
@@ -260,13 +306,13 @@ func SpawnProcessInRDJob(pid uint32, command []string) (*os.ProcessState, error)
 }
 
 // TerminateProcessInDirectory terminates all processes where the executable
-// resides within the given directory, as gracefully as possible.  If `force` is
+// resides within the given directory, as gracefully as possible.  If force is
 // set, SIGKILL is used instead.
 func TerminateProcessInDirectory(directory string, force bool) error {
 	var pids []uint32
 	// Try EnumProcesses until the number of pids returned is less than the
 	// buffer size.
-	err := directories.InvokeWin32WithBuffer(256, func(size int) error {
+	err := directories.InvokeWin32WithBuffer(func(size int) error {
 		pids = make([]uint32, size)
 		var bytesReturned uint32
 		err := windows.EnumProcesses(pids, &bytesReturned)
@@ -305,7 +351,7 @@ func TerminateProcessInDirectory(directory string, force bool) error {
 			}()
 
 			var executablePath string
-			err = directories.InvokeWin32WithBuffer(256, func(size int) error {
+			err = directories.InvokeWin32WithBuffer(func(size int) error {
 				nameBuf := make([]uint16, size)
 				charsWritten := uint32(size)
 				err := windows.QueryFullProcessImageName(hProc, 0, &nameBuf[0], &charsWritten)

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -297,7 +297,7 @@ func TerminateProcessInDirectory(directory string, force bool) error {
 				false,
 				pid)
 			if err != nil {
-				logrus.Infof("Ignoring error opening process %d: %s", pid, err)
+				logrus.Debugf("Ignoring error opening process %d: %s", pid, err)
 				return
 			}
 			defer func() {

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -17,6 +17,7 @@ limitations under the License.
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,236 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+type JOBOBJECT_BASIC_LIMIT_INFORMATION struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+type JOBOBJECT_EXTENDED_LIMIT_INFORMATION struct {
+	BasicLimitInformation JOBOBJECT_BASIC_LIMIT_INFORMATION
+	IoInfo                struct {
+		ReadOperationCount  uint64
+		WriteOperationCount uint64
+		OtherOperationCount uint64
+		ReadTransferCount   uint64
+		WriteTransferCount  uint64
+		OtherTransferCount  uint64
+	}
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+const (
+	jobName                              = "RancherDesktopJob"
+	JobObjectExtendedLimitInformation    = 9
+	JOB_OBJECT_LIMIT_BREAKAWAY_OK        = uint32(0x00000800)
+	JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE   = uint32(0x00002000)
+	JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK = uint32(0x00001000)
+	PROC_THREAD_ATTRIBUTE_JOB_LIST       = 0x0002000D // 13 + input
+)
+
+var (
+	hKernel32 = windows.NewLazySystemDLL("kernel32")
+
+	createJobObject           = hKernel32.NewProc("CreateJobObjectW")
+	queryInformationJobObject = hKernel32.NewProc("QueryInformationJobObject")
+	setInformationJobObject   = hKernel32.NewProc("SetInformationJobObject")
+	getProcessHeap            = hKernel32.NewProc("GetProcessHeap")
+	heapAlloc                 = hKernel32.NewProc("HeapAlloc")
+	heapFree                  = hKernel32.NewProc("HeapFree")
+)
+
+// Convert a list of arguments into a command line for use with CreateProcess.
+// This is the reverse of `windows.DecomposeCommandLine()`.
+func buildCommandLine(args []string) string {
+	// See https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments
+	// for details on how it must be parsed.
+	var result []byte
+
+	// argv[0], i.e. the executable name, must be treated specially.  It is quoted
+	// without any of the backslash escape rules.  This includes not being able to
+	// escape quotes.
+	if len(args) > 1 {
+		result = append(result, '"')
+		result = append(result, args[0]...)
+		result = append(result, '"')
+	}
+
+	for _, word := range args[1:] {
+		result = append(result, ' ')
+		slashes := 0
+		result = append(result, '"')
+		for _, ch := range []byte(word) {
+			if ch == '\\' {
+				slashes += 1
+			} else if ch == '"' {
+				// If a run of backslashes is followed by a quote, each backslash needs
+				// to be escaped by another backslash, and then the quote must be
+				// itself escaped.
+				for i := 0; i < slashes; i++ {
+					result = append(result, '\\', '\\')
+				}
+				result = append(result, '\\', '"')
+				slashes = 0
+			} else {
+				// If a run of backslashes is followed by a non-quote character, all of
+				// the backslashes are treated literally.
+				for i := 0; i < slashes; i++ {
+					result = append(result, '\\')
+				}
+				result = append(result, ch)
+				slashes = 0
+			}
+		}
+		// If the word ends in slashes, because we're adding a quote we must escape
+		// all of the slashes.
+		for i := 0; i < slashes; i++ {
+			result = append(result, '\\', '\\')
+		}
+		result = append(result, '"')
+	}
+
+	return string(result)
+}
+
+// Given a job handle, spawn a process in the given job.  The function does not
+// return until the process exits.
+func spawnProcessInJob(job windows.Handle, commandLine *uint16) (*os.ProcessState, error) {
+	logrus.Tracef("Spawning in job %x: %s", job, windows.UTF16PtrToString(commandLine))
+	// We need the handle to have a stable address for the jobs list; we
+	// do this by allocating memory in C to avoid the golang GC moving
+	// things around.
+	heap, _, err := getProcessHeap.Call(0, 0, 0)
+	if heap == 0 {
+		return nil, fmt.Errorf("failed to get process heap: %w", err)
+	}
+
+	jobList, _, err := heapAlloc.Call(heap, 0, unsafe.Sizeof(job))
+	if jobList == 0 {
+		return nil, fmt.Errorf("failed to allocate memory: %s", err)
+	}
+	defer func() {
+		_, _, _ = heapFree.Call(heap, 0, jobList)
+	}()
+	*(*windows.Handle)(unsafe.Pointer(jobList)) = job
+
+	attrList, err := windows.NewProcThreadAttributeList(1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate process attributes: %s", err)
+	}
+	err = attrList.Update(PROC_THREAD_ATTRIBUTE_JOB_LIST, unsafe.Pointer(jobList), unsafe.Sizeof(job))
+	if err != nil {
+		return nil, fmt.Errorf("failed to update process attributes: %s", err)
+	}
+	startupInfo := windows.StartupInfoEx{
+		StartupInfo: windows.StartupInfo{
+			Cb: uint32(unsafe.Sizeof(windows.StartupInfoEx{})),
+		},
+		ProcThreadAttributeList: attrList.List(),
+	}
+	var procInfo windows.ProcessInformation
+	err = windows.CreateProcess(
+		nil, commandLine, nil, nil, true, windows.EXTENDED_STARTUPINFO_PRESENT, nil, nil,
+		&startupInfo.StartupInfo, &procInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create process: %w", err)
+	}
+	defer func() {
+		_ = windows.CloseHandle(procInfo.Process)
+		_ = windows.CloseHandle(procInfo.Thread)
+	}()
+	proc, err := os.FindProcess(int(procInfo.ProcessId))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find process %d: %w", procInfo.ProcessId, err)
+	}
+	state, err := proc.Wait()
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// Spawn a process in the Rancher Desktop job.  If the job doesn't exist, ensure
+// that the given process has a handle to the new job.  Returns the resulting
+// process state after the process exits; the caller may get the process exit
+// code that way.
+func SpawnProcessInRDJob(pid uint32, command []string) (*os.ProcessState, error) {
+	jobNameBytes, err := windows.UTF16PtrFromString(jobName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert job name: %w", err)
+	}
+
+	// Creating a job that already exists will return the job, with
+	// ERROR_ALREADY_EXISTS as the error.  We can use that to determine if we need
+	// to do the initial setup.
+	jobUintptr, _, err := createJobObject.Call(
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(jobNameBytes)))
+	if jobUintptr == 0 {
+		return nil, fmt.Errorf("failed to create job: %w", err)
+	}
+	job := windows.Handle(jobUintptr)
+	defer func() {
+		_ = windows.CloseHandle(job)
+	}()
+	if !errors.Is(err, os.ErrExist) {
+		// The job was newly created.
+
+		// Set the job so processes can't break away, and it terminates when the
+		// last handle is closed.
+		var limits JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+		ok, _, err := queryInformationJobObject.Call(
+			uintptr(job),
+			JobObjectExtendedLimitInformation,
+			uintptr(unsafe.Pointer(&limits)),
+			unsafe.Sizeof(limits),
+			uintptr(unsafe.Pointer(nil)))
+		if ok == 0 {
+			return nil, fmt.Errorf("error looking up job limits: %w", err)
+		}
+		limits.BasicLimitInformation.LimitFlags &= ^(JOB_OBJECT_LIMIT_BREAKAWAY_OK | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK)
+		limits.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+		ok, _, err = setInformationJobObject.Call(
+			uintptr(job),
+			JobObjectExtendedLimitInformation,
+			uintptr(unsafe.Pointer(&limits)),
+			unsafe.Sizeof(limits))
+		if ok == 0 {
+			return nil, fmt.Errorf("error setting job limits: %w", err)
+		}
+
+		// Duplicate the job into the given process (but leaking it).  This way when
+		// the target process exits, it will shut down the job.
+		hProc, err := windows.OpenProcess(windows.PROCESS_DUP_HANDLE, false, pid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open parent process %d: %w", pid, err)
+		}
+		err = windows.DuplicateHandle(windows.CurrentProcess(), job, hProc, nil, 0, false, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inject job into parent process %d: %w", pid, err)
+		}
+	}
+
+	commandLine, err := windows.UTF16PtrFromString(buildCommandLine(command))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build command line: %w", err)
+	}
+	state, err := spawnProcessInJob(job, commandLine)
+	if err != nil {
+		return nil, fmt.Errorf("failed to spawn process: %w", err)
+	}
+
+	return state, nil
+}
+
 // TerminateProcessInDirectory terminates all processes where the executable
 // resides within the given directory, as gracefully as possible.  If `force` is
 // set, SIGKILL is used instead.
@@ -35,7 +266,7 @@ func TerminateProcessInDirectory(directory string, force bool) error {
 	var pids []uint32
 	// Try EnumProcesses until the number of pids returned is less than the
 	// buffer size.
-	err := directories.InvokeWin32WithBuffer(func(size int) error {
+	err := directories.InvokeWin32WithBuffer(256, func(size int) error {
 		pids = make([]uint32, size)
 		var bytesReturned uint32
 		err := windows.EnumProcesses(pids, &bytesReturned)
@@ -74,7 +305,7 @@ func TerminateProcessInDirectory(directory string, force bool) error {
 			}()
 
 			var executablePath string
-			err = directories.InvokeWin32WithBuffer(func(size int) error {
+			err = directories.InvokeWin32WithBuffer(256, func(size int) error {
 				nameBuf := make([]uint16, size)
 				charsWritten := uint32(size)
 				err := windows.QueryFullProcessImageName(hProc, 0, &nameBuf[0], &charsWritten)

--- a/src/go/rdctl/pkg/process/process_windows_test.go
+++ b/src/go/rdctl/pkg/process/process_windows_test.go
@@ -1,0 +1,31 @@
+package process
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestBuildCommandLine(t *testing.T) {
+	t.Parallel()
+	cases := [][]string{
+		{"arg0", "a b c", "d", "e"},
+		{"C:\\Program Files\\arg0\\\\", "ab\"c", "\\", "d"},
+		{"\\\\", "a\\\\\\b", "de fg", "h"},
+		{"arg0", "a\\\"b", "c", "d"},
+		{"arg0", "a\\\\b c", "d", "e"},
+		{"arg0", "ab\" c d"},
+	}
+	for _, testcase := range cases {
+		t.Run(strings.Join(testcase, " "), func(t *testing.T) {
+			t.Parallel()
+			result := buildCommandLine(testcase)
+			argv, err := windows.DecomposeCommandLine(result)
+			require.NoError(t, err, "failed to parse result %s", result)
+			assert.Equal(t, testcase, argv, "failed to round trip arguments via [%s]", result)
+		})
+	}
+}

--- a/src/go/rdctl/pkg/process/process_windows_test.go
+++ b/src/go/rdctl/pkg/process/process_windows_test.go
@@ -18,6 +18,9 @@ func TestBuildCommandLine(t *testing.T) {
 		{"arg0", "a\\\"b", "c", "d"},
 		{"arg0", "a\\\\b c", "d", "e"},
 		{"arg0", "ab\" c d"},
+		{"C:/Path\\with/mixed slashes"},
+		{"arg0", " leading", " and ", "trailing ", "space"},
+		{"special characters", "&", "|", ">", "<", "*", "\"", " "},
 	}
 	for _, testcase := range cases {
 		t.Run(strings.Join(testcase, " "), func(t *testing.T) {

--- a/src/go/wsl-helper/cmd/process_kill_windows.go
+++ b/src/go/wsl-helper/cmd/process_kill_windows.go
@@ -24,22 +24,22 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/process"
 )
 
-var killProcessViper = viper.New()
+var processKillViper = viper.New()
 
-// killProcessCmd is the `wsl-helper kill-process` command.
-var killProcessCmd = &cobra.Command{
-	Use:   "kill-process",
+// processKillCmd is the `wsl-helper process kill` command.
+var processKillCmd = &cobra.Command{
+	Use:   "kill",
 	Short: "Kill a given process",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return process.Kill(killProcessViper.GetInt("pid"))
+		return process.Kill(processKillViper.GetInt("pid"))
 	},
 }
 
 func init() {
-	killProcessCmd.Flags().Int("pid", 0, "PID of process to kill")
-	killProcessViper.AutomaticEnv()
-	if err := killProcessViper.BindPFlags(killProcessCmd.Flags()); err != nil {
+	processKillCmd.Flags().Int("pid", 0, "PID of process to kill")
+	processKillViper.AutomaticEnv()
+	if err := processKillViper.BindPFlags(processKillCmd.Flags()); err != nil {
 		logrus.WithError(err).Fatal("Failed to set up flags")
 	}
-	rootCmd.AddCommand(killProcessCmd)
+	processCmd.AddCommand(processKillCmd)
 }

--- a/src/go/wsl-helper/cmd/process_spawn_windows.go
+++ b/src/go/wsl-helper/cmd/process_spawn_windows.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var processSpawnViper = viper.New()
+
+// processSpawnCmd is the `wsl-helper process spawn` command.
+var processSpawnCmd = &cobra.Command{
+	Use:   "spawn",
+	Short: "Spawn a new process",
+	Long: `Spawn a new process, attached to a job that would be terminated when
+	the given parent process exits.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		ppid := processSpawnViper.GetUint32("parent")
+
+		if ppid == 0 {
+			ppid = uint32(os.Getpid())
+		}
+
+		state, err := process.SpawnProcessInRDJob(ppid, args)
+		if err != nil {
+			return fmt.Errorf("failed to spawn process: %w", err)
+		}
+
+		os.Exit(state.ExitCode())
+		return nil
+	},
+}
+
+func init() {
+	processSpawnCmd.Flags().Uint32("parent", 0, "PID of the parent process")
+	processSpawnViper.AutomaticEnv()
+	if err := processSpawnViper.BindPFlags(processSpawnCmd.Flags()); err != nil {
+		logrus.WithError(err).Fatal("Failed to set up flags")
+	}
+	processCmd.AddCommand(processSpawnCmd)
+}

--- a/src/go/wsl-helper/cmd/process_windows.go
+++ b/src/go/wsl-helper/cmd/process_windows.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// processCmd represents the `wsl-helper process ...` subcommand
+var processCmd = &cobra.Command{
+	Use:    "process",
+	Short:  "Commands for managing processes on Windows",
+	Hidden: true,
+}
+
+func init() {
+	rootCmd.AddCommand(processCmd)
+}

--- a/src/go/wsl-helper/go.mod
+++ b/src/go/wsl-helper/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/linuxkit/virtsock v0.0.0-20220523201153-1a23e78aa7a2
 	github.com/pkg/errors v0.9.1
+	github.com/rancher-sandbox/rancher-desktop/src/go/rdctl v0.0.0-20241129182547-3cfd26786896
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/src/go/wsl-helper/go.sum
+++ b/src/go/wsl-helper/go.sum
@@ -66,6 +66,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rancher-sandbox/rancher-desktop/src/go/rdctl v0.0.0-20241129182547-3cfd26786896 h1:VbEMcZuDq9q13bAXigZxQBKymwNqp++W8COjWlFpW8o=
+github.com/rancher-sandbox/rancher-desktop/src/go/rdctl v0.0.0-20241129182547-3cfd26786896/go.mod h1:6MtWsvj6s8fmoKiobs+bj/61+D+OdSVZZPfjBY18tfE=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
This puts any processes spawned by the extension in a job, so that they can be terminated when the main application exits.

We intentionally let the main Rancher Desktop process have a handle to the new job (which isn't ever referenced), and set the job up so that it will automatically terminate when all handles to that job are closed.  This means that as the main process exits, it will automatically cause all processes in that job to terminate (because it would have the only outstanding handle to the job).

For #7653