### PR TITLE
wsl-exec: Ensure a minimum set of PATH

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-exec
+++ b/pkg/rancher-desktop/assets/scripts/wsl-exec
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/ash
 
 # wsl-exec is used to execute user-issued shell commands from
 # rdctl shell ... in a correct namespace. If the experimental
@@ -8,6 +8,16 @@
 # in the default namespace.
 
 set -o errexit -o nounset
+
+# We may have WSLENV set to override PATH; however, that causes the default entries to be missing.
+str="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:"
+while [ -n "$str" ]; do
+  dir=${str%%:*}
+  if ! [[ ":${PATH}:" =~ :${dir}: ]]; then
+    export PATH="${PATH%:}:${dir}"
+  fi
+  str=${str#*:}
+done
 
 pid="$(cat /run/wsl-init.pid)"
 


### PR DESCRIPTION
If we override PATH when spawned via Windows (via setting WSLENV), the default set of entries do not get picked up because it makes no sense on the Windows side.  This means that basic system utilities end up missing; this causes issues like runc not being able to find iptables.

When wsl-exec is run, ensure that a hard-coded list is found.
