### PR TITLE
scripts/ts-wrapper: Exit on failure

### DIFF
--- a/scripts/lint-go.ts
+++ b/scripts/lint-go.ts
@@ -95,9 +95,6 @@ async function goLangCILint(fix: boolean): Promise<boolean> {
   if (fix) {
     args.push('--fix');
   }
-  if (process.env.GITHUB_ACTIONS) {
-    args.push('--out-format=colored-line-number');
-  }
   // golangci-lint blocks running in parallel by default (and it's unclear _why_
   // this is necessary).  To be safe, just pass in all of the modules at once
   // and let it go at its own pace.

--- a/scripts/ts-wrapper.js
+++ b/scripts/ts-wrapper.js
@@ -17,7 +17,20 @@ function main(args) {
   const finalArgs = [...childArgs, ...args];
 
   console.log(process.argv0, ...finalArgs);
-  spawnSync(process.argv0, finalArgs, { stdio: 'inherit' });
+  const result = spawnSync(process.argv0, finalArgs, { stdio: 'inherit' });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number') {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    console.log(`Process exited with signal ${ result.signal }`);
+    process.exit(-1);
+  }
 }
 
 if (require.main === module) {

--- a/src/go/rdctl/pkg/process/process_windows.go
+++ b/src/go/rdctl/pkg/process/process_windows.go
@@ -115,9 +115,10 @@ func buildCommandLine(args []string) string {
 		slashes := 0
 		_, _ = builder.WriteString(" \"")
 		for _, ch := range []byte(word) {
-			if ch == '\\' {
+			switch ch {
+			case '\\':
 				slashes += 1
-			} else if ch == '"' {
+			case '"':
 				// If a run of backslashes is followed by a quote, each backslash needs
 				// to be escaped by another backslash, and then the quote must be
 				// itself escaped.
@@ -126,7 +127,7 @@ func buildCommandLine(args []string) string {
 				}
 				_, _ = builder.WriteString("\\\"")
 				slashes = 0
-			} else {
+			default:
 				// If a run of backslashes is followed by a non-quote character, all of
 				// the backslashes are treated literally.
 				for i := 0; i < slashes; i++ {


### PR DESCRIPTION
Previously when we switched to `tsx` we missed checking the return value of the subprocess (as it doesn't throw an exception on error).  Check that properly so CI fails correctly when needed.

Fixes: 7074a4516885ae66f8d85c713409dfc237aa47e9