### PR TITLE
yarn: Default post-install scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
+enableScripts: false
 nodeLinker: node-modules
 
 plugins:

--- a/package.json
+++ b/package.json
@@ -161,6 +161,20 @@
     "typescript": "5.9.3",
     "webpack": "5.100.2"
   },
+  "dependenciesMeta": {
+    "electron": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "native-reg": {
+      "built": true
+    },
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "resolutions": {
     "string-width": "^4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14757,8 +14757,16 @@ __metadata:
   dependenciesMeta:
     dmg-license:
       optional: true
+    electron:
+      built: true
+    esbuild:
+      built: true
+    native-reg:
+      built: true
     posix-node:
       optional: true
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This disables post-install scripts by default, and only enables a small list that actually uses native components.  This potentially papers over the security issue du jour where a compromised package gets scripts added for credential stealing.