### PR TITLE
Add version subcomand to wsl-helper

### DIFF
--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -70,10 +70,12 @@ export class GoDependency implements Dependency {
 
     const buildArgs: string[] = ['build', '-ldflags', ldFlags.join(' '), '-o', outFile, '.'];
 
-    console.log(`Building go utility \x1B[1;33;40m${this.name}\x1B[0m from ${sourceDir} to ${outFile}...`);
+    const env = this.environment(context);
+
+    console.log(`Building go utility \x1B[1;33;40m${ this.name }\x1B[0m [${ env.GOOS }/${ env.GOARCH }] from ${ sourceDir } to ${ outFile }...`);
     await simpleSpawn('go', buildArgs, {
       cwd: sourceDir,
-      env: this.environment(context),
+      env,
     });
   }
 

--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -15,6 +15,19 @@ type GoDependencyOptions = {
    * Additional environment for the go compiler; e.g. for GOARCH overrides.
    */
   env?: NodeJS.ProcessEnv;
+
+  /**
+   * The version string to be stamped into the binary at build time.
+   * This is typically used with `-ldflags="-X ..."` to embed version information.
+   * Example: `1.18.1`.
+   */
+  version?: string;
+
+  /**
+   * The Go module path, typically as defined in `go.mod`. This should match the
+   * import path of the module (e.g., `github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper`).
+   */
+  modulePath?: string;
 };
 
 /**
@@ -49,8 +62,16 @@ export class GoDependency implements Dependency {
     const sourceDir = path.join(process.cwd(), 'src', 'go', this.sourcePath);
     const outFile = this.outFile(context);
 
-    console.log(`Building go utility \x1B[1;33;40m${ this.name }\x1B[0m from ${ sourceDir } to ${ outFile }...`);
-    await simpleSpawn('go', ['build', '-ldflags', '-s -w', '-o', outFile, '.'], {
+    const ldFlags: string[] = ['-s', '-w'];
+
+    if (this.options.version && this.options.modulePath) {
+      ldFlags.push(`-X ${ this.options.modulePath }/pkg/version.Version=${ this.options.version }`);
+    }
+
+    const buildArgs: string[] = ['build', '-ldflags', ldFlags.join(' '), '-o', outFile, '.'];
+
+    console.log(`Building go utility \x1B[1;33;40m${this.name}\x1B[0m from ${sourceDir} to ${outFile}...`);
+    await simpleSpawn('go', buildArgs, {
       cwd: sourceDir,
       env: this.environment(context),
     });
@@ -112,8 +133,13 @@ export class RDCtl extends GoDependency {
 }
 
 export class WSLHelper extends GoDependency {
-  constructor() {
-    super('wsl-helper', { outputPath: 'internal', env: { CGO_ENABLED: '0' } });
+  constructor(version: string) {
+    super('wsl-helper', {
+      outputPath: 'internal',
+      env:        { CGO_ENABLED: '0' },
+      modulePath: 'github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper',
+      version,
+    });
   }
 
   dependencies(context: DownloadContext): string[] {

--- a/scripts/dependencies/go-source.ts
+++ b/scripts/dependencies/go-source.ts
@@ -107,8 +107,12 @@ export class GoDependency implements Dependency {
 }
 
 export class RDCtl extends GoDependency {
-  constructor() {
-    super('rdctl');
+  constructor(version: string) {
+    super('rdctl', {
+      outputPath: 'bin',
+      modulePath: 'github.com/rancher-sandbox/rancher-desktop/src/go/rdctl',
+      version,
+    });
   }
 
   dependencies(context: DownloadContext): string[] {

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -45,7 +45,7 @@ const userTouchedDependencies = [
   new tools.DockerProvidedCredHelpers(),
   new tools.ECRCredHelper(),
   new tools.SpinCLI(),
-  new goUtils.RDCtl(),
+  new goUtils.RDCtl(versionToStamp),
   new goUtils.GoDependency('docker-credential-none'),
 ];
 
@@ -76,7 +76,7 @@ const windowsDependencies = [
 // Dependencies that are specific to WSL.
 const wslDependencies = [
   new Moproxy(),
-  new goUtils.RDCtl(),
+  new goUtils.RDCtl(versionToStamp),
   new goUtils.GoDependency('guestagent', 'staging'),
   new goUtils.GoDependency('networking/cmd/vm', 'staging/vm-switch'),
   new goUtils.GoDependency('networking/cmd/network', 'staging/network-setup'),

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,3 +1,4 @@
+import childProcess from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -24,6 +25,14 @@ type DependencyWithContext = {
  * The amount of time we allow the post-install script to run, in milliseconds.
  */
 const InstallTimeout = 10 * 60 * 1_000; // Ten minutes.
