### PR TITLE
API: Do not mention k8s in the reset message

### DIFF
--- a/bats/tests/containers/reset.bats
+++ b/bats/tests/containers/reset.bats
@@ -181,7 +181,7 @@ local_setup_file() {
 @test 'Reset VM' {
     run rdctl_reset --vm
     assert_success
-    assert_output --partial 'successfully reset'
+    assert_output 'Rancher Desktop wipe reset successful'
 }
 
 @test 'Verify VM modifications removed' {

--- a/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
+++ b/pkg/rancher-desktop/main/commandServer/httpCommandServer.ts
@@ -559,9 +559,9 @@ export class HttpCommandServer {
       error = payloadError;
     }
     if (!error) {
-      console.debug('k8sReset: succeeded 202');
       await this.commandWorker.k8sReset(context, mode);
-      response.status(202).type('txt').send('K8s cluster successfully reset');
+      console.debug(`k8sReset: ${ mode } succeeded`);
+      response.status(200).type('txt').send(`Rancher Desktop ${ mode } reset successful`);
     } else {
       console.debug(`k8sReset: write back status 400, error: ${ error }`);
       response.status(400).type('txt').send(error);


### PR DESCRIPTION
When we do a (fast/wipe) reset, do not mention k8s as that may not be appropriate for some reset scenarios.

Fixes #9099 