### PR TITLE
fix: Remove namespace related error messages in log tab

### DIFF
--- a/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
+++ b/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
@@ -73,7 +73,7 @@
         ref="containerLogs"
         :container-id="containerId"
         :is-container-running="isRunning"
-        :namespace="settings?.containers?.namespace"
+        :namespace="namespace"
       />
     </div>
   </div>
@@ -104,6 +104,8 @@ const searchTerm = ref('');
 // Vuex integration
 const isK8sReady = computed(() => store.getters['k8sManager/isReady']);
 const containers = computed(() => store.state['container-engine'].containers);
+const supportsNamespaces = computed(() => store.getters['container-engine/supportsNamespaces']);
+const namespace = computed(() => supportsNamespaces.value ? settings.value?.containers?.namespace : undefined);
 
 // Computed properties
 const containerId = computed(() => route.params.id as string || '');


### PR DESCRIPTION
When using moby as an engine, the log tab can show errors:
```
unknown flag: --namespace

Usage:  docker logs [OPTIONS] CONTAINER

Run 'docker logs --help' for more information
```
This is because namespace is being added to the docker logs command which does not support it (it's a containerd option).

The fix is to only add the namespace if it is supported by the engine.