### PR TITLE
Packaging: RPM spec updates

### DIFF
--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package rancher-desktop
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -83,10 +83,9 @@ Requires: openssh-clients
 
 %if 0%{?fedora} || 0%{?rhel}
 Requires: pass
-Requires: gnupg2
 %else
 Requires: password-store
-Requires: gpg2
+Requires: qemu-img
 %endif
 
 Requires: glibc
@@ -183,9 +182,6 @@ cp -ra ./* "%{buildroot}/opt/%{name}"
 
 # Link to the binary
 ln -sf "/opt/%{name}/rancher-desktop" "%{buildroot}%{_bindir}/rancher-desktop"
-
-%post
-update-desktop-database %{_prefix}/share/applications || true
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
- openSUSE: Drop explicit `gpg2` dependency.  We only need it because it is required by `password-store`, but that already has it as a dependency and there is no point for us to set it explicitly.
- Fedora: Drop explicit `gnupg2` dependency, for the same reason.
- openSUSE: Add explicit dependency on `qemu-img`; that is required by lima to run `qemu-img info` / resize.  On Fedora, `qemu` already requires `qemu-img` so this is not needed.
- All: Drop use of `update-desktop-database`.  That does not get pulled in by the Debian package, so it just shows up as an (ignored) error.  It is deprecated on openSUSE / Fedora anyway because newer versions of RPM has file-based triggers, so there is no need for us to do that explicitly.

Fixes #9145 (ignoring `qemu-hw-display-virtio-gpu` because that should be fixed by lima-vm/lima#3897)