### PR TITLE
Fix k3s version channel labels not updating properly

### DIFF
--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -487,6 +487,7 @@ export default class K3sHelper extends events.EventEmitter {
             entry.channels.push(channel);
             entry.channels.sort(this.compareChannels);
           }
+          this.versionFromChannel[channel] = version.version;
         }
       }
 
@@ -523,6 +524,7 @@ export default class K3sHelper extends events.EventEmitter {
    */
   initialize(): Promise<void> {
     if (!this.pendingInitialize) {
+      this.versionFromChannel = {};
       this.pendingInitialize = (async() => {
         await this.readCache();
         if (Object.keys(this.versions).length > 0) {
@@ -541,7 +543,6 @@ export default class K3sHelper extends events.EventEmitter {
         }
       })();
     }
-    this.versionFromChannel = {};
 
     return this.pendingInitialize;
   }


### PR DESCRIPTION
The versionFromChannel map was being reset on every call to initialize(), even when just returning the existing promise. This caused channel labels (stable, latest, v1.xx) to not be removed from old versions when they moved to newer versions, resulting in multiple patch versions showing in the recommended list.

Two fixes:
- Move versionFromChannel initialization inside the if block
- Update versionFromChannel after assigning channels to versions

Contains additional AI generated test for a scenario when initialize() is called again before the first call finishes. It should also be fixed by this PR, but I'm not sure if this can actually happen for real.

Fixes #9709