### PR TITLE
Move --simplify option to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,4 @@ indent_style = tab
 
 [*.{sh,bash,bats}]
 indent_size = 4
+simplify = true

--- a/bats/Makefile
+++ b/bats/Makefile
@@ -19,9 +19,9 @@ lint:
 	find tests -name '*.bash' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find tests -name '*.bats' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
 	find scripts -name '*.sh' | xargs shellcheck -s bash -e $(SC_EXCLUDES)
-	find tests -name '*.bash' | xargs shfmt --simplify --diff --indent 4
-	find tests -name '*.bats' | xargs shfmt --simplify --diff --indent 4
-	find scripts -name '*.sh' | xargs shfmt --simplify --diff --indent 4
+	find tests -name '*.bash' | xargs shfmt --diff
+	find tests -name '*.bats' | xargs shfmt --diff
+	find scripts -name '*.sh' | xargs shfmt --diff
 
 DEPS = bin/darwin/jq bin/linux/jq
 


### PR DESCRIPTION
Because in v3.12.0 using --simplify on the commandline disables editorconfig processing. Ref https://github.com/mvdan/sh/issues/1173