### PR TITLE
Skip compose down for extensions without containers

### DIFF
--- a/pkg/rancher-desktop/main/extensions/extensions.ts
+++ b/pkg/rancher-desktop/main/extensions/extensions.ts
@@ -554,6 +554,14 @@ export class ExtensionImpl implements Extension {
   }
 
   protected async uninstallContainers() {
+    const metadata = await this.metadata;
+
+    if (!isVMTypeImage(metadata.vm) && !isVMTypeComposefile(metadata.vm)) {
+      console.debug(`Extension ${ this.id } does not have containers to stop.`);
+
+      return;
+    }
+
     console.debug(`Running ${ this.id } compose down`);
     await this.client.composeDown({
       composeDir: path.join(this.dir, 'compose'),


### PR DESCRIPTION
During uninstall, check if the extension has containers (vm type is image or composefile) before attempting to run compose down. This matches the logic in installContainers() which only creates compose.yaml for extensions with containers.

Previously, uninstallContainers() would always try to run compose down, causing ENOENT errors for extensions without containers since no compose.yaml was ever created during installation.