### PR TITLE
Add a new container logs page

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -757,6 +757,7 @@ scinfo
 sconfig
 screencapture
 screenshots
+scrollback
 scriptdir
 scriptname
 scriptpath

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@docker/extension-api-client-types": "0.4.2",
     "@kubernetes/client-node": "0.18.1",
     "@rancher/components": "0.1.4",
-    "@xterm/addon-search": "^0.15.0",
     "async-mutex": "^0.5.0",
     "cookie-universal": "2.2.2",
     "core-js": "3.25.3",
@@ -93,10 +92,10 @@
     "vue-slider-component": "3.2.24",
     "vuex": "3.6.2",
     "which": "5.0.0",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-web-links": "^0.11.0",
-    "@xterm/addon-search": "^0.15.0",
+    "@xterm/xterm": "5.5.0",
+    "@xterm/addon-fit": "0.10.0",
+    "@xterm/addon-web-links": "0.11.0",
+    "@xterm/addon-search": "0.15.0",
     "yaml": "2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@docker/extension-api-client-types": "0.4.2",
     "@kubernetes/client-node": "0.18.1",
     "@rancher/components": "0.1.4",
+    "@xterm/addon-search": "^0.15.0",
     "async-mutex": "^0.5.0",
     "cookie-universal": "2.2.2",
     "core-js": "3.25.3",

--- a/package.json
+++ b/package.json
@@ -93,9 +93,10 @@
     "vue-slider-component": "3.2.24",
     "vuex": "3.6.2",
     "which": "5.0.0",
-    "xterm": "^5.4.0-beta.37",
-    "xterm-addon-fit": "^0.8.0",
-    "xterm-addon-web-links": "^0.9.0",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/addon-search": "^0.15.0",
     "yaml": "2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
     "vue-slider-component": "3.2.24",
     "vuex": "3.6.2",
     "which": "5.0.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
+    "xterm-addon-web-links": "^0.9.0",
     "yaml": "2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "vue-slider-component": "3.2.24",
     "vuex": "3.6.2",
     "which": "5.0.0",
-    "xterm": "^5.3.0",
+    "xterm": "^5.4.0-beta.37",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-web-links": "^0.9.0",
     "yaml": "2.8.0"

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -203,6 +203,13 @@ containers:
   title: Containers
   sortableTables:
     noRows: There are no containers to show
+  console:
+    title: Container Console
+    back: Back to Containers
+    loading: Loading container logs...
+    noLogs: No logs available
+    refresh: Refresh
+    fetchError: Failed to fetch container logs
   manage:
     table:
       header:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -203,8 +203,8 @@ containers:
   title: Containers
   sortableTables:
     noRows: There are no containers to show
-  console:
-    title: Container Console
+  logs:
+    title: Container Logs
     back: Back to Containers
     loading: Loading container logs...
     noLogs: No logs available

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -205,7 +205,6 @@ containers:
     noRows: There are no containers to show
   logs:
     title: Container Logs
-    back: Back to Containers
     loading: Loading container logs...
     noLogs: No logs available
     refresh: Refresh

--- a/pkg/rancher-desktop/entry/router.ts
+++ b/pkg/rancher-desktop/entry/router.ts
@@ -20,6 +20,7 @@ import ImagesAdd from '../pages/images/add.vue';
 import ImagesScan from '../pages/images/scans/_image-name.vue';
 import SnapshotsCreate from '../pages/snapshots/create.vue';
 import SnapshotsDialog from '../pages/snapshots/dialog.vue';
+import ContainerConsole from '../pages/containers/console/_id.vue';
 
 Vue.use(VueRouter);
 
