### PR TITLE
dependabot: disable webpack upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,12 @@ updates:
     # ignore until we arrive a solution that uses it.
     dependency-name: "@rancher/shell"
     versions: [">0.1"]
+  - # We are currently using @vue/cli-service which depends on an older version
+    # of webpack.  Upgrading webpack past what we currently have causes
+    # conflicts between the different versions of webpack.  Disable further
+    # updates of webpack until we can migrate off @vue/cli-service (which is
+    # unlikely to be fixed as it is in maintenance mode).
+    dependency-name: "webpack"
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"


### PR DESCRIPTION
We are currently using `@vue/cli-service` which pulls in an older version of `webpack`.  That is not compatible with versions past what we are currently using.  In order to upgrade `webpack` further, we will need to drop the usage of `@vue/cli-service`; the recommended path forward is to migrate to `vite`.