### PR TITLE
Add spin kube plugin to rddepman version checking

### DIFF
--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -627,3 +627,26 @@ export class SpinCLI implements Dependency, GitHubDependency {
     return semver.rcompare(version1, version2);
   }
 }
+
+export class SpinKubePlugin implements Dependency, GitHubDependency {
+  name = 'spinKubePlugin';
+  githubOwner = 'spinkube';
+  githubRepo = 'spin-plugin-kube';
+
+  download(context: DownloadContext): Promise<void> {
+    // We don't download anything there; `resources/setup-spin` does the installation.
+    return Promise.resolve();
+  }
+
+  async getAvailableVersions(includePrerelease = false): Promise<string[]> {
+    return await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
+  }
+
+  versionToTagName(version: string): string {
+    return `v${ version }`;
+  }
+
+  rcompareVersions(version1: string, version2: string): -1 | 0 | 1 {
+    return semver.rcompare(version1, version2);
+  }
+}

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -50,6 +50,7 @@ const dependencies: Dependency[] = [
   new tools.CertManager(),
   new tools.SpinOperator(),
   new tools.SpinCLI(),
+  new tools.SpinKubePlugin(),
 ];
 
 function git(...args: string[]): number | null {


### PR DESCRIPTION
No need to download it; we install the plugin via the `spin plugin` command.

Fixes #7814