### PR TITLE
golangci-lint: More linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - misspell
     - mnd
     - nakedret
+    - noctx
     - staticcheck
     - unconvert
     - unparam

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - ineffassign
     - misspell
     - mnd
+    - nakedret
     - staticcheck
     - unconvert
     - unparam

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,8 +45,6 @@ linters:
         - style
     gocyclo:
       min-complexity: 15
-    lll:
-      line-length: 140
     mnd:
       # don't include the "operation" and "assign"
       checks:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - mnd
     - staticcheck
     - unconvert
     - unparam
@@ -59,9 +60,15 @@ linters:
         - "2"
         - "3"
       ignored-functions:
-        - ^strings\.SplitN$
+        - ^make$
+        - ^net\.IPv4$
         - ^os\.FileMode$
         - ^os\.Mkdir(?:All)?$
+        - ^os\.(?:Open|Write)File$
+        - ^s\.waitForAppToDieOrKillIt$
+        - ^strings\.SplitN$
+        - ^tabwriter\.NewWriter$
+        - ^utils\.GetParentDir$
     nolintlint:
       allow-unused: false # report any unused nolint directives
       require-explanation: true

--- a/scripts/k3s-versions.go
+++ b/scripts/k3s-versions.go
@@ -60,11 +60,11 @@ func getK3sChannels(ctx context.Context) (map[string]string, error) {
 	for _, channel := range channels.Data {
 		switch {
 		case channel.Name == "latest" || channel.Name == "stable":
-			break
+			// process this channel.
 		case semver.Prerelease(channel.Latest) != "":
 			continue
 		case semver.IsValid(channel.Latest) && semver.Compare(channel.Latest, minimumVersion) >= 0:
-			break
+			// process this channel.
 		default:
 			continue
 		}
@@ -99,8 +99,7 @@ func getGithubReleasesPage(ctx context.Context, page int) ([]GithubRelease, erro
 		req.Header.Set("Authorization", "token "+token)
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request for %q: %w", url, err)
 	}

--- a/src/go/rdctl/cmd/api.go
+++ b/src/go/rdctl/cmd/api.go
@@ -101,19 +101,19 @@ func doAPICommand(cmd *cobra.Command, args []string) error {
 		}
 		method := apiSettings.Method
 		payload := bytes.NewBuffer(contents)
-		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequestWithPayload(method, endpoint, payload))
+		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequestWithPayload(cmd.Context(), method, endpoint, payload))
 	} else if apiSettings.Body != "" {
 		if apiSettings.Method == "" {
 			apiSettings.Method = "PUT"
 		}
 		method := apiSettings.Method
 		payload := bytes.NewBufferString(apiSettings.Body)
-		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequestWithPayload(method, endpoint, payload))
+		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequestWithPayload(cmd.Context(), method, endpoint, payload))
 	} else {
 		if apiSettings.Method == "" {
 			apiSettings.Method = "GET"
 		}
-		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequest(apiSettings.Method, endpoint))
+		result, errorPacket, err = client.ProcessRequestForAPI(rdClient.DoRequest(cmd.Context(), apiSettings.Method, endpoint))
 	}
 	return displayAPICallResult(result, errorPacket, err)
 }

