### PR TITLE
GitHub Actions: reusable workflows: pin versions

### DIFF
--- a/.github/actions/get-token/action.yaml
+++ b/.github/actions/get-token/action.yaml
@@ -27,7 +27,7 @@ runs:
   - id: gen-token
     name: Generate token
     if: github.repository == 'rancher-sandbox/rancher-desktop'
-    uses: actions/create-github-app-token@v1
+    uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
     with:
       app-id: ${{ env.APP_ID }}
       private-key: ${{ env.PRIVATE_KEY }}

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -7,22 +7,22 @@ runs:
   steps:
   # In case we're running on a self-hosted runner without `yarn` installed,
   # set up NodeJS, enable `yarn`, and then handle the caching.
-  - uses: actions/setup-node@v4
+  - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
     with:
       node-version-file: package.json
   - run: corepack enable yarn
     shell: bash
-  - uses: actions/setup-node@v4
+  - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
     with:
       node-version-file: package.json
       cache: yarn
 
-  - uses: actions/setup-go@v5
+  - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
     with:
       go-version-file: go.work
       cache-dependency-path: src/go/**/go.sum
 
-  - uses: actions/setup-python@v5
+  - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
     with:
       python-version: '3.x'
       cache: pip


### PR DESCRIPTION
Dependabot does not look at our reusable workflows (i.e. `.github/actions/*`) so we have to pin them manually.

`rancher-eio/read-vault-secrets@main` was not pinned because that's one of our own orgs.