### PR TITLE
rdctl: Implement `rdctl info`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -360,6 +360,7 @@ identitytoken
 ies
 iex
 ifaces
+ifname
 ifnotstart
 ifstarted
 iidfile
@@ -594,6 +595,7 @@ openssh
 openstack
 opensuse
 opentelekomcloudcontainerengine
+operstate
 opsgenie
 oracleoke
 orsection

--- a/bats/tests/utils/rdctl.bats
+++ b/bats/tests/utils/rdctl.bats
@@ -1,0 +1,61 @@
+load '../helpers/load'
+
+# Verify various operations of `rdctl`
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start Rancher Desktop' {
+    start_container_engine
+    wait_for_container_engine
+}
+
+@test 'rdctl info' {
+    run --separate-stderr rdctl info
+    assert_success
+    assert_output --partial 'Version:'
+}
+
+@test 'rdctl info --output=json' {
+    run --separate-stderr rdctl info --output=json
+    assert_success
+    json=$output
+    run jq_output .version
+    assert_success
+    assert_output --regexp '^v1\.'
+    output=$json
+    run jq_output '.["ip-address"]'
+    assert_success
+    assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+}
+
+@test 'rdctl info --field version' {
+    run rdctl info --field version
+    assert_success
+    assert_output --regexp '^v1\.'
+}
+
+@test 'rdctl info --field ip-address' {
+    run rdctl info --field ip-address
+    assert_success
+    if is_windows; then
+        # On Windows, the IP address should be constant.
+        assert_output 192.168.127.2
+    elif is_linux; then
+        assert_output 192.168.5.15 # qemu slirp
+    elif is_macos; then
+        address=$output
+        if is_true "$(get_setting '.application.adminAccess')"; then
+            # This is provided by the user's DHCP server
+            output=$address assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+        elif [[ $(get_setting .virtualMachine.type) == vz ]]; then
+            # macOS Virtualization.Framework NAT
+            output=$address assert_output --regexp '^192\.168\.205\.'
+        else
+            output=$address assert_output 192.168.5.15 # qemu slirp
+        fi
+    else
+        fail 'Unknown OS'
+    fi
+}

--- a/bats/tests/utils/rdctl.bats
+++ b/bats/tests/utils/rdctl.bats
@@ -43,7 +43,7 @@ load '../helpers/load'
         # On Windows, the IP address should be constant.
         assert_output 192.168.127.2
     elif is_linux; then
-        assert_output 192.168.5.15 # qemu slirp
+        assert_output 192.168.5.15 # qemu SLIRP
     elif is_macos; then
         address=$output
         if is_true "$(get_setting '.application.adminAccess')"; then
@@ -53,7 +53,7 @@ load '../helpers/load'
             # macOS Virtualization.Framework NAT
             output=$address assert_output --regexp '^192\.168\.205\.'
         else
-            output=$address assert_output 192.168.5.15 # qemu slirp
+            output=$address assert_output 192.168.5.15 # qemu SLIRP
         fi
     else
         fail 'Unknown OS'

--- a/src/go/rdctl/cmd/enum.go
+++ b/src/go/rdctl/cmd/enum.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import "fmt"
+
+// enumValue describes an enumeration for use with github.com/spf13/pflag
+type enumValue struct {
+	allowed []string // Allowed values
+	val     string   // Current value
+}
+
+func (v *enumValue) String() string {
+	return v.val
+}
+
+func (v *enumValue) Set(newVal string) error {
+	for _, candidate := range v.allowed {
+		if candidate == newVal {
+			v.val = candidate
+			return nil
+		}
+	}
+	return fmt.Errorf("value %q is not one of the allowed values: %+v", newVal, v.allowed)
+}
+
+func (v *enumValue) Type() string {
+	return "enum"
+}

