### PR TITLE
golangci-lint: Fix lints

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,6 +58,7 @@ linters:
     - goimports
     - goprintffuncname
     - gosimple
+    - govet
     - ineffassign
     - misspell
     - typecheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,7 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  gomnd:
+  mnd:
     # don't include the "operation" and "assign"
     checks:
       - argument

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,10 +42,9 @@ linters-settings:
   lll:
     line-length: 140
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    require-explanation: true
+    require-specific: true
 
 linters:
   disable-all: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,6 +61,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - staticcheck
     - typecheck
     - unconvert
     - unused

--- a/src/go/guestagent/pkg/docker/events.go
+++ b/src/go/guestagent/pkg/docker/events.go
@@ -175,7 +175,7 @@ func (e *EventMonitor) initializeRunningContainers(ctx context.Context) error {
 	return nil
 }
 
-func createPortMapping(ports []types.Port) (nat.PortMap, error) {
+func createPortMapping(ports []container.Port) (nat.PortMap, error) {
 	portMap := make(nat.PortMap)
 
 	for _, port := range ports {
@@ -268,7 +268,7 @@ func (e *EventMonitor) createLoopbackIPtablesRules(ctx context.Context, containe
 	return nil
 }
 
-func (e *EventMonitor) createIptablesRuleForContainer(ctx context.Context, container types.ContainerJSON) {
+func (e *EventMonitor) createIptablesRuleForContainer(ctx context.Context, container container.InspectResponse) {
 	// If the container's NetworkSettings.Networks map is not empty, it indicates that the container
 	// is connected to a Docker Compose network. In this case, we should inspect the map and
 	// configure the loopback address for each container's assigned IP address.

--- a/src/go/guestagent/pkg/kube/servicewatcher_linux.go
+++ b/src/go/guestagent/pkg/kube/servicewatcher_linux.go
@@ -89,7 +89,9 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 			if errors.As(err, &statusError) {
 				log.Debugw("kubernetes: got status error", log.Fields{
 					"status": statusError.Status(),
-					"debug":  fmt.Sprintf(statusError.DebugError()),
+					//nolint:govet // DebugError() returns the format string; but it's one of two
+					// literal strings.
+					"debug": fmt.Sprintf(statusError.DebugError()),
 				})
 			}
 			log.Errorw("kubernetes: unexpected error watching", log.Fields{

--- a/src/go/wsl-helper/pkg/dockerproxy/serve.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/serve.go
@@ -40,11 +40,14 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper/pkg/dockerproxy/util"
 )
 
+// requestContextKeyType is a type defined for the context key to be unique.
+type requestContextKeyType struct{}
+
 // RequestContextValue contains things we attach to incoming requests
 type RequestContextValue map[interface{}]interface{}
 
 // requestContext is the context key for requestContextValue
-var requestContext = struct{}{}
+var requestContext = requestContextKeyType{}
 
 type containerInspectResponseBody struct {
 	ID string `json:"Id"`


### PR DESCRIPTION
- Fix up nolintlint configuration
- gomnd has been renamed mnd
- Add govet
- Add staticcheck
  - This includes stopping usage of a couple deprecated types (that have been renamed).