### PR TITLE
Locked field errors must always be fatal

### DIFF
--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -18,6 +18,7 @@ import SERVICE_CRI_DOCKERD_SCRIPT from '@pkg/assets/scripts/service-cri-dockerd.
 import SERVICE_K3S_SCRIPT from '@pkg/assets/scripts/service-k3s.initd';
 import * as K8s from '@pkg/backend/k8s';
 import { KubeClient } from '@pkg/backend/kube/client';
+import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 import { checkConnectivity } from '@pkg/main/networking';
@@ -335,6 +336,10 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
           this.vm.noModalDialogs,
           this.vm.writeSetting.bind(this.vm));
       } catch (ex) {
+        // Locked field errors are fatal and will quit the application
+        if (ex instanceof LockedFieldError) {
+          throw ex;
+        }
         console.error(`Could not get desired version: ${ ex }`);
         available = false;
 

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -13,6 +13,7 @@ import INSTALL_K3S_SCRIPT from '@pkg/assets/scripts/install-k3s';
 import { BackendSettings, RestartReasons } from '@pkg/backend/backend';
 import BackendHelper, { MANIFEST_CERT_MANAGER, MANIFEST_SPIN_OPERATOR } from '@pkg/backend/backendHelper';
 import * as K8s from '@pkg/backend/k8s';
+import { LockedFieldError } from '@pkg/config/commandLineOptions';
 import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 import { checkConnectivity } from '@pkg/main/networking';
@@ -88,6 +89,10 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
           this.vm.noModalDialogs,
           this.vm.writeSetting.bind(this.vm));
       } catch (ex) {
+        // Locked field errors are fatal and will quit the application
+        if (ex instanceof LockedFieldError) {
+          throw ex;
+        }
         console.error(`Could not get desired version: ${ ex }`);
         available = false;
 


### PR DESCRIPTION
The idea of changing invalid / unavailable settings to default ones goes against the spirit of locking down settings and must not be possible.

Fixes #7818