### PR TITLE
Linux: fetch system certificates in parallel

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -306,6 +306,7 @@ globalrole
 globalrolebinding
 Gluster
 gname
+gnutls
 gocritic
 gofmt
 goland

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "intl-messageformat": "10.7.16",
     "jquery": "3.7.1",
     "jsonpath": "1.1.1",
-    "linux-ca": "2.0.1",
     "lodash": "4.17.21",
     "marked": "16.2.1",
     "native-reg": "1.1.1",

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -50,6 +50,7 @@ Requires: qemu-system-x86
 Requires: pass
 Requires: openssh-client
 Requires: gnupg
+Requires: gnutls-bin # To enumerate system certificates
 Requires: libasound2
 Requires: libatk1.0-0
 Requires: libatk-bridge2.0-0
@@ -111,6 +112,7 @@ Requires: mesa-libgbm
 Requires: libgcc
 Requires: gdk-pixbuf2
 Requires: glib
+Requires: gnutls-utils # To enumerate system certificates
 Requires: gtk3
 Requires: pango
 Requires: libxcb
@@ -118,6 +120,7 @@ Requires: libxkbcommon
 Requires: nspr
 Requires: nss
 %else
+Requires: gnutls # To enumerate system certificates
 Requires: libX11-6
 Requires: libXcomposite1
 Requires: libXdamage1

--- a/pkg/rancher-desktop/main/networking/index.ts
+++ b/pkg/rancher-desktop/main/networking/index.ts
@@ -5,9 +5,8 @@ import os from 'os';
 import util from 'util';
 
 import Electron from 'electron';
-import LinuxCA from 'linux-ca';
 
-import filterCert from './cert-parse';
+import getLinuxCertificates from './linux-ca';
 import getMacCertificates from './mac-ca';
 import ElectronProxyAgent from './proxy';
 import getWinCertificates from './win-ca';
@@ -127,7 +126,7 @@ export async function * getSystemCertificates(): AsyncIterable<string> {
   } else if (platform === 'darwin') {
     yield * getMacCertificates();
   } else if (platform === 'linux') {
-    yield * (await LinuxCA.getAllCerts(true)).flat().filter(filterCert);
+    yield * getLinuxCertificates();
   } else {
     throw new Error(`Cannot get system certificates on ${ platform }`);
   }

