### PR TITLE
Diagnostics: Update moby image store documentation URL

### DIFF
--- a/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
+++ b/pkg/rancher-desktop/main/diagnostics/mobyImageStore.ts
@@ -4,7 +4,7 @@ import { ContainerEngine } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
 
 const id = 'MOBY_IMAGE_STORE';
-const documentation = 'https://docs.rancherdesktop.io/troubleshooting/migrating-images/';
+const documentation = 'https://docs.rancherdesktop.io/how-to-guides/migrating-images/';
 
 let containerEngine: ContainerEngine = ContainerEngine.NONE;
 let state = {


### PR DESCRIPTION
Update the documentation link to point to the new location in how-to-guides.