### PR TITLE
Update to the latest version of Rancher Dashboard

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -360,12 +360,12 @@ test.describe.serial('Extensions', () => {
         });
       });
       test('can fetch from external sources', async() => {
-        const url = 'http://127.0.0.1:6120/LICENSES'; // dashboard
+        const url = 'http://127.0.0.1:6120/c/local/explorer/node'; // dashboard
 
         await retry(async() => {
           const result = evalInView(`ddClient.extension.vm.service.get("${ url }")`);
 
-          await expect(result).resolves.toContain('Copyright');
+          await expect(result).resolves.toContain('<title>Rancher</title>');
         });
       });
     });

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -13,7 +13,7 @@ dockerCompose: 2.32.4
 golangci-lint: 1.63.4
 trivy: 0.59.0
 steve: 0.1.0-beta9
-rancherDashboard: desktop-v0.1.1-alpha.4
+rancherDashboard: desktop-v2.11.0.rd2
 dockerProvidedCredentialHelpers: 0.8.2
 ECRCredentialHelper: 0.9.0
 mobyOpenAPISpec: "1.47"

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -13,7 +13,7 @@ dockerCompose: 2.32.4
 golangci-lint: 1.63.4
 trivy: 0.59.0
 steve: 0.1.0-beta9
-rancherDashboard: desktop-v0.1.1-alpha.3
+rancherDashboard: desktop-v0.1.1-alpha.4
 dockerProvidedCredentialHelpers: 0.8.2
 ECRCredentialHelper: 0.9.0
 mobyOpenAPISpec: "1.47"

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -13,7 +13,7 @@ dockerCompose: 2.32.4
 golangci-lint: 1.63.4
 trivy: 0.59.0
 steve: 0.1.0-beta9
-rancherDashboard: desktop-v2.7.0.beta.1
+rancherDashboard: desktop-v0.1.1-alpha.3
 dockerProvidedCredentialHelpers: 0.8.2
 ECRCredentialHelper: 0.9.0
 mobyOpenAPISpec: "1.47"

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -334,11 +334,11 @@ export class Steve implements Dependency, GitHubDependency {
 export class RancherDashboard implements Dependency, GitHubDependency {
   name = 'rancherDashboard';
   githubOwner = 'rancher-sandbox';
-  githubRepo = 'dashboard';
+  githubRepo = 'rancher-desktop-dashboard';
   versionRegex = /^desktop-v([0-9]+\.[0-9]+\.[0-9]+)\.([0-9a-zA-Z]+(\.[0-9a-zA-Z]+)+)$/;
 
   async download(context: DownloadContext): Promise<void> {
-    const baseURL = `https://github.com/rancher-sandbox/dashboard/releases/download/${ context.versions.rancherDashboard }`;
+    const baseURL = `https://github.com/rancher-sandbox/${ this.githubRepo }/releases/download/${ context.versions.rancherDashboard }`;
     const executableName = 'rancher-dashboard-desktop-embed';
     const url = `${ baseURL }/${ executableName }.tar.gz`;
     const destPath = path.join(context.resourcesDir, 'rancher-dashboard.tgz');


### PR DESCRIPTION
This updates the Rancher Desktop dependencies so that it directs to the new location for Dashboard builds: `https://github.com/rancher-sandbox/rancher-desktop-dashboard/`