### PR TITLE
UI: Change Kubernetes Error dialog title

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1175,8 +1175,8 @@ function showErrorDialog(title: string, message: string, fatal?: boolean) {
 }
 
 async function handleFailure(payload: any) {
-  let titlePart = 'Error Starting Kubernetes';
-  let message = 'There was an unknown error starting Kubernetes';
+  let titlePart = 'Error Starting Rancher Desktop';
+  let message = 'There was an unknown error starting Rancher Desktop';
   let secondaryMessage = '';
 
   if (payload instanceof K8s.KubernetesError) {
@@ -1196,12 +1196,12 @@ async function handleFailure(payload: any) {
   } else if (payload instanceof Error) {
     secondaryMessage = payload.toString();
   } else if (typeof payload === 'number') {
-    message = `Kubernetes was unable to start with the following exit code: ${ payload }`;
+    message = `Rancher Desktop was unable to start with the following exit code: ${ payload }`;
   } else if ('errorCode' in payload) {
     message = payload.message || message;
     titlePart = payload.context || titlePart;
   }
-  console.log(`Kubernetes was unable to start:`, payload);
+  console.log(`Rancher Desktop was unable to start:`, payload);
   try {
     // getFailureDetails is going to read from existing log files.
     // Wait 1 second before reading them to allow recent writes to appear in them.

--- a/pkg/rancher-desktop/pages/KubernetesError.vue
+++ b/pkg/rancher-desktop/pages/KubernetesError.vue
@@ -8,7 +8,7 @@
         />
         <span>
           <h2 data-test="k8s-error-header">
-            Kubernetes Error
+            {{ t('app.name') }} Error
           </h2>
           <h5>{{ versionString }}</h5>
         </span>
@@ -20,7 +20,7 @@
         </div>
         <div
           v-if="lastCommand"
-          class="error-part"
+          class="error-part command"
         >
           <h4>Last command run:</h4>
           <p>{{ lastCommand }}</p>
@@ -163,6 +163,10 @@ export default Vue.extend({
     margin-bottom: 1.5rem;
     h4 {
       margin-top: auto;
+    }
+    &.command p {
+      font-family: monospace;
+      white-space: pre-wrap;
     }
     &.grow {
       display: flex;

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -633,7 +633,7 @@ export async function openUnmetPrerequisitesDialog(reasonId: reqMessageId, ...ar
  */
 export async function openKubernetesErrorMessageWindow(titlePart: string, mainMessage: string, failureDetails: K8s.FailureDetails) {
   const window = openDialog('KubernetesError', {
-    title:  `Rancher Desktop - Kubernetes Error`,
+    title:  `Rancher Desktop - Error`,
     width:  800,
     height: 494,
     parent: getWindow('main') ?? undefined,


### PR DESCRIPTION
This changes the Kubernetes Error dialog to say Rancher Desktop Error instead, as Kubernetes is optional.  Note that this does not really change the internal implementation (it's still called KubernetesError.vue, for example).

Fixes #8369

![image](https://github.com/user-attachments/assets/2875a098-c004-4ad1-bf79-0bdfe03a4014)
Please ignore the extra chin at the bottom, that's from editing the text after the dialog got displayed.