### PR TITLE
Using the correct node version for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ you'll need to `source` that file.
 Currently we build Rancher Desktop with Node 20. To install it, run:
 
 ```
-nvm install 20.17
+nvm install 20.16
 ```
 
 Next, you'll need to install the yarn package manager:


### PR DESCRIPTION
Node version 20.17 doesn't seem to work for the local development and it had to be downgraded to 20.16. Updating the docs in order to help others.

<img width="1018" alt="Screenshot 2024-12-31 at 2 05 35 AM" src="https://github.com/user-attachments/assets/5063cbb6-004e-432c-8b95-cc4288337ad1" />
