### PR TITLE
helm needs docker-credentials-* on the PATH

### DIFF
--- a/bats/tests/helpers/commands.bash
+++ b/bats/tests/helpers/commands.bash
@@ -55,7 +55,10 @@ docker_exe() {
         "$PATH_RESOURCES/$PLATFORM/bin/docker$EXE" "$@" | no_cr
 }
 helm() {
-    "$PATH_RESOURCES/$PLATFORM/bin/helm$EXE" "$@" | no_cr
+    # Add path to bundled credential helpers to the front of the PATH; also
+    # ensure that on Windows, it gets exported.
+    PATH="$PATH_RESOURCES/$PLATFORM/bin:$PATH" WSLENV="PATH/l:${WSLENV:-}" \
+        "$PATH_RESOURCES/$PLATFORM/bin/helm$EXE" "$@" | no_cr
 }
 kubectl() {
     kubectl_exe --context rancher-desktop "$@"


### PR DESCRIPTION
Because it may load charts from OCI registries.

To fix errors like this:

```
 ✗ deploy wordpress
   (from function `helm' in file tests/helpers/commands.bash, line 58,
    in test file tests/k8s/wordpress.bats, line 27)
     `helm install wordpress bitnami/wordpress \' failed
   Error: INSTALLATION FAILED: failed to perform "FetchReference" on source: GET "https://registry-1.docker.io/v2/bitnamicharts/wordpress/manifests/25.0.24": exec: "docker-credential-osxkeychain": executable file not found in $PATH
```