### PR TITLE
Inspect tab

### DIFF
--- a/docs/development/features.md
+++ b/docs/development/features.md
@@ -118,7 +118,7 @@ Note:
 
 :heavy_check_mark: Cluster exploration - Rancher Dashboard (Preview)
 
-:sun_with_face: Container Exploration
+:heavy_check_mark: Container Exploration
 
 :sun_with_face: Configuration settings
 

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, ElectronApplication, Page } from '@playwright/test';
 
+import { ContainerInfoPage } from './pages/container-info-page';
 import { ContainerLogsPage } from './pages/container-logs-page';
 import { ContainerShellPage } from './pages/container-shell-page';
 import { ContainersPage } from './pages/containers-page';
@@ -75,6 +76,9 @@ test.describe.serial('Containers Tests', () => {
   });
 
   test('should display container logs page', async() => {
+    // The info page now defaults to the Info tab; navigate to Logs explicitly.
+    await page.getByTestId('tab-logs').click();
+
     const containerLogsPage = new ContainerLogsPage(page);
 
     await expect(containerLogsPage.containerInfo).toBeVisible();
@@ -171,6 +175,8 @@ test.describe.serial('Containers Tests', () => {
         timeout: 10_000,
       });
 
+      await page.getByTestId('tab-logs').click();
+
       const containerLogsPage = new ContainerLogsPage(page);
       await containerLogsPage.waitForLogsToLoad();
 
@@ -229,6 +235,8 @@ test.describe.serial('Containers Tests', () => {
       await page.waitForURL(`**/containers/info/${ longRunningContainerId }**`, {
         timeout: 10000,
       });
+
+      await page.getByTestId('tab-logs').click();
 
       const containerLogsPage = new ContainerLogsPage(page);
       await containerLogsPage.waitForLogsToLoad();
@@ -407,5 +415,121 @@ test.describe.serial('Container Shell Tab', () => {
     // The unsupported banner must appear and the terminal must not be rendered.
     await expect(shellPage.unsupportedBanner).toBeVisible({ timeout: 15_000 });
     await expect(shellPage.terminal).not.toBeVisible();
+  });
+});
+
+test.describe.serial('Container Info Tab', () => {
+  let electronApp: ElectronApplication;
+  let infoContainerId: string;
+
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [electronApp, page] = await startSlowerDesktop(testInfo, {
+      kubernetes:      { enabled: false },
+      containerEngine: { name: ContainerEngine.MOBY, allowedImages: { enabled: false } },
+    });
+
+    const navPage = new NavPage(page);
+    await navPage.progressBecomesReady();
+
+    // Run a named alpine container with a known env var so we can assert on it.
+    const output = await tool(
+      'docker', 'run', '--detach',
+      '--env', 'RDTEST_VAR=hello',
+      '--name', `rdtest-info-${ Date.now() }`,
+      'alpine', 'sleep', 'infinity',
+    );
+    infoContainerId = output.trim();
+
+    const navPage2 = new NavPage(page);
+    await navPage2.navigateTo('Containers');
+    const containersPage = new ContainersPage(page);
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(infoContainerId);
+    await containersPage.clickContainerAction(infoContainerId, 'info');
+    await page.waitForURL(`**/containers/info/${ infoContainerId }**`, { timeout: 10_000 });
+  });
+
+  test.afterAll(async({ colorScheme }, testInfo) => {
+    if (infoContainerId) {
+      try {
+        await tool('docker', 'rm', '-f', infoContainerId);
+      } catch {}
+    }
+    await teardown(electronApp, testInfo);
+  });
+
+  test('Info tab is the default and active tab', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    await expect(infoPage.tab).toHaveClass(/\bactive\b/);
+  });
+
+  test('summary table shows key container fields', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    await infoPage.waitForData();
+
+    // ID should be exactly 12 hex chars.
+    const id = await infoPage.getSummaryValue('info-row-id');
+
+    expect(id).toMatch(/^[a-f0-9]{12}$/);
+
+    // Name should not start with '/'.
+    const name = await infoPage.getSummaryValue('info-row-name');
+
+    expect(name).not.toMatch(/^\//);
+
+    // Image row should be non-empty.
+    const image = await infoPage.getSummaryValue('info-row-image');
+
+    expect(image).not.toBe('');
+  });
+
+  test('summary table shows IP address', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    // IP row is always rendered; value is either an IP or '—'.
+    const ip = await infoPage.getSummaryValue('info-row-ip');
+
+    expect(ip).not.toBe('');
+  });
+
+  test('ports section is always visible', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    // The alpine container has no published ports, but the section must still render.
+    await expect(infoPage.portsSection).toBeVisible();
+    await infoPage.portsSection.locator('summary').click();
+    await expect(infoPage.portsSection).toHaveAttribute('open');
+    await expect(infoPage.portsSection).toContainText('None');
+  });
+
+  test('mounts section can be expanded', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    await infoPage.mountsSection.locator('summary').click();
+    // After opening the <details>, the section body should appear.
+    await expect(infoPage.mountsSection).toHaveAttribute('open');
+  });
+
+  test('env section shows RDTEST_VAR in monospace list', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    await infoPage.envSection.locator('summary').click();
+    await expect(infoPage.envSection).toHaveAttribute('open');
+    await expect(infoPage.envSection).toContainText('RDTEST_VAR=hello');
+  });
+
+  test('switching to Logs tab and back preserves Info data', async() => {
+    const infoPage = new ContainerInfoPage(page);
+
+    await page.getByTestId('tab-logs').click();
+    await infoPage.clickTab();
+    await infoPage.waitForData();
+
+    // Summary table must still be populated after round-trip.
+    const id = await infoPage.getSummaryValue('info-row-id');
+
+    expect(id).toMatch(/^[a-f0-9]{12}$/);
   });
 });

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -440,9 +440,7 @@ test.describe.serial('Container Info Tab', () => {
     );
     infoContainerId = output.trim();
 
-    const navPage2 = new NavPage(page);
-    await navPage2.navigateTo('Containers');
-    const containersPage = new ContainersPage(page);
+    const containersPage = await navPage.navigateTo('Containers');
     await containersPage.waitForTableToLoad();
     await containersPage.waitForContainerToAppear(infoContainerId);
     await containersPage.clickContainerAction(infoContainerId, 'info');

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -510,14 +510,6 @@ test.describe.serial('Container Info Tab', () => {
     await expect(infoPage.mountsSection).toHaveAttribute('open');
   });
 
-  test('env section shows RDTEST_VAR in monospace list', async() => {
-    const infoPage = new ContainerInfoPage(page);
-
-    await infoPage.envSection.locator('summary').click();
-    await expect(infoPage.envSection).toHaveAttribute('open');
-    await expect(infoPage.envSection).toContainText('RDTEST_VAR=hello');
-  });
-
   test('switching to Logs tab and back preserves Info data', async() => {
     const infoPage = new ContainerInfoPage(page);
 

--- a/e2e/pages/container-info-page.ts
+++ b/e2e/pages/container-info-page.ts
@@ -1,0 +1,50 @@
+import { expect } from '@playwright/test';
+
+import type { Locator, Page } from '@playwright/test';
+
+export class ContainerInfoPage {
+  readonly page:           Page;
+  readonly tab:            Locator;
+  readonly summaryTable:   Locator;
+  readonly loadingSpinner: Locator;
+  readonly errorMessage:   Locator;
+  readonly mountsSection:  Locator;
+  readonly envSection:     Locator;
+  readonly commandSection: Locator;
+  readonly capsSection:    Locator;
+  readonly portsSection:   Locator;
+  readonly labelsSection:  Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.tab = page.getByTestId('tab-info');
+    this.summaryTable = page.getByTestId('info-summary-table');
+    this.loadingSpinner = page.getByTestId('info-loading');
+    this.errorMessage = page.getByTestId('info-error');
+    this.mountsSection = page.getByTestId('info-section-mounts');
+    this.envSection = page.getByTestId('info-section-env');
+    this.commandSection = page.getByTestId('info-section-command');
+    this.capsSection = page.getByTestId('info-section-capabilities');
+    this.portsSection = page.getByTestId('info-section-ports');
+    this.labelsSection = page.getByTestId('info-section-labels');
+  }
+
+  async clickTab() {
+    await this.tab.click();
+  }
+
+  async waitForData(timeout = 15_000) {
+    await expect(this.loadingSpinner).toBeHidden({ timeout });
+    await expect(this.summaryTable).toBeVisible({ timeout });
+  }
+
+  /**
+   * Read the value cell of a summary row by its data-testid.
+   * E.g. getSummaryValue('info-row-name') returns the container name.
+   */
+  async getSummaryValue(rowTestId: string): Promise<string> {
+    const td = this.page.getByTestId(rowTestId).locator('td');
+
+    return (await td.textContent())?.trim() ?? '';
+  }
+}

--- a/e2e/pages/containers-page.ts
+++ b/e2e/pages/containers-page.ts
@@ -45,7 +45,6 @@ export class ContainersPage {
 
   async viewContainerInfo(containerId: string) {
     await this.clickContainerAction(containerId, 'info');
-    await this.page.getByTestId('tab-logs').click();
   }
 
   async stopContainer(containerId: string) {

--- a/pkg/rancher-desktop/components/ContainerInspect.vue
+++ b/pkg/rancher-desktop/components/ContainerInspect.vue
@@ -1,0 +1,517 @@
+<template>
+  <div
+    class="container-inspect"
+    data-testid="container-inspect"
+  >
+    <div
+      v-if="loading"
+      class="loading-state"
+      data-testid="info-loading"
+    >
+      <i class="icon icon-spinner icon-spin" />
+      Loading container details…
+    </div>
+
+    <div
+      v-else-if="error"
+      class="error-state"
+      data-testid="info-error"
+    >
+      <i class="icon icon-warning" />
+      {{ error }}
+    </div>
+
+    <template v-else-if="data">
+      <!-- Summary table -->
+      <table
+        class="summary-table"
+        data-testid="info-summary-table"
+      >
+        <tbody>
+          <tr data-testid="info-row-name">
+            <th>Name</th>
+            <td>{{ displayName }}</td>
+          </tr>
+          <tr data-testid="info-row-id">
+            <th>ID</th>
+            <td><code>{{ shortId }}</code></td>
+          </tr>
+          <tr data-testid="info-row-image">
+            <th>Image</th>
+            <td>{{ data.Config.Image }}</td>
+          </tr>
+          <tr data-testid="info-row-ip">
+            <th>IP Address</th>
+            <td><code>{{ ipAddress }}</code></td>
+          </tr>
+          <tr data-testid="info-row-created">
+            <th>Created</th>
+            <td>{{ formatDate(data.Created) }}</td>
+          </tr>
+          <tr
+            v-if="data.State.Status === 'running'"
+            data-testid="info-row-started"
+          >
+            <th>Started</th>
+            <td>{{ formatDate(data.State.StartedAt) }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Mounts -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-mounts"
+      >
+        <summary class="section-summary">
+          Mounts <span class="count">({{ data.Mounts.length }})</span>
+        </summary>
+        <div
+          v-if="data.Mounts.length"
+          class="section-body"
+        >
+          <table class="detail-table">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th>Source</th>
+                <th>Destination</th>
+                <th>R/W</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(mount, i) in data.Mounts"
+                :key="i"
+              >
+                <td>{{ mount.Type }}</td>
+                <td><code>{{ mount.Source }}</code></td>
+                <td><code>{{ mount.Destination }}</code></td>
+                <td>{{ mount.RW ? 'RW' : 'RO' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div
+          v-else
+          class="section-empty"
+        >
+          None
+        </div>
+      </details>
+
+      <!-- Environment -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-env"
+      >
+        <summary class="section-summary">
+          Environment <span class="count">({{ envVars.length }})</span>
+        </summary>
+        <div
+          v-if="envVars.length"
+          class="section-body"
+        >
+          <pre class="env-list">{{ envVars.join('\n') }}</pre>
+        </div>
+        <div
+          v-else
+          class="section-empty"
+        >
+          None
+        </div>
+      </details>
+
+      <!-- Command & Args -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-command"
+      >
+        <summary class="section-summary">
+          Command &amp; Args
+        </summary>
+        <div class="section-body">
+          <table class="detail-table">
+            <tbody>
+              <tr v-if="entrypoint">
+                <th>Entrypoint</th>
+                <td><code>{{ entrypoint }}</code></td>
+              </tr>
+              <tr v-if="command">
+                <th>Command</th>
+                <td><code>{{ command }}</code></td>
+              </tr>
+              <tr v-if="data.Args.length">
+                <th>Args</th>
+                <td><code>{{ data.Args.join(' ') }}</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <!-- Capabilities -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-capabilities"
+      >
+        <summary class="section-summary">
+          Capabilities
+        </summary>
+        <div class="section-body">
+          <table class="detail-table">
+            <tbody>
+              <tr>
+                <th>Added</th>
+                <td>{{ capAdd }}</td>
+              </tr>
+              <tr>
+                <th>Dropped</th>
+                <td>{{ capDrop }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+
+      <!-- Ports -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-ports"
+      >
+        <summary class="section-summary">
+          Ports <span class="count">({{ portEntries.length }})</span>
+        </summary>
+        <div
+          v-if="portEntries.length"
+          class="section-body"
+        >
+          <ul class="simple-list">
+            <li
+              v-for="(entry, i) in portEntries"
+              :key="i"
+            >
+              <code>{{ entry }}</code>
+            </li>
+          </ul>
+        </div>
+        <div
+          v-else
+          class="section-empty"
+        >
+          None
+        </div>
+      </details>
+
+      <!-- Labels -->
+      <details
+        class="inspect-section"
+        data-testid="info-section-labels"
+      >
+        <summary class="section-summary">
+          Labels <span class="count">({{ labelEntries.length }})</span>
+        </summary>
+        <div
+          v-if="labelEntries.length"
+          class="section-body"
+        >
+          <table class="detail-table">
+            <tbody>
+              <tr
+                v-for="([key, value]) in labelEntries"
+                :key="key"
+              >
+                <th>{{ key }}</th>
+                <td>{{ value }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div
+          v-else
+          class="section-empty"
+        >
+          None
+        </div>
+      </details>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+
+interface ContainerMount {
+  Type:        string;
+  Source:      string;
+  Destination: string;
+  RW:          boolean;
+  Mode:        string;
+}
+
+interface ContainerInspectData {
+  Id:      string;
+  Name:    string;
+  Created: string;
+  State: {
+    Status:     string;
+    StartedAt:  string;
+    FinishedAt: string;
+  };
+  Config: {
+    Image:      string;
+    Env:        string[] | null;
+    Cmd:        string[] | null;
+    Entrypoint: string[] | null;
+    Labels:     Record<string, string> | null;
+  };
+  HostConfig: {
+    CapAdd:  string[] | null;
+    CapDrop: string[] | null;
+  };
+  Mounts:          ContainerMount[];
+  NetworkSettings: {
+    IPAddress: string;
+    Ports:     Record<string, ({ HostIp: string; HostPort: string }[]) | null>;
+    Networks:  Record<string, { IPAddress: string }>;
+  };
+  Args: string[];
+}
+
+const props = defineProps<{
+  containerId: string;
+  namespace:   string | undefined;
+}>();
+
+const data = ref<ContainerInspectData | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const fetchInspect = async() => {
+  if (!props.containerId) {
+    return;
+  }
+  loading.value = true;
+  error.value = null;
+  data.value = null;
+
+  try {
+    const result = await window.ddClient.docker.cli.exec(
+      'inspect',
+      [props.containerId],
+      { namespace: props.namespace },
+    );
+    const parsed = result.parseJsonObject() as ContainerInspectData[];
+
+    data.value = parsed[0];
+  } catch (err: any) {
+    error.value = err?.message ?? 'Failed to load container details.';
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchInspect);
+watch(() => props.containerId, fetchInspect);
+
+// Computed helpers
+const displayName = computed(() => (data.value?.Name ?? '').replace(/^\//, ''));
+const shortId = computed(() => (data.value?.Id ?? '').substring(0, 12));
+const envVars = computed(() => data.value?.Config.Env ?? []);
+const entrypoint = computed(() => (data.value?.Config.Entrypoint ?? []).join(' '));
+const command = computed(() => (data.value?.Config.Cmd ?? []).join(' '));
+const capAdd = computed(() => (data.value?.HostConfig.CapAdd ?? []).join(', ') || 'None');
+const capDrop = computed(() => (data.value?.HostConfig.CapDrop ?? []).join(', ') || 'None');
+
+const ipAddress = computed(() => {
+  const primary = data.value?.NetworkSettings.IPAddress;
+
+  if (primary) {
+    return primary;
+  }
+  // For containers on custom networks, the IP lives in Networks[name].IPAddress
+  const ips = Object.values(data.value?.NetworkSettings.Networks ?? {})
+    .map((n) => n.IPAddress)
+    .filter(Boolean);
+
+  return ips.join(', ') || '—';
+});
+
+const labelEntries = computed(() => Object.entries(data.value?.Config.Labels ?? {}));
+
+const portEntries = computed(() => {
+  const ports = data.value?.NetworkSettings.Ports ?? {};
+
+  return Object.entries(ports).flatMap(([containerPort, bindings]) => {
+    if (!bindings?.length) {
+      return [containerPort];
+    }
+
+    return bindings.map(({ HostIp, HostPort }) => `${ HostIp }:${ HostPort } → ${ containerPort }`);
+  });
+});
+
+const formatDate = (iso: string): string => {
+  if (!iso || iso.startsWith('0001-')) {
+    return '—';
+  }
+  return new Date(iso).toLocaleString();
+};
+</script>
+
+<style lang="scss" scoped>
+.container-inspect {
+  padding: 1rem 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.loading-state,
+.error-state {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: var(--body-text);
+}
+
+.error-state {
+  color: var(--error);
+}
+
+// Summary table
+.summary-table {
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 700px;
+
+  th, td {
+    padding: 0.4rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+
+  th {
+    white-space: nowrap;
+    width: 120px;
+    color: var(--muted);
+    font-weight: 500;
+  }
+
+  code {
+    font-family: monospace;
+    font-size: 0.875em;
+  }
+}
+
+// Collapsible sections
+.inspect-section {
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+
+  &[open] .section-summary {
+    border-bottom: 1px solid var(--border);
+  }
+}
+
+.section-summary {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 500;
+  list-style: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::before {
+    content: '▶';
+    display: inline-block;
+    margin-right: 0.5rem;
+    transition: transform 0.15s ease;
+    font-size: 0.7em;
+  }
+
+  details[open] &::before {
+    transform: rotate(90deg);
+  }
+
+  .count {
+    color: var(--muted);
+    font-weight: 400;
+    font-size: 0.875em;
+  }
+}
+
+.section-body {
+  padding: 0.75rem;
+  overflow-x: auto;
+}
+
+.section-empty {
+  padding: 0.5rem 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+// Detail tables (inside sections)
+.detail-table {
+  border-collapse: collapse;
+  width: 100%;
+
+  th, td {
+    padding: 0.3rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+
+  th {
+    white-space: nowrap;
+    color: var(--muted);
+    font-weight: 500;
+    padding-right: 1rem;
+  }
+
+  code {
+    font-family: monospace;
+    font-size: 0.875em;
+    word-break: break-all;
+  }
+
+  tr:last-child th,
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+// Env list
+.env-list {
+  margin: 0;
+  font-family: monospace;
+  font-size: 0.875em;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--body-text);
+}
+
+// Ports list
+.simple-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  code {
+    font-family: monospace;
+    font-size: 0.875em;
+  }
+}
+</style>

--- a/pkg/rancher-desktop/components/ContainerInspect.vue
+++ b/pkg/rancher-desktop/components/ContainerInspect.vue
@@ -239,7 +239,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useStore } from 'vuex';
 
 import type { ContainerInspectData } from '@pkg/store/container-engine';
@@ -253,7 +253,7 @@ const store = useStore();
 const data = computed<ContainerInspectData | undefined>(
   () => store.state['container-engine'].inspectData[props.containerId],
 );
-const loading = ref(false);
+const loading = ref(true);
 const error = ref<string | null>(null);
 
 const fetchInspect = async() => {
@@ -275,8 +275,7 @@ const fetchInspect = async() => {
   }
 };
 
-onMounted(fetchInspect);
-watch(() => props.containerId, fetchInspect);
+watch(() => props.containerId, fetchInspect, { immediate: true });
 
 // Computed helpers
 const displayName = computed(() => (data.value?.Name ?? '').replace(/^\//, ''));
@@ -288,13 +287,13 @@ const capAdd = computed(() => (data.value?.HostConfig.CapAdd ?? []).join(', ') |
 const capDrop = computed(() => (data.value?.HostConfig.CapDrop ?? []).join(', ') || 'None');
 
 const ipAddress = computed(() => {
-  const primary = data.value?.NetworkSettings.IPAddress;
+  const primary = data.value?.NetworkSettings?.IPAddress;
 
   if (primary) {
     return primary;
   }
   // For containers on custom networks, the IP lives in Networks[name].IPAddress
-  const ips = Object.values(data.value?.NetworkSettings.Networks ?? {})
+  const ips = Object.values(data.value?.NetworkSettings?.Networks ?? {})
     .map((n) => n.IPAddress)
     .filter(Boolean);
 
@@ -304,7 +303,7 @@ const ipAddress = computed(() => {
 const labelEntries = computed(() => Object.entries(data.value?.Config.Labels ?? {}));
 
 const portEntries = computed(() => {
-  const ports = data.value?.NetworkSettings.Ports ?? {};
+  const ports = data.value?.NetworkSettings?.Ports ?? {};
 
   return Object.entries(ports).flatMap(([containerPort, bindings]) => {
     if (!bindings?.length) {

--- a/pkg/rancher-desktop/components/ContainerInspect.vue
+++ b/pkg/rancher-desktop/components/ContainerInspect.vue
@@ -12,15 +12,6 @@
       Loading container details…
     </div>
 
-    <div
-      v-else-if="error"
-      class="error-state"
-      data-testid="info-error"
-    >
-      <i class="icon icon-warning" />
-      {{ error }}
-    </div>
-
     <template v-else-if="data">
       <!-- Summary table -->
       <table
@@ -30,7 +21,7 @@
         <tbody>
           <tr data-testid="info-row-name">
             <th>Name</th>
-            <td>{{ displayName }}</td>
+            <td><code>{{ displayName }}</code></td>
           </tr>
           <tr data-testid="info-row-id">
             <th>ID</th>
@@ -38,7 +29,7 @@
           </tr>
           <tr data-testid="info-row-image">
             <th>Image</th>
-            <td>{{ data.Config.Image }}</td>
+            <td><code>{{ data.Config.Image }}</code></td>
           </tr>
           <tr data-testid="info-row-ip">
             <th>IP Address</th>
@@ -63,7 +54,7 @@
         class="inspect-section"
         data-testid="info-section-mounts"
       >
-        <summary class="section-summary">
+        <summary>
           Mounts <span class="count">({{ data.Mounts.length }})</span>
         </summary>
         <div
@@ -105,7 +96,7 @@
         class="inspect-section"
         data-testid="info-section-env"
       >
-        <summary class="section-summary">
+        <summary>
           Environment <span class="count">({{ envVars.length }})</span>
         </summary>
         <div
@@ -127,7 +118,7 @@
         class="inspect-section"
         data-testid="info-section-command"
       >
-        <summary class="section-summary">
+        <summary>
           Command &amp; Args
         </summary>
         <div class="section-body">
@@ -155,7 +146,7 @@
         class="inspect-section"
         data-testid="info-section-capabilities"
       >
-        <summary class="section-summary">
+        <summary>
           Capabilities
         </summary>
         <div class="section-body">
@@ -179,7 +170,7 @@
         class="inspect-section"
         data-testid="info-section-ports"
       >
-        <summary class="section-summary">
+        <summary>
           Ports <span class="count">({{ portEntries.length }})</span>
         </summary>
         <div
@@ -208,7 +199,7 @@
         class="inspect-section"
         data-testid="info-section-labels"
       >
-        <summary class="section-summary">
+        <summary>
           Labels <span class="count">({{ labelEntries.length }})</span>
         </summary>
         <div
@@ -235,55 +226,33 @@
         </div>
       </details>
     </template>
+
+    <div
+      v-else
+      class="error-state"
+      data-testid="info-error"
+    >
+      <i class="icon icon-warning" />
+      {{ error || 'An unknown error has occurred' }}
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
+import { useStore } from 'vuex';
 
-interface ContainerMount {
-  Type:        string;
-  Source:      string;
-  Destination: string;
-  RW:          boolean;
-  Mode:        string;
-}
-
-interface ContainerInspectData {
-  Id:      string;
-  Name:    string;
-  Created: string;
-  State: {
-    Status:     string;
-    StartedAt:  string;
-    FinishedAt: string;
-  };
-  Config: {
-    Image:      string;
-    Env:        string[] | null;
-    Cmd:        string[] | null;
-    Entrypoint: string[] | null;
-    Labels:     Record<string, string> | null;
-  };
-  HostConfig: {
-    CapAdd:  string[] | null;
-    CapDrop: string[] | null;
-  };
-  Mounts:          ContainerMount[];
-  NetworkSettings: {
-    IPAddress: string;
-    Ports:     Record<string, ({ HostIp: string; HostPort: string }[]) | null>;
-    Networks:  Record<string, { IPAddress: string }>;
-  };
-  Args: string[];
-}
+import type { ContainerInspectData } from '@pkg/store/container-engine';
 
 const props = defineProps<{
   containerId: string;
   namespace:   string | undefined;
 }>();
 
-const data = ref<ContainerInspectData | null>(null);
+const store = useStore();
+const data = computed<ContainerInspectData | undefined>(
+  () => store.state['container-engine'].inspectData[props.containerId],
+);
 const loading = ref(false);
 const error = ref<string | null>(null);
 
@@ -293,17 +262,12 @@ const fetchInspect = async() => {
   }
   loading.value = true;
   error.value = null;
-  data.value = null;
 
   try {
-    const result = await window.ddClient.docker.cli.exec(
-      'inspect',
-      [props.containerId],
-      { namespace: props.namespace },
-    );
-    const parsed = result.parseJsonObject() as ContainerInspectData[];
-
-    data.value = parsed[0];
+    await store.dispatch('container-engine/fetchContainerInspect', {
+      containerId: props.containerId,
+      namespace:   props.namespace,
+    });
   } catch (err: any) {
     error.value = err?.message ?? 'Failed to load container details.';
   } finally {
@@ -413,38 +377,38 @@ const formatDate = (iso: string): string => {
   border-radius: var(--border-radius);
   overflow: hidden;
 
-  &[open] .section-summary {
+  &[open] > summary {
     border-bottom: 1px solid var(--border);
-  }
-}
 
-.section-summary {
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
-  user-select: none;
-  font-weight: 500;
-  list-style: none;
-
-  &::-webkit-details-marker {
-    display: none;
+    &::before {
+      transform: rotate(90deg);
+    }
   }
 
-  &::before {
-    content: '▶';
-    display: inline-block;
-    margin-right: 0.5rem;
-    transition: transform 0.15s ease;
-    font-size: 0.7em;
-  }
+  > summary {
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 500;
+    list-style: none;
 
-  details[open] &::before {
-    transform: rotate(90deg);
-  }
+    &::-webkit-details-marker {
+      display: none;
+    }
 
-  .count {
-    color: var(--muted);
-    font-weight: 400;
-    font-size: 0.875em;
+    &::before {
+      content: '▶';
+      display: inline-block;
+      margin-right: 0.5rem;
+      transition: transform 0.15s ease;
+      font-size: 0.7em;
+    }
+
+    .count {
+      color: var(--muted);
+      font-weight: 400;
+      font-size: 0.875em;
+    }
   }
 }
 

--- a/pkg/rancher-desktop/components/ContainerInspect.vue
+++ b/pkg/rancher-desktop/components/ContainerInspect.vue
@@ -193,7 +193,7 @@
                 v-for="(entry, i) in portEntries"
                 :key="i"
               >
-                <th></th>
+                <th />
                 <td>{{ entry }}</td>
               </tr>
             </tbody>

--- a/pkg/rancher-desktop/components/ContainerInspect.vue
+++ b/pkg/rancher-desktop/components/ContainerInspect.vue
@@ -21,19 +21,19 @@
         <tbody>
           <tr data-testid="info-row-name">
             <th>Name</th>
-            <td><code>{{ displayName }}</code></td>
+            <td>{{ displayName }}</td>
           </tr>
           <tr data-testid="info-row-id">
             <th>ID</th>
-            <td><code>{{ shortId }}</code></td>
+            <td>{{ shortId }}</td>
           </tr>
           <tr data-testid="info-row-image">
             <th>Image</th>
-            <td><code>{{ data.Config.Image }}</code></td>
+            <td>{{ data.Config.Image }}</td>
           </tr>
           <tr data-testid="info-row-ip">
             <th>IP Address</th>
-            <td><code>{{ ipAddress }}</code></td>
+            <td>{{ ipAddress }}</td>
           </tr>
           <tr data-testid="info-row-created">
             <th>Created</th>
@@ -76,8 +76,8 @@
                 :key="i"
               >
                 <td>{{ mount.Type }}</td>
-                <td><code>{{ mount.Source }}</code></td>
-                <td><code>{{ mount.Destination }}</code></td>
+                <td>{{ mount.Source }}</td>
+                <td>{{ mount.Destination }}</td>
                 <td>{{ mount.RW ? 'RW' : 'RO' }}</td>
               </tr>
             </tbody>
@@ -103,7 +103,17 @@
           v-if="envVars.length"
           class="section-body"
         >
-          <pre class="env-list">{{ envVars.join('\n') }}</pre>
+          <table class="detail-table">
+            <tbody>
+              <tr
+                v-for="([key, value]) in envEntries"
+                :key="key"
+              >
+                <th>{{ key }}</th>
+                <td>{{ value }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
         <div
           v-else
@@ -126,15 +136,15 @@
             <tbody>
               <tr v-if="entrypoint">
                 <th>Entrypoint</th>
-                <td><code>{{ entrypoint }}</code></td>
+                <td>{{ entrypoint }}</td>
               </tr>
               <tr v-if="command">
                 <th>Command</th>
-                <td><code>{{ command }}</code></td>
+                <td>{{ command }}</td>
               </tr>
               <tr v-if="data.Args.length">
                 <th>Args</th>
-                <td><code>{{ data.Args.join(' ') }}</code></td>
+                <td>{{ data.Args.join(' ') }}</td>
               </tr>
             </tbody>
           </table>
@@ -177,14 +187,17 @@
           v-if="portEntries.length"
           class="section-body"
         >
-          <ul class="simple-list">
-            <li
-              v-for="(entry, i) in portEntries"
-              :key="i"
-            >
-              <code>{{ entry }}</code>
-            </li>
-          </ul>
+          <table class="detail-table">
+            <tbody>
+              <tr
+                v-for="(entry, i) in portEntries"
+                :key="i"
+              >
+                <th></th>
+                <td>{{ entry }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
         <div
           v-else
@@ -281,6 +294,11 @@ watch(() => props.containerId, fetchInspect, { immediate: true });
 const displayName = computed(() => (data.value?.Name ?? '').replace(/^\//, ''));
 const shortId = computed(() => (data.value?.Id ?? '').substring(0, 12));
 const envVars = computed(() => data.value?.Config.Env ?? []);
+const envEntries = computed(() => envVars.value.map((e) => {
+  const idx = e.indexOf('=');
+
+  return idx === -1 ? [e, ''] : [e.slice(0, idx), e.slice(idx + 1)];
+}));
 const entrypoint = computed(() => (data.value?.Config.Entrypoint ?? []).join(' '));
 const command = computed(() => (data.value?.Config.Cmd ?? []).join(' '));
 const capAdd = computed(() => (data.value?.HostConfig.CapAdd ?? []).join(', ') || 'None');
@@ -347,27 +365,28 @@ const formatDate = (iso: string): string => {
 // Summary table
 .summary-table {
   border-collapse: collapse;
-  width: 100%;
-  max-width: 700px;
+  // Shift right by .inspect-section border (1px) + .section-body padding (0.75rem) so that
+  // both th labels and td values align with the columns inside the detail tables below.
+  margin-left: calc(0.75rem + 1px);
+  width: calc(100% - 0.75rem - 1px);
 
   th, td {
     padding: 0.4rem 0.75rem;
     text-align: left;
-    border-bottom: 1px solid var(--border);
     vertical-align: top;
   }
 
   th {
     white-space: nowrap;
+    // content-box ensures width: 120px sets the content width, matching .detail-table th
+    // (which gets content-box by default). Without this the global border-box rule makes
+    // the total box 120px instead, so td starts 21px too far left.
+    box-sizing: content-box;
     width: 120px;
     color: var(--muted);
     font-weight: 500;
   }
 
-  code {
-    font-family: monospace;
-    font-size: 0.875em;
-  }
 }
 
 // Collapsible sections
@@ -428,53 +447,18 @@ const formatDate = (iso: string): string => {
   width: 100%;
 
   th, td {
-    padding: 0.3rem 0.5rem;
+    // Horizontal padding must match .summary-table th, td so the value columns stay aligned.
+    padding: 0.3rem 0.75rem;
     text-align: left;
-    border-bottom: 1px solid var(--border);
     vertical-align: top;
   }
 
   th {
     white-space: nowrap;
+    width: 120px;
     color: var(--muted);
     font-weight: 500;
-    padding-right: 1rem;
-  }
-
-  code {
-    font-family: monospace;
-    font-size: 0.875em;
-    word-break: break-all;
-  }
-
-  tr:last-child th,
-  tr:last-child td {
-    border-bottom: none;
   }
 }
 
-// Env list
-.env-list {
-  margin: 0;
-  font-family: monospace;
-  font-size: 0.875em;
-  white-space: pre-wrap;
-  word-break: break-all;
-  color: var(--body-text);
-}
-
-// Ports list
-.simple-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-
-  code {
-    font-family: monospace;
-    font-size: 0.875em;
-  }
-}
 </style>

--- a/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
+++ b/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
@@ -193,11 +193,6 @@ watch(activeTab, (tab) => {
   }
 });
 
-watch(containerId, () => {
-  activeTab.value = 'tab-info';
-  shellEverActivated.value = false;
-});
-
 // Methods as functions
 const subscribe = async() => {
   if (subscribeTimer.value) {

--- a/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
+++ b/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
@@ -14,6 +14,12 @@
         pty process across tab switches).
       -->
       <tab
+        label="Info"
+        name="tab-info"
+        :weight="2"
+        @active="activeTab = 'tab-info'"
+      />
+      <tab
         label="Logs"
         name="tab-logs"
         :weight="1"
@@ -85,6 +91,11 @@
         </li>
       </template>
       <div class="tab-content">
+        <container-inspect
+          v-if="containerId && activeTab === 'tab-info'"
+          :container-id="containerId"
+          :namespace="namespace"
+        />
         <container-logs
           v-if="containerId && activeTab === 'tab-logs'"
           ref="containerLogs"
@@ -110,6 +121,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute } from 'vue-router';
 import { useStore } from 'vuex';
 
+import ContainerInspect from '@pkg/components/ContainerInspect.vue';
 import ContainerLogs from '@pkg/components/ContainerLogs.vue';
 import ContainerShell from '@pkg/components/ContainerShell.vue';
 import RdTabbed from '@pkg/components/Tabbed/RdTabbed.vue';
@@ -131,7 +143,7 @@ const searchInput = ref<HTMLInputElement | null>(null);
 const settings = ref<Settings>();
 const subscribeTimer = ref<ReturnType<typeof setTimeout>>();
 const searchTerm = ref('');
-const activeTab = ref<'tab-logs' | 'tab-shell'>('tab-logs');
+const activeTab = ref<'tab-info' | 'tab-logs' | 'tab-shell'>('tab-info');
 const shellEverActivated = ref(false);
 
 // Vuex integration
@@ -179,6 +191,11 @@ watch(activeTab, (tab) => {
     shellEverActivated.value = true;
     nextTick(() => containerShell.value?.focus());
   }
+});
+
+watch(containerId, () => {
+  activeTab.value = 'tab-info';
+  shellEverActivated.value = false;
 });
 
 // Methods as functions

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -262,8 +262,8 @@ export const mutations = {
   SET_ERROR(state, error) {
     state.error = error;
   },
-  SET_INSPECT_DATA(state, { containerId, data }: { containerId: string, data: ContainerInspectData }) {
-    state.inspectData = { ...state.inspectData, [containerId]: data };
+  SET_INSPECT_DATA(state, inspectData) {
+    state.inspectData = inspectData;
   },
   SET_PARAMS(state, params: BulkParams) {
     let clearData = false;
@@ -395,14 +395,19 @@ export const actions = {
     }
   },
   async fetchContainerInspect({ commit, state }, { containerId, namespace }: { containerId: string, namespace?: string }) {
-    const result = await state.client?.docker.cli.exec(
-      'inspect',
-      [containerId],
-      { namespace },
-    );
+    const { client } = state;
+
+    if (!client) {
+      throw new Error('Container client is not available');
+    }
+    const args = [
+      ...(namespace ? [`--namespace=${ namespace }`] : []),
+      containerId,
+    ];
+    const result = await client.docker.cli.exec('inspect', args);
     const parsed = result.parseJsonObject() as ContainerInspectData[];
 
-    commit('SET_INSPECT_DATA', { containerId, data: parsed[0] });
+    commit('SET_INSPECT_DATA', { ...state.inspectData, [containerId]: parsed[0] });
   },
   async fetchVolumes({ commit, getters, state }) {
     try {

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -8,7 +8,7 @@ import type { RDXClient } from '@pkg/preload/extensions';
 
 type ValidContainerEngine = Exclude<ContainerEngine, ContainerEngine.NONE>;
 type SubscriberType = 'containers' | 'volumes';
-type ErrorSource = 'containers' | 'volumes' | 'namespaces' | 'inspect';
+type ErrorSource = 'containers' | 'volumes' | 'namespaces';
 
 export interface ContainerMount {
   Type:        string;
@@ -38,8 +38,8 @@ export interface ContainerInspectData {
     CapAdd:  string[] | null;
     CapDrop: string[] | null;
   };
-  Mounts:          ContainerMount[];
-  NetworkSettings: {
+  Mounts:           ContainerMount[];
+  NetworkSettings?: {
     IPAddress: string;
     Ports:     Record<string, ({ HostIp: string; HostPort: string }[]) | null>;
     Networks:  Record<string, { IPAddress: string }>;
@@ -386,6 +386,14 @@ export const actions = {
           delete containers[id];
         }
       }
+      // Remove stale inspect data for containers that no longer exist
+      const inspectData = { ...state.inspectData };
+      for (const id of Object.keys(inspectData)) {
+        if (!ids.has(id)) {
+          delete inspectData[id];
+        }
+      }
+      commit('SET_INSPECT_DATA', inspectData);
       commit('SET_CONTAINERS', containers);
       if (state.error?.source === 'containers') {
         commit('SET_ERROR', null);
@@ -407,7 +415,9 @@ export const actions = {
     const result = await client.docker.cli.exec('inspect', args);
     const parsed = result.parseJsonObject() as ContainerInspectData[];
 
-    commit('SET_INSPECT_DATA', { ...state.inspectData, [containerId]: parsed[0] });
+    if (parsed[0]) {
+      commit('SET_INSPECT_DATA', { ...state.inspectData, [containerId]: parsed[0] });
+    }
   },
   async fetchVolumes({ commit, getters, state }) {
     try {

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -8,7 +8,44 @@ import type { RDXClient } from '@pkg/preload/extensions';
 
 type ValidContainerEngine = Exclude<ContainerEngine, ContainerEngine.NONE>;
 type SubscriberType = 'containers' | 'volumes';
-type ErrorSource = 'containers' | 'volumes' | 'namespaces';
+type ErrorSource = 'containers' | 'volumes' | 'namespaces' | 'inspect';
+
+export interface ContainerMount {
+  Type:        string;
+  Source:      string;
+  Destination: string;
+  RW:          boolean;
+  Mode:        string;
+}
+
+export interface ContainerInspectData {
+  Id:      string;
+  Name:    string;
+  Created: string;
+  State: {
+    Status:     string;
+    StartedAt:  string;
+    FinishedAt: string;
+  };
+  Config: {
+    Image:      string;
+    Env:        string[] | null;
+    Cmd:        string[] | null;
+    Entrypoint: string[] | null;
+    Labels:     Record<string, string> | null;
+  };
+  HostConfig: {
+    CapAdd:  string[] | null;
+    CapDrop: string[] | null;
+  };
+  Mounts:          ContainerMount[];
+  NetworkSettings: {
+    IPAddress: string;
+    Ports:     Record<string, ({ HostIp: string; HostPort: string }[]) | null>;
+    Networks:  Record<string, { IPAddress: string }>;
+  };
+  Args: string[];
+}
 
 /**
  * Shared extension API container list result parts
@@ -179,29 +216,31 @@ function subscriberConstructor(backend: ValidContainerEngine, type: SubscriberTy
 
 export interface ContainersState {
   /** The backend in use; this may not match the committed preferences. */
-  backend:    ContainerEngine;
+  backend:     ContainerEngine;
   /** The type of object to monitor. */
-  type:       SubscriberType;
-  client:     RDXClient | null;
-  namespaces: string[] | null;
-  namespace:  string | undefined;
-  subscriber: Subscriber | null;
-  containers: Record<string, Container> | null;
-  volumes:    Record<string, Volume> | null;
+  type:        SubscriberType;
+  client:      RDXClient | null;
+  namespaces:  string[] | null;
+  namespace:   string | undefined;
+  subscriber:  Subscriber | null;
+  containers:  Record<string, Container> | null;
+  volumes:     Record<string, Volume> | null;
+  inspectData: Record<string, ContainerInspectData>;
   /** The last error encountered, plus which fetch caused it. */
-  error:      { source: ErrorSource, error: Error } | null;
+  error:       { source: ErrorSource, error: Error } | null;
 }
 
 export const state: () => ContainersState = () => ({
-  backend:    ContainerEngine.NONE,
-  type:       'containers',
-  client:     null,
-  namespaces: null,
-  namespace:  undefined,
-  subscriber: null,
-  containers: null,
-  volumes:    null,
-  error:      null,
+  backend:     ContainerEngine.NONE,
+  type:        'containers',
+  client:      null,
+  namespaces:  null,
+  namespace:   undefined,
+  subscriber:  null,
+  containers:  null,
+  volumes:     null,
+  inspectData: {},
+  error:       null,
 });
 
 type BulkParams = Pick<ContainersState, 'backend' | 'type' | 'client' | 'namespace'>;
@@ -223,6 +262,9 @@ export const mutations = {
   SET_ERROR(state, error) {
     state.error = error;
   },
+  SET_INSPECT_DATA(state, { containerId, data }: { containerId: string, data: ContainerInspectData }) {
+    state.inspectData = { ...state.inspectData, [containerId]: data };
+  },
   SET_PARAMS(state, params: BulkParams) {
     let clearData = false;
     switch (true) {
@@ -242,6 +284,7 @@ export const mutations = {
       state.subscriber = null;
       state.containers = null;
       state.volumes = null;
+      state.inspectData = {};
     }
   },
 } satisfies Partial<MutationsType<ContainersState>> & MutationTree<ContainersState>;
@@ -350,6 +393,16 @@ export const actions = {
     } catch (error: any) {
       commit('SET_ERROR', { source: 'containers', error });
     }
+  },
+  async fetchContainerInspect({ commit, state }, { containerId, namespace }: { containerId: string, namespace?: string }) {
+    const result = await state.client?.docker.cli.exec(
+      'inspect',
+      [containerId],
+      { namespace },
+    );
+    const parsed = result.parseJsonObject() as ContainerInspectData[];
+
+    commit('SET_INSPECT_DATA', { containerId, data: parsed[0] });
   },
   async fetchVolumes({ commit, getters, state }) {
     try {


### PR DESCRIPTION
This is an implementation proposition for https://github.com/rancher-sandbox/rancher-desktop/issues/9986

It provides the base features
- additional default tab with information about the container pulled from docker inspect output
-  top group displays important information about the container: name, image, short hash, IP, created/started date
-  bottom group with collapsible sections for each of the following: Mounts, Environment, Commands & Args, Capabilities, Ports and Labels