### PR TITLE
Kube client: Remove spaces around field selector

### DIFF
--- a/pkg/rancher-desktop/backend/kube/client.ts
+++ b/pkg/rancher-desktop/backend/kube/client.ts
@@ -316,7 +316,7 @@ export class KubeClient extends events.EventEmitter {
     while (!this.shutdown) {
       const endpoints = await this.coreV1API.listNamespacedEndpoints({
         namespace,
-        fieldSelector: `metadata.name == ${ endpointName }`,
+        fieldSelector: `metadata.name==${ endpointName }`,
       });
       const items = endpoints.items.filter(item => item.metadata?.name === endpointName);
 


### PR DESCRIPTION
For some reason the kubernetes client upgrade caused the field selector parsing to change; while it previously accepted spaces around the operator it now returns an error.

Fixes #9026