### PR TITLE
Fix: docker exec hangs indefinitely when reading from stdin

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/platform/serve_windows.go
@@ -81,7 +81,12 @@ func Listen(endpoint string) (net.Listener, error) {
 		return nil, fmt.Errorf("endpoint %s does not start with protocol %s", endpoint, prefix)
 	}
 
-	listener, err := winio.ListenPipe(endpoint[len(prefix):], nil)
+	// Configure pipe in MessageMode to support Docker's half-close semantics
+	// - Enables zero-byte writes as EOF signals (CloseWrite)
+	// - Crucial for stdin stream termination in interactive containers
+	pipeConfig := &winio.PipeConfig{MessageMode: true}
+
+	listener, err := winio.ListenPipe(endpoint[len(prefix):], pipeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not listen on %s: %w", endpoint, err)
 	}

--- a/src/go/wsl-helper/pkg/dockerproxy/util/pipe_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/util/pipe_test.go
@@ -18,55 +18,120 @@ package util
 
 import (
 	"bytes"
-	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type nopReadWriteCloser struct {
-	io.ReadWriter
+// bidirectionalHalfClosePipe is a testing utility that simulates a bidirectional pipe
+// with the ability to half-close connections. It's designed to mimic scenarios
+// like interactive command-line operations where a client can send data and
+// then half-close the connection while waiting for a response.
+type bidirectionalHalfClosePipe struct {
+	r io.ReadCloser
+	w io.WriteCloser
 }
 
-func (nopReadWriteCloser) Close() error {
-	return nil
-}
+// newBidirectionalHalfClosePipe creates two interconnected bidirectional pipe endpoints.
+//
+// The function returns two bidirectionalHalfClosePipe instances that are connected
+// such that what is written to one's write endpoint can be read from the other's
+// read endpoint, and vice versa.
+//
+// Returns:
+//   - h1: First bidirectional pipe endpoint
+//   - h2: Second bidirectional pipe endpoint
+func newBidirectionalHalfClosePipe() (h1, h2 *bidirectionalHalfClosePipe) {
+	pr1, pw1 := io.Pipe()
+	pr2, pw2 := io.Pipe()
 
-type passthroughReadWriteCloser struct {
-	io.ReadCloser
-	io.WriteCloser
-}
-
-func newPipeReadWriter() io.ReadWriteCloser {
-	r, w := io.Pipe()
-	return &passthroughReadWriteCloser{
-		ReadCloser:  r,
-		WriteCloser: w,
+	h1 = &bidirectionalHalfClosePipe{
+		r: pr1, w: pw2,
 	}
+
+	h2 = &bidirectionalHalfClosePipe{
+		r: pr2, w: pw1,
+	}
+	return
 }
 
-func (p *passthroughReadWriteCloser) Close() error {
-	err := p.ReadCloser.Close()
-	if err != nil && !errors.Is(err, io.ErrClosedPipe) {
-		return err
-	}
-	err = p.WriteCloser.Close()
-	if err != nil && !errors.Is(err, io.ErrClosedPipe) {
-		return err
-	}
-	return nil
+func (h *bidirectionalHalfClosePipe) CloseWrite() error {
+	return h.w.Close()
 }
 
+func (h *bidirectionalHalfClosePipe) Close() error {
+	wErr := h.w.Close()
+	rErr := h.r.Close()
+
+	if wErr != nil {
+		return wErr
+	}
+	return rErr
+}
+
+func (h *bidirectionalHalfClosePipe) Read(p []byte) (n int, err error) {
+	return h.r.Read(p)
+}
+
+func (h *bidirectionalHalfClosePipe) Write(p []byte) (n int, err error) {
+	return h.w.Write(p)
+}
+
+// TestPipe verifies the functionality of the bidirectional pipe utility.
+//
+// The test simulates a scenario similar to interactive command execution,
+// such as a docker run -i command, which requires bidirectional communication.
+// This test case mimics scenarios like:
+// - Sending input to a Docker container via stdin
+// - Half-closing the input stream
+// - Receiving output from the container
+//
+// The test steps are:
+// 1. A client sends data
+// 2. The client half-closes the connection
+// 3. The server reads the data
+// 4. The server sends a return response
+// 5. The server half-closes the connection
+//
+// This approach is particularly relevant for interactive Docker runs where
+// the client needs to send input and then wait for the container's response,
+// while maintaining the ability to close streams independently.
 func TestPipe(t *testing.T) {
-	rw := newPipeReadWriter()
-	output := bytes.Buffer{}
-	data := &passthroughReadWriteCloser{
-		ReadCloser:  nopReadWriteCloser{bytes.NewBufferString("some data")},
-		WriteCloser: nopReadWriteCloser{&output},
-	}
-	err := Pipe(rw, data)
-	if assert.NoError(t, err) {
-		assert.Equal(t, "some data", output.String())
-	}
+	h1a, h1b := newBidirectionalHalfClosePipe()
+	h2a, h2b := newBidirectionalHalfClosePipe()
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine simulating the client-side operation
+	go func() {
+		defer wg.Done()
+		dataToSend := bytes.NewBufferString("some data")
+		_, err := h1a.Write(dataToSend.Bytes())
+		assert.NoError(t, err)
+		h1a.CloseWrite()
+
+		output, err := io.ReadAll(h1a)
+		assert.NoError(t, err)
+		assert.EqualValues(t, output, "return data")
+	}()
+
+	// Goroutine simulating the server-side operation
+	go func() {
+		defer wg.Done()
+		output, err := io.ReadAll(h2b)
+		assert.NoError(t, err)
+		assert.EqualValues(t, output, "some data")
+
+		dataToSend := bytes.NewBufferString("return data")
+		_, err = h2b.Write(dataToSend.Bytes())
+		assert.NoError(t, err)
+
+		h2b.CloseWrite()
+	}()
+
+	err := Pipe(h1b, h2a)
+	assert.NoError(t, err)
+	wg.Wait()
 }

--- a/src/go/wsl-helper/pkg/dockerproxy/util/reverse_proxy.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/util/reverse_proxy.go
@@ -1,0 +1,301 @@
+package util
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	hostHeaderValue = "api.moby.localhost"
+	targetProtocol  = "http://"
+)
+
+// ReverseProxy is a custom reverse proxy specifically designed for Rancher Desktop's
+// Docker API communication. Unlike the standard library's ReverseProxy, this
+// implementation provides explicit support for half-close connections and
+// HTTP protocol upgrades required by the Docker API.
+//
+// Key design features:
+// - Handles HTTP protocol upgrades (WebSocket-like connections)
+// - Supports half-close TCP connections
+// - Provides hooks for request/response modification
+// - Designed for specific Docker API interaction requirements
+type ReverseProxy struct {
+	// Dial provides a custom connection establishment method
+	Dial func(network, addr string) (net.Conn, error)
+
+	// Director allows modification of the outgoing request before forwarding
+	Director func(*http.Request)
+
+	// ModifyResponse enables post-processing of the backend response
+	ModifyResponse func(*http.Response) error
+
+	// ErrorLog defines an optional logger for recording errors encountered
+	// during request proxying. If not provided, the standard logger from
+	// the log package is used instead.
+	ErrorLog *log.Logger
+}
+
+// ServeHTTP implements the http.Handler interface, routing incoming
+// HTTP requests through the custom reverse proxy
+func (proxy ReverseProxy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	proxy.forwardRequest(rw, r)
+}
+
+// forwardRequest is the core method that handles request proxying,
+// with special handling for Docker API-specific requirements.
+//
+// Primary responsibilities:
+// - Establish backend connection
+// - Forward request to backend
+// - Handle response streaming
+// - Support protocol upgrades
+// - Ensure proper connection management
+func (proxy *ReverseProxy) forwardRequest(w http.ResponseWriter, r *http.Request) {
+	// Early check to ensure the ResponseWriter supports http.Flusher.
+	// This allows immediate error feedback to the client if the required
+	// functionality is not available, rather than failing later during streaming.
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		proxy.sendError(w, "expected http.ResponseWriter to be an http.Flusher", http.StatusInternalServerError)
+		return
+	}
+
+	// Leverage the original request's context as the base
+	ctx := r.Context()
+
+	// Create a new context with cancellation to ensure we can stop the flush
+	// The context will be canceled when the request is done or if needed earlier
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Establish a connection to the backend using a custom Dial method
+	backendConn, err := proxy.Dial("", "")
+	if err != nil {
+		proxy.sendError(w, "failed to connect to the backend: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer backendConn.Close()
+
+	// Create a new HTTP request with the same headers
+	url := targetProtocol + hostHeaderValue + r.RequestURI
+	newReq, err := http.NewRequestWithContext(ctx, r.Method, url, r.Body)
+	if err != nil {
+		proxy.sendError(w, "failed to create a request for the backend: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	newReq.Header = r.Header
+
+	// Director function
+	// Allows complete customization of the outgoing request
+	if proxy.Director != nil {
+		proxy.Director(newReq)
+	}
+	// Prevent automatic connection closure
+	newReq.Close = false
+
+	// Forward the modified request to the backend
+	if err = newReq.Write(backendConn); err != nil {
+		proxy.sendError(w, "failed to forward the request to the backend: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	// Read the response from the backend
+	backendResponse, err := http.ReadResponse(bufio.NewReader(backendConn), newReq)
+	if err != nil {
+		proxy.sendError(w, "failed to read the response from the backend: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer backendResponse.Body.Close()
+
+	// ModifyResponse function
+	// Allows post-processing of the backend response
+	if proxy.ModifyResponse != nil {
+		err := proxy.ModifyResponse(backendResponse)
+		if err != nil {
+			proxy.sendError(w, "failed to modify the response from the backend: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Propagate backend response headers to the client
+	for key, values := range backendResponse.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	// Write the response status code and headers and flush it immediately
+	w.WriteHeader(backendResponse.StatusCode)
+	flusher.Flush()
+
+	// Check if the response has a status code of 101 (Switching Protocols)
+	if backendResponse.StatusCode == http.StatusSwitchingProtocols {
+		proxy.handleUpgradedConnection(w, backendConn)
+		return
+	}
+
+	// Stream the response body back to the client
+	// flushedWriter is a critical component for supporting
+	// long-running, streaming connections like "docker log -f"
+	fw := newFlushedWriter(ctx, w)
+	_, err = io.Copy(fw, backendResponse.Body)
+	if err != nil {
+		proxy.logf("failed to stream the response body to the client: %v", err)
+	}
+}
+
+// handleUpgradedConnection manages HTTP protocol upgrades (e.g., WebSocket),
+// specifically tailored for Docker API's hijacking mechanism.
+//
+// This method:
+// - Hijacks the existing connection
+// - Manages buffered data
+// - Enables bidirectional communication after protocol upgrade
+func (proxy *ReverseProxy) handleUpgradedConnection(w http.ResponseWriter, backendConn net.Conn) {
+	// Cast writer to safely hijack the connection
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		proxy.logf("client response writer does not support http.Hijacker")
+		return
+	}
+
+	// Hijack attempts to take control of the underlying connection
+	// Returns:
+	// - clientConn: The raw network connection
+	// - bufferedClientConn: A buffered reader/writer for any pending data
+	clientConn, bufferedClientConn, err := hijacker.Hijack()
+	if err != nil {
+		proxy.logf("cannot hijack client connection: %v", err)
+		return
+	}
+	defer clientConn.Close()
+
+	// Flush any buffered data in the writer to ensure no data is lost
+	if bufferedClientConn.Writer.Buffered() > 0 {
+		if err := bufferedClientConn.Writer.Flush(); err != nil {
+			proxy.logf("failed to flush client connection: %v", err)
+			return
+		}
+	}
+
+	// Process any data already buffered in the reader before full duplex communication
+	// This prevents losing any data that might have been read but not yet processed
+	if bufferedLen := bufferedClientConn.Reader.Buffered(); bufferedLen > 0 {
+		bufferedData := make([]byte, bufferedLen)
+		_, err := bufferedClientConn.Reader.Read(bufferedData)
+		if err != nil {
+			proxy.logf("failed to read buffered data from the client: %v", err)
+			return
+		}
+		_, err = backendConn.Write(bufferedData)
+		if err != nil {
+			proxy.logf("failed to write buffered data to the backend: %v", err)
+			return
+		}
+	}
+
+	// Cast backend and client connections to HalfReadWriteCloser
+	var halfCloserBackendConn HalfReadWriteCloser
+	var halfCloserClientConn HalfReadWriteCloser
+	if halfCloser, ok := backendConn.(HalfReadWriteCloser); !ok {
+		proxy.logf("backend connection does not implement HalfReadCloseWriter")
+		return
+	} else {
+		halfCloserBackendConn = halfCloser
+	}
+	if halfCloser, ok := clientConn.(HalfReadWriteCloser); !ok {
+		proxy.logf("client connection does not implement HalfReadCloseWriter")
+		return
+	} else {
+		halfCloserClientConn = halfCloser
+	}
+
+	// Establish a bidirectional pipe between client and backend connections
+	// This allows full-duplex communication with support for half-closes
+	// Critical for Docker API's stream-based communication model
+	if err := Pipe(halfCloserClientConn, halfCloserBackendConn); err != nil {
+		proxy.logf("piping client to backend failed: %v", err)
+	}
+}
+
+func (proxy *ReverseProxy) sendError(w http.ResponseWriter, msg string, statusCode int) {
+	proxy.logf(msg)
+	http.Error(w, msg, statusCode)
+}
+
+func (p *ReverseProxy) logf(format string, args ...any) {
+	logger := p.ErrorLog
+	if logger == nil {
+		logger = log.Default()
+	}
+	logger.Printf(format, args...)
+}
+
+// flushedWriter wraps an io.Writer with periodic flushing capability.
+// It ensures that data is periodically flushed to the underlying writer.
+type flushedWriter struct {
+	w     io.Writer       // Underlying writer to which data is written.
+	mu    sync.Mutex      // Mutex to protect concurrent access to the writer and dirty flag.
+	ctx   context.Context // Context to control the lifecycle of the periodic flusher.
+	dirty bool            // Flag indicating whether the writer may have unflushed data.
+}
+
+// NewFlushedWriter creates and initializes a new flushedWriter instance.
+// The provided writer w must implement both io.Writer and http.Flusher interfaces.
+// If w does not implement http.Flusher, the writer will work but no periodic
+// flushing will be performed. It is the caller's responsibility to ensure
+// that w implements http.Flusher before instantiation if periodic flushing
+// is required.
+func newFlushedWriter(ctx context.Context, w io.Writer) *flushedWriter {
+	fw := &flushedWriter{
+		w:   w,
+		ctx: ctx,
+	}
+
+	// periodicFlusher runs a loop that periodically flushes the writer
+	periodicFlusher := func(flusher http.Flusher) {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-fw.ctx.Done():
+				return
+			case <-ticker.C:
+				fw.mu.Lock()
+				if fw.dirty {
+					flusher.Flush()
+					fw.dirty = false
+				}
+				fw.mu.Unlock()
+			}
+		}
+	}
+
+	// Type assert the writer to http.Flusher
+	if flusher, ok := w.(http.Flusher); ok {
+		// Start periodic flushing in a goroutine
+		go periodicFlusher(flusher)
+	}
+
+	return fw
+}
+
+// Write implements io.Writer and protects the underlying writer with a mutex
+func (fw *flushedWriter) Write(p []byte) (n int, err error) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+
+	n, err = fw.w.Write(p)
+	if n > 0 {
+		fw.dirty = true
+	}
+	return n, err
+}


### PR DESCRIPTION
This PR fixes the improper handling of half-closed connection behavior when attaching stdin to a container. The proper approach requires:
- The docker client receives a half-close of the connection from client to daemon (stdin)
- The connection from daemon to client (stdout, stderr) remains open until no more data is to be received

The first part of the issue is resolved by enabling MessageMode on Windows named pipes. This ensures that when stdin ends, an EOF is received on the reader, allowing proper half-closing of the connection.

The previous implementation used stdlib's httputil.DockerProxy to proxy from Windows named pipe to WSL hvsock. This proxy does not use CloseWrite on hijacked connections, preventing proper handling of this use case. By using Close() instead of CloseWrite(), both connection directions are closed simultaneously, causing the client to miss pending stdout/stderr content after stdin EOF.

This commit introduces a simpler custom `util.ReverseProxy` to replace httputil.DockerProxy, implementing proper handling of half-closed connections with explicit support for:
- HTTP protocol upgrades
- Half-close TCP connection management
- Precise stream handling for Docker API interactions

Closes #2094