### PR TITLE
WSL: Handle eth0 being renamed

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -371,6 +371,7 @@ INSTALLPROPERTY
 ioctl
 ipaddr
 iptable
+IRTT
 Isf
 isthebestmeshuggahalbum
 istio

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -5,10 +5,6 @@
 # ANSI color codes
 (?:\\(?:u00|x)1[Bb]|\x1b|\\u\{1[Bb]\})\[\d+(?:;\d+|)m
 
-# hit-count: 743 file-count: 13
-# hex runs
-\b[0-9a-fA-F]{16,}\b
-
 # hit-count: 739 file-count: 6
 # base64 encoded content, possibly wrapped in mime
 (?:^|[\s=;:?])[-a-zA-Z=;:/0-9+]{50,}(?:[\s=;:?]|$)
@@ -41,6 +37,11 @@ sha\d+:[0-9]*[a-f]{3,}[0-9a-f]*
 # hit-count: 10 file-count: 2
 # uuid:
 \b[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\b
+
+# hit-count: 743 file-count: 13
+# hex runs
+\b[0-9a-fA-F]{16,}\b
+\b[0-9A-F]{8,}\b
 
 # hit-count: 10 file-count: 1
 # css url wrappings

--- a/pkg/rancher-desktop/backend/__tests__/wsl.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/wsl.spec.ts
@@ -1,0 +1,75 @@
+import WSLBackend from '../wsl';
+
+describe('WSLBackend', () => {
+  describe('getIPAddress', () => {
+    const route = `
+      Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
+      eth0    00000000        01F019AC        0003    0       0       0       00000000        0       0       0
+      docker0 000011AC        00000000        0001    0       0       0       0000FFFF        0       0       0
+      eth0    00F019AC        00000000        0001    0       0       0       00F0FFFF        0       0       0
+    `;
+    const trie = `
+        +-- 0.0.0.0/0 3 0 5
+          |-- 0.0.0.0
+              /0 universe UNICAST
+          +-- 127.0.0.0/8 2 0 2
+              +-- 127.0.0.0/31 1 0 0
+                |-- 127.0.0.0
+                    /8 host LOCAL
+                |-- 127.0.0.1
+                    /32 host LOCAL
+              |-- 127.255.255.255
+                /32 link BROADCAST
+          +-- 172.16.0.0/12 2 0 2
+              +-- 172.17.0.0/16 2 0 2
+                +-- 172.17.0.0/31 1 0 0
+                    |-- 172.17.0.0
+                      /16 link UNICAST
+                    |-- 172.17.0.1
+                      /32 host LOCAL
+                |-- 172.17.255.255
+                    /32 link BROADCAST
+              +-- 172.25.240.0/20 2 0 2
+                +-- 172.25.240.0/23 2 0 2
+                    |-- 172.25.240.0
+                      /20 link UNICAST
+                    |-- 172.25.241.207
+                      /32 host LOCAL
+                |-- 172.25.255.255
+                    /32 link BROADCAST
+    `;
+
+    it('should return an IP address', async() => {
+      function readFile(fileName: string): Promise<string> {
+        if (fileName === '/proc/net/route') {
+          return Promise.resolve(route);
+        }
+        if (fileName === '/proc/net/fib_trie') {
+          return Promise.resolve(`Main:\n${ trie }Local:\n${ trie }`);
+        }
+
+        return Promise.reject(new Error(`Read unexpected file ${ fileName }`));
+      }
+      const expected = '172.25.241.207';
+      const actual = WSLBackend.prototype['getIPAddress'].call(null, readFile);
+
+      await expect(actual).resolves.toEqual(expected);
+    });
+    it('should accept non-standard network interface name', async() => {
+      function readFile(fileName: string): Promise<string> {
+        if (fileName === '/proc/net/route') {
+          return Promise.resolve(route.replaceAll('eth0', 'eth3'));
+        }
+        if (fileName === '/proc/net/fib_trie') {
+          return Promise.resolve(`Main:\n${ trie }Local:\n${ trie }`);
+        }
+
+        return Promise.reject(new Error(`Read unexpected file ${ fileName }`));
+      }
+      const expected = '172.25.241.207';
+      const actual = WSLBackend.prototype['getIPAddress'].call(null, readFile);
+
+      await expect(actual).resolves.toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
Change how we parse for the current IP address in WSL so that we don't rely on the interface being named `eth0`.  Fixes #7989 (where it's named `eth3` instead).

We blacklist `localhost`, `docker0`, `cni0`, `veth…`, etc.  The actual parsing parse is refactored into a separate function so it can be tested easier.