### PR TITLE
Pull images before running them in bats/tests/containers/switch-engines.bats

### DIFF
--- a/bats/tests/containers/host-network-ports.bats
+++ b/bats/tests/containers/host-network-ports.bats
@@ -21,7 +21,7 @@ local_setup() {
 
 run_container_with_host_network_driver() {
     local image="python:slim"
-    ctrctl pull "$image"
+    ctrctl pull --quiet "$image"
     ctrctl run -d --network=host --restart=no "$image" "$@"
 }
 

--- a/bats/tests/containers/published-ports.bats
+++ b/bats/tests/containers/published-ports.bats
@@ -12,7 +12,7 @@ load '../helpers/load'
 }
 
 run_container_with_published_port() {
-    ctrctl pull "$IMAGE_NGINX"
+    ctrctl pull --quiet "$IMAGE_NGINX"
     ctrctl run -d -p "$@" --restart=no "$IMAGE_NGINX"
 }
 

--- a/bats/tests/containers/run-rancher.bats
+++ b/bats/tests/containers/run-rancher.bats
@@ -16,7 +16,7 @@ RD_FILE_RAMDISK_SIZE=12 # We need more disk to run the Rancher image.
     local rancher_image
     rancher_image="rancher/rancher:$(rancher_image_tag)"
 
-    ctrctl pull "$rancher_image"
+    ctrctl pull --quiet "$rancher_image"
     ctrctl run --privileged -d --restart=no -p 8080:80 -p 8443:443 --name rancher "$rancher_image"
 }
 

--- a/bats/tests/containers/switch-engines.bats
+++ b/bats/tests/containers/switch-engines.bats
@@ -14,6 +14,8 @@ switch_container_engine() {
 }
 
 pull_containers() {
+    ctrctl pull --quiet "$IMAGE_NGINX"
+    ctrctl pull --quiet "$IMAGE_BUSYBOX"
     ctrctl run -d -p 8085:80 --restart=no "$IMAGE_NGINX"
     ctrctl run -d --restart=always "$IMAGE_BUSYBOX" /bin/sh -c "sleep inf"
     run ctrctl ps --format '{{json .Image}}'

--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -39,7 +39,7 @@ local_setup_file() {
 }
 
 @test 'deploy nginx - always restart' {
-    ctrctl pull "$IMAGE_NGINX"
+    ctrctl pull --quiet "$IMAGE_NGINX"
     run ctrctl run -d -p 8585:80 --restart=always --name nginx-restart "$IMAGE_NGINX"
     assert_success
 }


### PR DESCRIPTION
This allows us to use `--quiet` to avoid flooding the logs with pull progress messages.

Might be coincidence, but after making this change the test no longer failed with "context deadline exceeded" for me on Windows. I suspect the slow pull performance may have contributed to the likelihood of hitting the timeout.

Also adds `--quiet` option to some other places that pull without it.

Fixes #9505