### PR TITLE
E2E: Fix macOS tests

### DIFF
--- a/e2e/backend.e2e.spec.ts
+++ b/e2e/backend.e2e.spec.ts
@@ -9,7 +9,7 @@ import semver from 'semver';
 import { NavPage } from './pages/nav-page';
 import { getAlternateSetting, startSlowerDesktop, teardown } from './utils/TestUtils';
 
-import { Settings, ContainerEngine, VMType } from '@pkg/config/settings';
+import { Settings, ContainerEngine, VMType, MountType } from '@pkg/config/settings';
 import fetch from '@pkg/utils/fetch';
 import paths from '@pkg/utils/paths';
 import { RecursivePartial, RecursiveKeys } from '@pkg/utils/typeUtils';
@@ -21,7 +21,13 @@ test.describe.serial('KubernetesBackend', () => {
   let page: Page;
 
   test.beforeAll(async({ colorScheme }, testInfo) => {
-    [electronApp, page] = await startSlowerDesktop(testInfo);
+    [electronApp, page] = await startSlowerDesktop(testInfo, {
+      virtualMachine: {
+        mount: {
+          type: MountType.REVERSE_SSHFS,
+        }
+      }
+    });
   });
 
   test.afterAll(({ colorScheme }, testInfo) => teardown(electronApp, testInfo));

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -131,7 +131,11 @@ test.describe.serial('Main App Test', () => {
       }
     }
 
-    await expect(virtualMachine.reverseSshFs).toBeChecked();
+    if (os.platform() === 'darwin' && parseInt(os.release()) >= 23) {
+      await expect(virtualMachine.virtiofs).toBeChecked();
+    } else {
+      await expect(virtualMachine.reverseSshFs).toBeChecked();
+    }
 
     await virtualMachine.ninep.click();
     await expect(virtualMachine.cacheMode).toBeVisible();


### PR DESCRIPTION
Now that we default to vz + virtiofs, we need to some E2E tests:

- Preferences: fix expectations of what is checked
- Backend: force SSHFS mount type so we don't get conflicts with qemu