### PR TITLE
Diagnostics: implement docker context check

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -41,7 +41,7 @@ import { Tray } from '@pkg/main/tray';
 import setupUpdate from '@pkg/main/update';
 import { spawnFile } from '@pkg/utils/childProcess';
 import getCommandLineArgs from '@pkg/utils/commandLine';
-import DockerDirManager from '@pkg/utils/dockerDirManager';
+import dockerDirManager from '@pkg/utils/dockerDirManager';
 import { isDevEnv } from '@pkg/utils/environment';
 import Logging, { clearLoggingDirectory, setLogLevel } from '@pkg/utils/logging';
 import { fetchMacOsVersion, getMacOsVersion } from '@pkg/utils/osVersion';
@@ -82,7 +82,6 @@ clearLoggingDirectory();
 const SNAPSHOT_OPERATION = 'Snapshot operation in progress';
 
 const ipcMainProxy = getIpcMainProxy(console);
-const dockerDirManager = new DockerDirManager(path.join(os.homedir(), '.docker'));
 const k8smanager = newK8sManager();
 const diagnostics: DiagnosticsManager = new DiagnosticsManager();
 
@@ -1250,7 +1249,7 @@ async function getExtensionManager() {
 
 function newK8sManager() {
   const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
-  const mgr = K8sFactory(arch, dockerDirManager);
+  const mgr = K8sFactory(arch);
 
   mgr.on('state-changed', async(state: K8s.State) => {
     try {

--- a/pkg/rancher-desktop/backend/factory.ts
+++ b/pkg/rancher-desktop/backend/factory.ts
@@ -8,9 +8,8 @@ import MockBackend from './mock';
 import WSLBackend from './wsl';
 
 import { LimaKubernetesBackendMock, WSLKubernetesBackendMock } from '@pkg/backend/mock_screenshots';
-import DockerDirManager from '@pkg/utils/dockerDirManager';
 
-export default function factory(arch: Architecture, dockerDirManager: DockerDirManager): VMBackend {
+export default function factory(arch: Architecture): VMBackend {
   const platform = os.platform();
 
   if (process.env.RD_MOCK_BACKEND === '1') {
@@ -20,7 +19,7 @@ export default function factory(arch: Architecture, dockerDirManager: DockerDirM
   switch (platform) {
   case 'linux':
   case 'darwin':
-    return new LimaBackend(arch, dockerDirManager, (backend: LimaBackend) => {
+    return new LimaBackend(arch, (backend: LimaBackend) => {
       if (process.env.RD_MOCK_FOR_SCREENSHOTS) {
         return new LimaKubernetesBackendMock(arch, backend);
       } else {

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -50,6 +50,7 @@ export class DiagnosticsManager {
         const imports = (await Promise.all([
           import('./connectedToInternet'),
           import('./dockerCliSymlinks'),
+          import('./dockerContext'),
           import('./integrationsWindows'),
           import('./kubeConfigSymlink'),
           import('./kubeContext'),

--- a/pkg/rancher-desktop/main/diagnostics/dockerContext.ts
+++ b/pkg/rancher-desktop/main/diagnostics/dockerContext.ts
@@ -1,0 +1,57 @@
+import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, DiagnosticsCheckerSingleResult } from './types';
+
+import { ContainerEngine } from '@pkg/config/settings';
+import mainEvents from '@pkg/main/mainEvents';
+import dockerDirManager from '@pkg/utils/dockerDirManager';
+
+const dockerContextChecker: DiagnosticsChecker = {
+  id:       'DOCKER_CONTEXT',
+  category: DiagnosticsCategory.ContainerEngine,
+  async applicable(): Promise<boolean> {
+    const settings = await mainEvents.invoke('settings-fetch');
+
+    return settings.containerEngine.name === ContainerEngine.MOBY;
+  },
+  async check(): Promise<DiagnosticsCheckerSingleResult[]> {
+    const results: DiagnosticsCheckerSingleResult[] = [];
+    for (const variable of ['DOCKER_HOST', 'DOCKER_CONTEXT', 'DOCKER_CONFIG']) {
+      if (variable in process.env) {
+        results.push({
+          id:          `DOCKER_CONTEXT_ENV_${ variable }`,
+          description: `\`${ variable }\` environment variable is set.`,
+          passed:      false,
+          fixes:       [{ description: `Unset \`${ variable }\`.` }],
+        });
+      }
+    }
+
+    const settings = await mainEvents.invoke('settings-fetch');
+    const useDefaultContext = process.platform === 'win32' || settings.application.adminAccess;
+    const currentContext = await dockerDirManager.currentDockerContext ?? 'default';
+    const desiredContext = useDefaultContext
+      ? 'default'
+      : await dockerDirManager.getDesiredDockerContext(settings.application.adminAccess, currentContext);
+
+    if (currentContext !== desiredContext) {
+      results.push({
+        id:          'DOCKER_CONTEXT',
+        description: `Docker context is currently \`${ currentContext }\` instead of \`${ desiredContext }\`.`,
+        passed:      false,
+        fixes:       [{
+          description: `Run \`docker context use ${ desiredContext }\``,
+        }],
+      });
+    } else {
+      results.push({
+        id:          'DOCKER_CONTEXT',
+        description: `Correctly using context \`${ currentContext }\``,
+        passed:      true,
+        fixes:       [],
+      });
+    }
+
+    return results;
+  },
+};
+
+export default dockerContextChecker;

--- a/pkg/rancher-desktop/utils/__tests__/dockerDirManager.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/dockerDirManager.spec.ts
@@ -8,7 +8,6 @@ import { jest } from '@jest/globals';
 import mockModules from '../testUtils/mockModules';
 
 import * as childProcess from '@pkg/utils/childProcess';
-import type DockerDirManager from '@pkg/utils/dockerDirManager';
 import paths from '@pkg/utils/paths';
 
 const spawnFile = childProcess.spawnFile;
@@ -34,11 +33,11 @@ const itUnix = os.platform() === 'win32' ? it.skip : it;
 const itDarwin = os.platform() === 'darwin' ? it : it.skip;
 const itLinux = os.platform() === 'linux' ? it : it.skip;
 const describeUnix = os.platform() === 'win32' ? describe.skip : describe;
-const { default: DockerDirManagerCtor } = await import('@pkg/utils/dockerDirManager');
+const { DockerDirManager } = await import('@pkg/utils/dockerDirManager');
 
 describe('DockerDirManager', () => {
   /** The instance of LimaBackend under test. */
-  let subj: DockerDirManager;
+  let subj: InstanceType<typeof DockerDirManager>;
   /** A directory we can use for scratch files during the test. */
   let workdir: string;
 
@@ -46,7 +45,7 @@ describe('DockerDirManager', () => {
     modules['@pkg/utils/childProcess'].spawnFile.mockImplementation(spawnFile);
     await expect((async() => {
       workdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rancher-desktop-lima-test-'));
-      subj = new DockerDirManagerCtor(path.join(workdir, '.docker'));
+      subj = new DockerDirManager(path.join(workdir, '.docker'));
     })()).resolves.toBeUndefined();
   });
   afterEach(async() => {

--- a/pkg/rancher-desktop/utils/__tests__/dockerDirManager.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/dockerDirManager.spec.ts
@@ -19,6 +19,7 @@ const modules = mockModules({
   '@pkg/utils/logging': {
     background: {
       debug: jest.fn(),
+      error: jest.fn(),
       /** Mocked console.log() to check messages. */
       log:   jest.fn(),
     },

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -6,6 +6,7 @@ import yaml from 'yaml';
 
 import paths from './paths';
 
+import mainEvents from '@pkg/main/mainEvents';
 import { spawnFile } from '@pkg/utils/childProcess';
 import clone from '@pkg/utils/clone';
 import Logging from '@pkg/utils/logging';
@@ -143,7 +144,7 @@ export class DockerDirManager {
    * @param currentContext The current context.
    * @returns Undefined for default context; string containing context name for other contexts.
    */
-  protected async getDesiredDockerContext(weOwnDefaultSocket: boolean, currentContext: string | undefined): Promise<string | undefined> {
+  async getDesiredDockerContext(weOwnDefaultSocket: boolean, currentContext: string | undefined): Promise<string | undefined> {
     if (weOwnDefaultSocket) {
       return undefined;
     }
@@ -318,6 +319,13 @@ export class DockerDirManager {
   }
 
   /**
+   * Return the current docker context.
+   */
+  get currentDockerContext(): Promise<string | undefined> {
+    return this.readDockerConfig().then(cfg => cfg.currentContext);
+  }
+
+  /**
    * Clear the docker context if we changed it for running without admin privileges
    */
   async clearDockerContext(): Promise<void> {
@@ -364,6 +372,9 @@ export class DockerDirManager {
     if (JSON.stringify(newConfig) !== JSON.stringify(currentConfig)) {
       await this.writeDockerConfig(newConfig);
     }
+
+    // Trigger diagnostics, ignoring results.
+    mainEvents.invoke('diagnostics-trigger', 'DOCKER_CONTEXT').catch(e => console.error(e));
   }
 
   /**

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -40,7 +40,7 @@ interface PartialDockerConfig {
  * Manages everything under the docker CLI config directory (except, at
  * the time of writing, docker CLI plugins).
  */
-export default class DockerDirManager {
+export class DockerDirManager {
   protected readonly dockerDirPath:        string;
   protected readonly dockerContextDirPath: string;
   /**
@@ -385,3 +385,8 @@ export default class DockerDirManager {
     }
   }
 }
+
+/**
+ * Export a singleton instance of the docker dir manager by default.
+ */
+export default new DockerDirManager(path.join(os.homedir(), '.docker'));


### PR DESCRIPTION
This checks the docker context to ensure it is set correctly.

Fixes #7783

This also makes `dockerDirManager` a singleton because that's how it's used anyway; makes this cleaner.