### PR TITLE
Fix linux docker proxy

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve.go
@@ -1,0 +1,5 @@
+package platform
+
+import "net"
+
+type DialFunc func() (net.Conn, error)

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_linux.go
@@ -37,15 +37,15 @@ const DefaultEndpoint = "unix:///var/run/docker.sock"
 var ErrListenerClosed = net.ErrClosed
 
 // MakeDialer computes the dial function.
-func MakeDialer(proxyEndpoint string) (func() (net.Conn, error), error) {
-	dialer := func() (net.Conn, error) {
+func MakeDialer(proxyEndpoint string) (DialFunc, error) {
+	return func() (net.Conn, error) {
 		conn, err := net.Dial("unix", proxyEndpoint)
 		if err != nil {
 			return nil, err
 		}
+
 		return conn, nil
-	}
-	return dialer, nil
+	}, nil
 }
 
 // Listen on the given Unix socket endpoint.

--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows.go
@@ -36,18 +36,21 @@ const DefaultEndpoint = "npipe:////./pipe/docker_engine"
 var ErrListenerClosed = winio.ErrPipeListenerClosed
 
 // MakeDialer computes the dial function.
-func MakeDialer(port uint32) (func() (net.Conn, error), error) {
+func MakeDialer(port uint32) (DialFunc, error) {
 	vmGUID, err := probeVMGUID(port)
 	if err != nil {
 		return nil, fmt.Errorf("could not detect WSL2 VM: %w", err)
 	}
+
 	dial := func() (net.Conn, error) {
 		conn, err := dialHvsock(vmGUID, port)
 		if err != nil {
 			return nil, err
 		}
+
 		return conn, nil
 	}
+
 	return dial, nil
 }
 

--- a/src/go/wsl-helper/pkg/dockerproxy/serve_tcp.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve_tcp.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerproxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+type connectionProviderFunc func([]byte) (io.ReadWriteCloser, error)
+
+func readHeader(src io.ReadWriteCloser) ([]byte, error) {
+	// read up to 64 bytes from request
+	buff := make([]byte, 0xffff)
+	n, err := src.Read(buff)
+	if err != nil {
+		return nil, err
+	}
+	b := buff[:n]
+
+	return b, err
+}
+
+func pipe(wg *sync.WaitGroup, src, dst io.ReadWriter) {
+	defer wg.Done()
+
+	_, err := io.Copy(src, dst)
+	if err != nil {
+		fmt.Printf("copy failed '%s'\n", err)
+		return
+	}
+}
+
+// proxyTCPConn takes over local connection passed in, calls provider() passing
+// up to 64 bytes of the received header. The provider must return a remote connection
+func proxyTCPConn(src net.Conn, provider connectionProviderFunc) {
+	defer src.Close()
+
+	header, err := readHeader(src)
+	if err != nil {
+		fmt.Printf("error reading: %v", err)
+		return
+	}
+
+	dst, err := provider(header)
+	if err != nil {
+		fmt.Printf("remote connection failed: %s", err)
+		return
+	}
+	defer dst.Close()
+
+	// send header to remote
+	_, err = dst.Write(header)
+	if err != nil {
+		fmt.Printf("write failed '%s'\n", err)
+		return
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go pipe(wg, src, dst)
+	go pipe(wg, dst, src)
+
+	wg.Wait()
+}

--- a/src/go/wsl-helper/pkg/dockerproxy/util/in_memory_socket.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/util/in_memory_socket.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2021 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+var errClosed = errors.New("use of closed network connection")
+
+// InMemorySocket implements net.Listener using in-memory only connections.
+type InMemorySocket struct {
+	chConn  chan net.Conn
+	chClose chan struct{}
+	mu      sync.Mutex
+}
+
+// dummyAddr is used to satisfy net.Addr for the in-mem socket
+// it is just stored as a string and returns the string for all calls
+type dummyAddr string
+
+// NewInMemorySocket creates an in-memory only net.Listener
+// The addr argument can be any string, but is used to satisfy the `Addr()` part
+// of the net.Listener interface
+func NewInMemorySocket() *InMemorySocket {
+	return &InMemorySocket{
+		chConn:  make(chan net.Conn, 8),
+		chClose: make(chan struct{}),
+	}
+}
+
+// Addr returns the socket's addr string to satisfy net.Listener
+func (s *InMemorySocket) Addr() net.Addr {
+	return dummyAddr("in_memory_address")
+}
+
+// Accept implements the Accept method in the Listener interface; it waits for the next call and returns a generic Conn.
+func (s *InMemorySocket) Accept() (net.Conn, error) {
+	select {
+	case conn := <-s.chConn:
+		return conn, nil
+	case <-s.chClose:
+		return nil, errClosed
+	}
+}
+
+// Close closes the listener. It will be unavailable for use once closed.
+func (s *InMemorySocket) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case <-s.chClose:
+	default:
+		close(s.chClose)
+	}
+	return nil
+}
+
+// Dial is used to establish a connection with the in-mem server
+func (s *InMemorySocket) Dial(network, addr string) (net.Conn, error) {
+	srvConn, clientConn := net.Pipe()
+	select {
+	case s.chConn <- srvConn:
+	case <-s.chClose:
+		return nil, errClosed
+	}
+
+	return clientConn, nil
+}
+
+// Network returns the addr string, satisfies net.Addr
+func (a dummyAddr) Network() string {
+	return string(a)
+}
+
+// String returns the string form
+func (a dummyAddr) String() string {
+	return string(a)
+}


### PR DESCRIPTION
Fixes #3239

I added some logging to the proxy and observed the /attach API call converting to a websocket. This websocket is streaming data to/from the container.
I suspected the issue stemming from nonstandard docker behaviour when it comes to websockets, as one of the pipes gets closed when the container does not have stdin open.
 
The docker client knows the container spec and when stdin on the container is closed, outbound pipe from the client is EOF whilst the inbound pipe (stdout/err from container) is streaming data.

The issue can be worked around if you set DOCKER_HOST to `/mnt/wsl/rancher-desktop/run/docker.sock` effectively isolating the issue to the wsl-helper proxy.

The PR is proof of concept - starts a proxy on the TCP level, and conditionally sends connections to the original proxy capable of munging the request data etc.

To verify fix, run

```
go build -o ./wsl-helper ./ && sudo ./wsl-helper docker-proxy serve --verbose --endpoint unix:///tmp/docker-wsl.sock --proxy-endpoint /mnt/wsl/rancher-desktop/run/docker.sock
```

```
export DOCKER_HOST=unix:///tmp/docker-wsl.sock
docker run --rm -p 8888:80 nginx
```

used https://github.com/jpillora/go-tcp-proxy
and https://github.com/docker/go-connections/blob/master/sockets/inmem_socket.go