### PR TITLE
RDX: Throw exceptions on errors

### DIFF
--- a/pkg/rancher-desktop/main/extensions/manager.ts
+++ b/pkg/rancher-desktop/main/extensions/manager.ts
@@ -1,4 +1,5 @@
 import { ChildProcessByStdio, spawn } from 'child_process';
+import http from 'http';
 import path from 'path';
 import { Readable } from 'stream';
 
@@ -219,7 +220,10 @@ export class ExtensionManagerImpl implements ExtensionManager {
       const extensionId = this.getExtensionIdFromEvent(event);
 
       if (!extensionId) {
-        return; // Sender frame has gone away, no need to fetch anymore.
+        // Sender frame has gone away, no need to fetch anymore.
+        return {
+          statusCode: -1, name: 'Request aborted', message: 'Request aborted',
+        };
       }
       if (extensionId === EXTENSION_APP) {
         throw new Error('HTTP fetch from main app not implemented yet');
@@ -254,7 +258,9 @@ export class ExtensionManagerImpl implements ExtensionManager {
       };
       const response = await fetch(url.toString(), options);
 
-      return await response.text();
+      return {
+        statusCode: response.status, name: http.STATUS_CODES[response.status] ?? 'Unknown', message: await response.text(),
+      };
     });
 
     // Import image for port forwarding

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -200,7 +200,7 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
 
       console.debug(`spawn/blocking got result:`, process.env.RD_TEST === 'e2e' ? JSON.stringify(response) : response);
 
-      return {
+      const result = {
         cmd:    response.cmd,
         signal: typeof response.result === 'string' ? response.result : undefined,
         code:   typeof response.result === 'number' ? response.result : undefined,
@@ -216,6 +216,12 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
           return JSON.parse(response.stdout);
         },
       };
+
+      if (result.signal || result.code) {
+        throw result;
+      }
+
+      return result;
     })();
   }
 

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -135,8 +135,8 @@ export interface IpcMainInvokeEvents {
   /** Execute the given command and return the results. */
   'extensions/spawn/blocking': (options: import('@pkg/main/extensions/types').SpawnOptions) => import('@pkg/main/extensions/types').SpawnResult;
   'extensions/ui/show-open': (options: import('electron').OpenDialogOptions) => import('electron').OpenDialogReturnValue;
-  /** Fetch data from the backend, or arbitrary host ignoring CORS. */
-  'extensions/vm/http-fetch': (config: import('@docker/extension-api-client-types').v1.RequestConfig) => any;
+  /* Fetch data from the backend, or arbitrary host ignoring CORS. */
+  'extensions/vm/http-fetch': (config: import('@docker/extension-api-client-types').v1.RequestConfig) => import('@docker/extension-api-client-types').v1.ServiceError;
   // #endregion
 
   // #region Versions


### PR DESCRIPTION
This changes `ddClient.extension.*.cli.exec()` and `ddClient.extension.vm.service.*()` to throw when the command / request fails.