### PR TITLE
RDX: UI: Uninstall extensions without version

### DIFF
--- a/pkg/rancher-desktop/components/MarketplaceCard.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCard.vue
@@ -131,9 +131,10 @@ export default {
     appInstallation(action) {
       this.loading = true;
       this.resetBanners();
+      const extensionId = action === 'uninstall' ? this.extensionWithoutVersion : this.versionedExtension;
 
       fetch(
-        `http://localhost:${ this.credentials?.port }/v1/extensions/${ action }?id=${ this.versionedExtension }`,
+        `http://localhost:${ this.credentials?.port }/v1/extensions/${ action }?id=${ extensionId }`,
         {
           method:  'POST',
           headers: new Headers({


### PR DESCRIPTION
When uninstalling extensions from the UI, do not specify the version; if the installed version does not match the version in the marketplace this would lead to the extension not uninstalling.

Fixes #8255