### PR TITLE
packaging: win32: Move signingHashAlgorithms to signtoolOptions

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -35,7 +35,8 @@ mac:
   - { from: dist/electron-builder.yaml, to: electron-builder.yml }
 win:
   target: [ zip ]
-  signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2
+  signtoolOptions:
+    signingHashAlgorithms: [ sha256 ] # We only support Windows 10 + WSL2
   requestedExecutionLevel: asInvoker # The _app_ doesn't need privileges
   extraFiles:
   - build/wix/*

--- a/scripts/lib/sign-win32.ts
+++ b/scripts/lib/sign-win32.ts
@@ -7,6 +7,7 @@ import path from 'path';
 
 import { getSignVendorPath } from 'app-builder-lib/out/codeSign/windowsSignToolManager';
 import defaults from 'lodash/defaultsDeep';
+import merge from 'lodash/merge';
 import yaml from 'yaml';
 
 import { simpleSpawn } from 'scripts/simple_process';
@@ -21,8 +22,8 @@ type signFileFn = (...filePath: string[]) => Promise<void>;
  * when signing the installer.
  */
 const REQUIRED_WINDOWS_CONFIG = {
-  signingHashAlgorithms: ['sha256'],
-  target:                'zip',
+  signtoolOptions: { signingHashAlgorithms: ['sha256'] },
+  target:          'zip',
 };
 
 /**
@@ -66,7 +67,7 @@ export async function sign(workDir: string): Promise<string[]> {
 
   config.win ??= {};
   defaults(config.win, DEFAULT_WINDOWS_CONFIG);
-  Object.assign(config.win, REQUIRED_WINDOWS_CONFIG);
+  merge(config.win, REQUIRED_WINDOWS_CONFIG);
   config.win.certificateSha1 = certFingerprint;
 
   const toolPath = path.join(await getSignVendorPath(), 'windows-10', process.arch, 'signtool.exe');


### PR DESCRIPTION
The field has moved in electron-builder 25.1.7 and the old location was deprecated.

For now, this just suppresses a deprecation warning; presumably it will cease to be supported in some future electron-builder release.