### PR TITLE
Signing: Fix Windows signing

### DIFF
--- a/build/signing-config-win.yaml
+++ b/build/signing-config-win.yaml
@@ -6,7 +6,7 @@
 .:
 - Rancher Desktop.exe
 - wix-custom-action.dll
-- '!d3dcompiler_47.dll' # spellcheck-ignore-line
+- '!dxcompiler.dll'     # spellcheck-ignore-line
 - '!ffmpeg.dll'
 - '!libEGL.dll'         # spellcheck-ignore-line
 - '!libGLESv2.dll'      # spellcheck-ignore-line


### PR DESCRIPTION
Two new files from Electron are now being packaged; one of them is already signed with a Microsoft signature.  Add code to skip already signed files, and to flag signing files that are already signed.

The Packaging CI run has been failing on `main` since a7e187a6766705634d8762f46a49a21253e49ff9.