### PR TITLE
BATS: Tag tests that pass on experimental openSUSE distro

### DIFF
--- a/bats/README.md
+++ b/bats/README.md
@@ -55,6 +55,14 @@ cd bats
 RD_CONTAINER_RUNTIME=moby RD_USE_IMAGE_ALLOW_LIST=false ./bats-core/bin/bats tests/registry/creds.bats
 ```
 
+There is an experimental subset of BATS tests that pass with an under-construction openSUSE based
+distribution; that can be selected via the `opensuse` tag:
+
+```sh
+cd bats
+./bats-core/bin/bats --filter-tags opensuse tests/*/
+```
+
 ### On Windows:
 
 BATS must be executed from within a WSL distribution. (You have to cd into `/mnt/c/REPOSITORY_LOCATION` from your unix shell.)

--- a/bats/tests/compose/compose.bats
+++ b/bats/tests/compose/compose.bats
@@ -1,3 +1,5 @@
+# bats file_tags=opensuse
+
 load '../helpers/load'
 
 local_setup() {

--- a/bats/tests/containers/host-connectivity.bats
+++ b/bats/tests/containers/host-connectivity.bats
@@ -2,6 +2,7 @@
 # On Windows, You need to create a firewall rule to allow communication
 # between the host and the container. Please check the below link for instructions.
 # https://docs.rancherdesktop.io/faq#q-can-containers-reach-back-to-host-services-via-hostdockerinternal
+# bats file_tags=opensuse
 
 load '../helpers/load'
 

--- a/bats/tests/containers/host-network-ports.bats
+++ b/bats/tests/containers/host-network-ports.bats
@@ -1,3 +1,5 @@
+# bats file_tags=opensuse
+
 load '../helpers/load'
 
 LOCALHOST="127.0.0.1"

--- a/bats/tests/containers/init.bats
+++ b/bats/tests/containers/init.bats
@@ -1,4 +1,5 @@
 # verify that running a container with --init is working
+# bats file_tags=opensuse
 
 load '../helpers/load'
 

--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -1,3 +1,5 @@
+# bats file_tags=opensuse
+
 load '../helpers/load'
 
 @test 'factory reset' {

--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -1,3 +1,5 @@
+# bats file_tags=opensuse
+
 load '../helpers/load'
 RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.
 

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -1,3 +1,5 @@
+# bats file_tags=opensuse
+
 load '../helpers/load'
 
 : "${RD_INFO:=false}"

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -1,4 +1,5 @@
 # Test case 11 & 12
+# bats file_tags=opensuse
 
 load '../helpers/load'
 RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.


### PR DESCRIPTION
Currently only some of the BATS tests pass on the experimental openSUSE distro; this tags them so they can be selected with:

    ./bats-core/bin/bats --filter-tags opensuse tests/*/

This currently only works correctly on macOS; other platforms will need to be tested separately.

Note that for `RD_CONTAINER_ENGINE=moby` the docker CLI plugins need to be correctly set up first.