### PR TITLE
Latch: Add reset capability, tests

### DIFF
--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -61,9 +61,9 @@ enum SyncStateKey {
 type SyncState =
   { state: SyncStateKey.IDLE } |
   /** The `active` promise will be resolved once the current sync is complete. */
-  { state: SyncStateKey.ACTIVE, active: ReturnType<typeof Latch> } |
+  { state: SyncStateKey.ACTIVE, active: ReturnType<typeof Latch<void>> } |
   /** The `queued` promise will be resolved after the current sync +1 is complete. */
-  { state: SyncStateKey.QUEUED, active: ReturnType<typeof Latch>, queued: ReturnType<typeof Latch> };
+  { state: SyncStateKey.QUEUED, active: ReturnType<typeof Latch<void>>, queued: ReturnType<typeof Latch<void>> };
 
 /**
  * DiagnosticKey limits the `key` argument of the diagnostic events.

--- a/pkg/rancher-desktop/utils/__tests__/latch.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/latch.spec.ts
@@ -14,9 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { jest } from '@jest/globals';
+
 import Latch from '../latch';
 
 describe('Latch', () => {
+  it('returns a promise', () => {
+    const latch = Latch();
+    expect(latch).toBeInstanceOf(Promise);
+    expect(latch[Symbol.toStringTag]).toEqual((new Promise(() => {}))[Symbol.toStringTag]);
+  });
+
   it('can be resolved', async() => {
     const latch = Latch();
     let resolved = false;
@@ -76,6 +84,17 @@ describe('Latch', () => {
     await assertion;
   }, 100);
 
+  it('can handle multiple waiters', async() => {
+    const expected = 42;
+    const latch = Latch<typeof expected>();
+    const assertion1 = expect(latch).resolves.toBe(expected);
+    const assertion2 = expect(latch).resolves.toBe(expected);
+    setTimeout(() => {
+      latch.resolve(expected);
+    }, 0);
+    await Promise.all([assertion1, assertion2]);
+  }, 100);
+
   it('can be rejected', async() => {
     const error = new Error('test');
     const latch = Latch();
@@ -113,66 +132,67 @@ describe('Latch', () => {
     await assertion;
   }, 100);
 
-  it('can be reset', async() => {
+  it('can be rejected without any handlers and then reset', async() => {
+    // If a latch is rejected and then reset, it should not cause an
+    // UnhandledPromiseRejectionWarning even if we never await the latch.
+    // Note that it _should_ cause an UnhandledPromiseRejectionWarning if we
+    // never reset the latch, but testing for that is not possible with jest
+    // because it always catches it and fails the test.
     const latch = Latch();
-    let resolved = false;
-    const assertion1 = expect(latch).resolves.toBe(undefined);
-    setTimeout(() => {
-      expect(resolved).toBe(false);
-      resolved = true;
-      latch.resolve();
-    }, 0);
-    expect(resolved).toBe(false);
-    await assertion1;
-    expect(resolved).toBe(true);
-
+    latch.reject(new Error('rejected latch should not cause unhandled rejection'));
     latch.reset();
 
-    let rejected = false;
-    const error = new Error('test');
-    const assertion2 = expect(latch).rejects.toThrow(error);
-    setTimeout(() => {
-      expect(rejected).toBe(false);
-      rejected = true;
-      latch.reject(error);
-    }, 0);
-    expect(rejected).toBe(false);
-    await assertion2;
-    expect(rejected).toBe(true);
+    // Wait a tick to allow any unhandled microtask rejections to surface.
+    await new Promise(resolve => setTimeout(resolve, 10));
   }, 100);
 
-  it('can be reset multiple times', async() => {
-    const latch = Latch();
-    let resolved = false;
-    const assertion1 = expect(latch).resolves.toBe(undefined);
-    setTimeout(() => {
-      expect(resolved).toBe(false);
-      resolved = true;
-      latch.reset();
-      latch.reset();
-      latch.resolve();
-    }, 0);
-    expect(resolved).toBe(false);
-    await assertion1;
-    expect(resolved).toBe(true);
+  it('can be reset', async() => {
+    const inputs: (number | Error)[] = [42, new Error('one'), 123, new Error('two')];
+    const latch = Latch<number>();
+
+    for (const [i, expected] of inputs.entries()) {
+      const assertion = expected instanceof Error
+        ? expect(latch).rejects.toThrow(expected)
+        : expect(latch).resolves.toBe(expected);
+      let settled = false;
+      setTimeout(() => {
+        expect(settled).toBe(false);
+        if (expected instanceof Error) {
+          latch.reject(expected);
+        } else {
+          latch.resolve(expected);
+        }
+        settled = true;
+      }, 0);
+      expect(settled).toBe(false);
+      await assertion;
+      expect(settled).toBe(true);
+
+      // Reset at least once after each iteration; also test that we can call it
+      // multiple times in a row.
+      for (let j = 0; j < i + 1; ++j) {
+        latch.reset();
+      }
+    }
   }, 100);
 
   it('can reset while pending', async() => {
-    const latch = Latch();
+    const expected = 42;
+    const latch = Latch<number>();
     let resolved = false;
-    const assertion = expect(latch).resolves.toBe(undefined);
+    const assertion = expect(latch).resolves.toBe(expected);
     setTimeout(() => {
       expect(resolved).toBe(false);
       latch.reset();
       resolved = true;
-      latch.resolve();
+      latch.resolve(expected);
     }, 0);
     expect(resolved).toBe(false);
     await assertion;
     expect(resolved).toBe(true);
   }, 100);
 
-  it('runs finally callback', async() => {
+  it('runs finally callback on resolve', async() => {
     const latch = Latch();
     let finallyCalled = false;
     latch.finally(() => {
@@ -186,6 +206,20 @@ describe('Latch', () => {
     expect(finallyCalled).toBe(false);
     await assertion;
     expect(finallyCalled).toBe(true);
+  }, 100);
+
+  it('runs finally callback on reject', async() => {
+    const latch = Latch();
+    const callback = jest.fn();
+    const error = new Error('test');
+    const assertion = expect(latch.finally(callback)).rejects.toThrow(error);
+    setTimeout(() => {
+      expect(callback).not.toHaveBeenCalled();
+      latch.reject(error);
+    }, 0);
+    expect(callback).not.toHaveBeenCalled();
+    await assertion;
+    expect(callback).toHaveBeenCalled();
   }, 100);
 
   it('can be resolved before being awaited', async() => {

--- a/pkg/rancher-desktop/utils/__tests__/latch.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/latch.spec.ts
@@ -1,0 +1,197 @@
+/*
+Copyright © 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Latch from '../latch';
+
+describe('Latch', () => {
+  it('can be resolved', async() => {
+    const latch = Latch();
+    let resolved = false;
+    const assertion = expect(latch).resolves.toBe(undefined);
+    setTimeout(() => {
+      expect(resolved).toBe(false);
+      resolved = true;
+      latch.resolve();
+    }, 0);
+    expect(resolved).toBe(false);
+    await assertion;
+    expect(resolved).toBe(true);
+  }, 100);
+
+  it('can be resolved with a value', async() => {
+    const latch = Latch<number>();
+    let resolved = false;
+    const assertion = expect(latch).resolves.toBe(123);
+    setTimeout(() => {
+      expect(resolved).toBe(false);
+      resolved = true;
+      latch.resolve(123);
+    }, 0);
+    expect(resolved).toBe(false);
+    await assertion;
+    expect(resolved).toBe(true);
+  }, 100);
+
+  it('can be resolved without any handlers', async() => {
+    // If the latch resolves and it internally rejects a promise, it should not
+    // cause an UnhandledPromiseRejectionWarning even if we never await the latch.
+    Latch().resolve();
+
+    // Wait a tick to allow any unhandled microtask rejections to surface.
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }, 100);
+
+  it('accepts invalid then callbacks', async() => {
+    const latch = Latch();
+    // @ts-expect-error - then callback is not a function
+    const chained = latch.then(123);
+    const assertion = expect(chained).resolves.toBe(undefined);
+    setTimeout(() => {
+      latch.resolve();
+    }, 0);
+    await assertion;
+  }, 100);
+
+  it('can chain then without a callback', async() => {
+    const expected = 999;
+    const latch = Latch<typeof expected>();
+    const chained = latch.then();
+    const assertion = expect(chained).resolves.toBe(expected);
+    setTimeout(() => {
+      latch.resolve(expected);
+    }, 0);
+    await assertion;
+  }, 100);
+
+  it('can be rejected', async() => {
+    const error = new Error('test');
+    const latch = Latch();
+    let rejected = false;
+    const assertion = expect(latch).rejects.toThrow(error);
+    setTimeout(() => {
+      expect(rejected).toBe(false);
+      rejected = true;
+      latch.reject(error);
+    }, 0);
+    expect(rejected).toBe(false);
+    await assertion;
+    expect(rejected).toBe(true);
+  }, 100);
+
+  it('can chain catch without a callback', async() => {
+    const error = new Error('test');
+    const latch = Latch();
+    const chained = latch.catch();
+    const assertion = expect(chained).rejects.toThrow(error);
+    setTimeout(() => {
+      latch.reject(error);
+    }, 0);
+    await assertion;
+  }, 100);
+
+  it('accepts invalid catch callbacks', async() => {
+    const latch = Latch();
+    // @ts-expect-error - catch callback is not a function
+    const chained = latch.catch(123);
+    const assertion = expect(chained).rejects.toThrow(new Error('test'));
+    setTimeout(() => {
+      latch.reject(new Error('test'));
+    }, 0);
+    await assertion;
+  }, 100);
+
+  it('can be reset', async() => {
+    const latch = Latch();
+    let resolved = false;
+    const assertion1 = expect(latch).resolves.toBe(undefined);
+    setTimeout(() => {
+      expect(resolved).toBe(false);
+      resolved = true;
+      latch.resolve();
+    }, 0);
+    expect(resolved).toBe(false);
+    await assertion1;
+    expect(resolved).toBe(true);
+
+    latch.reset();
+
+    let rejected = false;
+    const error = new Error('test');
+    const assertion2 = expect(latch).rejects.toThrow(error);
+    setTimeout(() => {
+      expect(rejected).toBe(false);
+      rejected = true;
+      latch.reject(error);
+    }, 0);
+    expect(rejected).toBe(false);
+    await assertion2;
+    expect(rejected).toBe(true);
+  }, 100);
+
+  it('can be reset multiple times', async() => {
+    const latch = Latch();
+    let resolved = false;
+    const assertion1 = expect(latch).resolves.toBe(undefined);
+    setTimeout(() => {
+      expect(resolved).toBe(false);
+      resolved = true;
+      latch.reset();
+      latch.reset();
+      latch.resolve();
+    }, 0);
+    expect(resolved).toBe(false);
+    await assertion1;
+    expect(resolved).toBe(true);
+  }, 100);
+
+  it('can reset while pending', async() => {
+    const latch = Latch();
+    let resolved = false;
+    const assertion = expect(latch).resolves.toBe(undefined);
+    setTimeout(() => {
+      expect(resolved).toBe(false);
+      latch.reset();
+      resolved = true;
+      latch.resolve();
+    }, 0);
+    expect(resolved).toBe(false);
+    await assertion;
+    expect(resolved).toBe(true);
+  }, 100);
+
+  it('runs finally callback', async() => {
+    const latch = Latch();
+    let finallyCalled = false;
+    latch.finally(() => {
+      finallyCalled = true;
+    });
+    const assertion = expect(latch).resolves.toBe(undefined);
+    setTimeout(() => {
+      expect(finallyCalled).toBe(false);
+      latch.resolve();
+    }, 0);
+    expect(finallyCalled).toBe(false);
+    await assertion;
+    expect(finallyCalled).toBe(true);
+  }, 100);
+
+  it('can be resolved before being awaited', async() => {
+    const expected = 42;
+    const latch = Latch<typeof expected>();
+    latch.resolve(expected);
+    await expect(latch).resolves.toBe(expected);
+  });
+});

--- a/pkg/rancher-desktop/utils/latch.ts
+++ b/pkg/rancher-desktop/utils/latch.ts
@@ -1,32 +1,145 @@
+/*
+Copyright © 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Interface Latch is a simple extension on Promise that is resolved via calling
  * a method.  It is essentially a simplified barrier.
  *
  * @see https://en.wikipedia.org/wiki/Barrier_(computer_science)
  */
-interface Latch extends Promise<void> {
+interface Latch<T> extends Promise<T> {
   /** Calling the resolve() method resolves the Latch. */
-  resolve(): void;
+  resolve(value: T): void;
   /** Calling the reject() method rejects the Latch. */
   reject(reason: any): void;
+  /** Calling the reset() method resets the Latch to an unresolved state. */
+  reset(): void;
 }
 
 /**
  * Creates a Latch that is an extension of a Promise that can be resolved via
  * calling a method on that Promise.
  */
-export default function Latch(): Latch {
-  const holder: { resolve?: () => void, reject?: (reason: any) => void } = {};
-  const result: Latch = new Promise<void>((resolve, reject) => {
-    holder.resolve = resolve;
-    holder.reject = reject;
-  }) as any;
-
-  if (!holder.resolve || !holder.reject) {
-    throw new Error('Promise created, but resolve/reject function not set');
+export default function Latch<T = void>(): Latch<T> {
+  /**
+   * ResetState is the enum value of `state.reset` that indicates whether the
+   * latch was settled or reset.  This is used to determine whether we should
+   * return the result of the latch or wait for it to be settled again.
+   */
+  enum ResetState {
+    /** The latch was resolved or rejected. */
+    SETTLED,
+    /** The latch was reset. */
+    RESET,
   }
-  result.resolve = holder.resolve;
-  result.reject = holder.reject;
 
-  return result;
+  /**
+   * The state of the latch, which includes the promise that will be resolved
+   * when the latch is settled and the promise that will be resolved when the
+   * latch is reset.
+   */
+  const state = {
+    promise: Promise.withResolvers<T>(),
+    reset:   Promise.withResolvers<ResetState>(),
+  };
+
+  /** Wait for the latch to be settled, looping while it's reset. */
+  async function waitForSettled() {
+    while (true) {
+      const { promise } = state.promise;
+      const { promise: reset } = state.reset;
+      const [p, r] = await Promise.allSettled([promise, reset]);
+
+      if (r.status === 'fulfilled') {
+        if (r.value === ResetState.SETTLED) {
+          // The latch was resolved; return the resolved value.
+          return p;
+        }
+        // If we get here, the latch was reset; try again.
+      } else {
+        // This should never reject.
+        throw r.reason;
+      }
+    }
+  }
+
+  return {
+    async then(onfulfilled, onrejected) {
+      const result = await waitForSettled();
+
+      if (result.status === 'fulfilled') {
+        // If onfulfilled is not provided, it's implicitly identity, per
+        // ECMA-262 27.2.2.1 step 1.d.i.1; MDN phrases it as:
+        // > If it is not a function, it is internally replaced with an identity
+        // > function ((x) => x) which simply passes the fulfillment value forward.
+        // However, the TypeScript typings here don't have a proper fallback.
+        if (typeof onfulfilled === 'function') {
+          return onfulfilled(result.value);
+        }
+        return Promise.resolve(result.value) as any;
+      } else {
+        if (typeof onrejected === 'function') {
+          return onrejected(result.reason);
+        }
+        return Promise.reject(result.reason);
+      }
+    },
+    async catch(onrejected) {
+      const result = await waitForSettled();
+
+      if (result.status === 'rejected') {
+        if (typeof onrejected === 'function') {
+          return onrejected(result.reason);
+        }
+        return Promise.reject(result.reason);
+      }
+      // The latch was resolved; return the resolved value.
+      return result.value;
+    },
+    async finally(onfinally) {
+      const result = await waitForSettled();
+
+      // The latch was settled; call the finally callback.
+      if (typeof onfinally === 'function') {
+        // If the return value is a promise, await on it so we can propagate
+        // any rejections from it.
+        await Promise.resolve(onfinally());
+      }
+
+      return result.status === 'fulfilled' ? result.value : Promise.reject(result.reason);
+    },
+    resolve(value: T) {
+      state.promise.resolve(value);
+      state.reset.resolve(ResetState.SETTLED);
+    },
+    reject(reason) {
+      state.promise.reject(reason);
+      state.reset.resolve(ResetState.SETTLED);
+    },
+    reset() {
+      const { promise: oldPromise, reset: oldReset } = state;
+      state.promise = Promise.withResolvers<T>();
+      state.reset = Promise.withResolvers<ResetState>();
+      // Settle the previous promises, so that we can check the new ones.
+      oldReset.resolve(ResetState.RESET);
+      // Prevent UnhandledPromiseRejectionWarning, because we don't know what
+      // dummy value to resolve with.
+      oldPromise.promise.catch(() => {});
+      oldPromise.reject(new Error('Latch reset'));
+    },
+    [Symbol.toStringTag]: Promise.prototype[Symbol.toStringTag],
+  };
 }

--- a/pkg/rancher-desktop/utils/latch.ts
+++ b/pkg/rancher-desktop/utils/latch.ts
@@ -30,22 +30,22 @@ interface Latch<T> extends Promise<T> {
 }
 
 /**
+ * ResetState is the enum value of `state.reset` that indicates whether the
+ * latch was settled or reset.  This is used to determine whether we should
+ * return the result of the latch or wait for it to be settled again.
+ */
+enum ResetState {
+  /** The latch was resolved or rejected. */
+  SETTLED,
+  /** The latch was reset. */
+  RESET,
+}
+
+/**
  * Creates a Latch that is an extension of a Promise that can be resolved via
  * calling a method on that Promise.
  */
 export default function Latch<T = void>(): Latch<T> {
-  /**
-   * ResetState is the enum value of `state.reset` that indicates whether the
-   * latch was settled or reset.  This is used to determine whether we should
-   * return the result of the latch or wait for it to be settled again.
-   */
-  enum ResetState {
-    /** The latch was resolved or rejected. */
-    SETTLED,
-    /** The latch was reset. */
-    RESET,
-  }
-
   /**
    * The state of the latch, which includes the promise that will be resolved
    * when the latch is settled and the promise that will be resolved when the
@@ -57,89 +57,59 @@ export default function Latch<T = void>(): Latch<T> {
   };
 
   /** Wait for the latch to be settled, looping while it's reset. */
-  async function waitForSettled() {
+  async function waitForSettled(): Promise<T> {
     while (true) {
-      const { promise } = state.promise;
-      const { promise: reset } = state.reset;
-      const [p, r] = await Promise.allSettled([promise, reset]);
+      // Capture the promises, so if somebody resolves, then resets, we still
+      // return the result of the first resolution.
+      const { reset: { promise: reset }, promise: { promise: p } } = state;
 
-      if (r.status === 'fulfilled') {
-        if (r.value === ResetState.SETTLED) {
-          // The latch was resolved; return the resolved value.
-          return p;
-        }
-        // If we get here, the latch was reset; try again.
-      } else {
-        // This should never reject.
-        throw r.reason;
+      if (await reset === ResetState.SETTLED) {
+        // The latch was settled; return the result.
+        return p;
       }
+      // The latch was reset; loop and wait again with new state.
     }
   }
 
-  return {
-    async then(onfulfilled, onrejected) {
-      const result = await waitForSettled();
-
-      if (result.status === 'fulfilled') {
-        // If onfulfilled is not provided, it's implicitly identity, per
-        // ECMA-262 27.2.2.1 step 1.d.i.1; MDN phrases it as:
-        // > If it is not a function, it is internally replaced with an identity
-        // > function ((x) => x) which simply passes the fulfillment value forward.
-        // However, the TypeScript typings here don't have a proper fallback.
-        if (typeof onfulfilled === 'function') {
-          return onfulfilled(result.value);
-        }
-        return Promise.resolve(result.value) as any;
-      } else {
-        if (typeof onrejected === 'function') {
-          return onrejected(result.reason);
-        }
-        return Promise.reject(result.reason);
-      }
+  return Object.create((Promise.prototype as Latch<T>), {
+    then: {
+      value(onfulfilled?: ((value: T) => any) | null, onrejected?: ((reason: any) => any) | null) {
+        return waitForSettled().then(onfulfilled, onrejected);
+      },
     },
-    async catch(onrejected) {
-      const result = await waitForSettled();
-
-      if (result.status === 'rejected') {
-        if (typeof onrejected === 'function') {
-          return onrejected(result.reason);
-        }
-        return Promise.reject(result.reason);
-      }
-      // The latch was resolved; return the resolved value.
-      return result.value;
+    catch: {
+      value(onrejected?: ((reason: any) => any) | null) {
+        return waitForSettled().catch(onrejected);
+      },
     },
-    async finally(onfinally) {
-      const result = await waitForSettled();
-
-      // The latch was settled; call the finally callback.
-      if (typeof onfinally === 'function') {
-        // If the return value is a promise, await on it so we can propagate
-        // any rejections from it.
-        await Promise.resolve(onfinally());
-      }
-
-      return result.status === 'fulfilled' ? result.value : Promise.reject(result.reason);
+    finally: {
+      value(onfinally?: (() => any) | null) {
+        return waitForSettled().finally(onfinally);
+      },
     },
-    resolve(value: T) {
-      state.promise.resolve(value);
-      state.reset.resolve(ResetState.SETTLED);
+    resolve: {
+      value(value: T) {
+        state.promise.resolve(value);
+        state.reset.resolve(ResetState.SETTLED);
+      },
     },
-    reject(reason) {
-      state.promise.reject(reason);
-      state.reset.resolve(ResetState.SETTLED);
+    reject: {
+      value(reason: any) {
+        state.promise.reject(reason);
+        state.reset.resolve(ResetState.SETTLED);
+      },
     },
-    reset() {
-      const { promise: oldPromise, reset: oldReset } = state;
-      state.promise = Promise.withResolvers<T>();
-      state.reset = Promise.withResolvers<ResetState>();
-      // Settle the previous promises, so that we can check the new ones.
-      oldReset.resolve(ResetState.RESET);
-      // Prevent UnhandledPromiseRejectionWarning, because we don't know what
-      // dummy value to resolve with.
-      oldPromise.promise.catch(() => {});
-      oldPromise.reject(new Error('Latch reset'));
+    reset: {
+      value() {
+        const { reset: oldReset, promise: oldPromise } = state;
+        state.promise = Promise.withResolvers<T>();
+        state.reset = Promise.withResolvers<ResetState>();
+        // Resolve the reset state, so `waitForSettled` will loop.
+        oldReset.resolve(ResetState.RESET);
+        // Attach a catch to the old promise to avoid unhandled rejections if
+        // it was rejected.
+        oldPromise.promise.catch(() => { /* ignore */ });
+      },
     },
-    [Symbol.toStringTag]: Promise.prototype[Symbol.toStringTag],
-  };
+  });
 }


### PR DESCRIPTION
This rewrites the latch class to allow the caller to reset it; this is useful for things like reconnections.

This also adds tests to ensure that we are correctly implementing it.