### PR TITLE
nerdctl-stub: inject seccomp profile for run/create commands

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/nerdctl
+++ b/pkg/rancher-desktop/assets/scripts/nerdctl
@@ -4,33 +4,6 @@ if [ -f /usr/local/openresty/nginx/conf/allowed-images.conf ]; then
   export HTTPS_PROXY=http://127.0.0.1:3128
 fi
 
-# Apply the Docker default seccomp profile unless the caller has already
-# specified a seccomp policy.  nerdctl on WSL2 runs containers unconfined
-# without this; the profile also blocks AF_ALG sockets (CVE-2026-31431).
-SECCOMP_PROFILE=/etc/rancher-desktop/seccomp.json
-if [ -f "$SECCOMP_PROFILE" ]; then
-  case "$1" in
-    run|create)
-      has_seccomp=0
-      prev_security_opt=0
-      for arg in "$@"; do
-        if [ "$prev_security_opt" -eq 1 ]; then
-          case "$arg" in seccomp=*) has_seccomp=1; break;; esac
-          prev_security_opt=0
-        fi
-        case "$arg" in
-          --security-opt=seccomp=*) has_seccomp=1; break;;
-          --security-opt) prev_security_opt=1;;
-        esac
-      done
-      if [ "$has_seccomp" -eq 0 ]; then
-        cmd="$1"; shift
-        set -- "$cmd" "--security-opt" "seccomp=$SECCOMP_PROFILE" "$@"
-      fi
-      ;;
-  esac
-fi
-
 # On WSL, we need to enter the correct pid &c. namespace for nerdctl to work
 # correctly.
 

--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -251,6 +251,7 @@ func parseArgs() (*parsedArgs, error) {
 		_ = cleanupParseArgs()
 		return nil, err
 	}
+	result.args = injectSeccompOpt(result.args)
 	return result, nil
 }
 

--- a/src/go/nerdctl-stub/seccomp.go
+++ b/src/go/nerdctl-stub/seccomp.go
@@ -1,0 +1,68 @@
+package main
+
+import "strings"
+
+const seccompProfile = "/etc/rancher-desktop/seccomp.json"
+
+// injectSeccompOpt splices --security-opt seccomp=<profile> into parsed args
+// for "run" and "create" subcommands (including "container run" / "container
+// create") if no seccomp option is already present.  It is called on the args
+// that the stub assembles and passes to Linux nerdctl, so global flags such as
+// --namespace or --address may precede the subcommand.
+func injectSeccompOpt(args []string) []string {
+	pos := seccompInjectionPos(args)
+	if pos < 0 {
+		return args
+	}
+	for i, arg := range args {
+		if arg == "--security-opt" && i+1 < len(args) && strings.HasPrefix(args[i+1], "seccomp=") {
+			return args
+		}
+		if strings.HasPrefix(arg, "--security-opt=seccomp=") {
+			return args
+		}
+	}
+	out := make([]string, 0, len(args)+2)
+	out = append(out, args[:pos]...)
+	out = append(out, "--security-opt", "seccomp="+seccompProfile)
+	out = append(out, args[pos:]...)
+	return out
+}
+
+// seccompInjectionPos returns the index in args at which --security-opt should
+// be inserted (i.e. one past the subcommand name), or -1 if this is not a
+// command that needs a seccomp profile.
+//
+// It uses the root command's options map to skip global flag–value pairs
+// without hardcoding flag names, so it stays correct as nerdctl adds globals.
+func seccompInjectionPos(args []string) int {
+	rootOpts := commands[""].options
+
+	// Skip over global flags (and their values) to reach the subcommand.
+	i := 0
+	for i < len(args) && strings.HasPrefix(args[i], "-") {
+		flag := args[i]
+		if strings.Contains(flag, "=") {
+			i++ // --flag=value: value is inline, no extra element
+		} else if handler, ok := rootOpts[flag]; ok && handler != nil {
+			i += 2 // flag takes a separate value argument
+		} else {
+			i++ // boolean flag
+		}
+	}
+
+	if i >= len(args) {
+		return -1
+	}
+
+	switch args[i] {
+	case "run", "create":
+		return i + 1
+	case "container":
+		// "container" has no options of its own; the next element is the subcommand.
+		if i+1 < len(args) && (args[i+1] == "run" || args[i+1] == "create") {
+			return i + 2
+		}
+	}
+	return -1
+}

