### PR TITLE
Update expinio-docker-extension URL for screenshot script

### DIFF
--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -59,7 +59,7 @@ test.describe.serial('Main App Test', () => {
     await page.waitForTimeout(2500);
 
     await retry(async() => {
-      await tool('rdctl', 'extension', 'install', 'ghcr.io/rancher-sandbox/epinio-desktop-extension');
+      await tool('rdctl', 'extension', 'install', 'splatform/epinio-docker-desktop');
     }, { tries: 5 });
     await retry(async() => {
       await tool('rdctl', 'extension', 'install', 'docker/logs-explorer-extension');
@@ -72,7 +72,7 @@ test.describe.serial('Main App Test', () => {
 
   test.afterAll(async({ colorScheme }, testInfo) => {
     await clearUserProfile();
-    await tool('rdctl', 'extension', 'uninstall', 'ghcr.io/rancher-sandbox/epinio-desktop-extension');
+    await tool('rdctl', 'extension', 'uninstall', 'splatform/epinio-docker-desktop');
     await tool('rdctl', 'extension', 'uninstall', 'docker/logs-explorer-extension');
 
     return teardown(electronApp, testInfo);


### PR DESCRIPTION
The extension catalog has already been updated to use the upstream version of the extension (#8519); the screenshot script should match (except we use `latest`, not a pinned version here).