### PR TITLE
Don't include leading `v` in dependencies.yaml for check-spelling

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -25,4 +25,4 @@ spinOperator: 0.4.0
 certManager: 1.16.2
 spinCLI: 3.1.1
 spinKubePlugin: 0.3.1
-check-spelling: v0.0.24
+check-spelling: 0.0.24

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -240,17 +240,15 @@ export class CheckSpelling implements Dependency, GitHubDependency {
   }
 
   async getAvailableVersions(includePrerelease = false): Promise<string[]> {
-    const versions = await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
-
-    return versions.map(v => `v${ v }`);
+    return await getPublishedVersions(this.githubOwner, this.githubRepo, includePrerelease);
   }
 
   versionToTagName(version: string): string {
-    return version;
+    return `v${ version }`;
   }
 
   rcompareVersions(version1: string, version2: string): -1 | 0 | 1 {
-    return semver.rcompare(version1.replace(/^v/, ''), version2.replace(/^v/, ''));
+    return semver.rcompare(version1, version2);
   }
 }
 

--- a/scripts/spelling.sh
+++ b/scripts/spelling.sh
@@ -64,7 +64,7 @@ find_script() {
     local script=$checkout/unknown-words.sh
     local repo=https://github.com/check-spelling/check-spelling
     local version
-    version=$(yq --exit-status .check-spelling pkg/rancher-desktop/assets/dependencies.yaml)
+    version="v$(yq --exit-status .check-spelling pkg/rancher-desktop/assets/dependencies.yaml)"
 
     if [[ ! -d "$checkout" ]]; then
         git clone --branch "$version" --depth 1 "$repo" "$checkout" >&2


### PR DESCRIPTION
Use the same format and logic as for all other GitHub based releases.