### PR TITLE
wsl-init: remove exploit-path modules to block CVE-2026-43284, CVE-2026-43500, CVE-2026-31431

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -12,6 +12,7 @@ adrg
 airgap
 aks
 alertmanager
+algif
 alibaba
 aliyun
 aliyunecs
@@ -147,6 +148,7 @@ didinit
 diffdisk
 digitalocean
 dirents
+dirtyfrag
 distatus
 distros
 Dlg
@@ -202,6 +204,7 @@ factoryreset
 fakercfile
 fanotify
 fav
+fcrypt
 fdx
 featurename
 FEEEFEEE
@@ -443,6 +446,7 @@ pageup
 parsesection
 pascalize
 pathspec
+pcbc
 pcs
 pdp
 persistentvolume
@@ -524,6 +528,7 @@ resourcequota
 resourceset
 restclient
 restoretip
+reswan
 reusecab
 rioinfo
 rke
@@ -546,6 +551,7 @@ runlevel
 runtimeclass
 runtimeclasses
 rvf
+rxrpc
 scaleio
 scanbenchmark
 scanprofile
@@ -715,6 +721,7 @@ xauth
 XAUTHORITY
 xdev
 xec
+xfrm
 xfs
 xmlout
 xorg

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -664,6 +664,7 @@ unexposing
 unparsable
 upcloud
 Upgradable
+upperdir
 useb
 userdb
 userpreference

--- a/pkg/rancher-desktop/assets/scripts/wsl-init
+++ b/pkg/rancher-desktop/assets/scripts/wsl-init
@@ -71,20 +71,11 @@ fi
 # User impact: in-VM use of IPsec ESP (strongSwan, libreswan), AFS/kAFS, and
 # AF_ALG AEAD will fail.
 #
-# Implementation note — why rm -f works across all WSL distros:
-#   WSL2 provides the kernel modules via a single overlayfs superblock
-#   (mounted with uuid=on) that is set up in the initial kernel namespace
-#   and inherited by every WSL distro via mount-namespace propagation.
-#   Because uuid=on causes the kernel to reuse the same superblock for
-#   any mount with matching parameters, ALL running distros share the
-#   same overlayfs instance and see the same upper-dir state.  A whiteout
-#   written by wsl-init is therefore effective machine-wide, not just
-#   inside the rancher-desktop distro.
-#
-#   The upper dir lives in the WSL2 kernel's volatile rootfs (RAM-based,
-#   discarded on VM shutdown), so whiteouts are automatically cleared when
-#   the VM stops.  wsl-init re-applies them on every boot, giving a clean
-#   apply-on-start / forget-on-stop lifecycle with no cleanup required.
+# WSL2 mounts the kernel modules via a single overlayfs shared by every
+# distro through mount-namespace propagation, so the rm -f below applies
+# machine-wide.  The overlay's upperdir and workdir are in a tmpfs mount,
+# so whiteouts vanish on VM shutdown and wsl-init re-applies them on every
+# boot.
 rm -f \
     /lib/modules/*/kernel/net/ipv4/esp4.ko \
     /lib/modules/*/kernel/net/ipv4/esp4.ko.xz \

--- a/pkg/rancher-desktop/assets/scripts/wsl-init
+++ b/pkg/rancher-desktop/assets/scripts/wsl-init
@@ -47,5 +47,53 @@ if [ -f /var/lib/resolv.conf ]; then
     ln -s -f /var/lib/resolv.conf /etc/resolv.conf
 fi
 
