### PR TITLE
RDX: POST: Encode data as JSON

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -384,11 +384,26 @@ test.describe.serial('Extensions', () => {
           await expect(result).resolves.toContain('<title>Rancher</title>');
         });
       });
-      test('can post values', async() => {
-        await retry(async() => {
-          const result = evalInView(`ddClient.extension.vm.service.post("/foo", "hello")`);
+      test.describe('can post values', () => {
+        test('with string body', async() => {
+          await retry(async() => {
+            const result = evalInView(`ddClient.extension.vm.service.post("/foo", "hello")`);
 
-          await expect(result).resolves.toEqual('hello');
+            await expect(result).resolves.toMatchObject({
+              headers: { 'Content-Type': expect.arrayContaining([expect.stringMatching(/^text\/plain\b/)]) },
+              body:    'hello',
+            });
+          });
+        });
+        test('with JSON body', async() => {
+          await retry(async() => {
+            const result = evalInView(`ddClient.extension.vm.service.post("/foo", {foo: 'bar'})`);
+
+            await expect(result).resolves.toMatchObject({
+              headers: { 'Content-Type': expect.arrayContaining([expect.stringMatching(/^application\/json\b/)]) },
+              body:    JSON.stringify({ foo: 'bar' }),
+            });
+          });
         });
       });
     });

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -309,8 +309,16 @@ class Client implements v1.DockerDesktopClient {
    * that wraps ddClient.extension.vm.service.request().
    */
   protected makeRequest(method: string, url: string, data?: any): Promise<unknown> {
+    const headers: Record<string, string> = {};
+
+    if (typeof data === 'object') {
+      // For objects, pass the value as JSON.
+      headers['Content-Type'] = 'application/json';
+      data = JSON.stringify(data);
+    }
+
     return this.request({
-      method, url, data, headers: {},
+      method, url, data, headers,
     });
   }
 


### PR DESCRIPTION
When the user does a POST/PUT/PATCH with contents, if the contents is an object, encode it as JSON.  This should be closer to what DD does.

This is done in two commits so if we need to cherry-pick the change into the branch we can do so without the test. But whether we'll do that is uncertain at this point.
