### PR TITLE
Make sure that wsl-exec maintains the correct working directory

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-exec
+++ b/pkg/rancher-desktop/assets/scripts/wsl-exec
@@ -28,4 +28,6 @@ fi
 if [ $# -eq 0 ]; then
   set -- /bin/sh
 fi
-exec /usr/bin/nsenter -n -p -m -t "${pid}" "$@"
+# If -w$PWD is specified on the first nsenter, then `wsl-exec pwd`
+# fails with "pwd: getcwd: No such file or directory"
+exec /usr/bin/nsenter -n -p -m -t "${pid}" /usr/bin/nsenter "-w${PWD}" "$@"


### PR DESCRIPTION
Without it the command is executed from the root directory, which breaks commands like `nerdctl compose` that look for files in the current directory.

Fixes #7819