### PR TITLE
rdctl: Fix obvious factory reset errors.

### DIFF
--- a/src/go/rdctl/cmd/internalProcessWaitKill.go
+++ b/src/go/rdctl/cmd/internalProcessWaitKill.go
@@ -39,7 +39,7 @@ exit, and once it does, terminates all processes within the same process group.`
 		if err != nil {
 			return fmt.Errorf("failed to get process ID: %w", err)
 		}
-		return process.WaitForProcessAndKillGroup(pid)
+		return process.KillProcessGroup(pid, true)
 	},
 }
 

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -412,11 +412,10 @@ func FindPidOfProcess(executable string) (int, error) {
 	return mainPid, nil
 }
 
-// Wait for the process identified by the given pid to exit, then kill all
-// processes in the same process group.  This blocks until the given process
-// exits.
-func WaitForProcessAndKillGroup(pid int) error {
-	return errors.New("WaitForProcessAndKillGroup is not implemented on Windows")
+// Kill the process group the given process belongs to.  If wait is set, block
+// until the target process exits first before doing so.
+func KillProcessGroup(pid int, wait bool) error {
+	return errors.New("KillProcessGroup is not implemented on Windows")
 }
 
 // TerminateProcessInDirectory terminates all processes where the executable

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -428,6 +428,10 @@ func TerminateProcessInDirectory(directory string, force bool) error {
 		if err != nil {
 			pid = 0
 		}
+		if pid == uint32(os.Getpid()) {
+			// Skip terminating the current process.
+			return nil
+		}
 		relPath, err := filepath.Rel(directory, executablePath)
 		if err != nil {
 			// This may be because they're on different drives, network shares, etc.

--- a/src/go/rdctl/pkg/shutdown/shutdown.go
+++ b/src/go/rdctl/pkg/shutdown/shutdown.go
@@ -246,7 +246,7 @@ func terminateRancherDesktopFunc(appDir string) func(context.Context) error {
 			if err != nil {
 				return err
 			}
-			return process.WaitForProcessAndKillGroup(pid)
+			return process.KillProcessGroup(pid, false)
 		})())
 
 		errors = multierror.Append(errors, process.TerminateProcessInDirectory(appDir, true))


### PR DESCRIPTION
- win32: Do not shut down current process during factory reset (fixes #7940)

  When doing a factory reset, do not kill the current process (i.e. the `rdctl factory-reset` one), as that would prevent the rest of the factory reset process from occurring.
- *nix: Do not wait for main process to exit before killing it (fixes #7943)

  When doing a factory reset, do no wait for the main process to exit gracefully before terminating it, as that would not normally happen.  Instead, just kill its process group (including the main process itself) without waiting.
    

