### PR TITLE
UI: SortableTable: fix row key

### DIFF
--- a/pkg/rancher-desktop/components/SortableTable/index.vue
+++ b/pkg/rancher-desktop/components/SortableTable/index.vue
@@ -1295,7 +1295,7 @@ export default {
         </slot>
         <template
           v-for="(row, i) in groupedRows.rows"
-          :key="i"
+          :key="row.row[keyField]"
         >
           <slot
             name="main-row"


### PR DESCRIPTION
Instead of using the row number as the key, use the row key field.  This fixes issues where a row gets hidden and the next row takes its place, causing the vue component state to be erroneously kept.

This is already fixed (differently) in `@rancher/components` and we'll pick up their fix when we next update.

Fixes #9126