### PR TITLE
scripts: install-latest-ci: support linux user install

### DIFF
--- a/bats/tests/helpers/paths.bash
+++ b/bats/tests/helpers/paths.bash
@@ -83,7 +83,7 @@ if is_linux; then
 
     set_path_resources \
         "/opt/rancher-desktop" \
-        "/no user location on linux" \
+        "$HOME/opt/rancher-desktop" \
         "$PATH_REPO_ROOT/dist/linux-unpacked" \
         "resources/resources"
 fi


### PR DESCRIPTION
This makes linux user install drop files in `~/opt/rancher-desktop` to make it easier to test CI without needing root.  This is a somewhat non-standard location; it's mainly intended for CI.