### PR TITLE
Image: Fix PATH when running image commands

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -594,7 +594,7 @@ async function startK8sManager() {
  */
 
 function setupImageProcessor() {
-  const imageProcessor = getImageProcessor(cfg.containerEngine.name, k8smanager.executor);
+  const imageProcessor = getImageProcessor(cfg.containerEngine.name, k8smanager);
 
   currentImageProcessor?.deactivate();
   if (!imageEventHandler) {

--- a/pkg/rancher-desktop/backend/images/imageFactory.ts
+++ b/pkg/rancher-desktop/backend/images/imageFactory.ts
@@ -1,4 +1,4 @@
-import { VMExecutor } from '@pkg/backend/backend';
+import { VMBackend } from '@pkg/backend/backend';
 import { ImageProcessor } from '@pkg/backend/images/imageProcessor';
 import MobyImageProcessor from '@pkg/backend/images/mobyImageProcessor';
 import NerdctlImageProcessor from '@pkg/backend/images/nerdctlImageProcessor';
@@ -9,7 +9,7 @@ const cachedImageProcessors: Partial<Record<ContainerEngine, ImageProcessor>> = 
 /**
  * Return the appropriate ImageProcessor singleton for the specified ContainerEngine.
  */
-export function getImageProcessor(engineName: ContainerEngine, executor: VMExecutor): ImageProcessor {
+export function getImageProcessor(engineName: ContainerEngine, executor: VMBackend): ImageProcessor {
   if (!(engineName in cachedImageProcessors)) {
     switch (engineName) {
     case ContainerEngine.MOBY:

--- a/pkg/rancher-desktop/backend/images/imageProcessor.ts
+++ b/pkg/rancher-desktop/backend/images/imageProcessor.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import { EventEmitter } from 'events';
 import timers from 'timers';
 
-import { VMExecutor } from '@pkg/backend/backend';
+import { VMBackend, VMExecutor } from '@pkg/backend/backend';
 import mainEvents from '@pkg/main/mainEvents';
 import { ChildProcess, ErrorCommand } from '@pkg/utils/childProcess';
 import Logging from '@pkg/utils/logging';
@@ -70,7 +70,7 @@ interface ProcessChildOutputOptions {
  * an active ImageProcessor can be dropped.
  */
 export abstract class ImageProcessor extends EventEmitter {
-  protected executor:      VMExecutor;
+  protected backend:       VMBackend;
   // Sometimes the `images` subcommand repeatedly fires the same error message.
   // Instead of logging it every time, keep track of the current error and give a count instead.
   private lastErrorMessage = '';
@@ -90,9 +90,9 @@ export abstract class ImageProcessor extends EventEmitter {
   // which imageProcessor is currently active, and it can direct events to that.
   protected active = false;
 
-  protected constructor(executor: VMExecutor) {
+  protected constructor(backend: VMBackend) {
     super();
-    this.executor = executor;
+    this.backend = backend;
     this._refreshImages = this.refreshImages.bind(this);
     this.on('newListener', (event: string | symbol) => {
       if (!this.active) {
@@ -195,7 +195,7 @@ export abstract class ImageProcessor extends EventEmitter {
     }
 
     return await this.processChildOutput(
-      this.executor.spawn({ root: true }, ...args),
+      this.backend.executor.spawn({ root: true }, ...args),
       {
         commandName:    'trivy',
         subcommandName: 'image',


### PR DESCRIPTION
Previously, running image commands from the UI (e.g. to pull an image) was not setting up PATH correctly.  Fix this by using the centralized wrapper for the container engine commands instead of doing a separate thing; this also allows us to remove special casing for nerdctl/moby (since it's already done elsewhere).

Fixes #9516