### PR TITLE
Startup profiling

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -732,7 +732,7 @@ Runas
 runbook
 runc
 rundir
-runlevels
+runlevel
 RUnlock
 runtimeclass
 runtimeclasses

--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.2
 
 use (
 	./scripts
@@ -13,5 +11,6 @@ use (
 	./src/go/networking
 	./src/go/rdctl
 	./src/go/spin-stub
+	./src/go/startup-profile
 	./src/go/wsl-helper
 )

--- a/src/go/startup-profile/.gitignore
+++ b/src/go/startup-profile/.gitignore
@@ -1,0 +1,2 @@
+*.cpuprofile
+*.json

--- a/src/go/startup-profile/README.md
+++ b/src/go/startup-profile/README.md
@@ -1,0 +1,16 @@
+# startup-profile
+
+This is a tool to profile Rancher Desktop startup to try to guide optimizing
+startup times.  It scrapes various logs to generate data that can be loaded into
+Chrome developer tools.
+
+## Usage
+
+1. Start Rancher Desktop using `yarn dev`.
+2. Wait until startup is complete; keep it running.
+3. Run this tool (via `go run .`) to generate a `.cpuprofile` file.
+4. Open Chrome (or other Chromium-derived browser) developer tools, and go to
+   the _Performance_ tab.
+5. Click on the _Load Profile_ button (looks something like `↥`) and load the
+   generated file.
+6. Alternatively, load the same file using https://profiler.firefox.com/

--- a/src/go/startup-profile/go.mod
+++ b/src/go/startup-profile/go.mod
@@ -1,0 +1,5 @@
+module github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile
+
+go 1.24.2
+
+require golang.org/x/sync v0.16.0

--- a/src/go/startup-profile/go.sum
+++ b/src/go/startup-profile/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=

--- a/src/go/startup-profile/main.go
+++ b/src/go/startup-profile/main.go
@@ -1,0 +1,45 @@
+// Command startup-profile generates a Chrome devtools profile format.
+// The output can be loaded via https://profiler.firefox.com/ or via Chrome
+// devtools (Performance tab).
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// marshalledPath represents a path.  It implements [encoding.TextMarshaler] and
+// [encoding.TextUnmarshaler].
+type marshalledPath string
+
+func (p *marshalledPath) MarshalText() ([]byte, error) {
+	return []byte(*p), nil
+}
+
+func (p *marshalledPath) UnmarshalText(text []byte) error {
+	abs, err := filepath.Abs(string(text))
+	if err != nil {
+		return err
+	}
+	if info, err := os.Stat(filepath.Dir(abs)); err != nil {
+		return err
+	} else if !info.IsDir() {
+		return fmt.Errorf("parent %s is not a directory", filepath.Dir(abs))
+	}
+	*p = marshalledPath(abs)
+	return nil
+}
+
+func main() {
+	outPath := marshalledPath("rancher-desktop.cpuprofile")
+	flag.TextVar(&outPath, "out", &outPath, "File name to write the output to")
+	flag.Parse()
+
+	if err := run(context.Background(), outPath); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/src/go/startup-profile/model/event.go
+++ b/src/go/startup-profile/model/event.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+type EventPhase string
+
+const (
+	EventPhaseBegin   = EventPhase("B")
+	EventPhaseEnd     = EventPhase("E")
+	EventPhaseInstant = EventPhase("i")
+)
+
+// Event describes something happening.  It is in Google's Trace Event Format,
+// as described in https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.uxpopqvbjezh
+type Event struct {
+	Name     string     `json:"name"`
+	Category string     `json:"cat"`
+	Phase    EventPhase `json:"ph"`
+	// Each event must have a timestamp; the `time` field is generated when rendering.
+	TimeStamp time.Time      `json:"-time-stamp"`
+	PID       int            `json:"pid"`
+	TID       int            `json:"tid"`
+	Args      map[string]any `json:"args"`
+
+	// Event time in microseconds since start of trace; generated when rendering.
+	Time int64 `json:"ts"`
+	// Duration of "begin" events; generated when rendering.
+	Duration time.Duration `json:"-duration"`
+}

--- a/src/go/startup-profile/parsers/const.go
+++ b/src/go/startup-profile/parsers/const.go
@@ -1,0 +1,3 @@
+package parsers
+
+const osWindows = "windows"

--- a/src/go/startup-profile/parsers/dmesg.go
+++ b/src/go/startup-profile/parsers/dmesg.go
@@ -1,0 +1,83 @@
+package parsers
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/rdctl"
+)
+
+// Parse `dmesg` output
+func ParseDmesg(ctx context.Context) ([]*model.Event, error) {
+	if runtime.GOOS == osWindows {
+		// dmesg isn't useful on Windows, because we use WSL2 there so messages may
+		// be related to a different distribution.
+		return nil, nil
+	}
+	_, err := rdctl.Rdctl(ctx, "shell", "sudo",
+		"sh", "-c", "date -u +'@@STOP@@ %FT%TZ' >> /dev/kmsg") // spellcheck-ignore-line
+	if err != nil {
+		return nil, fmt.Errorf("failed to mark timestamp in dmesg: %w", err)
+	}
+	stdout, err := rdctl.Rdctl(ctx, "shell", "sudo", "dmesg")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dmesg: %w", err)
+	}
+	lineMatcher := regexp.MustCompile(`^\[\s*(\d+\.\d+)\] (.*)$`)
+	ignoreMatcher := regexp.MustCompile(`^(?:audit:|cni0:|veth[0-9a-f]+:|kauditd_printk_skb)`)
+	var timeOffset time.Time
+	scanner := bufio.NewScanner(stdout)
+	type entry struct {
+		offset  int64
+		message string
+	}
+	var entries []entry
+	for scanner.Scan() {
+		lineMatch := lineMatcher.FindStringSubmatch(scanner.Text())
+		if len(lineMatch) != 3 {
+			continue
+		}
+		if strings.HasPrefix(lineMatch[2], "@@STOP@@ ") {
+			offset, err := strconv.ParseFloat(lineMatch[1], 64)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing time offset: %q: %w", scanner.Text(), err)
+			}
+			timeOffset, err = time.Parse(time.RFC3339, lineMatch[2][len("@@STOP@@ "):])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing current time: %w", err)
+			}
+			timeOffset = timeOffset.Add(-time.Duration(int64(offset * float64(time.Second))))
+			break
+		}
+		if ignoreMatcher.MatchString(lineMatch[2]) {
+			// Skip uninteresting line.
+			continue
+		}
+		offset, err := strconv.ParseFloat(lineMatch[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time offset: %q: %w", scanner.Text(), err)
+		}
+		entries = append(entries, entry{offset: int64(offset * float64(time.Second)), message: lineMatch[2]})
+	}
+
+	if timeOffset.IsZero() {
+		return nil, fmt.Errorf("failed to find time offset")
+	}
+	results := make([]*model.Event, 0, len(entries))
+	for _, entry := range entries {
+		results = append(results, &model.Event{
+			Name:      entry.message,
+			Category:  "dmesg",
+			Phase:     model.EventPhaseInstant,
+			TimeStamp: timeOffset.Add(time.Duration(entry.offset)),
+		})
+	}
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/interface.go
+++ b/src/go/startup-profile/parsers/interface.go
@@ -1,0 +1,44 @@
+package parsers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/rdctl"
+)
+
+// A Parser is a function that processes some kind of log file and emits events
+// into the provided channel.
+type Parser func(context.Context) ([]*model.Event, error)
+
+// Given the name of a log file, return a scanner that reads from the given file
+// in the Rancher Desktop logs directory.
+func readRDLogFile(ctx context.Context, name string) (*bufio.Scanner, error) {
+	var paths struct {
+		Logs string `json:"logs"`
+	}
+	stdout, err := rdctl.Rdctl(ctx, "paths")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get paths: %w", err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &paths); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal paths: %w", err)
+	}
+	logPath := filepath.Join(paths.Logs, name)
+	logFile, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %s: %w", logPath, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = logFile.Close()
+	}()
+
+	return bufio.NewScanner(logFile), nil
+}

