### PR TITLE
Improve download failure handling

### DIFF
--- a/scripts/lib/download.ts
+++ b/scripts/lib/download.ts
@@ -44,6 +44,14 @@ async function fetchWithRetry(url: string) {
   }
 }
 
+function checkDownloadStatusOrThrow(url: string, response: Response): void {
+  if (!response.ok) {
+    const requestId = response.headers.get('x-github-request-id');
+    const requestAnnotation = requestId ? ` [request: ${ requestId }]` : '';
+    throw new Error(`Error downloading ${ url } (${ response.status }) ${ response.statusText }${ requestAnnotation }`);
+  }
+}
+
 /**
  * Download the given URL, making the result executable.
  * @param url The URL to download
@@ -72,9 +80,7 @@ export async function download(url: string, destPath: string, options: DownloadO
   await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
   const response = await fetchWithRetry(url);
 
-  if (!response.ok) {
-    throw new Error(`Error downloading ${ url }: ${ response.statusText }`);
-  }
+  checkDownloadStatusOrThrow(url, response);
   if (!response.body) {
     throw new Error(`Error downloading ${ url }: did not receive response body`);
   }
@@ -141,11 +147,7 @@ async function getChecksumForFile(inputPath: string, checksumAlgorithm: Checksum
 export async function getResource(url: string): Promise<string> {
   const response = await fetchWithRetry(url);
 
-  if (!response.ok) {
-    const requestId = response.headers.get('x-github-request-id');
-    const requestAnnotation = requestId ? ` [request: ${ requestId }]` : '';
-    throw new Error(`Error downloading ${ url } (${ response.status }) ${ response.statusText }${ requestAnnotation }`);
-  }
+  checkDownloadStatusOrThrow(url, response);
 
   return await response.text();
 }


### PR DESCRIPTION
- log response status
- log request id (which should always be available)
- leave space after url so clicking it could work

Note that there's a current partial outage which would explain the errors: https://www.githubstatus.com/incidents/xntfc1fz5rfb (but afaict the incident was only reported after the errors showed up...)

[Before](https://github.com/check-spelling-sandbox/rancher-desktop/actions/runs/20117125295/job/57793404804#step:3:331):
>   POSTINSTALL ERROR:  Error: Error downloading https://github.com/flavio/kuberlr/releases/download/v0.6.1/checksums.txt: Service Unavailable

Note that the GitHub log viewer unfortunately makes the link:

<img width="805" height="43" alt="Screenshot 2025-12-11 at 11 50 46 AM" src="https://github.com/user-attachments/assets/116ed45f-2de9-454c-868f-280b75bf0152" />

>  POSTINSTALL ERROR:  Error: Error downloading [https://github.com/flavio/kuberlr/releases/download/v0.6.1/checksums.txt:](https://github.com/flavio/kuberlr/releases/download/v0.6.1/checksums.txt:) Service Unavailable

... which leads to a 404...

Hopefully the after will be closer to:

>   POSTINSTALL ERROR:  Error: Error downloading https://github.com/flavio/kuberlr/releases/download/v0.6.1/checksums.txt (503) Service Unavailable [C2Ax:2B61Fx:32E240x:486BF7x:693AD9Ax]

Where the request ID is something you can use to talk to GitHub support.
