### PR TITLE
RDX: Update preload script loading

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -211,14 +211,20 @@ function createView() {
   const webPreferences: Electron.WebPreferences = {
     nodeIntegration:     false,
     contextIsolation:    true,
-    preload:             path.join(paths.resources, 'preload.js'),
     sandbox:             true,
     additionalArguments: [JSON.stringify(hostInfo)],
   };
 
   if (currentExtension?.id) {
     webPreferences.partition = `persist:rdx-${ currentExtension.id }`;
-    const webRequest = Electron.session.fromPartition(webPreferences.partition).webRequest;
+    const session = Electron.session.fromPartition(webPreferences.partition);
+    const { webRequest } = session;
+
+    session.registerPreloadScript({
+      id:       `rdx-preload-${ currentExtension.id }`,
+      filePath: path.join(paths.resources, 'preload.js'),
+      type:     'frame',
+    });
 
     webRequest.onBeforeSendHeaders((details, callback) => {
       const source = details.webContents?.getURL() ?? '';


### PR DESCRIPTION
Electron has a new API for dealing with preload scripts now; use that instead of the previous API, which they are likely to remove.