### PR TITLE
UI: Add badge for upgradable extensions

### DIFF
--- a/pkg/rancher-desktop/components/MarketplaceCatalog.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCatalog.vue
@@ -1,13 +1,12 @@
 <script lang="ts">
-import semver from 'semver';
 import Vue, { VueConstructor } from 'vue';
 import { mapGetters } from 'vuex';
 
 import MarketplaceCard from '@pkg/components/MarketplaceCard.vue';
 import { Settings, ContainerEngine } from '@pkg/config/settings';
-import { ExtensionState, MarketplaceData } from '@pkg/store/extensions.js';
+import type { ExtensionState, MarketplaceData } from '@pkg/store/extensions';
 
-type ExtensionData = MarketplaceData & { installed: boolean };
+type ExtensionData = MarketplaceData;
 
 interface VuexBindings {
   getPreferences: Settings;
@@ -17,33 +16,14 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
   name:       'marketplace-catalog',
   components: { MarketplaceCard },
   data() {
-    return {
-      searchValue: '',
-      loading:     true,
-      credentials: {
-        user:     '',
-        password: '',
-        port:     0,
-      },
-    };
-  },
-  async fetch() {
-    this.credentials = await this.$store.dispatch(
-      'credentials/fetchCredentials',
-    );
-
-    if (!this.credentials) {
-      return;
-    }
-
-    this.loading = false;
+    return { searchValue: '' };
   },
   computed: {
     ...mapGetters('preferences', ['getPreferences']),
-    ...mapGetters('extensions', { installedExtensions: 'list', extensions: 'marketData' }) as {
-        installedExtensions: () => ({ id: string } & ExtensionState )[],
-        extensions: () => MarketplaceData[],
-      },
+    ...mapGetters('extensions', ['installedExtensions', 'marketData']) as {
+      installedExtensions: () => ExtensionState[],
+      marketData: () => MarketplaceData[],
+    },
     containerEngine(): string {
       return this.getPreferences.containerEngine.name;
     },
@@ -57,15 +37,9 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       return this.getPreferences.application.extensions.allowed.list;
     },
     filteredExtensions(): ExtensionData[] {
-      let tempExtensions = this.extensions
+      let tempExtensions = this.marketData
         .filter((item) => {
           return this.isAllowed(item.slug);
-        })
-        .map((item) => {
-          return {
-            ...item,
-            installed: this.isInstalled(item.slug),
-          };
         });
 
       if (this.searchValue) {
@@ -84,20 +58,14 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
     },
   },
   methods: {
-    isInstalled(slug: string) {
-      return !!this.installedExtensions.find(item => item?.id === slug);
-    },
-    isOutdated(slug: string) {
-      const available = this.extensions.find(item => item.slug === slug);
-      const installed = this.installedExtensions.find(item => item?.id === slug);
-
-      return available && installed && semver.gt(available.version, installed.version);
-    },
     installedVersion(slug: string) {
       return this.installedExtensions.find(item => item.id === slug)?.version;
     },
     isAllowed(slug: string) {
       return !this.allowedListEnabled || this.allowedExtensions.includes(slug);
+    },
+    installedExtension(slug: string) {
+      return this.installedExtensions.find(item => item.id === slug);
     },
   },
 });
@@ -117,7 +85,6 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       {{ t('marketplace.noResults') }}
     </div>
     <div
-      v-if="!loading"
       class="extensions-content"
     >
       <div
