### PR TITLE
dependencies: bump fs-xattr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,9 +36,6 @@ updates:
     # ignore until we arrive a solution that uses it.
     dependency-name: "@rancher/shell"
     versions: [">0.1"]
-  - # fs-xattr 0.4.0 later are esm-only.
-    dependency-name: "fs-xattr"
-    versions: [">0.3"]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "optionalDependencies": {
     "dmg-license": "1.0.11",
-    "fs-xattr": "0.3.1",
+    "fs-xattr": "0.4.0",
     "posix-node": "0.12.0"
   },
   "browserslist": [

--- a/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/manageLinesInFile.spec.ts
@@ -83,22 +83,22 @@ describe('manageLinesInFile', () => {
     testUnix('Preserves extended attributes', async() => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This only fails on Windows
       // @ts-ignore // fs-xattr is not available on Windows.
-      const { get, list, set } = await import('fs-xattr');
+      const { listAttributes, getAttribute, setAttribute } = await import('fs-xattr');
 
       const unmanagedContents = 'existing lines\n';
       const attributeKey = 'user.io.rancherdesktop.test';
       const attributeValue = 'sample attribute contents';
 
       await fs.promises.writeFile(rcFilePath, unmanagedContents);
-      await set(rcFilePath, attributeKey, attributeValue);
+      await setAttribute(rcFilePath, attributeKey, attributeValue);
       await expect(manageLinesInFile(rcFilePath, [TEST_LINE_1], true)).resolves.not.toThrow();
 
-      const allAttrs: string[] = await list(rcFilePath);
+      const allAttrs: string[] = await listAttributes(rcFilePath);
       // filter out attributes like com.apple.provenance that the OS might add
       const filteredAttrs = allAttrs.filter(item => !item.startsWith('com.apple.'));
 
       expect(filteredAttrs).toEqual([attributeKey]);
-      await expect(get(rcFilePath, attributeKey)).resolves.toEqual(Buffer.from(attributeValue, 'utf-8'));
+      await expect(getAttribute(rcFilePath, attributeKey)).resolves.toEqual(Buffer.from(attributeValue, 'utf-8'));
     });
 
     test('Delete file when false and it contains only the managed lines', async() => {
@@ -123,8 +123,8 @@ describe('manageLinesInFile', () => {
       if (process.platform !== 'win32') {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This only fails on Windows
         // @ts-ignore // fs-xattr is not available on Windows.
-        const { list } = await import('fs-xattr');
-        const allAttrs: string[] = await list(rcFilePath);
+        const { listAttributes } = await import('fs-xattr');
+        const allAttrs: string[] = await listAttributes(rcFilePath);
         // filter out attributes like com.apple.provenance that the OS might add
         const filteredAttrs = allAttrs.filter(item => !item.startsWith('com.apple.'));
 

--- a/pkg/rancher-desktop/integrations/manageLinesInFile.ts
+++ b/pkg/rancher-desktop/integrations/manageLinesInFile.ts
@@ -155,12 +155,12 @@ async function copyFileExtendedAttributes(fromPath: string, toPath: string): Pro
   try {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This only fails on Windows
     // @ts-ignore // fs-xattr is not available on Windows
-    const { list, get, set } = await import('fs-xattr');
+    const { listAttributes, getAttribute, setAttribute } = await import('fs-xattr');
 
-    for (const attr of await list(fromPath)) {
-      const value = await get(fromPath, attr);
+    for (const attr of await listAttributes(fromPath)) {
+      const value = await getAttribute(fromPath, attr);
 
-      await set(toPath, attr, value);
+      await setAttribute(toPath, attr, value);
     }
   } catch (cause) {
     if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6801,10 +6801,10 @@ fs-monkey@^1.0.4:
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.6.tgz#8ead082953e88d992cf3ff844faa907b26756da2"
   integrity sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==
 
-fs-xattr@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/fs-xattr/-/fs-xattr-0.3.1.tgz#a23d88571031f6c56f26d59e0bab7d2e12f49f77"
-  integrity sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==
+fs-xattr@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/fs-xattr/-/fs-xattr-0.4.0.tgz#30797399631287b740994a0bfab7822295e5f482"
+  integrity sha512-Lw90zx483YTGiHfR67IPtrbrZ+yBr1/W98v/iyTeSkUbixg/wrHfX5x9oMUOnirC5P7SZ5HlrpnIRMMqt8Ej0A==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -11166,16 +11166,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11198,7 +11189,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11211,13 +11202,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12238,7 +12222,7 @@ word-wrap@^1.2.5, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12254,15 +12238,6 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
It was blocked due to using ES modules, which we can use now.