### PR TITLE
CI: Fix smoke tests

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -98,7 +98,8 @@ runs:
             ${{ steps.sudo.outputs.sudo }} dnf install --assumeyes \
               at-spi2-atk cups-libs git GraphicsMagick gtk3 jq \
               libva nss pass procps-ng sudo xorg-x11-server-Xvfb \
-              /usr/bin/script
+              /usr/bin/script \
+              --setopt=excludepkgs=systemd-standalone-tmpfiles
             exit 0;;
           debian|ubuntu)
             ${{ steps.sudo.outputs.sudo }} apt-get update

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -83,7 +83,7 @@ runs:
           suse|opensuse)
             ${{ steps.sudo.outputs.sudo }} zypper --non-interactive install \
               fuse gawk git GraphicsMagick gtk3-tools jq mozilla-nss \
-              noto-sans-fonts password-store sudo xvfb-run
+              noto-sans-fonts password-store sudo xvfb-run xauth which
             if [[ ${GITHUB_JOB:-unknown} =~ appimage ]]; then
               ${{ steps.sudo.outputs.sudo }} zypper --non-interactive install \
                 libasound2 openssh-clients

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -257,6 +257,7 @@ etcdbackup
 etest
 euid
 eula
+excludepkgs
 excludesection
 Executability
 EXITDIALOGOPTIONALCHECKBOX
@@ -839,6 +840,7 @@ timespan
 tini
 TKE
 tmpconfig
+tmpfiles
 tmpfs
 tmppath
 tmutil
@@ -931,6 +933,7 @@ wslutils
 WWID
 wwn
 wws
+xauth
 XAUTHORITY
 Xcomposite
 Xdamage


### PR DESCRIPTION
This fixes smoke tests for Leap and Fedora (in separate commits).

Leap: In 15.6, `xvfb-run` runs `which` without having it in `Requires:`.  This has been fixed in later versions, but the `latest` image is still 15.6 for some reason.

Fedora: `systemd-standalone-tmpfiles` conflicts with `systemd`, but we require the latter for other dependencies.  We need to explicitly avoid installing the former when installing the set of basic things required.