### PR TITLE
Remove problematic :description prop that caused markup `<code>` to show in first run dialog

### DIFF
--- a/pkg/rancher-desktop/components/PathManagementSelector.vue
+++ b/pkg/rancher-desktop/components/PathManagementSelector.vue
@@ -94,7 +94,6 @@ export default defineComponent({
         :name="groupName"
         :value="value"
         :label="option.label"
-        :description="option.description"
         :val="option.value"
         :disabled="isDisabled"
         :mode="mode"


### PR DESCRIPTION
Fixes #9016