### PR TITLE
Configure trivy to scan local images instead of downloading them again

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -176,6 +176,11 @@ provision:
     mount bpffs -t bpf /sys/fs/bpf
     mount --make-shared /sys/fs/bpf
     mount --make-shared /sys/fs/cgroup
+- # we run trivy as root now; remove any cached databases installed into the user directory by previous version
+  # trivy.db is 600M and trivy-java.db is 1.1G
+  mode: user
+  script: |
+    rm -rf "${HOME}/.cache/trivy"
 portForwards:
 - guestPortRange: [1, 65535]
   guestIPMustBeZero: true

--- a/pkg/rancher-desktop/backend/images/mobyImageProcessor.ts
+++ b/pkg/rancher-desktop/backend/images/mobyImageProcessor.ts
@@ -25,7 +25,7 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
   }
 
   protected get processorName() {
-    return 'moby';
+    return 'docker';
   }
 
   protected async runImagesCommand(args: string[], sendNotifications = true): Promise<imageProcessor.childResultType> {
@@ -35,7 +35,14 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
       args.unshift('--context', 'rancher-desktop');
     }
 
-    return await this.processChildOutput(spawn(executable('docker'), args), subcommandName, sendNotifications);
+    return await this.processChildOutput(
+      spawn(executable('docker'), args),
+      {
+        subcommandName,
+        notifications: {
+          stdout: sendNotifications, stderr: sendNotifications, ok: sendNotifications,
+        },
+      });
   }
 
   async buildImage(dirPart: string, filePart: string, taggedImageName: string): Promise<imageProcessor.childResultType> {
@@ -69,15 +76,8 @@ export default class MobyImageProcessor extends imageProcessor.ImageProcessor {
       false);
   }
 
-  async scanImage(taggedImageName: string): Promise<imageProcessor.childResultType> {
-    return await this.runTrivyCommand(
-      [
-        '--quiet',
-        'image',
-        '--format',
-        'json',
-        taggedImageName,
-      ]);
+  scanImage(taggedImageName: string, namespace: string): Promise<imageProcessor.childResultType> {
+    return this.runTrivyScan(taggedImageName);
   }
 
   relayNamespaces(): Promise<void> {

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -13,7 +13,16 @@ import semver from 'semver';
 import tar from 'tar-stream';
 
 import {
-  BackendError, BackendEvents, BackendProgress, BackendSettings, execOptions, FailureDetails, RestartReasons, State, VMBackend, VMExecutor,
+  BackendError,
+  BackendEvents,
+  BackendProgress,
+  BackendSettings,
+  execOptions,
+  FailureDetails,
+  RestartReasons,
+  State,
+  VMBackend,
+  VMExecutor,
 } from './backend';
 import BackendHelper from './backendHelper';
 import { ContainerEngineClient, MobyClient, NerdctlClient } from './containerClient';
@@ -904,7 +913,12 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     if (typeof optionsOrCommand === 'string') {
       args.push(optionsOrCommand);
     } else {
-      throw new TypeError('Not supported yet');
+      const options: execOptions = optionsOrCommand;
+
+      // runTrivyScan() calls spawn({root: true}, …), which we ignore because we are already running as root
+      if (options.expectFailure || options.logStream || options.env) {
+        throw new TypeError('Not supported yet');
+      }
     }
     args.push(...command);
 

--- a/pkg/rancher-desktop/components/Images.vue
+++ b/pkg/rancher-desktop/components/Images.vue
@@ -361,7 +361,7 @@ export default {
     scanImage(obj) {
       const taggedImageName = `${ obj.imageName.trim() }:${ this.imageTag(obj.tag) }`;
 
-      this.$router.push({ name: 'images-scans-image-name', params: { image: taggedImageName } });
+      this.$router.push({ name: 'images-scans-image-name', params: { image: taggedImageName, namespace: this.selectedNamespace } });
     },
     imageTag(tag) {
       return tag === '<none>' ? 'latest' : `${ tag.trim() }`;

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -58,6 +58,7 @@ export default {
   data() {
     return {
       image:                            this.$route.params.image,
+      namespace:                        this.$route.params.namespace,
       showImageOutput:                  true,
       imageManagerOutput:               '',
       imageOutputCuller:                null,
@@ -128,7 +129,7 @@ export default {
   methods: {
     scanImage() {
       this.startRunningCommand('trivy-image');
-      ipcRenderer.send('do-image-scan', this.image);
+      ipcRenderer.send('do-image-scan', this.image, this.namespace);
     },
     startRunningCommand(command) {
       this.imageOutputCuller = getImageOutputCuller(command);

--- a/pkg/rancher-desktop/router.js
+++ b/pkg/rancher-desktop/router.js
@@ -107,7 +107,7 @@ export const routerOptions = {
     component: _20fa1c70,
     name:      'images-add',
   }, {
-    path:      '/images/scans/:image-name?',
+    path:      '/images/scans/:image-name?/:namespace?',
     component: _1165c4f2,
     name:      'images-scans-image-name',
   }, {

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -43,7 +43,7 @@ export interface IpcMainEvents {
   'confirm-do-image-deletion': (imageName: string, imageID: string) => void;
   'do-image-build': (taggedImageName: string) => void;
   'do-image-pull': (imageName: string) => void;
-  'do-image-scan': (imageName: string) => void;
+  'do-image-scan': (imageName: string, namespace: string) => void;
   'do-image-push': (imageName: string, imageID: string, tag: string) => void;
   'do-image-deletion': (imageName: string, imageID: string) => void;
   'do-image-deletion-batch': (images: string[]) => void;


### PR DESCRIPTION
Run as root so trivy has access to the containerd socket.

Don't output the trivy JSON to the browser; this is extremely slow when the output is several megabytes.

Also don't output the trivy JSON to images.log, as it makes the file unwieldy.

<hr>

On the first scan `trivy` needs to download `trivy.db`, which is almost 600MB. Subsequent scans are then almost instantaneous. Even results for `python:latest` show up in a second, which used to take almost a minute when the JSON was output to the browser.

Fixes #539
