### PR TITLE
BATS: containers/wasm: update to changes

### DIFF
--- a/bats/tests/containers/wasm.bats
+++ b/bats/tests/containers/wasm.bats
@@ -27,7 +27,7 @@ local_teardown_file() {
 }
 
 @test 'start engine without wasm support' {
-    start_container_engine
+    start_container_engine --experimental.container-engine.web-assembly.enabled=false
     wait_for_container_engine
 }
 
@@ -65,8 +65,10 @@ hello() {
 
 @test 'verify shim is not configured in container engine' {
     run hello spin v2 rust 8080 80
+    assert_nothing                           # We assert after removing the container.
+    ctrctl rm --force spin-demo-8080 || true # Force delete the container if it got created.
     assert_failure
-    assert_output --partial "operating system is not supported"
+    assert_output --regexp 'operating system is not supported|binary not installed'
 }
 
 @test 'enable wasm support' {


### PR DESCRIPTION
- When we expect to start without WASM support, explicitly set the preference to make it clear that is not the issue.
- When checking that WASM isn't configured, manually remove the container if it was accidentally created so follow-up tests would pass correctly. We still fail the test in that case.
- Update the error message when shim is not configured.

I'm not sure if that last change is correct; without the update (the _binary not installed_ part), the output is:

```
 ✗ verify shim is not configured in container engine
   (from function `assert_output' in file bats-assert/src/assert_output.bash, line 186,
    in test file tests/containers/wasm.bats, line 70)
     `assert_output --partial "operating system is not supported"' failed
   spin-demo-8080

   -- output does not contain substring --
   substring (1 lines):
     operating system is not supported
   output (14 lines):
     Unable to find image 'ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0' locally
     v0.10.0: Pulling from deislabs/containerd-wasm-shims/examples/spin-rust-hello
     032342d286f3: Pulling fs layer
     a4aba4465d1d: Pulling fs layer
     8f6c8af1ac07: Pulling fs layer
     a4aba4465d1d: Download complete
     032342d286f3: Download complete
     8f6c8af1ac07: Download complete
     Digest: sha256:221265a115e546def1456129f6c198f9081e4ab2c13a6140ea922b9713a08312
     Status: Downloaded newer image for ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
     docker: Error response from daemon: failed to create task for container: failed to start shim: failed to resolve runtime path: runtime "io.containerd.spin.v2" binary not installed "containerd-shim-spin-v2": file does not exist: unknown

     Run 'docker run --help' for more information
     e4b4189a017584a8fad94844142a5f98ee9a1b2b1a36e761db83da4138f3b744
   --
```

I'm assuming that this should be interpreted as an expected failure; but if that's not the case, we'll need to figure out what other changes we need.