### PR TITLE
Fix Installed tab button clicks and Vue 3 compatibility

### DIFF
--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -69,11 +69,13 @@ export default defineComponent({
       return ext.labels?.['org.opencontainers.image.title'] ?? ext.id;
     },
     async uninstall(installed: ExtensionState) {
-      this.$set(this.busy, installed.id, true);
+      this.busy = { ...this.busy, [installed.id]: true };
       try {
         await this.$store.dispatch('extensions/uninstall', { id: installed.id });
       } finally {
-        this.$delete(this.busy, installed.id);
+        const { [installed.id]: _, ...rest } = this.busy;
+
+        this.busy = rest;
       }
     },
     async upgrade(installed: ExtensionState) {
@@ -83,11 +85,13 @@ export default defineComponent({
         // Should not have reached here.
         return;
       }
-      this.$set(this.busy, installed.id, true);
+      this.busy = { ...this.busy, [installed.id]: true };
       try {
         await this.$store.dispatch('extensions/install', { id });
       } finally {
-        this.$delete(this.busy, installed.id);
+        const { [installed.id]: _, ...rest } = this.busy;
+
+        this.busy = rest;
       }
     },
   },
@@ -97,7 +101,7 @@ export default defineComponent({
 <template>
   <div>
     <sortable-table
-      key-field="description"
+      key-field="id"
       :loading="loading"
       :headers="headers"
       :rows="installedExtensions"
@@ -146,14 +150,14 @@ export default defineComponent({
             <button
               v-if="!busy[row.id] && row.canUpgrade"
               class="btn btn-sm role-primary"
-              @click="upgrade(row)"
+              @click.stop="upgrade(row)"
             >
               {{ t('extensions.installed.list.upgrade') }}
             </button>
             <button
               :disabled="busy[row.id]"
               class="btn btn-sm role-danger"
-              @click="uninstall(row)"
+              @click.stop="uninstall(row)"
             >
               {{ t('extensions.installed.list.uninstall') }}
             </button>


### PR DESCRIPTION
The "Uninstall" buttons on the "Installed" tab no longer work; the ones on the "Catalog" tab do.

This fix has been prepared by AI; please review with extra care!

---

Three related fixes for the installed extensions page:

1. Add .stop modifier to upgrade/uninstall button click handlers to prevent event propagation to parent row handlers.

2. Replace Vue 2 reactivity APIs (this.$set, this.$delete) with Vue 3 compatible spread operators for updating the busy state object.

3. Change key-field from "description" to "id". ExtensionState has no description field, so all rows had undefined keys. While Vue 2 was tolerant of this, using the actual unique identifier is correct.