### PR TITLE
BATS: Factory-reset: fix for Linux

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -231,9 +231,9 @@ check_rd_context() {
 
 check_lima() {
     skip_on_windows
-    # Check if VM was killed
+    # Check that the VM has been removed and no longer exists.
     run limactl ls
-    "${assert}_output" --partial "No instance found"
+    "${assert}_output" --regexp "No instance found|no such file or directory"
 }
 
 check_WSL() {


### PR DESCRIPTION
On Linux, if `$LIMA_HOME` does not exist, it (probably accidentally) shows `no such file or directory` instead of `No instance found`.  Update the check to allow for that.

Jan says it probably comes down to:
https://github.com/lima-vm/lima/blob/ba5409441bee1711e3f36911ed4b50b04dfe06b0/cmd/limactl/main.go#L136-L143

`fsutil.IsNFS` always return `false, nil` on non-Linux platforms, but on Linux it can return `?, ErrNotExist`.