### PR TITLE
Always use CPU type "host" on aarch64

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -1,5 +1,10 @@
 # Default Lima configuration; parts will be overridden in code.
 
+# Rancher Desktop ships with a patched QEMU that supports the Apple M4 CPU
+# So override Lima 1.0.3 falling back to cortex-a72.
+cpuType:
+  aarch64: host
+
 ssh:
   loadDotSSHPubKeys: false
 firmware:


### PR DESCRIPTION
This prevents Lima 1.0.3+ from falling back to cortex-a72 on the M4 CPU.

Fixes #8023

This change is easier than setting `QEMU_SYSTEM_AARCH64` as suggested in #8023.