### PR TITLE
 Fix iptables scanner to assign correct HostIP

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -447,6 +447,7 @@ libxfixes
 libxkbcommon
 libxrandr
 limactl
+limaiptables
 limaloc
 linds
 linebreak

--- a/src/go/guestagent/main.go
+++ b/src/go/guestagent/main.go
@@ -194,8 +194,9 @@ func main() {
 		})
 
 		group.Go(func() error {
-			iptablesScanner := iptables.New(ctx, portTracker, k8sServiceListenerIP, iptablesUpdateInterval)
-			err := iptablesScanner.ForwardPorts()
+			iptablesScanner := iptables.NewIptablesScanner()
+			iptablesHandler := iptables.New(ctx, portTracker, iptablesScanner, k8sServiceListenerIP, iptablesUpdateInterval)
+			err := iptablesHandler.ForwardPorts()
 			if err != nil {
 				return fmt.Errorf("iptables port forwarding failed: %w", err)
 			}

--- a/src/go/guestagent/main.go
+++ b/src/go/guestagent/main.go
@@ -173,15 +173,15 @@ func main() {
 	}
 
 	if *enableKubernetes {
+		k8sServiceListenerIP := net.ParseIP(*k8sServiceListenerAddr)
+
+		if k8sServiceListenerIP == nil || !(k8sServiceListenerIP.Equal(net.IPv4zero) ||
+			k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) {
+			log.Fatalf("empty or none valid input for Kubernetes service listener IP address %s. "+
+				"Valid options are 0.0.0.0 and 127.0.0.1.", *k8sServiceListenerAddr)
+		}
+
 		group.Go(func() error {
-			k8sServiceListenerIP := net.ParseIP(*k8sServiceListenerAddr)
-
-			if k8sServiceListenerIP == nil || !(k8sServiceListenerIP.Equal(net.IPv4zero) ||
-				k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) {
-				log.Fatalf("empty or none valid input for Kubernetes service listener IP address %s. "+
-					"Valid options are 0.0.0.0 and 127.0.0.1.", *k8sServiceListenerAddr)
-			}
-
 			// Watch for kube
 			err := kube.WatchForServices(ctx,
 				*configPath,
@@ -190,18 +190,18 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("kubernetes service watcher failed: %w", err)
 			}
+			return nil
+		})
 
+		group.Go(func() error {
+			iptablesScanner := iptables.New(ctx, portTracker, k8sServiceListenerIP, iptablesUpdateInterval)
+			err := iptablesScanner.ForwardPorts()
+			if err != nil {
+				return fmt.Errorf("iptables port forwarding failed: %w", err)
+			}
 			return nil
 		})
 	}
-
-	group.Go(func() error {
-		err := iptables.ForwardPorts(ctx, portTracker, iptablesUpdateInterval)
-		if err != nil {
-			return fmt.Errorf("iptables port forwarding failed: %w", err)
-		}
-		return nil
-	})
 
 	group.Go(func() error {
 		procScanner, err := procnet.NewProcNetScanner(ctx, portTracker, procNetScanInterval)

--- a/src/go/guestagent/main.go
+++ b/src/go/guestagent/main.go
@@ -177,7 +177,7 @@ func main() {
 
 		if k8sServiceListenerIP == nil || !(k8sServiceListenerIP.Equal(net.IPv4zero) ||
 			k8sServiceListenerIP.Equal(net.IPv4(127, 0, 0, 1))) {
-			log.Fatalf("empty or none valid input for Kubernetes service listener IP address %s. "+
+			log.Fatalf("empty or invalid input for Kubernetes service listener IP address %s. "+
 				"Valid options are 0.0.0.0 and 127.0.0.1.", *k8sServiceListenerAddr)
 		}
 

--- a/src/go/guestagent/pkg/iptables/iptables_test.go
+++ b/src/go/guestagent/pkg/iptables/iptables_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright © 2024 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iptables_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	limaIptables "github.com/lima-vm/lima/pkg/guestagent/iptables"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/iptables"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardPorts(t *testing.T) {
+	tests := []struct {
+		name                       string
+		remove                     bool
+		listenerIP                 net.IP
+		expectedEntries            []limaIptables.Entry
+		expectedEntriesAfterRemove []limaIptables.Entry
+		expectedAddFuncErr         error
+	}{
+		{
+			name:       "With localhost listener and valid port mappings",
+			listenerIP: net.IPv4(127, 0, 0, 1),
+			expectedEntries: []limaIptables.Entry{
+				{TCP: true, IP: net.IPv4(192, 168, 20, 10), Port: 1080},
+				{TCP: true, IP: net.IPv4(192, 168, 20, 11), Port: 1081},
+				{TCP: true, IP: net.IPv4(192, 168, 20, 12), Port: 1082},
+			},
+		},
+		{
+			name:       "With wildcard listener and valid port mappings",
+			listenerIP: net.IPv4(0, 0, 0, 0),
+			expectedEntries: []limaIptables.Entry{
+				{TCP: true, IP: net.IPv4(192, 168, 21, 10), Port: 1080},
+				{TCP: true, IP: net.IPv4(192, 168, 21, 11), Port: 1081},
+				{TCP: true, IP: net.IPv4(192, 168, 21, 12), Port: 1082},
+			},
+		},
+		{
+			name:       "With entries removed",
+			remove:     true,
+			listenerIP: net.IPv4(0, 0, 0, 0),
+			expectedEntries: []limaIptables.Entry{
+				{TCP: true, IP: net.IPv4(192, 168, 22, 10), Port: 1080},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 11), Port: 1081},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 12), Port: 1082},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 13), Port: 1083},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 14), Port: 1084},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptablesScanner := fakeScanner{
+				expectedEntries: tt.expectedEntries,
+				expectedErr:     tt.expectedAddFuncErr,
+			}
+
+			testTracker := fakeTracker{
+				receivedID:          make(chan string),
+				receivedRemoveID:    make(chan string),
+				receivedPortMapping: make(chan nat.PortMap),
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			interval := time.Second
+			iptablesHandler := iptables.New(ctx, &testTracker, &iptablesScanner, tt.listenerIP, interval)
+
+			go func() {
+				require.NoError(t, iptablesHandler.ForwardPorts())
+				cancel()
+			}()
+
+			for i := 0; i < len(tt.expectedEntries); i++ {
+				id := <-testTracker.receivedID
+				expectedID := utils.GenerateID(entryToString(tt.expectedEntries[i]))
+				require.Equal(t, expectedID, id)
+
+				pm := <-testTracker.receivedPortMapping
+				portProto, err := nat.NewPort("tcp", strconv.Itoa(tt.expectedEntries[i].Port))
+				require.NoError(t, err)
+
+				expectedPortBinding := nat.PortBinding{
+					HostIP:   tt.listenerIP.String(),
+					HostPort: strconv.Itoa(tt.expectedEntries[i].Port),
+				}
+				require.Contains(t, pm[portProto], expectedPortBinding)
+			}
+
+			if tt.remove {
+				removedEntries := []limaIptables.Entry{
+					{TCP: true, IP: net.IPv4(192, 168, 22, 11), Port: 1081},
+					{TCP: true, IP: net.IPv4(192, 168, 22, 12), Port: 1082},
+				}
+				// update the entries
+				updatedEntries := []limaIptables.Entry{
+					{TCP: true, IP: net.IPv4(192, 168, 22, 10), Port: 1080},
+					{TCP: true, IP: net.IPv4(192, 168, 22, 13), Port: 1083},
+					{TCP: true, IP: net.IPv4(192, 168, 22, 14), Port: 1084},
+					{TCP: true, IP: net.IPv4(192, 168, 22, 15), Port: 1085},
+				}
+				iptablesScanner.expectedEntries = updatedEntries
+
+				for i := 0; i < len(removedEntries); i++ {
+					id := <-testTracker.receivedRemoveID
+					expectedID := utils.GenerateID(entryToString(removedEntries[i]))
+					require.Equal(t, expectedID, id)
+				}
+
+				addedElement := updatedEntries[len(updatedEntries)-1]
+				id := <-testTracker.receivedID
+				expectedID := utils.GenerateID(entryToString(addedElement))
+				require.Equal(t, expectedID, id)
+
+				pm := <-testTracker.receivedPortMapping
+				portProto, err := nat.NewPort("tcp", strconv.Itoa(addedElement.Port))
+				require.NoError(t, err)
+
+				expectedPortMap := nat.PortMap{
+					portProto: []nat.PortBinding{
+						{
+							HostIP:   tt.listenerIP.String(),
+							HostPort: strconv.Itoa(addedElement.Port),
+						},
+					},
+				}
+				require.ElementsMatch(t, pm[portProto], expectedPortMap[portProto])
+			}
+		})
+	}
+}
+
+func TestForwardPortsSamePortDifferentIP(t *testing.T) {
+	duplicatedPort := 1084
+	tests := []struct {
+		name               string
+		listenerIP         net.IP
+		expectedEntries    []limaIptables.Entry
+		expectedAddFuncErr error
+	}{
+		{
+			name:       "Same Port with different IP",
+			listenerIP: net.IPv4(0, 0, 0, 0),
+			expectedEntries: []limaIptables.Entry{
+				{TCP: true, IP: net.IPv4(192, 168, 22, 10), Port: 1080},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 11), Port: 1081},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 12), Port: 1082},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 13), Port: 1083},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 14), Port: duplicatedPort},
+				{TCP: true, IP: net.IPv4(192, 168, 22, 15), Port: duplicatedPort},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iptablesScanner := fakeScanner{
+				expectedEntries: tt.expectedEntries,
+				expectedErr:     tt.expectedAddFuncErr,
+			}
+
+			testTracker := fakeTracker{
+				receivedID:          make(chan string),
+				receivedRemoveID:    make(chan string),
+				receivedPortMapping: make(chan nat.PortMap),
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			interval := time.Second
+			iptablesHandler := iptables.New(ctx, &testTracker, &iptablesScanner, tt.listenerIP, interval)
+
+			go func() {
+				require.NoError(t, iptablesHandler.ForwardPorts())
+				cancel()
+			}()
+
+			for i := 0; i < len(tt.expectedEntries); i++ {
+				id := <-testTracker.receivedID
+				expectedID := utils.GenerateID(entryToString(tt.expectedEntries[i]))
+				require.Equal(t, expectedID, id)
+
+				pm := <-testTracker.receivedPortMapping
+				portProto, err := nat.NewPort("tcp", strconv.Itoa(tt.expectedEntries[i].Port))
+				require.NoError(t, err)
+
+				// Port bindings for the same port on different IP addresses should appear only once
+				// in the port mapping. This is because the HostIP is always controlled by the
+				// k8sServiceListenerAddr, which means that duplicate entries with the same port
+				// but different IPs are unnecessary and should not be handled.
+				if tt.expectedEntries[i].Port == duplicatedPort {
+					require.Len(t, pm[portProto], 1)
+				}
+
+				expectedPortBinding := nat.PortBinding{
+					HostIP:   tt.listenerIP.String(),
+					HostPort: strconv.Itoa(tt.expectedEntries[i].Port),
+				}
+				require.Contains(t, pm[portProto], expectedPortBinding)
+			}
+		})
+	}
+}
+
+// Fake Tracker implementation for mocking behavior
+type fakeTracker struct {
+	receivedID          chan string
+	receivedRemoveID    chan string
+	receivedPortMapping chan nat.PortMap
+	expectedAddFuncErr  error
+}
+
+func (f *fakeTracker) Get(containerID string) nat.PortMap {
+	return nil
+}
+
+func (f *fakeTracker) Add(containerID string, portMapping nat.PortMap) error {
+	f.receivedID <- containerID
+	f.receivedPortMapping <- portMapping
+	return f.expectedAddFuncErr
+}
+
+func (f *fakeTracker) Remove(containerID string) error {
+	f.receivedRemoveID <- containerID
+	return nil
+}
+
+func (f *fakeTracker) RemoveAll() error {
+	return nil
+}
+
+// Fake Scanner to simulate iptables entries
+type fakeScanner struct {
+	expectedEntries []limaIptables.Entry
+	expectedErr     error
+}
+
+func (f *fakeScanner) GetPorts() ([]limaIptables.Entry, error) {
+	return f.expectedEntries, f.expectedErr
+}
+
+// Utility function to convert iptables entry to string
+func entryToString(ip limaIptables.Entry) string {
+	return net.JoinHostPort(ip.IP.String(), strconv.Itoa(ip.Port))
+}

