### PR TITLE
Bump trivy from 0.69.1 to 0.69.2

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerCLI: 29.2.1
 dockerBuildx: 0.31.1
 dockerCompose: 5.1.0
 golangci-lint: 2.10.1
-trivy: 0.69.1
+trivy: 0.69.2
 steve: 0.1.0-beta9.1
 rancherDashboard: 2.11.1.rd3
 dockerProvidedCredentialHelpers: 0.9.5


### PR DESCRIPTION
Due to a security incident trivy has removed all existing releases from GitHub as a precautionary action. See https://github.com/aquasecurity/trivy/discussions/10265 for details.

It seems like none of the deleted GitHub assets had been tampered with, so it should be safe to continue to use them.

The removal of the current dependency breaks rancherbot, so automatic updates to 0.69.2 has to be done manually.

Fixes #9942