### PR TITLE
Screenshots: Force display Rosetta options

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         include:
         - platform: mac
+          # Use an x86_64 platform because arm64 runners don't have nested
+          # virtualization available.
           runs-on: macos-13
         - platform: win
           runs-on: windows-latest

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -59,7 +59,7 @@ export default defineComponent({
       return semver.lt(this.macOsVersion.version, '13.0.0') || (this.isArm && semver.lt(this.macOsVersion.version, '13.3.0'));
     },
     rosettaDisabled(): boolean {
-      return !this.isArm;
+      return !this.isArm && !(process.env.RD_TEST ?? '').includes('screenshots');
     },
     arch(): string {
       return this.isArm ? 'arm64' : 'x64';

--- a/pkg/rancher-desktop/integrations/manageLinesInFile.ts
+++ b/pkg/rancher-desktop/integrations/manageLinesInFile.ts
@@ -164,7 +164,7 @@ async function copyFileExtendedAttributes(fromPath: string, toPath: string): Pro
       }
     }
   } catch (cause) {
-    if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {
+    if (process.env.NODE_ENV === 'test' && !(process.env.RD_TEST ?? '').includes('e2e')) {
       // When running unit tests, assume they do not have extended attributes.
       return;
     }

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -252,7 +252,7 @@ function getExec(scope: SpawnOptions['scope']): v1.Exec {
     return (async() => {
       const response = await ipcRenderer.invoke('extensions/spawn/blocking', safeOptions);
 
-      console.debug(`spawn/blocking got result:`, process.env.RD_TEST === 'e2e' ? JSON.stringify(response) : response);
+      console.debug(`spawn/blocking got result:`, (process.env.RD_TEST ?? '').includes('e2e') ? JSON.stringify(response) : response);
 
       const result = {
         cmd:    response.cmd,

--- a/pkg/rancher-desktop/utils/dockerDirManager.ts
+++ b/pkg/rancher-desktop/utils/dockerDirManager.ts
@@ -272,7 +272,7 @@ export class DockerDirManager {
     }
     // When running E2E tests in CI, use "none".  Note that we use the default
     // value when running unit tests in CI.
-    const e2eInCI = process.env.CI && process.env.RD_TEST === 'e2e';
+    const e2eInCI = process.env.CI && (process.env.RD_TEST ?? '').includes('e2e');
 
     if (e2eInCI && await this.credHelperWorking('none')) {
       return 'none';

--- a/pkg/rancher-desktop/utils/environment.ts
+++ b/pkg/rancher-desktop/utils/environment.ts
@@ -4,7 +4,7 @@
  * environment
  */
 const isDev = /^(?:dev|test)/i.test(process.env.NODE_ENV || '');
-const isE2E = /^e2e/i.test(process.env.RD_TEST ?? '');
+const isE2E = /e2e/i.test(process.env.RD_TEST ?? '');
 
 export const isDevEnv = isDev || isE2E;
 export const isDevBuild = !isE2E && isDev;

--- a/pkg/rancher-desktop/utils/logging.ts
+++ b/pkg/rancher-desktop/utils/logging.ts
@@ -69,7 +69,7 @@ export class Log {
    * @note This is only used during E2E tests where we do a factory reset.
    */
   protected reopen(mode = 'w') {
-    if (process.env.RD_TEST === 'e2e') {
+    if ((process.env.RD_TEST ?? '').includes('e2e')) {
       // If we're running E2E tests, we may need to create the log directory.
       // We don't do this normally because it's synchronous and slow.
       fs.mkdirSync(path.dirname(this.path), { recursive: true });
@@ -84,7 +84,7 @@ export class Log {
     // If we're running unit tests, output to the console rather than file.
     // However, _don't_ do so for end-to-end tests in Playwright.
     // We detect Playwright via an environment variable we set in scripts/e2e.ts
-    if (process.env.NODE_ENV === 'test' && process.env.RD_TEST !== 'e2e') {
+    if (process.env.NODE_ENV === 'test' && (process.env.RD_TEST ?? '').includes('e2e')) {
       this.console = globalThis.console;
     } else {
       this.console = new Console(this.stream);
@@ -195,7 +195,7 @@ export default new Proxy<Module>({}, {
  * the system, so that logs from another instance are not deleted.
  */
 export function clearLoggingDirectory(): void {
-  if (process.env.RD_TEST === 'e2e' || process.type !== 'browser') {
+  if ((process.env.RD_TEST ?? '').includes('e2e') || process.type !== 'browser') {
     return;
   }
 

--- a/pkg/rancher-desktop/vue.config.mjs
+++ b/pkg/rancher-desktop/vue.config.mjs
@@ -40,6 +40,7 @@ export default {
     config.plugin('define-plugin').use(webpack.DefinePlugin, [{
       'process.client':       JSON.stringify(true),
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+      'process.env.RD_TEST':  JSON.stringify(process.env.RD_TEST || ''),
 
       'process.env.FEATURE_DIAGNOSTICS_FIXES': process.env.RD_ENV_DIAGNOSTICS_FIXES === '1',
 

--- a/pkg/rancher-desktop/window/preferences.ts
+++ b/pkg/rancher-desktop/window/preferences.ts
@@ -99,7 +99,7 @@ export function openPreferences() {
   });
 
   window.on('close', (event) => {
-    if (!isDirty || process.env.RD_TEST === 'e2e') {
+    if (!isDirty || (process.env.RD_TEST ?? '').includes('e2e')) {
       return;
     }
 

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -114,7 +114,7 @@ class E2ETestRunner extends events.EventEmitter {
           ].join('\n'));
         }
       }
-      process.env.RD_TEST = 'e2e';
+      process.env.RD_TEST = process.env.npm_lifecycle_event || 'e2e'; // May include "screenshots"
 
       // Set feature flags
       process.env.RD_ENV_EXTENSIONS = '1';


### PR DESCRIPTION
Currently we need the real backend to be running to take screenshots.  But in CI we only have x86_64 runners available (because aarch64 runners do not have nested virtualization available).  This means the screenshots we take end up not showing the Rosetta options; fix that by force enabling that option when taking screenshots.

This also makes sure all uses of `RD_TEST` use a substring match.