### PR TITLE
macOS: Small startup speed improvements

### DIFF
--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -136,11 +136,10 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
    */
   async install(config: BackendSettings, desiredVersion: semver.SemVer, allowSudo: boolean) {
     await this.progressTracker.action('Installing k3s', 50, async() => {
-      // installK3s removes old config and makes sure the directories are recreated
-      await this.installK3s(desiredVersion);
-
       const promises: Promise<void>[] = [];
 
+      // installK3s removes old manifests and static workloads.
+      promises.push(this.installK3s(desiredVersion));
       promises.push(this.writeServiceScript(config, desiredVersion, allowSudo));
       if (config.experimental?.containerEngine?.webAssembly?.enabled) {
         promises.push(BackendHelper.configureRuntimeClasses(this.vm));


### PR DESCRIPTION
Run more things in parallel
- Notably, this means getting all system certs in parallel (instead of doing the async iterator thing). This takes up more resources while to runs, but cuts about a second.

This isn't _that_ great an improvement though. Ultimately we can't do too much without making deeper changes (e.g. not manually installing packages at boot time) at this time.