### PR TITLE
fix: missing WSLInterop.

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/wsl-init
+++ b/pkg/rancher-desktop/assets/scripts/wsl-init
@@ -43,6 +43,13 @@ mount --make-shared /sys/fs/cgroup
 mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc
 mount --make-shared /proc/sys/fs/binfmt_misc
 
+# Some environments may not have binfmt_misc enabled / mounted, and WSLInterop
+# may already be registered, so only add the handler when it is possible and
+# necessary.
+if [ -w /proc/sys/fs/binfmt_misc/register ] && [ ! -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then
+    echo ':WSLInterop:M::MZ::/init:PF' > /proc/sys/fs/binfmt_misc/register
+fi
+
 if [ -f /var/lib/resolv.conf ]; then
     ln -s -f /var/lib/resolv.conf /etc/resolv.conf
 fi


### PR DESCRIPTION
# Change Summary

## Problem
WSLInterop might not be available in WSL after mounting binfmt_misc.

https://github.com/rancher-sandbox/rancher-desktop/blob/28fb8406f8713a394f0a9de3914df13c46182191/pkg/rancher-desktop/assets/scripts/wsl-init#L41-L44

## How to reproduce the problem
1. Troubleshoot > Factory Reset (will close rancher-desktop)
2. `wsl --shutdown`
3. Run rancher-desktop with kubernetes disabled and moby as container engine.
4. Let rancher finish its initialization.
5. `wsl` to enter wsl environment.
6. `ls /proc/sys/fs/binfmt_misc`

Then there should be no WSLInterop as shown in the video below.

By the way, this problem doesn't happen if you expose the docker socket:
  
<img width="754" height="503" alt="image" src="https://github.com/user-attachments/assets/8fdbe1ae-7bac-47f8-bcd2-9ef4f0f75573" />

## Tests

https://github.com/user-attachments/assets/cf794d03-a0fa-4540-aeb9-a144fee7928b

https://github.com/user-attachments/assets/0e3b36c4-4968-46e2-a22c-cb76ca7be651

## Related Issues
* https://github.com/rancher-sandbox/rancher-desktop/issues/9985