### PR TITLE
Switch from macos-13 to macos-latest for screenshots

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
         - platform: mac
-          runs-on: macos-13
+          runs-on: macos-latest
         - platform: win
           runs-on: windows-latest
         - platform: linux


### PR DESCRIPTION
That way we should capture the Rosetta settings specific to aarch64 hosts.