### PR TITLE
BATS: containers/reset: pre-pull images

### DIFF
--- a/bats/tests/containers/reset.bats
+++ b/bats/tests/containers/reset.bats
@@ -150,6 +150,7 @@ local_setup_file() {
 }
 
 @test 'Deploy kubernetes workloads' {
+    CONTAINERD_NAMESPACE=k8s.io ctrctl image pull --quiet "${IMAGE_NGINX:?}"
     kubectl create deployment --replicas 2 --image "${IMAGE_NGINX:?}" bats-nginx
     kubectl wait --for=condition=Available deployment/bats-nginx
 }
@@ -174,6 +175,7 @@ local_setup_file() {
 }
 
 @test 'Re-deploy kubernetes workloads' {
+    CONTAINERD_NAMESPACE=k8s.io ctrctl image pull --quiet "${IMAGE_NGINX:?}"
     kubectl create deployment --replicas 2 --image "${IMAGE_NGINX:?}" bats-nginx
     kubectl wait --for=condition=Available deployment/bats-nginx
 }


### PR DESCRIPTION
Pulling the images could take some time; `kubectl wait` by default only waits for 30 seconds.  Make the test more stable by explicitly pulling the relevant image ahead of time, so that is not part of the wait.