### PR TITLE
Extend retries for containers/wasm test

### DIFF
--- a/bats/tests/containers/wasm.bats
+++ b/bats/tests/containers/wasm.bats
@@ -144,7 +144,7 @@ verify_shim() {
     semver_eq "$output" "$MANUAL_VERSION"
 
     hello "$shim" "$version" "$lang" "$port" "$external_port"
-    try --max 5 --delay 2 curl --silent --fail "http://localhost:${port}/hello"
+    try --max 10 --delay 3 curl --silent --fail "http://localhost:${port}/hello"
 }
 
 @test 'verify spin shim' {


### PR DESCRIPTION
I've seen it fail multiple times, but the failure is not reproducible. Maybe retrying for only 5 × 2 seconds is not long enough.