### PR TITLE
WSL: Ignore errors when shutting down

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1588,12 +1588,17 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
       await this.progressTracker.action('Shutting Down...', 10, async() => {
         if (await this.isDistroRegistered({ runningOnly: true })) {
-          await this.stopService('k3s');
-          await this.stopService('docker');
-          await this.stopService('containerd');
-          await this.stopService('rd-openresty');
-          await this.stopService('rancher-desktop-guestagent');
-          await this.stopService('buildkitd');
+          const services = ['k3s', 'docker', 'containerd', 'rd-openresty',
+            'rancher-desktop-guestagent', 'buildkitd'];
+
+          for (const service of services) {
+            try {
+              await this.stopService(service);
+            } catch (ex) {
+              // Do not allow errors here to prevent us from stopping.
+              console.error(`Failed to stop service ${ service }:`, ex);
+            }
+          }
           try {
             await this.stopService('local');
           } catch (ex) {
@@ -1606,7 +1611,14 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         this.process = null;
         if (initProcess) {
           initProcess.kill('SIGTERM');
-          await this.execCommand('/usr/bin/killall', '-q', '/usr/local/bin/network-setup');
+          try {
+            await this.execCommand({ expectFailure: true }, '/usr/bin/killall', '/usr/local/bin/network-setup');
+          } catch (ex) {
+            // `killall` returns failure if it fails to kill (e.g. if the
+            // process does not exist); `-q` only suppresses printing any error
+            // messages.
+            console.error('Ignoring error shutting down network-setup:', ex);
+          }
         }
         await this.hostSwitchProcess.stop();
         if (await this.isDistroRegistered({ runningOnly: true })) {

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -144,12 +144,14 @@ func main() {
 		logrus.Fatalf("failed to switch back to original namespace: %v", err)
 	}
 	if err := configureVethPair(WSLVeth, WSLVethIP); err != nil {
-		logrus.Fatalf("failed setting up veth: %s for rancher desktop namespace: %v", WSLVeth, err)
+		logrus.Fatalf("failed setting up veth: %s for default namespace: %v", WSLVeth, err)
 	}
 
 	if err := originNS.Close(); err != nil {
 		logrus.Errorf("failed to close original NS, ignoring error: %v", err)
 	}
+
+	logrus.Trace("Network setup complete, waiting for vm-switch")
 
 	if err := vmSwitchCmd.Wait(); err != nil {
 		logrus.Errorf("vm-switch exited with error: %v", err)


### PR DESCRIPTION
When shutting down, ignore errors taking down the individual services or when killing network-setup.  Since we will terminate the WSL distribution anyway, any errors at that stage are harmless.
    
This appears to fix issues with Windows E2E tests; it seems like we end up falling over trying to shut down and disrupt the following test step.

Fixes: #7939, #7983