### PR TITLE
Revert "build(deps-dev): bump electron-builder from 26.2.0 to 26.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "css-loader": "7.1.2",
     "ejs": "3.1.10",
     "electron": "39.2.3",
-    "electron-builder": "26.3.0",
+    "electron-builder": "26.2.0",
     "eslint": "9.39.1",
     "eslint-plugin-vue": "10.5.1",
     "extract-zip": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6677,9 +6677,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app-builder-lib@npm:26.3.0":
-  version: 26.3.0
-  resolution: "app-builder-lib@npm:26.3.0"
+"app-builder-lib@npm:26.2.0":
+  version: 26.2.0
+  resolution: "app-builder-lib@npm:26.2.0"
   dependencies:
     "@develar/schema-utils": "npm:~2.6.5"
     "@electron/asar": "npm:3.4.1"
@@ -6691,15 +6691,15 @@ __metadata:
     "@malept/flatpak-bundler": "npm:^0.4.0"
     "@types/fs-extra": "npm:9.0.13"
     async-exit-hook: "npm:^2.0.1"
-    builder-util: "npm:26.3.0"
-    builder-util-runtime: "npm:9.5.1"
+    builder-util: "npm:26.1.0"
+    builder-util-runtime: "npm:9.5.0"
     chromium-pickle-js: "npm:^0.2.0"
-    ci-info: "npm:4.3.1"
+    ci-info: "npm:^4.2.0"
     debug: "npm:^4.3.4"
     dotenv: "npm:^16.4.5"
     dotenv-expand: "npm:^11.0.6"
     ejs: "npm:^3.1.8"
-    electron-publish: "npm:26.3.0"
+    electron-publish: "npm:26.1.0"
     fs-extra: "npm:^10.1.0"
     hosted-git-info: "npm:^4.1.0"
     isbinaryfile: "npm:^5.0.0"
@@ -6716,9 +6716,9 @@ __metadata:
     tiny-async-pool: "npm:1.3.0"
     which: "npm:^5.0.0"
   peerDependencies:
-    dmg-builder: 26.3.0
-    electron-builder-squirrel-windows: 26.3.0
-  checksum: 10c0/ea393d6d98e484d1743de247dc658b0e49240f0cdb1c3fcd1ba980cb5c0b04cadbe89ceda58f3aadf4c8f5628522bb4b2e5e1f9639977f58f5f476004e0512d6
+    dmg-builder: 26.2.0
+    electron-builder-squirrel-windows: 26.2.0
+  checksum: 10c0/81fba154eab87837c0a1cc156a0f5db5ffa06cb78a905aff2a8f4c35aca4dba3e361cf835d1a8df4eef3819f6c93d4be3163cd7901b0c63b4bef7c691f1794ad
   languageName: node
   linkType: hard
 
@@ -7283,6 +7283,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:9.5.0":
+  version: 9.5.0
+  resolution: "builder-util-runtime@npm:9.5.0"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10c0/797f4f8129557de6f5699991974f1701e464646664a14f841870fca0ddb05cb63cb8f2ca3c082cd6215690048c5e12df8404e7ccec371640eed9edc8cb592ae6
+  languageName: node
+  linkType: hard
+
 "builder-util-runtime@npm:9.5.1":
   version: 9.5.1
   resolution: "builder-util-runtime@npm:9.5.1"
@@ -7293,14 +7303,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builder-util@npm:26.3.0":
-  version: 26.3.0
-  resolution: "builder-util@npm:26.3.0"
+"builder-util@npm:26.1.0":
+  version: 26.1.0
+  resolution: "builder-util@npm:26.1.0"
   dependencies:
     7zip-bin: "npm:~5.2.0"
     "@types/debug": "npm:^4.1.6"
     app-builder-bin: "npm:5.0.0-alpha.12"
-    builder-util-runtime: "npm:9.5.1"
+    builder-util-runtime: "npm:9.5.0"
     chalk: "npm:^4.1.2"
     ci-info: "npm:^4.2.0"
     cross-spawn: "npm:^7.0.6"
@@ -7314,7 +7324,7 @@ __metadata:
     stat-mode: "npm:^1.0.0"
     temp-file: "npm:^3.4.0"
     tiny-async-pool: "npm:1.3.0"
-  checksum: 10c0/80c6ca1a6adf4b8f3b8066286ad094ff274bfa905a17f158fb57794dd27178f1de82b35c909eed0ff10452163992ccc01a07986709cc4d20ca4b445cfba84e41
+  checksum: 10c0/0e1bcc04452cda8eaa1d63f338e05c1280f0539ee9dd7a9d4d17f75dff323d0d34de184fc146e3bdb1e1f1578bc0070569b1701312b509e802c97bfe4fed24b1
   languageName: node
   linkType: hard
 
@@ -7566,13 +7576,6 @@ __metadata:
   version: 0.2.0
   resolution: "chromium-pickle-js@npm:0.2.0"
   checksum: 10c0/0a95bd280acdf05b0e08fa1a0e1db58c815dd24e92d639add8f494d23a8a49c26e4829721224d68f2f0e57a69047714db29bcff6deb5d029332321223416cb29
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:4.3.1":
-  version: 4.3.1
-  resolution: "ci-info@npm:4.3.1"
-  checksum: 10c0/7dd82000f514d76ddfe7775e4cb0d66e5c638f5fa0e2a3be29557e898da0d32ac04f231217d414d07fb968b1fbc6d980ee17ddde0d2c516f23da9cfff608f6c1
   languageName: node
   linkType: hard
 
