### PR TITLE
UI: Containers: Handle backend becoming unready

### DIFF
--- a/pkg/rancher-desktop/entry/store.ts
+++ b/pkg/rancher-desktop/entry/store.ts
@@ -59,8 +59,8 @@ export function mapTypedGetters
   N extends keyof Modules,
   M extends Modules[N] extends { getters: any } ? Modules[N]['getters'] : never,
   K extends keyof M,
-  G extends Record<K, string>,
->(namespace: N, mappings: G): { [key in keyof G as G[key]]: () => ReturnType<M[key]> };
+  G extends Record<string, K>,
+>(namespace: N, mappings: G): { [key in keyof G]: () => ReturnType<M[G[key]]> };
 // Actual implementation defers to mapGetters.
 export function mapTypedGetters(namespace: string, arg: any) {
   return mapGetters(namespace, arg);

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -269,9 +269,12 @@ export const actions = {
       commit('SET_SUBSCRIBER', null);
     }
   },
-  unsubscribe({ state }) {
+  unsubscribe({ commit, state }) {
     state.subscriber?.destroy();
     state.subscriber = null;
+    // Clear the state; this is needed if the backend becomes unready.
+    state.containers = null;
+    state.volumes = null;
   },
   async fetchNamespaces({ commit, state, getters }) {
     try {


### PR DESCRIPTION
If the backend becomes unready, we need to unsubscribe to the events and turn back to the loading state, in order to avoid having errors from the backend disconnecting.  There is a similar bug in the volumes handling.

Fixes #9545