### PR TITLE
Add ddClient.extension.id and version fields for RDX

### DIFF
--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -199,9 +199,12 @@ let lastOpenExtension: { id: string, relPath: string } | undefined;
  */
 function createView() {
   const mainWindow = getWindow('main');
-  const hostInfo = {
-    arch:     process.arch,
-    hostname: os.hostname(),
+  const decodedExtensionId = currentExtension?.id ? Buffer.from(currentExtension.id, 'hex').toString() : undefined;
+  const extensionVersion = decodedExtensionId ? getSettings().application.extensions.installed[decodedExtensionId] : undefined;
+  const extensionContext = {
+    arch:             process.arch,
+    hostname:         os.hostname(),
+    extensionVersion,
   };
 
   if (!mainWindow) {
@@ -212,7 +215,7 @@ function createView() {
     nodeIntegration:     false,
     contextIsolation:    true,
     sandbox:             true,
-    additionalArguments: [JSON.stringify(hostInfo)],
+    additionalArguments: [JSON.stringify(extensionContext)],
   };
 
   if (currentExtension?.id) {


### PR DESCRIPTION
This fix has been prepared by AI; please review with extra care!

---

The ddClient.extension object provided to extensions was missing the id and version fields, and the image field only contained the extension ID without the version tag.

According to Docker Desktop Extension API:
- image: full image reference (id:version)
- id: image name without tag
- version: just the tag

Fix by:
1. Look up extension version from settings in window/index.ts
2. Pass extensionId and extensionVersion to preload script
3. Update RDXClient constructor to set id, version, and image properly