### PR TITLE
Bump qemu from 9.1.2.rd1 to 9.2.0.rd1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,5 +1,5 @@
 lima: 1.0.2.rd1
-qemu: 9.1.2.rd1
+qemu: 9.2.0.rd1
 socketVMNet: 1.2.1
 alpineLimaISO:
   isoVersion: 0.2.41.rd3


### PR DESCRIPTION
Signed-off-by: Rancher Desktop Dependency Manager <donotuse@rancherdesktop.io>
(cherry picked from commit d469c46dfb039198d0f7664352df46f440c5db69)