### PR TITLE
Lima: inotify support

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -377,6 +377,7 @@ indentless
 ine
 Infof
 Infoln
+inotifywait
 installable
 INSTALLMESSAGE
 INSTALLPROPERTY

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -695,6 +695,10 @@ components:
                         cacheMode:
                           type: string
                           enum: [none, loose, fscache, mmap]
+                    inotify:
+                      type: boolean
+                      x-rd-platforms: [darwin, linux]
+                      x-rd-usage: file modification notification support, only for writable mounts
                 proxy:
                   type: object
                   x-rd-platforms: [win32]

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -372,6 +372,11 @@ virtualMachine:
         virtiofs:
           label: virtiofs
           description: Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+    inotify:
+      label: Enable filesystem event monitoring
+      tooltip: >-
+        Only works with writable mounts, with a limited set of events.
+        File deletions are not notified.
   proxy:
     legend: WSL Proxy
     label: Enable the proxy used by rancher-desktop

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -114,6 +114,7 @@ export type LimaConfiguration = {
   disk?: number;
   mounts?: LimaMount[];
   mountType: 'reverse-sshfs' | '9p' | 'virtiofs';
+  mountInotify?: boolean;
   ssh: {
     localPort: number;
     loadDotSSHPubKeys?: boolean;
@@ -635,6 +636,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       memory:       (this.cfg?.virtualMachine.memoryInGB || 4) * 1024 * 1024 * 1024,
       mounts:       this.getMounts(),
       mountType:    this.cfg?.experimental.virtualMachine.mount.type,
+      mountInotify: this.cfg?.experimental.virtualMachine.mount.inotify,
       ssh:          { localPort: await this.sshPort },
       hostResolver: {
         hosts: {
@@ -2155,6 +2157,7 @@ CREDFWD_URL='http://${ SLIRP.HOST_GATEWAY }:${ stateInfo.port }'
       'experimental.virtualMachine.mount.9p.protocolVersion': undefined,
       'experimental.virtualMachine.mount.9p.securityModel':   undefined,
       'experimental.virtualMachine.mount.type':               undefined,
+      'experimental.virtualMachine.mount.inotify':            undefined,
       'experimental.virtualMachine.sshPortForwarder':         undefined,
       'virtualMachine.type':                                  undefined,
       'virtualMachine.useRosetta':                            undefined,

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineVolumes.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineVolumes.vue
@@ -1,8 +1,10 @@
 <script lang="ts">
 
 import Vue from 'vue';
+import { mapGetters } from 'vuex';
 
 import MountTypeSelector from '@pkg/components/MountTypeSelector.vue';
+import RdCheckbox from '@pkg/components/form/RdCheckbox.vue';
 import { Settings } from '@pkg/config/settings';
 import { RecursiveTypes } from '@pkg/utils/typeUtils';
 
@@ -10,14 +12,15 @@ import type { PropType } from 'vue';
 
 export default Vue.extend({
   name:       'preferences-virtual-machine-volumes',
-  components: { MountTypeSelector },
+  components: { MountTypeSelector, RdCheckbox },
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
       required: true,
     },
   },
-  methods: {
+  computed: { ...mapGetters('preferences', ['isPreferenceLocked']) },
+  methods:  {
     onChange<P extends keyof RecursiveTypes<Settings>>(property: P, value: RecursiveTypes<Settings>[P]) {
       this.$store.dispatch('preferences/updatePreferencesData', { property, value });
     },
@@ -30,6 +33,14 @@ export default Vue.extend({
     <mount-type-selector
       :preferences="preferences"
       @update="onChange"
+    />
+    <rd-checkbox
+      is-experimental
+      label-key="virtualMachine.mount.inotify.label"
+      tooltip-key="virtualMachine.mount.inotify.tooltip"
+      :value="preferences.experimental.virtualMachine.mount.inotify"
+      :is-locked="isPreferenceLocked('experimental.virtualMachine.mount.inotify')"
+      @input="onChange('experimental.virtualMachine.mount.inotify', $event)"
     />
   </div>
 </template>

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -131,6 +131,7 @@ export const defaultSettings = {
           msizeInKib:      128,
           cacheMode:       CacheMode.MMAP,
         },
+        inotify: false,
       },
       proxy: {
         enabled:  false,

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -126,6 +126,7 @@ export default class SettingsValidator {
               msizeInKib:      this.checkLima(this.check9P(this.checkNumber(4, Number.POSITIVE_INFINITY))),
               cacheMode:       this.checkLima(this.check9P(this.checkEnum(...Object.values(CacheMode)))),
             },
+            inotify: this.checkLima(this.checkBoolean),
           },
           proxy: {
             enabled:  this.checkPlatform('win32', this.checkBoolean),


### PR DESCRIPTION
This adds an experimental setting to enable inotify support (only on darwin/linux), using the support that Lima already provides.

Includes a BATS test (in a second commit).