### PR TITLE
Packaging: Linux: Work around Debian postinst issues

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -652,6 +652,7 @@ portproxy
 portstorage
 Postgre
 postgresql
+postinst
 postrotate
 POSTROUTING
 PQgrl

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -188,6 +188,11 @@ cp -ra ./* "%{buildroot}/opt/%{name}"
 # Link to the binary
 ln -sf "/opt/%{name}/rancher-desktop" "%{buildroot}%{_bindir}/rancher-desktop"
 
+%post
+# This is needed to ensure Debian packages have proper file permissions;
+# otherwise the postinst script is not generated correctly.
+true
+
 %files
 %defattr(-,root,root,-)
 %dir /opt/%{name}


### PR DESCRIPTION
If there is no `%post` script it appears that the Debian postinst script does not get generated, which causes chrome-sandbox to not get suid set which in turn causes the app to fail to start.

This only needs to be in the branch to be effective (because OBS just checks out the files from the branch); it is not necessary to rebuild the binaries other than whatever happens in OBS.