### PR TITLE
package.json: Bump fs-xattr to 0.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,9 +49,6 @@ updates:
     # Assume the next release will fix it.
     dependency-name: "unfetch"
     versions: ["5.0.0"]
-  - # fs-xattr 0.4.0 later are esm-only.
-    dependency-name: "fs-xattr"
-    versions: [">0.3"]
   - # octokit 4 and later are esm-only.
     dependency-name: "octokit"
     versions: [">3"]

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
   },
   "optionalDependencies": {
     "dmg-license": "1.0.11",
-    "fs-xattr": "0.3.1",
+    "fs-xattr": "0.4.0",
     "posix-node": "0.12.0"
   },
   "browserslist": [

--- a/pkg/rancher-desktop/integrations/manageLinesInFile.ts
+++ b/pkg/rancher-desktop/integrations/manageLinesInFile.ts
@@ -155,12 +155,12 @@ async function copyFileExtendedAttributes(fromPath: string, toPath: string): Pro
   try {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This only fails on Windows
     // @ts-ignore // fs-xattr is not available on Windows
-    const { list, get, set } = await import('fs-xattr');
+    const { listAttributes, getAttribute, setAttribute } = await import('fs-xattr');
 
-    for (const attr of await list(fromPath)) {
-      const value = await get(fromPath, attr);
+    for (const attr of await listAttributes(fromPath)) {
+      const value = await getAttribute(fromPath, attr);
 
-      await set(toPath, attr, value);
+      await setAttribute(toPath, attr, value);
     }
   } catch (cause) {
     if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7469,10 +7469,10 @@ fs-monkey@^1.0.4:
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.4.tgz#ee8c1b53d3fe8bb7e5d2c5c5dfc0168afdd2f747"
   integrity sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==
 
-fs-xattr@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/fs-xattr/-/fs-xattr-0.3.1.tgz#a23d88571031f6c56f26d59e0bab7d2e12f49f77"
-  integrity sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==
+fs-xattr@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/fs-xattr/-/fs-xattr-0.4.0.tgz#30797399631287b740994a0bfab7822295e5f482"
+  integrity sha512-Lw90zx483YTGiHfR67IPtrbrZ+yBr1/W98v/iyTeSkUbixg/wrHfX5x9oMUOnirC5P7SZ5HlrpnIRMMqt8Ej0A==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
With the various Electron bumps we no longer have issues loading ES modules so we can upgrade correctly.

Of course, the new version has an API change too.

Tested on macOS, with a packaged build.  Manually added an xattr to `~/.bash_profile` and ensured it stayed across file modifications.