### PR TITLE
CI: Package: Use windows-latest

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -45,7 +45,7 @@ jobs:
           arch: aarch64
           runs-on: macos-latest
         - platform: win
-          runs-on: windows-2019
+          runs-on: windows-latest
         - platform: linux
           runs-on: ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
windows-2019 is now being deprecated; switch to windows-latest instead.