--- a/src/go/guestagent/pkg/iptables/scanner.go
+++ b/src/go/guestagent/pkg/iptables/scanner.go
@@ -1,0 +1,33 @@
+/*
+Copyright © 2024 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package iptables handles forwarding ports found in iptables DNAT
+package iptables
+
+import "github.com/lima-vm/lima/pkg/guestagent/iptables"
+
+// Scanner is the interface that wraps the GetPorts method which
+// is used to scan the iptables.
+type Scanner interface {
+	GetPorts() ([]iptables.Entry, error)
+}
+
+type IptablesScanner struct{}
+
+func NewIptablesScanner() *IptablesScanner {
+	return &IptablesScanner{}
+}
+
+func (i *IptablesScanner) GetPorts() ([]iptables.Entry, error) {
+	return iptables.GetPorts()
+}

--- a/src/go/guestagent/pkg/procnet/scanner_linux.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux.go
@@ -22,8 +22,6 @@ package procnet
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -37,6 +35,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/lima-vm/lima/pkg/guestagent/procnettcp"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/tracker"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/utils"
 )
 
 type action string
@@ -91,7 +90,7 @@ func (p *ProcNetScanner) ForwardPorts() error {
 			for port, bindings := range newPortMap {
 				if _, exists := previousPortMap[port]; !exists {
 					log.Infof("/proc/net scanner added port: %s -> %+v", port, bindings)
-					err := p.tracker.Add(generateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())), nat.PortMap{
+					err := p.tracker.Add(utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())), nat.PortMap{
 						port: bindings,
 					})
 					if err != nil {
@@ -108,7 +107,7 @@ func (p *ProcNetScanner) ForwardPorts() error {
 			for port, previousBindings := range previousPortMap {
 				if _, exists := newPortMap[port]; !exists {
 					log.Infof("/proc/net scanner removed port: %s -> %+v", port, previousBindings)
-					err := p.tracker.Remove(generateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())))
+					err := p.tracker.Remove(utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())))
 					if err != nil {
 						log.Errorf("/proc/net scanner failed to remove port: %s", err)
 						continue
@@ -233,10 +232,4 @@ func writeSysctl(path string, value string) error {
 	}
 	log.Infof("/proc/net scanner enabled %s", routeLocalnet)
 	return nil
-}
-
-func generateID(entry string) string {
-	hasher := sha256.New()
-	hasher.Write([]byte(entry))
-	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/src/go/guestagent/pkg/utils/util.go
+++ b/src/go/guestagent/pkg/utils/util.go
@@ -13,7 +13,11 @@ limitations under the License.
 
 package utils
 
-import "errors"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+)
 
 var (
 	ErrExecIptablesRule  = errors.New("failed updating iptables rules")
@@ -28,4 +32,10 @@ func NormalizeHostIP(ip string) string {
 		return ip
 	}
 	return "0.0.0.0"
+}
+
+func GenerateID(entry string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(entry))
+	return hex.EncodeToString(hasher.Sum(nil))
 }


### PR DESCRIPTION
The iptables scanner previously assigned a wildcard IP to HostIP, but now it uses the `k8sServiceListenerAddr` property to correctly set the HostIP. This ensures proper configuration of port mappings, reflecting the user's settings (`127.0.0.1` or `0.0.0.0`).

Additionally, the iptables scanner now only runs when Kubernetes is enabled, reducing duplicated port mapping noise caused by other APIs (e.g., containerd). This change aligns with the original purpose of the iptables scanner, which was designed to handle port mappings for Kubernetes that were not published via the Kubernetes API.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7891 
and 
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/7825