### PR TITLE
fix: use HTTPS HEAD request for network connectivity check

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/connectedToInternet.ts
+++ b/pkg/rancher-desktop/main/diagnostics/connectedToInternet.ts
@@ -31,10 +31,9 @@ mainEvents.on('settings-update', settings => {
  */
 async function checkNetworkConnectivity(): Promise<boolean> {
   const request = net.request({
-    // Using HTTP request that returns a 301 redirect response instead of a 20+ kB web page
-    url:         'http://docs.rancherdesktop.io/',
+    method:      'HEAD',
+    url:         'https://docs.rancherdesktop.io/',
     credentials: 'omit',
-    redirect:    'manual',
     cache:       'no-cache',
   });
   const timeoutId = setTimeout(() => {


### PR DESCRIPTION
This PR updates the internet connectivity diagnostic to use an HTTPS `HEAD` request instead of an unencrypted HTTP `GET`. The previous approach leaked the `Host` header in plaintext, which could reveal Rancher Desktop usage to network observers.

Using `HEAD` over HTTPS provides full transport encryption while avoiding unnecessary data transfer (0-byte response body vs. ~20 KB for the previous `GET`). It also results in a slightly smaller overall request size (627 bytes vs. 669 bytes).

This improves user privacy with no functional impact and minimal overhead.
