### PR TITLE
nerdctl: fix seccomp injection for Windows nerdctl-stub

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/nerdctl
+++ b/pkg/rancher-desktop/assets/scripts/nerdctl
@@ -9,6 +9,12 @@ fi
 # without this; the profile also blocks AF_ALG sockets (CVE-2026-31431).
 SECCOMP_PROFILE=/etc/rancher-desktop/seccomp.json
 if [ -f "$SECCOMP_PROFILE" ]; then
+  # nerdctl-stub (Windows) prepends "--address <sock>" before the subcommand;
+  # strip it here since CONTAINERD_ADDRESS is already exported above.
+  case "$1" in
+    --address|-a) shift 2;;
+    --address=*|-a=*) shift;;
+  esac
   case "$1" in
     run|create)
       has_seccomp=0


### PR DESCRIPTION
The Windows nerdctl-stub calls the wrapper as: `nerdctl --address <sock> run [args]`

This caused the seccomp injection block (`case "$1" in run|create`) to never fire because `$1` was `--address`, not the subcommand.

Strip `--address/-a` at the top of the seccomp block since `CONTAINERD_ADDRESS` is already exported above; after that `$1` is the subcommand as expected.