### PR TITLE
Fix: Container volume unmount failure with nested mounts on WSL2

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -388,7 +388,7 @@ func (b *bindManager) mungeContainersStartResponse(req *http.Response, contextVa
 			"container": templates["id"],
 			"bind":      mountDir,
 		})
-		err := unix.Unmount(mountDir, 0)
+		err := unix.Unmount(mountDir, unix.MNT_DETACH|unix.UMOUNT_NOFOLLOW)
 		if err != nil {
 			logEntry.WithError(err).Error("failed to unmount")
 			return fmt.Errorf("could not unmount bind mount %s: %w", mountDir, err)


### PR DESCRIPTION
When executing docker CLI on WSL2, containers that mount volumes with nested mounts fail to unmount them after running. For example:

$ docker run --rm --volume /lib/modules:/lib/modules alpine ls /lib/modules 5.15.167.4-microsoft-standard-WSL2
docker: Error response from daemon: failed to modify the response from the backend: munger failed for /containers/706d9ae2589c9d182688bffb9231de545ab82dc51185ff25813ce18c2a89b8d3/start: could not unmount bind mount /mnt/wsl/rancher-desktop/run/docker-mounts/6efe3666-a5cc-42b2-8ddd-5dc326a49ff3: device or resource busy.

This happens because in WSL2 /lib/modules has nested mounts, but the issue occurs in any scenario with nested mounts.

The existing code correctly mounts the volume at startup by calling unix.Mount with flags MS_BIND and MS_REC (which recursively binds all nested mounts).

This commit changes the unmount flags on the call to unix.Umount from none to MNT_DETACH and UMOUNT_NOFOLLOW. MNT_DETACH performs a lazy unmount that disconnects the filesystem and all nested filesystems while making them unavailable for new accesses. UMOUNT_NOFOLLOW prevents following symbolic links during unmount operations, which improves security and avoids potential unmount path escapes.

Tested with the nested-mounts.sh script which reproduces the issue reliably.

Closes #8250