### PR TITLE
scripts: Update moby openapi path

### DIFF
--- a/scripts/dependencies/moby-openapi.ts
+++ b/scripts/dependencies/moby-openapi.ts
@@ -15,7 +15,7 @@ export class MobyOpenAPISpec extends GlobalDependency(VersionedDependency) {
   readonly releaseFilter = 'custom';
 
   async download(context: DownloadContext): Promise<void> {
-    const baseUrl = `https://raw.githubusercontent.com/${ this.githubOwner }/${ this.githubRepo }/master/docs/api`;
+    const baseUrl = `https://raw.githubusercontent.com/${ this.githubOwner }/${ this.githubRepo }/master/api/docs`;
     const url = `${ baseUrl }/v${ context.versions.mobyOpenAPISpec }.yaml`;
     const outPath = path.join(process.cwd(), 'src', 'go', 'wsl-helper', 'pkg', 'dockerproxy', 'swagger.yaml');
 
@@ -36,7 +36,7 @@ export class MobyOpenAPISpec extends GlobalDependency(VersionedDependency) {
 
   async getAvailableVersions(): Promise<string[]> {
     // get list of files in repo directory
-    const githubPath = 'docs/api';
+    const githubPath = 'api/docs';
     const args = {
       owner: this.githubOwner, repo: this.githubRepo, path: githubPath,
     };


### PR DESCRIPTION
It was moved around in their repository.

https://github.com/moby/moby/commit/4d5a7289a0e0513a7f1a58567af6151ea6e84a8e