### PR TITLE
Linux: renable use of process groups

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -110,6 +110,16 @@ let pendingRestartContext: CommandWorkerInterface.CommandContext | undefined;
 let httpCommandServer: HttpCommandServer|null = null;
 const httpCredentialHelperServer = new HttpCredentialHelperServer();
 
+if (process.platform === 'linux') {
+  // On Linux, put Electron into a new process group so that we can more
+  // reliably kill processes we spawn from extensions.
+  try {
+    require('posix-node').setpgid(0, 0);
+  } catch (ex) {
+    console.error(`Ignoring error setting process group: ${ ex }`);
+  }
+}
+
 // Scheme must be registered before the app is ready
 Electron.protocol.registerSchemesAsPrivileged([
   { scheme: 'app', privileges: { secure: true, standard: true } },

--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
   },
   "optionalDependencies": {
     "dmg-license": "1.0.11",
-    "fs-xattr": "0.3.1"
+    "fs-xattr": "0.3.1",
+    "posix-node": "0.12.0"
   },
   "browserslist": [
     "node 18",

--- a/src/go/rdctl/cmd/internalProcessWaitKill.go
+++ b/src/go/rdctl/cmd/internalProcessWaitKill.go
@@ -21,7 +21,6 @@ package cmd
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/process"
 	"github.com/spf13/cobra"
@@ -39,12 +38,6 @@ exit, and once it does, terminates all processes within the same process group.`
 		pid, err := cmd.Flags().GetInt("pid")
 		if err != nil {
 			return fmt.Errorf("failed to get process ID: %w", err)
-		}
-		if runtime.GOOS == "linux" {
-			// TODO: We can't use the process group on Linux, because Electron does
-			// not always create a new one.  But for now still wait for the
-			// process to exit
-			return process.WaitForProcess(pid)
 		}
 		return process.KillProcessGroup(pid, true)
 	},

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -413,7 +413,8 @@ func FindPidOfProcess(executable string) (int, error) {
 }
 
 // Kill the process group the given process belongs to.  If wait is set, block
-// until the target process exits first before doing so.
+// until the target process exits first before doing so.  On Linux, the process
+// group is only killed if the given pid is its own process group leader.
 func KillProcessGroup(pid int, wait bool) error {
 	return errors.New("KillProcessGroup is not implemented on Windows")
 }

--- a/src/go/rdctl/pkg/shutdown/shutdown.go
+++ b/src/go/rdctl/pkg/shutdown/shutdown.go
@@ -237,21 +237,17 @@ func terminateRancherDesktopFunc(appDir string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		var errors *multierror.Error
 
-		// TODO: We can't use the process group on Linux, because Electron does
-		// not always create a new one.
-		if runtime.GOOS != "linux" {
-			errors = multierror.Append(errors, (func() error {
-				mainExe, err := p.GetMainExecutable(ctx)
-				if err != nil {
-					return err
-				}
-				pid, err := process.FindPidOfProcess(mainExe)
-				if err != nil {
-					return err
-				}
-				return process.KillProcessGroup(pid, false)
-			})())
-		}
+		errors = multierror.Append(errors, (func() error {
+			mainExe, err := p.GetMainExecutable(ctx)
+			if err != nil {
+				return err
+			}
+			pid, err := process.FindPidOfProcess(mainExe)
+			if err != nil {
+				return err
+			}
+			return process.KillProcessGroup(pid, false)
+		})())
 
 		errors = multierror.Append(errors, process.TerminateProcessInDirectory(appDir, true))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11030,6 +11030,13 @@ portfinder@^1.0.26:
     debug "^3.2.7"
     mkdirp "^0.5.6"
 
+posix-node@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/posix-node/-/posix-node-0.12.0.tgz#318f9de664cd532fe19d4d73c364077a7eaeb906"
+  integrity sha512-/CUfwwGM0lHcSaU3w/Sh8gQTFAzQ4ef1GUvOIfgcnvI0aWLp3NJpHhD14scbtRjQL6KOCqdaMgYdAzHyjImAig==
+  dependencies:
+    debug "^4.3.4"
+
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -12556,16 +12563,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12634,7 +12632,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12647,13 +12645,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13984,7 +13975,7 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14005,15 +13996,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This adds code to manually set a process group on Linux only, and to re-enable the use of process groups to terminate processes on shutdown.

Fixes #7653 