### PR TITLE
Diagnostics: docker context: fix current context

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/dockerContext.ts
+++ b/pkg/rancher-desktop/main/diagnostics/dockerContext.ts
@@ -25,12 +25,11 @@ const dockerContextChecker: DiagnosticsChecker = {
       }
     }
 
+    const DEFAULT_CONTEXT = 'default';
     const settings = await mainEvents.invoke('settings-fetch');
     const useDefaultContext = process.platform === 'win32' || settings.application.adminAccess;
-    const currentContext = await dockerDirManager.currentDockerContext ?? 'default';
-    const desiredContext = useDefaultContext
-      ? 'default'
-      : await dockerDirManager.getDesiredDockerContext(settings.application.adminAccess, currentContext);
+    const currentContext = await dockerDirManager.currentDockerContext ?? DEFAULT_CONTEXT;
+    const desiredContext = await dockerDirManager.getDesiredDockerContext(useDefaultContext, undefined) ?? DEFAULT_CONTEXT;
 
     if (currentContext !== desiredContext) {
       results.push({


### PR DESCRIPTION
We actually expect the "current context" argument to be `undefined`, since that's there to avoid changing the context under from the user unexpectedly; since we're not making any changes, it should always be unset.

I considered watching a file watcher, but that depends on whether the diagnostic is applicable (i.e. it shouldn't watch things when using containerd), so it didn't seem like it should live in the same PR.