### PR TITLE
Update Electron's console-message event handlers

### DIFF
--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -172,9 +172,11 @@ test.describe.serial('Extensions', () => {
       });
 
       await view.evaluate((v, { window }) => {
-        v.webContents.addListener('console-message', (event, level, message, line, source) => {
-          const levelName = (['verbose', 'info', 'warning', 'error'])[level];
-          const outputMessage = `[${ levelName }] ${ message } @${ source }:${ line }`;
+        v.webContents.addListener('console-message', (event) => {
+          const {
+            message, level, lineNumber, sourceId,
+          } = event;
+          const outputMessage = `[${ level }] ${ message } @${ sourceId }:${ lineNumber }`;
 
           window.webContents.executeJavaScript(`console.log(${ JSON.stringify(outputMessage) })`);
         });

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -70,11 +70,11 @@ export function createWindow(name: string, url: string, options: Electron.Browse
   }
 
   window = new BrowserWindow(options);
-  window.webContents.on('console-message', (event, level, message, line, sourceId) => {
-    const levelNum = level === 0 ? 0 : level === 1 ? 1 : level === 2 ? 2 : level === 3 ? 3 : 0;
-    const key = ['debug', 'info', 'warn', 'error'] as const;
+  window.webContents.on('console-message', (event) => {
+    const { level, lineNumber, message } = event;
+    const method = level === 'warning' ? 'warn' : level;
 
-    console[key[levelNum]](`${ name }@${ line }: ${ message }`);
+    console[method](`${ name }@${ lineNumber }: ${ message }`);
   });
   window.webContents.on('will-navigate', (event, input) => {
     if (isInternalURL(input)) {


### PR DESCRIPTION
The extra arguments on `console-message` has been deprecated, and now all the them can be gotten from the `event` object.

See release notes for Electron 35 (https://github.com/electron/electron/pull/43617).