@@ -30,6 +31,9 @@ const routes: Array<RouteConfig> = [
   },
   {
     path: '/Containers', component: Containers, name: 'Containers',
+  },
+  {
+    path: '/containers/console/:id', component: ContainerConsole, name: 'containers-console-id',
   },
   {
     path: '/PortForwarding', component: PortForwarding, name: 'Port Forwarding',

--- a/pkg/rancher-desktop/entry/router.ts
+++ b/pkg/rancher-desktop/entry/router.ts
@@ -20,7 +20,7 @@ import ImagesAdd from '../pages/images/add.vue';
 import ImagesScan from '../pages/images/scans/_image-name.vue';
 import SnapshotsCreate from '../pages/snapshots/create.vue';
 import SnapshotsDialog from '../pages/snapshots/dialog.vue';
-import ContainerConsole from '../pages/containers/console/_id.vue';
+import ContainerConsole from '../pages/containers/logs/_id.vue';
 
 Vue.use(VueRouter);
 

--- a/pkg/rancher-desktop/entry/router.ts
+++ b/pkg/rancher-desktop/entry/router.ts
@@ -20,7 +20,7 @@ import ImagesAdd from '../pages/images/add.vue';
 import ImagesScan from '../pages/images/scans/_image-name.vue';
 import SnapshotsCreate from '../pages/snapshots/create.vue';
 import SnapshotsDialog from '../pages/snapshots/dialog.vue';
-import ContainerConsole from '../pages/containers/logs/_id.vue';
+import ContainerLogs from '../pages/containers/logs/_id.vue';
 
 Vue.use(VueRouter);
 
@@ -33,7 +33,7 @@ const routes: Array<RouteConfig> = [
     path: '/Containers', component: Containers, name: 'Containers',
   },
   {
-    path: '/containers/console/:id', component: ContainerConsole, name: 'containers-console-id',
+    path: '/containers/logs/:id', component: ContainerLogs, name: 'containers-logs-id',
   },
   {
     path: '/PortForwarding', component: PortForwarding, name: 'Port Forwarding',

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -241,9 +241,9 @@ export default {
   }
 
   .body {
-    display: grid;
     grid-area: body;
-    grid-template-rows: auto 1fr;
+    display: flex;
+    flex-direction: column;
     padding: 0 20px 20px 20px;
     overflow: auto;
   }

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -189,6 +189,12 @@ export default Vue.extend({
 
         container.availableActions = [
           {
+            label:      'Console',
+            action:     'viewConsole',
+            enabled:    true,
+            bulkable:   false,
+          },
+          {
             label:      'Stop',
             action:     'stopContainer',
             enabled:    this.isRunning(container),
@@ -226,6 +232,12 @@ export default Vue.extend({
         if (!container.deleteContainer) {
           container.deleteContainer = (...args) => {
             this.deleteContainer(...(args?.length > 0 ? args : [container]));
+          };
+        }
+
+        if (!container.viewConsole) {
+          container.viewConsole = () => {
+            this.viewConsole(container);
           };
         }
 
@@ -371,6 +383,9 @@ export default Vue.extend({
     },
     async deleteContainer(container) {
       await this.execCommand('rm', container);
+    },
+    viewConsole(container) {
+      this.$router.push(`/containers/console/${container.Id}`);
     },
     isRunning(container) {
       return container.State === 'running' || container.Status === 'Up';

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -189,8 +189,8 @@ export default Vue.extend({
 
         container.availableActions = [
           {
-            label:      'Console',
-            action:     'viewConsole',
+            label:      'Logs',
+            action:     'viewLogs',
             enabled:    true,
             bulkable:   false,
           },
@@ -235,9 +235,9 @@ export default Vue.extend({
           };
         }
 
-        if (!container.viewConsole) {
-          container.viewConsole = () => {
-            this.viewConsole(container);
+        if (!container.viewLogs) {
+          container.viewLogs = () => {
+            this.viewLogs(container);
           };
         }
 
@@ -384,8 +384,8 @@ export default Vue.extend({
     async deleteContainer(container) {
       await this.execCommand('rm', container);
     },
-    viewConsole(container) {
-      this.$router.push(`/containers/console/${container.Id}`);
+    viewLogs(container) {
+      this.$router.push(`/containers/logs/${container.Id}`);
     },
     isRunning(container) {
       return container.State === 'running' || container.Status === 'Up';

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -1,0 +1,416 @@
+<template>
+  <div class="container-console">
+    <div class="console-header">
+      <div class="header-left">
+        <button
+          class="btn role-secondary"
+          @click="goBack"
+        >
+          <i class="icon icon-chevron-left" />
+          {{ t('containers.console.back') }}
+        </button>
+      </div>
+      <div class="header-center">
+        <h1>{{ t('containers.console.title') }}</h1>
+        <div class="container-info">
+          <span class="container-name">{{ containerName }}</span>
+          <badge-state
+            :color="isContainerRunning ? 'bg-success' : 'bg-darker'"
+            :label="containerState"
+          />
+        </div>
+      </div>
+      <div class="header-right">
+        <button
+          class="btn role-secondary"
+          @click="refreshLogs"
+          :disabled="isLoading"
+        >
+          <i class="icon icon-refresh" />
+          {{ t('containers.console.refresh') }}
+        </button>
+      </div>
+    </div>
+
+    <div class="console-content">
+      <div
+        v-if="isLoading"
+        class="loading-container"
+      >
+        <loading-indicator>
+          {{ t('containers.console.loading') }}
+        </loading-indicator>
+      </div>
+
+      <div
+        v-else-if="error"
+        class="error-container"
+      >
+        <banner color="error">
+          <span class="icon icon-info-circle icon-lg" />
+          {{ error }}
+        </banner>
+      </div>
+
+      <div
+        v-else
+        class="logs-container"
+      >
+        <textarea
+          ref="consoleOutput"
+          v-model="logs"
+          class="console-output"
+          readonly
+          :placeholder="t('containers.console.noLogs')"
+          @scroll="onUserScroll"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { BadgeState, Banner } from '@rancher/components';
+import Vue from 'vue';
+import { mapGetters } from 'vuex';
+
+import LoadingIndicator from '@pkg/components/LoadingIndicator.vue';
+import { ContainerEngine } from '@pkg/config/settings';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+
+let logInterval = null;
+
+export default Vue.extend({
+  name: 'ContainerConsole',
+  title: 'Container Console',
+  components: {
+    BadgeState,
+    Banner,
+    LoadingIndicator,
+  },
+  data() {
+    return {
+      settings: undefined,
+      ddClient: null,
+      logs: '',
+      isLoading: true,
+      error: null,
+      containerName: '',
+      containerState: '',
+      isContainerRunning: false,
+      autoScroll: true,
+    };
+  },
+  computed: {
+    ...mapGetters('k8sManager', { isK8sReady: 'isReady' }),
+    containerId() {
+      return this.$route.params.id;
+    },
+    isNerdCtl() {
+      return this.settings?.containerEngine?.name === ContainerEngine.CONTAINERD;
+    },
+    selectedNamespace() {
+      return this.settings?.containers?.namespace;
+    },
+  },
+  async mounted() {
+    this.$store.dispatch('page/setHeader', {
+      title: this.t('containers.console.title'),
+      description: '',
+    });
+
+    ipcRenderer.on('settings-read', (event, settings) => {
+      this.settings = settings;
+      this.initializeConsole();
+    });
+
+    ipcRenderer.send('settings-read');
+    this.initializeConsole();
+  },
+  beforeDestroy() {
+    this.stopStreaming();
+    ipcRenderer.removeAllListeners('settings-read');
+  },
+  methods: {
+    async initializeConsole() {
+      if (window.ddClient && this.isK8sReady && this.settings) {
+        this.ddClient = window.ddClient;
+        await this.getContainerInfo();
+        await this.fetchLogs();
+        
+        if (this.isContainerRunning) {
+          this.startStreaming();
+        }
+      }
+    },
+    async getContainerInfo() {
+      try {
+        const listOptions = { all: true };
+        
+        if (this.isNerdCtl && this.selectedNamespace) {
+          listOptions.namespace = this.selectedNamespace;
+        }
+        
+        const containers = await this.ddClient?.docker.listContainers(listOptions);
+        
+        const container = containers.find(c => c.Id === this.containerId || c.Id.startsWith(this.containerId));
+        
+        if (container) {
+          const names = Array.isArray(container.Names) ? container.Names : container.Names.split(/\s+/);
+          this.containerName = names[0]?.replace(/_[a-z0-9-]{36}_[0-9]+/, '') || container.Id.substring(0, 12);
+          this.containerState = container.State || container.Status;
+          this.isContainerRunning = container.State === 'running' || container.Status === 'Up';
+        } else {
+          this.containerName = this.containerId.substring(0, 12);
+          this.containerState = 'unknown';
+          this.isContainerRunning = false;
+        }
+      } catch (error) {
+        console.error('Error getting container info:', error);
+        this.containerName = this.containerId.substring(0, 12);
+        this.containerState = 'unknown';
+        this.isContainerRunning = false;
+      }
+    },
+    async fetchLogs(follow = false) {
+      try {
+        this.isLoading = true;
+        this.error = null;
+
+        console.log('Fetching logs for container:', this.containerId);
+
+        const options = {
+          cwd: '/',
+        };
+
+        // Only add namespace for containerd/nerdctl, not Docker
+        if (this.isNerdCtl && this.selectedNamespace) {
+          options.namespace = this.selectedNamespace;
+        }
+
+        const args = [];
+        
+        if (follow) {
+          args.push('-f');
+        }
+        
+        if (!follow) {
+          args.push('--tail', '100');
+        }
+        
+        args.push('-t');
+        
+        args.push(this.containerId);
+
+        console.log('Docker logs command args:', args);
+        console.log('Options:', options);
+
+        const { stderr, stdout } = await this.ddClient.docker.cli.exec(
+          'logs',
+          args,
+          options
+        );
+
+        console.log('Docker logs stdout:', stdout);
+        console.log('Docker logs stderr:', stderr);
+
+        if (stderr && !stdout) {
+          throw new Error(stderr);
+        }
+
+        if (follow) {
+          this.logs += stdout || '';
+          if (this.autoScroll) {
+            this.scrollToBottom();
+          }
+        } else {
+          this.logs = stdout || '';
+          this.scrollToBottom();
+        }
+      } catch (error) {
+        console.error('Error fetching logs:', error);
+        this.error = error.message || this.t('containers.console.fetchError');
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    async refreshLogs() {
+      await this.fetchLogs(false);
+    },
+    startStreaming() {
+      if (!this.isContainerRunning) {
+        return;
+      }
+      
+      logInterval = setInterval(async () => {
+        try {
+          const options = {
+            cwd: '/',
+          };
+
+          if (this.isNerdCtl && this.selectedNamespace) {
+            options.namespace = this.selectedNamespace;
+          }
+
+          const args = ['--since', '1s', '-t', this.containerId];
+
+          const { stdout } = await this.ddClient.docker.cli.exec(
+            'logs',
+            args,
+            options
+          );
+
+          if (stdout) {
+            this.logs += stdout;
+            if (this.autoScroll) {
+              this.scrollToBottom();
+            }
+          }
+        } catch (error) {
+          console.error('Error streaming logs:', error);
+        }
+      }, 500);
+    },
+    stopStreaming() {
+      if (logInterval) {
+        clearInterval(logInterval);
+        logInterval = null;
+      }
+    },
+    scrollToBottom() {
+      this.$nextTick(() => {
+        if (this.$refs.consoleOutput) {
+          this.$refs.consoleOutput.scrollTop = this.$refs.consoleOutput.scrollHeight;
+        }
+      });
+    },
+    onUserScroll() {
+      if (this.$refs.consoleOutput) {
+        const element = this.$refs.consoleOutput;
+        const isAtBottom = element.scrollTop + element.clientHeight >= element.scrollHeight - 10;
+
+        this.autoScroll = isAtBottom;
+      }
+    },
+    goBack() {
+      this.$router.push('/Containers');
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.container-console {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.console-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--nav-bg);
+
+  .header-left,
+  .header-right {
+    flex: 1;
+    display: flex;
+    gap: 10px;
+  }
+
+  .header-right {
+    justify-content: flex-end;
+  }
+
+  .header-center {
+    flex: 2;
+    text-align: center;
+
+    h1 {
+      margin: 0 0 5px 0;
+      font-size: 1.5em;
+    }
+
+    .container-info {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+
+      .container-name {
+        font-family: monospace;
+        font-weight: bold;
+        color: var(--primary);
+      }
+    }
+  }
+
+  .btn {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+}
+
+.console-content {
+  flex: 1;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.loading-container,
+.error-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 200px;
+}
+
+.logs-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.console-output {
+  flex: 1;
+  width: 100%;
+  min-height: 400px;
+  font-family: 'Courier New', 'Monaco', monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  background: var(--body-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  padding: 15px;
+  resize: none;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary);
+  }
+
+  &::placeholder {
+    color: var(--muted);
+    font-style: italic;
+  }
+}
+
+// Dark theme adjustments
+.theme-dark {
+  .console-output {
+    background: #1a1a1a;
+    color: #e0e0e0;
+    border-color: #444;
+  }
+}
+</style>

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -340,13 +340,17 @@ export default Vue.extend({
             cursorBlink: false,
             disableStdin: true,
             convertEol: true,
-            scrollback: 10000
+            scrollback: 10000,
+            wordWrap: true
           });
 
           this.fitAddon = new FitAddon();
           this.terminal.loadAddon(this.fitAddon);
 
-          this.terminal.loadAddon(new WebLinksAddon());
+          this.terminal.loadAddon(new WebLinksAddon((event, uri) => {
+            event.preventDefault();
+            window.open(uri, '_blank');
+          }));
 
           this.terminal.open(this.$refs.terminalContainer);
           this.fitAddon.fit();

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -121,6 +121,13 @@ export default Vue.extend({
       return this.convertAnsiToHtml(this.logs);
     },
   },
+  watch: {
+    formattedLogs() {
+      if (this.autoScroll) {
+        this.scrollToBottom();
+      }
+    },
+  },
   async mounted() {
     this.$store.dispatch('page/setHeader', {
       title: this.t('containers.console.title'),
@@ -185,8 +192,6 @@ export default Vue.extend({
         this.isLoading = true;
         this.error = null;
 
-        console.log('Fetching logs for container:', this.containerId);
-
         const options = {
           cwd: '/',
         };
@@ -210,17 +215,11 @@ export default Vue.extend({
 
         args.push(this.containerId);
 
-        console.log('Docker logs command args:', args);
-        console.log('Options:', options);
-
         const { stderr, stdout } = await this.ddClient.docker.cli.exec(
           'logs',
           args,
           options
         );
-
-        console.log('Docker logs stdout:', stdout);
-        console.log('Docker logs stderr:', stderr);
 
         if (stderr && !stdout) {
           throw new Error(stderr);
@@ -287,9 +286,11 @@ export default Vue.extend({
     },
     scrollToBottom() {
       this.$nextTick(() => {
-        if (this.$refs.consoleOutput) {
-          this.$refs.consoleOutput.scrollTop = this.$refs.consoleOutput.scrollHeight;
-        }
+        this.$nextTick(() => {
+          if (this.$refs.consoleOutput) {
+            this.$refs.consoleOutput.scrollTop = this.$refs.consoleOutput.scrollHeight;
+          }
+        });
       });
     },
     onUserScroll() {

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -57,8 +57,8 @@
             <div class="search-widget" :class="{ 'expanded': isSearchExpanded }">
               <button
                 class="search-toggle-btn"
+                :class="{ 'active': isSearchExpanded, 'role-tertiary': isSearchExpanded }"
                 @click="toggleSearch"
-                :class="{ 'active': isSearchExpanded }"
                 :aria-label="isSearchExpanded ? 'Close search' : 'Open search'"
                 :aria-expanded="isSearchExpanded"
                 title="Search"
@@ -78,7 +78,7 @@
                 />
                 <div class="search-controls">
                   <button
-                    class="search-btn"
+                    class="search-btn role-tertiary"
                     @click="searchPrevious"
                     :disabled="!searchTerm"
                     aria-label="Previous match"
@@ -87,7 +87,7 @@
                     <i class="icon icon-chevron-up" aria-hidden="true" />
                   </button>
                   <button
-                    class="search-btn"
+                    class="search-btn role-tertiary"
                     @click="searchNext"
                     :disabled="!searchTerm"
                     aria-label="Next match"
@@ -96,7 +96,7 @@
                     <i class="icon icon-chevron-down" aria-hidden="true" />
                   </button>
                   <button
-                    class="search-close-btn"
+                    class="search-close-btn role-tertiary"
                     @click="toggleSearch"
                     aria-label="Close search"
                     title="Close search"
@@ -179,7 +179,7 @@ export default Vue.extend({
 
     ipcRenderer.send('settings-read');
     this.initializeConsole();
-    
+
     // Add global keyboard shortcut for search
     window.addEventListener('keydown', this.handleGlobalKeydown);
   },
@@ -739,11 +739,10 @@ export default Vue.extend({
     opacity: 0.3;
     cursor: not-allowed;
   }
-  
+
   &:focus,
   &:active,
   &:focus-visible {
-    outline: none !important;
     box-shadow: none !important;
   }
 
@@ -763,7 +762,6 @@ export default Vue.extend({
   display: flex;
   align-items: center;
   justify-content: center;
-  outline: none !important;
 
   &:hover {
     background: var(--primary-hover-bg);
@@ -773,7 +771,6 @@ export default Vue.extend({
   &:focus,
   &:active,
   &:focus-visible {
-    outline: none !important;
     box-shadow: none !important;
   }
 

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -21,14 +21,6 @@
         </div>
       </div>
       <div class="header-right">
-        <button
-          class="btn role-secondary"
-          @click="refreshLogs"
-          :disabled="isLoading"
-        >
-          <i class="icon icon-refresh" />
-          {{ t('containers.console.refresh') }}
-        </button>
       </div>
     </div>
 
@@ -252,9 +244,6 @@ export default Vue.extend({
           this.initializeTerminal();
         }
       }
-    },
-    async refreshLogs() {
-      await this.fetchLogs(false);
     },
     startStreaming() {
       if (!this.isContainerRunning) {

--- a/pkg/rancher-desktop/pages/containers/console/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/console/_id.vue
@@ -302,8 +302,10 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .container-console {
   height: 100%;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .console-header {
@@ -361,6 +363,7 @@ export default Vue.extend({
   display: flex;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
 }
 
 .loading-container,
@@ -381,7 +384,6 @@ export default Vue.extend({
 .console-output {
   flex: 1;
   width: 100%;
-  min-height: 400px;
   font-family: 'Courier New', 'Monaco', monospace;
   font-size: 12px;
   line-height: 1.4;

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -529,6 +529,10 @@ export default Vue.extend({
   :deep(.xterm-screen) {
     background: transparent !important;
   }
+
+  :deep(.xterm-selection) {
+    overflow: hidden;
+  }
 }
 
 

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="container-console">
-    <div class="console-header">
+  <div class="container-logs">
+    <div class="logs-header">
       <div class="header-left">
         <button
           class="btn role-secondary"
           @click="goBack"
         >
           <i class="icon icon-chevron-left" />
-          {{ t('containers.console.back') }}
+          {{ t('containers.logs.back') }}
         </button>
       </div>
       <div class="header-center">
-        <h1>{{ t('containers.console.title') }}</h1>
+        <h1>{{ t('containers.logs.title') }}</h1>
         <div class="container-info">
           <span class="container-name">{{ containerName }}</span>
           <badge-state
@@ -24,13 +24,13 @@
       </div>
     </div>
 
-    <div class="console-content">
+    <div class="logs-content">
       <div
         v-if="isLoading"
         class="loading-container"
       >
         <loading-indicator>
-          {{ t('containers.console.loading') }}
+          {{ t('containers.logs.loading') }}
         </loading-indicator>
       </div>
 
@@ -129,8 +129,8 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 let logInterval = null;
 
 export default Vue.extend({
-  name: 'ContainerConsole',
-  title: 'Container Console',
+  name: 'ContainerLogs',
+  title: 'Container Logs',
   components: {
     BadgeState,
     Banner,
@@ -168,17 +168,17 @@ export default Vue.extend({
   },
   async mounted() {
     this.$store.dispatch('page/setHeader', {
-      title: this.t('containers.console.title'),
+      title: this.t('containers.logs.title'),
       description: '',
     });
 
     ipcRenderer.on('settings-read', (event, settings) => {
       this.settings = settings;
-      this.initializeConsole();
+      this.initializeLogs();
     });
 
     ipcRenderer.send('settings-read');
-    this.initializeConsole();
+    this.initializeLogs();
 
     // Add global keyboard shortcut for search
     window.addEventListener('keydown', this.handleGlobalKeydown);
@@ -192,7 +192,7 @@ export default Vue.extend({
     window.removeEventListener('keydown', this.handleGlobalKeydown);
   },
   methods: {
-    async initializeConsole() {
+    async initializeLogs() {
       if (window.ddClient && this.isK8sReady && this.settings) {
         this.ddClient = window.ddClient;
         await this.getContainerInfo();
@@ -301,7 +301,7 @@ export default Vue.extend({
         }
       } catch (error) {
         console.error('Error fetching logs:', error);
-        this.error = error.message || this.t('containers.console.fetchError');
+        this.error = error.message || this.t('containers.logs.fetchError');
       } finally {
         this.isLoading = false;
         if (!this.terminal) {
@@ -502,14 +502,14 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 @import '@xterm/xterm/css/xterm.css';
-.container-console {
+.container-logs {
   height: 87vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-.console-header {
+.logs-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -558,7 +558,7 @@ export default Vue.extend({
   }
 }
 
-.console-content {
+.logs-content {
   flex: 1;
   padding: 20px;
   display: flex;

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="container-logs">
-    <h1 class="title">{{ t('containers.logs.title') }}</h1>
 
     <div class="container-info">
       <span class="container-name">{{ containerName }}</span>

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -275,24 +275,23 @@ export default Vue.extend({
         const streamArgs = ['--follow', '--timestamps', '--tail', '0', this.containerId];
 
         this.streamProcess = this.ddClient.docker.cli.exec('logs', streamArgs, streamOptions);
-        
-        // Reset reconnect attempts on successful connection
+
         this.reconnectAttempts = 0;
 
         console.log('Started streaming logs for container:', this.containerId);
 
       } catch (error) {
         console.error('Error starting log stream:', error);
-        
+
         const errorMessages = {
           'No such container': 'Container not found. It may have been removed.',
           'permission denied': 'Permission denied. Check Docker access permissions.',
           'connection refused': 'Cannot connect to Docker. Is Docker running?'
         };
-        
+
         const errorKey = Object.keys(errorMessages).find(key => error.message.includes(key));
         this.error = errorKey ? errorMessages[errorKey] : (error.message || this.t('containers.logs.fetchError'));
-        
+
         this.isLoading = false;
         if (!this.terminal) {
           this.initializeTerminal();
@@ -314,10 +313,10 @@ export default Vue.extend({
       if (this.reconnectAttempts < this.maxReconnectAttempts && this.isContainerRunning) {
         this.reconnectAttempts++;
         console.log(`Attempting to reconnect stream (${this.reconnectAttempts}/${this.maxReconnectAttempts})...`);
-        
+
         // Exponential backoff: 1s, 2s, 4s, 8s, 16s
         const delay = Math.pow(2, this.reconnectAttempts - 1) * 1000;
-        
+
         setTimeout(() => {
           this.startStreaming();
         }, delay);
@@ -326,7 +325,6 @@ export default Vue.extend({
       }
     },
     startContainerChecking() {
-      // Check container status every 30 seconds
       this.containerCheckInterval = setInterval(() => {
         this.getContainerInfo();
       }, 30000);
@@ -364,7 +362,7 @@ export default Vue.extend({
               brightCyan: '#a4ffff',
               brightWhite: '#ffffff'
             },
-            fontSize: 12,
+            fontSize: 14,
             fontFamily: '\'Courier New\', \'Monaco\', monospace',
             cursorBlink: false,
             disableStdin: true,
@@ -429,11 +427,10 @@ export default Vue.extend({
       });
     },
     performSearch() {
-      // Debounce search to avoid performance issues with large logs
       if (this.searchDebounceTimer) {
         clearTimeout(this.searchDebounceTimer);
       }
-      
+
       this.searchDebounceTimer = setTimeout(() => {
         if (!this.searchAddon || !this.searchTerm) {
           if (this.searchAddon) {
@@ -448,7 +445,7 @@ export default Vue.extend({
         } catch (error) {
           console.error('Search error:', error);
         }
-      }, 300); // 300ms debounce
+      }, 300);
     },
     searchNext() {
       if (!this.searchAddon || !this.searchTerm) return;
@@ -504,7 +501,7 @@ export default Vue.extend({
     "info info search"
     "content content content";
   gap: 1rem;
-  padding: 20px;
+  padding: 1.25rem;
   overflow: hidden;
   min-height: 0;
 
@@ -523,8 +520,9 @@ export default Vue.extend({
   grid-area: info;
   display: flex;
   align-items: center;
-  gap: 10px;
-  justify-self: center;
+  gap: 0.625rem;
+  justify-self: start;
+  padding-left: 0.625rem;
 
   .container-name {
     font-family: monospace;
@@ -538,7 +536,7 @@ export default Vue.extend({
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 40px;
+  padding: 2.5rem;
 }
 
 .terminal-container {
@@ -551,7 +549,7 @@ export default Vue.extend({
   flex-direction: column;
 
   :deep(.xterm) {
-    padding: 15px;
+    padding: 1rem;
     height: 100%;
   }
 
@@ -569,7 +567,7 @@ export default Vue.extend({
   border: 1px solid var(--border);
   border-radius: var(--border-radius);
   overflow: hidden;
-  padding: 0 4px;
+  padding: 0 0.25rem;
   justify-self: end;
 
   button {
@@ -583,7 +581,7 @@ export default Vue.extend({
 .search-icon {
   color: var(--muted);
   font-size: 14px;
-  margin: 0 8px;
+  margin: 0 0.5rem;
 }
 
 .search-input {
@@ -591,7 +589,7 @@ export default Vue.extend({
   background: transparent;
   color: var(--body-text);
   font-size: 13px;
-  padding: 6px 10px;
+  padding: 0.375rem 0.625rem;
   min-width: 200px;
   font-family: var(--font-family-mono), monospace;
   height: 32px;
@@ -616,7 +614,7 @@ export default Vue.extend({
 .search-btn {
   background: transparent;
   border: none;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
   cursor: pointer;
   color: var(--muted);
   transition: all 0.2s ease;
@@ -654,7 +652,7 @@ export default Vue.extend({
 .search-close-btn {
   background: transparent;
   border: none;
-  padding: 6px 8px;
+  padding: 0.375rem 0.5rem;
   cursor: pointer;
   color: var(--muted);
   transition: all 0.2s ease;

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -11,43 +11,43 @@
     </div>
 
     <div class="search-widget">
-      <i class="icon icon-search search-icon" aria-hidden="true" />
+      <i aria-hidden="true" class="icon icon-search search-icon"/>
       <input
         ref="searchInput"
         v-model="searchTerm"
-        type="text"
+        aria-label="Search in logs"
         class="search-input"
         placeholder="Search logs..."
-        aria-label="Search in logs"
+        type="text"
         @input="performSearch"
         @keydown="handleSearchKeydown"
       />
       <button
-        class="search-btn role-tertiary"
-        @click="searchPrevious"
         :disabled="!searchTerm"
         aria-label="Previous match"
+        class="search-btn role-tertiary"
         title="Previous match"
+        @click="searchPrevious"
       >
-        <i class="icon icon-chevron-up" aria-hidden="true" />
+        <i aria-hidden="true" class="icon icon-chevron-up"/>
       </button>
       <button
-        class="search-btn role-tertiary"
-        @click="searchNext"
         :disabled="!searchTerm"
         aria-label="Next match"
+        class="search-btn role-tertiary"
         title="Next match"
+        @click="searchNext"
       >
-        <i class="icon icon-chevron-down" aria-hidden="true" />
+        <i aria-hidden="true" class="icon icon-chevron-down"/>
       </button>
       <button
-        class="search-close-btn role-tertiary"
-        @click="clearSearch"
         :disabled="!searchTerm"
         aria-label="Clear search"
+        class="search-close-btn role-tertiary"
         title="Clear search"
+        @click="clearSearch"
       >
-        <i class="icon icon-x" aria-hidden="true" />
+        <i aria-hidden="true" class="icon icon-x"/>
       </button>
     </div>
 
@@ -60,10 +60,10 @@
 
     <banner
       v-else-if="error"
-      color="error"
       class="content-state"
+      color="error"
     >
-      <span class="icon icon-info-circle icon-lg" />
+      <span class="icon icon-info-circle icon-lg"/>
       {{ error }}
     </banner>
 
@@ -76,17 +76,17 @@
 </template>
 
 <script>
-import { BadgeState, Banner } from '@rancher/components';
+import {BadgeState, Banner} from '@rancher/components';
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
-import { SearchAddon } from '@xterm/addon-search';
+import {mapGetters} from 'vuex';
+import {Terminal} from '@xterm/xterm';
+import {FitAddon} from '@xterm/addon-fit';
+import {WebLinksAddon} from '@xterm/addon-web-links';
+import {SearchAddon} from '@xterm/addon-search';
 
 import LoadingIndicator from '@pkg/components/LoadingIndicator.vue';
-import { ContainerEngine } from '@pkg/config/settings';
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import {ContainerEngine} from '@pkg/config/settings';
+import {ipcRenderer} from '@pkg/utils/ipcRenderer';
 
 export default Vue.extend({
   name: 'ContainerLogs',
@@ -114,7 +114,7 @@ export default Vue.extend({
     };
   },
   computed: {
-    ...mapGetters('k8sManager', { isK8sReady: 'isReady' }),
+    ...mapGetters('k8sManager', {isK8sReady: 'isReady'}),
     containerId() {
       return this.$route.params.id;
     },
@@ -163,7 +163,7 @@ export default Vue.extend({
     },
     async getContainerInfo() {
       try {
-        const listOptions = { all: true };
+        const listOptions = {all: true};
 
         if (this.isNerdCtl && this.selectedNamespace) {
           listOptions.namespace = this.selectedNamespace;
@@ -206,7 +206,7 @@ export default Vue.extend({
 
         const args = ['--timestamps', this.containerId];
 
-        const { stderr, stdout } = await this.ddClient.docker.cli.exec(
+        const {stderr, stdout} = await this.ddClient.docker.cli.exec(
           'logs',
           args,
           options
@@ -350,6 +350,17 @@ export default Vue.extend({
             this.terminal.write(this.pendingLogs);
             this.pendingLogs = '';
           }
+          this.terminal.attachCustomKeyEventHandler((event) => {
+            if (event.key === '/') {
+              event.preventDefault();
+              if (this.$refs.searchInput) {
+                this.$refs.searchInput.focus();
+                this.$refs.searchInput.select();
+              }
+              return false;
+            }
+            return true;
+          });
 
           window.addEventListener('resize', () => {
             if (this.fitAddon) {
@@ -554,7 +565,7 @@ export default Vue.extend({
   font-size: 13px;
   padding: 6px 10px;
   min-width: 200px;
-  font-family: var(--font-family-mono),monospace;
+  font-family: var(--font-family-mono), monospace;
   height: 32px;
   outline: none;
 

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -196,7 +196,7 @@ export default Vue.extend({
           initialOptions.namespace = this.hasNamespaceSelected;
         }
 
-        const initialArgs = ['--timestamps', '--tail', '1000', this.containerId];
+        const initialArgs = ['--timestamps', '--tail', '10000', this.containerId];
 
         const {stderr, stdout} = await this.ddClient.docker.cli.exec(
             'logs',
@@ -211,6 +211,7 @@ export default Vue.extend({
         if (stdout) {
           if (this.terminal) {
             this.terminal.write(stdout);
+            this.terminal.scrollToBottom();
           } else {
             this.pendingLogs = stdout;
           }
@@ -250,7 +251,7 @@ export default Vue.extend({
           streamOptions.namespace = this.hasNamespaceSelected;
         }
 
-        const streamArgs = ['--follow', '--timestamps', this.containerId];
+        const streamArgs = ['--follow', '--timestamps', '--tail', '0', this.containerId];
 
         this.streamProcess = this.ddClient.docker.cli.exec('logs', streamArgs, streamOptions);
 
@@ -308,7 +309,7 @@ export default Vue.extend({
             cursorBlink: false,
             disableStdin: true,
             convertEol: true,
-            scrollback: 10000,
+            scrollback: 50000,
             wordWrap: true
           });
 
@@ -326,8 +327,13 @@ export default Vue.extend({
           this.terminal.open(this.$refs.terminalContainer);
           this.fitAddon.fit();
 
+          let hideCursorEscapeCode = '\x1b[?25l\''
+
+          this.terminal.write(hideCursorEscapeCode);
+
           if (this.pendingLogs) {
             this.terminal.write(this.pendingLogs);
+            this.terminal.scrollToBottom();
             this.pendingLogs = '';
           }
           this.terminal.attachCustomKeyEventHandler((event) => {
@@ -421,18 +427,6 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 @import '@xterm/xterm/css/xterm.css';
-
-:global(.body) {
-  display: flex !important;
-  flex-direction: column !important;
-
-  > div {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-}
 
 .container-logs {
   flex: 1;

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -118,11 +118,8 @@ export default Vue.extend({
     containerId() {
       return this.$route.params.id;
     },
-    isNerdCtl() {
-      return this.settings?.containerEngine?.name === ContainerEngine.CONTAINERD;
-    },
-    selectedNamespace() {
-      return this.settings?.containers?.namespace;
+    hasNamespaceSelected() {
+      return this.settings?.containerEngine?.name === ContainerEngine.CONTAINERD && this.settings?.containers?.namespace;
     },
   },
   async mounted() {
@@ -165,8 +162,8 @@ export default Vue.extend({
       try {
         const listOptions = {all: true};
 
-        if (this.isNerdCtl && this.selectedNamespace) {
-          listOptions.namespace = this.selectedNamespace;
+        if (this.hasNamespaceSelected) {
+          listOptions.namespace = this.hasNamespaceSelected;
         }
 
         const containers = await this.ddClient?.docker.listContainers(listOptions);
@@ -199,9 +196,8 @@ export default Vue.extend({
           cwd: '/',
         };
 
-        // Only add namespace for containerd/nerdctl, not Docker
-        if (this.isNerdCtl && this.selectedNamespace) {
-          options.namespace = this.selectedNamespace;
+        if (this.hasNamespaceSelected) {
+          options.namespace = this.hasNamespaceSelected;
         }
 
         const args = ['--timestamps', this.containerId];
@@ -269,8 +265,8 @@ export default Vue.extend({
           },
         };
 
-        if (this.isNerdCtl && this.selectedNamespace) {
-          options.namespace = this.selectedNamespace;
+        if (this.hasNamespaceSelected) {
+          options.namespace = this.hasNamespaceSelected;
         }
 
         const args = ['--follow', '--timestamps', this.containerId];

--- a/yarn.lock
+++ b/yarn.lock
@@ -12110,7 +12110,16 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12133,7 +12142,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12146,6 +12155,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13373,8 +13389,7 @@ word-wrap@^1.2.5, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13390,6 +13405,15 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"
@@ -13462,6 +13486,21 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xterm-addon-fit@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz#48ca99015385141918f955ca7819e85f3691d35f"
+  integrity sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==
+
+xterm-addon-web-links@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz#c65b18588d1f613e703eb6feb7f129e7ff1c63e7"
+  integrity sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==
+
+xterm@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.3.0.tgz#867daf9cc826f3d45b5377320aabd996cb0fce46"
+  integrity sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,22 +4050,22 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-"@xterm/addon-fit@^0.10.0":
+"@xterm/addon-fit@0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
   integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
 
-"@xterm/addon-search@^0.15.0":
+"@xterm/addon-search@0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.15.0.tgz#5c772d5f14c26546c4bfbeb0c3d4b3333057411f"
   integrity sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==
 
-"@xterm/addon-web-links@^0.11.0":
+"@xterm/addon-web-links@0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz#f283513b8c713757bad8e3bf04b6becc3b4e585f"
   integrity sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==
 
-"@xterm/xterm@^5.5.0":
+"@xterm/xterm@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
   integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,10 +4050,25 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-fit@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
+  integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
+
 "@xterm/addon-search@^0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.15.0.tgz#5c772d5f14c26546c4bfbeb0c3d4b3333057411f"
   integrity sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==
+
+"@xterm/addon-web-links@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz#f283513b8c713757bad8e3bf04b6becc3b4e585f"
+  integrity sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==
+
+"@xterm/xterm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
+  integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -13491,21 +13506,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xterm-addon-fit@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz#48ca99015385141918f955ca7819e85f3691d35f"
-  integrity sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==
-
-xterm-addon-web-links@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz#c65b18588d1f613e703eb6feb7f129e7ff1c63e7"
-  integrity sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==
-
-xterm@^5.4.0-beta.37:
-  version "5.4.0-beta.37"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.4.0-beta.37.tgz#bae127be8c939f096232d9858e77a457d6b77ddf"
-  integrity sha512-ys+mXqLFrJc7khmYN/MgBnfLv38NgXfkwkEXsCZKHGqn3h2xUBvTvsrSEWO3NQeDPLj4zMr1RwqTblMK9St3BA==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4050,6 +4050,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-search@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.15.0.tgz#5c772d5f14c26546c4bfbeb0c3d4b3333057411f"
+  integrity sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13497,10 +13497,10 @@ xterm-addon-web-links@^0.9.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz#c65b18588d1f613e703eb6feb7f129e7ff1c63e7"
   integrity sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==
 
-xterm@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.3.0.tgz#867daf9cc826f3d45b5377320aabd996cb0fce46"
-  integrity sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==
+xterm@^5.4.0-beta.37:
+  version "5.4.0-beta.37"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.4.0-beta.37.tgz#bae127be8c939f096232d9858e77a457d6b77ddf"
+  integrity sha512-ys+mXqLFrJc7khmYN/MgBnfLv38NgXfkwkEXsCZKHGqn3h2xUBvTvsrSEWO3NQeDPLj4zMr1RwqTblMK9St3BA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
**Summary**

#8812 

Add a container console logs page that shows the real-time logs of the container. Useful for debug output and whatnot.

The motivation stems from working with Spring Boot projects that have extensive log error messages, in which it is helpful to see the console output of the container directly inside Rancher Desktop.

Tested with containerd and docker containers, both work.

**Changes**

- Add new container console logs page (pages/containers/console/_id.vue)

**Features**
- Search functionality with highlighting and navigation (previous/next)
- Real-time log streaming for running containers
- Historical log viewing for stopped containers

- Terminal emulation with xterm.js including:

  - Clickable web links
  - Automatic resizing on window changes