### PR TITLE
Bump to NodeJS 22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
   ignore:
   - # Needs to be updated along with NodeJS version.
     dependency-name: "@types/node"
-    versions: [">20"]
+    update-types: [version-update:semver-major]
   - # Need to migrate to Vue 3 before moving beyond 2.7.x.
     dependency-name: "vue"
     versions: [">2"]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can now clone the repository and run `yarn`.
 2. Open a PowerShell prompt (hit Windows Key + `X` and open `Windows PowerShell`).
 3. Install [Scoop] via `iwr -useb get.scoop.sh | iex`.
 4. Install 7zip, git, go, mingw, nvm, and unzip via `scoop install 7zip git go mingw nvm python unzip`.
-   Check node version with `nvm list`. If node v20 is not installed or set as the current version, then install using `nvm install 20` and set as current using `nvm use 20.xx.xx`.
+   Check node version with `nvm list`. If node v22 is not installed or set as the current version, then install using `nvm install 22` and set as current using `nvm use 22.xx.xx`.
 5. Install the yarn package manager via `npm install --global yarn`
 6. Install Visual Studio 2017 or higher. As of this writing the latest version is available at [https://visualstudio.microsoft.com/downloads/]; if that's changed, a good search engine should find it.
 7. Make sure you have the `Windows SDK` component installed. This [Visual Studio docs] describes steps to install components.
@@ -139,10 +139,10 @@ Note that this script adds code dealing with `nvm` to a profile file
 (like `~/.bash_profile`). To add access to `nvm` to a current shell session,
 you'll need to `source` that file.
 
-Currently we build Rancher Desktop with Node 20. To install it, run:
+Currently we build Rancher Desktop with Node 22. To install it, run:
 
 ```
-nvm install 20.16
+nvm install 22.14
 ```
 
 Next, you'll need to install the yarn package manager:
@@ -173,9 +173,9 @@ yarn
 
 Ensure you have the following installed:
 
-- [Node.js][Node.js] v20. **Make sure you have any development packages
+- [Node.js][Node.js] v22. **Make sure you have any development packages
   installed.** For example, on openSUSE Leap 15.6 you would need to install
-  `nodejs20` and `nodejs20-devel`.
+  `nodejs22` and `nodejs22-devel`.
 
 - [yarn classic][yarn-classic]
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "containers@suse.com"
   },
   "engines": {
-    "node": "20.16.0"
+    "node": "^22.14.0"
   },
   "packageManager": "yarn@1.22.21",
   "repository": {
@@ -117,7 +117,7 @@
     "@types/jest": "29.5.14",
     "@types/lodash": "4.17.16",
     "@types/mustache": "4.2.5",
-    "@types/node": "20.17.12",
+    "@types/node": "22.13.9",
     "@types/node-fetch": "2.6.9",
     "@types/node-forge": "1.3.11",
     "@types/plist": "3.0.5",
@@ -185,7 +185,7 @@
     "posix-node": "0.12.0"
   },
   "browserslist": [
-    "node 18",
-    "electron >= 26"
+    "node 22",
+    "electron >= 35"
   ]
 }

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -1021,7 +1021,7 @@ export default class K3sHelper extends events.EventEmitter {
       const userYAML = this.ensureContentsAreYAML(exportConfig(userConfig));
       const writeStream = fs.createWriteStream(workPath, { mode: 0o600 });
 
-      await new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         writeStream.on('error', reject);
         writeStream.on('finish', resolve);
         writeStream.end(userYAML, 'utf-8');

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1539,10 +1539,10 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
       await new Promise<void>((resolve, reject) => {
         proc.stdout?.on('data', (chunk: Buffer | string) => {
-          stdout.push(Buffer.from(chunk));
+          stdout.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
         });
         proc.stderr?.on('data', (chunk: Buffer | string) => {
-          stderr.push(Buffer.from(chunk));
+          stderr.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
         });
         proc.on('error', reject);
         proc.on('exit', (code, signal) => {

--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -526,10 +526,10 @@ export class ExtensionManagerImpl implements ExtensionManager {
     let errored = false;
 
     process.stdout.on('data', (data: string | Buffer) => {
-      stdout.push(Buffer.from(data));
+      stdout.push(typeof data === 'string' ? Buffer.from(data) : data);
     });
     process.stderr.on('data', (data: string | Buffer) => {
-      stderr.push(Buffer.from(data));
+      stderr.push(typeof data === 'string' ? Buffer.from(data) : data);
     });
 
     return new Promise((resolve, reject) => {

--- a/scripts/populate-update-server.ts
+++ b/scripts/populate-update-server.ts
@@ -89,7 +89,7 @@ async function getChecksum(name: string, filenameOverride?: string): Promise<ass
   const stat = await fs.promises.stat(filepath);
   const input = fs.createReadStream(filepath);
   const hasher = crypto.createHash('sha512');
-  const promise = new Promise((resolve) => {
+  const promise = new Promise<void>((resolve) => {
     input.on('end', resolve);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,9 +13,9 @@
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@achrinza/node-ipc@^9.2.5":
-  version "9.2.7"
-  resolved "https://registry.yarnpkg.com/@achrinza/node-ipc/-/node-ipc-9.2.7.tgz#cc418f9218d24d9b87f32207e5d6e71c64e241f8"
-  integrity sha512-/EvNkqB4HNxPWCZASmgrjqG8gIdPOolD67LGASvGMp/FY5ne0rbvpYg5o9x8RmgjAl8KdmNQ4YlV1et9DYiW8g==
+  version "9.2.9"
+  resolved "https://registry.yarnpkg.com/@achrinza/node-ipc/-/node-ipc-9.2.9.tgz#ab4815d9b16f1c83a479fe8791522a3abebb1c6a"
+  integrity sha512-7s0VcTwiK/0tNOVdSX9FWMeFdOEcsAOz9HesBldXxFMaGvIak7KC2z9tV9EgsQXn6KUsWsfIkViMNuIo0GoZDQ==
   dependencies:
     "@node-ipc/js-queue" "2.0.3"
     event-pubsub "4.3.0"
@@ -3086,12 +3086,12 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@20.17.12":
-  version "20.17.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.12.tgz#ee3b7d25a522fd95608c1b3f02921c97b93fcbd6"
-  integrity sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==
+"@types/node@22.13.9":
+  version "22.13.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.9.tgz#5d9a8f7a975a5bd3ef267352deb96fb13ec02eca"
+  integrity sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.20.0"
 
 "@types/node@^16":
   version "16.18.65"
@@ -12661,16 +12661,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12739,7 +12730,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12752,13 +12743,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -14094,7 +14078,7 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14115,15 +14099,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Electron will require this soon, so doing this early in the release cycle seems sensible.

The second commit is just pointless type shuffling because `@types/node` can't seem to stay stable.

Note that there's a sneaky `@achrinza/node-ipc` bump in `yarn.lock` because the newer version is required to support NodeJS 22, but we don't directly depend on it.