### PR TITLE
moby: Log errors on wait-for-ready failures

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -65,7 +65,8 @@ export class MobyClient implements ContainerEngineClient {
   }
 
   async waitForReady(): Promise<void> {
-    let successCount = 0; let failureCount = 0;
+    let successCount = 0;
+    let failureCount = 0;
     let lastOutput = { stdout: '', stderr: '' };
 
     // Wait for ten consecutive successes, clearing out successCount whenever we
@@ -81,21 +82,19 @@ export class MobyClient implements ContainerEngineClient {
       } catch (ex) {
         successCount = 0;
         failureCount++;
-        if (failureCount > 10) {
-          // If we've been error for a while, log the output.
-          if (ex && typeof ex === 'object') {
-            const output = { stdout: '', stderr: '' };
+        // If we've been erroring for a while, log the output.
+        if (failureCount > 10 && ex && typeof ex === 'object') {
+          const output = { stdout: '', stderr: '' };
 
-            if ('stdout' in ex && typeof ex.stdout === 'string') {
-              output.stdout = ex.stdout;
-            }
-            if ('stderr' in ex && typeof ex.stderr === 'string') {
-              output.stderr = ex.stderr;
-            }
-            if (output.stdout !== lastOutput.stdout || output.stderr !== lastOutput.stderr) {
-              console.error('Failed to run docker system info (will retry):', output);
-              lastOutput = output;
-            }
+          if ('stdout' in ex && typeof ex.stdout === 'string') {
+            output.stdout = ex.stdout;
+          }
+          if ('stderr' in ex && typeof ex.stderr === 'string') {
+            output.stderr = ex.stderr;
+          }
+          if (output.stdout !== lastOutput.stdout || output.stderr !== lastOutput.stderr) {
+            console.error(`Failed to run docker system info after ${ failureCount } failures (will retry):`, output);
+            lastOutput = output;
           }
         }
       }

--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -65,7 +65,8 @@ export class MobyClient implements ContainerEngineClient {
   }
 
   async waitForReady(): Promise<void> {
-    let successCount = 0;
+    let successCount = 0; let failureCount = 0;
+    let lastOutput = { stdout: '', stderr: '' };
 
     // Wait for ten consecutive successes, clearing out successCount whenever we
     // hit an error.  In the ideal case this is a ten-second delay in startup
@@ -74,10 +75,29 @@ export class MobyClient implements ContainerEngineClient {
     // fails to do so).
     while (successCount < 10) {
       try {
-        await this.runClient(['system', 'info'], 'ignore');
+        await this.runClient(['system', 'info'], 'pipe');
         successCount++;
+        failureCount = 0;
       } catch (ex) {
         successCount = 0;
+        failureCount++;
+        if (failureCount > 10) {
+          // If we've been error for a while, log the output.
+          if (ex && typeof ex === 'object') {
+            const output = { stdout: '', stderr: '' };
+
+            if ('stdout' in ex && typeof ex.stdout === 'string') {
+              output.stdout = ex.stdout;
+            }
+            if ('stderr' in ex && typeof ex.stderr === 'string') {
+              output.stderr = ex.stderr;
+            }
+            if (output.stdout !== lastOutput.stdout || output.stderr !== lastOutput.stderr) {
+              console.error('Failed to run docker system info (will retry):', output);
+              lastOutput = output;
+            }
+          }
+        }
       }
       await util.promisify(setTimeout)(1_000);
     }


### PR DESCRIPTION
We're getting some reports that the `docker system info` line (or somewhere in that area) is getting stuck; try to log the output after it's stuck for a while to see if we can determine the cause.

This is to help with debugging #7086.