### PR TITLE
Set correct log level and overwrite file on start

### DIFF
--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -451,9 +451,11 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
 
   protected async runWslProxy() {
     const debug = this.debug ? 'true' : 'false';
+    const logDir = await this.wslify(paths.logs);
+    const logfile = path.posix.join(logDir, 'wsl-proxy.log');
 
     try {
-      await this.execCommand('/usr/local/bin/wsl-proxy', '-debug', debug);
+      await this.execCommand('/usr/local/bin/wsl-proxy', `-debug=${ debug }`, `-logfile=${ logfile }`);
     } catch (err: any) {
       console.log('Error trying to start wsl-proxy in default namespace:', err);
     }

--- a/src/go/networking/cmd/proxy/wsl_integration_linux.go
+++ b/src/go/networking/cmd/proxy/wsl_integration_linux.go
@@ -91,5 +91,7 @@ func setupLogging(logFile string) {
 
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		logrus.SetLevel(logrus.InfoLevel)
 	}
 }

--- a/src/go/networking/pkg/log/log.go
+++ b/src/go/networking/pkg/log/log.go
@@ -23,7 +23,7 @@ const fileMode = 0666
 
 // SetOutputFile sets the logger output with a given file
 func SetOutputFile(filePath string, logger *logrus.Logger) error {
-	logFile, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, fileMode)
+	logFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Set log level to Info when `-debug=false` to avoid unwanted debug logs
- Overwrite log file instead of appending to prevent log growth across restarts
- Overrides default log path to the the path where reset of the logs are

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/8501