### PR TITLE
BATS: extensions: use SUSE BCI images

### DIFF
--- a/bats/tests/extensions/testdata/Dockerfile
+++ b/bats/tests/extensions/testdata/Dockerfile
@@ -1,16 +1,16 @@
-FROM registry.opensuse.org/opensuse/bci/golang:stable AS builder
+FROM registry.suse.com/bci/golang:latest AS builder
 WORKDIR /usr/src/app
 COPY bin/dummy.go .
 ENV GOOS=windows
 RUN go build -o /dummy.exe -ldflags '-s -w' dummy.go
 
-FROM registry.opensuse.org/opensuse/bci/golang:stable AS server-builder
+FROM registry.suse.com/bci/golang:latest AS server-builder
 WORKDIR /usr/src/app
 COPY bin/server.go .
 ENV GOOS=linux
 RUN go build -o /server -ldflags '-s -w' server.go
 
-FROM registry.opensuse.org/opensuse/bci/bci-minimal
+FROM registry.suse.com/bci/bci-minimal:16.0
 ARG variant=basic
 
 ADD ${variant}.json /metadata.json

--- a/e2e/extensions.e2e.spec.ts
+++ b/e2e/extensions.e2e.spec.ts
@@ -124,8 +124,13 @@ test.describe.serial('Extensions', () => {
   test('build and install testing extension', async() => {
     const dataDir = path.join(srcDir, 'bats', 'tests', 'extensions', 'testdata');
 
-    await ctrctl('build', '--tag', 'rd/extension/everything', '--build-arg', 'variant=everything', dataDir);
-    await spawnFile(rdctl, ['api', '-XPOST', '/v1/extensions/install?id=rd/extension/everything']);
+    try {
+      await ctrctl('build', '--tag', 'rd/extension/everything', '--build-arg', 'variant=everything', dataDir);
+      await spawnFile(rdctl, ['api', '-XPOST', '/v1/extensions/install?id=rd/extension/everything']);
+    } catch (ex) {
+      console.error(ex);
+      throw ex;
+    }
   });
 
   test('use extension protocol handler', async() => {


### PR DESCRIPTION
It looks like `registry.opensuse.org` has connection issues from GitHub Actions runners (they show as connection refused); this cannot be replicated locally, so they may have been explicitly blocked.  Use `registry.suse.com` (with equivalent images there) instead.