### PR TITLE
implement collapsing for container groups & other container grouping improvements

### DIFF
--- a/pkg/rancher-desktop/components/DiagnosticsBody.vue
+++ b/pkg/rancher-desktop/components/DiagnosticsBody.vue
@@ -262,6 +262,17 @@ export default defineComponent({
     }
 
     .group-row {
+      font-weight: bold;
+
+      .group-tab {
+        i {
+          cursor: pointer;
+          &:hover {
+            color: var(--primary);
+          }
+        }
+      }
+
       .col-description {
         font-weight: bold;
         .group-tab {

--- a/pkg/rancher-desktop/components/SortableTable/grouping.js
+++ b/pkg/rancher-desktop/components/SortableTable/grouping.js
@@ -9,6 +9,23 @@ export default {
       return this.groupOptions?.find((go) => go.value === this.group);
     },
 
+    /**
+     * Group counts based on all filtered rows (before collapse filtering)
+     */
+    groupCounts() {
+      const groupKey = this.groupBy;
+      if (!groupKey) {
+        return {};
+      }
+
+      const counts = {};
+      for (const obj of this.filteredRows) {
+        const key = get(obj, groupKey) || '';
+        counts[key] = (counts[key] || 0) + 1;
+      }
+      return counts;
+    },
+
     groupedRows() {
       const groupKey = this.groupBy;
       const refKey = this.groupRef || this.selectedGroupOption?.groupLabelKey || groupKey;

--- a/pkg/rancher-desktop/components/SortableTable/index.vue
+++ b/pkg/rancher-desktop/components/SortableTable/index.vue
@@ -110,6 +110,11 @@ export default {
       type:    Array,
       default: null,
     },
+    collapsedGroups: {
+      // Object tracking which groups are collapsed, e.g. { "group1": false }
+      type:    Object,
+      default: () => ({}),
+    },
 
     defaultSortBy: {
       // Default field to sort by if none is specified
@@ -1276,6 +1281,7 @@ export default {
           name="group-row"
           :group="groupedRows"
           :full-colspan="fullColspan"
+          :group-counts="groupCounts"
         >
           <tr class="group-row">
             <td :colspan="fullColspan">

--- a/pkg/rancher-desktop/components/SortableTable/paging.js
+++ b/pkg/rancher-desktop/components/SortableTable/paging.js
@@ -2,12 +2,32 @@ import { ROWS_PER_PAGE } from '@pkg/store/prefs';
 
 export default {
   computed: {
+    collapsedFilteredRows() {
+      if (!this.groupBy || Object.keys(this.collapsedGroups).length === 0) {
+        return this.filteredRows;
+      }
+
+      const seenGroups = new Set();
+
+      return this.filteredRows.filter(row => {
+        const groupKey = row[this.groupBy];
+        const isCollapsed = this.collapsedGroups[groupKey] === false;
+
+        if (!seenGroups.has(groupKey)) {
+          seenGroups.add(groupKey);
+          return true;
+        }
+
+        return !isCollapsed;
+      });
+    },
+
     totalRows() {
       if (this.externalPaginationEnabled) {
         return this.externalPaginationResult?.count || 0;
       }
 
-      return this.filteredRows.length;
+      return this.collapsedFilteredRows.length;
     },
 
     indexFrom() {
@@ -53,9 +73,9 @@ export default {
       if (this.externalPaginationEnabled) {
         return this.rows;
       } else if ( this.paging ) {
-        return this.filteredRows.slice(this.indexFrom - 1, this.indexTo);
+        return this.collapsedFilteredRows.slice(this.indexFrom - 1, this.indexTo);
       } else {
-        return this.filteredRows;
+        return this.collapsedFilteredRows;
       }
     },
   },

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -21,6 +21,7 @@
       :loading="!containersList"
       group-by="projectGroup"
       :group-sort="['projectGroup']"
+      :collapsed-groups="expanded"
     >
       <template #header-middle>
         <div class="header-middle">
@@ -102,11 +103,25 @@
           </div>
         </td>
       </template>
-      <template #group-row="{ group }">
-        <tr class="group-row">
+      <template #group-row="{ group, groupCounts }">
+        <tr
+          :ref="`group-${group.ref}`"
+          class="group-row"
+          :aria-expanded="expanded[group.ref] !== false"
+        >
           <td :colspan="headers.length + 1">
             <div class="group-tab">
-              {{ group.ref }} ({{ group.rows.length }})
+              <i
+                data-title="Toggle Expand"
+                :class="{
+                  icon: true,
+                  'icon-chevron-right': expanded[group.ref] === false,
+                  'icon-chevron-down': expanded[group.ref] !== false,
+                }"
+                @click.stop="toggleExpand(group.ref)"
+              />
+              {{ group.ref }}
+              <span v-if="expanded[group.ref] === false"> ({{ groupCounts[group.ref] || group.rows.length }})</span>
             </div>
           </td>
         </tr>
@@ -145,6 +160,7 @@ export default defineComponent({
       showRunning:          false,
       containersNamespaces: [],
       error:                null,
+      expanded:             {},
       headers:              [
         // INFO: Disable for now since we can only get the running containers.
         {
@@ -541,6 +557,13 @@ export default defineComponent({
         return shell.openExternal(`http://localhost:${ hostPort }`);
       }
     },
+    toggleExpand(group) {
+      if (this.expanded[group] === undefined) {
+        this.expanded[group] = false;
+      } else {
+        this.expanded[group] = !this.expanded[group];
+      }
+    },
   },
 });
 </script>
@@ -608,5 +631,25 @@ export default defineComponent({
 .port-container {
   display: flex;
   gap: 5px;
+}
+
+.group-row {
+  font-weight: bold;
+
+  .group-tab {
+
+    i {
+      cursor: pointer;
+      &:hover {
+        color: var(--primary);
+      }
+    }
+  }
+
+  &[aria-expanded="false"] {
+    :deep(~ .main-row) {
+      display: none;
+    }
+  }
 }
 </style>

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -160,7 +160,7 @@ export default defineComponent({
       showRunning:          false,
       containersNamespaces: [],
       error:                null,
-      expanded:             {},
+      expanded:             { 'Kubernetes System': false },
       headers:              [
         // INFO: Disable for now since we can only get the running containers.
         {
@@ -228,7 +228,11 @@ export default defineComponent({
         const composeProject = container.Labels?.['com.docker.compose.project'];
 
         if (k8sPodName && k8sNamespace) {
-          container.projectGroup = `${ k8sNamespace }/${ k8sPodName }`;
+          if (k8sNamespace === 'kube-system') {
+            container.projectGroup = 'Kubernetes System';
+          } else {
+            container.projectGroup = `${ k8sNamespace }/${ k8sPodName }`;
+          }
         } else if (composeProject) {
           container.projectGroup = composeProject;
         } else {
@@ -416,11 +420,6 @@ export default defineComponent({
         } else {
           return a.State.localeCompare(b.State);
         }
-      });
-
-      // Filter out images from "kube-system" namespace
-      this.containersList = this.containersList.filter((container) => {
-        return container.Labels['io.kubernetes.pod.namespace'] !== 'kube-system';
       });
     },
     async stopContainer(container) {


### PR DESCRIPTION
- [x] Container group collapsing
  - [x] only show container count when in collapsed state
  - [x] ...
- [x] add a group for Kubernetes "system" container (and have it collapsed initially).
- [x] ...

I also added `cursor: pointer;` && a hover effect for Diagnostics group collapsing to match