### PR TITLE
moby-openapi: Add new fixup

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -89,7 +89,6 @@ bpffs
 breadcrumb
 browserhome
 brucebean
-bsdextrautils
 bsdtar
 btime
 bugtracker
@@ -377,6 +376,7 @@ INSTALLMESSAGE
 INSTALLPROPERTY
 ioctl
 ipaddr
+IPAM
 iptable
 Isf
 islabel

--- a/scripts/dependencies/moby-openapi.ts
+++ b/scripts/dependencies/moby-openapi.ts
@@ -47,6 +47,10 @@ export class MobyOpenAPISpec extends GlobalDependency(VersionedDependency) {
     if (_.get(contents, 'definitions.Network.properties.Created.x-go-type.import.package') === 'time') {
       _.set(contents, 'definitions.Network.properties.Created.x-go-type.hints.noValidation', true);
     }
+    // Having the x-go-type here confuses swagger.
+    if (_.has(contents, 'definitions.IPAMStatus.properties.Subnets.x-go-type')) {
+      delete _.get(contents, 'definitions.IPAMStatus.properties.Subnets')['x-go-type'];
+    }
 
     await fs.promises.writeFile(modifiedPath, yaml.stringify(contents), 'utf-8');
 


### PR DESCRIPTION
Upstream is adding more x-go-type fields that break generation.