### PR TITLE
Implement collapsing for container groups

### DIFF
--- a/pkg/rancher-desktop/components/DiagnosticsBody.vue
+++ b/pkg/rancher-desktop/components/DiagnosticsBody.vue
@@ -264,8 +264,8 @@ export default defineComponent({
     .group-row {
       .col-description {
         font-weight: bold;
-        .group-tab {
-          border-top-left-radius: 0;
+        .group-tab .icon {
+          cursor: pointer;
         }
       }
       .col-mute {

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -103,10 +103,23 @@
         </td>
       </template>
       <template #group-row="{ group }">
-        <tr class="group-row">
+        <tr
+          class="group-row"
+          :aria-expanded="!collapsed[group.ref]"
+        >
           <td :colspan="headers.length + 1">
             <div class="group-tab">
-              {{ group.ref }} ({{ group.rows.length }})
+              <i
+                data-title="Toggle Expand"
+                :class="{
+                  icon: true,
+                  'icon-chevron-right': !!collapsed[group.ref],
+                  'icon-chevron-down': !collapsed[group.ref],
+                }"
+                @click.stop="toggleExpand(group.ref)"
+              />
+              {{ group.ref }}
+              <span v-if="!!collapsed[group.ref]"> ({{ group.rows.length }})</span>
             </div>
           </td>
         </tr>
@@ -146,6 +159,8 @@ export default defineComponent({
       error:                      null,
       isComponentMounted:         false,
       setupTimeoutId:             null,
+      /** @type Record<string, boolean> */
+      collapsed:                   {},
       headers:                    [
         {
           name:  'containerState',
@@ -619,6 +634,10 @@ export default defineComponent({
         return shell.openExternal(`http://localhost:${ hostPort }`);
       }
     },
+
+    toggleExpand(group) {
+      this.collapsed[group] = !this.collapsed[group];
+    },
   },
 });
 </script>
@@ -627,6 +646,25 @@ export default defineComponent({
 .containers {
   &-status {
     padding: 8px 5px;
+  }
+
+  .group-row {
+    .group-tab {
+      font-weight: bold;
+      .icon {
+        cursor: pointer;
+      }
+    }
+    &[aria-expanded="false"] {
+      :deep(~ .main-row) {
+        visibility: collapse;
+        .checkbox-container {
+          /* When using visibility:collapse, the row selection checkbox produces
+           * some artifacts; force it to display:none to avoid flickering. */
+          display: none;
+        }
+      }
+    }
   }
 }
 

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -147,7 +147,6 @@ export default defineComponent({
       isComponentMounted:         false,
       setupTimeoutId:             null,
       headers:                    [
-        // INFO: Disable for now since we can only get the running containers.
         {
           name:  'containerState',
           label: this.t('containers.manage.table.header.state'),


### PR DESCRIPTION
This is a replacement for #9020. Note that I did _not_ do some of the nice extras, like the default group for `kube-system`.  I did, however, remove the `border-top-left-radius` override on the assumption that if the `SortableTable` had it by default we should leave it to be consistent with dashboard.