### PR TITLE
Add welcome extension feature

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1552,6 +1552,21 @@ class BackgroundCommandWorker implements CommandWorkerInterface {
     if (!em) {
       return { status: 503, data: 'Extension manager is not ready yet.' };
     }
+
+    // Prevent uninstalling the welcome extension
+    if (state === 'uninstall') {
+      const welcomeImage = cfg.application.extensions.welcome;
+
+      if (welcomeImage) {
+        // Extract the image name without tag for comparison
+        const imageWithoutTag = image.includes(':') ? image.split(':')[0] : image;
+
+        if (imageWithoutTag === welcomeImage) {
+          return { status: 403, data: `The welcome extension ${ welcomeImage } cannot be uninstalled` };
+        }
+      }
+    }
+
     const extension = await em.getExtension(image, { preferInstalled: state === 'uninstall' });
 
     if (state === 'install') {

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -563,6 +563,9 @@ components:
                   x-rd-usage: installed extensions and their tag
                   additionalProperties:
                     type: string
+                welcome:
+                  type: string
+                  x-rd-usage: welcome extension shown at top of sidebar
             pathManagementStrategy:
               type: string
               enum: [manual, rcfiles]

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -1,5 +1,21 @@
 <template>
   <nav>
+    <!-- Welcome extension shown at top, with icon -->
+    <RouterLink
+      v-if="welcomeExtensionWithUI"
+      :data-test="`extension-nav-welcome`"
+      :to="extensionRoute(welcomeExtensionWithUI)"
+    >
+      <nav-item
+        :id="`extension:${welcomeExtensionWithUI.id}`"
+        class="welcome-extension"
+      >
+        <template #before>
+          <nav-icon-extension :extension-id="welcomeExtensionWithUI.id" />
+        </template>
+        {{ welcomeExtensionWithUI.metadata.ui['dashboard-tab'].title }}
+      </nav-item>
+    </RouterLink>
     <ul>
       <li
         v-for="item in items"
@@ -114,6 +130,10 @@ export default defineComponent({
       type:     Array as PropType<ExtensionState[]>,
       required: true,
     },
+    welcomeExtension: {
+      type:    Object as PropType<ExtensionState | undefined>,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -136,6 +156,25 @@ export default defineComponent({
       }
 
       return this.extensions.filter<ExtensionWithUI>(hasUI);
+    },
+    welcomeExtensionWithUI(): ExtensionWithUI | undefined {
+      if (!this.welcomeExtension) {
+        return undefined;
+      }
+      if (!this.welcomeExtension.metadata.ui?.['dashboard-tab']?.title) {
+        return undefined;
+      }
+
+      return this.welcomeExtension as ExtensionWithUI;
+    },
+  },
+  watch: {
+    welcomeExtensionWithUI(newVal: ExtensionWithUI | undefined) {
+      // Auto-navigate to welcome extension when it becomes available,
+      // but only if the user is still on the General page
+      if (newVal && this.$route.path === '/General') {
+        this.$router.push(this.extensionRoute(newVal));
+      }
     },
   },
   methods: {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -70,6 +70,8 @@ export const defaultSettings = {
       },
       /** Installed extensions, mapping to the installed version (tag). */
       installed: { } as Record<string, string>,
+      /** Welcome extension shown at top of sidebar, loaded first. */
+      welcome:   '' as string,
     },
     pathManagementStrategy: process.platform === 'win32' ? PathManagementStrategy.Manual : PathManagementStrategy.RcFiles,
     telemetry:              { enabled: true },

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -8,7 +8,8 @@
     <rd-nav
       class="nav"
       :items="routes"
-      :extensions="installedExtensions"
+      :extensions="regularExtensions"
+      :welcome-extension="welcomeExtension"
       @open-dashboard="openDashboard"
       @open-preferences="openPreferences"
     />
@@ -84,7 +85,7 @@ export default {
     },
     ...mapState('credentials', ['credentials']),
     ...mapTypedState('diagnostics', ['diagnostics']),
-    ...mapGetters('extensions', ['installedExtensions']),
+    ...mapGetters('extensions', ['installedExtensions', 'regularExtensions', 'welcomeExtension']),
   },
 
   beforeMount() {

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -84,6 +84,7 @@ export default class SettingsValidator {
             list:    this.checkExtensionAllowList,
           },
           installed: this.checkInstalledExtensions,
+          welcome:   this.checkString,
         },
         pathManagementStrategy: this.checkLima(this.checkEnum(...Object.values(PathManagementStrategy))),
         telemetry:              { enabled: this.checkBoolean },

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -50,8 +50,9 @@ export default defineComponent({
     emptyStateBody(): string {
       return this.t('extensions.installed.emptyState.body', { }, true);
     },
-    ...mapGetters('extensions', ['installedExtensions']) as {
-      installedExtensions: () => ExtensionState[],
+    // Use regularExtensions to exclude the welcome extension from the list
+    ...mapGetters('extensions', ['regularExtensions']) as {
+      regularExtensions: () => ExtensionState[],
     },
   },
   async beforeMount() {
@@ -100,7 +101,7 @@ export default defineComponent({
       key-field="description"
       :loading="loading"
       :headers="headers"
-      :rows="installedExtensions"
+      :rows="regularExtensions"
       :search="false"
       :table-actions="false"
       :row-actions="false"

--- a/pkg/rancher-desktop/store/extensions.ts
+++ b/pkg/rancher-desktop/store/extensions.ts
@@ -127,6 +127,35 @@ export const getters = {
   installedExtensions(state): ExtensionState[] {
     return Object.values(state.extensions);
   },
+  /**
+   * Get the welcome extension if configured and installed.
+   * @param state Extension state
+   * @param _getters Unused
+   * @param rootState Root state to access preferences
+   */
+  welcomeExtension(state, _getters, rootState): ExtensionState | undefined {
+    const welcomeId = rootState.preferences?.preferences?.application?.extensions?.welcome;
+
+    if (!welcomeId) {
+      return undefined;
+    }
+
+    return state.extensions[welcomeId];
+  },
+  /**
+   * Get installed extensions excluding the welcome extension.
+   * These are shown in the regular extensions section of the nav.
+   */
+  regularExtensions(state, _getters, rootState): ExtensionState[] {
+    const welcomeId = rootState.preferences?.preferences?.application?.extensions?.welcome;
+    const extensions = Object.values(state.extensions);
+
+    if (!welcomeId) {
+      return extensions;
+    }
+
+    return extensions.filter(ext => ext.id !== welcomeId);
+  },
   marketData(): MarketplaceData[] {
     return MARKETPLACE_DATA;
   },


### PR DESCRIPTION
This is an experimental extension used by a hackweek project. Not clear if we want to merge it to Rancher Desktop, but I wanted to make sure the code doesn't get lost.

Screenshot shows how the feature could be used; the example extension is not part of this PR.

<img width="2784" height="1664" alt="CleanShot 2025-12-05 at 14 53 12@2x" src="https://github.com/user-attachments/assets/b503dc79-dadc-4092-8ae2-fcb7f9b49abb" />

---

Add application.extensions.welcome setting for a special extension that:
- Loads first before other extensions
- Appears at top of sidebar (above General) with its icon
- Auto-navigates to the welcome extension when it loads (if on General page)
- Is hidden from the Extensions catalog/installed list
- Cannot be uninstalled via rdctl (returns 403 Forbidden)

Changes:
- config/settings.ts: Add welcome property to extensions settings
- manager.ts: Load welcome extension first in init()
- store/extensions.ts: Add welcomeExtension and regularExtensions getters
- Nav.vue: Show welcome extension at top of nav, auto-navigate when loaded
- default.vue: Pass welcome and regular extensions to Nav
- installed.vue: Use regularExtensions to hide welcome from list
- background.ts: Block uninstall of welcome extension with 403