### PR TITLE
UI: containers: Fix log copy

### DIFF
--- a/pkg/rancher-desktop/components/ContainerLogs.vue
+++ b/pkg/rancher-desktop/components/ContainerLogs.vue
@@ -131,7 +131,6 @@ export default defineComponent({
           disableStdin: true,
           convertEol:   true,
           scrollback:   50000,
-          wordWrap:     true,
         });
 
         this.fitAddon = new FitAddon();
@@ -144,6 +143,11 @@ export default defineComponent({
           event.preventDefault();
           shell.openExternal(uri);
         }));
+
+        // Disable key events to allow normal behaviour such as copy/paste.
+        this.terminal.attachCustomKeyEventHandler(event => {
+          return false;
+        });
 
         this.terminal.open(this.$refs.terminalContainer);
 


### PR DESCRIPTION
The terminal was handling all key presses, including intercepting Ctrl+C as interrupt.  However, since we don't actually have input, that is not useful; add a manual key handler so that it gets handled by the browser framework (as a copy) instead.

The `wordWrap` option doesn't exist in `Terminal` constructor; remove it because it doesn't do anything.

Fixes #9788