### PR TITLE
Debian: libgdk-pixbuf2.0-0 → libgdk-pixbuf-2.0-0

### DIFF
--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -62,7 +62,7 @@ Requires: libdrm2
 Requires: libexpat1
 Requires: libgbm1
 Requires: libgcc1
-Requires: libgdk-pixbuf2.0-0
+Requires: libgdk-pixbuf-2.0-0
 Requires: libglib2.0-0
 Requires: libglib2.0-dev
 Requires: libgtk-3-0


### PR DESCRIPTION
The old name is no longer supported in Debian 13.
The new name is included at least since Debian 12 and Ubuntu 24.04.

Ref https://packages.debian.org/sid/libgdk-pixbuf2.0-0
Ref https://launchpad.net/ubuntu/noble/+package/libgdk-pixbuf2.0-0

Fixes #9105 