### PR TITLE
package.json: Remove nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "jest-environment-jsdom": "30.2.0",
     "js-yaml-loader": "1.2.2",
     "mustache": "4.2.0",
-    "nan": "2.23.1",
     "node-addon-api": "8",
     "node-gyp": "11.5.0",
     "node-gyp-build": "4.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13097,15 +13097,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:2.23.1":
-  version: 2.23.1
-  resolution: "nan@npm:2.23.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/bda21d2eeea65d49d673d0ec63030212264a55b4a7e6546a73b5a1540dcfa3c3f3cc0e7f23940d2e8edd4dc58525e97941d533d3be55a2da2158489150de32b9
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
@@ -14821,7 +14812,6 @@ __metadata:
     lodash: "npm:4.17.21"
     marked: "npm:16.4.1"
     mustache: "npm:4.2.0"
-    nan: "npm:2.23.1"
     native-reg: "npm:1.1.1"
     node-addon-api: "npm:8"
     node-forge: "npm:1.3.1"


### PR DESCRIPTION
This was originally added to pin the version to something supported by the version of Electron we were using at the time; it looks like the dependency that used it no longer exists, so we no longer need to pin it.