### PR TITLE
Windows: call `runtime.LockOSThread` in `network-setup`

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-init
+++ b/pkg/rancher-desktop/assets/scripts/wsl-init
@@ -21,7 +21,7 @@ if [ $$ -ne "1" ]; then
     # from WSL.
     exec /usr/local/bin/network-setup --logfile "$NETWORK_SETUP_LOG" \
     --vm-switch-path /usr/local/bin/vm-switch --vm-switch-logfile \
-    "$VM_SWITCH_LOG" --unshare-arg "${0}"
+    "$VM_SWITCH_LOG" ${RD_DEBUG:+-debug} --unshare-arg "${0}"
 fi
 
 # Mark directories that we will need to bind mount as shared mounts.

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1041,15 +1041,20 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
     // The process should already be gone by this point, but make sure.
     this.process?.kill('SIGTERM');
+    const env: Record<string, string> = {
+      ...process.env,
+      WSLENV:           `${ process.env.WSLENV }:DISTRO_DATA_DIRS:LOG_DIR/p:RD_DEBUG`,
+      DISTRO_DATA_DIRS: DISTRO_DATA_DIRS.join(':'),
+      LOG_DIR:          paths.logs,
+    };
+
+    if (this.debug) {
+      env.RD_DEBUG = '1';
+    }
     this.process = childProcess.spawn('wsl.exe',
       ['--distribution', INSTANCE_NAME, '--exec', '/usr/local/bin/wsl-init'],
       {
-        env: {
-          ...process.env,
-          WSLENV:           `${ process.env.WSLENV }:DISTRO_DATA_DIRS:LOG_DIR/p`,
-          DISTRO_DATA_DIRS: DISTRO_DATA_DIRS.join(':'),
-          LOG_DIR:          paths.logs,
-        },
+        env,
         stdio:       ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       });


### PR DESCRIPTION
We're seeing Windows E2E test failures intermittently in #7939 along the lines of _failed setting up veth: veth-rd-ns for rancher desktop namespace: Link not found_.  I _think_ this is happening because we got our threads switched out some time between creating the new namespace (and switching to it) and trying to use that link name.

Note that this is actually all documented in the [`netns` module](https://pkg.go.dev/github.com/vishvananda/netns#pkg-overview).

This also has a commit to enable debug logging for `network-setup` when the application-global debug flag is enabled.