### PR TITLE
BATS: pass `--context rancher-desktop` to `spin kube deploy`

### DIFF
--- a/bats/tests/k8s/spinkube-npm.bats
+++ b/bats/tests/k8s/spinkube-npm.bats
@@ -41,7 +41,7 @@ local_setup() {
 }
 
 @test 'deploy app to kubernetes' {
-    spin kube deploy --from "$MY_APP_IMAGE"
+    spin kube deploy --context rancher-desktop --from "$MY_APP_IMAGE"
 }
 
 # TODO replace ingress with port-forwarding

--- a/bats/tests/k8s/spinkube.bats
+++ b/bats/tests/k8s/spinkube.bats
@@ -27,7 +27,7 @@ local_setup() {
 @test 'deploy app to kubernetes' {
     # Newer versions of the sample app have moved from "deislabs" to "spinkube":
     # ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.13.0
-    spin kube deploy --from ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
+    spin kube deploy --context rancher-desktop --from ghcr.io/deislabs/containerd-wasm-shims/examples/spin-rust-hello:v0.10.0
 }
 
 # TODO replace ingress with port-forwarding


### PR DESCRIPTION
Unlike the `kubectl` and `helm` wrappers which always specify `--context rancher-desktop`, the `spin` wrapper doesn't (since `spin` has many non-k8s subcommands). This causes `spin kube deploy` to use the default kubeconfig context, which may point to a stale or different cluster.