### PR TITLE
Diagnostics: Add moby image store check

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -413,9 +413,9 @@ export default class SettingsValidator {
         mergedSettings.containerEngine.mobyStorageDriver === 'classic'
     ) {
       const message: string = {
-        'containerEngine.name':                             'Cannot switch to moby container engine with classic storage when WASM is enabled.',
-        'experimental.containerEngine.webAssembly.enabled': 'Cannot enable WASM with classic storage for moby.',
-        'containerEngine.mobyStorageDriver':                'Cannot switch to classic storage for moby when WASM is enabled.',
+        'containerEngine.name':                             'Cannot switch to moby container engine with classic storage when WebAssembly is enabled.',
+        'experimental.containerEngine.webAssembly.enabled': 'Cannot enable WebAssembly with classic storage for moby.',
+        'containerEngine.mobyStorageDriver':                'Cannot switch to classic storage for moby when WebAssembly is enabled.',
       }[fqname];
 
       if (currentValue !== desiredValue) {

--- a/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
+++ b/pkg/rancher-desktop/main/diagnostics/diagnostics.ts
@@ -38,6 +38,9 @@ export class DiagnosticsManager {
   /** Time stamp of when the last check occurred. */
   lastUpdate = new Date(0);
 
+  /** Last known applicable state, for message limiting. */
+  applicable: Record<DiagnosticsChecker['id'], boolean> = {};
+
   /** Last known check results, indexed by the checker id. */
   results: Record<DiagnosticsChecker['id'], DiagnosticsCheckerResult | DiagnosticsCheckerSingleResult[]> = {};
 
@@ -60,6 +63,7 @@ export class DiagnosticsManager {
           import('./kubeVersionsAvailable'),
           import('./limaDarwin'),
           import('./limaOverrides'),
+          import('./mobyImageStore'),
           import('./mockForScreenshots'),
           import('./pathManagement'),
           import('./rdBinInShell'),
@@ -118,7 +122,11 @@ export class DiagnosticsManager {
       }
     })))
       .map(([checker, applicable]) => {
-        console.debug(`${ checker.id } is ${ applicable ? '' : 'not ' }applicable`);
+        if (applicable !== this.applicable[checker.id]) {
+          const verb = this.applicable[checker.id] === undefined ? 'is' : 'turned';
+          console.debug(`${ checker.id } ${ verb } ${ applicable ? '' : 'not ' }applicable`);
+          this.applicable[checker.id] = applicable;
+        }
 
         return [checker, applicable] as const;
       })

--- a/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
+++ b/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
@@ -48,22 +48,29 @@ class CheckMobyImageStore implements DiagnosticsChecker {
       };
     }
 
