### PR TITLE
Bump trivy from 0.58.0 to 0.58.1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerCLI: 27.4.1
 dockerBuildx: 0.19.3
 dockerCompose: 2.32.1
 golangci-lint: 1.62.2
-trivy: 0.58.0
+trivy: 0.58.1
 steve: 0.1.0-beta9
 rancherDashboard: desktop-v2.7.0.beta.1
 dockerProvidedCredentialHelpers: 0.8.2


### PR DESCRIPTION
Signed-off-by: Rancher Desktop Dependency Manager <donotuse@rancherdesktop.io>
(cherry picked from commit dee0fa1b38dd9092942cf5f54c391343c53d00b5)