### PR TITLE
Vue 3: Remove Nuxt routing configs

### DIFF
--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -1,6 +1,3 @@
-<router lang="yaml">
-  name: General
-</router>
 <template>
   <div class="general">
     <div>

--- a/pkg/rancher-desktop/pages/PortForwarding.vue
+++ b/pkg/rancher-desktop/pages/PortForwarding.vue
@@ -1,6 +1,3 @@
-<router lang="yaml">
-  name: Port Forwarding
-</router>
 <template>
   <PortForwarding
     class="content"


### PR DESCRIPTION
This was meant for use with `@nuxtjs/router-extras`; but since we already removed Nuxt this wasn't being used at all.