### PR TITLE
Fix screenshot sizing

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -198,6 +198,7 @@ deislabs
 destinationrule
 DETECTEXCEPTIONS
 developercertificate
+DEVMODE
 dfile
 didinit
 diffdisk

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -845,6 +845,7 @@ Tracef
 traefik
 transitioning
 trivy
+TStr
 TVar
 tvf
 ucmonitor

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -84,7 +84,7 @@ export class Screenshots {
 
   protected async screenshotWindows(outPath: string, includeAll: boolean) {
     const script = path.resolve(import.meta.dirname, 'screenshot.ps1');
-    const args = [script, '-FilePath', outPath, '-Title', `'${ this.windowTitle }'`];
+    const args = ['-ExecutionPolicy', 'Bypass', script, '-FilePath', outPath, '-Title', `'${ this.windowTitle }'`];
 
     if (!includeAll) {
       args.push('-Foreground');

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -169,3 +169,19 @@ export class PreferencesScreenshots extends Screenshots {
     await this.screenshot(path);
   }
 }
+
+// If needed, set the screen resolution in CI.
+await (async function() {
+  if (!process.env.CI) {
+    return;
+  }
+  switch (process.platform) {
+  case 'win32': {
+    const script = path.resolve(import.meta.dirname, 'set-display-resolution.ps1');
+    await spawnFile(
+      'powershell.exe',
+      ['-ExecutionPolicy', 'Bypass', script],
+      { stdio: 'inherit' });
+  }
+  }
+})();

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -54,6 +54,12 @@ test.describe.serial('Main App Test', () => {
     screenshot = new MainWindowScreenshots(page, { directory: `${ colorScheme }/main`, log: console });
 
     await page.emulateMedia({ colorScheme });
+    await (await electronApp.browserWindow(page)).evaluate(browserWindow => {
+      // Ensure the window is of the correct size, and near the top left corner
+      // in case the screen is too small.  But it needs to be lower than the
+      // macOS menu bar.
+      browserWindow.setBounds({ x: 64, y: 64, width: 1024, height: 768 });
+    });
 
     await navPage.progressBecomesReady();
 

--- a/screenshots/set-display-resolution.ps1
+++ b/screenshots/set-display-resolution.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+  Set the display resolution on the current monitor to a pre-set size.
+.DESCRIPTION
+  Set the current display to at least 1440x900x32, for use with CI where the
+  display is smaller than expected.
+#>
+
+Param(
+  [switch]$ChangeResolution = !!$ENV:CI
+)
+
+$cSharpSource = @'
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace DisplayResolution {
+  [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
+  internal struct DEVMODE {
+    public const int CCHDEVICENAME = 32; // multimon.h
+    public const int CCHFORMNAME = 32; // wingdi.h
+
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
+    public string dmDeviceName;
+    public UInt16 dmSpecVersion;
+    public UInt16 dmDriverVersion;
+    public UInt16 dmSize;
+    public UInt16 dmDriverExtra;
+    public UInt32 dmFields;
+
+    // using the DUMMYSTRUCTNAME2 variant because it has the right size
+    public Int32 dmPositionX;
+    public Int32 dmPositionY;
+    public UInt32 dmDisplayOrientation;
+    public UInt32 dmDisplayFixedOutput;
+
+    public short dmColor;
+    public short dmDuplex;
+    public short dmYResolution;
+    public short dmTTOption;
+    public short dmCollate;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
+    public string dmFormName;
+    public UInt16 dmLogPixels;
+    public UInt32 dmBitsPerPel;
+    public UInt32 dmPelsWidth;
+    public UInt32 dmPelsHeight;
+    public UInt32 dmDisplayFlags;
+    public UInt32 dmDisplayFrequency;
+  }
+
+  internal class User32 {
+    public const UInt32 ENUM_CURRENT_SETTINGS = unchecked((uint)-1);
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern Int32 EnumDisplaySettings(
+      String lpszDeviceName,
+      UInt32 iModeNum,
+      ref DEVMODE lpDevMode);
+
+    public const Int32 DISP_CHANGE_SUCCESSFUL = 0; // winuser.h
+    public const Int32 DISP_CHANGE_RESTART = 1; // winuser.h
+    public const Int32 DISP_CHANGE_FAILED = -1; // winuser.h
+    public const Int32 DISP_CHANGE_BADMODE = -2; // winuser.h
+    public const Int32 DISP_CHANGE_NOTUPDATED = -3; // winuser.h
+    public const Int32 DISP_CHANGE_BADFLAGS = -4; // winuser.h
+    public const Int32 DISP_CHANGE_BADPARAM = -5; // winuser.h
+    public const Int32 DISP_CHANGE_BADDUALVIEW = -6; // winuser.h
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern Int32 ChangeDisplaySettings(
+      ref DEVMODE lpDevMode,
+      UInt32 dwFlags);
+  }
+
+  public class DisplayResolution {
+    static public void SetResolution(bool changeResolution) {
+      DEVMODE dm = new DEVMODE(), bestMode = new DEVMODE();
+      ulong bestSize = 0;
+      dm.dmDeviceName = new String(new char[DEVMODE.CCHDEVICENAME]);
+      dm.dmFormName = new String(new char[DEVMODE.CCHFORMNAME]);
+      dm.dmSize = (UInt16)Marshal.SizeOf(dm);
+
+      var rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
+      if (rv == 0) {
+        int error = Marshal.GetLastWin32Error();
+        throw new InvalidOperationException(
+          String.Format("Failed to get current display settings: {0:x}", error));
+      }
+
+      Console.WriteLine(String.Format(
+        "Current display is {0}x{1}",
+        dm.dmPelsWidth, dm.dmPelsHeight));
+
+      for (UInt32 i = 0; ; i++) {
+        rv = User32.EnumDisplaySettings(null, i, ref dm);
+        if (rv == 0) {
+          break;
+        }
+        Console.WriteLine(String.Format(
+          "#{0,3} {1,6}x{2,-6} ({3})", i, dm.dmPelsWidth, dm.dmPelsHeight, dm.dmBitsPerPel));
+        if (dm.dmPelsWidth >= 1440 && dm.dmPelsHeight >= 900 && dm.dmBitsPerPel >= 32) {
+          if (dm.dmPelsWidth * dm.dmPelsHeight > bestSize) {
+            bestSize = dm.dmPelsWidth * dm.dmPelsHeight;
+            bestMode = dm;
+          }
+        }
+      }
+
+      if (bestSize < 1) {
+        throw new NotSupportedException("Desired resolution is not found");
+      }
+      Console.WriteLine(String.Format(
+        "Picking resolution: {0}x{1} ({2})",
+        bestMode.dmPelsWidth, bestMode.dmPelsHeight, bestMode.dmBitsPerPel));
+      if (changeResolution) {
+        rv = User32.ChangeDisplaySettings(ref bestMode, 0);
+        if (rv != User32.DISP_CHANGE_SUCCESSFUL) {
+          throw new InvalidOperationException(
+            String.Format("Failed to change resolution: {0}", rv));
+        }
+      }
+
+      rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
+      if (rv == 0) {
+        int error = Marshal.GetLastWin32Error();
+        throw new InvalidOperationException(
+          String.Format("Failed to get modified display settings: {0:x}", error));
+      }
+
+      Console.WriteLine(String.Format(
+        "Modified display is {0}x{1}",
+        dm.dmPelsWidth, dm.dmPelsHeight));
+    }
+  }
+}
+
+'@
+
+Add-Type $cSharpSource
+[DisplayResolution.DisplayResolution]::SetResolution($ChangeResolution)

--- a/screenshots/set-display-resolution.ps1
+++ b/screenshots/set-display-resolution.ps1
@@ -2,11 +2,19 @@
 .SYNOPSIS
   Set the display resolution on the current monitor to a pre-set size.
 .DESCRIPTION
-  Set the current display to at least 1440x900x32, for use with CI where the
-  display is smaller than expected.
+  Set the current display to at least the desired size, for use with CI where
+  the display is smaller than expected.
 #>
 
 Param(
+  # The minimum width to set; return an error if this is not supported.
+  [UInt32]$MinimumWidth = 1440,
+  # The minimum height to set; return an error if this is not supported.
+  [UInt32]$MinimumHeight = 900,
+  # The minimum bits per pixel to set; return an error if this is not supported.
+  [UInt32]$MinimumBitsPerPixel = 32,
+  # If set, actually change the resolution.
+  [PSDefaultValue(Help='True, if running in CI; otherwise false')]
   [switch]$ChangeResolution = !!$ENV:CI
 )
 
@@ -15,115 +23,113 @@ $cSharpSource = @'
 using System;
 using System.Runtime.InteropServices;
 
-namespace DisplayResolution {
-  [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
-  internal struct DEVMODE {
-    [MarshalAs(23, SizeConst = 32)]
-    public string dmDeviceName;
-    public UInt16 dmSpecVersion;
-    public UInt16 dmDriverVersion;
-    public UInt16 dmSize;
-    public UInt16 dmDriverExtra;
-    public UInt32 dmFields;
+[StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
+internal struct DEVMODE {
+  [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+  public string dmDeviceName;
+  public UInt16 dmSpecVersion;
+  public UInt16 dmDriverVersion;
+  public UInt16 dmSize;
+  public UInt16 dmDriverExtra;
+  public UInt32 dmFields;
 
-    public Int32 dmPositionX;
-    public Int32 dmPositionY;
-    public UInt32 dmDisplayOrientation;
-    public UInt32 dmDisplayFixedOutput;
+  public Int32 dmPositionX;
+  public Int32 dmPositionY;
+  public UInt32 dmDisplayOrientation;
+  public UInt32 dmDisplayFixedOutput;
 
-    public short dmColor;
-    public short dmDuplex;
-    public short dmVerticalResolution;
-    public short dmTTOption;
-    public short dmCollate;
-    [MarshalAs(23, SizeConst = 32)]
-    public string dmFormName;
-    public UInt16 dmLogPixels;
-    public UInt32 dmBitsPerPixel;
-    public UInt32 dmPixelsWidth;
-    public UInt32 dmPixelsHeight;
-    public UInt32 dmDisplayFlags;
-    public UInt32 dmDisplayFrequency;
-  }
+  public short dmColor;
+  public short dmDuplex;
+  public short dmVerticalResolution;
+  public short dmTTOption;
+  public short dmCollate;
+  [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+  public string dmFormName;
+  public UInt16 dmLogPixels;
+  public UInt32 dmBitsPerPixel;
+  public UInt32 dmPixelsWidth;
+  public UInt32 dmPixelsHeight;
+  public UInt32 dmDisplayFlags;
+  public UInt32 dmDisplayFrequency;
+}
 
-  internal class User32 {
-    public const UInt32 ENUM_CURRENT_SETTINGS = unchecked((uint)-1);
-    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    public static extern Int32 EnumDisplaySettings(
-      String deviceName,
-      UInt32 modeNum,
-      ref DEVMODE devMode);
+internal class User32 {
+  public const UInt32 ENUM_CURRENT_SETTINGS = unchecked((uint)-1);
+  [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+  public static extern Int32 EnumDisplaySettings(
+    String deviceName,
+    UInt32 modeNum,
+    ref DEVMODE devMode);
 
-    public const Int32 DISP_CHANGE_SUCCESSFUL = 0;
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    public static extern Int32 ChangeDisplaySettings(
-      ref DEVMODE devMode,
-      UInt32 flags);
-  }
+  public const Int32 DISP_CHANGE_SUCCESSFUL = 0;
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+  public static extern Int32 ChangeDisplaySettings(
+    ref DEVMODE devMode,
+    UInt32 flags);
+}
 
-  public class DisplayResolution {
-    static public void SetResolution(bool changeResolution) {
-      DEVMODE dm = new DEVMODE(), bestMode = new DEVMODE();
-      ulong bestSize = 0;
-      dm.dmDeviceName = new String(new char[32]);
-      dm.dmFormName = new String(new char[32]);
-      dm.dmSize = (UInt16)Marshal.SizeOf(dm);
+public class DisplayResolution {
+  static public void SetResolution(bool changeResolution, UInt32 MinWidth, UInt32 MinHeight, UInt32 MinBitsPerPixel) {
+    DEVMODE dm = new DEVMODE(), bestMode = new DEVMODE();
+    ulong bestSize = 0;
+    dm.dmDeviceName = new String(new char[32]);
+    dm.dmFormName = new String(new char[32]);
+    dm.dmSize = (UInt16)Marshal.SizeOf(dm);
 
-      var rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
-      if (rv == 0) {
-        int error = Marshal.GetLastWin32Error();
-        throw new InvalidOperationException(
-          String.Format("Failed to get current display settings: {0:x}", error));
-      }
-
-      Console.WriteLine(String.Format(
-        "Current display is {0}x{1}",
-        dm.dmPixelsWidth, dm.dmPixelsHeight));
-
-      for (UInt32 i = 0; ; i++) {
-        rv = User32.EnumDisplaySettings(null, i, ref dm);
-        if (rv == 0) {
-          break;
-        }
-        Console.WriteLine(String.Format(
-          "#{0,3} {1,6}x{2,-6} ({3})", i, dm.dmPixelsWidth, dm.dmPixelsHeight, dm.dmBitsPerPixel));
-        if (dm.dmPixelsWidth >= 1440 && dm.dmPixelsHeight >= 900 && dm.dmBitsPerPixel >= 32) {
-          if (dm.dmPixelsWidth * dm.dmPixelsHeight > bestSize) {
-            bestSize = dm.dmPixelsWidth * dm.dmPixelsHeight;
-            bestMode = dm;
-          }
-        }
-      }
-
-      if (bestSize < 1) {
-        throw new NotSupportedException("Desired resolution is not found");
-      }
-      Console.WriteLine(String.Format(
-        "Picking resolution: {0}x{1} ({2})",
-        bestMode.dmPixelsWidth, bestMode.dmPixelsHeight, bestMode.dmBitsPerPixel));
-      if (changeResolution) {
-        rv = User32.ChangeDisplaySettings(ref bestMode, 0);
-        if (rv != User32.DISP_CHANGE_SUCCESSFUL) {
-          throw new InvalidOperationException(
-            String.Format("Failed to change resolution: {0}", rv));
-        }
-      }
-
-      rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
-      if (rv == 0) {
-        int error = Marshal.GetLastWin32Error();
-        throw new InvalidOperationException(
-          String.Format("Failed to get modified display settings: {0:x}", error));
-      }
-
-      Console.WriteLine(String.Format(
-        "Modified display is {0}x{1}",
-        dm.dmPixelsWidth, dm.dmPixelsHeight));
+    var rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
+    if (rv == 0) {
+      int error = Marshal.GetLastWin32Error();
+      throw new InvalidOperationException(
+        String.Format("Failed to get current display settings: {0:x}", error));
     }
+
+    Console.WriteLine(String.Format(
+      "Current display is {0}x{1} ({2})",
+      dm.dmPixelsWidth, dm.dmPixelsHeight, dm.dmBitsPerPixel));
+
+    for (UInt32 i = 0; ; i++) {
+      rv = User32.EnumDisplaySettings(null, i, ref dm);
+      if (rv == 0) {
+        break;
+      }
+      Console.WriteLine(String.Format(
+        "#{0,3} {1,6}x{2,-6} ({3})", i, dm.dmPixelsWidth, dm.dmPixelsHeight, dm.dmBitsPerPixel));
+      if (dm.dmPixelsWidth >= MinWidth && dm.dmPixelsHeight >= MinHeight && dm.dmBitsPerPixel >= MinBitsPerPixel) {
+        if (dm.dmPixelsWidth * dm.dmPixelsHeight > bestSize) {
+          bestSize = dm.dmPixelsWidth * dm.dmPixelsHeight;
+          bestMode = dm;
+        }
+      }
+    }
+
+    if (bestSize < 1) {
+      throw new NotSupportedException("Desired resolution is not found");
+    }
+    Console.WriteLine(String.Format(
+      "Picking resolution: {0}x{1} ({2})",
+      bestMode.dmPixelsWidth, bestMode.dmPixelsHeight, bestMode.dmBitsPerPixel));
+    if (changeResolution) {
+      rv = User32.ChangeDisplaySettings(ref bestMode, 0);
+      if (rv != User32.DISP_CHANGE_SUCCESSFUL) {
+        throw new InvalidOperationException(
+          String.Format("Failed to change resolution: {0}", rv));
+      }
+    }
+
+    rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
+    if (rv == 0) {
+      int error = Marshal.GetLastWin32Error();
+      throw new InvalidOperationException(
+        String.Format("Failed to get modified display settings: {0:x}", error));
+    }
+
+    Console.WriteLine(String.Format(
+      "Modified display is {0}x{1}",
+      dm.dmPixelsWidth, dm.dmPixelsHeight));
   }
 }
 
 '@
 
 Add-Type $cSharpSource
-[DisplayResolution.DisplayResolution]::SetResolution($ChangeResolution)
+[DisplayResolution]::SetResolution($ChangeResolution, $MinimumWidth, $MinimumHeight, $MinimumBitsPerPixel)

--- a/screenshots/set-display-resolution.ps1
+++ b/screenshots/set-display-resolution.ps1
@@ -18,10 +18,7 @@ using System.Runtime.InteropServices;
 namespace DisplayResolution {
   [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Auto)]
   internal struct DEVMODE {
-    public const int CCHDEVICENAME = 32; // multimon.h
-    public const int CCHFORMNAME = 32; // wingdi.h
-
-    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
+    [MarshalAs(23, SizeConst = 32)]
     public string dmDeviceName;
     public UInt16 dmSpecVersion;
     public UInt16 dmDriverVersion;
@@ -29,7 +26,6 @@ namespace DisplayResolution {
     public UInt16 dmDriverExtra;
     public UInt32 dmFields;
 
-    // using the DUMMYSTRUCTNAME2 variant because it has the right size
     public Int32 dmPositionX;
     public Int32 dmPositionY;
     public UInt32 dmDisplayOrientation;
@@ -37,15 +33,15 @@ namespace DisplayResolution {
 
     public short dmColor;
     public short dmDuplex;
-    public short dmYResolution;
+    public short dmVerticalResolution;
     public short dmTTOption;
     public short dmCollate;
-    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
+    [MarshalAs(23, SizeConst = 32)]
     public string dmFormName;
     public UInt16 dmLogPixels;
-    public UInt32 dmBitsPerPel;
-    public UInt32 dmPelsWidth;
-    public UInt32 dmPelsHeight;
+    public UInt32 dmBitsPerPixel;
+    public UInt32 dmPixelsWidth;
+    public UInt32 dmPixelsHeight;
     public UInt32 dmDisplayFlags;
     public UInt32 dmDisplayFrequency;
   }
@@ -54,30 +50,23 @@ namespace DisplayResolution {
     public const UInt32 ENUM_CURRENT_SETTINGS = unchecked((uint)-1);
     [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     public static extern Int32 EnumDisplaySettings(
-      String lpszDeviceName,
-      UInt32 iModeNum,
-      ref DEVMODE lpDevMode);
+      String deviceName,
+      UInt32 modeNum,
+      ref DEVMODE devMode);
 
-    public const Int32 DISP_CHANGE_SUCCESSFUL = 0; // winuser.h
-    public const Int32 DISP_CHANGE_RESTART = 1; // winuser.h
-    public const Int32 DISP_CHANGE_FAILED = -1; // winuser.h
-    public const Int32 DISP_CHANGE_BADMODE = -2; // winuser.h
-    public const Int32 DISP_CHANGE_NOTUPDATED = -3; // winuser.h
-    public const Int32 DISP_CHANGE_BADFLAGS = -4; // winuser.h
-    public const Int32 DISP_CHANGE_BADPARAM = -5; // winuser.h
-    public const Int32 DISP_CHANGE_BADDUALVIEW = -6; // winuser.h
+    public const Int32 DISP_CHANGE_SUCCESSFUL = 0;
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     public static extern Int32 ChangeDisplaySettings(
-      ref DEVMODE lpDevMode,
-      UInt32 dwFlags);
+      ref DEVMODE devMode,
+      UInt32 flags);
   }
 
   public class DisplayResolution {
     static public void SetResolution(bool changeResolution) {
       DEVMODE dm = new DEVMODE(), bestMode = new DEVMODE();
       ulong bestSize = 0;
-      dm.dmDeviceName = new String(new char[DEVMODE.CCHDEVICENAME]);
-      dm.dmFormName = new String(new char[DEVMODE.CCHFORMNAME]);
+      dm.dmDeviceName = new String(new char[32]);
+      dm.dmFormName = new String(new char[32]);
       dm.dmSize = (UInt16)Marshal.SizeOf(dm);
 
       var rv = User32.EnumDisplaySettings(null, User32.ENUM_CURRENT_SETTINGS, ref dm);
@@ -89,7 +78,7 @@ namespace DisplayResolution {
 
       Console.WriteLine(String.Format(
         "Current display is {0}x{1}",
-        dm.dmPelsWidth, dm.dmPelsHeight));
+        dm.dmPixelsWidth, dm.dmPixelsHeight));
 
       for (UInt32 i = 0; ; i++) {
         rv = User32.EnumDisplaySettings(null, i, ref dm);
@@ -97,10 +86,10 @@ namespace DisplayResolution {
           break;
         }
         Console.WriteLine(String.Format(
-          "#{0,3} {1,6}x{2,-6} ({3})", i, dm.dmPelsWidth, dm.dmPelsHeight, dm.dmBitsPerPel));
-        if (dm.dmPelsWidth >= 1440 && dm.dmPelsHeight >= 900 && dm.dmBitsPerPel >= 32) {
-          if (dm.dmPelsWidth * dm.dmPelsHeight > bestSize) {
-            bestSize = dm.dmPelsWidth * dm.dmPelsHeight;
+          "#{0,3} {1,6}x{2,-6} ({3})", i, dm.dmPixelsWidth, dm.dmPixelsHeight, dm.dmBitsPerPixel));
+        if (dm.dmPixelsWidth >= 1440 && dm.dmPixelsHeight >= 900 && dm.dmBitsPerPixel >= 32) {
+          if (dm.dmPixelsWidth * dm.dmPixelsHeight > bestSize) {
+            bestSize = dm.dmPixelsWidth * dm.dmPixelsHeight;
             bestMode = dm;
           }
         }
@@ -111,7 +100,7 @@ namespace DisplayResolution {
       }
       Console.WriteLine(String.Format(
         "Picking resolution: {0}x{1} ({2})",
-        bestMode.dmPelsWidth, bestMode.dmPelsHeight, bestMode.dmBitsPerPel));
+        bestMode.dmPixelsWidth, bestMode.dmPixelsHeight, bestMode.dmBitsPerPixel));
       if (changeResolution) {
         rv = User32.ChangeDisplaySettings(ref bestMode, 0);
         if (rv != User32.DISP_CHANGE_SUCCESSFUL) {
@@ -129,7 +118,7 @@ namespace DisplayResolution {
 
       Console.WriteLine(String.Format(
         "Modified display is {0}x{1}",
-        dm.dmPelsWidth, dm.dmPelsHeight));
+        dm.dmPixelsWidth, dm.dmPixelsHeight));
     }
   }
 }


### PR DESCRIPTION
This fixes the screenshots so the main window is always ~1024x768.  Note that on Windows, this includes changing the screen resolution, because CI machines by default have a resolution of 1024x768 so all screenshots would include the task bar otherwise.

Fixes #9011 (… probably because the screen was so tiny.)

The first commit conflicts with #9036 because it fixes issues taking screenshots itself; it can be rebased if that lands first.