### PR TITLE
dependabot: allow bumping vue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,6 @@ updates:
   - # Needs to be updated along with NodeJS version.
     dependency-name: "@types/node"
     update-types: [version-update:semver-major]
-  - # Need to migrate to Vue 3 before moving beyond 2.7.x.
-    dependency-name: "vue"
-    versions: [">2"]
-  - # @vue/test-utils v2 is for Vue 3; we're on Vue 2 for now
-    dependency-name: "@vue/test-utils"
-    versions: [">1"]
   - # node-fetch 3+ requires ECMAScript modules; we still have issues with them.
     dependency-name: "node-fetch"
     versions: [">2"]


### PR DESCRIPTION
We are now on Vue 3, so we can bump it at will.  This also means we can bump `@vue/test-utils`.