@@ -8587,12 +8590,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dmg-builder@npm:26.3.0":
-  version: 26.3.0
-  resolution: "dmg-builder@npm:26.3.0"
+"dmg-builder@npm:26.2.0":
+  version: 26.2.0
+  resolution: "dmg-builder@npm:26.2.0"
   dependencies:
-    app-builder-lib: "npm:26.3.0"
-    builder-util: "npm:26.3.0"
+    app-builder-lib: "npm:26.2.0"
+    builder-util: "npm:26.1.0"
     dmg-license: "npm:^1.0.11"
     fs-extra: "npm:^10.1.0"
     iconv-lite: "npm:^0.6.2"
@@ -8600,7 +8603,7 @@ __metadata:
   dependenciesMeta:
     dmg-license:
       optional: true
-  checksum: 10c0/b6bf3f6a054976b840d34fc4da7523d08ac1725f12932642a8743aff09c1eebd0a2c9ce93ac332ed5d130ba921bf9510e4a12e036ae8d527938d667a2cf5bd00
+  checksum: 10c0/9c7b0c5626ae47e7ee33f9d3754ade8f28ca25ef5a1acaa9e9d3c096ab52601d454ef49ad9746f955475628c27e988b67afa8cadf7cc9b4a0adda0662ca475fc
   languageName: node
   linkType: hard
 
@@ -8787,16 +8790,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-builder@npm:26.3.0":
-  version: 26.3.0
-  resolution: "electron-builder@npm:26.3.0"
+"electron-builder@npm:26.2.0":
+  version: 26.2.0
+  resolution: "electron-builder@npm:26.2.0"
   dependencies:
-    app-builder-lib: "npm:26.3.0"
-    builder-util: "npm:26.3.0"
-    builder-util-runtime: "npm:9.5.1"
+    app-builder-lib: "npm:26.2.0"
+    builder-util: "npm:26.1.0"
+    builder-util-runtime: "npm:9.5.0"
     chalk: "npm:^4.1.2"
     ci-info: "npm:^4.2.0"
-    dmg-builder: "npm:26.3.0"
+    dmg-builder: "npm:26.2.0"
     fs-extra: "npm:^10.1.0"
     lazy-val: "npm:^1.0.5"
     simple-update-notifier: "npm:2.0.0"
@@ -8804,23 +8807,23 @@ __metadata:
   bin:
     electron-builder: cli.js
     install-app-deps: install-app-deps.js
-  checksum: 10c0/8d4bf43887f2187185275aeb4576ac442ed4344a8155a877a903f64c7e0da93006c05b15689ab5017aad7ca03593f1af1538ecbc414409a80f94c66007b7f507
+  checksum: 10c0/bc35fe4cb7651d517c8d75b1d9cf2d571ba1260d33cb19753847b7d766ad1f43d4c287329d9686cac77912cad9a6455657a179dfb923ba69040b77f820f21fb8
   languageName: node
   linkType: hard
 
-"electron-publish@npm:26.3.0":
-  version: 26.3.0
-  resolution: "electron-publish@npm:26.3.0"
+"electron-publish@npm:26.1.0":
+  version: 26.1.0
+  resolution: "electron-publish@npm:26.1.0"
   dependencies:
     "@types/fs-extra": "npm:^9.0.11"
-    builder-util: "npm:26.3.0"
-    builder-util-runtime: "npm:9.5.1"
+    builder-util: "npm:26.1.0"
+    builder-util-runtime: "npm:9.5.0"
     chalk: "npm:^4.1.2"
     form-data: "npm:^4.0.0"
     fs-extra: "npm:^10.1.0"
     lazy-val: "npm:^1.0.5"
     mime: "npm:^2.5.2"
-  checksum: 10c0/f2e0bf2ce50e3a33fec25a80a36d29f5967c1c88baba57ef6b3edb7cd33445e58cef19bcae02a5079659a5677c972cb972bd74a6793d59d4cccd5345ff47ee2d
+  checksum: 10c0/f6593e007f47bea311ab9678c31f724a3c0826de4e0f8ea917d4c3d073d3470ede6a093b51408cd53dd790bb1baa4d5b7647a8cd935d0ff3b4d011050e861f0b
   languageName: node
   linkType: hard
 
@@ -14731,7 +14734,7 @@ __metadata:
     dompurify: "npm:3.3.0"
     ejs: "npm:3.1.10"
     electron: "npm:39.2.3"
-    electron-builder: "npm:26.3.0"
+    electron-builder: "npm:26.2.0"
     electron-updater: "npm:6.7.2"
     eslint: "npm:9.39.1"
     eslint-plugin-vue: "npm:10.5.1"


### PR DESCRIPTION
This reverts commit 301fd7203d7195daf9eff1c30a531f993ae04b86. That version of electron-builder introduces an issue such that some packages are not correctly installed in the resulting packaged build.

See also: https://github.com/electron-userland/electron-builder/issues/9394

Fixes #9563