### PR TITLE
Revert "Update spinkube-npm BATS test to adjust for upstream changes"

### DIFF
--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -85,7 +85,7 @@ EOF
     local host
     host=$(traefik_hostname)
 
-    run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}/hello/bats"
+    run --separate-stderr try curl --connect-timeout 5 --fail "http://${host}"
     assert_success
-    assert_output --regexp '^hello bats'
+    assert_output --regexp '^(Hello|hello)'
 }


### PR DESCRIPTION
Revert #8120 because the spinkube SDK has made further changes, that broke the new test again.

But they have restored the response to the `/` root path to be the same as before, so the original test now works again.