### PR TITLE
BATS: Add resoures/bin to PATH

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -49,8 +49,10 @@ docker() {
     docker_exe --context $RD_DOCKER_CONTEXT "$@"
 }
 docker_exe() {
-    # Add path to bundled credential helpers to the front of the PATH
-    PATH="$PATH_RESOURCES/$PLATFORM/bin:$PATH" "$PATH_RESOURCES/$PLATFORM/bin/docker$EXE" "$@" | no_cr
+    # Add path to bundled credential helpers to the front of the PATH; also
+    # ensure that on Windows, it gets exported.
+    PATH="$PATH_RESOURCES/$PLATFORM/bin:$PATH" WSLENV="PATH/l:$WSLENV" \
+        "$PATH_RESOURCES/$PLATFORM/bin/docker$EXE" "$@" | no_cr
 }
 helm() {
     "$PATH_RESOURCES/$PLATFORM/bin/helm$EXE" "$@" | no_cr
@@ -66,7 +68,10 @@ limactl() {
     LIMA_HOME="$LIMA_HOME" "$PATH_RESOURCES/$PLATFORM/lima/bin/limactl" "$@"
 }
 nerdctl() {
-    "$PATH_RESOURCES/$PLATFORM/bin/nerdctl$EXE" --namespace "$CONTAINERD_NAMESPACE" "$@" | no_cr
+    # Add path to bundled credential helpers to the front of the PATH; also
+    # ensure that on Windows, it gets exported.
+    PATH="$PATH_RESOURCES/$PLATFORM/bin:$PATH" WSLENV="PATH/l:$WSLENV" \
+        "$PATH_RESOURCES/$PLATFORM/bin/nerdctl$EXE" --namespace "$CONTAINERD_NAMESPACE" "$@" | no_cr
 }
 # Run `rdctl`; if $RD_TIMEOUT is set, the value is used as the first argument to
 # the `timeout` command.

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -71,7 +71,8 @@ source "$PATH_BATS_HELPERS/profile.bash"
 # rdctl from commands.bash, and jq_output from utils.bash
 source "$PATH_BATS_HELPERS/vm.bash"
 
-# Use Linux utilities (like jq) on WSL
+# Add BATS helper executables to $PATH.  On Windows, we use the Linux version
+# from WSL.
 export PATH="$PATH_BATS_ROOT/bin/${OS/windows/linux}:$PATH"
 
 # If called from foo() this function will call local_foo() if it exist.


### PR DESCRIPTION
This is needed for credential helpers to be found, at least on Windows.  This is normally done by the installer, but that does not happen when testing with the zip install.