### PR TITLE
Revert alpine-lima bump to 0.2.43.rd1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -2,8 +2,8 @@ lima: 1.0.6.rd1
 qemu: 9.2.0.rd2
 socketVMNet: 1.2.1
 alpineLimaISO:
-  isoVersion: 0.2.43.rd1
-  alpineVersion: 3.21.3
+  isoVersion: 0.2.41.rd5
+  alpineVersion: 3.20.3
 WSLDistro: "0.78"
 kuberlr: 0.6.0
 helm: 3.17.2


### PR DESCRIPTION
This reverts commit a015ceddbdb5ce352b0bf2e24e70ce1e10140c72, reversing changes made to 006dbc22a14ae3d59a565d7d179bcc7e25e8b87c.

The bump to the ISO causes Linux to fail to boot:

    [    2.584528] Loading user settings from /media/sr0/alpine.apkovl.tar.gz...
     * Loading user settings from /media/sr0/alpine.apkovl.tar.gz: 8
    [    4.550823] Loading user settings from /media/sr0/alpine.apkovl.tar.gz: ok.
    ok.
    [    4.572230] Installing packages to root filesystem...
     * Installing packages to root filesystem: WARNING: opening /media/sr0/apks: No such file or directory
    8OK: 0 MiB in 0 packages
    [    4.587601] Installing packages to root filesystem: ok.
    ok.
    /sbin/init not found in new root. Launching emergency recovery shell