### PR TITLE
screenshots: attempt to fix the intro image

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -126,6 +126,9 @@ jobs:
           if [[ $name =~ ^[0-9]+_ ]]; then
               name="${name#*_}"
           fi
+          if [[ name == "intro" ]]; then
+            continue
+          fi
           out="out/${window}/${platform}_${name}"
           mkdir -p "$(dirname "$out")"
           cp "$line" "$out"
@@ -137,9 +140,7 @@ jobs:
         # image on the right, each showing Kubernetes settings.
         sudo DEBIAN_FRONTEND=noninteractive apt-get install graphicsmagick # spellcheck-ignore-line
         mkdir -p out/getting-started
-        gm composite -gravity center in/darwin/light/preferences/*_kubernetes.png in/darwin/light/main/*_General.png darwin.png
-        gm composite -gravity center in/win32/light/preferences/*_kubernetes.png in/win32/light/main/*_General.png win32.png
-        gm convert darwin.png win32.png +append out/getting-started/introduction_preferences_tabKubernetes.png
+        gm convert in/darwin/light/main/*_intro.png in/win32/light/main/*_intro.png +append out/getting-started/introduction_preferences_tabKubernetes.png
     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: screenshots.zip

--- a/screenshots/screenshot.ps1
+++ b/screenshots/screenshot.ps1
@@ -5,6 +5,8 @@
   Take a screenshot of the active window and output it to a PNG file.
 .PARAMETER FilePath
   The name of the file to write to.  The file will be a PNG.
+.PARAMETER Foreground
+  If set, make the window foreground or otherwise visible first.
 .PARAMETER Title
   The title of the window to capture; defaults to the active window.
 #>
@@ -12,6 +14,7 @@ Param(
   [Parameter(
     Mandatory = $true
   )][string]$FilePath,
+  [switch]$Foreground,
   [string]$Title
 )
 
@@ -24,10 +27,10 @@ using System.Runtime.InteropServices;
 
 namespace Screenshot {
   public class Screenshot {
-    public void Take(string filePath, string title) {
+    public void Take(string filePath, string title, bool foreground) {
       Image img;
       if (title != "") {
-        img = CaptureWindowWithTitle(title);
+        img = CaptureWindowWithTitle(title, foreground);
       } else {
         img = CaptureActiveWindow();
       }
@@ -38,8 +41,11 @@ namespace Screenshot {
       return CaptureWindow(User32.GetForegroundWindow());
     }
 
-    public Image CaptureWindowWithTitle(string title) {
+    public Image CaptureWindowWithTitle(string title, bool foreground) {
       IntPtr hwnd = User32.FindWindow(null, title);
+      if (!foreground) {
+        return CaptureWindow(hwnd);
+      }
       if (User32.SetForegroundWindow(hwnd) != 0) {
         return CaptureWindow(hwnd);
       }
@@ -139,4 +145,4 @@ namespace Screenshot {
 
 Add-Type $cSharpSource -ReferencedAssemblies 'System.Drawing'
 
-(New-Object Screenshot.Screenshot).Take($FilePath, $Title)
+(New-Object Screenshot.Screenshot).Take($FilePath, $Title, $Foreground)

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -367,4 +367,36 @@ test.describe.serial('Main App Test', () => {
       await prefScreenshot.take('kubernetes', 'lockedFields');
     });
   });
+
+  test('Intro Image', async({ colorScheme }) => {
+    await navPage.navigateTo('General');
+    const bounds = await navPage.page.evaluate(() => {
+      window.resizeTo(1024, 768);
+
+      return {
+        top: window.screenTop, left: window.screenLeft, width: window.outerWidth, height: window.outerHeight,
+      };
+    });
+
+    await navPage.preferencesButton.click();
+    await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
+    const preferencesPage = electronApp.windows()[1];
+
+    await preferencesPage.evaluate((bounds) => {
+      const {
+        top, left, width, height,
+      } = bounds;
+
+      window.moveTo(left + (width - window.outerWidth) / 2, top + (height - window.outerHeight) / 2);
+    }, bounds);
+
+    try {
+      await preferencesPage.emulateMedia({ colorScheme });
+      await preferencesPage.waitForTimeout(250);
+      await preferencesPage.bringToFront();
+      await screenshot.take('intro', true);
+    } finally {
+      preferencesPage.close({ runBeforeUnload: true });
+    }
+  });
 });


### PR DESCRIPTION
This tries to fix things so that we can generate the intro image instead of having to reuse an old screenshot.

Sample image (from CI run, so the version was set to 1.0.0):
![introduction_preferences_tabKubernetes](https://github.com/user-attachments/assets/b62245d6-1316-435b-814b-dca7e6654c6f)
