### PR TITLE
Add snapcraft package for Rancher Desktop

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -117,6 +117,7 @@ copypac
 coredns
 cpanm
 cpanminus
+craftctl
 crds
 credfwd
 CREDHELPER
@@ -341,6 +342,7 @@ logdna
 loglines
 logz
 lte
+lzo
 mabels
 macarm
 machinedeployment
@@ -407,6 +409,7 @@ nothrow
 notifempty
 notset
 npipe
+nspr
 nsenter
 nsis
 NSISUNINSTALLCOMMAND
@@ -417,6 +420,7 @@ oapi
 objectset
 octicons
 openapitools
+opengl
 openldapconfig
 openrc
 openresty
@@ -587,6 +591,7 @@ SLSA
 smanager
 smokris
 snakize
+snapcraft
 softmmu
 someothername
 somepaththatshouldnevereverexist

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -111,6 +111,30 @@ jobs:
           rancher-desktop.AppImage
           rancher-desktop.AppImage.sha512sum
 
+    - name: Build Snap package
+      run: |
+        sudo snap install snapcraft --classic
+        sudo snap install multipass
+        sudo snap set snapcraft provider=multipass
+        
+        cp rancher-desktop-linux-*.zip packaging/linux/rancher-desktop-linux.zip
+        
+        cd packaging/linux
+        snapcraft pack
+        cd ../..
+        
+        sha512sum packaging/linux/rancher-desktop*.snap > rancher-desktop.snap.sha512sum
+        mv packaging/linux/rancher-desktop*.snap rancher-desktop.snap
+
+    - name: Upload Linux Snap
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: application-linux.snap
+        if-no-files-found: error
+        path: |
+          rancher-desktop.snap
+          rancher-desktop.snap.sha512sum
+
   smoke-test:
     name: Smoke test
     needs: download-artifacts
@@ -321,5 +345,44 @@ jobs:
       if: always()
       with:
         name: logs-appimage-${{ matrix.id }}.zip
+        path: ${{ github.workspace }}/logs
+        if-no-files-found: warn
+
+  snap-smoke-test:
+    name: Smoke test Snap
+    needs: download-artifacts
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up environment
+      uses: ./.github/actions/setup-environment
+
+    - name: Set log directory
+      run: |
+        echo "RD_LOGS_DIR=$PWD/logs" >> "$GITHUB_ENV"
+        mkdir -p "$PWD/logs"
+
+    - name: Download Snap
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        name: application-linux.snap
+
+    - name: Run smoke test
+      run: >-
+        xvfb-run --auto-servernum
+        --server-args='-screen 0 1280x960x24'
+        .github/workflows/smoke-test/smoke-test.sh
+      env:
+        RD_DEBUG_ENABLED: '1'
+        RD_TEST: smoke
+
+    - name: Upload logs
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      if: always()
+      with:
+        name: logs-snap.zip
         path: ${{ github.workspace }}/logs
         if-no-files-found: warn

