### PR TITLE
Merge 1.21 to main

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -652,6 +652,7 @@ portproxy
 portstorage
 Postgre
 postgresql
+postinst
 postrotate
 POSTROUTING
 PQgrl

--- a/packaging/linux/rancher-desktop.spec
+++ b/packaging/linux/rancher-desktop.spec
@@ -188,6 +188,11 @@ cp -ra ./* "%{buildroot}/opt/%{name}"
 # Link to the binary
 ln -sf "/opt/%{name}/rancher-desktop" "%{buildroot}%{_bindir}/rancher-desktop"
 
+%post
+# This is needed to ensure Debian packages have proper file permissions;
+# otherwise the postinst script is not generated correctly.
+true
+
 %files
 %defattr(-,root,root,-)
 %dir /opt/%{name}


### PR DESCRIPTION
The bulk of the release-1.21 changes have already been merged back, but #9544 was merged after the v1.21 tag and is still missing in main.