### PR TITLE
Remove internal uses of `rdctl factory-reset`

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -909,7 +909,7 @@ async function doFactoryReset(keepSystemImages: boolean) {
   // Don't wait for this process to return -- the whole point is for us to not be running.
   const tmpdir = os.tmpdir();
   const outfile = await fs.promises.open(path.join(tmpdir, 'rdctl-stdout.txt'), 'w');
-  const args = ['factory-reset', `--remove-kubernetes-cache=${ (!keepSystemImages) ? 'true' : 'false' }`];
+  const args = ['reset', '--factory', `--cache=${ (!keepSystemImages) ? 'true' : 'false' }`];
 
   if (cfg.application.debug) {
     args.push('--verbose=true');
@@ -920,7 +920,7 @@ async function doFactoryReset(keepSystemImages: boolean) {
     });
 
   rdctl.unref();
-  console.debug(`If factory-reset fails, the rdctl factory-reset output files are in ${ tmpdir }`);
+  console.debug(`If reset fails, the rdctl reset output files are in ${ tmpdir }`);
 }
 
 ipcMainProxy.on('factory-reset', (event, keepSystemImages) => {

--- a/docs/development/factory-reset.md
+++ b/docs/development/factory-reset.md
@@ -1,4 +1,4 @@
-When `rdctl factory-reset` is launched from the UI, it writes its stdout into
+When `rdctl reset --factory` is launched from the UI, it writes its stdout into
 `TMP/rdctl-stdout.txt`
 
 where on linux `TMP` is usually `/tmp`,
@@ -8,6 +8,6 @@ on macOS it's given by `$TMPDIR`
 and on Windows by `%TEMP%`(command shell) or `$env:TEMP`(powershell).
 
 
-This is most useful during development. When the UI runs in debug mode, it spawns `rdctl factory-reset` with the `--verbose` option.
+This is most useful during development. When the UI runs in debug mode, it spawns `rdctl reset --factory` with the `--verbose` option.
 
-We can't write the output into the `logs` directory as `factory-reset` deletes it.
+We can't write the output into the `logs` directory as `reset --factory` deletes it.

--- a/e2e/credentials-server.e2e.spec.ts
+++ b/e2e/credentials-server.e2e.spec.ts
@@ -221,7 +221,7 @@ describeWithCreds('Credentials server', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeAll(async({ colorScheme }, testInfo) => {
-    await tool('rdctl', 'factory-reset', '--verbose');
+    await tool('rdctl', 'reset', '--factory', '--verbose');
     [electronApp, page] = await startSlowerDesktop(testInfo, { kubernetes: { enabled: false } });
   });
 

--- a/e2e/lockedFields.e2e.spec.ts
+++ b/e2e/lockedFields.e2e.spec.ts
@@ -74,7 +74,7 @@ test.describe('Locked fields', () => {
   const proposedK8sVersion = '1.26.1';
 
   test.beforeAll(async() => {
-    await tool('rdctl', 'factory-reset', '--verbose');
+    await tool('rdctl', 'reset', '--factory', '--verbose');
     reopenLogs();
   });
 
@@ -99,7 +99,7 @@ test.describe('Locked fields', () => {
 
   test.afterAll(async({ colorScheme }, testInfo) => {
     await teardown(electronApp, testInfo);
-    await tool('rdctl', 'factory-reset', '--verbose');
+    await tool('rdctl', 'reset', '--factory', '--verbose');
     reopenLogs();
   });
 

--- a/e2e/preferences.e2e.spec.ts
+++ b/e2e/preferences.e2e.spec.ts
@@ -32,7 +32,7 @@ test.describe.serial('Main App Test', () => {
 
   test.afterAll(async({ colorScheme }, testInfo) => {
     await teardown(electronApp, testInfo);
-    await tool('rdctl', 'factory-reset', '--verbose');
+    await tool('rdctl', 'reset', '--factory', '--verbose');
     reopenLogs();
   });
 


### PR DESCRIPTION
That command has been deprecated in favour of `rdctl reset --factory`; use that instead when we need to do a factory reset from code (and also in E2E tests).  A separate PR (#9077) already exists for BATS.

This is a follow-up to #8890