### PR TITLE
Fix AppImage building on OBS

### DIFF
--- a/packaging/linux/appimage.yml
+++ b/packaging/linux/appimage.yml
@@ -11,7 +11,6 @@ script:
   - unzip $BUILD_SOURCE_DIR/rancher-desktop.zip -d $BUILD_APPDIR/opt/rancher-desktop
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/rancher-desktop.desktop $BUILD_APPDIR
   - convert -resize 512x512 $BUILD_APPDIR/opt/rancher-desktop/resources/resources/icons/logo-square-512.png $BUILD_APPDIR/rancher-desktop.png
-  - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/rancher-desktop.appdata.xml $BUILD_APPDIR/usr/share/metainfo
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/bin/qemu-* $BUILD_APPDIR/usr/bin
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/share/qemu $BUILD_APPDIR/usr/share
   - mv $BUILD_APPDIR/opt/rancher-desktop/resources/resources/linux/lima/lib $BUILD_APPDIR/usr


### PR DESCRIPTION
The version of AppImageKit in OpenSUSE Leap 15.5 does not run the AppStream validator with `--no-net`, but OBS does not allow network access.  This means we will always fail the validation (until we move to a new AppImageKit). For now, remove the AppStream metadata to work around the issue.

Fixes #7859 with some project configuration changes that do not live in the repo:

Project meta configuration (moved to `toolchain.15.5`, added the `openSUSE:Leap:15.5` repo):
```xml
  <repository name="AppImage">
    <path project="OBS:AppImage" repository="toolchain.15.5"/>
    <path project="openSUSE:Leap:15.5" repository="standard"/>
    <arch>x86_64</arch>
  </repository>
```

Project configuration:
```
%if "%_repository" == "AppImage"
Type: appimage
Repotype: staticlinks
Patterntype: none

Required: build-pkg2appimage

Prefer: -libsystemd0-mini
Prefer: -udev-mini
Prefer: -libudev-mini1
Prefer: -systemd-mini
%endif
```
- Drop the special casing of `AppStream`, since that doesn't seem to help anymore (it just breaks the build)
- Drop the `Prefer: createrepo_c` because the Python implementation is no longer available.
- Disprefer various `systemd`-related `-mini` packages, because they cause dependency resolution errors.  Since we now enable the full Leap repo, we'll end up installing the full things instead (and they don't end up packaged in the `.AppImage`).

---
Note that by switching to 15.5 as a base, we will no longer run on some older distributions; on 15.0, we see things like:
> ``rancher-desktop: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/.mount_rancheg1e92X/usr/lib64/libcairo.so.2)``

---
Alternatively, we can also use a second package to build the AppImage, and just tell it to install the `rancher-desktop` RPM we build next to it.  That leads to a much slimmer `appimage.yml` but it's a bit larger.  The two configuration changes will still need to be applied, and the issue with dependencies will likely remain.