### PR TITLE
rdctl: Don't use process groups on Linux

### DIFF
--- a/src/go/rdctl/cmd/internalProcessWaitKill.go
+++ b/src/go/rdctl/cmd/internalProcessWaitKill.go
@@ -21,6 +21,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/spf13/cobra"
@@ -38,6 +39,12 @@ exit, and once it does, terminates all processes within the same process group.`
 		pid, err := cmd.Flags().GetInt("pid")
 		if err != nil {
 			return fmt.Errorf("failed to get process ID: %w", err)
+		}
+		if runtime.GOOS == "linux" {
+			// TODO: We can't use the process group on Linux, because Electron does
+			// not always create a new one.  But for now still wait for the
+			// process to exit
+			return process.WaitForProcess(pid)
 		}
 		return process.KillProcessGroup(pid, true)
 	},

--- a/src/go/rdctl/pkg/shutdown/shutdown.go
+++ b/src/go/rdctl/pkg/shutdown/shutdown.go
@@ -237,17 +237,21 @@ func terminateRancherDesktopFunc(appDir string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		var errors *multierror.Error
 
-		errors = multierror.Append(errors, (func() error {
-			mainExe, err := p.GetMainExecutable(ctx)
-			if err != nil {
-				return err
-			}
-			pid, err := process.FindPidOfProcess(mainExe)
-			if err != nil {
-				return err
-			}
-			return process.KillProcessGroup(pid, false)
-		})())
+		// TODO: We can't use the process group on Linux, because Electron does
+		// not always create a new one.
+		if runtime.GOOS != "linux" {
+			errors = multierror.Append(errors, (func() error {
+				mainExe, err := p.GetMainExecutable(ctx)
+				if err != nil {
+					return err
+				}
+				pid, err := process.FindPidOfProcess(mainExe)
+				if err != nil {
+					return err
+				}
+				return process.KillProcessGroup(pid, false)
+			})())
+		}
 
 		errors = multierror.Append(errors, process.TerminateProcessInDirectory(appDir, true))
 


### PR DESCRIPTION
Disable killing all processes in the process on Linux, as Electron does not create a new process group when running from the RPM/deb package.  Leave it using process groups on macOS, as launchd still does it.

It is expected that we will revert this once we sort out process groups on Linux.

This is the release-1.17 version of #7965