### PR TITLE
[1.19] Kube cgroup delete

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -425,6 +425,7 @@ KONTANIER
 kotlin
 ksh
 Kubectx
+kubepods
 kuberlr
 Kubewarden
 kurrent

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -216,6 +216,10 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     }
     this.cfg = config;
 
+    // Clean up kubernetes cgroups before we start, as Kubernetes 1.31.0+ fails
+    // to start if these are left over.  We need to remove all cgroups named
+    // "kubepods" as well as their descendants (which are expected to all be
+    // empty).
     await this.progressTracker.action('Removing stale state', 50,
       this.vm.execCommand('busybox', 'find', '/sys/fs/cgroup', '-name', 'kubepods', '-exec',
         'busybox', 'find', '{}', '-type', 'd', '-delete', ';', '-prune'));


### PR DESCRIPTION
On Kubernetes 1.31.0+, we fail to Reset Kubernetes due to issues with the left-over cgroups on the previous shut down. Manually delete them before starting k3s to fix the issue.

This is the 1.19-branch version of #8681 which fixes #8648.