### PR TITLE
Bump minimum supported Kubernetes version to 1.25.3

### DIFF
--- a/bats/tests/helpers/defaults.bash
+++ b/bats/tests/helpers/defaults.bash
@@ -201,10 +201,10 @@ using_dev_mode() {
 # Kubernetes versions
 
 # The main Kubernetes version to test.
-: "${RD_KUBERNETES_VERSION:=1.23.6}"
+: "${RD_KUBERNETES_VERSION:=1.29.6}"
 
 # A secondary Kubernetes version; this is used for testing upgrades.
-: "${RD_KUBERNETES_ALT_VERSION:=1.22.7}"
+: "${RD_KUBERNETES_ALT_VERSION:=1.25.7}"
 
 # RD_K3S_VERSIONS specifies a list of k3s versions. foreach_k3s_version()
 # can dynamically register a test to run once for each version in the
@@ -215,7 +215,7 @@ using_dev_mode() {
 # "all" will fetch the list of all k3s releases from GitHub
 # "latest" will fetch the list of latest versions from the release channel
 
-: "${RD_K3S_MIN:=1.21.0}"
+: "${RD_K3S_MIN:=1.25.3}"
 : "${RD_K3S_MAX:=1.99.0}"
 : "${RD_K3S_VERSIONS:=$RD_KUBERNETES_VERSION}"
 

--- a/bats/tests/profile/deployment.bats
+++ b/bats/tests/profile/deployment.bats
@@ -11,7 +11,7 @@ local_setup() {
     ALLOWED_EXTENSION_TAG="0.0.7"
     FORBIDDEN_EXTENSION_TAG="0.0.5"
     FORBIDDEN_EXTENSION="ignatandrei/blockly-automation" # spellcheck-ignore-line
-    KUBERNETES_RANDOM_VERSION="1.23.5"
+    KUBERNETES_RANDOM_VERSION="1.29.5"
 
     # profile settings should be the opposite of the default config
     if using_docker; then

--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -90,7 +90,7 @@ test.describe.serial('KubernetesBackend', () => {
         // The Kubernetes version could be empty if it's previously disabled.
         // Set something.
         const updatedSettings: RecursivePartial<Settings> = {
-          kubernetes: { version: '1.23.4' },
+          kubernetes: { version: '1.29.4' },
           version:    10 as Settings['version'],
         };
 
@@ -100,7 +100,7 @@ test.describe.serial('KubernetesBackend', () => {
       const newSettings: RecursivePartial<Settings> = {
         containerEngine: { name: getAlternateSetting(currentSettings, 'containerEngine.name', ContainerEngine.CONTAINERD, ContainerEngine.MOBY) },
         kubernetes:      {
-          version: getAlternateSetting(currentSettings, 'kubernetes.version', '1.23.6', '1.23.5'),
+          version: getAlternateSetting(currentSettings, 'kubernetes.version', '1.29.6', '1.29.5'),
           port:    getAlternateSetting(currentSettings, 'kubernetes.port', 6443, 6444),
           enabled: getAlternateSetting(currentSettings, 'kubernetes.enabled', true, false),
           options: {

--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -208,7 +208,7 @@ test.describe('Command server', () => {
     const settings = await resp.json();
     const desiredEnabled = !settings.kubernetes.enabled;
     const desiredEngine = 'flip';
-    const desiredVersion = /1.23.4/.test(settings.kubernetes.version) ? 'v1.19.1' : 'v1.23.4';
+    const desiredVersion = /1.29.4/.test(settings.kubernetes.version) ? 'v1.19.1' : 'v1.29.4';
     const requestedSettings = _.merge({}, settings, {
       version:         CURRENT_SETTINGS_VERSION,
       containerEngine: {

--- a/e2e/startup-profiles.e2e.spec.ts
+++ b/e2e/startup-profiles.e2e.spec.ts
@@ -80,13 +80,13 @@ async function createDefaultUserRegistryProfileWithIncorrectTypes() {
 async function createDefaultUserRegistryProfileWithValidDataButNoVersion() {
   const base = 'HKCU\\SOFTWARE\\Rancher Desktop\\Profile\\Defaults\\kubernetes';
 
-  await addRegistryEntry(base, 'version', 'REG_SZ', '1.21.0');
+  await addRegistryEntry(base, 'version', 'REG_SZ', '1.29.0');
 }
 
 async function createLockedUserRegistryProfileWithValidDataButNoVersion() {
   const base = 'HKCU\\SOFTWARE\\Rancher Desktop\\Profile\\Locked\\kubernetes';
 
-  await addRegistryEntry(base, 'version', 'REG_SZ', '1.21.0');
+  await addRegistryEntry(base, 'version', 'REG_SZ', '1.29.0');
 }
 
 test.describe.serial('starting up with profiles', () => {

--- a/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
+++ b/pkg/rancher-desktop/backend/__tests__/k3sHelper.spec.ts
@@ -8,12 +8,7 @@ import util from 'util';
 import fetch from 'node-fetch';
 import semver from 'semver';
 
-import K3sHelper, {
-  buildVersion,
-  ChannelMapping,
-  NoCachedK3sVersionsError,
-  ReleaseAPIEntry,
-} from '../k3sHelper';
+import K3sHelper, { buildVersion, ChannelMapping, NoCachedK3sVersionsError, ReleaseAPIEntry } from '../k3sHelper';
 
 import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
 import paths from '@pkg/utils/paths';
@@ -415,7 +410,7 @@ describe(K3sHelper, () => {
       ['finds the oldest newer major version', 'v3.1.2+k3s3',
         ['v1.2.9+k3s1', 'v1.2.9+k3s4', 'v4.2.8+k3s1', 'v4.3.0+k3s1'], 'v4.2.8+k3s1'],
       ['finds the oldest newer minor version', 'v1.12.2+k3s3',
-        ['v1.2.9+k3s1', 'v1.7.0+k3s1', 'v1.23.9+k3s4', 'v2.12.8+k3s1'], 'v1.23.9+k3s4'],
+        ['v1.2.9+k3s1', 'v1.7.0+k3s1', 'v1.29.9+k3s4', 'v2.12.8+k3s1'], 'v1.29.9+k3s4'],
       ['finds the oldest newer patch version at the start of the list', 'v1.12.2+k3s3',
         ['v1.12.4+k3s1', 'v1.12.4+k3s4', 'v1.12.8+k3s1', 'v1.12.9+k3s4'], 'v1.12.4+k3s4'],
       ['finds the oldest newer patch version inside the list', 'v1.12.10+k3s99',

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -138,7 +138,7 @@ export default class K3sHelper extends events.EventEmitter {
   protected readonly releaseApiAccept = 'application/vnd.github.v3+json';
   protected readonly resourcesPath = path.join(paths.resources, 'k3s-versions.json');
   protected readonly cachePath = path.join(paths.cache, 'k3s-versions.json');
-  protected readonly minimumVersion = new semver.SemVer('1.21.0');
+  protected readonly minimumVersion = new semver.SemVer('1.25.3');
   /**
    * versionFromChannel is a mapping from the channel name to the latest (short)
    * version in that channel.

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1426,18 +1426,6 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
               }),
               this.progressTracker.action('Installing k3s', 100, async() => {
                 await this.kubeBackend.deleteIncompatibleData(version);
-                // On older versions of K3s, we need to enable ip_forward to allow traefik to work.
-                // Otherwise the "svclb" pods exit immediately.  This needs to be done in the
-                // default namespace; it does not seem to inherit from the RD network namespace.
-                const versionsNeedingForward = [
-                  '<1.23.13',
-                  '>=1.24.0 <1.24.7',
-                  '>=1.25.0 <1.25.3',
-                ];
-
-                if (semver.satisfies(version, versionsNeedingForward.join(' || '))) {
-                  await this.execCommand('/sbin/sysctl', '-w', 'net.ipv4.ip_forward=1');
-                }
                 await this.kubeBackend.install(config, version, false);
               })]));
           }

--- a/pkg/rancher-desktop/config/__tests__/commandLineOptions.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/commandLineOptions.spec.ts
@@ -26,7 +26,7 @@ describe('commandLineOptions', () => {
         name: settings.ContainerEngine.MOBY,
       },
       kubernetes: {
-        version: '1.23.5',
+        version: '1.29.5',
         port:    6443,
         enabled: true,
         options: {
@@ -72,17 +72,17 @@ describe('commandLineOptions', () => {
     });
 
     test('one option with embedded equal sign should change only one value', () => {
-      const newPrefs = updateFromCommandLine(prefs, lockedSettings, ['--kubernetes.version=1.23.6']);
+      const newPrefs = updateFromCommandLine(prefs, lockedSettings, ['--kubernetes.version=1.29.6']);
 
-      expect(newPrefs.kubernetes.version).toBe('1.23.6');
+      expect(newPrefs.kubernetes.version).toBe('1.29.6');
       newPrefs.kubernetes.version = origPrefs.kubernetes.version;
       expect(newPrefs).toEqual(origPrefs);
     });
 
     test('one option over two args should change only one value', () => {
-      const newPrefs = updateFromCommandLine(prefs, lockedSettings, ['--kubernetes.version', '1.23.7']);
+      const newPrefs = updateFromCommandLine(prefs, lockedSettings, ['--kubernetes.version', '1.29.7']);
 
-      expect(newPrefs.kubernetes.version).toBe('1.23.7');
+      expect(newPrefs.kubernetes.version).toBe('1.29.7');
       newPrefs.kubernetes.version = origPrefs.kubernetes.version;
       expect(newPrefs).toEqual(origPrefs);
     });

--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -102,7 +102,7 @@ describe('settings', () => {
       name: 'moby',
     },
     kubernetes: {
-      version: '1.23.15',
+      version: '1.29.15',
       enabled: true,
     },
     WSL: {

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -18,7 +18,7 @@ const cfg = _.merge(
   {},
   settings.defaultSettings,
   {
-    kubernetes:  { version: '1.23.4' },
+    kubernetes:  { version: '1.29.4' },
     application: { pathManagementStrategy: PathManagementStrategy.Manual },
   });
 const subject = new SettingsValidator();
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 cfg.virtualMachine.memoryInGB ||= getDefaultMemory();
-subject.k8sVersions = ['1.23.4', '1.0.0'];
+subject.k8sVersions = ['1.29.4', '1.0.0'];
 describe(SettingsValidator, () => {
   it('should do nothing when given existing settings', () => {
     const [needToUpdate, errors] = subject.validateSettings(cfg, cfg);

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -378,12 +378,6 @@ export default class SettingsValidator {
 
         return false;
       }
-      if (mergedSettings.kubernetes.version === '' || semver.gt('1.22.0', mergedSettings.kubernetes.version)) {
-        errors.push(`Setting ${ fqname } requires Kubernetes 1.22 or later`);
-        this.isFatal = true;
-
-        return false;
-      }
     }
 
     return currentValue !== desiredValue;

--- a/scripts/k3s-versions.go
+++ b/scripts/k3s-versions.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// golang.org/x/mod/semver *requires* a leading 'v' on versions, and will add missing minor/patch numbers.
-	minimumVersion = "v1.21"
+	minimumVersion = "v1.25.3"
 	// The K3s channels endpoint
 	k3sChannelsEndpoint = "https://update.k3s.io/v1-release/channels"
 )


### PR DESCRIPTION
This is necessary because containerd 2.0 no longer support the CRI v1alpha2 API.

We needed to move at least to 1.23+, but that is also ancient. Moving to 1.25+, which is the oldest version that still gets extended support on EKS and is also the oldest version supported by Rancher 2.8 (which is also already end-of-life).

Move to 1.25.3+ so I could delete some special case code needing to enable IPv4 ip forwarding to allow traefik to work on WSL2.