### PR TITLE
Lima: Changes to investigate startup speed

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/mobyClient.ts
@@ -70,7 +70,7 @@ export class MobyClient implements ContainerEngineClient {
     let lastOutput = { stdout: '', stderr: '' };
 
     // Wait for ten consecutive successes, clearing out successCount whenever we
-    // hit an error.  In the ideal case this is a ten-second delay in startup
+    // hit an error.  In the ideal case this is a five-second delay in startup
     // time.  We use `docker system info` because that needs to talk to the
     // socket to fetch data about the engine (and it returns an error if it
     // fails to do so).
@@ -98,7 +98,7 @@ export class MobyClient implements ContainerEngineClient {
           }
         }
       }
-      await util.promisify(setTimeout)(1_000);
+      await util.promisify(setTimeout)(500);
     }
   }
 

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -243,7 +243,8 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
         ]));
     }
 
-    await this.k3sHelper.getCompatibleKubectlVersion(this.activeVersion);
+    await this.progressTracker.action('Ensuring compatible kubectl', 50,
+      this.k3sHelper.getCompatibleKubectlVersion(this.activeVersion));
     if (this.cfg?.kubernetes?.options.flannel) {
       await this.progressTracker.action(
         'Waiting for nodes',


### PR DESCRIPTION
This is starting to investigate our startup speed; however, there isn't much to see here yet.

- Make it possible to debug the main process (using `yarn dev --inspect-brk`) with Chrome dev tools.
- Add more labels for the progress tracker, to help figure out why startup is slow. (Spoiler: about half of it is in `limactl start` by itself)
- Make (on Lima at least) waiting for the container engine client to be parallel with installing Kubernetes, and reduce how long it takes for a successful run.