### PR TITLE
Screenshots: Improve reliability

### DIFF
--- a/e2e/pages/preferences/virtualMachine.ts
+++ b/e2e/pages/preferences/virtualMachine.ts
@@ -38,8 +38,8 @@ export class VirtualMachineNav {
     this.qemu = page.locator('[data-test="QEMU"]');
     this.vz = page.locator('[data-test="VZ"]');
     this.useRosetta = page.locator('[data-test="useRosetta"]');
-    this.tabHardware = page.locator('.tab >> text=Hardware');
-    this.tabVolumes = page.locator('.tab >> text=Volumes');
-    this.tabEmulation = page.locator('.tab >> text=Emulation');
+    this.tabHardware = page.getByTestId('hardware');
+    this.tabVolumes = page.getByTestId('volumes');
+    this.tabEmulation = page.getByTestId('emulation');
   }
 }

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -372,14 +372,17 @@ test.describe.serial('Main App Test', () => {
           await e2ePreferences.virtualMachine.tabEmulation.click();
           await expect(e2ePreferences.virtualMachine.vmType).toBeVisible();
           await prefScreenshot.take('virtualMachine', 'tabEmulation');
+
+          // If applicable, switch to VZ so we can use virtiofs.
+          if (await e2ePreferences.virtualMachine.vz.isEnabled()) {
+            await page.waitForTimeout(afterCheckedTimeout);
+            await expect(e2ePreferences.virtualMachine.vz).toBeVisible();
+            await e2ePreferences.virtualMachine.vz.click({ position: { x: 10, y: 10 } });
+            await expect(e2ePreferences.virtualMachine.vz).toBeChecked();
+          }
         });
 
         test('VolumesTab-virtiofs', async() => {
-          if (await e2ePreferences.virtualMachine.vz.isEnabled()) {
-            await e2ePreferences.virtualMachine.vz.click();
-            await expect(e2ePreferences.virtualMachine.vz).toBeChecked();
-          }
-
           await e2ePreferences.virtualMachine.tabVolumes.click();
           if (await e2ePreferences.virtualMachine.virtiofs.isEnabled()) {
             await e2ePreferences.virtualMachine.virtiofs.click();


### PR DESCRIPTION
If we're using 9p, the VZ option has text to switch to sshfs or virtiofs. However, that test contains a link that switches to the volumes tab, and that link happens to be roughly in the middle of the label.  This means that when we try to click on the VZ radio, it actually switches the page instead and everything is confused.

See also commit a20e00c90fe5bd8ae1ea8982185ccffbbd56e17e where this happened in the other place with click on the vz radio.