### PR TITLE
Update docker compose test

### DIFF
--- a/bats/tests/compose/compose.bats
+++ b/bats/tests/compose/compose.bats
@@ -39,6 +39,11 @@ verify_running_container() {
     verify_running_container "http://${HOST_IP}:8000" "$expected_output"
 }
 
+@test 'verify connectivity via host.docker.internal' {
+    local expected_output="Hello World!"
+    verify_running_container "http://localhost:8080/app" "$expected_output"
+}
+
 @test 'compose down' {
     run ctrctl compose --project-directory "$TESTDATA_DIR_HOST" down
     assert_success

--- a/bats/tests/compose/testdata/compose.yaml
+++ b/bats/tests/compose/testdata/compose.yaml
@@ -2,6 +2,8 @@ services:
   nginx:
     container_name: nginx
     image: nginx
+    volumes:
+    - ./nginx.conf:/etc/nginx/nginx.conf
     ports:
     - '127.0.0.1:8080:80'
   web:

--- a/bats/tests/compose/testdata/nginx.conf
+++ b/bats/tests/compose/testdata/nginx.conf
@@ -1,0 +1,29 @@
+worker_processes  1;
+
+error_log  stderr info;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    sendfile      on;
+    proxy_read_timeout 5s;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        # Serve the default nginx welcome page
+        location / {
+            root /usr/share/nginx/html;
+            index index.html;
+        }
+
+        # Proxy requests to /app to the backend service
+        location /app {
+            proxy_pass http://host.docker.internal:8000/;
+        }
+    }
+}


### PR DESCRIPTION
Allows the docker compose test to access the app via host.docker.internal.

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/8155