--- a/src/go/rdctl/cmd/createProfile.go
+++ b/src/go/rdctl/cmd/createProfile.go
@@ -17,8 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -62,7 +64,7 @@ can be imported into the Windows registry using the "eg import FILE" command.`,
 		if err := cobra.NoArgs(cmd, args); err != nil {
 			return err
 		}
-		result, err := createProfile()
+		result, err := createProfile(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -81,7 +83,7 @@ func init() {
 	createProfileCmd.Flags().BoolVar(&UseCurrentSettings, "from-settings", false, "Use current settings")
 }
 
-func createProfile() (string, error) {
+func createProfile(ctx context.Context) (string, error) {
 	err := validateProfileFormatFlags()
 	if err != nil {
 		return "", err
@@ -107,7 +109,7 @@ func createProfile() (string, error) {
 		}
 		rdClient := client.NewRDClient(connectionInfo)
 		command := client.VersionCommand("", "settings")
-		output, err = client.ProcessRequestForUtility(rdClient.DoRequest("GET", command))
+		output, err = client.ProcessRequestForUtility(rdClient.DoRequest(ctx, http.MethodGet, command))
 	}
 	if err != nil {
 		return "", err

--- a/src/go/rdctl/cmd/extensionInstall.go
+++ b/src/go/rdctl/cmd/extensionInstall.go
@@ -18,7 +18,9 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
@@ -35,7 +37,7 @@ The <image-id> is an image reference, e.g. splatform/epinio-docker-desktop:lates
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return installExtension(args)
+		return installExtension(cmd.Context(), args)
 	},
 }
 
@@ -43,7 +45,7 @@ func init() {
 	extensionCmd.AddCommand(installCmd)
 }
 
-func installExtension(args []string) error {
+func installExtension(ctx context.Context, args []string) error {
 	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
@@ -54,7 +56,7 @@ func installExtension(args []string) error {
 	// https://stackoverflow.com/questions/20847357/golang-http-client-always-escaped-the-url
 	// Looks like http.NewRequest(method, url) escapes the URL
 
-	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest("POST", endpoint))
+	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest(ctx, http.MethodPost, endpoint))
 	if errorPacket != nil || err != nil {
 		return displayAPICallResult(result, errorPacket, err)
 	}

--- a/src/go/rdctl/cmd/extensionList.go
+++ b/src/go/rdctl/cmd/extensionList.go
@@ -19,8 +19,10 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -38,7 +40,7 @@ var listCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return listExtensions()
+		return listExtensions(cmd.Context())
 	},
 }
 
@@ -46,14 +48,14 @@ func init() {
 	extensionCmd.AddCommand(listCmd)
 }
 
-func listExtensions() error {
+func listExtensions(ctx context.Context) error {
 	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
 	}
 	rdClient := client.NewRDClient(connectionInfo)
 	endpoint := fmt.Sprintf("/%s/extensions", client.APIVersion)
-	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest("GET", endpoint))
+	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest(ctx, http.MethodGet, endpoint))
 	if errorPacket != nil || err != nil {
 		return displayAPICallResult([]byte{}, errorPacket, err)
 	}

--- a/src/go/rdctl/cmd/extensionUninstall.go
+++ b/src/go/rdctl/cmd/extensionUninstall.go
@@ -19,7 +19,9 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
@@ -34,7 +36,7 @@ The <image-id> is an image reference, e.g. splatform/epinio-docker-desktop:lates
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return uninstallExtension(args)
+		return uninstallExtension(cmd.Context(), args)
 	},
 }
 
@@ -42,7 +44,7 @@ func init() {
 	extensionCmd.AddCommand(uninstallCmd)
 }
 
-func uninstallExtension(args []string) error {
+func uninstallExtension(ctx context.Context, args []string) error {
 	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return fmt.Errorf("failed to get connection info: %w", err)
@@ -50,7 +52,7 @@ func uninstallExtension(args []string) error {
 	rdClient := client.NewRDClient(connectionInfo)
 	imageID := args[0]
 	endpoint := fmt.Sprintf("/%s/extensions/uninstall?id=%s", client.APIVersion, imageID)
-	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest("POST", endpoint))
+	result, errorPacket, err := client.ProcessRequestForAPI(rdClient.DoRequest(ctx, http.MethodPost, endpoint))
 	if errorPacket != nil || err != nil {
 		return displayAPICallResult(result, errorPacket, err)
 	}

--- a/src/go/rdctl/cmd/listSettings.go
+++ b/src/go/rdctl/cmd/listSettings.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
@@ -34,7 +36,7 @@ var listSettingsCmd = &cobra.Command{
 			return err
 		}
 		cmd.SilenceUsage = true
-		result, err := getListSettings()
+		result, err := getListSettings(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -47,12 +49,12 @@ func init() {
 	rootCmd.AddCommand(listSettingsCmd)
 }
 
-func getListSettings() ([]byte, error) {
+func getListSettings(ctx context.Context) ([]byte, error) {
 	connectionInfo, err := config.GetConnectionInfo(false)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to get connection info: %w", err)
 	}
 	rdClient := client.NewRDClient(connectionInfo)
 	command := client.VersionCommand("", "settings")
-	return client.ProcessRequestForUtility(rdClient.DoRequest("GET", command))
+	return client.ProcessRequestForUtility(rdClient.DoRequest(ctx, http.MethodGet, command))
 }

--- a/src/go/rdctl/cmd/set.go
+++ b/src/go/rdctl/cmd/set.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
@@ -67,7 +68,7 @@ func doSetCommand(cmd *cobra.Command) error {
 
 	command := client.VersionCommand("", "settings")
 	buf := bytes.NewBuffer(jsonBuffer)
-	result, err := client.ProcessRequestForUtility(rdClient.DoRequestWithPayload("PUT", command, buf))
+	result, err := client.ProcessRequestForUtility(rdClient.DoRequestWithPayload(cmd.Context(), http.MethodPut, command, buf))
 	if err != nil {
 		return err
 	}

--- a/src/go/rdctl/cmd/shutdown.go
+++ b/src/go/rdctl/cmd/shutdown.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
@@ -65,7 +66,7 @@ func doShutdown(ctx context.Context, shutdownSettings *shutdownSettingsStruct, i
 	if err == nil && connectionInfo != nil {
 		rdClient := client.NewRDClient(connectionInfo)
 		command := client.VersionCommand("", "shutdown")
-		output, _ = client.ProcessRequestForUtility(rdClient.DoRequest("PUT", command))
+		output, _ = client.ProcessRequestForUtility(rdClient.DoRequest(ctx, http.MethodPut, command))
 		logrus.WithError(err).Trace("Shut down requested")
 	}
 	err = shutdown.FinishShutdown(ctx, shutdownSettings.WaitForShutdown, initiatingCommand)

--- a/src/go/rdctl/cmd/snapshotList.go
+++ b/src/go/rdctl/cmd/snapshotList.go
@@ -13,6 +13,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// The maximum number of runes to output for tabular output.
+	tableMaxRunes = 63
+)
+
 // SortableSnapshots are []snapshot.Snapshot sortable by date created.
 type SortableSnapshots []snapshot.Snapshot
 
@@ -81,7 +86,7 @@ func tabularOutput(snapshots []snapshot.Snapshot) error {
 	fmt.Fprintf(writer, "NAME\tCREATED\tDESCRIPTION\n")
 	for _, aSnapshot := range snapshots {
 		prettyCreated := aSnapshot.Created.Format(time.RFC1123)
-		desc := truncateAtNewlineOrMaxRunes(aSnapshot.Description, 63)
+		desc := truncateAtNewlineOrMaxRunes(aSnapshot.Description, tableMaxRunes)
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", aSnapshot.Name, prettyCreated, desc)
 	}
 	writer.Flush()

--- a/src/go/rdctl/cmd/snapshotUnlock.go
+++ b/src/go/rdctl/cmd/snapshotUnlock.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/snapshot"
@@ -18,7 +19,7 @@ normal circumstances.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return exitWithJSONOrErrorCondition(unlockSnapshot())
+		return exitWithJSONOrErrorCondition(unlockSnapshot(cmd.Context()))
 	},
 }
 
@@ -27,10 +28,10 @@ func init() {
 	snapshotUnlockCmd.Flags().BoolVarP(&outputJSONFormat, "json", "", false, "output json format")
 }
 
-func unlockSnapshot() error {
+func unlockSnapshot(ctx context.Context) error {
 	manager, err := snapshot.NewManager()
 	if err != nil {
 		return fmt.Errorf("failed to create snapshot manager: %w", err)
 	}
-	return manager.Unlock(manager.Paths, false)
+	return manager.Unlock(ctx, manager.Paths, false)
 }

--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -58,7 +58,7 @@ func init() {
  * If Rancher Desktop is currently running, treat this like a `set` command, and pass all the args to that.
  */
 func doStartOrSetCommand(cmd *cobra.Command) error {
-	_, err := getListSettings()
+	_, err := getListSettings(cmd.Context())
 	if err == nil {
 		// Unavoidable race condition here.
 		// There's no system-wide mutex that will let us guarantee that if rancher desktop is running when

--- a/src/go/rdctl/pkg/client/utils.go
+++ b/src/go/rdctl/pkg/client/utils.go
@@ -56,14 +56,14 @@ func ProcessRequestForUtility(response *http.Response, err error) ([]byte, error
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		// Note that response.Status includes response.StatusCode
 		switch response.StatusCode {
-		case http.StatusBadRequest:
+		case http.StatusBadRequest: // 400
 			statusMessage = response.Status
 			// Prefer the error message in the body written by the command-server, not the one from the http server.
-		case http.StatusUnauthorized:
+		case http.StatusUnauthorized: // 401
 			return nil, fmt.Errorf("%s: user/password not accepted", response.Status)
-		case http.StatusRequestEntityTooLarge:
+		case http.StatusRequestEntityTooLarge: // 413
 			return nil, fmt.Errorf("%s", response.Status)
-		case http.StatusInternalServerError:
+		case http.StatusInternalServerError: // 500
 			return nil, fmt.Errorf("%s: server-side problem: please consult the server logs for more information", response.Status)
 		default:
 			return nil, fmt.Errorf("%s (unexpected server error)", response.Status)

--- a/src/go/rdctl/pkg/client/utils.go
+++ b/src/go/rdctl/pkg/client/utils.go
@@ -56,14 +56,14 @@ func ProcessRequestForUtility(response *http.Response, err error) ([]byte, error
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		// Note that response.Status includes response.StatusCode
 		switch response.StatusCode {
-		case 400:
+		case http.StatusBadRequest:
 			statusMessage = response.Status
 			// Prefer the error message in the body written by the command-server, not the one from the http server.
-		case 401:
+		case http.StatusUnauthorized:
 			return nil, fmt.Errorf("%s: user/password not accepted", response.Status)
-		case 413:
+		case http.StatusRequestEntityTooLarge:
 			return nil, fmt.Errorf("%s", response.Status)
-		case 500:
+		case http.StatusInternalServerError:
 			return nil, fmt.Errorf("%s: server-side problem: please consult the server logs for more information", response.Status)
 		default:
 			return nil, fmt.Errorf("%s (unexpected server error)", response.Status)

--- a/src/go/rdctl/pkg/directories/directories_windows.go
+++ b/src/go/rdctl/pkg/directories/directories_windows.go
@@ -24,10 +24,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// The initial buffer size for use with InvokeWin32WithBuffer
+const initialBufferSize = 256
+
 // InvokeWin32WithBuffer calls the given function with increasing buffer sizes
 // until it does not return ERROR_INSUFFICIENT_BUFFER.
 func InvokeWin32WithBuffer(cb func(size int) error) error {
-	size := 256
+	size := initialBufferSize
 	for {
 		err := cb(size)
 		if err == nil {

--- a/src/go/rdctl/pkg/lock/mock.go
+++ b/src/go/rdctl/pkg/lock/mock.go
@@ -1,14 +1,18 @@
 package lock
 
-import "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+import (
+	"context"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+)
 
 type MockBackendLock struct {
 }
 
-func (lock *MockBackendLock) Lock(appPaths *paths.Paths, action string) error {
+func (lock *MockBackendLock) Lock(ctx context.Context, appPaths *paths.Paths, action string) error {
 	return nil
 }
 
-func (lock *MockBackendLock) Unlock(appPaths *paths.Paths, restart bool) error {
+func (lock *MockBackendLock) Unlock(ctx context.Context, appPaths *paths.Paths, restart bool) error {
 	return nil
 }

--- a/src/go/rdctl/pkg/snapshot/manager.go
+++ b/src/go/rdctl/pkg/snapshot/manager.go
@@ -130,14 +130,14 @@ func (manager *Manager) Create(ctx context.Context, name, description string) (S
 		Description: description,
 	}
 	action := fmt.Sprintf("Creating snapshot %q", name)
-	if err := manager.Lock(manager.Paths, action); err != nil {
+	if err := manager.Lock(ctx, manager.Paths, action); err != nil {
 		return snapshot, err
 	}
 	defer func() {
 		if err != nil {
 			os.RemoveAll(manager.SnapshotDirectory(snapshot))
 		}
-		unlockErr := manager.Unlock(manager.Paths, true)
+		unlockErr := manager.Unlock(ctx, manager.Paths, true)
 		if err == nil {
 			err = unlockErr
 		}
@@ -211,12 +211,12 @@ func (manager *Manager) Restore(ctx context.Context, name string) (err error) {
 	}
 
 	action := fmt.Sprintf("Restoring snapshot %q", name)
-	if err := manager.Lock(manager.Paths, action); err != nil {
+	if err := manager.Lock(ctx, manager.Paths, action); err != nil {
 		return err
 	}
 	defer func() {
 		// Restart the backend only if a data reset occurred
-		unlockErr := manager.Unlock(manager.Paths, !errors.Is(err, ErrDataReset))
+		unlockErr := manager.Unlock(ctx, manager.Paths, !errors.Is(err, ErrDataReset))
 		if err == nil {
 			err = unlockErr
 		}

--- a/src/go/wsl-helper/pkg/dockerproxy/util/reverse_proxy.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/util/reverse_proxy.go
@@ -14,6 +14,8 @@ import (
 const (
 	hostHeaderValue = "api.moby.localhost"
 	targetProtocol  = "http://"
+	// The amount of time between flushes for a flushWriter
+	flushInterval = 100 * time.Millisecond
 )
 
 // ReverseProxy is a custom reverse proxy specifically designed for Rancher Desktop's
@@ -278,7 +280,7 @@ func newFlushedWriter(ctx context.Context, w io.Writer) *flushedWriter {
 
 	// periodicFlusher runs a loop that periodically flushes the writer
 	periodicFlusher := func(flusher http.Flusher) {
-		ticker := time.NewTicker(100 * time.Millisecond)
+		ticker := time.NewTicker(flushInterval)
 		defer ticker.Stop()
 
 		for {


### PR DESCRIPTION
- Add `mnd`
  - We're skipping doing `s.waitForAPpToDieOrKillIt()` for now; that will be fixed in a later commit.
- Remove unused `lll` options
- Add `nakedret`
- Add `noctx`

> 20 files changed, 135 insertions(+), 88 deletions(-)