### PR TITLE
fix: update Alpine ISO to 3.23.0 to fix Docker image config bug

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -2,8 +2,8 @@ lima: 1.2.1.rd2
 qemu: 9.2.0.rd2
 socketVMNet: 1.2.2
 alpineLimaISO:
-  isoVersion: 0.2.46.rd5
-  alpineVersion: 3.22.2
+  isoVersion: 0.2.47.rd1
+  alpineVersion: 3.23.0
 WSLDistro: "0.93"
 kuberlr: 0.6.1
 helm: 4.0.4


### PR DESCRIPTION
## Summary

Update alpineLimaISO from v0.2.46.rd5 (Alpine 3.22.2) to v0.2.47.rd1 (Alpine 3.23.0).

## Problem

Alpine 3.22 ships with Docker 28.3.3 which has a bug where `docker inspect` returns empty image config metadata for multi-platform OCI images. This causes Kubernetes `runAsNonRoot` security context validation to fail even when images correctly specify a non-root USER.

```json
{
  "Architecture": "",
  "Os": "",
  "Config": {
    "User": "",
    "Entrypoint": null
  }
}
```

This results in pods failing with:
```
Error: container has runAsNonRoot and image will run as root
```

## Root Cause

- Upstream moby bug: https://github.com/moby/moby/issues/51566
- Fix PR: https://github.com/moby/moby/pull/51629

The bug is triggered when images share compressed layers (e.g., after loading k3s airgap images).

## Solution

Alpine 3.23 ships with Docker 29.1.3 which includes the fix.

Fixes: #9671
Fixes: #9739