### PR TITLE
CI: explicitly install pass on Linux as needed

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -40,6 +40,9 @@ runs:
     if: runner.os == 'Linux'
     shell: bash
     run: |
+      sudo apt-get update
+      sudo apt-get install pass
+
       # Configure the agent to allow default passwords
       HOMEDIR="$(gpgconf --list-dirs homedir)" # spellcheck-ignore-line
       mkdir -p "${HOMEDIR}"


### PR DESCRIPTION
For GitHub hosted runners, Ubuntu 20.x and 22.x had pass pre-installed, but it was no longer included in the 24.x runners.

Note that the upstream repo has `ubuntu-latest` mapping to 24.x, but my fork has it at 22.x… but the PR should still be fine.

This PR is made from the merge-base of `main` and `release-1.7`, so we should be able to land this on the branch too.