### PR TITLE
Update spinkube-npm BATS test to adjust for upstream changes

### DIFF
--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -85,7 +85,7 @@ EOF
     local host
     host=$(traefik_hostname)
 
-    run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}"
+    run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}/hello/bats"
     assert_success
-    assert_output --regexp '^(Hello|hello)'
+    assert_output --regexp '^hello bats'
 }


### PR DESCRIPTION
The sample app generated by the JavaScript SDK uses different routes now: https://github.com/fermyon/spin-js-sdk/commit/64bde83dac745872aea490cc2f5d341de4d9851d