### PR TITLE
Add `/var/run/docker.sock.raw` in the VM

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1895,6 +1895,9 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           }
           break;
         case ContainerEngine.MOBY:
+          // The string is for shell expansion, not a JS template string.
+          // eslint-disable-next-line no-template-curly-in-string
+          await this.writeConf('docker', { DOCKER_OPTS: '--host=unix:///var/run/docker.sock --host=unix:///var/run/docker.sock.raw ${DOCKER_OPTS:-}' });
           await this.startService('docker');
           break;
         case ContainerEngine.NONE:

--- a/src/go/wsl-helper/pkg/dockerproxy/start.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/start.go
@@ -105,6 +105,7 @@ func Start(port uint32, dockerSocket string, args []string) error {
 
 	args = append(args,
 		fmt.Sprintf("--host=unix://%s", dockerSocket),
+		"--host=unix:///var/run/docker.sock.raw",
 		"--host=unix:///var/run/docker.sock")
 	cmd := exec.Command(dockerd, args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This adds `/var/run/docker.sock.raw` as a second socket that dockerd listens on in the VM (lima and WSL).  It is otherwise unused, but is needed for some extensions.

Fixes #5084.

Note that theoretically we should make `/var/run/docker.sock` actually do path translation of some sort or something, but what we _actually_ need to do there is not clear enough so that's skipped for now.