### PR TITLE
Prevent non‑semver “unknown” app versions during local packaging

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -157,7 +157,7 @@ class Builder {
     const fallbackVersion = buildUtils.packageMeta.version ?? Builder.DEFAULT_VERSION;
     const fallbackSuffix = '-fallback';
     let fullBuildVersion: string;
-    const fallbackTaggedVersion = semver.valid(`${fallbackVersion}${fallbackSuffix}`) ?? Builder.DEFAULT_VERSION;
+    const fallbackTaggedVersion = semver.valid(`${ fallbackVersion }${ fallbackSuffix }`) ?? Builder.DEFAULT_VERSION;
     try {
       fullBuildVersion = semver.valid(childProcess.execFileSync('git', ['describe', '--tags']).toString()) ?? fallbackTaggedVersion;
     } catch {


### PR DESCRIPTION
- Fixes #9825 .
- Prevent non‑semver “unknown” app versions during local packaging. 
- Local packaging on repos without tags should preserve the existing `git describe` flow and only fall back to `package.json` version when that call fails. This avoids injecting non‑semver versions while keeping the original intent intact. Without this change, `yarn package` would return `dist/rancher-desktop-unknown-linux.zip` instead of `dist/rancher-desktop-1.22.0-fallback-linux.zip`. This prevents access to the main interface of `./dist/linux-unpacked/rancher-desktop`.
- It's hard to say what kind of unit tests are easy to write here, so the actual verification process is as follows:
```bash
sudo apt update && sudo apt upgrade --assume-yes

sudo tee /etc/profile.d/myenvvars.sh <<'EOF'
export GALLIUM_DRIVER="d3d12"
EOF

# In PowerShell 7, execute `wsl --terminate Ubuntu-24.04`
sudo usermod -a -G kvm "$USER"
sudo apt install --assume-yes pass libnspr4 libnss3 libasound2t64 build-essential zlib1g-dev unzip imagemagick libcairo2

tee /tmp/foo.txt <<EOF
Key-Type: DSA
Key-Length: 1024
Subkey-Type: ELG-E
Subkey-Length: 1024
Name-Real: Joe Tester
Name-Comment: with stupid passphrase
Name-Email: joe@foo.bar
Expire-Date: 0
Passphrase: abc
%commit
EOF

gpg --batch --generate-key /tmp/foo.txt
pass init $(gpg --list-secret-keys --with-colons "joe@foo.bar" | awk -F: '$1 == "fpr" {print $10; exit}')

sudo tee --append /etc/sysctl.conf <<EOF
net.ipv4.ip_unprivileged_port_start=80
EOF

sudo sysctl --load
echo "deb [trusted=yes] https://apt.fury.io/versionfox/ /" | sudo tee /etc/apt/sources.list.d/versionfox.list
sudo apt update
sudo apt install --assume-yes vfox
echo 'eval "$(vfox activate bash)"' >> ~/.bashrc
source ~/.bashrc
vfox add golang nodejs
vfox install golang@1.25.6 nodejs@22.22.0
vfox use --global golang@1.25.6
vfox use --global nodejs@22.22.0
npm uninstall -g yarn pnpm
npm install -g corepack

git clone --depth 1 -b fix-package https://github.com/linghengqian/rancher-desktop.git
cd ./rancher-desktop/
corepack install
yarn install
yarn build
yarn package
./dist/linux-unpacked/rancher-desktop
./dist/linux-unpacked/rancher-desktop
```
- <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/a367eca6-990e-45c2-bd68-aa7b2664e9a2" />