### PR TITLE
Add banner to handle errors for Containers page instead of window.alert()

### DIFF
--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -4,9 +4,8 @@
       v-if="error"
       color="error"
       @close="error = null"
-    >
-      {{ error }}
-    </banner>
+      v-text="error"
+    />
     <SortableTable
       ref="sortableTableRef"
       class="containersTable"
@@ -431,9 +430,9 @@ export default Vue.extend({
 
           if (typeof rawMessage === 'string') {
             // Extract message from fatal/error format: time="..." level=fatal msg="actual message"
-            const msgMatch = rawMessage.match(/msg="([^"]+)"/);
+            const msgMatch = rawMessage.match(/msg="((?:[^"\\]|\\.)*)"/);
             if (msgMatch) {
-              return msgMatch[1].replace(/\\n/g, ' '); // Replace \n with spaces
+              return msgMatch[1];
             }
 
             // Fallback: remove timestamp and level prefixes

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -4,8 +4,9 @@
       v-if="error"
       color="error"
       @close="error = null"
-      v-text="error"
-    />
+    >
+      {{ error }}
+    </banner>
     <SortableTable
       ref="sortableTableRef"
       class="containersTable"


### PR DESCRIPTION
#8893

This changes displaying error messages with window.alert() to using the banner component in the Containers page.

similar to how it is done for the volumes page implementation here: #8856 