### PR TITLE
extensions: set PATH when spawning host executables

### DIFF
--- a/bats/tests/extensions/testdata/bin/dummy.go
+++ b/bats/tests/extensions/testdata/bin/dummy.go
@@ -14,11 +14,12 @@ func main() {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	if err, ok := err.(*exec.ExitError); ok {
-		if err.ExitCode() > -1 {
-			os.Exit(err.ExitCode())
+	if exitError, ok := err.(*exec.ExitError); ok {
+		if exitError.ExitCode() > -1 {
+			os.Exit(exitError.ExitCode())
 		}
-	} else if err != nil {
+	}
+	if err != nil {
 		log.Fatal(err)
 	}
 }

--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -396,6 +396,7 @@ test.describe.serial('Extensions', () => {
         // evalInView; we serialize it as JSON and deserialize again to remove them.
         const result = evalInView(`
           ddClient.extension.host.cli.exec("${ command }", ["false"])
+          .then(v => Promise.resolve(JSON.parse(JSON.stringify(v))))
           .catch(v => Promise.reject(JSON.parse(JSON.stringify(v))))
         `);
 


### PR DESCRIPTION
This ensures that the platform's bin directory (containing, among other things, docker credential helpers) are added to PATH when we spawn host executables.  This is needed if the extension bundles tools like `helm` or `kubectl`.

Note that we add them to the end so the extension can still override it. Also, we add the rest of the environment variables too, so that for example `kubectl` can find `$HOME`.\

Fixes #8598