### PR TITLE
Packaging: Remove macOS Bluetooth strings

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -25,6 +25,8 @@ mac:
   hardenedRuntime: true
   gatekeeperAssess: false
   extendInfo:
+    NSBluetoothAlwaysUsageDescription: ~
+    NSBluetoothPeripheralUsageDescription: ~
     NSCameraUsageDescription: ~
     NSMicrophoneUsageDescription: ~
   icon: ./resources/icons/mac-icon.png


### PR DESCRIPTION
These don't actually get used, ever, but it's good to remove the strings so we don't accidentally use them.

Fixes #5711