--- a/src/go/rdctl/cmd/info.go
+++ b/src/go/rdctl/cmd/info.go
@@ -1,0 +1,151 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/info"
+)
+
+var infoSettings struct {
+	Field  string
+	Output string
+}
+
+// infoCmd represents the `rdctl info` command
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Return information about Rancher Desktop",
+	Long:  makeLongHelp(),
+	RunE:  doInfoCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+	infoCmd.Flags().StringVarP(&infoSettings.Field, "field", "f", "", "return only a specific field")
+	infoCmd.Flags().VarP(&enumValue{
+		val:     "text",
+		allowed: []string{"text", "json"},
+	}, "output", "o", "output format")
+}
+
+// Generates help text for each field available.
+func makeLongHelp() string {
+	var builder strings.Builder
+
+	_, _ = builder.WriteString("Returns information about Rancher Desktop.  The command returns all\n")
+	_, _ = builder.WriteString("fields in JSON by default, but a single field can be selected.\n")
+	_, _ = builder.WriteString("\n")
+	_, _ = builder.WriteString("The available fields are:\n")
+
+	typ := reflect.TypeFor[info.Info]()
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		helpText := field.Tag.Get("help")
+		if helpText == "" {
+			continue
+		}
+		fieldName := strings.SplitN(field.Tag.Get("json"), ",", 2)[0]
+		_, _ = fmt.Fprintf(&builder, "  %-10s    %s\n", fieldName, helpText)
+	}
+	return builder.String()
+}
+
+func doInfoCommand(cmd *cobra.Command, args []string) error {
+	var result info.Info
+	var rdClient client.RDClient
+
+	if connectionInfo, err := config.GetConnectionInfo(false); err == nil {
+		rdClient = client.NewRDClient(connectionInfo)
+	}
+
+	if infoSettings.Field != "" {
+		handler, ok := info.Handlers[infoSettings.Field]
+		if !ok {
+			return fmt.Errorf("unknown field %q", infoSettings.Field)
+		}
+
+		// No longer emit usage info on errors
+		cmd.SilenceUsage = true
+
+		if err := handler(cmd.Context(), &result, rdClient); err != nil {
+			return err
+		}
+
+		value := reflect.ValueOf(result)
+		typ := value.Type()
+		for i := range typ.NumField() {
+			field := typ.Field(i)
+			tag := strings.SplitN(field.Tag.Get("json"), ",", 2)[0]
+			if tag == infoSettings.Field {
+				_, err := fmt.Println(value.Field(i).Interface())
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+
+		return fmt.Errorf("failed to find JSON field %q", infoSettings.Field)
+	}
+
+	// No longer emit usage info on errors
+	cmd.SilenceUsage = true
+
+	for _, handler := range info.Handlers {
+		if err := handler(cmd.Context(), &result, rdClient); err != nil {
+			return err
+		}
+	}
+
+	switch cmd.Flags().Lookup("output").Value.String() {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(result); err != nil {
+			return err
+		}
+	default:
+		writer := tabwriter.NewWriter(os.Stdout, 0, 4, 1, ' ', 0)
+		value := reflect.ValueOf(result)
+		for i := range value.NumField() {
+			field := value.Type().Field(i)
+			name, ok := field.Tag.Lookup("name")
+			if !ok {
+				name = field.Name
+			}
+			if _, err := fmt.Fprintf(writer, "%s:\t%s\n", name, value.Field(i)); err != nil {
+				return err
+			}
+		}
+		if err := writer.Flush(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/go/rdctl/cmd/info.go
+++ b/src/go/rdctl/cmd/info.go
@@ -58,7 +58,7 @@ func makeLongHelp() string {
 	var builder strings.Builder
 
 	_, _ = builder.WriteString("Returns information about Rancher Desktop.  The command returns all\n")
-	_, _ = builder.WriteString("fields in JSON by default, but a single field can be selected.\n")
+	_, _ = builder.WriteString("fields by default, but a single field can be selected with '--field'.\n")
 	_, _ = builder.WriteString("\n")
 	_, _ = builder.WriteString("The available fields are:\n")
 

--- a/src/go/rdctl/cmd/shell.go
+++ b/src/go/rdctl/cmd/shell.go
@@ -17,26 +17,11 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
-	"context"
-	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"runtime"
-	"slices"
-	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/text/encoding/unicode"
 
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lima"
-	p "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/utils"
-	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shell"
 )
 
 // shellCmd represents the shell command
@@ -69,145 +54,12 @@ func init() {
 func doShellCommand(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 
-	commandName, err := directories.GetLimactlPath()
+	shellCommand, err := shell.SpawnCommand(cmd.Context(), args...)
 	if err != nil {
 		return err
 	}
-
-	if runtime.GOOS == "windows" {
-		distroNames := []string{wsl.DistributionName}
-		found := false
-
-		if _, err = os.Stat(commandName); err == nil {
-			// If limactl is available, try the lima distribution first.
-			distroNames = append([]string{lima.InstanceFullName}, distroNames...)
-		}
-
-		for _, distroName := range distroNames {
-			err = assertWSLIsRunning(cmd.Context(), distroName)
-			if err == nil {
-				commandName = "wsl"
-				args = append([]string{
-					"--distribution", distroName,
-					"--exec", "/usr/local/bin/wsl-exec",
-				}, args...)
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			// We did not find a running distribution that we can use.
-			// No further output wanted, so just exit with the desired status.
-			fmt.Fprintf(os.Stderr, "%s", err)
-			os.Exit(1)
-		}
-	} else {
-		paths, err := p.GetPaths()
-		if err != nil {
-			return err
-		}
-		if err := directories.SetupLimaHome(paths.AppHome); err != nil {
-			return err
-		}
-		if err := setupPathEnvVar(paths); err != nil {
-			return err
-		}
-		if !checkLimaIsRunning(cmd.Context(), commandName) {
-			// No further output wanted, so just exit with the desired status.
-			os.Exit(1)
-		}
-		args = append([]string{"shell", lima.InstanceName}, args...)
-	}
-	shellCommand := exec.CommandContext(cmd.Context(), commandName, args...)
 	shellCommand.Stdin = os.Stdin
 	shellCommand.Stdout = os.Stdout
 	shellCommand.Stderr = os.Stderr
 	return shellCommand.Run()
-}
-
-// Set up the PATH environment variable for limactl.
-func setupPathEnvVar(paths *p.Paths) error {
-	if runtime.GOOS != "windows" {
-		// This is only needed on Windows.
-		return nil
-	}
-	msysDir := filepath.Join(utils.GetParentDir(paths.Resources, 2), "msys")
-	pathList := filepath.SplitList(os.Getenv("PATH"))
-	if slices.Contains(pathList, msysDir) {
-		return nil
-	}
-	pathList = append([]string{msysDir}, pathList...)
-	return os.Setenv("PATH", strings.Join(pathList, string(os.PathListSeparator)))
-}
-
-const restartDirective = "Either run 'rdctl start' or start the Rancher Desktop application first"
-
-func checkLimaIsRunning(ctx context.Context, commandName string) bool {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	//nolint:gosec // The command name is auto-detected, and the instance name is constant.
-	cmd := exec.CommandContext(ctx, commandName, "ls", lima.InstanceName, "--format", "{{.Status}}")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		logrus.Errorf("Failed to run %q: %s\n", cmd, err)
-		return false
-	}
-	limaState := strings.TrimRight(stdout.String(), "\n")
-	// We can do an equals check here because we should only have received the status for VM 0
-	if limaState == "Running" {
-		return true
-	}
-	if limaState != "" {
-		fmt.Fprintf(os.Stderr,
-			"The Rancher Desktop VM needs to be in state \"Running\" in order to execute 'rdctl shell', but it is currently in state %q.\n%s.\n", limaState, restartDirective)
-		return false
-	}
-	errorMsg := stderr.String()
-	if strings.Contains(errorMsg, fmt.Sprintf("No instance matching %s found.", lima.InstanceName)) {
-		logrus.Errorf("The Rancher Desktop VM needs to be created.\n%s.\n", restartDirective)
-	} else if errorMsg != "" {
-		fmt.Fprintln(os.Stderr, errorMsg)
-	} else {
-		fmt.Fprintln(os.Stderr, "Underlying limactl check failed with no output.")
-	}
-	return false
-}
-
-// Check that WSL is running the given distribution; if not, an error will be
-// returned with a message suitable for printing to the user.
-func assertWSLIsRunning(ctx context.Context, distroName string) error {
-	// Ignore error messages; none are expected here
-	rawOutput, err := exec.CommandContext(ctx, "wsl", "--list", "--verbose").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to run `wsl --list --verbose: %w", err)
-	}
-	decoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
-	output, err := decoder.Bytes(rawOutput)
-	if err != nil {
-		return fmt.Errorf("failed to read WSL output ([% q]...); error: %w", rawOutput[:12], err)
-	}
-	isListed := false
-	targetState := ""
-	for _, line := range regexp.MustCompile(`\r?\n`).Split(string(output), -1) {
-		fields := regexp.MustCompile(`\s+`).Split(strings.TrimLeft(line, " \t"), -1)
-		if fields[0] == "*" {
-			fields = fields[1:]
-		}
-		if len(fields) >= 2 && fields[0] == distroName {
-			isListed = true
-			targetState = fields[1]
-			break
-		}
-	}
-	const desiredState = "Running"
-	if targetState == desiredState {
-		return nil
-	}
-	if !isListed {
-		return fmt.Errorf("the Rancher Desktop WSL distribution needs to be running in order to execute 'rdctl shell', but it currently is not.\n%s", restartDirective)
-	}
-	return fmt.Errorf("the Rancher Desktop WSL distribution needs to be in state %q in order to execute 'rdctl shell', but it is currently in state %q.\n%s", desiredState, targetState, restartDirective)
 }

--- a/src/go/rdctl/pkg/command/command.go
+++ b/src/go/rdctl/pkg/command/command.go
@@ -1,0 +1,70 @@
+// Package command implements helpers for command-line handling.
+package command
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+)
+
+type commandNameContextKey struct{}
+
+// WithCommandName returns a new context that keeps track of the command being
+// invoked.
+func WithCommandName(ctx context.Context, commandName string) context.Context {
+	return context.WithValue(ctx, commandNameContextKey{}, commandName)
+}
+
+// FatalError is an error that should stop execution immediately, without using
+// the normal cobra error handling.
+type FatalError interface {
+	error
+	// ExitCode returns the process exit code that should be set.
+	ExitCode() int
+}
+
+// simpleFatalError implements FatalError
+type simpleFatalError struct {
+	message  string
+	exitCode int
+}
+
+func (e *simpleFatalError) Error() string {
+	return e.message
+}
+
+func (e *simpleFatalError) ExitCode() int {
+	return e.exitCode
+}
+
+// NewFatalError returns an error implementing FatalError
+func NewFatalError(message string, exitCode int) error {
+	return &simpleFatalError{
+		message:  message,
+		exitCode: exitCode,
+	}
+}
+
+const restartDirective = "Either run 'rdctl start' or start the Rancher Desktop application first"
+
+// NewVMStateError returns an error stating that the Rancher Desktop VM (or WSL
+// distribution) is not in the correct state.  If actualState is the empty
+// string, then it signifies that the VM does not exist.
+func NewVMStateError(ctx context.Context, desiredState, actualState string) error {
+	commandName := "rdctl"
+	if value, ok := ctx.Value(commandNameContextKey{}).(string); ok {
+		commandName = value
+	}
+
+	status := fmt.Sprintf("needs to be running in order to execute '%s', but it currently is not.", commandName)
+	if actualState != "" {
+		status = fmt.Sprintf("needs to be in state %q in order to execute '%s', but it is current in state %q.", desiredState, commandName, actualState)
+	}
+	vm := "VM"
+	if runtime.GOOS == "windows" {
+		vm = "WSL distribution"
+	}
+	return NewFatalError(
+		fmt.Sprintf("The Rancher Desktop %s %s\n%s", vm, status, restartDirective),
+		1)
+}

--- a/src/go/rdctl/pkg/command/command.go
+++ b/src/go/rdctl/pkg/command/command.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package command implements helpers for command-line handling.
 package command
 

--- a/src/go/rdctl/pkg/info/ipaddress.go
+++ b/src/go/rdctl/pkg/info/ipaddress.go
@@ -1,0 +1,72 @@
+package info
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/shell"
+)
+
+type interfaceInfo struct {
+	InterfaceName string `json:"ifname"`
+	Flags         []string
+	State         string `json:"operstate"`
+	MACAddress    string `json:"address"`
+	Addresses     []struct {
+		Family       string
+		Local        string
+		PrefixLength uint `json:"prefixlen"`
+		Broadcast    string
+		Scope        string
+	} `json:"addr_info"`
+}
+
+func getIPAddress(ctx context.Context, result *Info, _ client.RDClient) error {
+	cmd, err := shell.SpawnCommand(ctx, "ip", "-json", "address", "show")
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	var interfaces []interfaceInfo
+	if err := json.Unmarshal(buf.Bytes(), &interfaces); err != nil {
+		return err
+	}
+
+	// The list of interface names to try, varying by OS.
+	interfaceNames := map[string][]string{
+		"darwin":  {"rd0", "vznat", "rd1", "eth0"},
+		"linux":   {"eth0"},
+		"windows": {"eth0"},
+	}[runtime.GOOS]
+
+	for _, ifaceName := range interfaceNames {
+		for _, iface := range interfaces {
+			if iface.InterfaceName != ifaceName {
+				continue
+			}
+			for _, addr := range iface.Addresses {
+				if addr.Family == "inet" && addr.Scope == "global" {
+					result.IPAddress = addr.Local
+					return nil
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("failed to find IP address")
+}
+
+func init() {
+	register("ip-address", getIPAddress)
+}

--- a/src/go/rdctl/pkg/info/ipaddress.go
+++ b/src/go/rdctl/pkg/info/ipaddress.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package info
 
 import (

--- a/src/go/rdctl/pkg/info/struct.go
+++ b/src/go/rdctl/pkg/info/struct.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
 )
 
-// An Info describes the output the user will receive when running `rdctl info`
+// Info describes the output the user will receive when running `rdctl info`
 // with no special options.
 type Info struct {
 	Version   string `json:"version" help:"Rancher Desktop application version"`

--- a/src/go/rdctl/pkg/info/struct.go
+++ b/src/go/rdctl/pkg/info/struct.go
@@ -1,0 +1,30 @@
+package info
+
+import (
+	"context"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+)
+
+// An Info describes the output the user will receive when running `rdctl info`
+// with no special options.
+type Info struct {
+	Version string `json:"version" help:"Rancher Desktop application version"`
+}
+
+// HandlerFunc is the generic interface to populate the [Info] result structure.
+// The function is expected to fill in the fields it knows.
+// The given client may be `nil` if the configuration is invalid.
+type HandlerFunc func(context.Context, *Info, client.RDClient) error
+
+// Handlers that have been registered; the key should be the same as the JSON
+// field tag (on struct [Info]).
+var Handlers map[string]HandlerFunc
+
+// Register a handler for a given field.
+func register(name string, handler HandlerFunc) {
+	if Handlers == nil {
+		Handlers = make(map[string]HandlerFunc)
+	}
+	Handlers[name] = handler
+}

--- a/src/go/rdctl/pkg/info/struct.go
+++ b/src/go/rdctl/pkg/info/struct.go
@@ -9,7 +9,8 @@ import (
 // An Info describes the output the user will receive when running `rdctl info`
 // with no special options.
 type Info struct {
-	Version string `json:"version" help:"Rancher Desktop application version"`
+	Version   string `json:"version" help:"Rancher Desktop application version"`
+	IPAddress string `json:"ip-address" help:"IP address to use to contact the VM"`
 }
 
 // HandlerFunc is the generic interface to populate the [Info] result structure.

--- a/src/go/rdctl/pkg/info/struct.go
+++ b/src/go/rdctl/pkg/info/struct.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package info
 
 import (

--- a/src/go/rdctl/pkg/info/version.go
+++ b/src/go/rdctl/pkg/info/version.go
@@ -1,0 +1,17 @@
+package info
+
+import (
+	"context"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/version"
+)
+
+func getVersion(ctx context.Context, result *Info, _ client.RDClient) error {
+	result.Version = version.Version
+	return nil
+}
+
+func init() {
+	register("version", getVersion)
+}

--- a/src/go/rdctl/pkg/info/version.go
+++ b/src/go/rdctl/pkg/info/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package info
 
 import (

--- a/src/go/rdctl/pkg/shell/shell.go
+++ b/src/go/rdctl/pkg/shell/shell.go
@@ -1,0 +1,165 @@
+package shell
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/text/encoding/unicode"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/directories"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/lima"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/utils"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/wsl"
+)
+
+// Spawn a command that, when run, will be executed in the VM with the given
+// arguments.
+func SpawnCommand(ctx context.Context, args ...string) (*exec.Cmd, error) {
+	commandName, err := directories.GetLimactlPath()
+	if err != nil {
+		return nil, err
+	}
+
+	if runtime.GOOS == "windows" {
+		distroNames := []string{wsl.DistributionName}
+		found := false
+
+		if _, err = os.Stat(commandName); err == nil {
+			// If limactl is available, try the lima distribution first.
+			distroNames = append([]string{lima.InstanceFullName}, distroNames...)
+		}
+
+		for _, distroName := range distroNames {
+			err = assertWSLIsRunning(ctx, distroName)
+			if err == nil {
+				commandName = "wsl"
+				args = append([]string{
+					"--distribution", distroName,
+					"--exec", "/usr/local/bin/wsl-exec",
+				}, args...)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// We did not find a running distribution that we can use.
+			// No further output wanted, so just exit with the desired status.
+			fmt.Fprintf(os.Stderr, "%s", err)
+			os.Exit(1)
+		}
+	} else {
+		p, err := paths.GetPaths()
+		if err != nil {
+			return nil, err
+		}
+		if err := directories.SetupLimaHome(p.AppHome); err != nil {
+			return nil, err
+		}
+		if err := setupPathEnvVar(p); err != nil {
+			return nil, err
+		}
+		if !checkLimaIsRunning(ctx, commandName) {
+			// No further output wanted, so just exit with the desired status.
+			os.Exit(1)
+		}
+		args = append([]string{"shell", lima.InstanceName}, args...)
+	}
+	return exec.CommandContext(ctx, commandName, args...), nil
+}
+
+// Set up the PATH environment variable for limactl.
+func setupPathEnvVar(p *paths.Paths) error {
+	if runtime.GOOS != "windows" {
+		// This is only needed on Windows.
+		return nil
+	}
+	msysDir := filepath.Join(utils.GetParentDir(p.Resources, 2), "msys")
+	pathList := filepath.SplitList(os.Getenv("PATH"))
+	if slices.Contains(pathList, msysDir) {
+		return nil
+	}
+	pathList = append([]string{msysDir}, pathList...)
+	return os.Setenv("PATH", strings.Join(pathList, string(os.PathListSeparator)))
+}
+
+const restartDirective = "Either run 'rdctl start' or start the Rancher Desktop application first"
+
+func checkLimaIsRunning(ctx context.Context, commandName string) bool {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	//nolint:gosec // The command name is auto-detected, and the instance name is constant.
+	cmd := exec.CommandContext(ctx, commandName, "ls", lima.InstanceName, "--format", "{{.Status}}")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		logrus.Errorf("Failed to run %q: %s\n", cmd, err)
+		return false
+	}
+	limaState := strings.TrimRight(stdout.String(), "\n")
+	// We can do an equals check here because we should only have received the status for VM 0
+	if limaState == "Running" {
+		return true
+	}
+	if limaState != "" {
+		fmt.Fprintf(os.Stderr,
+			"The Rancher Desktop VM needs to be in state \"Running\" in order to execute 'rdctl shell', but it is currently in state %q.\n%s.\n", limaState, restartDirective)
+		return false
+	}
+	errorMsg := stderr.String()
+	if strings.Contains(errorMsg, fmt.Sprintf("No instance matching %s found.", lima.InstanceName)) {
+		logrus.Errorf("The Rancher Desktop VM needs to be created.\n%s.\n", restartDirective)
+	} else if errorMsg != "" {
+		fmt.Fprintln(os.Stderr, errorMsg)
+	} else {
+		fmt.Fprintln(os.Stderr, "Underlying limactl check failed with no output.")
+	}
+	return false
+}
+
+// Check that WSL is running the given distribution; if not, an error will be
+// returned with a message suitable for printing to the user.
+func assertWSLIsRunning(ctx context.Context, distroName string) error {
+	// Ignore error messages; none are expected here
+	rawOutput, err := exec.CommandContext(ctx, "wsl", "--list", "--verbose").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run `wsl --list --verbose: %w", err)
+	}
+	decoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
+	output, err := decoder.Bytes(rawOutput)
+	if err != nil {
+		return fmt.Errorf("failed to read WSL output ([% q]...); error: %w", rawOutput[:12], err)
+	}
+	isListed := false
+	targetState := ""
+	for _, line := range regexp.MustCompile(`\r?\n`).Split(string(output), -1) {
+		fields := regexp.MustCompile(`\s+`).Split(strings.TrimLeft(line, " \t"), -1)
+		if fields[0] == "*" {
+			fields = fields[1:]
+		}
+		if len(fields) >= 2 && fields[0] == distroName {
+			isListed = true
+			targetState = fields[1]
+			break
+		}
+	}
+	const desiredState = "Running"
+	if targetState == desiredState {
+		return nil
+	}
+	if !isListed {
+		return fmt.Errorf("the Rancher Desktop WSL distribution needs to be running in order to execute 'rdctl shell', but it currently is not.\n%s", restartDirective)
+	}
+	return fmt.Errorf("the Rancher Desktop WSL distribution needs to be in state %q in order to execute 'rdctl shell', but it is currently in state %q.\n%s", desiredState, targetState, restartDirective)
+}

--- a/src/go/rdctl/pkg/shell/shell.go
+++ b/src/go/rdctl/pkg/shell/shell.go
@@ -1,3 +1,21 @@
+/*
+Copyright © 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package shell contains a function to help with spawning commands in the
+// Rancher Desktop VM.
 package shell
 
 import (

--- a/src/go/rdctl/pkg/shell/shell.go
+++ b/src/go/rdctl/pkg/shell/shell.go
@@ -134,7 +134,7 @@ func assertWSLIsRunning(ctx context.Context, distroName string) error {
 	// Ignore error messages; none are expected here
 	rawOutput, err := exec.CommandContext(ctx, "wsl", "--list", "--verbose").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to run `wsl --list --verbose: %w", err)
+		return fmt.Errorf("failed to run 'wsl --list --verbose': %w", err)
 	}
 	decoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
 	output, err := decoder.Bytes(rawOutput)


### PR DESCRIPTION
This implements `rdctl info`; by default, it emits a table, but `rdctl info --output=json` can be used instead to emit JSON output, or `rdctl info --field=version` can be used to emit only a specific field.

Other than the version, it only implements `ip-address`, which shows the IP address inside the VM.

Fixes #5526

Should only be merged after https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/pull/131 has been deployed, since it uses `ip -json` which is not available with busybox `ip`.

Reviewing commit-by-commit may be useful; also `git {log|diff} --color-moved`.