### PR TITLE
Bump helm from 4.0.4 to 4.0.5

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -6,7 +6,7 @@ alpineLimaISO:
   alpineVersion: 3.23.0
 WSLDistro: "0.94"
 kuberlr: 0.6.1
-helm: 4.0.4
+helm: 4.0.5
 dockerCLI: 29.1.4
 dockerBuildx: 0.30.1
 dockerCompose: 5.0.1


### PR DESCRIPTION
(cherry picked from commit 0820e20040ef4b2a9477b14fd6852a327c81a020)