### PR TITLE
Run BATS with `--errexit`

### DIFF
--- a/bats/tests/containers/allowed-images.bats
+++ b/bats/tests/containers/allowed-images.bats
@@ -25,8 +25,8 @@ RD_USE_IMAGE_ALLOW_LIST=true
 }
 
 assert_pull_fails() {
-    run ctrctl pull "$1" || return
-    assert_failure || return
+    run ctrctl pull "$1"
+    assert_failure
     assert_output --regexp "(UNAUTHORIZED|Forbidden)"
 }
 

--- a/bats/tests/containers/wasm.bats
+++ b/bats/tests/containers/wasm.bats
@@ -36,7 +36,7 @@ shim_version() {
     local version=$2
 
     run rdctl shell "containerd-shim-${shim}-${version}" -v
-    assert_success || return
+    assert_success
     semver "$output"
 }
 
@@ -88,7 +88,7 @@ hello() {
 
 check_container_logs() {
     run ctrctl logs spin-demo-8080
-    assert_success || return
+    assert_success
     assert_output --partial "Available Routes"
 }
 

--- a/bats/tests/helpers/kubernetes.bash
+++ b/bats/tests/helpers/kubernetes.bash
@@ -41,14 +41,14 @@ unwrap_kube_list() {
     local json=$output
 
     run jq_output '.kind'
-    assert_success || return
+    assert_success
     if [[ $output == "List" ]]; then
         run jq --raw-output '.items | length' <<<"$json"
-        assert_success || return
-        assert_output "1" || return
+        assert_success
+        assert_output "1"
 
         run jq --raw-output '.items[0]' <<<"$json"
-        assert_success || return
+        assert_success
         json=$output
     fi
     echo "$json"
@@ -57,7 +57,7 @@ unwrap_kube_list() {
 assert_kube_deployment_available() {
     local jsonpath="jsonpath={.status.conditions[?(@.type=='Available')].status}"
     run --separate-stderr kubectl get deployment "$@" --output "$jsonpath"
-    assert_success || return
+    assert_success
     assert_output "True"
 }
 
@@ -68,23 +68,23 @@ wait_for_kube_deployment_available() {
 
 assert_pod_containers_are_running() {
     run kubectl get pod "$@" --output json
-    assert_success || return
+    assert_success
 
     # Make sure the query returned just a single pod
     run unwrap_kube_list
-    assert_success || return
+    assert_success
 
     # Confirm that **all** containers of the pod are in "running" state
     run jq_output '[.status.containerStatuses[].state | keys] | add | unique | .[]'
-    assert_success || return
+    assert_success
     assert_output "running"
 }
 
 traefik_ip() {
     local jsonpath='jsonpath={.status.loadBalancer.ingress[0].ip}'
     run --separate-stderr kubectl get service traefik --namespace kube-system --output "$jsonpath"
-    assert_success || return
-    assert_output || return
+    assert_success
+    assert_output
     echo "$output"
 }
 
@@ -96,7 +96,7 @@ traefik_hostname() {
         # BUG BUG BUG
 
         # local ip
-        # ip=$(traefik_ip) || return
+        # ip=$(traefik_ip)
         # echo "${ip}.sslip.io"
 
         # caller must have called `skip_unless_host_ip`

--- a/bats/tests/helpers/load.bash
+++ b/bats/tests/helpers/load.bash
@@ -1,5 +1,8 @@
 set -o errexit -o nounset -o pipefail
 
+# Make sure run() will execute all functions with errexit enabled
+export BATS_RUN_ERREXIT=1
+
 # RD_HELPERS_LOADED is set when bats/helpers/load.bash has been loaded
 RD_HELPERS_LOADED=1
 

--- a/bats/tests/helpers/utils.bash
+++ b/bats/tests/helpers/utils.bash
@@ -103,7 +103,7 @@ join_map() {
     local elem
     local result=""
     for elem in "$@"; do
-        elem=$(eval "$map" '"$elem"') || return
+        elem=$(eval "$map" '"$elem"')
         if [[ -z $result ]]; then
             result=$elem
         else
@@ -205,7 +205,7 @@ semver_gt() {
 
 get_setting() {
     run rdctl api /settings
-    assert_success || return
+    assert_success
     jq_output "$@"
 }
 
@@ -316,7 +316,7 @@ update_allowed_patterns() {
         pid=$(get_service_pid "$CONTAINER_ENGINE_SERVICE")
     fi
 
-    rdctl api settings -X PUT --input - <<EOF || return
+    rdctl api settings -X PUT --input - <<EOF
 {
   "version": 8,
   "containerEngine": {
@@ -329,10 +329,10 @@ update_allowed_patterns() {
 EOF
     # Wait for container engine (and Kubernetes) to be ready again
     if [[ -n ${pid:-} ]]; then
-        try --max 15 --delay 5 refute_service_pid "$CONTAINER_ENGINE_SERVICE" "$pid" || return
-        wait_for_container_engine || return
+        try --max 15 --delay 5 refute_service_pid "$CONTAINER_ENGINE_SERVICE" "$pid"
+        wait_for_container_engine
         if [[ $(get_setting .kubernetes.enabled) == "true" ]]; then
-            wait_for_kubelet || return
+            wait_for_kubelet
         fi
     fi
 }
@@ -353,15 +353,15 @@ create_file() {
     fi
 
     local contents # Base64 encoded file contents
-    contents="$(base64)" || return
+    contents="$(base64)"
 
     local winParent
     local winDest
-    winParent="$(wslpath -w "$(dirname "$dest")")" || return
-    winDest="$(wslpath -w "$dest")" || return
+    winParent="$(wslpath -w "$(dirname "$dest")")"
+    winDest="$(wslpath -w "$dest")"
     PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "New-Item -ItemType Directory -ErrorAction SilentlyContinue '$winParent'" || true
     local command="[IO.File]::WriteAllBytes('$winDest', \$([System.Convert]::FromBase64String('$contents')))"
-    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "$command" || return
+    PowerShell.exe -NoProfile -NoLogo -NonInteractive -Command "$command"
 }
 
 # unique_filename /tmp/image .png

--- a/bats/tests/helpers/utils.bats
+++ b/bats/tests/helpers/utils.bats
@@ -55,6 +55,18 @@ fails() {
 
 ########################################################################
 
+errexit() {
+    false
+    true
+}
+
+@test 'run() calls functions with errexit enabled' {
+    run errexit
+    assert_failure
+}
+
+########################################################################
+
 @test 'to_lower Upper and Lower' {
     is "upper and lower"
 }

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -307,7 +307,7 @@ EOF
 get_container_engine_info() {
     run ctrctl info
     echo "$output"
-    assert_success || return
+    assert_success
     assert_output --partial "Server Version:"
 }
 
@@ -317,11 +317,11 @@ docker_context_exists() {
         return
     fi
     run docker_exe context ls -q
-    assert_success || return
+    assert_success
     assert_line "$RD_DOCKER_CONTEXT"
     # Ensure that the context actually exists by reading from the file.
     run docker_exe context inspect "$RD_DOCKER_CONTEXT" --format '{{ .Name }}'
-    assert_success || return
+    assert_success
     assert_output "$RD_DOCKER_CONTEXT"
 }
 
@@ -367,11 +367,11 @@ get_service_pid() {
     local service_name=$1
     if using_systemd; then
         RD_TIMEOUT=10s run rdshell systemctl show --property MainPID --value "$service_name.service"
-        assert_success || return
+        assert_success
         echo "$output"
     else
         RD_TIMEOUT=10s run rdshell sh -c "RC_SVCNAME=$service_name /usr/libexec/rc/bin/service_get_value pidfile"
-        assert_success || return
+        assert_success
         RD_TIMEOUT=10s rdshell cat "$output"
     fi
 }
@@ -409,14 +409,14 @@ assert_service_status() {
         RD_TIMEOUT=10s run rdsudo systemctl is-active "$service_name"
         # `systemctl is-active` returns 0 on active, and non-0 on non-active.
         if [[ $expect == started ]]; then
-            assert_success || return
+            assert_success
         fi
         assert_line "$mapped_status"
     else
         RD_TIMEOUT=10s run rdsudo rc-service "$service_name" status
         # rc-service report non-zero status (3) when the service is stopped
         if [[ $expect == started ]]; then
-            assert_success || return
+            assert_success
         fi
         assert_output --partial "status: ${expect}"
     fi

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -88,9 +88,9 @@ EOF
 
 assert_helm_charts_are_deleted() {
     run --separate-stderr kubectl get helmcharts --namespace kube-system
-    assert_success || return
-    refute_line traefik || return
-    refute_line spin-operator || return
+    assert_success
+    refute_line traefik
+    refute_line spin-operator
     refute_line cert-manager
 }
 

--- a/bats/tests/k8s/wasm.bats
+++ b/bats/tests/k8s/wasm.bats
@@ -10,18 +10,18 @@ local_setup() {
 get_runtime_classes() {
     # kubectl may emit warnings here; ensure that we don't fall over.
     run --separate-stderr kubectl get RuntimeClasses --output json
-    assert_success || return
+    assert_success
 
     if [[ -n $stderr ]]; then
         # Check that we got a deprecation warning:
         # Warning: node.k8s.io/v1beta1 RuntimeClass is deprecated in v1.22+, unavailable in v1.25+
-        output=$stderr assert_output --partial deprecated || return
+        output=$stderr assert_output --partial deprecated
     fi
 
     local rtc=$output
     run jq '.items | length' <<<"$rtc"
-    assert_success || return
-    ((output > 0)) || return
+    assert_success
+    ((output > 0))
     echo "$rtc"
 }
 

--- a/bats/tests/registry/creds.bats
+++ b/bats/tests/registry/creds.bats
@@ -168,17 +168,17 @@ restart_container_engine() {
     # restart; however, restarting containerd again seems to fix this.
     # So we need to keep trying until the registry container is not `created`.
     # BUG BUG BUG
-    service_control "$CONTAINER_ENGINE_SERVICE" restart || return
+    service_control "$CONTAINER_ENGINE_SERVICE" restart
 
-    service_control --ifstarted rd-openresty restart || return
+    service_control --ifstarted rd-openresty restart
 
-    wait_for_container_engine || return
+    wait_for_container_engine
 
     trace "$(ctrctl ps -a)"
     if using_containerd; then
         run ctrctl ps --filter status=created,name=registry --format '{{.Names}}'
-        assert_success || return
-        refute_output registry || return
+        assert_success
+        refute_output registry
     fi
 }
 


### PR DESCRIPTION
This means all functions called by `run()` will run with `errexit` enabled and don't need to do the silly `|| return` dance anymore to make sure a failure is reported to the caller.