### PR TITLE
Disables GUI integration for WSL

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-data.conf
+++ b/pkg/rancher-desktop/assets/scripts/wsl-data.conf
@@ -1,6 +1,9 @@
 # This is the /etc/wsl.conf for use with rancher-desktop-data
 # As we do not have an actual data distribution, this file is included as part
 # of the application and written out at runtime.
+[general]
+# Disable GUI integration, only CLI apps work.
+guiApplications=false
 
 [automount]
 # Prevent processing /etc/fstab, since it doesn't exist.


### PR DESCRIPTION
Disables GUI integration in WSL by setting `guiApplications=false`. This change is primarily intended to prevent the fatal error caused by nerdctl, as described [here](https://github.com/rancher-sandbox/rancher-desktop/issues/1993).

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/9388