### PR TITLE
Fix spell check issue

### DIFF
--- a/pkg/rancher-desktop/mixins/vue-select-overrides.js
+++ b/pkg/rancher-desktop/mixins/vue-select-overrides.js
@@ -1,13 +1,13 @@
 export default {
   methods: {
     mappedKeys(map, vm) {
-      // Defaults found at - https://github.com/sagalbot/vue-select/blob/master/src/components/Select.vue#L947
+      // Defaults found at - https://github.com/sagalbot/vue-select/blob/v3.20.4/src/components/Select.vue#L1324
       const out = { ...map };
 
       // tab
       (out[9] = (e) => {
-        // user esc'd
         if (!vm.open) {
+          // Already closed.
           return;
         }
 


### PR DESCRIPTION
The spell checker doesn't like `esc'd` anymore; change the comment so we don't include that string.  Also update the URL nearby so it actually points at a tag, instead of just `master`.

Note that, as far as I can tell, we don't actually use `<LabeledSelect>` anywhere; it's used in `<SortableTable>`, but only when advanced filtering is on, and I don't think that's true for anything we use.

This only changes comments.