### PR TITLE
Fix codesigning of the spin executable

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -25,7 +25,7 @@ entitlements:
     - com.apple.security.cs.allow-jit
     - com.apple.security.hypervisor
   - paths:
-    - Contents/Resources/resources/darwin/bin/spin
+    - Contents/Resources/resources/darwin/internal/spin
     entitlements:
     - com.apple.security.cs.allow-unsigned-executable-memory
   - paths:


### PR DESCRIPTION
It has been moved from .../darwin/bin to .../darwin/internal in #7815.

Ref #8773, which should not be closed until this change has been cherry-picked into `release-1.19`.