### PR TITLE
UI: First-run: focus on accept button

### DIFF
--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -76,6 +76,7 @@
     </rd-fieldset>
     <div class="button-area">
       <button
+        v-focus
         data-test="accept-btn"
         class="role-primary"
         @click="close"

--- a/pkg/rancher-desktop/plugins/directives.js
+++ b/pkg/rancher-desktop/plugins/directives.js
@@ -7,6 +7,8 @@ export default {
 
         if ('LabeledTooltip' in components) {
           refs.value?.focus();
+        } else {
+          _el.focus();
         }
       },
     });


### PR DESCRIPTION
When the first run dialog opens, focus on the accept button by default. Fixes #9130