### PR TITLE
build(deps): bump core-js from 3.25.3 to 3.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@xterm/xterm": "5.5.0",
     "async-mutex": "^0.5.0",
     "cookie-universal": "2.2.2",
-    "core-js": "3.25.3",
+    "core-js": "3.44.0",
     "cross-spawn": "7.0.6",
     "dayjs": "1.11.13",
     "dompurify": "3.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,15 +5243,10 @@ core-js-compat@^3.40.0, core-js-compat@^3.44.0, core-js-compat@^3.8.3:
   dependencies:
     browserslist "^4.25.1"
 
-core-js@3.25.3:
-  version "3.25.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.3.tgz#cbc2be50b5ddfa7981837bd8c41639f27b166593"
-  integrity sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==
-
-core-js@^3.8.3:
-  version "3.41.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.41.0.tgz#57714dafb8c751a6095d028a7428f1fb5834a776"
-  integrity sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==
+core-js@3.44.0, core-js@^3.8.3:
+  version "3.44.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.44.0.tgz#db4fd4fa07933c1d6898c8b112a1119a9336e959"
+  integrity sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==
 
 core-util-is@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is a duplicate of #8970 that is not being managed by dependabot, so hopefully won't be closed automatically.

---
Bumps [core-js](https://github.com/zloirock/core-js/tree/HEAD/packages/core-js) from 3.25.3 to 3.44.0.
- [Release notes](https://github.com/zloirock/core-js/releases)
- [Changelog](https://github.com/zloirock/core-js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/zloirock/core-js/commits/v3.44.0/packages/core-js)

---
updated-dependencies:
- dependency-name: core-js dependency-version: 3.44.0 dependency-type: direct:production update-type: version-update:semver-minor ...