### PR TITLE
Dependabot: allow upgrading node-fetch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,6 @@ updates:
   - # Needs to be updated along with NodeJS version.
     dependency-name: "@types/node"
     update-types: [version-update:semver-major]
-  - # node-fetch 3+ requires ECMAScript modules; we still have issues with them.
-    dependency-name: "node-fetch"
-    versions: [">2"]
-  - # This needs to be done in lockstep with node-fetch.
-    dependency-name: "@types/node-fetch"
-    versions: [">2"]
   - # We don't utilize @rancher/shell in a meaningful way. It is safe to
     # ignore until we arrive a solution that uses it.
     dependency-name: "@rancher/shell"


### PR DESCRIPTION
We no longer have issues with ECMAScript modules.  Also, we no longer use node-fetch directly.