### PR TITLE
Add scheduled workflow to deduplicate yarn.lock

### DIFF
--- a/.github/workflows/yarn-dedupe.yaml
+++ b/.github/workflows/yarn-dedupe.yaml
@@ -29,6 +29,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: ./.github/actions/yarn-install
-    - run: ./scripts/yarn-dedupe.sh
+    - run: ./scripts/yarn-dedupe.sh --push
       env:
         GITHUB_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}

--- a/scripts/yarn-dedupe.sh
+++ b/scripts/yarn-dedupe.sh
@@ -1,22 +1,37 @@
 #!/bin/bash
 
-# Deduplicate yarn.lock and create a pull request if anything changes.
+# Deduplicate yarn.lock and optionally push a pull request.
 # Expects to run from the repository root on the main branch.
+#
+# Usage: yarn-dedupe.sh [--push]
+#
+# Without --push, runs yarn dedupe and reports changes (safe for local use).
+# With --push, commits, pushes, and creates a PR if one does not already exist.
 
 set -eu
 
-BRANCH_NAME="yarn-dedupe"
-NEW_PR="true"
+PUSH="false"
+for arg in "$@"; do
+    case "$arg" in
+        --push) PUSH="true" ;;
+        *) echo "Unknown option: $arg" >&2; exit 1 ;;
+    esac
+done
 
-if git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null; then
-    NEW_PR="false"
-fi
+BRANCH_NAME="yarn-dedupe"
 
 yarn dedupe
 
 # Exit if yarn.lock is unchanged
 if git diff --quiet yarn.lock; then
-    echo "yarn dedupe made no changes."
+    echo "yarn.lock is already deduplicated."
+    exit
+fi
+
+if [ "$PUSH" = "false" ]; then
+    echo "yarn.lock has duplicates that yarn dedupe would remove."
+    echo "Run with --push to commit, push, and open a PR."
+    git diff --stat yarn.lock
     exit
 fi
 
@@ -31,12 +46,13 @@ git add yarn.lock
 git commit --signoff --message "Run yarn dedupe"
 git push --force origin "$BRANCH_NAME"
 
-if [ "$NEW_PR" = "false" ]; then
-    exit
+# Create a PR only if one does not already exist for this branch.
+if gh pr list --head "$BRANCH_NAME" --json number --jq '.[].number' | grep --quiet .; then
+    echo "PR already exists for branch $BRANCH_NAME; skipping creation."
+else
+    gh pr create \
+        --title "Deduplicate yarn.lock" \
+        --body "Automated pull request to remove duplicate dependency resolutions from yarn.lock." \
+        --head "$BRANCH_NAME" \
+        --base main
 fi
-
-gh pr create \
-    --title "Deduplicate yarn.lock" \
-    --body "Automated pull request to remove duplicate dependency resolutions from yarn.lock." \
-    --head "$BRANCH_NAME" \
-    --base main


### PR DESCRIPTION
Add a workflow that runs yarn dedupe monthly and on manual dispatch. If the lockfile changes, the workflow creates a pull request. This keeps main free of duplicate dependency resolutions without coupling to the release merge process.

Fixes #9804