### PR TITLE
UI: Fix broken checkboxes

### DIFF
--- a/pkg/rancher-desktop/components/Preferences/WslProxy.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslProxy.vue
@@ -63,7 +63,7 @@ export default defineComponent({
         :label="t('virtualMachine.proxy.label', { }, true)"
         :value="preferences.experimental.virtualMachine.proxy.enabled"
         :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.enabled')"
-        @input="onChange('experimental.virtualMachine.proxy.enabled', $event)"
+        @update:value="onChange('experimental.virtualMachine.proxy.enabled', $event)"
       />
     </rd-fieldset>
     <hr>

--- a/pkg/rancher-desktop/components/WSLIntegration.vue
+++ b/pkg/rancher-desktop/components/WSLIntegration.vue
@@ -14,7 +14,7 @@
         :label="item.name"
         :disabled="item.disabled"
         :description="item.description"
-        @input="toggleIntegration(item.name, $event)"
+        @update:value="toggleIntegration(item.name, $event)"
       />
     </div>
   </section>
@@ -82,7 +82,7 @@ export default defineComponent({
 
   methods: {
     toggleIntegration(name: string, value: boolean) {
-      this.$set(this.busy, name, value);
+      this.busy.name = value;
       this.$emit('integration-set', name, value);
     },
   },

--- a/pkg/rancher-desktop/pages/Troubleshooting.vue
+++ b/pkg/rancher-desktop/pages/Troubleshooting.vue
@@ -27,7 +27,7 @@
             :tooltip="debugModeTooltip"
             :is-locked="debugLocked"
             label="Enable debug mode"
-            @input="updateDebug"
+            @update:value="updateDebug"
           />
         </template>
       </troubleshooting-line-item>


### PR DESCRIPTION
A few checkboxes were missed in the migration to Vue 3; this had the effect of making them ignore clicks.  This fixes those cases.

Fixes #9103