### PR TITLE
Remove Skipped Host Connectivity Test

### DIFF
--- a/bats/tests/containers/host-connectivity.bats
+++ b/bats/tests/containers/host-connectivity.bats
@@ -1,7 +1,3 @@
-# Test case 36
-# On Windows, You need to create a firewall rule to allow communication
-# between the host and the container. Please check the below link for instructions.
-# https://docs.rancherdesktop.io/faq#q-can-containers-reach-back-to-host-services-via-hostdockerinternal
 # bats file_tags=opensuse
 
 load '../helpers/load'
@@ -10,23 +6,12 @@ load '../helpers/load'
     factory_reset
 }
 
-skip_on_legacy_networking() {
-    if is_windows && ! using_networking_tunnel; then
-        # The test also works with a firewall rule, but somehow the rule seems to
-        # stop working randomly and then needs to be deleted and recreated. We are
-        # not automating this just for the sake of the legacy implementation.
-        skip "This test requires the new networking tunnel on Windows"
-    fi
-}
-
 @test 'start container engine' {
-    skip_on_legacy_networking
     start_container_engine
     wait_for_container_engine
 }
 
 verify_host_connectivity() {
-    skip_on_legacy_networking
     run ctrctl run --rm "$IMAGE_BUSYBOX" timeout -s INT 10 ping -c 5 "$1"
     assert_success
     assert_output --partial "5 packets transmitted, 5 packets received, 0% packet loss"


### PR DESCRIPTION
This test no longer needs to be skipped and should now run successfully on all platforms.