### PR TITLE
Create sudoers file internally instead of calling `limactl sudoers`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -555,6 +555,7 @@ NONINFRINGEMENT
 noproxy
 norestart
 normaliser
+NOSETENV
 nothrow
 notifempty
 notset


### PR DESCRIPTION
The `limactl sudoers` command will fail if socket_vmnet is not yet installed into the secure path. So we would need to ask the user for the sudo password twice: once to install socket_vmnet, and then again to install the sudoers file. By "guessing" the content beforehand we can install both at the same time.

Signed-off-by: Jan Dubois <jan.dubois@suse.com>
(cherry picked from commit 2fabc3424213f26bda715c725d5c39482a14c975)