### PR TITLE
Fix containerd exit event

### DIFF
--- a/src/go/guestagent/main.go
+++ b/src/go/guestagent/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	var portTracker tracker.Tracker
 
-	wslProxyForwarder := forwarder.NewWSLProxyForwarder("/run/wsl-proxy.sock")
+	wslProxyForwarder := forwarder.NewWSLProxyForwarder(ctx, "/run/wsl-proxy.sock")
 	portTracker = tracker.NewAPITracker(ctx, wslProxyForwarder, tracker.GatewayBaseURL, *tapIfaceIP, *adminInstall)
 	// Manually register the port for K8s API, we would
 	// only want to send this manual port mapping if both

--- a/src/go/guestagent/pkg/forwarder/wslproxy.go
+++ b/src/go/guestagent/pkg/forwarder/wslproxy.go
@@ -16,8 +16,10 @@ limitations under the License.
 package forwarder
 
 import (
+	"context"
 	"encoding/json"
 	"net"
+	"time"
 
 	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/types"
 )
@@ -27,18 +29,22 @@ import (
 // For more information on Rancher Desktop WSL Proxy, refer to the source code at:
 // https://github.com/rancher-sandbox/rancher-desktop/blob/main/src/go/networking/cmd/proxy/wsl_integration_linux.go
 type WSLProxyForwarder struct {
+	ctx         context.Context
+	dialer      net.Dialer
 	proxySocket string
 }
 
-func NewWSLProxyForwarder(proxySocket string) *WSLProxyForwarder {
+func NewWSLProxyForwarder(ctx context.Context, proxySocket string) *WSLProxyForwarder {
 	return &WSLProxyForwarder{
+		ctx:         ctx,
+		dialer:      net.Dialer{Timeout: 5 * time.Second},
 		proxySocket: proxySocket,
 	}
 }
 
 // Send forwards the port mappings to WSL Proxy.
 func (v *WSLProxyForwarder) Send(portMapping types.PortMapping) error {
-	conn, err := net.Dial("unix", v.proxySocket)
+	conn, err := v.dialer.DialContext(v.ctx, "unix", v.proxySocket)
 	if err != nil {
 		return err
 	}

--- a/src/go/networking/cmd/proxy/wsl_integration_linux.go
+++ b/src/go/networking/cmd/proxy/wsl_integration_linux.go
@@ -15,6 +15,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"net"
 	"os"
@@ -53,6 +54,9 @@ func main() {
 
 	setupLogging(logFile)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	socket, err := net.Listen("unix", socketFile)
 	if err != nil {
 		logrus.Fatalf("failed to create listener for published ports: %s", err)
@@ -62,7 +66,7 @@ func main() {
 		UpstreamAddress: upstreamAddr,
 		UDPBufferSize:   udpBuffer,
 	}
-	proxy := portproxy.NewPortProxy(socket, proxyConfig)
+	proxy := portproxy.NewPortProxy(ctx, socket, proxyConfig)
 
 	// Handle graceful shutdown
 	sigCh := make(chan os.Signal, 1)

--- a/src/go/networking/pkg/portproxy/server_test.go
+++ b/src/go/networking/pkg/portproxy/server_test.go
@@ -54,7 +54,7 @@ func TestNewPortProxyUDP(t *testing.T) {
 		UpstreamAddress: testServerIP,
 		UDPBufferSize:   1024,
 	}
-	portProxy := portproxy.NewPortProxy(localListener, proxyConfig)
+	portProxy := portproxy.NewPortProxy(context.Background(), localListener, proxyConfig)
 	go portProxy.Start()
 
 	_, testPort, err := net.SplitHostPort(targetConn.LocalAddr().String())
@@ -138,7 +138,7 @@ func TestNewPortProxyTCP(t *testing.T) {
 	proxyConfig := &portproxy.ProxyConfig{
 		UpstreamAddress: testServerIP,
 	}
-	portProxy := portproxy.NewPortProxy(localListener, proxyConfig)
+	portProxy := portproxy.NewPortProxy(context.Background(), localListener, proxyConfig)
 	go portProxy.Start()
 
 	getURL := fmt.Sprintf("http://localhost:%s", testPort)
@@ -217,7 +217,10 @@ func marshalAndSend(listener net.Listener, portMapping types.PortMapping) error 
 	if err != nil {
 		return err
 	}
-	c, err := net.Dial(listener.Addr().Network(), listener.Addr().String())
+	testDialer := net.Dialer{
+		Timeout: 5 * time.Second,
+	}
+	c, err := testDialer.DialContext(context.Background(), listener.Addr().Network(), listener.Addr().String())
 	if err != nil {
 		return err
 	}

--- a/src/go/networking/pkg/utils/pipe.go
+++ b/src/go/networking/pkg/utils/pipe.go
@@ -15,14 +15,19 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"io"
 	"net"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
 
-func Pipe(conn net.Conn, upstreamAddr string) {
-	upstream, err := net.Dial("tcp", upstreamAddr)
+func Pipe(ctx context.Context, conn net.Conn, upstreamAddr string) {
+	dialer := net.Dialer{
+		Timeout: 5 * time.Second,
+	}
+	upstream, err := dialer.DialContext(ctx, "tcp", upstreamAddr)
 	if err != nil {
 		logrus.Errorf("Failed to dial upstream %s: %s", upstreamAddr, err)
 		return

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_unix.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_unix.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 )
 
-func CheckProcessWindows() (bool, error) {
+func CheckProcessWindows(ctx context.Context) (bool, error) {
 	return false, fmt.Errorf("internal error: CheckProcessWindows shouldn't be called")
 }
 

--- a/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
+++ b/src/go/rdctl/pkg/factoryreset/factory_reset_windows.go
@@ -39,8 +39,8 @@ import (
 //
 // It does this by calling `tasklist`, the Windows answer to ps(1)
 
-func CheckProcessWindows() (bool, error) {
-	cmd := exec.Command("tasklist", "/NH", "/FI", "IMAGENAME eq Rancher Desktop.exe", "/FO", "CSV")
+func CheckProcessWindows(ctx context.Context) (bool, error) {
+	cmd := exec.CommandContext(ctx, "tasklist", "/NH", "/FI", "IMAGENAME eq Rancher Desktop.exe", "/FO", "CSV")
 	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 	allOutput, err := cmd.CombinedOutput()
 	if err != nil {

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,7 +338,7 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.27.6"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.26.10", "@babel/parser@^7.26.9", "@babel/parser@^7.27.0", "@babel/parser@^7.27.2", "@babel/parser@^7.27.5", "@babel/parser@^7.28.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.26.10", "@babel/parser@^7.26.9", "@babel/parser@^7.27.0", "@babel/parser@^7.27.2", "@babel/parser@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.0.tgz#979829fbab51a29e13901e5a80713dbcb840825e"
   integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
@@ -3638,17 +3638,6 @@
     semver "^7.3.4"
     strip-ansi "^6.0.0"
 
-"@vue/compiler-core@3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.17.tgz#23d291bd01b863da3ef2e26e7db84d8e01a9b4c5"
-  integrity sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==
-  dependencies:
-    "@babel/parser" "^7.27.5"
-    "@vue/shared" "3.5.17"
-    entities "^4.5.0"
-    estree-walker "^2.0.2"
-    source-map-js "^1.2.1"
-
 "@vue/compiler-core@3.5.18":
   version "3.5.18"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.18.tgz#521a138cdd970d9bfd27e42168d12f77a04b2074"
@@ -3660,14 +3649,6 @@
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
-"@vue/compiler-dom@3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz#7bc19a20e23b670243a64b47ce3a890239b870be"
-  integrity sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==
-  dependencies:
-    "@vue/compiler-core" "3.5.17"
-    "@vue/shared" "3.5.17"
-
 "@vue/compiler-dom@3.5.18":
   version "3.5.18"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz#e13504492c3061ec5bbe6a2e789f15261d4f03a7"
@@ -3675,21 +3656,6 @@
   dependencies:
     "@vue/compiler-core" "3.5.18"
     "@vue/shared" "3.5.18"
-
-"@vue/compiler-sfc@3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz#c518871276e26593612bdab36f3f5bcd053b13bf"
-  integrity sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==
-  dependencies:
-    "@babel/parser" "^7.27.5"
-    "@vue/compiler-core" "3.5.17"
-    "@vue/compiler-dom" "3.5.17"
-    "@vue/compiler-ssr" "3.5.17"
-    "@vue/shared" "3.5.17"
-    estree-walker "^2.0.2"
-    magic-string "^0.30.17"
-    postcss "^8.5.6"
-    source-map-js "^1.2.1"
 
 "@vue/compiler-sfc@3.5.18", "@vue/compiler-sfc@^3.5.13":
   version "3.5.18"
@@ -3705,14 +3671,6 @@
     magic-string "^0.30.17"
     postcss "^8.5.6"
     source-map-js "^1.2.1"
-
-"@vue/compiler-ssr@3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz#14ba3b7bba6e0e1fd02002316263165a5d1046c7"
-  integrity sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==
-  dependencies:
-    "@vue/compiler-dom" "3.5.17"
-    "@vue/shared" "3.5.17"
 
 "@vue/compiler-ssr@3.5.18":
   version "3.5.18"
@@ -3808,11 +3766,6 @@
   dependencies:
     "@vue/compiler-ssr" "3.5.18"
     "@vue/shared" "3.5.18"
-
-"@vue/shared@3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.17.tgz#e8b3a41f0be76499882a89e8ed40d86a70fa4b70"
-  integrity sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==
 
 "@vue/shared@3.5.18", "@vue/shared@^3.5.13":
   version "3.5.18"


### PR DESCRIPTION
Exiting from `nerdctl exec` also triggers an exit event. Therefore, it's important to verify the container's status to ensure it's still running before removing its port binding.