### PR TITLE
wsl-helper: fixup for golangci-lint unused linter

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/helpers.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/helpers.go
@@ -1,3 +1,5 @@
+//go:build linux || windows
+
 /*
 Copyright © 2021 SUSE LLC
 


### PR DESCRIPTION
This file is only built on Windows and Linux; add a go build constraint so golangci-lint doesn't pick it up for darwin (and complain about unused linters).