### PR TITLE
integrations: win32: mkdir before creating file

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -469,6 +469,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       config.cliPluginsExtraDirs ??= [];
       config.cliPluginsExtraDirs.push(binDir);
 
+      await fs.promises.mkdir(path.dirname(configPath), { recursive: true });
       await fs.promises.writeFile(configPath, JSON.stringify(config), 'utf-8');
       this.diagnostic({ key: 'docker-plugins' });
     } catch (error) {


### PR DESCRIPTION
If the `~/.docker` directory does not exist, create it before trying to write a file in it.

Fixes #8645