+
+/**
+ * Retrieves the application version from package.json to stamp Go binaries.
+ * This version number ensures Go utilities like WSL helpers are tagged with
+ * the same version as the main application, maintaining consistency across
+ * all components of Rancher Desktop.
+ */
+const versionToStamp = getStampVersion();
 
 // Dependencies that should be installed into places that users touch
 // (so users' WSL distros and hosts as of the time of writing).
@@ -59,7 +68,7 @@ const windowsDependencies = [
   new WSLDistroImage(),
   new Wix(),
   new goUtils.GoDependency('networking/cmd/host', 'internal/host-switch'),
-  new goUtils.WSLHelper(),
+  new goUtils.WSLHelper(versionToStamp),
   new goUtils.NerdctlStub(),
   new goUtils.SpinStub(),
 ];
@@ -72,7 +81,7 @@ const wslDependencies = [
   new goUtils.GoDependency('networking/cmd/vm', 'staging/vm-switch'),
   new goUtils.GoDependency('networking/cmd/network', 'staging/network-setup'),
   new goUtils.GoDependency('networking/cmd/proxy', 'staging/wsl-proxy'),
-  new goUtils.WSLHelper(),
+  new goUtils.WSLHelper(versionToStamp),
   new goUtils.NerdctlStub(),
 ];
 
@@ -254,3 +263,15 @@ const keepScriptAlive = setTimeout(() => { }, 24 * 3600 * 1000);
     process.exit(exitCode);
   }
 })();
+
+/**
+* Gets the version string for Go tools from git.
+* Format: {tag}-{commits}-{hash}{dirty}
+* Examples: v1.18.0, v1.18.0-39-gf46609959, v1.18.0-39-gf46609959.m
+*/
+function getStampVersion(): string {
+  const gitCommand = 'git describe --match v[0-9]* --dirty=.m --always --tags';
+  const stdout = childProcess.execSync(gitCommand, { encoding: 'utf-8' });
+
+  return stdout;
+}

--- a/src/go/rdctl/cmd/version.go
+++ b/src/go/rdctl/cmd/version.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,7 @@ var showVersionCmd = &cobra.Command{
 	Short: "Shows the CLI version.",
 	Long:  `Shows the CLI version.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, err := fmt.Printf("rdctl client version: %s, targeting server version: %s\n", client.Version, client.ApiVersion)
+		_, err := fmt.Printf("rdctl client version: %s, targeting server version: %s\n", version.Version, client.ApiVersion)
 		return err
 	},
 }

--- a/src/go/rdctl/pkg/client/client.go
+++ b/src/go/rdctl/pkg/client/client.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	Version    = "1.1.0"
 	ApiVersion = "v1"
 )
 

--- a/src/go/rdctl/pkg/version/version.go
+++ b/src/go/rdctl/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "0.0.0"

--- a/src/go/wsl-helper/cmd/version.go
+++ b/src/go/wsl-helper/cmd/version.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// showVersionCmd represents the showVersion command
+var showVersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Shows the wsl-helper version.",
+	Long:  `Shows the wsl-helper version.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := fmt.Printf("wsl-helper version: %s\n", version.Version)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(showVersionCmd)
+}

--- a/src/go/wsl-helper/pkg/version/version.go
+++ b/src/go/wsl-helper/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "0.0.0"


### PR DESCRIPTION
Added a version subcommand in a similar way to `rdctl version`. This task is mostly trivial, however I am not sure which version number to use and where it is more appropiate to store the version constant.

Closes #5808