--- a/src/go/nerdctl-stub/seccomp_test.go
+++ b/src/go/nerdctl-stub/seccomp_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeccompInjectionPos(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "run with no global flags",
+			args: []string{"run", "alpine"},
+			want: 1,
+		},
+		{
+			name: "create with no global flags",
+			args: []string{"create", "alpine"},
+			want: 1,
+		},
+		{
+			name: "container run",
+			args: []string{"container", "run", "alpine"},
+			want: 2,
+		},
+		{
+			name: "container create",
+			args: []string{"container", "create", "alpine"},
+			want: 2,
+		},
+		{
+			name: "run after --address (stub path)",
+			args: []string{"--address", "/run/k3s/containerd/containerd.sock", "run", "alpine"},
+			want: 3,
+		},
+		{
+			name: "run after --namespace",
+			args: []string{"--namespace", "buildkit", "run", "alpine"},
+			want: 3,
+		},
+		{
+			name: "run after --debug boolean flag",
+			args: []string{"--debug", "run", "alpine"},
+			want: 2,
+		},
+		{
+			name: "run after --address=... inline value",
+			args: []string{"--address=/run/k3s/containerd/containerd.sock", "run", "alpine"},
+			want: 2,
+		},
+		{
+			name: "not a run/create command",
+			args: []string{"ps"},
+			want: -1,
+		},
+		{
+			name: "container exec (not run/create)",
+			args: []string{"container", "exec", "alpine"},
+			want: -1,
+		},
+		{
+			name: "empty args",
+			args: []string{},
+			want: -1,
+		},
+		{
+			name: "only global flags",
+			args: []string{"--debug"},
+			want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, seccompInjectionPos(tt.args))
+		})
+	}
+}
+
+func TestInjectSeccompOpt(t *testing.T) {
+	t.Parallel()
+	profile := "seccomp=" + seccompProfile
+
+	injected := func(args ...string) []string {
+		pos := seccompInjectionPos(args)
+		out := make([]string, 0, len(args)+2)
+		out = append(out, args[:pos]...)
+		out = append(out, "--security-opt", "seccomp="+seccompProfile)
+		out = append(out, args[pos:]...)
+		return out
+	}
+
+	t.Run("injects for run", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"--address", "/sock", "run", "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, injected(args...), got)
+	})
+
+	t.Run("injects for container run", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"container", "run", "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, injected(args...), got)
+	})
+
+	t.Run("no double inject when --security-opt seccomp= already set", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"run", "--security-opt", profile, "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("no double inject when --security-opt=seccomp= already set", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"run", "--security-opt=" + profile, "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("no double inject when other seccomp profile set", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"run", "--security-opt", "seccomp=/custom.json", "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("no inject for non-run commands", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"ps"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("no inject when caller sets seccomp=unconfined", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"run", "--security-opt", "seccomp=unconfined", "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, args, got)
+	})
+
+	t.Run("injects when --security-opt has a non-seccomp value", func(t *testing.T) {
+		t.Parallel()
+		args := []string{"run", "--security-opt", "no-new-privileges", "alpine"}
+		got := injectSeccompOpt(args)
+		assert.Equal(t, injected(args...), got)
+	})
+}


### PR DESCRIPTION
The previous approach (#10226) injected `--security-opt seccomp=...` in the `/usr/local/bin/nerdctl` shell wrapper.  That worked for direct calls inside the Rancher Desktop VM, but not when the wrapper is invoked via `nerdctl-stub`, because the stub always prepends `--address <sock>` before the subcommand, making `$1` "--address" instead of "run" or "create".

Move the injection into the `nerdctl-stub` Go code instead.  After argument parsing, `injectSeccompOpt()` scans the parsed args, uses the root command's options map to skip global flag-value pairs, and splices `--security-opt seccomp=<profile>` immediately after the subcommand name. This handles all forms:

```
  nerdctl run ...
  nerdctl container run ...
  nerdctl --address <sock> run ...
  nerdctl --namespace buildkit run ...
  nerdctl --address=<sock> run ...
```

The injection is skipped if the caller has already specified any seccomp policy via `--security-opt seccomp=...` or `--security-opt=seccomp=...`

The shell wrapper at `/usr/local/bin/nerdctl` is reverted to its original form.  The stub now covers every userspace path that still needs the profile -- Windows host CLI and WSL integration.  macOS and Linux use a non-vulnerable kernel.