### PR TITLE
Make all proto lower

### DIFF
--- a/src/go/guestagent/pkg/containerd/events_linux.go
+++ b/src/go/guestagent/pkg/containerd/events_linux.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/Masterminds/log-go"
 	"github.com/containerd/containerd"
@@ -395,7 +396,7 @@ func createPortMappingFromString(portMapping string) (nat.PortMap, error) {
 	}
 
 	for _, port := range ports {
-		portMapKey, err := nat.NewPort(port.Protocol, strconv.Itoa(port.ContainerPort))
+		portMapKey, err := nat.NewPort(strings.ToLower(port.Protocol), strconv.Itoa(port.ContainerPort))
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/guestagent/pkg/docker/events.go
+++ b/src/go/guestagent/pkg/docker/events.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/Masterminds/log-go"
 	"github.com/docker/docker/api/types"
@@ -182,7 +183,7 @@ func createPortMapping(ports []types.Port) (nat.PortMap, error) {
 			continue
 		}
 
-		portMapKey, err := nat.NewPort(port.Type, strconv.Itoa(int(port.PrivatePort)))
+		portMapKey, err := nat.NewPort(strings.ToLower(port.Type), strconv.Itoa(int(port.PrivatePort)))
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/guestagent/pkg/iptables/iptables.go
+++ b/src/go/guestagent/pkg/iptables/iptables.go
@@ -101,6 +101,7 @@ func ForwardPorts(ctx context.Context, tracker tracker.Tracker, updateInterval t
 				name := entryToString(p)
 				if err := tracker.Add(generateID(name), portMap); err != nil {
 					log.Errorf("iptables scanner failed to forward portmap for %s: %s", name, err)
+					continue
 				}
 				log.Infof("iptables scanner forwarded portmap for %s", name)
 			}

--- a/src/go/guestagent/pkg/kube/servicewatcher_linux.go
+++ b/src/go/guestagent/pkg/kube/servicewatcher_linux.go
@@ -50,15 +50,15 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 	sharedInformer := serviceInformer.Informer()
 	_, _ = sharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			log.Debugf("Service Informer: Add func called with: %+v", obj)
+			log.Tracef("Service Informer: Add func called with: %+v", obj)
 			handleUpdate(nil, obj, eventCh)
 		},
 		DeleteFunc: func(obj interface{}) {
-			log.Debugf("Service Informer: Del func called with: %+v", obj)
+			log.Tracef("Service Informer: Del func called with: %+v", obj)
 			handleUpdate(obj, nil, eventCh)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			log.Debugf("Service Informer: Update func called with old object %+v and new Object: %+v", oldObj, newObj)
+			log.Tracef("Service Informer: Update func called with old object %+v and new Object: %+v", oldObj, newObj)
 			handleUpdate(oldObj, newObj, eventCh)
 		},
 	})

--- a/src/go/guestagent/pkg/kube/watcher_linux.go
+++ b/src/go/guestagent/pkg/kube/watcher_linux.go
@@ -233,8 +233,9 @@ func createPortMapping(ports map[int32]corev1.Protocol, k8sServiceListenerIP net
 	portMap := make(nat.PortMap)
 
 	for port, proto := range ports {
-		log.Debugf("create port mapping for port %d, protocol %s", port, proto)
-		portMapKey, err := nat.NewPort(string(proto), strconv.Itoa(int(port)))
+		protocol := strings.ToLower(string(proto))
+		log.Debugf("create port mapping for port %d, protocol %s", port, protocol)
+		portMapKey, err := nat.NewPort(protocol, strconv.Itoa(int(port)))
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/guestagent/pkg/procnet/scanner_linux.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/log-go"
@@ -186,7 +187,7 @@ func addValidProtoEntryToPortMap(entry procnettcp.Entry, portMap nat.PortMap) er
 
 func addEntryToPortMap(entry procnettcp.Entry, portMap nat.PortMap) error {
 	port := strconv.Itoa(int(entry.Port))
-	portMapKey, err := nat.NewPort(entry.Kind, port)
+	portMapKey, err := nat.NewPort(strings.ToLower(entry.Kind), port)
 	if err != nil {
 		return fmt.Errorf("generating portMapKey protocol: %s, port: %d failed: %w",
 			entry.Kind,

--- a/src/go/networking/pkg/portproxy/server.go
+++ b/src/go/networking/pkg/portproxy/server.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	gvisorTypes "github.com/containers/gvisor-tap-vsock/pkg/types"
@@ -94,15 +95,16 @@ func (p *PortProxy) handleEvent(conn net.Conn) {
 
 func (p *PortProxy) exec(pm types.PortMapping) {
 	for portProto, portBindings := range pm.Ports {
-		logrus.Debugf("received the following port: [%s] and protocol: [%s] from portMapping: %+v", portProto.Port(), portProto.Proto(), pm)
+		proto := strings.ToLower(portProto.Proto())
+		logrus.Debugf("received the following port: [%s] and protocol: [%s] from portMapping: %+v", portProto.Port(), proto, pm)
 
-		switch gvisorTypes.TransportProtocol(portProto.Proto()) {
+		switch gvisorTypes.TransportProtocol(proto) {
 		case gvisorTypes.TCP:
 			p.handleTCP(portBindings, pm.Remove)
 		case gvisorTypes.UDP:
 			p.handleUDP(portBindings, pm.Remove)
 		default:
-			logrus.Warnf("unsupported protocol: [%s]", portProto.Proto())
+			logrus.Warnf("unsupported protocol: [%s]", proto)
 		}
 	}
 }


### PR DESCRIPTION
The protocol string (proto) was inconsistently cased (e.g., `TCP` vs `tcp`), which caused issues in some parts of the code. This change ensures that the protocol is always converted to lowercase when creating port mappings, preventing errors caused by casing mismatches.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7880