--- a/pkg/rancher-desktop/main/networking/linux-ca.ts
+++ b/pkg/rancher-desktop/main/networking/linux-ca.ts
@@ -1,0 +1,65 @@
+/**
+ * This module fetches system CAs on Linux.  The command lines are based on the
+ * `linux-ca` package on NPM, but none of the code is copied.
+ */
+
+import checkCertValidity from './cert-parse';
+
+import { spawnFile } from '@pkg/utils/childProcess';
+import Logging from '@pkg/utils/logging';
+import { defined } from '@pkg/utils/typeUtils';
+
+const console = Logging.networking;
+
+/**
+ * Asynchronously enumerate the certificate authorities that should be used to
+ * build the Rancher Desktop trust store, in PEM format in undefined order.
+ */
+export default async function * getLinuxCertificates(): AsyncIterable<string> {
+  const tokenURLs = await Array.fromAsync(listTokens());
+  const promises = tokenURLs.map(listCertificates).map(async function(certURLIterable) {
+    return (await Array.fromAsync(certURLIterable)).map(getCertificate);
+  });
+  const certs = await Promise.all((await Promise.all(promises)).flat());
+
+  yield * certs.filter(defined).filter(checkCertValidity);
+}
+
+async function * listTokens(): AsyncIterable<string> {
+  try {
+    const { stdout } = await spawnFile('p11tool', ['--list-token-urls'],
+      { stdio: ['ignore', 'pipe', console] });
+
+    for (const line of stdout.split(/\n/).filter(x => x)) {
+      yield line.trim();
+    }
+  } catch (ex) {
+    console.error(`Error listing system certificate tokens, ignoring: ${ ex }`);
+  }
+}
+
+async function * listCertificates(tokenURL: string): AsyncIterable<string> {
+  try {
+    const { stdout } = await spawnFile(
+      'p11tool', ['--list-all-trusted', '--only-urls', '--batch', tokenURL],
+      { stdio: ['ignore', 'pipe', console] });
+
+    for (const line of stdout.split(/\n/).filter(x => x)) {
+      yield line.trim();
+    }
+  } catch (ex) {
+    console.error(`Error listing system certificates, ignoring: ${ ex }`);
+  }
+}
+
+async function getCertificate(certURL: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await spawnFile(
+      'p11tool', ['--export', certURL],
+      { stdio: ['ignore', 'pipe', console] });
+
+    return stdout.trim();
+  } catch (ex) {
+    console.error(`Error getting system certificate, ignoring: ${ ex }`);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,27 +1921,6 @@
     jest-haste-map "30.1.0"
     slash "^3.0.0"
 
-"@jest/transform@30.1.0":
-  version "30.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-30.1.0.tgz#817966d1517ad33ee67a45bb114b492adfdf55ce"
-  integrity sha512-OvzganIbExZDS2jl37re14XSJXK3sREyGP641RL+Ek1galupCMLWHlxop+4wQnVX7e3fxF6C3W16VzWdl2ducQ==
-  dependencies:
-    "@babel/core" "^7.27.4"
-    "@jest/types" "30.0.5"
-    "@jridgewell/trace-mapping" "^0.3.25"
-    babel-plugin-istanbul "^7.0.0"
-    chalk "^4.1.2"
-    convert-source-map "^2.0.0"
-    fast-json-stable-stringify "^2.1.0"
-    graceful-fs "^4.2.11"
-    jest-haste-map "30.1.0"
-    jest-regex-util "30.0.1"
-    jest-util "30.0.5"
-    micromatch "^4.0.8"
-    pirates "^4.0.7"
-    slash "^3.0.0"
-    write-file-atomic "^5.0.1"
-
 "@jest/transform@30.1.1":
   version "30.1.1"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-30.1.1.tgz#9ed736ee0e8787d5648401193603e0026d11f0b0"
@@ -4360,19 +4339,6 @@ babel-core@7.0.0-bridge.0:
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
-babel-jest@30.1.0:
-  version "30.1.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.1.0.tgz#e270e5852b5ed171fc146dcef97a022241515fce"
-  integrity sha512-xoF2zwb3po3dOJMahde//mE284gcxp9WH8TTbo3Y102fas7Ga1mjGUwrw137RmvUkuA2liISRlg2BFQhmTfeHg==
-  dependencies:
-    "@jest/transform" "30.1.0"
-    "@types/babel__core" "^7.20.5"
-    babel-plugin-istanbul "^7.0.0"
-    babel-preset-jest "30.0.1"
-    chalk "^4.1.2"
-    graceful-fs "^4.2.11"
-    slash "^3.0.0"
-
 babel-jest@30.1.1:
   version "30.1.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.1.1.tgz#6813b0a89c3f141ffad1f5b9bde304c26df8fbfd"
@@ -5768,7 +5734,7 @@ dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
-duplexer@^0.1.1, duplexer@^0.1.2, duplexer@~0.1.1:
+duplexer@^0.1.2, duplexer@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -6305,19 +6271,6 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-event-stream@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-4.0.1.tgz#4092808ec995d0dd75ea4580c1df6a74db2cde65"
-  integrity sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==
-  dependencies:
-    duplexer "^0.1.1"
-    from "^0.1.7"
-    map-stream "0.0.7"
-    pause-stream "^0.0.11"
-    split "^1.0.1"
-    stream-combiner "^0.2.2"
-    through "^2.3.8"
-
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -6698,7 +6651,7 @@ fresh@^2.0.0:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
-from@^0.1.7, from@~0:
+from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
@@ -8368,14 +8321,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linux-ca@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/linux-ca/-/linux-ca-2.0.1.tgz#247d0cb0783a8dbb49bc54ba1d8a109a9fe13e76"
-  integrity sha512-BJkElPi6APDa+oekBQumZUEsxPCeAR0rgIGcba7Xc3o9zLpN6oh92gMp/u4hEvE5dAdsVHbOX7WXtRQcdWKkXA==
-  dependencies:
-    event-stream "^4.0.1"
-    node-forge "^0.10.0"
-
 loader-runner@^4.1.0, loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
@@ -8600,11 +8545,6 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
-
-map-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
-  integrity sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==
 
 map-stream@~0.1.0:
   version "0.1.0"
@@ -9043,11 +8983,6 @@ node-forge@1.3.1, node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp-build@4, node-gyp-build@4.8.4:
   version "4.8.4"
@@ -9534,7 +9469,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pause-stream@0.0.11, pause-stream@^0.0.11:
+pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   integrity sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==
@@ -10839,13 +10774,6 @@ split@0.3:
   dependencies:
     through "2"
 
-split@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
-  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
-  dependencies:
-    through "2"
-
 sprintf-js@^1.1.2, sprintf-js@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
@@ -10936,14 +10864,6 @@ stream-buffers@^3.0.2:
   resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.3.tgz#9fc6ae267d9c4df1190a781e011634cac58af3cd"
   integrity sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==
 
-stream-combiner@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
-  integrity sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==
-  dependencies:
-    duplexer "~0.1.1"
-    through "~2.3.4"
-
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
@@ -10979,16 +10899,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^2.1.1, string-width@^4, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11011,7 +10922,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11024,13 +10935,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11254,7 +11158,7 @@ thread-loader@^3.0.0:
     neo-async "^2.6.2"
     schema-utils "^3.0.0"
 
-through@2, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
+through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
@@ -12028,7 +11932,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12044,15 +11948,6 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Replace the `linux-ca` package with equivalent code that runs `p11tool` in parallel to reduce startup time.  Also add `gnutls` (for `p11tool`) to RPM spec dependencies, since that was needed to fetch system certificates (and had been before too, we just missed it).