### PR TITLE
Dependabot: disable go-openapi/swag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,9 @@ updates:
     default-days: 7
   open-pull-requests-limit: 12
   labels: ["component/dependencies"]
+  ignore:
+  - # Swagger dependencies must match whatever the CLI generate.
+    dependency-name: "github.com/go-openapi/swag"
   groups:
     golang-x:
       patterns: ["golang.org/x/*"]


### PR DESCRIPTION
The version for this depends on the version used by the CLI, i.e. `github.com/go-swagger/go-swagger` — bumping `go-openapi/swag` by itself just leads to broken builds; see #9585 for an example.  To make sure we don't forget to bump it in the future, the second commit adds a lint check to make sure our version of `go-openapi/swag` always matches the version in `github.com/go-swagger/go-swagger`.
