### PR TITLE
Dependabot: Try to update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,8 @@ updates:
 # Maintain dependencies for GitHub Actions
 - package-ecosystem: "github-actions"
   directories:
-    - "/"
-    - "/.github/actions/*/"
+  - "/"
+  - "/.github/actions/*/"
   schedule:
     interval: "daily"
   cooldown:


### PR DESCRIPTION
We have in-repo actions that aren't getting updated by dependabot; try to configure dependabot to find them.

Sample action run: https://github.com/mook-as/rd/actions/runs/18693524900/job/53304962854
This resulted in:


|         |      Changes to Dependabot Pull Requests                 |
--- | ---
| created | actions/setup-node ( from 5.0.0 to 6.0.0 )               |
| created | actions/create-github-app-token ( from 1.11.6 to 2.1.4 ) |
| created | actions/setup-go ( from 5.3.0 to 6.0.0 )                 |
| created | actions/setup-python ( from 5.4.0 to 6.0.0 )             |
| created | actions/setup-node ( from 4.3.0 to 6.0.0 )               |
