### PR TITLE
Explicitly specify shfmt indent

### DIFF
--- a/bats/Makefile
+++ b/bats/Makefile
@@ -19,9 +19,9 @@ lint:
 	find tests -name '*.bash' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find tests -name '*.bats' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find scripts -name '*.sh' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
-	find tests -name '*.bash' | xargs shfmt -s -d
-	find tests -name '*.bats' | xargs shfmt -s -d
-	find scripts -name '*.sh' | xargs shfmt -s -d
+	find tests -name '*.bash' | xargs shfmt --simplify --diff --indent 4
+	find tests -name '*.bats' | xargs shfmt --simplify --diff --indent 4
+	find scripts -name '*.sh' | xargs shfmt --simplify --diff --indent 4
 
 DEPS = bin/darwin/jq bin/linux/jq
 


### PR DESCRIPTION
It looks like the shfmt v3.12.0 update has broken the .editorconfig lookup in the repo root directory. Specifying the indent explicitly for now.

Upstream issue: https://github.com/mvdan/sh/issues/1173