### PR TITLE
Fix containerd exit event

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -245,6 +245,7 @@ entrypoints
 epinio
 EPONY
 ERRFILE
+errdefs
 errgroup
 Errorln
 Errorw


### PR DESCRIPTION
Exiting from `nerdctl exec` also triggers an exit event. Therefore, it's important to verify the container's status to ensure it's still running before removing its port binding.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/9034