### PR TITLE
Allowed images bats

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -24,9 +24,14 @@ RD_USE_IMAGE_ALLOW_LIST=true
     ctrctl pull --quiet "$IMAGE_PYTHON"
 }
 
+assert_pull_fails() {
+    run ctrctl pull "$1" || return
+    assert_failure || return
+    assert_output --regexp "(UNAUTHORIZED|Forbidden)"
+}
+
 @test 'verify pull ruby fails' {
-    run ctrctl pull "$IMAGE_RUBY"
-    assert_failure
+    try --max 9 --delay 10 assert_pull_fails "$IMAGE_RUBY"
 }
 
 @test 'drop python from the allowed-image list, add ruby' {
@@ -40,8 +45,7 @@ RD_USE_IMAGE_ALLOW_LIST=true
 }
 
 @test 'verify pull python fails' {
-    run ctrctl pull --quiet "$IMAGE_PYTHON"
-    assert_failure
+    try --max 9 --delay 10 assert_pull_fails "$IMAGE_PYTHON"
 }
 
 @test 'verify pull ruby succeeds' {

--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -45,7 +45,8 @@ RD_USE_IMAGE_ALLOW_LIST=true
 }
 
 @test 'verify pull ruby succeeds' {
-    ctrctl pull --quiet "$IMAGE_RUBY"
+    # when using VZ and when traefik is enabled, then pulling the image does not always succeed on the first attempt
+    try --max 9 --delay 10 ctrctl pull --quiet "$IMAGE_RUBY"
 }
 
 @test 'clear all patterns' {
@@ -71,5 +72,6 @@ verify_no_nginx() {
 }
 
 @test 'verify pull python succeeds because allowedImages filter is disabled' {
-    ctrctl pull --quiet "$IMAGE_PYTHON"
+    # when using VZ and when traefik is enabled, then pulling the image does not always succeed on the first attempt
+    try --max 9 --delay 10 ctrctl pull --quiet "$IMAGE_PYTHON"
 }

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -120,7 +120,7 @@ verify_default_credStore() {
     run ctrctl pull --quiet "$IMAGE_BUSYBOX"
     if using_image_allow_list; then
         assert_failure
-        assert_output --regexp "(unauthorized|Forbidden)"
+        assert_output --regexp "(UNAUTHORIZED|Forbidden)"
     else
         assert_success
     fi


### PR DESCRIPTION
With this PR all 4 regular BATS runs (moby/containerd on qemu/vz) ran with 0 failures on macOS M1.

I believe there are additional tests that will fail with `RD_USE_IMAGE_ALLOW_LIST=true`, but they can be addressed in a separate PR.