@@ -127,11 +94,8 @@ export default (Vue as VueConstructor<Vue & VuexBindings>).extend({
       >
         <MarketplaceCard
           :extension="item"
+          :installed="installedExtension(item.slug)"
           :data-test="`extension-card-${item.title.toLowerCase()}`"
-          :is-installed="item.installed"
-          :installed-version="installedVersion(item.slug)"
-          :credentials="credentials"
-          @update:extension="isInstalled"
         />
       </div>
     </div>

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -73,11 +73,11 @@ import NavItem from './NavItem.vue';
 
 import DashboardButton from '@pkg/components/DashboardOpen.vue';
 import PreferencesButton from '@pkg/components/Preferences/ButtonOpen.vue';
-import type { ExtensionMetadata } from '@pkg/main/extensions/types';
+import type { ExtensionState } from '@pkg/store/extensions';
 import { hexEncode } from '@pkg/utils/string-encode';
 
-type ExtensionWithUI = ExtensionMetadata & {
-  ui: { 'dashboard-tab': { title: string } };
+type ExtensionWithUI = ExtensionState & {
+  metadata: { ui: { 'dashboard-tab': { title: string } } };
 };
 
 export default Vue.extend({
@@ -90,7 +90,7 @@ export default Vue.extend({
   },
   props: {
     items: {
-      type:      Array,
+      type:      Array as PropType<{route: string; error?: number; experimental?: boolean}[]>,
       required:  true,
       validator: (value: {route: string, error?: number}[]) => {
         const nuxt: NuxtApp = (global as any).$nuxt;
@@ -112,7 +112,7 @@ export default Vue.extend({
       },
     },
     extensions: {
-      type:     Array as PropType<{ id: string, metadata: ExtensionMetadata }[]>,
+      type:     Array as PropType<ExtensionState[]>,
       required: true,
     },
   },
@@ -133,10 +133,12 @@ export default Vue.extend({
     };
   },
   computed: {
-    extensionsWithUI(): { id: string, metadata: ExtensionWithUI }[] {
-      const allExtensions: { id: string, metadata: ExtensionMetadata }[] = (this as any).extensions;
+    extensionsWithUI(): ExtensionWithUI[] {
+      function hasUI(ext: ExtensionState): ext is ExtensionWithUI {
+        return !!ext.metadata.ui?.['dashboard-tab']?.title;
+      }
 
-      return allExtensions.filter(ext => ext.metadata?.ui?.['dashboard-tab']) as any;
+      return this.extensions.filter<ExtensionWithUI>(hasUI);
     },
   },
   methods: {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -8,7 +8,7 @@
     <rd-nav
       class="nav"
       :items="routes"
-      :extensions="extensions"
+      :extensions="installedExtensions"
       @open-dashboard="openDashboard"
       @open-preferences="openPreferences"
     />
@@ -76,12 +76,13 @@ export default {
     paths() {
       return mainRoutes.map(r => r.route);
     },
+    /** @returns {number} The number of errors. */
     errorCount() {
       return this.diagnostics.filter(diagnostic => !diagnostic.mute).length;
     },
     ...mapState('credentials', ['credentials']),
     ...mapGetters('diagnostics', ['diagnostics']),
-    ...mapGetters('extensions', { extensions: 'list' }),
+    ...mapGetters('extensions', ['installedExtensions']),
   },
 
   beforeMount() {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -71,14 +71,29 @@ export default {
 
   computed: {
     routes() {
-      return mainRoutes.map(route => route.route === '/Diagnostics' ? { ...route, error: this.errorCount } : route);
+      const badges = {
+        '/Diagnostics': this.diagnosticsCount,
+        '/Extensions':  this.extensionUpgradeCount,
+      };
+
+      return mainRoutes.map((route) => {
+        if (route.route in badges) {
+          return { ...route, error: badges[route.route] };
+        }
+
+        return route;
+      });
     },
     paths() {
       return mainRoutes.map(r => r.route);
     },
-    /** @returns {number} The number of errors. */
-    errorCount() {
+    /** @returns {number} The number of diagnostics errors. */
+    diagnosticsCount() {
       return this.diagnostics.filter(diagnostic => !diagnostic.mute).length;
+    },
+    /** @returns {number} The number of extensions with upgrade available. */
+    extensionUpgradeCount() {
+      return this.installedExtensions.filter(ext => ext.canUpgrade).length;
     },
     ...mapState('credentials', ['credentials']),
     ...mapGetters('diagnostics', ['diagnostics']),

--- a/pkg/rancher-desktop/pages/Images.vue
+++ b/pkg/rancher-desktop/pages/Images.vue
@@ -57,7 +57,7 @@ export default {
         .map(image => image.imageName);
     },
     installedExtensionImages() {
-      return this.extensions.map(image => image.id);
+      return this.installedExtensions.map(image => image.id);
     },
     protectedImages() {
       return [
@@ -69,7 +69,7 @@ export default {
     },
     ...mapGetters('k8sManager', { k8sState: 'getK8sState' }),
     ...mapGetters('imageManager', { imageManagerState: 'getImageManagerState' }),
-    ...mapGetters('extensions', { extensions: 'list' }),
+    ...mapGetters('extensions', ['installedExtensions']),
   },
 
   watch: {


### PR DESCRIPTION
This adds a badge in the left navigation bar, similar to the diagnostics badge, that shows the number of extensions with updates available.

Unfortunately it looked too invasive to add the same to the "installed" tab.

This also moves calculating whether an extension can be updated into the extensions vuex store, so that it can be shared by three places (the nav bar, the catalog, and the installed list).

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/7c29e0ba-7d07-4247-8d92-e84efc94bfde" />

This is a draft because it depends on #8309.