### PR TITLE
Add fallback to Linux config when Windows config absent in WSL

### DIFF
--- a/src/go/rdctl/pkg/config/config.go
+++ b/src/go/rdctl/pkg/config/config.go
@@ -60,21 +60,16 @@ var (
 // DefineGlobalFlags sets up the global flags, available for all sub-commands
 func DefineGlobalFlags(rootCmd *cobra.Command) {
 	var configDir string
-	var err error
 	if runtime.GOOS == "linux" && isWSLDistro() {
 		ctx := rootCmd.Context()
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		if configDir, err = wslifyConfigDir(ctx); err == nil {
-			windowsConfigPath := filepath.Join(configDir, "rancher-desktop", "rd-engine.json")
-			if _, statErr := os.Stat(windowsConfigPath); statErr != nil {
-				configDir = ""
-			} else {
-				configDir = filepath.Join(configDir, "rancher-desktop")
+		if wslConfigDir, err := wslifyConfigDir(ctx); err == nil {
+			windowsConfigPath := filepath.Join(wslConfigDir, "rancher-desktop", "rd-engine.json")
+			if _, statErr := os.Stat(windowsConfigPath); statErr == nil {
+				configDir = filepath.Join(wslConfigDir, "rancher-desktop")
 			}
-		} else {
-			configDir = ""
 		}
 	}
 	if configDir == "" {

--- a/src/go/rdctl/pkg/config/config_test.go
+++ b/src/go/rdctl/pkg/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -243,42 +242,6 @@ func TestGetConnectionInfo_MissingRequiredFields(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "insufficient connection settings")
-}
-
-func TestPersistentPreRunE_Verbose(t *testing.T) {
-	originalLevel := logrus.GetLevel()
-	t.Cleanup(func() {
-		logrus.SetLevel(originalLevel)
-	})
-
-	originalVerbose := verbose
-	t.Cleanup(func() {
-		verbose = originalVerbose
-	})
-
-	verbose = true
-	err := PersistentPreRunE(nil, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, logrus.TraceLevel, logrus.GetLevel())
-}
-
-func TestPersistentPreRunE_NotVerbose(t *testing.T) {
-	originalLevel := logrus.GetLevel()
-	t.Cleanup(func() {
-		logrus.SetLevel(originalLevel)
-	})
-
-	logrus.SetLevel(logrus.InfoLevel)
-
-	originalVerbose := verbose
-	t.Cleanup(func() {
-		verbose = originalVerbose
-	})
-
-	verbose = false
-	err := PersistentPreRunE(nil, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, logrus.InfoLevel, logrus.GetLevel())
 }
 
 func TestIsWSLDistro(t *testing.T) {


### PR DESCRIPTION
- Fixes #9857 .
- Add fallback to Linux config when Windows config absent in WSL.
- Previously, when the WSL environment variables existed and integration tests were run on Linux, Rancher Desktop would always look for the non-existent `/mnt/c/Users/lingh/AppData/Local/rancher-desktop/rd-engine.json`. I believe that when this file is missing, it should look for `~/.local/share/rancher-desktop/rd-engine.json`.
- I tested the current PR on Ubuntu 24.04 WSL. Most integration tests were fixed by the PR, with only two failing. Strangely, when I ran the integration tests for the `main` branch in Windows Hyper-V VM, both tests also failed, while GitHub Actions CI worked perfectly. From this perspective, I think these two failed unit tests could be discussed in a separate issue.

``` 
2 failed
   e2e/backend.e2e.spec.ts:94:5 › KubernetesBackend › requiresRestartReasons › should detect changes
   e2e/credentials-server.e2e.spec.ts:287:3 › Credentials server › should be able to use the API ──
```
- <img width="2452" height="1332" alt="image" src="https://github.com/user-attachments/assets/ddd5c551-db86-49e9-93f3-5a0bb898a805" />
- <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/63db6628-2b6f-4b57-8413-1a914584086a" />


