### PR TITLE
Wait for Steve to be ready before enabling dashboard button

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1266,13 +1266,13 @@ function newK8sManager() {
         }
         currentImageProcessor?.relayNamespaces();
 
-        if (enabledK8s && state === K8s.State.STARTED) {
-          // Wait for Steve to be ready before notifying the UI that K8s is started,
-          // so the dashboard button is only enabled when Steve can accept connections.
+        if (enabledK8s) {
           await Steve.getInstance().start();
         }
       }
 
+      // Notify UI after Steve is ready, so the dashboard button is only enabled
+      // when Steve can accept connections.
       window.send('k8s-check-state', state);
 
       if (state === K8s.State.STOPPING) {


### PR DESCRIPTION
The dashboard button was being enabled as soon as K8s reached the STARTED state, but Steve (which serves the dashboard API on port 9443) wasn't ready to accept connections yet. This caused the dashboard to show a spinner that never went away if clicked too quickly.

This change makes Steve.start() wait until Steve is actually accepting connections before returning, and delays sending the STARTED state to the UI until after Steve is ready.

Fixes #8217