### PR TITLE
RDX: Bypass CORS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -238,6 +238,9 @@ Object.assign(module.exports.rules, {
 
   // destructuring: don't error if `a` is reassigned, but `b` is never reassigned
   'prefer-const': ['error', { destructuring: 'all' }],
+
+  // This one assumes all callbacks have errors in the first argument, which isn't likely.
+  'n/no-callback-literal': 'off',
 });
 module.exports.rules['key-spacing'][1].align.mode = 'strict';
 

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -658,6 +658,7 @@ poweroff
 PQgrl
 prakhar
 prebuilds
+preflights
 Privs
 PROCARGS
 procnet

--- a/background.ts
+++ b/background.ts
@@ -183,8 +183,12 @@ mainEvents.handle('settings-fetch', () => {
 Electron.protocol.registerSchemesAsPrivileged([{ scheme: 'app' }, {
   scheme:     'x-rd-extension',
   privileges: {
-    standard:        true,
-    supportFetchAPI: true,
+    standard:            true,
+    secure:              true,
+    bypassCSP:           true,
+    allowServiceWorkers: true,
+    supportFetchAPI:     true,
+    corsEnabled:         true,
   },
 }]);
 

--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -287,6 +287,11 @@ export class ExtensionImpl implements Extension {
       console.error(`Ignoring error running ${ this.id } post-install script: ${ ex }`);
     }
 
+    // Since we now run extensions in a separate session, register the protocol handler there.
+    const encodedId = Buffer.from(this.id).toString('hex');
+
+    await mainEvents.invoke('extensions/register-protocol', `persist:rdx-${ encodedId }`);
+
     console.debug(`Install ${ this.id }: install complete.`);
 
     return true;

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -131,6 +131,12 @@ interface MainEventNames {
   'extensions/shutdown'(): Promise<void>;
 
   /**
+   * Register the extension protocol handler in the given webContents partition.
+   * @param partition The partition name; likely "persist:rdx-..."
+   */
+  'extensions/register-protocol'(partition: string): Promise<void>;
+
+  /**
    * Emitted on application quit, used to shut down any integrations.  This
    * requires feedback from the handler to know when all tasks are complete.
    */

--- a/pkg/rancher-desktop/main/networking/index.ts
+++ b/pkg/rancher-desktop/main/networking/index.ts
@@ -62,7 +62,7 @@ export default async function setupNetworking() {
       pluginDevUrls.some(x => url.startsWith(x))
     ) {
       event.preventDefault();
-      // eslint-disable-next-line n/no-callback-literal
+
       callback(true);
 
       return;
@@ -70,7 +70,7 @@ export default async function setupNetworking() {
 
     if (dashboardUrls.some(x => url.startsWith(x)) && 'dashboard' in windowMapping) {
       event.preventDefault();
-      // eslint-disable-next-line n/no-callback-literal
+
       callback(true);
 
       return;
@@ -87,7 +87,7 @@ export default async function setupNetworking() {
           // an attacker generating a cert with the same serial.
           if (cert === certificate.data.replace(/\r/g, '')) {
             console.log(`Accepting system certificate for ${ certificate.subjectName } (${ certificate.fingerprint })`);
-            // eslint-disable-next-line n/no-callback-literal
+
             callback(true);
 
             return;
@@ -100,7 +100,6 @@ export default async function setupNetworking() {
 
     console.log(`Not handling certificate error ${ error } for ${ url }`);
 
-    // eslint-disable-next-line n/no-callback-literal
     callback(false);
   });
 

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -197,7 +197,7 @@ let lastOpenExtension: { id: string, relPath: string } | undefined;
 /**
  * Attaches a browser view to the main window
  */
-const createView = () => {
+function createView() {
   const mainWindow = getWindow('main');
   const hostInfo = {
     arch:     process.arch,
@@ -208,15 +208,18 @@ const createView = () => {
     throw new Error('Failed to get main window, cannot create view');
   }
 
-  view = new WebContentsView({
-    webPreferences: {
-      nodeIntegration:     false,
-      contextIsolation:    true,
-      preload:             path.join(paths.resources, 'preload.js'),
-      sandbox:             true,
-      additionalArguments: [JSON.stringify(hostInfo)],
-    },
-  });
+  const webPreferences: Electron.WebPreferences = {
+    nodeIntegration:     false,
+    contextIsolation:    true,
+    preload:             path.join(paths.resources, 'preload.js'),
+    sandbox:             true,
+    additionalArguments: [JSON.stringify(hostInfo)],
+  };
+
+  if (currentExtension?.id) {
+    webPreferences.partition = `persist:rdx-${ currentExtension.id }`;
+  }
+  view = new WebContentsView({ webPreferences });
   mainWindow.contentView.addChildView(view);
   mainWindow.contentView.addListener('bounds-changed', () => {
     setImmediate(() => mainWindow.webContents.send('extensions/getContentArea'));
@@ -225,7 +228,7 @@ const createView = () => {
   const backgroundColor = nativeTheme.shouldUseDarkColors ? '#202c33' : '#f4f4f6';
 
   view.setBackgroundColor(backgroundColor);
-};
+}
 
 /**
  * Updates the browser view size and position

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -246,6 +246,8 @@ function createView() {
       // ideally we can just disable `webSecurity` instead, that seems to break
       // the preload script (which breaks the extension APIs).
       const responseHeaders: Record<string, string|string[]> = { ...details.responseHeaders };
+      // HTTP headers use case-insensitive comparison; but accents should count
+      // as different characters (even though it should be ASCII only).
       const { compare } = new Intl.Collator('en', { sensitivity: 'accent' });
       const overwriteHeaders = [
         'Access-Control-Allow-Headers',
@@ -266,7 +268,7 @@ function createView() {
         // For CORS preflights, also change the status code.
         const prefix = /\s+/.exec(details.statusLine)?.shift() ?? 'HTTP/1.1';
 
-        callback({ responseHeaders, statusLine: `${ prefix } 204` });
+        callback({ responseHeaders, statusLine: `${ prefix } 204 No Content` });
       }
     });
   }

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -52,6 +52,10 @@ export function getWindow(name: string): Electron.BrowserWindow | null {
   return (name in windowMapping) ? BrowserWindow.fromId(windowMapping[name]) : null;
 }
 
+function isInternalURL(url: string) {
+  return url.startsWith(`${ webRoot }/`) || url.startsWith('x-rd-extension://');
+}
+
 /**
  * Open a given window; if it is already open, focus it.
  * @param name The window identifier; this controls window re-use.
@@ -64,10 +68,6 @@ export function createWindow(name: string, url: string, options: Electron.Browse
   if (restoreWindow(window)) {
     return window;
   }
-
-  const isInternalURL = (url: string) => {
-    return url.startsWith(`${ webRoot }/`) || url.startsWith('x-rd-extension://');
-  };
 
   window = new BrowserWindow(options);
   window.webContents.on('console-message', (event, level, message, line, sourceId) => {
@@ -218,6 +218,57 @@ function createView() {
 
   if (currentExtension?.id) {
     webPreferences.partition = `persist:rdx-${ currentExtension.id }`;
+    const webRequest = Electron.session.fromPartition(webPreferences.partition).webRequest;
+
+    webRequest.onBeforeSendHeaders((details, callback) => {
+      const source = details.webContents?.getURL() ?? '';
+      const requestHeaders = { ...details.requestHeaders };
+
+      if (isInternalURL(source)) {
+        // If the request is coming from the extension, remove the Origin: header
+        // because it has x-rd-extension:// nonsense (relative to the server).
+        delete requestHeaders.Origin;
+      }
+      callback({ requestHeaders });
+    });
+
+    webRequest.onHeadersReceived((details, callback) => {
+      const sourceURL = details.webContents?.getURL() ?? '';
+
+      if (!isInternalURL(sourceURL)) {
+        // Do not rewrite requests from outside the extension (e.g. iframe).
+        callback({});
+
+        return;
+      }
+
+      // Insert (or overwrite) CORS headers to pretend this was allowed.  While
+      // ideally we can just disable `webSecurity` instead, that seems to break
+      // the preload script (which breaks the extension APIs).
+      const responseHeaders: Record<string, string|string[]> = { ...details.responseHeaders };
+      const { compare } = new Intl.Collator('en', { sensitivity: 'accent' });
+      const overwriteHeaders = [
+        'Access-Control-Allow-Headers',
+        'Access-Control-Allow-Methods',
+        'Access-Control-Allow-Origin',
+      ];
+
+      for (const header of overwriteHeaders) {
+        const match = Object.keys(responseHeaders).find(k => compare(header, k) === 0);
+
+        responseHeaders[match ?? header] = '*';
+      }
+
+      if (details.method !== 'OPTIONS') {
+        // For any request that's not a CORS preflight, just overwrite the headers.
+        callback({ responseHeaders });
+      } else {
+        // For CORS preflights, also change the status code.
+        const prefix = /\s+/.exec(details.statusLine)?.shift() ?? 'HTTP/1.1';
+
+        callback({ responseHeaders, statusLine: `${ prefix } 204` });
+      }
+    });
   }
   view = new WebContentsView({ webPreferences });
   mainWindow.contentView.addChildView(view);


### PR DESCRIPTION
For compatibility reasons, we need to let the extensions enjoy Internet-wide access without having to worry about silly things like CORS.  Fixes #8285.

Unfortunately, trying to properly disable CORS did not work: the only thing that managed was to set `webSecurity: false`, but that broke the preload script (as in, it wasn't being loaded at all).

As a workaround, I'm intercepting requests and responses and faking the CORS response to be always successful.