### PR TITLE
Windows: Don't abort everything if `$HOME` is not writable

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -48,6 +48,7 @@ export class DiagnosticsManager {
       const imports = (await Promise.all([
         import('./connectedToInternet'),
         import('./dockerCliSymlinks'),
+        import('./integrationsWindows'),
         import('./kubeConfigSymlink'),
         import('./kubeContext'),
         import('./kubeVersionsAvailable'),

--- a/pkg/rancher-desktop/main/diagnostics/integrationsWindows.ts
+++ b/pkg/rancher-desktop/main/diagnostics/integrationsWindows.ts
@@ -11,9 +11,11 @@ const CheckWindowsIntegrations: DiagnosticsChecker = {
     return Promise.resolve(process.platform === 'win32');
   },
   check(): Promise<DiagnosticsCheckerSingleResult[]> {
-    return Promise.resolve(Object.entries(cachedResults).map(([id, result]) => {
+    const resultMapper = ([id, result]: [string, DiagnosticsCheckerResult]) => {
       return ({ ...result, id });
-    }));
+    };
+
+    return Promise.resolve(Object.entries(cachedResults).map(resultMapper));
   },
 };
 

--- a/pkg/rancher-desktop/main/diagnostics/integrationsWindows.ts
+++ b/pkg/rancher-desktop/main/diagnostics/integrationsWindows.ts
@@ -1,0 +1,43 @@
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
+
+import mainEvents from '@pkg/main/mainEvents';
+
+const cachedResults: Record<string, DiagnosticsCheckerResult> = {};
+
+const CheckWindowsIntegrations: DiagnosticsChecker = {
+  id:       'WINDOWS_INTEGRATIONS',
+  category: DiagnosticsCategory.ContainerEngine,
+  applicable() {
+    return Promise.resolve(process.platform === 'win32');
+  },
+  check(): Promise<DiagnosticsCheckerSingleResult[]> {
+    return Promise.resolve(Object.entries(cachedResults).map(([id, result]) => {
+      return ({ ...result, id });
+    }));
+  },
+};
+
+mainEvents.on('diagnostics-event', (payload) => {
+  if (payload.id !== 'integrations-windows') {
+    return;
+  }
+  const { distro, key, error } = payload;
+  const message = error?.message ?? error?.toString();
+
+  cachedResults[`${ distro || '<main>' }-${ key }`] = {
+    passed: false,
+    fixes:  [],
+    ...(() => {
+      if (!error) {
+        return { passed: true, description: `${ distro }/${ key } passed` };
+      }
+      if (distro) {
+        return { description: `Error managing distribution ${ distro }: ${ key }: ${ message }` };
+      }
+
+      return { description: `Error managing ${ key }: ${ message }` };
+    })(),
+  };
+});
+
+export default CheckWindowsIntegrations;

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -166,6 +166,7 @@ interface MainEventNames {
  * 'diagnostics-event' event.
  */
 type DiagnosticsEventPayload =
+  { id: 'integrations-windows', distro?: string, key: string, error?: Error } |
   { id: 'kube-versions-available', available: boolean } |
   { id: 'path-management', fileName: string; error: Error | undefined };
 


### PR DESCRIPTION
This fixes Windows such that if we fail to create `~/.kube` we don't fall over immediately and end up hanging indefinitely waiting for Kubernetes.  Instead, we can proceed until the correct step and correctly throw up an error when we attempt to update the `kubeconfig`.

This also contains the start of reporting Windows integration errors as diagnostics, so that users can take action easier.

This is related to #7824 but does not fix it (because we still fail to write the `kubeconfig`).