### PR TITLE
Spinkube: don't assume git

### DIFF
--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -20,6 +20,10 @@ local_setup() {
     wait_for_kube_deployment_available --namespace spin-operator spin-operator-controller-manager
 }
 
+@test 'wait for spinkube executor' {
+    try kubectl get SpinAppExecutors.core.spinkube.dev/containerd-shim-spin
+}
+
 @test 'deploy app to kubernetes' {
     # Newer versions of the sample app have moved from "deislabs" to "spinkube":
     # ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.13.0

--- a/resources/setup-spin
+++ b/resources/setup-spin
@@ -48,7 +48,15 @@ install_plugin() {
   version=$2
   echo "Installing plugin ${plugin} version ${version}"
   "$spin" plugins uninstall "$plugin" || true
-  "$spin" plugins install --yes --version "${version}" "$plugin"
+  # `spin plugins install` requires `git`; however, we can provide the URL of a
+  # remote manifest instead.
+  local url_base="https://github.com/spinframework/spin-plugins/raw/refs/heads/main/manifests/${plugin}"
+  local url="${url_base}/${plugin}@${version}.json"
+  if ! curl --head --silent --fail "${url}" &>/dev/null; then
+    echo "Plugin not available at ${url}, installing unversioned instead."
+    url="${url_base}/${plugin}.json"
+  fi
+  "$spin" plugins install --yes --url "${url}"
   rc=$?; test $rc -ne 0 && echo "Exit status is $rc"
 }
 


### PR DESCRIPTION
`spin plugins install` assumes that `git` is available (it clones https://github.com/spinframework/spin-plugins to find the manifests); we can't do that here.

Also, fix the spinkube BATS test by waiting for the executor in addition to the operator.