### PR TITLE
Fix RDX metadata caching after reinstall

### DIFF
--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -548,6 +548,14 @@ export class ExtensionImpl implements Extension {
       }
     }
 
+    // Clear memoized caches so that if the extension is reinstalled, fresh
+    // metadata will be extracted from the Docker image.
+    this._metadata = undefined;
+    this._labels = undefined;
+    this._iconName = undefined;
+    this._composeFile = undefined;
+    this._composeName = '';
+
     mainEvents.emit('settings-write', { application: { extensions: { installed: { [this.id]: undefined } } } });
 
     return true;


### PR DESCRIPTION
When an extension was uninstalled and reinstalled, the ExtensionImpl instance was reused from the manager's cache but its memoized properties (_metadata, _labels, _iconName, _composeFile, _composeName) were never cleared. This caused stale metadata to be used instead of extracting fresh metadata from the updated Docker image.

Clear all memoized caches in uninstall() so that reinstalling an extension correctly re-extracts metadata from the Docker image.