### PR TITLE
feat: Enable UDP port forwarding in Lima

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -185,3 +185,4 @@ portForwards:
 - guestPortRange: [1, 65535]
   guestIPMustBeZero: true
   hostIP: "0.0.0.0"
+  proto: any


### PR DESCRIPTION
This change modifies the default Lima configuration to allow UDP port forwarding. It adds `proto: any` to the `portForwards` configuration, enabling both TCP and UDP protocols.

close #9409 