### PR TITLE
fix `Could not dispose an addon that has not been loaded` error

### DIFF
--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -185,16 +185,16 @@ export default defineComponent({
           window.removeEventListener('resize', this.resizeHandler);
           this.resizeHandler = null;
         }
-        
+
         if (this.searchAddon) {
           this.searchAddon.clearDecorations();
           this.searchAddon = null;
         }
-        
+
         if (this.fitAddon) {
           this.fitAddon = null;
         }
-        
+
         this.terminal.dispose();
         this.terminal = null;
       } catch (error) {

--- a/pkg/rancher-desktop/pages/containers/logs/_id.vue
+++ b/pkg/rancher-desktop/pages/containers/logs/_id.vue
@@ -179,7 +179,28 @@ export default defineComponent({
   beforeUnmount() {
     this.stopStreaming();
     this.stopContainerChecking();
-    this.terminal?.dispose();
+    if (this.terminal) {
+      try {
+        if (this.resizeHandler) {
+          window.removeEventListener('resize', this.resizeHandler);
+          this.resizeHandler = null;
+        }
+        
+        if (this.searchAddon) {
+          this.searchAddon.clearDecorations();
+          this.searchAddon = null;
+        }
+        
+        if (this.fitAddon) {
+          this.fitAddon = null;
+        }
+        
+        this.terminal.dispose();
+        this.terminal = null;
+      } catch (error) {
+        console.error('Error disposing terminal:', error);
+      }
+    }
     ipcRenderer.off('settings-read', this.onSettingsRead);
     window.removeEventListener('keydown', this.handleGlobalKeydown);
     if (this.resizeHandler) {


### PR DESCRIPTION
When navigating in to a container logs page, and then clicking the back arrow I was getting this error