### PR TITLE
moby: Don't set DOCKER_HOST in current process

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -502,7 +502,7 @@ export class MobyClient implements ContainerEngineClient {
       dirsToAdd.push(executableDir);
     }
 
-    const opts = _.merge({ env: process.env }, options ?? {}, {
+    const opts = _.merge({ env: _.merge({}, process.env) }, options ?? {}, {
       env: {
         DOCKER_HOST: this.endpoint,
         PATH:        `${ process.env.PATH }${ path.delimiter }${ dirsToAdd.join(path.delimiter) }`,


### PR DESCRIPTION
We were accidentally setting `DOCKER_HOST` in the current process when spawning the `docker` CLI; fix things so that no longer happens.  This fixes an issue where we'd report an diagnostics issue because that is set.

Fixes #9113