### PR TITLE
nerdctl: Use /bin/tar inside the VM

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -206,7 +206,7 @@ export class NerdctlClient implements ContainerEngineClient {
         '--dereference', '--one-file-system', '--sparse', '--files-from', fileList,
       ].filter(defined);
 
-      await this.vm.execCommand({ root: true }, '/usr/bin/tar', ...args);
+      await this.vm.execCommand({ root: true }, '/bin/tar', ...args);
 
       // Copy the archive to the host
       const hostWorkDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rd-nerdctl-copy-'));
@@ -374,7 +374,7 @@ export class NerdctlClient implements ContainerEngineClient {
       await archiveFinished;
 
       await this.vm.copyFileIn(path.join(hostDir, archiveName), path.posix.join(workDir, archiveName));
-      await this.vm.execCommand('/usr/bin/tar', 'xf', path.posix.join(workDir, archiveName), '-C', resultDir);
+      await this.vm.execCommand('/bin/tar', 'xf', path.posix.join(workDir, archiveName), '-C', resultDir);
       succeeded = true;
 
       return resultDir;


### PR DESCRIPTION
Alpine (at least currently) no longer provides a /usr/bin/tar, because that confuses their usrmerge scripts (and because busybox only provides a /bin/tar).  Make sure we invoke /bin/tar instead of /usr/bin/tar to work around the issue until their usrmerge is complete.

For invocations on the host, continue to use /usr/bin/tar to reduce changes until somebody complains; it seems unlikely that Alpine users are running Rancher Desktop (or indeed, any sort of GUI).

See: https://gitlab.alpinelinux.org/alpine/aports/-/commit/42e55f3af538fc79d9583d5236bbb3e39934bcf2

Fixes #9463