### PR TITLE
Move macos-13 runners to macos-15-intel

### DIFF
--- a/.github/workflows/bats/get-tests.py
+++ b/.github/workflows/bats/get-tests.py
@@ -18,7 +18,7 @@ import sys
 from typing import Iterator, List, Literal, get_args
 
 Platforms = Literal["linux", "mac", "win"]
-Hosts = Literal["ubuntu-latest", "macos-13", "windows-latest"]
+Hosts = Literal["ubuntu-latest", "macos-15-intel", "windows-latest"]
 Engines = Literal["containerd", "moby"]
 
 @dataclasses.dataclass
@@ -56,7 +56,7 @@ def skip_test(test: Result) -> bool:
     Check if a given test should be skipped.
     We skip some tests because the CI machines can't handle them.
     """
-    if test.host == "macos-13" and test.name.startswith("k8s/"):
+    if test.host == "macos-15-intel" and test.name.startswith("k8s/"):
         # The macOS CI runners are slow; skip some tests that can be tested on
         # other OSes.
         skipped_tests = ("verify-cached-images",)
@@ -73,7 +73,7 @@ for test in (os.environ.get("TESTS", None) or "*").split():
     for platform in platforms:
       host: Hosts = {
          "linux": "ubuntu-latest",
-         "mac": "macos-13",
+         "mac": "macos-15-intel",
          "win": "windows-latest",
       }[platform]
       for name in resolve_test(test, platform):

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -40,7 +40,7 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-13
+          runs-on: macos-15-intel
         - platform: mac
           arch: aarch64
           runs-on: macos-latest

--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -22,7 +22,7 @@ jobs:
         - platform: mac
           # Use an x86_64 platform because arm64 runners don't have nested
           # virtualization available.
-          runs-on: macos-13
+          runs-on: macos-15-intel
         - platform: win
           runs-on: windows-latest
         - platform: linux

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -119,7 +119,7 @@ jobs:
       matrix:
         include:
         - { platform: macos-aarch64, runs-on: macos-14 }
-        - { platform: macos-x86_64, runs-on: macos-13 }
+        - { platform: macos-x86_64, runs-on: macos-15-intel }
         - { platform: win32, runs-on: windows-latest }
         - { platform: linux, runs-on: ubuntu-latest }
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -10,7 +10,7 @@ jobs:
         include:
         - platform: mac
           arch: x86_64
-          runs-on: macos-13
+          runs-on: macos-15-intel
         - platform: mac
           arch: aarch64
           runs-on: macos-latest


### PR DESCRIPTION
The macos-13 runners are being retired, and macos-15-intel is the only remaining x86_64 runner available. We cannot run on aarch64 because they don't support nested virtualization.

There will be brown-outs of the macos-13 runner in November, so better switch now: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/