### PR TITLE
package.json: Add `@eslint/js` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@electron/fuses": "^2.0.0",
     "@electron/notarize": "3.1.1",
     "@eslint/compat": "2.0.2",
+    "@eslint/js": "9.39.2",
     "@playwright/test": "1.58.2",
     "@types/cross-spawn": "6.0.6",
     "@types/dompurify": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14625,6 +14625,7 @@ __metadata:
     "@electron/fuses": "npm:^2.0.0"
     "@electron/notarize": "npm:3.1.1"
     "@eslint/compat": "npm:2.0.2"
+    "@eslint/js": "npm:9.39.2"
     "@kubernetes/client-node": "npm:1.4.0"
     "@napi-rs/xattr": "npm:^1.0.3"
     "@playwright/test": "npm:1.58.2"


### PR DESCRIPTION
This is used in ESLint configuration; add it so we can correctly update eslint.

This unblocks #9896.