### PR TITLE
Lima: add config to use SSH port forwarder

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -719,6 +719,10 @@ components:
                       type: array
                       x-rd-usage: list of hostname to exclude from using the proxy
                       items: { type: string }
+                sshPortForwarder:
+                  type: boolean
+                  x-rd-platforms: [darwin, linux]
+                  x-rd-usage: use SSH for port forwarding instead of gRPC
         WSL:
           type: object
           x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -789,11 +789,20 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   /**
    * Run `limactl` with the given arguments.
    */
-  async lima(this: Readonly<this>, ...args: string[]): Promise<void> {
+  async lima(this: Readonly<this>, env: NodeJS.ProcessEnv, ...args: string[]): Promise<void>;
+  async lima(this: Readonly<this>, ...args: string[]): Promise<void>;
+  async lima(this: Readonly<this>, envOrArg: NodeJS.ProcessEnv | string, ...args: string[]): Promise<void> {
+    const env = LimaBackend.limaEnv;
+
+    if (typeof envOrArg === 'string') {
+      args = [envOrArg].concat(args);
+    } else {
+      Object.assign(env, envOrArg);
+    }
     args = this.debug ? ['--debug'].concat(args) : args;
     try {
       const { stdout, stderr } = await childProcess.spawnFile(LimaBackend.limactl, args,
-        { env: LimaBackend.limaEnv, stdio: ['ignore', 'pipe', 'pipe'] });
+        { env, stdio: ['ignore', 'pipe', 'pipe'] });
       const formatBreak = stderr || stdout ? '\n' : '';
 
       console.log(`> limactl ${ args.join(' ') }${ formatBreak }${ stderr }${ stdout }`);
@@ -1773,7 +1782,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
     await this.progressTracker.action('Starting virtual machine', 100, async() => {
       try {
-        await this.lima('start', '--tty=false', await this.isRegistered ? MACHINE_NAME : this.CONFIG_PATH);
+        const env: NodeJS.ProcessEnv = {};
+
+        if (this.cfg?.experimental.virtualMachine.sshPortForwarder) {
+          env.LIMA_SSH_PORT_FORWARDER = 'true';
+        }
+        await this.lima(env, 'start', '--tty=false', await this.isRegistered ? MACHINE_NAME : this.CONFIG_PATH);
       } finally {
         // Symlink the logs (especially if start failed) so the users can find them
         const machineDir = path.join(paths.lima, MACHINE_NAME);
@@ -2141,6 +2155,7 @@ CREDFWD_URL='http://${ SLIRP.HOST_GATEWAY }:${ stateInfo.port }'
       'experimental.virtualMachine.mount.9p.protocolVersion': undefined,
       'experimental.virtualMachine.mount.9p.securityModel':   undefined,
       'experimental.virtualMachine.mount.type':               undefined,
+      'experimental.virtualMachine.sshPortForwarder':         undefined,
       'virtualMachine.type':                                  undefined,
       'virtualMachine.useRosetta':                            undefined,
     }));

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -141,6 +141,8 @@ export const defaultSettings = {
         noproxy:  ['0.0.0.0/8', '10.0.0.0/8', '127.0.0.0/8', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16',
           '224.0.0.0/4', '240.0.0.0/4'],
       },
+      /** Lima only: use SSH port forwarding instead of gRPC. */
+      sshPortForwarder: false,
     },
   },
 };

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -135,6 +135,7 @@ export default class SettingsValidator {
             username: this.checkPlatform('win32', this.checkString),
             noproxy:  this.checkPlatform('win32', this.checkUniqueStringArray),
           },
+          sshPortForwarder: this.checkLima(this.checkBoolean),
         },
       },
       WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },


### PR DESCRIPTION
This adds an `experimental.virtualMachine.sshPortForwarder` config value that, if set, sets the environment variable `LIMA_SSH_PORT_FORWARDER` when invoking `limactl start`.

This doesn't include any testing yet; I'm not sure this flag warrants a BATS test.  See #8697.