### PR TITLE
Windows: Startup speed improvements

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -34,6 +34,7 @@ var dockerproxyServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the docker socket proxy server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		isInternalCommand = true
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")

--- a/src/go/wsl-helper/cmd/root.go
+++ b/src/go/wsl-helper/cmd/root.go
@@ -18,10 +18,16 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// If isInternalCommand is set, when the command has an error we will use logrus
+// to display the error.
+var isInternalCommand bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -36,7 +42,13 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
+	err := rootCmd.Execute()
+	if !isInternalCommand {
+		cobra.CheckErr(err)
+	} else if err != nil {
+		logrus.Error(err)
+		os.Exit(1)
+	}
 }
 
 func init() {


### PR DESCRIPTION
- Run some unrelated Kubernetes startup steps in parallel (instead of in series).
- Start Kubernetes while still waiting for container engine to be ready.
- Quicker timeout when checking if we can connect to the Hyper-V socket.
- Make the wsl-helper logs more uniform (for easier parsing).

This (especially the socket timeout) seems to cut start time by nearly half on my machine (~40s to ~20s).