### PR TITLE
Switch Linux GitHub runner from Ubuntu 20.04 → 22.04

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -47,7 +47,7 @@ jobs:
         - platform: win
           runs-on: windows-2019
         - platform: linux
-          runs-on: ubuntu-20.04
+          runs-on: ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Fixes #8224 