--- a/src/go/startup-profile/parsers/lima-ha.go
+++ b/src/go/startup-profile/parsers/lima-ha.go
@@ -1,0 +1,59 @@
+package parsers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/rdctl"
+)
+
+func ParseLimaHostAgentLogs(ctx context.Context) ([]*model.Event, error) {
+	var paths struct {
+		Lima string `json:"lima"`
+	}
+	stdout, err := rdctl.Rdctl(ctx, "paths")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get paths: %w", err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &paths); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal paths: %w", err)
+	}
+	if paths.Lima == "" {
+		// On Windows, we don't use Lima, so this would not deserialize.
+		return nil, nil
+	}
+	logPath := filepath.Join(paths.Lima, "0", "ha.stderr.log")
+	logFile, err := os.Open(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+	var results []*model.Event
+	scanner := bufio.NewScanner(logFile)
+	for scanner.Scan() {
+		var data struct {
+			Level   string    `json:"level"`
+			Message string    `json:"msg"`
+			Time    time.Time `json:"time"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &data); err != nil {
+			// Ignore any lines that are not JSON
+			continue
+		}
+		if !data.Time.IsZero() {
+			results = append(results, &model.Event{
+				Name:      data.Message,
+				Category:  "lima.ha.stderr.log",
+				Phase:     model.EventPhaseInstant,
+				TimeStamp: data.Time,
+			})
+		}
+	}
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/lima-init.go
+++ b/src/go/startup-profile/parsers/lima-init.go
@@ -1,0 +1,45 @@
+package parsers
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/rdctl"
+)
+
+// ParseLimaInitLogs parses /var/log/lima-init.log in a Lima VM.
+func ParseLimaInitLogs(ctx context.Context) ([]*model.Event, error) {
+	// Run `rdctl shell` to print the lima-init logs; if the file does not exist,
+	// still return success (this will be the case on Windows).
+	stdout, err := rdctl.Rdctl(ctx, "shell", "sudo",
+		"sh", "-c", "cat /var/log/lima-init.log || true")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lima-init logs: %w", err)
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^LIMA ([^|]+)\|\s*(.*)$`)
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) < 3 {
+			continue
+		}
+		date, err := time.Parse(time.RFC3339, matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		results = append(results, &model.Event{
+			Name:      matches[2],
+			Category:  "lima-init",
+			Phase:     model.EventPhaseInstant,
+			TimeStamp: date,
+		})
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/networking.go
+++ b/src/go/startup-profile/parsers/networking.go
@@ -1,0 +1,56 @@
+package parsers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+func ParseNetworkingLogs(ctx context.Context) ([]*model.Event, error) {
+	scanner, err := readRDLogFile(ctx, "networking.log")
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^(\d+-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z): (.*)$`)
+	beginMatcher := regexp.MustCompile(`^getting certificates from (.*?)\.{3}$`)
+	endMatcher := regexp.MustCompile(`^got certificates from (.*?)$`)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) != matcher.NumSubexp()+1 {
+			continue
+		}
+		parsedTime, err := time.Parse(time.RFC3339, matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		if m := beginMatcher.FindStringSubmatch(matches[2]); len(m) == beginMatcher.NumSubexp()+1 {
+			results = append(results, &model.Event{
+				Name:      m[1],
+				Category:  "networking.log",
+				Phase:     model.EventPhaseBegin,
+				TimeStamp: parsedTime,
+			})
+		} else if m := endMatcher.FindStringSubmatch(matches[2]); len(m) == endMatcher.NumSubexp()+1 {
+			results = append(results, &model.Event{
+				Name:      m[1],
+				Category:  "networking.log",
+				Phase:     model.EventPhaseEnd,
+				TimeStamp: parsedTime,
+			})
+		} else {
+			results = append(results, &model.Event{
+				Name:      matches[2],
+				Category:  "networking.log",
+				Phase:     model.EventPhaseInstant,
+				TimeStamp: parsedTime,
+			})
+		}
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/progress.go
+++ b/src/go/startup-profile/parsers/progress.go
@@ -1,0 +1,53 @@
+package parsers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"runtime"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+// ParseProgress parses the Rancher Desktop backend logs for progress tracker
+// events.
+func ParseProgress(ctx context.Context) ([]*model.Event, error) {
+	logName := "lima.log"
+	if runtime.GOOS == osWindows {
+		logName = "wsl.log"
+	}
+
+	scanner, err := readRDLogFile(ctx, logName)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^(\d+.*?Z): Progress: (started|finished) (.*)$`)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) < matcher.NumSubexp()+1 {
+			continue
+		}
+		date := matches[1]
+		state := matches[2]
+		description := matches[3]
+
+		parsedTime, err := time.Parse(time.RFC3339, date)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		phase := model.EventPhaseBegin
+		if state == "finished" {
+			phase = model.EventPhaseEnd
+		}
+		results = append(results, &model.Event{
+			Name:      description,
+			Category:  logName,
+			Phase:     phase,
+			TimeStamp: parsedTime,
+		})
+	}
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/rc.go
+++ b/src/go/startup-profile/parsers/rc.go
@@ -1,0 +1,58 @@
+package parsers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"runtime"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/rdctl"
+)
+
+func ProcessRCLogs(ctx context.Context) ([]*model.Event, error) {
+	stdout, err := rdctl.Rdctl(ctx, "shell", "sudo",
+		"sh", "-c", "cat /var/log/rc.log || echo 'MISSING'")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rc.log: %w", err)
+	}
+	if bytes.HasPrefix(stdout.Bytes(), []byte("MISSING")) {
+		log.Println("Failed to open /var/log/rc.log")
+		return nil, nil
+	}
+	matcher := regexp.MustCompile(`^rc (.*?) logging (started|stopped) at (.*)$`)
+	location := time.UTC
+	if runtime.GOOS == osWindows {
+		location = time.Local
+	}
+	var results []*model.Event
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		match := matcher.FindStringSubmatch(scanner.Text())
+		if match == nil {
+			continue
+		}
+		level := match[1]
+		action := match[2]
+		timeStamp, err := time.ParseInLocation(time.ANSIC, match[3], location)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		phase := model.EventPhaseBegin
+		if action == "stopped" {
+			phase = model.EventPhaseEnd
+		}
+		results = append(results, &model.Event{
+			Name:      fmt.Sprintf("runlevel %s", level),
+			Category:  "rc",
+			Phase:     phase,
+			TimeStamp: timeStamp.UTC(),
+		})
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/windows-guest-agent.go
+++ b/src/go/startup-profile/parsers/windows-guest-agent.go
@@ -1,0 +1,43 @@
+package parsers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"runtime"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+func ParseWindowsGuestAgentLogs(ctx context.Context) ([]*model.Event, error) {
+	if runtime.GOOS != osWindows {
+		return nil, nil
+	}
+
+	scanner, err := readRDLogFile(ctx, "rancher-desktop-guestagent.log")
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^(\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2})\s+\[.*?\]\s+(.*)$`)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) != matcher.NumSubexp()+1 {
+			continue
+		}
+		timestamp, err := time.ParseInLocation("2006/01/02 15:04:05", matches[1], time.Local)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		results = append(results, &model.Event{
+			Name:      matches[2],
+			Category:  "guest-agent",
+			Phase:     model.EventPhaseInstant,
+			TimeStamp: timestamp,
+		})
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/windows-integration.go
+++ b/src/go/startup-profile/parsers/windows-integration.go
@@ -1,0 +1,43 @@
+package parsers
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"runtime"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+func ParseWindowsIntegrationLogs(ctx context.Context) ([]*model.Event, error) {
+	if runtime.GOOS != osWindows {
+		return nil, nil
+	}
+
+	scanner, err := readRDLogFile(ctx, "integrations.log")
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z):\s+(.*)$`)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) != matcher.NumSubexp()+1 {
+			continue
+		}
+		timestamp, err := time.Parse(time.RFC3339, matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+		results = append(results, &model.Event{
+			Name:      matches[2],
+			Category:  "integrations",
+			Phase:     model.EventPhaseInstant,
+			TimeStamp: timestamp,
+		})
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/parsers/wsl-helper.go
+++ b/src/go/startup-profile/parsers/wsl-helper.go
@@ -1,0 +1,56 @@
+package parsers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+func ParseWSLHelperLogs(ctx context.Context) ([]*model.Event, error) {
+	scanner, err := readRDLogFile(ctx, "wsl-helper.log")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []*model.Event
+	matcher := regexp.MustCompile(`^time="(.*?)" level=(\w+) msg=(".*?"|[^"]\w+)`)
+	for scanner.Scan() {
+		matches := matcher.FindStringSubmatch(scanner.Text())
+		if len(matches) != matcher.NumSubexp()+1 {
+			continue
+		}
+
+		if matches[2] == "debug" {
+			continue
+		}
+
+		timestamp, err := time.Parse(time.RFC3339, matches[1])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing time: %q: %w", scanner.Text(), err)
+		}
+
+		msg := matches[3]
+		var result string
+		if err := json.Unmarshal([]byte(msg), &result); err == nil {
+			msg = result
+		}
+
+		results = append(results, &model.Event{
+			Name:      msg,
+			Category:  "wsl-helper",
+			Phase:     model.EventPhaseInstant,
+			TimeStamp: timestamp,
+		})
+	}
+
+	return results, nil
+}

