### PR TITLE
dependabot: don't pull in oktokit 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,9 @@ updates:
   - # fs-xattr 0.4.0 later are esm-only.
     dependency-name: "fs-xattr"
     versions: [">0.3"]
+  - # octokit 4 and later are esm-only.
+    dependency-name: "octokit"
+    versions: [">3"]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"


### PR DESCRIPTION
That requires using ES modules, which we are still having issues with.

This is mostly to close #8065 and related until we properly deal with ES modules.