### PR TITLE
Cherry-picks for 1.92.2 release

### DIFF
--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -25,7 +25,7 @@ entitlements:
     - com.apple.security.cs.allow-jit
     - com.apple.security.hypervisor
   - paths:
-    - Contents/Resources/resources/darwin/bin/spin
+    - Contents/Resources/resources/darwin/internal/spin
     entitlements:
     - com.apple.security.cs.allow-unsigned-executable-memory
   - paths:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rancher-desktop",
   "productName": "Rancher Desktop",
   "license": "Apache-2.0",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": {
     "name": "SUSE",
     "email": "containers@suse.com"

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -2,7 +2,7 @@ lima: 1.0.6.rd2
 qemu: 9.2.0.rd2
 socketVMNet: 1.2.1
 alpineLimaISO:
-  isoVersion: 0.2.43.rd4
+  isoVersion: 0.2.43.rd6
   alpineVersion: 3.21.3
 WSLDistro: "0.83"
 kuberlr: 0.6.0

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -23,6 +23,6 @@ moproxy: 0.5.1
 spinShim: 0.19.0
 spinOperator: 0.5.0
 certManager: 1.17.2
-spinCLI: 3.2.0
+spinCLI: 3.3.0
 spinKubePlugin: 0.4.0
 check-spelling: 0.0.24

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -4,7 +4,7 @@ socketVMNet: 1.2.1
 alpineLimaISO:
   isoVersion: 0.2.43.rd6
   alpineVersion: 3.21.3
-WSLDistro: "0.83"
+WSLDistro: "0.84"
 kuberlr: 0.6.0
 helm: 3.18.0
 dockerCLI: 28.1.1

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -9,7 +9,7 @@ kuberlr: 0.6.0
 helm: 3.18.0
 dockerCLI: 28.1.1
 dockerBuildx: 0.24.0
-dockerCompose: 2.36.2
+dockerCompose: 2.37.1
 golangci-lint: 2.1.6
 trivy: 0.62.1
 steve: 0.1.0-beta9


### PR DESCRIPTION
* Bump package version to 1.19.2
* Downgrade Linux kernel from 6.12 → 6.6 for OpenJDK
* Bump nerdctl 2.1.1 → 2.1.2
* Bump docker-compose 2.36.2 → 2.37.1
* Bump spin from 3.2.0 → 3.3.0
* Fix signing of spin binary on macOS