--- a/src/go/startup-profile/rdctl/rdctl.go
+++ b/src/go/startup-profile/rdctl/rdctl.go
@@ -1,0 +1,47 @@
+package rdctl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// Run rdctl and return its standard output.
+func Rdctl(ctx context.Context, args ...string) (*bytes.Buffer, error) {
+	exe, err := exec.LookPath("rdctl")
+	if err != nil {
+		relPath := "resources/linux/bin/rdctl"
+		switch runtime.GOOS {
+		case "darwin":
+			relPath = "resources/darwin/bin/rdctl"
+		case "windows":
+			relPath = `resources\win32\bin\rdctl.exe`
+		}
+		dir, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get working directory: %w", err)
+		}
+		for dir != filepath.Dir(dir) {
+			exe = filepath.Join(dir, relPath)
+			if _, err := os.Stat(exe); err == nil {
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if dir == filepath.Dir(dir) {
+			return nil, fmt.Errorf("could not find rdctl")
+		}
+	}
+	buf := &bytes.Buffer{}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/src/go/startup-profile/render/model.go
+++ b/src/go/startup-profile/render/model.go
@@ -1,0 +1,34 @@
+package render
+
+import "time"
+
+type nodeId int64
+
+// https://chromedevtools.github.io/devtools-protocol/1-3/Profiler/#type-Profile
+// This is the root object of the document.
+type profile struct {
+	Nodes      []*profileNode `json:"nodes"`
+	StartTime  int64          `json:"startTime"`
+	EndTime    int64          `json:"endTime"`
+	Samples    []nodeId       `json:"samples"`
+	TimeDeltas []int64        `json:"timeDeltas"`
+}
+
+// https://chromedevtools.github.io/devtools-protocol/1-3/Profiler/#type-ProfileNode
+type profileNode struct {
+	Id        nodeId        `json:"id"`
+	CallFrame callFrame     `json:"callFrame"`
+	Children  []nodeId      `json:"children,omitempty"`
+	StartTime time.Time     `json:"-startTime"`
+	StopTime  time.Time     `json:"-stopTime"`
+	Duration  time.Duration `json:"-duration"`
+}
+
+// https://chromedevtools.github.io/devtools-protocol/1-3/Runtime/#type-CallFrame
+type callFrame struct {
+	FunctionName string `json:"functionName"`
+	ScriptId     string `json:"scriptId"`
+	Url          string `json:"url"`
+	LineNumber   int64  `json:"lineNumber"`
+	ColumnNumber int64  `json:"columnNumber"`
+}

--- a/src/go/startup-profile/render/process.go
+++ b/src/go/startup-profile/render/process.go
@@ -1,0 +1,148 @@
+package render
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+// Normalize events from a single source.  This means:
+// - All begin/end pairs have a minimum delta (i.e. not zero-time).
+// - All begin events have a duration set (i.e. not zero-time).
+// - All instant events have a duration set (i.e. not zero-time).
+// - Any events following zero-time events have been moved back.
+func ProcessSource(ctx context.Context, name string, events []*model.Event) error {
+	// If we have no events, don't touch anything.
+	if len(events) == 0 {
+		return nil
+	}
+
+	// Make sure the inputs are in chronological order.
+	slices.SortStableFunc(events, func(a, b *model.Event) int {
+		return a.TimeStamp.Compare(b.TimeStamp)
+	})
+
+	// For any instant events, as well as begin/end pairs of time zero, set their
+	// time to one microsecond.
+	minimumTime := events[0].TimeStamp
+	for i, event := range events {
+		if event.TimeStamp.Before(minimumTime) {
+			event.TimeStamp = minimumTime
+		}
+		switch event.Phase {
+		case model.EventPhaseBegin:
+			// TODO: make this not O(n^2)
+			var endEvent *model.Event
+			for j := i + 1; endEvent == nil && j < len(events); j++ {
+				candidate := events[j]
+				if candidate.Phase != model.EventPhaseEnd {
+					continue
+				}
+				if candidate.Category != event.Category {
+					// Should not happen: this should be from the same source.
+					panic(fmt.Sprintf("Unexpected category %s/%s", candidate.Category, event.Category))
+				}
+				if candidate.Name != event.Name {
+					continue
+				}
+				endEvent = candidate
+			}
+			if endEvent == nil {
+				return fmt.Errorf("failed to find end event for %+v", event)
+			}
+			if endEvent.TimeStamp.After(event.TimeStamp) {
+				event.Duration = endEvent.TimeStamp.Sub(event.TimeStamp)
+				continue
+			}
+			// If we get here, then this is a begin/end pair with zero time.
+			event.Duration = time.Microsecond
+			minimumTime = event.TimeStamp.Add(event.Duration)
+		case model.EventPhaseEnd:
+			endTime := event.TimeStamp.Add(time.Microsecond)
+			if minimumTime.Before(endTime) {
+				minimumTime = endTime
+			}
+		case model.EventPhaseInstant:
+			event.Duration = time.Microsecond
+			if event.TimeStamp.Before(minimumTime) {
+				event.TimeStamp = minimumTime
+			}
+			minimumTime = event.TimeStamp.Add(event.Duration)
+		}
+	}
+
+	if f, err := os.Create(name + ".json"); err == nil {
+		encoder := json.NewEncoder(f)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(events); err != nil {
+			slog.ErrorContext(ctx, "error writing debug logs", "processor", name, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// Process the events to normalize them.  At this point, ProcessSource must have
+// been called already (but the events may be out of order).
+func processEvents(events []*model.Event) error {
+	// Start time is the time of the chronologically first event.
+	startTime := time.Now()
+	// Beginnings is a map from category then name to the event index for the "begin" event
+	beginnings := make(map[string]map[string]int)
+	// Endings is a map from the begin event to the end event, by event id.
+	endings := make(map[int]int)
+
+	for i, event := range events {
+		if !event.TimeStamp.IsZero() && event.TimeStamp.Before(startTime) {
+			startTime = event.TimeStamp
+		}
+		switch event.Phase {
+		case model.EventPhaseBegin:
+			if _, ok := beginnings[event.Category]; !ok {
+				beginnings[event.Category] = make(map[string]int)
+			}
+			beginnings[event.Category][event.Name] = i
+		case model.EventPhaseEnd:
+			names, ok := beginnings[event.Category]
+			if !ok {
+				return fmt.Errorf("events out of order: found ending event %+v before category", event)
+			}
+			beginId, ok := names[event.Name]
+			if !ok {
+				return fmt.Errorf("events out of order: found ending event %+v before beginning", event)
+			}
+			endings[beginId] = i
+			event.TimeStamp = events[beginId].TimeStamp.Add(events[beginId].Duration)
+		}
+	}
+
+	for _, event := range events {
+		if event.TimeStamp.IsZero() {
+			event.TimeStamp = startTime.Add(-time.Nanosecond)
+		}
+	}
+
+	// Process the events to make sure they have (offset) times
+	slices.SortStableFunc(events, func(a, b *model.Event) int {
+		if start := a.TimeStamp.Compare(b.TimeStamp); start != 0 {
+			return start
+		}
+		// Compare by duration, with longer events first.
+		// Do not otherwise sort them, to keep things like dmesg lines in order.
+		return -cmp.Compare(a.Duration, b.Duration)
+	})
+
+	// Set the time-since-start field.
+	for _, event := range events {
+		event.Time = int64(event.TimeStamp.Sub(events[0].TimeStamp) / time.Microsecond)
+	}
+
+	return nil
+}

--- a/src/go/startup-profile/render/render.go
+++ b/src/go/startup-profile/render/render.go
@@ -1,0 +1,177 @@
+package render
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"slices"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+)
+
+// Render the events into a data structure suitable to be JSON-encoded into a
+// file as a Chrome CPU profile.
+func Render(ctx context.Context, events []*model.Event) (any, error) {
+	// Insert a fake root event at the start
+	events = append([]*model.Event{
+		{
+			Name:     "(root)",
+			Category: "root",
+			Phase:    model.EventPhaseBegin,
+			Time:     0,
+		},
+	}, events...)
+
+	if err := processEvents(events); err != nil {
+		return nil, err
+	}
+
+	profile := profile{
+		StartTime: events[0].TimeStamp.UnixMicro(),
+		EndTime:   events[len(events)-1].TimeStamp.UnixMicro(),
+	}
+
+	events[0].Duration = events[len(events)-1].TimeStamp.Sub(events[0].TimeStamp)
+
+	// Insert the end of the fake root event at the end
+	events = append(events, &model.Event{
+		Name:     "(root)",
+		Category: "root",
+		Phase:    model.EventPhaseEnd,
+		Time:     profile.EndTime - profile.StartTime,
+	})
+
+	if f, err := os.Create("processed.json"); err == nil {
+		encoder := json.NewEncoder(f)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(events); err != nil {
+			slog.ErrorContext(ctx, "error writing debug logs", "error", err)
+		}
+	}
+
+	var stack []*profileNode
+	var lastTime int64
+	nextId := nodeId(1)
+	for i, event := range events {
+		switch event.Phase {
+		case model.EventPhaseBegin:
+			if i >= len(events)-1 {
+				// This is the last event; but it's a begin phase
+				return nil, fmt.Errorf("invalid event stream: last event is in phase begin: %+v", event)
+			}
+			node := profileNode{
+				Id: nextId,
+				CallFrame: callFrame{
+					FunctionName: event.Name,
+					ScriptId:     event.Category,
+					Url:          event.Category,
+					LineNumber:   -1,
+					ColumnNumber: -1,
+				},
+				StartTime: event.TimeStamp,
+				StopTime:  event.TimeStamp.Add(event.Duration),
+				Duration:  event.Duration,
+			}
+			profile.Nodes = append(profile.Nodes, &node)
+			nextId++
+			if len(stack) > 0 {
+				stack[len(stack)-1].Children = append(stack[len(stack)-1].Children, node.Id)
+			}
+			stack = append(stack, &node)
+			nextEvent := events[i+1]
+			if event.Time < nextEvent.Time {
+				// The next event is at a different time; insert this node.
+				profile.Samples = append(profile.Samples, node.Id)
+				profile.TimeDeltas = append(profile.TimeDeltas, max(event.Time-lastTime, 1))
+				lastTime = event.Time
+			}
+		case model.EventPhaseEnd:
+			if i < 1 {
+				return nil, fmt.Errorf("invalid event stream: first event is in phase end: %+v", event)
+			}
+			if len(stack) < 1 {
+				return nil, fmt.Errorf("invalid event stream: ending with empty stack: %+v", event)
+			}
+			for j := len(stack) - 1; j >= 0; j-- {
+				if stack[j].CallFrame.FunctionName != event.Name {
+					continue
+				}
+				if stack[j].CallFrame.ScriptId != event.Category {
+					continue
+				}
+				// We need to remove this item from the stack; however, logically this
+				// means we need to recreate any nodes on top (with new IDs) because
+				// the profile is supposed to have matching stacks.
+				for k := j; k < len(stack)-1; k++ {
+					node := profileNode{
+						Id:        nextId,
+						CallFrame: stack[k+1].CallFrame,
+						Children:  slices.Clone(stack[k+1].Children),
+						StartTime: event.TimeStamp,
+						StopTime:  event.TimeStamp.Add(event.Duration),
+						Duration:  event.Duration,
+					}
+					stack[k] = &node
+					profile.Nodes = append(profile.Nodes, &node)
+					nextId++
+					if k > 0 {
+						stack[k-1].Children = append(stack[k-1].Children, node.Id)
+					}
+				}
+				stack = stack[:len(stack)-1]
+				break
+			}
+			emitSample := len(stack) > 0
+			if len(events)-1 > i {
+				// There are more events; check if the next event has a time change
+				nextEvent := events[i+1]
+				emitSample = emitSample && event.Time != nextEvent.Time
+			}
+			if emitSample {
+				// The next event is at a different time; insert this node.
+				profile.Samples = append(profile.Samples, stack[len(stack)-1].Id)
+				profile.TimeDeltas = append(profile.TimeDeltas, max(event.Time-lastTime, 1))
+				lastTime = event.Time
+			}
+		case model.EventPhaseInstant:
+			if i < 1 {
+				return nil, fmt.Errorf("invalid event stream: first event is instant: %+v", event)
+			}
+			if len(stack) < 1 {
+				return nil, fmt.Errorf("invalid event stream: instant event with no stack: %+v", event)
+			}
+			node := profileNode{
+				Id: nextId,
+				CallFrame: callFrame{
+					FunctionName: event.Name,
+					ScriptId:     event.Category,
+					Url:          event.Category,
+					LineNumber:   -1,
+					ColumnNumber: -1,
+				},
+				StartTime: event.TimeStamp,
+				StopTime:  event.TimeStamp.Add(event.Duration),
+				Duration:  event.Duration,
+			}
+			nextId++
+			stackTop := stack[len(stack)-1]
+			// Always emit instant events directly, even if no time has passed
+			stackTop.Children = append(stackTop.Children, node.Id)
+			profile.Nodes = append(profile.Nodes, &node)
+			profile.Samples = append(profile.Samples, node.Id)
+			profile.TimeDeltas = append(profile.TimeDeltas, max(event.Time-lastTime, 0))
+			lastTime = event.Time
+			// If there isn't another event at the same time, "sample" the parent again
+			if events[i+1].Time > event.Time {
+				profile.Samples = append(profile.Samples, stackTop.Id)
+				profile.TimeDeltas = append(profile.TimeDeltas, 0)
+			}
+		default:
+			return nil, fmt.Errorf("invalid event stream: unknown phase: %+v", event)
+		}
+	}
+
+	return profile, nil
+}

--- a/src/go/startup-profile/run.go
+++ b/src/go/startup-profile/run.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/model"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/parsers"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/startup-profile/render"
+)
+
+func run(ctx context.Context, outPath marshalledPath) error {
+	// Normalize the output path, in case it's still the default value.
+	if err := outPath.UnmarshalText([]byte(outPath)); err != nil {
+		return fmt.Errorf("error normalizing output path %s: %w", outPath, err)
+	}
+
+	// Set up the channel we will use to read events
+	mutex := sync.Mutex{}
+	events := make([]*model.Event, 0, 1024)
+	group, ctx := errgroup.WithContext(context.Background())
+
+	// Run the individual data collectors
+	processors := map[string]parsers.Parser{
+		"lima":                parsers.ParseLimaInitLogs,
+		"progress":            parsers.ParseProgress,
+		"dmesg":               parsers.ParseDmesg,
+		"openrc":              parsers.ProcessRCLogs,
+		"host-agent":          parsers.ParseLimaHostAgentLogs,
+		"networking":          parsers.ParseNetworkingLogs,
+		"windows-guest-agent": parsers.ParseWindowsGuestAgentLogs,
+		"windows-integration": parsers.ParseWindowsIntegrationLogs,
+		"wsl-helper":          parsers.ParseWSLHelperLogs,
+	}
+
+	for name, p := range processors {
+		group.Go(func() error {
+			results, err := p(ctx)
+			if err != nil {
+				return err
+			}
+			if err := render.ProcessSource(ctx, name, results); err != nil {
+				return err
+			}
+			mutex.Lock()
+			events = append(events, results...)
+			mutex.Unlock()
+			slog.InfoContext(ctx, "got events", "source", name, "count", len(results))
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return err
+	}
+	if len(events) < 1 {
+		return fmt.Errorf("no events found")
+	}
+
+	// Emit the output
+	data, err := render.Render(ctx, events)
+	if err != nil {
+		return err
+	}
+	outFile, err := os.Create(string(outPath))
+	if err != nil {
+		return fmt.Errorf("failed to create output file %s: %w", outPath, err)
+	}
+	encoder := json.NewEncoder(outFile)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode events: %w", err)
+	}
+	if err := outFile.Close(); err != nil {
+		return fmt.Errorf("failed to flush output file %s: %w", outPath, err)
+	}
+	return nil
+}


### PR DESCRIPTION
This adds a tool to try to generate profiling events from logs, in the style that can be imported by Chrome devtools.  Firefox has a webtool that can load the same file, but it doesn't understand that our samples may have very different intervals.

The code itself isn't very interesting, as much as the output. As an example run from a Windows machine: [windows.cpuprofile](https://github.com/user-attachments/files/22125171/windows.cpuprofile)
