### PR TITLE
Fixes UDP BATS test for containerd

### DIFF
--- a/bats/tests/containers/published-udp-ports.bats
+++ b/bats/tests/containers/published-udp-ports.bats
@@ -5,7 +5,7 @@ load '../helpers/load'
 }
 
 build_alpine_socat_image() {
-    cat <<EOF | docker build -t socat-udp-test -f- .
+    cat <<EOF | ctrctl build -t socat-udp-test -f- .
 FROM ${IMAGE_ALPINE}
 RUN apk add --no-cache socat
 CMD ["sh", "-c", "socat -v -T1 UDP-RECVFROM:\${PORT},fork STDOUT"]

--- a/src/go/guestagent/pkg/containerd/events_linux.go
+++ b/src/go/guestagent/pkg/containerd/events_linux.go
@@ -303,6 +303,7 @@ func execIptablesRules(ctx context.Context, portMappings nat.PortMap, containerI
 					namespace,
 					pid,
 					portProto.Port(),
+					portProto.Proto(),
 					portBinding.HostPort)
 				if err != nil {
 					errs = append(errs, err)
@@ -333,7 +334,7 @@ func execIptablesRules(ctx context.Context, portMappings nat.PortMap, containerI
 // After the existing rule, the following new rule is added:
 //
 //	DNAT       tcp  --  anywhere             anywhere             tcp dpt:9119 to:10.4.0.22:80.
-func createLoopbackIPtablesRules(ctx context.Context, networks []string, containerID, namespace, pid, port, destinationPort string) error {
+func createLoopbackIPtablesRules(ctx context.Context, networks []string, containerID, namespace, pid, port, protocol, destinationPort string) error {
 	eth0IP, err := extractIPAddress(pid)
 	if err != nil {
 		return err
@@ -363,7 +364,7 @@ func createLoopbackIPtablesRules(ctx context.Context, networks []string, contain
 			"iptables",
 			"--table", "nat",
 			"--append", chainName,
-			"--protocol", "tcp",
+			"--protocol", protocol,
 			"--destination", "0.0.0.0/0",
 			"--jump", "DNAT",
 			"--dport", destinationPort,


### PR DESCRIPTION
Fixes the UDP test for Windows when running with containerd.
- Fixes the hardcoded docker that was used during building the image
- An iptables rule was always being created for TCP when hostIP was set to localhost. This has been fixed to correctly pass the protocol, ensuring that the iptables rule is created according to the specified protocol.

Fixes windows: https://github.com/rancher-sandbox/rancher-desktop/issues/8884