-    if (state.hasClassicData && state.useSnapshotter) {
-      if (state.hasSnapshotterData) {
-        return {
-          passed:        false,
-          description:   `There are images in both the moby classic storage driver and the containerd image store.  Currently using the containerd snapshotter.`,
-          fixes:         [],
-          documentation,
-        };
+    if (state.hasClassicData && state.hasSnapshotterData) {
+      let description = 'There are images in both the moby classic storage driver and the containerd image store.';
+      if (state.useSnapshotter) {
+        description += '  Currently using the containerd snapshotter.';
+      } else {
+        description += '  Currently using the moby classic storage driver.';
       }
+      return {
+        passed:        false,
+        description,
+        fixes:         [],
+        documentation,
+      };
+    }
+    if (state.hasClassicData && state.useSnapshotter) {
       return {
         passed:        false,
         description:   `There are images in the moby classic storage driver, but the containerd snapshotter is being used.`,
         fixes:         [],
         documentation,
       };
-    } else if (state.hasSnapshotterData && !state.useSnapshotter) {
+    }
+    if (state.hasSnapshotterData && !state.useSnapshotter) {
       return {
         passed:        false,
         description:   `There are images in the containerd image store, but the moby classic storage driver is being used.`,

--- a/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
+++ b/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
@@ -1,0 +1,83 @@
+import { DiagnosticsCategory, DiagnosticsChecker } from './types';
+
+import { ContainerEngine } from '@pkg/config/settings';
+import mainEvents from '@pkg/main/mainEvents';
+
+const id = 'MOBY_IMAGE_STORE';
+const documentation = 'https://docs.rancherdesktop.io/troubleshooting/migrating-images/';
+
+let containerEngine: ContainerEngine = ContainerEngine.NONE;
+let state = {
+  hasClassicData:     false,
+  hasSnapshotterData: false,
+  useSnapshotter:     false,
+};
+
+mainEvents.on('settings-update', (settings) => {
+  containerEngine = settings.containerEngine.name;
+});
+
+mainEvents.on('diagnostics-event', (payload) => {
+  if (payload.id === 'moby-storage') {
+    state = payload;
+    mainEvents.invoke('diagnostics-trigger', id);
+  }
+});
+
+/**
+ * We use moby's containerd image store for new VMs, as well as when WASM is
+ * enabled; however, the migration in Rancher Desktop 1.21 had a bug that caused
+ * some users to end up using the containerd snapshotter when they still had
+ * data in the old moby image store.  Detect when we have data in both and warn
+ * the user.
+ */
+class CheckMobyImageStore implements DiagnosticsChecker {
+  readonly id = id;
+
+  category = DiagnosticsCategory.ContainerEngine;
+  applicable(): Promise<boolean> {
+    return Promise.resolve(containerEngine === ContainerEngine.MOBY);
+  }
+
+  async check() {
+    if (!await this.applicable()) {
+      return {
+        passed:      true,
+        description: 'Moby container engine is not in use',
+        fixes:       [],
+      };
+    }
+
+    if (state.hasClassicData && state.useSnapshotter) {
+      if (state.hasSnapshotterData) {
+        return {
+          passed:        false,
+          description:   `There are images in both the moby classic storage driver and the containerd image store.  Currently using the containerd snapshotter.`,
+          fixes:         [],
+          documentation,
+        };
+      }
+      return {
+        passed:        false,
+        description:   `There are images in the moby classic storage driver, but the containerd snapshotter is being used.`,
+        fixes:         [],
+        documentation,
+      };
+    } else if (state.hasSnapshotterData && !state.useSnapshotter) {
+      return {
+        passed:        false,
+        description:   `There are images in the containerd image store, but the moby classic storage driver is being used.`,
+        fixes:         [],
+        documentation,
+      };
+    }
+
+    return {
+      passed:      true,
+      description: `There are no issues with the moby image store: classic:${ state.hasClassicData } snapshotter:${ state.hasSnapshotterData } using snapshotter:${ state.useSnapshotter }`,
+      fixes:       [],
+    };
+  }
+}
+
+export default new CheckMobyImageStore();

--- a/pkg/rancher-desktop/main/mainEvents.ts
+++ b/pkg/rancher-desktop/main/mainEvents.ts
@@ -174,6 +174,7 @@ interface MainEventNames {
 type DiagnosticsEventPayload =
   { id: 'integrations-windows', distro?: string, key: string, error?: Error } |
   { id: 'kube-versions-available', available: boolean } |
+  { id: 'moby-storage', hasClassicData: boolean, hasSnapshotterData: boolean, useSnapshotter: boolean } |
   { id: 'network-connectivity', connected: boolean } |
   { id: 'path-management', fileName: string; error: Error | undefined };
 


### PR DESCRIPTION
This checks to see if we end up having images in the "wrong" image store; that is, images in the containerd snapshotter when using the classic storage drivers, or in the classic storage drivers when using the containerd snapshotter.

Fixes #9733

~This is _intentionally_ missing the signoff trailer because it needs the settings from #9732 to match up.  Currently there's two TODO comments.~

Logic redone to just steal the work of #9745 and report on the info that got (and decision made).  This ensures we'll never drift between implementations.