### PR TITLE
screenshots: mac: don't capture attached windows

### DIFF
--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -77,7 +77,7 @@ export class Screenshots {
     if (!windowId) {
       throw new Error(`Failed to find window ID for ${ this.windowTitle }: ${ stderr || '(no stderr)' }`);
     }
-    await spawnFile('screencapture', ['-o', '-l', windowId.trim(), outPath], { stdio: this.log });
+    await spawnFile('screencapture', ['-o', '-a', '-l', windowId.trim(), outPath], { stdio: this.log });
   }
 
   protected async screenshotWindows(outPath: string) {


### PR DESCRIPTION
Since we now set the main window as the parent of the preferences window, by default `screencapture` will also include the main window when we attempt to take a screenshot of the preferences window.  Add the `-a` option to `screencapture` (_Do not capture attached windows._) to avoid this behaviour and only include the preferences window itself.

Fixes #8674 (or at least it should, we should double check.)