### PR TITLE
WiX: Fix verify dialog message

### DIFF
--- a/build/wix/verify.wxs
+++ b/build/wix/verify.wxs
@@ -15,9 +15,8 @@
           X="0" Y="44" Width="370" Height="0" />
 
         <Control Id="InstallText" Type="Text"
-          X="25" Y="70" Width="320" Height="80" Hidden="yes" NoPrefix="yes"
-          Text="!(loc.VerifyReadyDlgInstallText)">
-        </Control>
+          X="25" Y="70" Width="320" Height="80" NoPrefix="yes"
+          Text="!(loc.VerifyReadyDlgInstallText)" />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
         <Control Id="Back" Type="PushButton" X="156" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)">


### PR DESCRIPTION
We removed the `<Condition Action="show">` in 255e0dc5553d but forgot to make the control not hidden by default.

Fixes #8119 

Updated dialog:

per-user | per-machine
--- | ---
![image](https://github.com/user-attachments/assets/c1686372-5230-4e6d-9ec6-0b45f70fa7bc) | ![image](https://github.com/user-attachments/assets/8cc42ba5-d905-4475-944b-e3ee0b32adc3)
