### PR TITLE
UI: Tooltips: Fix HTML escaping

### DIFF
--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -115,7 +115,7 @@ export default defineComponent({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t(`prefs.onlyWithVZ_${ this.arch }`) };
+        tooltip = { content: this.t(`prefs.onlyWithVZ_${ this.arch }`, undefined, true) };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -20,7 +20,7 @@
           <i
             v-if="item.experimental"
             v-tooltip="{
-              content: t('prefs.experimental'),
+              content: t('prefs.experimental', undefined, true),
               placement: 'right',
             }"
             :class="`icon icon-flask`"

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -73,7 +73,7 @@ export default defineComponent({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t(`prefs.onlyFromVentura_${ this.arch }`) };
+        tooltip = { content: this.t(`prefs.onlyFromVentura_${ this.arch }`, undefined, true) };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/components/RdInput.vue
+++ b/pkg/rancher-desktop/components/RdInput.vue
@@ -36,7 +36,7 @@ export default defineComponent({
       <i
         v-if="isLocked"
         v-tooltip="{
-          content: tooltip || t('preferences.locked.tooltip'),
+          content: tooltip || t('preferences.locked.tooltip', undefined, true),
           placement: 'right',
         }"
         class="icon icon-lock"

--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -62,7 +62,7 @@ export default defineComponent({
       <i
         v-if="isLocked"
         v-tooltip="{
-          content: tooltip || t('preferences.locked.tooltip'),
+          content: tooltip || t('preferences.locked.tooltip', undefined, true),
           placement: 'right',
         }"
         class="icon icon-lock"

--- a/pkg/rancher-desktop/components/StatusBarItem.vue
+++ b/pkg/rancher-desktop/components/StatusBarItem.vue
@@ -36,7 +36,7 @@ export default defineComponent({
 
       return undefined;
     },
-    getTooltip(): { content: string, placement: string, popperClass: string } {
+    getTooltip() {
       return {
         content:     `<b>${ this.t(this.data.label.tooltip) }</b>: ${ this.data.value }`,
         html:        true,
@@ -58,7 +58,7 @@ export default defineComponent({
   <div class="status-bar-item">
     <span
       v-if="data"
-      v-tooltip="getTooltip"
+      v-clean-tooltip="getTooltip"
     >
       <img
         v-if="isSvgIcon"

--- a/pkg/rancher-desktop/components/Version.vue
+++ b/pkg/rancher-desktop/components/Version.vue
@@ -18,7 +18,7 @@ export default defineComponent({
     return { version: this.t('product.versionChecking') };
   },
   computed: {
-    getTooltip(): { content: string, placement: string, classes: string } {
+    getTooltip() {
       return {
         content:     `<b>${ this.t('product.version') }</b>: ${ this.version }`,
         html:        true,
@@ -38,7 +38,7 @@ export default defineComponent({
 
 <template>
   <span
-    v-tooltip="isStatusBarItem ? getTooltip : {}"
+    v-clean-tooltip="isStatusBarItem ? getTooltip : {}"
     class="versionInfo"
   >
     <i

--- a/pkg/rancher-desktop/components/form/RdCheckbox.vue
+++ b/pkg/rancher-desktop/components/form/RdCheckbox.vue
@@ -75,7 +75,7 @@ export default defineComponent({
           <i
             v-if="isLocked"
             v-tooltip="{
-              content: tooltip || t('preferences.locked.tooltip'),
+              content: tooltip || t('preferences.locked.tooltip', undefined, true),
               placement: 'right',
             }"
             class="icon icon-lock"

--- a/pkg/rancher-desktop/components/form/RdFieldset.vue
+++ b/pkg/rancher-desktop/components/form/RdFieldset.vue
@@ -57,7 +57,7 @@ export default defineComponent({
         />
         <i
           v-if="isLocked"
-          v-tooltip="{
+          v-clean-tooltip="{
             content: lockedTooltip,
             html: true,
             placement: 'right',
@@ -66,7 +66,7 @@ export default defineComponent({
         />
         <i
           v-else-if="legendTooltip"
-          v-tooltip="{
+          v-clean-tooltip="{
             content: legendTooltip,
             html: true,
           }"

--- a/pkg/rancher-desktop/components/form/TooltipIcon.vue
+++ b/pkg/rancher-desktop/components/form/TooltipIcon.vue
@@ -20,7 +20,7 @@ export default {
 <template>
   <i
     v-tooltip="{
-      content: t(tooltipText),
+      content: t(tooltipText, undefined, true),
       placement: tooltipPlacement,
     }"
     :class="`icon ${icon}`"


### PR DESCRIPTION
When we use the i18n plugin (`this.t(...)`), by default the result is HTML-escaped; since `v-tooltip` inserts that text into `textContent` directly via `v-text`, that means we end up displaying HTML-escaped content to the user directly.  Audit the callers and use raw mode (i.e. do not escape) or use `v-clean-tooltip` as needed.

Fixes #9115