### PR TITLE
Diagnostics: connectivity: add settings for check interval

### DIFF
--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -792,6 +792,17 @@ components:
               # TODO It is not possible to modify this setting via `rdctl set`.
               x-rd-usage: diagnostic ids that have been muted
               additionalProperties: true
+            connectivity:
+              type: object
+              properties:
+                interval:
+                  type: integer
+                  x-rd-usage: >-
+                    Number of milliseconds before polling for network access;
+                    set this to zero to disable background connectivity checking.
+                timeout:
+                  type: integer
+                  x-rd-usage: Number of milliseconds to wait before timing out
 
     diagnostics:
       type: object

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -118,8 +118,12 @@ export const defaultSettings = {
     namespace: 'default',
   },
   diagnostics: {
-    showMuted:   false,
-    mutedChecks: {} as Record<string, boolean>,
+    showMuted:    false,
+    mutedChecks:  {} as Record<string, boolean>,
+    connectivity: {
+      interval: 5_000,
+      timeout:  5_000,
+    },
   },
   /**
    * Experimental settings

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -158,8 +158,12 @@ export default class SettingsValidator {
         namespace: this.checkString,
       },
       diagnostics: {
-        mutedChecks: this.checkBooleanMapping,
-        showMuted:   this.checkBoolean,
+        mutedChecks:  this.checkBooleanMapping,
+        showMuted:    this.checkBoolean,
+        connectivity: {
+          interval: this.checkNumber(0, 2 ** 31 - 1),
+          timeout:  this.checkNumber(1, 2 ** 31 - 1),
+        },
       },
     };
     this.canonicalizeSynonyms(newSettings);

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -174,6 +174,7 @@ interface MainEventNames {
 type DiagnosticsEventPayload =
   { id: 'integrations-windows', distro?: string, key: string, error?: Error } |
   { id: 'kube-versions-available', available: boolean } |
+  { id: 'network-connectivity', connected: boolean } |
   { id: 'path-management', fileName: string; error: Error | undefined };
 
 /**


### PR DESCRIPTION
This adds a setting to adjust how often to do the network connectivity check, in milliseconds, where setting it to zero disables the check.  Also update the check itself to use lower-level APIs to avoid the issue with Electron not handling redirects correctly (which seems to actually cause the check to always pass).

Fixes #8785; the K3s versions offline thing does update based on this.