### PR TITLE
k3sHelper: k3s channels: Allow `channel` instead of `channels`

### DIFF
--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -380,11 +380,11 @@ export default class K3sHelper extends events.EventEmitter {
       }
 
       if (channelResponse.ok) {
-        const ResourceTypeChannels = 'channels';
+        const ValidResourceTypes = ['channel', 'channels'];
         const DataTypeChannel = 'channel';
 
         type ChannelResponse = {
-          resourceType: typeof ResourceTypeChannels;
+          resourceType: string;
           data?: {
             type: typeof DataTypeChannel;
             name: string;
@@ -394,7 +394,7 @@ export default class K3sHelper extends events.EventEmitter {
         const channels: ChannelResponse = await channelResponse.json();
 
         console.debug(`Got K3s update channel data: ${ channels.data?.map(ch => ch.name) }`);
-        if (channels.resourceType !== ResourceTypeChannels) {
+        if (!ValidResourceTypes.includes(channels.resourceType)) {
           throw new Error(`Channel response does not have correct resource type: ${ channels.resourceType }`);
         }
 


### PR DESCRIPTION
It looks like a server-side change had made this possibly singular instead of plural.  Accept both so we can take whichever the server happens to present.

Fixes #7904 (if there are no other reasons for it).