### PR TITLE
Revert "Switch from macos-13 to macos-latest for screenshots"

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
         - platform: mac
-          runs-on: macos-latest
+          runs-on: macos-13
         - platform: win
           runs-on: windows-latest
         - platform: linux


### PR DESCRIPTION
This reverts commit 13ed604e8ad067d420300c2f0922cae974550350.

macos-latest is running on M1/M2 machines that don't support nested virtualizations, so Rancher Desktop won't run on them.