### PR TITLE
Diagnostics: refresh vuex store on run

### DIFF
--- a/pkg/rancher-desktop/components/DiagnosticsButtonRun.vue
+++ b/pkg/rancher-desktop/components/DiagnosticsButtonRun.vue
@@ -41,9 +41,7 @@ export default defineComponent({
   },
   methods: {
     async onClick() {
-      const credentials = await this.$store.dispatch('credentials/fetchCredentials');
-
-      await this.$store.dispatch('diagnostics/runDiagnostics', credentials);
+      await this.$store.dispatch('diagnostics/runDiagnostics');
     },
   },
 });

--- a/pkg/rancher-desktop/entry/store.ts
+++ b/pkg/rancher-desktop/entry/store.ts
@@ -1,4 +1,4 @@
-import { createStore } from 'vuex';
+import { createStore, ModuleTree, Plugin } from 'vuex';
 
 import * as ActionMenu from '../store/action-menu';
 import * as ApplicationSettings from '../store/applicationSettings';
@@ -15,21 +15,24 @@ import * as ResourceFetch from '../store/resource-fetch';
 import * as Snapshots from '../store/snapshots';
 import * as TransientSettings from '../store/transientSettings';
 
+const modules: Record<string, ModuleTree<any> & { plugins?: Plugin<any>[] }> = {
+  'action-menu':       ActionMenu,
+  applicationSettings: ApplicationSettings,
+  credentials:         Credentials,
+  diagnostics:         Diagnostics,
+  extensions:          Extensions,
+  i18n:                I18n,
+  imageManager:        ImageManager,
+  k8sManager:          K8sManager,
+  page:                Page,
+  preferences:         Preferences,
+  prefs:               Prefs,
+  'resource-fetch':    ResourceFetch,
+  snapshots:           Snapshots,
+  transientSettings:   TransientSettings,
+};
+
 export default createStore<any>({
-  modules: {
-    'action-menu':       { namespaced: true, ...ActionMenu },
-    applicationSettings: { namespaced: true, ...ApplicationSettings },
-    credentials:         { namespaced: true, ...Credentials },
-    diagnostics:         { namespaced: true, ...Diagnostics },
-    extensions:          { namespaced: true, ...Extensions },
-    i18n:                { namespaced: true, ...I18n },
-    imageManager:        { namespaced: true, ...ImageManager },
-    k8sManager:          { namespaced: true, ...K8sManager },
-    page:                { namespaced: true, ...Page },
-    preferences:         { namespaced: true, ...Preferences },
-    prefs:               { namespaced: true, ...Prefs },
-    'resource-fetch':    { namespaced: true, ...ResourceFetch },
-    snapshots:           { namespaced: true, ...Snapshots },
-    transientSettings:   { namespaced: true, ...TransientSettings },
-  },
+  modules: Object.fromEntries(Object.entries(modules).map(([k, v]) => [k, { namespaced: true, ...v }])),
+  plugins: Object.values(modules).flatMap(v => v.plugins ?? []),
 });

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -159,7 +159,7 @@ export default {
         return;
       }
       await this.$store.dispatch('preferences/fetchPreferences', this.credentials);
-      await this.$store.dispatch('diagnostics/fetchDiagnostics', this.credentials);
+      await this.$store.dispatch('diagnostics/fetchDiagnostics');
     },
 
     openDashboard() {

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -2,6 +2,7 @@ import { DiagnosticsCategory, DiagnosticsChecker, DiagnosticsCheckerResult, Diag
 
 import mainEvents from '@pkg/main/mainEvents';
 import Logging from '@pkg/utils/logging';
+import { send } from '@pkg/window';
 
 const console = Logging.diagnostics;
 
@@ -39,6 +40,8 @@ export class DiagnosticsManager {
 
   /** Last known check results, indexed by the checker id. */
   results: Record<DiagnosticsChecker['id'], DiagnosticsCheckerResult | DiagnosticsCheckerSingleResult[]> = {};
+
+  updateTimeout: ReturnType<typeof setTimeout> | undefined;
 
   /** Mapping of category name to diagnostic ids */
   readonly checkerIdByCategory: Partial<Record<DiagnosticsCategory, string[]>> = {};
@@ -171,6 +174,11 @@ export class DiagnosticsManager {
     } catch (e) {
       console.error(`ERROR checking ${ checker.id }`, { e });
     }
+
+    if (this.updateTimeout !== undefined) {
+      clearTimeout(this.updateTimeout);
+    }
+    this.updateTimeout = setTimeout(() => send('diagnostics/update'), 500);
   }
 
   /**

--- a/pkg/rancher-desktop/pages/Diagnostics.vue
+++ b/pkg/rancher-desktop/pages/Diagnostics.vue
@@ -14,7 +14,7 @@ export default defineComponent({
     const credentials = await this.$store.dispatch('credentials/fetchCredentials');
 
     await this.$store.dispatch('preferences/fetchPreferences', credentials);
-    await this.$store.dispatch('diagnostics/fetchDiagnostics', credentials);
+    await this.$store.dispatch('diagnostics/fetchDiagnostics');
   },
   mounted() {
     this.$store.dispatch(

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -194,6 +194,7 @@ export interface IpcRendererEvents {
     failureDetails: import('@pkg/backend/k8s').FailureDetails
   ) => void;
   'update-network-status': (status: boolean) => void;
+  'diagnostics/update':    () => void;
 
   // #region Images
   'images-process-cancelled': () => void;


### PR DESCRIPTION
This triggers an event shortly after the diagnostics are run; the event then causes the diagnostics vuex store to fetch the results again. Since the latter doesn't have credentials, just use the credentials store instead of requiring the caller to pass it in.

Fixes https://github.com/rancher-sandbox/rancher-desktop/pull/8933#issuecomment-3120484578