### PR TITLE
Add /api to WebSocket upgrade handler for pod logs

### DIFF
--- a/pkg/rancher-desktop/main/dashboardServer/index.ts
+++ b/pkg/rancher-desktop/main/dashboardServer/index.ts
@@ -105,6 +105,8 @@ export class DashboardServer {
           return this.proxies['/v3'].upgrade(req, socket, head);
         } else if (req.url?.startsWith('/k8s/')) {
           return this.proxies['/k8s'].upgrade(req, socket, head);
+        } else if (req.url?.startsWith('/api/')) {
+          return this.proxies['/api'].upgrade(req, socket, head);
         } else {
           console.log(`Unknown Web socket upgrade request for ${ req.url }`);
         }


### PR DESCRIPTION
The dashboard server's WebSocket upgrade handler was missing the `/api` path, which is needed for pod log streaming. The `/api` proxy was already configured (line 35), but wasn't wired up in the upgrade handler.

Pod logs use WebSocket connections to `/api/v1/namespaces/.../pods/.../log`, which were being rejected with "Unknown Web socket upgrade request".

Required for #3212