### PR TITLE
*nix: Kill process group when main process exits

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -265,6 +265,7 @@ fdx
 featurename
 FEEEFEEE
 femto
+Fflags
 ffi
 ficlone
 filekey
@@ -599,7 +600,7 @@ penpot
 persistentvolume
 persistentvolumeclaim
 PFlags
-PGID
+pgid
 pgrep
 pidfile
 pidfd
@@ -615,6 +616,7 @@ pkill
 plists
 plusplus
 plutil
+POLLIN
 podmetrics
 podmonitor
 podsecuritypolicytemplate

--- a/src/go/rdctl/cmd/internal.go
+++ b/src/go/rdctl/cmd/internal.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// internalCmd represents the `rdctl internal` command, for cases when we need
+// internalCmd represents the `rdctl internal` command, which is used for
 // native code.
 var internalCmd = &cobra.Command{
 	Use:    "internal",
@@ -32,7 +32,7 @@ var internalCmd = &cobra.Command{
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return fmt.Errorf("%q expects subcommands.", cmd.CommandPath())
+		return fmt.Errorf("%q expects subcommands", cmd.CommandPath())
 	},
 }
 

--- a/src/go/rdctl/cmd/internal.go
+++ b/src/go/rdctl/cmd/internal.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd implements the rdctl commands
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// internalCmd represents the `rdctl internal` command, for cases when we need
+// native code.
+var internalCmd = &cobra.Command{
+	Use:    "internal",
+	Short:  "Rancher Desktop internal commands",
+	Long:   `rdctl internal provides commands for Rancher Desktop internal use`,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("%q expects subcommands.", cmd.CommandPath())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(internalCmd)
+}

--- a/src/go/rdctl/cmd/internalProcess.go
+++ b/src/go/rdctl/cmd/internalProcess.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd implements the rdctl commands
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// internalCmd represents the `rdctl internal process` command, which contains
+// commands for dealing with (host) processes.
+var internalProcessCmd = &cobra.Command{
+	Use:   "process",
+	Short: "Process-related subcommands",
+	Long:  `rdctl internal process contains subcommands dealing with processes.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("%q expects subcommands.", cmd.CommandPath())
+	},
+}
+
+func init() {
+	internalCmd.AddCommand(internalProcessCmd)
+}

--- a/src/go/rdctl/cmd/internalProcess.go
+++ b/src/go/rdctl/cmd/internalProcess.go
@@ -31,7 +31,7 @@ var internalProcessCmd = &cobra.Command{
 	Long:  `rdctl internal process contains subcommands dealing with processes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return fmt.Errorf("%q expects subcommands.", cmd.CommandPath())
+		return fmt.Errorf("%q expects subcommands", cmd.CommandPath())
 	},
 }
 

--- a/src/go/rdctl/cmd/internalProcessWaitKill.go
+++ b/src/go/rdctl/cmd/internalProcessWaitKill.go
@@ -1,0 +1,64 @@
+//go:build unix
+
+/*
+Copyright © 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd implements the rdctl commands
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+// internalCmd represents the `rdctl internal process` command, which contains
+// commands for dealing with (host) processes.
+var internalProcessWaitKillCmd = &cobra.Command{
+	Use:   "wait-kill",
+	Short: "Wait for a process and then kill of the processes in its group.",
+	Long: `rdctl internal process wait-kill waits for the given process to exit,
+then kills all processes in the same process group.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		pid, err := cmd.Flags().GetInt("pid")
+		if err != nil {
+			return fmt.Errorf("failed to get process ID: %w", err)
+		}
+		pgid, err := unix.Getpgid(pid)
+		if err != nil {
+			return fmt.Errorf("failed to get process group id for %d: %w", pid, err)
+		}
+		if err = process.WaitForProcess(pid); err != nil {
+			return fmt.Errorf("failed to wait for process: %w", err)
+		}
+		err = unix.Kill(-pgid, unix.SIGTERM)
+		if err != nil && !errors.Is(err, unix.ESRCH) {
+			return fmt.Errorf("failed to send SIGTERM: %w", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	internalProcessCmd.AddCommand(internalProcessWaitKillCmd)
+	internalProcessWaitKillCmd.Flags().Int("pid", 0, "process to wait for")
+	_ = internalProcessWaitKillCmd.MarkFlagRequired("pid")
+}

--- a/src/go/rdctl/cmd/internalProcessWaitKill.go
+++ b/src/go/rdctl/cmd/internalProcessWaitKill.go
@@ -33,8 +33,8 @@ import (
 var internalProcessWaitKillCmd = &cobra.Command{
 	Use:   "wait-kill",
 	Short: "Wait for a process and then kill of the processes in its group.",
-	Long: `rdctl internal process wait-kill waits for the given process to exit,
-then kills all processes in the same process group.`,
+	Long: `The 'rdctl internal process wait-kill' command waits for the specified process to
+exit, and once it does, terminates all processes within the same process group.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		pid, err := cmd.Flags().GetInt("pid")

--- a/src/go/rdctl/pkg/process/process_darwin.go
+++ b/src/go/rdctl/pkg/process/process_darwin.go
@@ -91,7 +91,9 @@ func WaitForProcess(pid int) error {
 		return fmt.Errorf("failed to initialize process monitoring: %w", err)
 	}
 	defer func() {
-		_ = unix.Close(queue)
+		if err := unix.Close(queue); err != nil {
+			logrus.Warnf("Ignoring failure to close kqueue: %s", err)
+		}
 	}()
 	change := unix.Kevent_t{
 		Ident:  uint64(pid),


### PR DESCRIPTION
This adds a `rdctl internal process wait-kill` command which waits for the given pid to exit, and then kills its whole process group.  This is used to kill any extension-spawned processes (as long as they haven't detached into a new process group).  This is only needed on linux / darwin because Windows has a different implementation where extension-spawned processes are moved into a job that terminates when the main process terminates instead.

This is the equivalent to #7838 but implemented completely differently.