### PR TITLE
lima: Default to SSH port forwarder

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1780,9 +1780,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       try {
         const env: NodeJS.ProcessEnv = {};
 
-        if (this.cfg?.experimental.virtualMachine.sshPortForwarder) {
-          env.LIMA_SSH_PORT_FORWARDER = 'true';
-        }
+        env.LIMA_SSH_PORT_FORWARDER = this.cfg?.experimental.virtualMachine.sshPortForwarder ? 'true' : 'false';
         await this.lima(env, 'start', '--tty=false', await this.isRegistered ? MACHINE_NAME : this.CONFIG_PATH);
       } finally {
         // Symlink the logs (especially if start failed) so the users can find them

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -147,7 +147,7 @@ export const defaultSettings = {
           '224.0.0.0/4', '240.0.0.0/4'],
       },
       /** Lima only: use SSH port forwarding instead of gRPC. */
-      sshPortForwarder: false,
+      sshPortForwarder: true,
     },
   },
 };


### PR DESCRIPTION
Change the default to use the SSH port forwarder instead of the GRPC one due to reported issues.  Also force set the environment variable so we can ignore Lima defaults.

There has been issues intermittently reported upstream that makes us not confident enough in the GRPC stack to set it as the default.  We haven't released anything with the defaults flipped yet, so migration should not be needed at this point.

Fixes #9040