### PR TITLE
Add k3s --debug option when running in debug mode

### DIFF
--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -385,6 +385,9 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     if (!cfg.kubernetes.options.traefik) {
       config.ADDITIONAL_ARGS += ' --disable traefik';
     }
+    if (cfg.application.debug) {
+      config.ADDITIONAL_ARGS += ' --debug';
+    }
     await this.vm.writeFile('/etc/init.d/cri-dockerd', SERVICE_CRI_DOCKERD_SCRIPT, 0o755);
     await this.vm.writeConf('cri-dockerd', {
       LOG_DIR: paths.logs,

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1421,6 +1421,9 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                   console.log(`Disabling flannel and network policy`);
                   k3sConf.ADDITIONAL_ARGS += ' --flannel-backend=none --disable-network-policy';
                 }
+                if (config.application.debug) {
+                  config.ADDITIONAL_ARGS += ' --debug';
+                }
 
                 await this.writeConf('k3s', k3sConf);
               }),


### PR DESCRIPTION
Note that `k3s server --docker --debug` doesn't seem to work because cri-dockerd sets the debug level back to `info`.