### PR TITLE
Remove vdeSwitch and vdeVMNet keys if exists

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -877,6 +877,7 @@ UTCTIME
 vcenter
 vcpus
 vcs
+vde
 VDropdown
 VERSIONSTRING
 vertificate

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1462,6 +1462,13 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
     config.paths['socketVMNet'] = '/opt/rancher-desktop/bin/socket_vmnet';
 
+    // Clean up deprecated keys in config.paths, if present.
+    // These keys are no longer used and may cause errors
+    // during rdctl shutdown when upgrading to version
+    // 1.20.x or later.
+    delete (config.paths as any)['vdeSwitch'];
+    delete (config.paths as any)['vdeVMNet'];
+
     if (config.group === 'staff') {
       config.group = 'everyone';
     }


### PR DESCRIPTION
After upgrading to RD 1.20, if `networks.yaml` contains references to `vdeSwitch` or `vdeVMNet`, a warning is shown during `rdctl shutdown`.
This change ensures that these deprecated keys are removed from `networks.yaml` to prevent any warnings.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/9293