+# Block modules that enable known exploit paths:
+#   esp4/esp6  — dirtyfrag (CVE-2026-43284) XFRM ESP page-cache write primitive;
+#                also blocks Copy_Fail2 (xfrm ESP-in-UDP MSG_SPLICE_PAGES variant)
+#                and its esp6_input IPv6 counterpart
+#   rxrpc      — dirtyfrag (CVE-2026-43500) AF_RXRPC path via pcbc(fcrypt)
+#   algif_aead — copy.fail (CVE-2026-31431) AF_ALG AEAD in-place page-cache write
+#
+# Without these modules the exploits cannot obtain a page-cache write primitive,
+# protecting k3s pods and unprivileged VM processes that are not covered by the
+# container seccomp profile.
+#
+# None of these modules serve a purpose inside the Rancher Desktop VM:
+#   esp4/esp6  implement IPsec ESP, used for site-to-site VPN gateways
+#              (e.g. strongSwan) — the RD VM is not one.
+#   rxrpc      implements the RxRPC protocol, used almost exclusively by
+#              AFS (Andrew File System) — not present in any RD workload.
+#   algif_aead exposes AEAD crypto to userspace via AF_ALG sockets, used
+#              by some crypto libraries to offload to hardware accelerators.
+#              The VM has no hardware crypto, so OpenSSL and friends fall
+#              back to their software implementations transparently.
+#
+# User impact: in-VM use of IPsec ESP (strongSwan, libreswan), AFS/kAFS, and
+# AF_ALG AEAD will fail.
+#
+# Implementation note — why rm -f works across all WSL distros:
+#   WSL2 provides the kernel modules via a single overlayfs superblock
+#   (mounted with uuid=on) that is set up in the initial kernel namespace
+#   and inherited by every WSL distro via mount-namespace propagation.
+#   Because uuid=on causes the kernel to reuse the same superblock for
+#   any mount with matching parameters, ALL running distros share the
+#   same overlayfs instance and see the same upper-dir state.  A whiteout
+#   written by wsl-init is therefore effective machine-wide, not just
+#   inside the rancher-desktop distro.
+#
+#   The upper dir lives in the WSL2 kernel's volatile rootfs (RAM-based,
+#   discarded on VM shutdown), so whiteouts are automatically cleared when
+#   the VM stops.  wsl-init re-applies them on every boot, giving a clean
+#   apply-on-start / forget-on-stop lifecycle with no cleanup required.
+rm -f \
+    /lib/modules/*/kernel/net/ipv4/esp4.ko \
+    /lib/modules/*/kernel/net/ipv4/esp4.ko.xz \
+    /lib/modules/*/kernel/net/ipv6/esp6.ko \
+    /lib/modules/*/kernel/net/ipv6/esp6.ko.xz \
+    /lib/modules/*/kernel/net/rxrpc/rxrpc.ko \
+    /lib/modules/*/kernel/net/rxrpc/rxrpc.ko.xz \
+    /lib/modules/*/kernel/crypto/algif_aead.ko \
+    /lib/modules/*/kernel/crypto/algif_aead.ko.xz
+
 # Run init (which never exits).
 exec /sbin/init


### PR DESCRIPTION
Blocks all known exploit paths by removing the kernel modules they require:

- **`esp4` / `esp6`** — dirtyfrag (CVE-2026-43284) XFRM ESP page-cache write primitive; also blocks Copy_Fail2 (xfrm ESP-in-UDP `MSG_SPLICE_PAGES` variant) and its `esp6_input` IPv6 counterpart.
- **`rxrpc`** — dirtyfrag (CVE-2026-43500) AF_RXRPC path via `pcbc(fcrypt)`.
- **`algif_aead`** — copy.fail (CVE-2026-31431) AF_ALG AEAD in-place page-cache write.

## Defense impact

Without these modules the exploits cannot obtain a page-cache write primitive, protecting k3s pods and unprivileged VM processes that are not covered by the container seccomp profile.

## Why removal is safe

None of these modules serve a purpose inside the Rancher Desktop VM:

- **`esp4` / `esp6`** implement IPsec ESP, used for site-to-site VPN gateways (e.g. strongSwan) — not a role the RD VM plays.
- **`rxrpc`** implements the RxRPC protocol, used almost exclusively by AFS (Andrew File System) — not present in any RD workload.
- **`algif_aead`** exposes AEAD crypto to userspace via AF_ALG sockets, used by some crypto libraries to offload to hardware accelerators. The VM has no hardware crypto, so OpenSSL and friends fall back to their software implementations transparently.

## User impact

In-VM use of IPsec ESP (strongSwan, libreswan), AFS/kAFS, and AF_ALG AEAD will fail.

## Implementation note: why `rm -f` works across all WSL distros

WSL2 provides the kernel modules via a single overlayfs superblock (mounted with `uuid=on`) that is set up in the initial kernel namespace and inherited by every WSL distro via mount-namespace propagation. Because `uuid=on` causes the kernel to reuse the same superblock for any mount with matching parameters, all running distros share the same overlayfs instance and see the same upper-dir state. A whiteout written by `wsl-init` is therefore effective machine-wide, not just inside the rancher-desktop distro.

The upper dir lives in the WSL2 kernel's volatile rootfs (RAM-based, discarded on VM shutdown), so whiteouts are automatically cleared when the VM stops. `wsl-init` re-applies them on every boot, giving a clean apply-on-start / forget-on-stop lifecycle with no cleanup required.