--- a/.github/workflows/smoke-test/smoke-test.sh
+++ b/.github/workflows/smoke-test/smoke-test.sh
@@ -125,7 +125,8 @@ install_darwin() {
 # Assume the first argument given is a path to the Rancher Desktop zip file;
 # install it, and set the global variable RDCTL to the path of the rdctl
 # executable.  If the archive is an AppImage file instead, then this function
-# instead sets APPIMAGE_PID.
+# instead sets APPIMAGE_PID.  If the archive is a snap file, it installs via
+# snap.
 install_linux() {
     if [[ $(id --user) -eq 0 ]]; then
         echo "This script should not be run as root" >&2
@@ -142,6 +143,22 @@ install_linux() {
                 --no-modal-dialogs --kubernetes.enabled \
                 --application.updater.enabled=false&
             APPIMAGE_PID=$!
+            return
+        elif [[ "$archiveName" =~ .*\.snap$ ]]; then
+            sudo snap install --dangerous "$archiveName"
+            sudo snap alias rancher-desktop.docker docker
+            sudo snap alias rancher-desktop.nerdctl nerdctl
+            sudo snap alias rancher-desktop.kubectl kubectl
+            sudo snap alias rancher-desktop.helm helm
+            sudo snap alias rancher-desktop.spin spin
+            sudo snap alias rancher-desktop.rdctl rdctl
+            sudo snap alias rancher-desktop.kuberlr kuberlr
+            sudo snap alias rancher-desktop.docker-credential-ecr-login docker-credential-ecr-login
+            sudo snap alias rancher-desktop.docker-credential-none docker-credential-none
+            sudo snap alias rancher-desktop.docker-credential-pass docker-credential-pass
+            sudo snap alias rancher-desktop.docker-credential-secretservice docker-credential-secretservice
+            cleanups+=("sudo snap remove rancher-desktop --purge")
+            RDCTL="/snap/rancher-desktop/current/opt/rancher-desktop/resources/resources/linux/bin/rdctl"
             return
         else
             sudo mkdir -p /opt/rancher-desktop

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /src/go/rdctl/pkg/options/generated/*.go
 /e2e/e2e/test-results/.last-run.json
 /.yarn/
+/packaging/linux/*.zip
+/packaging/linux/*.snap

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,3 +12,4 @@ ask around!
 [Signing Rancher Desktop Releases](signing.md)  
 [Generating Screenshots for User Documentation](../../screenshots/README.md)  
 [Information on how to setup and run BATS tests](../../bats/README.md)  
+[Build and install the Snapcraft package locally](snapcraft.md)

--- a/docs/development/snapcraft.md
+++ b/docs/development/snapcraft.md
@@ -1,0 +1,110 @@
+# Build and install the Snapcraft package locally
+
+This document contains information on how to build and install Snapcraft packages locally.
+
+## Prerequisites
+
+Developers need to configure `kvm`, `pass`, install the C/C++ compiler toolchain, Node.js, Golang, yarn, Snapcraft,
+and configure `/etc/sysctl.conf` appropriately.
+
+For Ubuntu 24.04, a possible configuration example is as follows,
+
+```bash
+sudo apt update && sudo apt upgrade --assume-yes
+sudo usermod -a -G kvm "$USER"
+newgrp kvm
+sudo apt install --assume-yes pass build-essential
+
+tee /tmp/foo.txt <<EOF
+Key-Type: DSA
+Key-Length: 1024
+Subkey-Type: ELG-E
+Subkey-Length: 1024
+Name-Real: Joe Tester
+Name-Comment: with stupid passphrase
+Name-Email: joe@foo.bar
+Expire-Date: 0
+Passphrase: abc
+%commit
+EOF
+
+gpg --batch --generate-key /tmp/foo.txt
+pass init "<joe@foo.bar>"
+
+sudo tee --append /etc/sysctl.conf <<EOF
+net.ipv4.ip_unprivileged_port_start=80
+EOF
+
+sudo sysctl --load
+curl -sSL https://raw.githubusercontent.com/version-fox/vfox/main/install.sh | bash
+echo 'eval "$(vfox activate bash)"' >> ~/.bashrc
+source ~/.bashrc
+vfox add nodejs golang
+vfox install nodejs@22.22.0 golang@1.25.6
+vfox use --global golang@1.25.6
+vfox use --global nodejs@22.22.0
+npm uninstall -g yarn pnpm
+npm install -g corepack
+
+sudo snap install snapcraft --classic
+sudo snap install multipass
+sudo snap set snapcraft provider=multipass
+```
+
+## Build Snapcraft Packages
+
+For Ubuntu 24.04, a possible configuration example is as follows,
+
+```bash
+cd ./rancher-desktop/
+corepack install
+yarn
+yarn build
+yarn package
+cp dist/rancher-desktop-*-linux.zip packaging/linux/rancher-desktop-linux.zip
+cd ./packaging/linux/
+snapcraft clean
+snapcraft pack
+```
+
+## Install unsigned Snapcraft packages
+
+For Ubuntu 24.04, a possible configuration example is as follows,
+
+```bash
+cd ./rancher-desktop/
+cd ./packaging/linux/
+sudo snap install --dangerous ./rancher-desktop_*.snap
+sudo snap alias rancher-desktop.docker docker
+sudo snap alias rancher-desktop.nerdctl nerdctl
+sudo snap alias rancher-desktop.kubectl kubectl
+sudo snap alias rancher-desktop.helm helm
+sudo snap alias rancher-desktop.spin spin
+sudo snap alias rancher-desktop.rdctl rdctl
+sudo snap alias rancher-desktop.kuberlr kuberlr
+sudo snap alias rancher-desktop.docker-credential-ecr-login docker-credential-ecr-login
+sudo snap alias rancher-desktop.docker-credential-none docker-credential-none
+sudo snap alias rancher-desktop.docker-credential-pass docker-credential-pass
+sudo snap alias rancher-desktop.docker-credential-secretservice docker-credential-secretservice
+```
+
+## Run the Snapcraft package
+
+To run the Snapcraft package, you can directly run `rancher-desktop`.
+
+```bash
+snap run rancher-desktop
+```
+
+Or use `rdctl`,
+
+```bash
+rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
+```
+
+All Rancher Desktop command-line tools are available, for example,
+
+```bash
+docker info
+docker run hello-world
+```

--- a/packaging/linux/snapcraft.yaml
+++ b/packaging/linux/snapcraft.yaml
@@ -1,0 +1,167 @@
+name: rancher-desktop
+title: Rancher Desktop
+summary: Kubernetes and container management on the desktop
+description: |
+  Rancher Desktop is an open-source project to bring Kubernetes and
+  container management to the desktop.
+  
+  Features:
+  - Run Kubernetes locally with containerd or dockerd (moby)
+  - Build, push, and pull container images
+  - Access kubectl and other Kubernetes CLI tools
+  - Manage container workloads with nerdctl or docker CLI
+license: Apache-2.0
+adopt-info: rancher-desktop
+grade: stable
+confinement: strict
+contact: https://github.com/rancher-sandbox/rancher-desktop/discussions
+issues: https://github.com/rancher-sandbox/rancher-desktop/issues
+source-code: https://github.com/rancher-sandbox/rancher-desktop
+website: https://rancherdesktop.io
+donation: https://github.com/sponsors/rancher
+base: core24
+lint:
+  ignore:
+    - library
+compression: lzo
+
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+
+apps:
+  rancher-desktop:
+    command: opt/rancher-desktop/rancher-desktop --no-sandbox
+    desktop: usr/share/applications/rancher-desktop.desktop
+    extensions:
+      - gnome
+    plugs:
+      - home
+      - network
+      - network-bind
+      - desktop
+      - desktop-legacy
+      - x11
+      - wayland
+      - opengl
+      - browser-support
+      - mount-observe
+      - process-control
+      - system-observe
+      - kvm
+  rdctl:
+    command: opt/rancher-desktop/resources/resources/linux/bin/rdctl
+    extensions:
+      - gnome
+    plugs:
+      - home
+      - network
+    aliases:
+      - rdctl
+  docker:
+    command: opt/rancher-desktop/resources/resources/linux/bin/docker
+    plugs:
+      - home
+      - network
+    aliases:
+      - docker
+  nerdctl:
+    command: opt/rancher-desktop/resources/resources/linux/bin/nerdctl
+    plugs:
+      - home
+      - network
+    aliases:
+      - nerdctl
+  kubectl:
+    command: opt/rancher-desktop/resources/resources/linux/bin/kubectl
+    plugs:
+      - home
+      - network
+    aliases:
+      - kubectl
+  helm:
+    command: opt/rancher-desktop/resources/resources/linux/bin/helm
+    plugs:
+      - home
+      - network
+    aliases:
+      - helm
+  spin:
+    command: opt/rancher-desktop/resources/resources/linux/bin/spin
+    plugs:
+      - home
+      - network
+    aliases:
+      - spin
+  kuberlr:
+    command: opt/rancher-desktop/resources/resources/linux/bin/kuberlr
+    plugs:
+      - home
+      - network
+    aliases:
+      - kuberlr
+  docker-credential-ecr-login:
+    command: opt/rancher-desktop/resources/resources/linux/bin/docker-credential-ecr-login
+    plugs:
+      - home
+      - network
+    aliases:
+      - docker-credential-ecr-login
+  docker-credential-none:
+    command: opt/rancher-desktop/resources/resources/linux/bin/docker-credential-none
+    plugs:
+      - home
+    aliases:
+      - docker-credential-none
+  docker-credential-pass:
+    command: opt/rancher-desktop/resources/resources/linux/bin/docker-credential-pass
+    plugs:
+      - home
+    aliases:
+      - docker-credential-pass
+  docker-credential-secretservice:
+    command: opt/rancher-desktop/resources/resources/linux/bin/docker-credential-secretservice
+    plugs:
+      - home
+    aliases:
+      - docker-credential-secretservice
+
+parts:
+  rancher-desktop:
+    plugin: dump
+    source: rancher-desktop-linux.zip
+    source-type: zip
+    organize:
+      '*': opt/rancher-desktop/
+    override-prime: |
+      craftctl default
+      
+      APPDATA="${CRAFT_PRIME}/opt/rancher-desktop/resources/resources/linux/rancher-desktop.appdata.xml"
+      VERSION=$(sed -n 's/.*<release version="\([^"]*\)".*/\1/p' "$APPDATA" | head -1)
+      if [ -z "$VERSION" ]; then
+        echo "ERROR: Failed to extract version from appdata.xml"
+        exit 1
+      fi
+      craftctl set version="$VERSION"
+      
+      icon="${CRAFT_PRIME}/opt/rancher-desktop/resources/resources/icons/logo-square-512.png"
+      for size in 512x512 256x256 128x128 96x96 64x64 48x48 32x32 24x24 16x16; do
+        mkdir -p "${CRAFT_PRIME}/usr/share/icons/hicolor/${size}/apps"
+        convert -resize "${size}" "${icon}" \
+          "${CRAFT_PRIME}/usr/share/icons/hicolor/${size}/apps/rancher-desktop.png"
+      done
+      
+      mkdir -p "${CRAFT_PRIME}/usr/share/applications"
+      mkdir -p "${CRAFT_PRIME}/usr/share/metainfo"
+      cp "${CRAFT_PRIME}/opt/rancher-desktop/resources/resources/linux/rancher-desktop.desktop" \
+        "${CRAFT_PRIME}/usr/share/applications/rancher-desktop.desktop"
+      sed -i 's|Icon=rancher-desktop|Icon=/usr/share/icons/hicolor/512x512/apps/rancher-desktop.png|' \
+        "${CRAFT_PRIME}/usr/share/applications/rancher-desktop.desktop"
+      
+      chmod 4755 "${CRAFT_PRIME}/opt/rancher-desktop/chrome-sandbox"
+    build-packages:
+      - imagemagick
+    stage-packages:
+      - libnspr4
+      - libnss3


### PR DESCRIPTION
- For https://github.com/rancher-sandbox/rancher-desktop/issues/9847 .
- Add snapcraft package for Rancher Desktop.
  - This is clearly preliminary work, as both signing the snapcraft package and uploading it to https://snapcraft.io/ require creating a `Ubuntu One` account. Since I'm not a maintainer of rancher-desktop, signing the snapcraft package using my `Ubuntu One` account isn't quite appropriate.
  - I honestly don't know how to best handle `docker-credential-*`. Perhaps we can find some context later; can refer to https://github.com/canonical/docker-snap/issues/10 .
  - Another potential, yet-to-be-determined change is that the snapcraft CLI can build artifacts from git. Currently, to maintain consistency with appimage's build process, a zip file built via yarn is used.
  - The primary reference for smoketest is the Rancher Desktop appimage. However, unlike the appimage, I found that once I deleted the lima qemu binary, Rancher Desktop couldn't start the virtual machine at all. Therefore, I kept the lima qemu binary in the snapcraft package.
  - One peculiar issue is that the welcome screen doesn't appear when users first open Rancher Desktop. But I think this is a minor problem.
  - The use of multipass as a build provider for snapcraft was influenced by https://github.com/canonical/lxd/issues/17696 . There is a bug with lxd on WSL, and the fix has not yet been published to lxd's default channel. Some background information can be found at https://snapcraft.io/blog/faster-snap-development-additional-tips-and-tricks . The main difference between multipass and lxd is that multipass creates a virtual machine instead of a container.
  - The main issue with `sudo snap alias` is that `snap install` doesn't process `aliases` in `snapcraft.yaml` at all. To automatically create `aliases` during the `snap install` phase, we need to apply for automatic aliases at https://forum.snapcraft.io/ as per the instructions at https://snapcraft.io/docs/how-to-guides/manage-snaps/apps-and-aliases/#p-19557-application-commands . Furthermore, only packages downloaded from `snapcraft.io` will have aliases created by `snap`. 
    - If the user does not create an alias, it means that `docker info` cannot be executed; instead, `rancher-desktop.docker info` must be executed.
  - Since `snapcraft.yaml`, like `Dockerfile`, cannot access its parent directory, it seems impossible to avoid `cp dist/rancher-desktop-*-linux.zip packaging/linux/rancher-desktop-linux.zip` unless `snapcraft.yaml` is placed in the root directory of git.
   -  All verification work was performed under Ubuntu 24.04 WSL. One issue this raises is that I'm not entirely sure if GPU support is available. For WSL, since the snapcraft package can't access `libdxcore.so` and `libd3d12.so` mentioned at https://devblogs.microsoft.com/directx/directx-heart-linux/ and https://devblogs.microsoft.com/commandline/d3d12-gpu-video-acceleration-in-the-windows-subsystem-for-linux-now-available/, it naturally can't access the driver on Windows 11. Also see https://forum.snapcraft.io/t/video-accelation-va-api-on-core22/48154 . The most awkward part of this problem is that my local development environment is a laptop, which doesn't have an Nvidia graphics card at all.
```bash
sudo apt update && sudo apt upgrade --assume-yes

sudo tee /etc/profile.d/myenvvars.sh <<'EOF'
export GALLIUM_DRIVER="d3d12"
EOF

source /etc/profile.d/myenvvars.sh
sudo usermod -a -G kvm "$USER"
newgrp kvm
sudo apt install --assume-yes pass build-essential

tee /tmp/foo.txt <<EOF
Key-Type: DSA
Key-Length: 1024
Subkey-Type: ELG-E
Subkey-Length: 1024
Name-Real: Joe Tester
Name-Comment: with stupid passphrase
Name-Email: joe@foo.bar
Expire-Date: 0
Passphrase: abc
%commit
EOF

gpg --batch --generate-key /tmp/foo.txt
pass init "<joe@foo.bar>"

sudo tee --append /etc/sysctl.conf <<EOF
net.ipv4.ip_unprivileged_port_start=80
EOF

sudo sysctl --load
curl -sSL https://raw.githubusercontent.com/version-fox/vfox/main/install.sh | bash
echo 'eval "$(vfox activate bash)"' >> ~/.bashrc
source ~/.bashrc
vfox add nodejs golang
vfox install nodejs@22.22.0 golang@1.25.6
vfox use --global golang@1.25.6
vfox use --global nodejs@22.22.0
npm uninstall -g yarn pnpm
npm install -g corepack

sudo snap install snapcraft --classic
sudo snap install multipass
sudo snap set snapcraft provider=multipass

git clone --depth 1 --branch snapcraft https://github.com/linghengqian/rancher-desktop.git
cd ./rancher-desktop/
corepack install
yarn
yarn build
yarn package
cp dist/rancher-desktop-*-linux.zip packaging/linux/rancher-desktop-linux.zip
cd ./packaging/linux/
snapcraft clean
snapcraft pack
sudo snap install --dangerous ./rancher-desktop_*.snap
sudo snap alias rancher-desktop.docker docker
sudo snap alias rancher-desktop.nerdctl nerdctl
sudo snap alias rancher-desktop.kubectl kubectl
sudo snap alias rancher-desktop.helm helm
sudo snap alias rancher-desktop.spin spin
sudo snap alias rancher-desktop.rdctl rdctl
sudo snap alias rancher-desktop.docker-credential-secretservice docker-credential-secretservice
sudo snap alias rancher-desktop.docker-credential-pass docker-credential-pass
sudo snap alias rancher-desktop.docker-credential-none docker-credential-none
sudo snap alias rancher-desktop.docker-credential-ecr-login docker-credential-ecr-login
sudo snap alias rancher-desktop.kuberlr kuberlr
sudo snap connect rancher-desktop:kvm
sudo snap connect rancher-desktop:mount-observe
sudo snap connect rancher-desktop:process-control
sudo snap connect rancher-desktop:system-observe
sudo snap connect rancher-desktop:password-manager-service

snap run rancher-desktop
# Exit the `rancher-desktop` via the GUI.
rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
# Open a new Ubuntu WSL login shell terminal.
docker info
docker run hello-world
sudo snap remove rancher-desktop --purge
```
-  <img width="2594" height="1698" alt="image" src="https://github.com/user-attachments/assets/33f27adf-7f0e-408f-864e-68cdd857aac8" />
- <img width="2460" height="1698" alt="image" src="https://github.com/user-attachments/assets/8bceec33-d597-4d37-8f1f-c246cfce42a3" />
