### PR TITLE
RDX: Don't apply preload script if already applied

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -219,12 +219,15 @@ function createView() {
     webPreferences.partition = `persist:rdx-${ currentExtension.id }`;
     const session = Electron.session.fromPartition(webPreferences.partition);
     const { webRequest } = session;
+    const id = `rdx-preload-${ currentExtension.id }`;
 
-    session.registerPreloadScript({
-      id:       `rdx-preload-${ currentExtension.id }`,
-      filePath: path.join(paths.resources, 'preload.js'),
-      type:     'frame',
-    });
+    if (!session.getPreloadScripts().some(script => script.id === id)) {
+      session.registerPreloadScript({
+        id,
+        filePath: path.join(paths.resources, 'preload.js'),
+        type:     'frame',
+      });
+    }
 
     webRequest.onBeforeSendHeaders((details, callback) => {
       const source = details.webContents?.getURL() ?? '';


### PR DESCRIPTION
If the preload script has already been applied to the session, do not apply it again as that causes an error.

Fixes: 2ad5bce65a779090be3ebab8c7cb5f77a4cf6132