### PR TITLE
Install spin templates from spin/templates/vMAJOR.MINOR tag

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1512,8 +1512,8 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         const version = semver.parse(DEPENDENCY_VERSIONS.spinCLI);
         const env = {
           ...process.env,
-          KUBE_PLUGIN_VERSION:  DEPENDENCY_VERSIONS.spinKubePlugin,
-          SPIN_TEMPLATE_BRANCH: (version ? `v${ version.major }.${ version.minor }` : 'main'),
+          KUBE_PLUGIN_VERSION: DEPENDENCY_VERSIONS.spinKubePlugin,
+          SPIN_TEMPLATES_TAG:  (version ? `spin/templates/v${ version.major }.${ version.minor }` : 'unknown'),
         };
 
         promises.push(this.spawnWithCapture(executable('setup-spin'), { env }));

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1366,8 +1366,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                 try {
                   const version = semver.parse(DEPENDENCY_VERSIONS.spinCLI);
                   const env = {
-                    KUBE_PLUGIN_VERSION:  DEPENDENCY_VERSIONS.spinKubePlugin,
-                    SPIN_TEMPLATE_BRANCH: (version ? `v${ version.major }.${ version.minor }` : 'main'),
+                    KUBE_PLUGIN_VERSION: DEPENDENCY_VERSIONS.spinKubePlugin,
+                    SPIN_TEMPLATES_TAG:  (version ? `spin/templates/v${ version.major }.${ version.minor }` : 'unknown'),
                   };
                   const wslenv = Object.keys(env).join(':');
 

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -587,8 +587,8 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       if (state && this.settings.experimental?.containerEngine?.webAssembly) {
         const version = semver.parse(DEPENDENCY_VERSIONS.spinCLI);
         const env = {
-          KUBE_PLUGIN_VERSION:  DEPENDENCY_VERSIONS.spinKubePlugin,
-          SPIN_TEMPLATE_BRANCH: (version ? `v${ version.major }.${ version.minor }` : 'main'),
+          KUBE_PLUGIN_VERSION: DEPENDENCY_VERSIONS.spinKubePlugin,
+          SPIN_TEMPLATES_TAG:  (version ? `spin/templates/v${ version.major }.${ version.minor }` : 'unknown'),
         };
         const wslenv = Object.keys(env).join(':');
 

--- a/resources/setup-spin
+++ b/resources/setup-spin
@@ -33,11 +33,14 @@ fi
 
 install_templates() {
   repo=$1
-  branch=$2
 
-  echo "Installing templates ${repo} from branch ${branch}"
-  url="https://github.com/fermyon/${repo}/archive/refs/heads/${branch}.tar.gz"
-  "$spin" templates install --update --tar "$url"
+  echo "Installing ${repo} templates from tag ${SPIN_TEMPLATES_TAG}"
+  url="https://github.com/spinframework/${repo}/archive/refs/tags/${SPIN_TEMPLATES_TAG}.tar.gz"
+  if ! "$spin" templates install --update --tar "$url"; then
+    echo "Install failed, falling back to main branch"
+    url="https://github.com/spinframework/${repo}/archive/refs/heads/main.tar.gz"
+    "$spin" templates install --update --tar "$url"
+  fi
 }
 
 install_plugin() {
@@ -49,9 +52,9 @@ install_plugin() {
   rc=$?; test $rc -ne 0 && echo "Exit status is $rc"
 }
 
-install_templates spin "${SPIN_TEMPLATE_BRANCH:-main}"
-install_templates spin-python-sdk main
-install_templates spin-js-sdk main
+install_templates spin
+install_templates spin-python-sdk
+install_templates spin-js-sdk
 
 install_plugin kube "${KUBE_PLUGIN_VERSION:-0.3.1}"
 

--- a/scripts/dependencies/tools.ts
+++ b/scripts/dependencies/tools.ts
@@ -593,7 +593,7 @@ export class SpinOperator implements GitHubDependency {
 
 export class SpinCLI implements GitHubDependency {
   name = 'spinCLI';
-  githubOwner = 'fermyon';
+  githubOwner = 'spinframework';
   githubRepo = 'spin';
 
   async download(context: DownloadContext): Promise<void> {


### PR DESCRIPTION
which seems to be the built-in preferred tag to install via git. Fall back to using `main` if the tag does not exist (spin-python-sdk).

Fixes #8522