### PR TITLE
procnet: don't shadow CNI portmap with PREROUTING DNAT

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -154,11 +154,12 @@ distros
 Dlg
 dlgbmp
 dlicense
-DNAT
+dnat
 dnsmasq
 doclink
 donotuse
 dport
+dpts
 dri
 Duex
 dustin
@@ -393,6 +394,7 @@ neu
 newauth
 newfs
 newpid
+nft
 nginx
 ngx
 ninep
@@ -485,6 +487,7 @@ projectroletemplatebinding
 Prometheis
 prometheusrule
 PROMPTROLLBACKCOST
+prot
 protip
 PROXYLIST
 PSelected
@@ -726,6 +729,7 @@ xfrm
 xfs
 xmlout
 xorg
+xtables
 XVar
 xwininfo
 xyzzy

--- a/src/go/guestagent/pkg/procnet/scanner_linux.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux.go
@@ -22,10 +22,12 @@ package procnet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +49,71 @@ const (
 
 const routeLocalnet = "/proc/sys/net/ipv4/conf/eth0/route_localnet"
 
+// portAlreadyExposedSubstring is the substring tracker.Add returns when
+// another component has already exposed the port (typically the
+// containerd or docker events handler on /tasks/start). The string
+// originates in the /services/forwarder/expose API response and survives
+// the tracker's wrapping. ForwardPorts treats this case as success: the
+// engine has wired up the authoritative CNI rule, leaving procnet
+// nothing to do.
+const portAlreadyExposedSubstring = "proxy already running"
+
+// portState records what procnet has done for a port currently observed
+// on /proc/net.
+//
+//	bindings: the binding set captured at first sighting.
+//	delegated: an engine owns the proxy. Set when an engine chain
+//	  (CNI-HOSTPORT-DNAT or DOCKER) already references the port, OR
+//	  when tracker.Add returns portAlreadyExposedSubstring against an
+//	  ID procnet does not already own. The cleanup path must skip
+//	  tracker.Remove in this case -- the engine owns the tracker entry
+//	  under its container ID, and our synthetic ID would walk an empty
+//	  portStorage entry.
+//	appendFailed: a previous tick succeeded at tracker.Add but failed
+//	  at execLoopbackIPtablesRule (typically xtables lock contention).
+//	  The next tick retries only the iptables Append, leaving the
+//	  tracker entry alone.
+//
+// State machine for a single port:
+//
+//	First sighting: defer until next tick (stability gate filters out
+//	  the OCI createRuntime hook's transient reservation socket).
+//	Second sighting: probe engine chain.
+//	  Engine-managed: delegate (delegated=true); no tracker.Add.
+//	  Not engine-managed: tracker.Add.
+//	    Succeeds: Append iptables rule; record success or
+//	      appendFailed=true on transient error.
+//	    "proxy already running": classify via tracker.Get(synthetic).
+//	      We own it: resume ownership (delegated=false, partial-failure
+//	        retry path -- apiForwarder.Expose succeeded on an earlier
+//	        tick but wsl-proxy.Send failed, leaving portStorage
+//	        populated).
+//	      Engine owns it: delegate (delegated=true).
+//	    Other error: log once at Error, retry quietly next tick.
+//	Listener disappears:
+//	  Delegated: drop the local marker; the engine's events handler
+//	    does the unexpose under its container ID.
+//	  Owned: tracker.Remove + iptables Delete; retain the entry on
+//	    transient Delete error so the next tick retries.
+//
+// The full state machine is covered end-to-end by published-ports.bats;
+// a portStateTracker extraction with an injectable tracker.Tracker would
+// make the transitions unit-testable.
+type portState struct {
+	bindings     []nat.PortBinding
+	delegated    bool
+	appendFailed bool
+}
+
+// dnatRuleRe matches a single DNAT rule line in `iptables --list <chain>
+// --numeric` output. Capture groups: (1) protocol (tcp|udp), then ONE of
+// (2) single-port `dpt:N` or (3) multiport list `dports N[,N…]`. The
+// port-range form `dpts:LO:HI` is intentionally NOT matched; see
+// dnatChainContainsPort for the rationale.
+var dnatRuleRe = regexp.MustCompile(
+	`\b(tcp|udp)\b[^\n]*?(?:dpt:([0-9]+)|dports ([0-9]+(?:,[0-9]+)*))\b`,
+)
+
 type ProcNetScanner struct {
 	context       context.Context
 	LocalnetRoute bool
@@ -66,7 +133,31 @@ func (p *ProcNetScanner) ForwardPorts() error {
 	ticker := time.NewTicker(p.scanInterval)
 	defer ticker.Stop()
 
-	var previousPortMap nat.PortMap
+	// seenLastScan holds the ports observed in the previous tick. The
+	// stability gate exposes only ports seen in two consecutive scans,
+	// filtering out the transient reservation socket that nerdctl's OCI
+	// createRuntime hook opens before CNI installs its iptables rules.
+	// Without the gate, the engine-chain probe below sees no rule yet,
+	// the rogue PREROUTING DNAT lands, and the eventual
+	// CNI-HOSTPORT-DNAT entry stays shadowed for the container's
+	// lifetime.
+	//
+	// The gate costs one tick (~3 s) before genuine --network=host
+	// listeners reach the host. Bridge-network ports are unaffected;
+	// the containerd/docker events handler exposes them via tracker.Add
+	// on /tasks/start. Revisit if the 3 s delay becomes a real
+	// complaint -- a pid/cgroup classifier could remove the latency at
+	// the cost of fragile /proc traversal (the process may exit before
+	// the read, comm names drift across engine renames, and cgroup
+	// inspection is the most invasive).
+	//
+	// See the portState type comment for the full state machine.
+	// addErrorLogged drops the Errorf to Debugf after the first failed
+	// tracker.Add for a port, preventing a 3-second retry-storm log
+	// flood when host-switch or wsl-proxy stays down.
+	var seenLastScan nat.PortMap
+	added := make(map[nat.Port]portState)
+	addErrorLogged := make(map[nat.Port]bool)
 
 	for {
 		select {
@@ -86,60 +177,192 @@ func (p *ProcNetScanner) ForwardPorts() error {
 				}
 			}
 
-			// Add new ports
+			// Add ports observed in two consecutive scans (stability gate).
 			for port, bindings := range newPortMap {
-				if _, exists := previousPortMap[port]; !exists {
-					log.Infof("/proc/net scanner added port: %s -> %+v", port, bindings)
-					err := p.tracker.Add(utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())), nat.PortMap{
-						port: bindings,
-					})
-					if err != nil {
+				if state, alreadyAdded := added[port]; alreadyAdded {
+					// Retry the iptables Append for a port whose previous
+					// tick failed only on the rule write. tracker.Add is
+					// not reissued -- the tracker entry already exists.
+					if state.appendFailed {
+						if err := p.execLoopbackIPtablesRule(state.bindings, port, Append); err != nil {
+							log.Debugf("/proc/net scanner retry of iptables Append for %s still failing: %s", port, err)
+						} else {
+							state.appendFailed = false
+							added[port] = state
+							log.Infof("/proc/net scanner installed deferred iptables rule for port: %s", port)
+						}
+					}
+					continue
+				}
+				if _, sawLastScan := seenLastScan[port]; !sawLastScan {
+					log.Debugf("/proc/net scanner deferring port %s on first sighting", port)
+					continue
+				}
+				// Engine-chain probe before tracker.Add. When the engine
+				// already manages the port (its CNI/DOCKER chain rule is
+				// in place), delegate ownership entirely: skip tracker.Add
+				// and the iptables Append, mark the local state delegated,
+				// and let the engine's events handler own the proxy. This
+				// closes the race where procnet wins tracker.Add against a
+				// not-yet-fired events handler and ties the proxy lifetime
+				// to /proc/net observation instead of the container's. A
+				// transient probe error defers the port without orphaning
+				// state.
+				managed, err := p.engineManagesLoopbackBinding(port, bindings)
+				if err != nil {
+					log.Errorf("/proc/net scanner engine-chain probe failed for %s; deferring: %s", port, err)
+					continue
+				}
+				if managed {
+					log.Debugf("/proc/net scanner delegating port %s to engine-managed chain", port)
+					added[port] = portState{bindings: bindings, delegated: true}
+					delete(addErrorLogged, port)
+					continue
+				}
+				syntheticID := utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))
+				if err := p.tracker.Add(syntheticID, nat.PortMap{port: bindings}); err != nil {
+					if strings.Contains(err.Error(), portAlreadyExposedSubstring) {
+						// "proxy already running" reaches us in two shapes.
+						// Genuine engine delegation: the engine's events
+						// handler called tracker.Add first under its
+						// container ID; gvisor-tap-vsock has the proxy and
+						// our synthetic Add lost the race. Mark delegated
+						// so cleanup leaves the engine's proxy alone.
+						// Partial-failure retry: a prior tick succeeded at
+						// apiForwarder.Expose (so gvisor-tap-vsock has the
+						// proxy and portStorage[synthetic] is populated)
+						// but failed downstream (typically wsl-proxy.Send).
+						// The substring is the same, but we own the entry;
+						// delegating would skip the cleanup we still need.
+						// portStorage[synthetic] tells the two apart.
+						if len(p.tracker.Get(syntheticID)) > 0 {
+							log.Debugf("/proc/net scanner port %s already added by procnet; resuming ownership after partial-failure retry", port)
+							added[port] = portState{bindings: bindings, delegated: false}
+							delete(addErrorLogged, port)
+							continue
+						}
+						log.Debugf("/proc/net scanner port %s already exposed elsewhere, delegating", port)
+						added[port] = portState{bindings: bindings, delegated: true}
+						delete(addErrorLogged, port)
+						continue
+					}
+					if addErrorLogged[port] {
+						log.Debugf("/proc/net scanner still failing to add port %s: %s", port, err)
+					} else {
 						log.Errorf("/proc/net scanner failed to add port: %s", err)
-						continue
+						addErrorLogged[port] = true
 					}
-					if err = p.execLoopbackIPtablesRule(bindings, port, Append); err != nil {
-						log.Errorf("/proc/net scanner creating loopback iptable rules for portbinding: %v failed: %s", bindings, err)
-					}
+					continue
+				}
+				delete(addErrorLogged, port)
+				log.Infof("/proc/net scanner added port: %s -> %+v", port, bindings)
+				appendErr := p.execLoopbackIPtablesRule(bindings, port, Append)
+				if appendErr != nil {
+					// Retain the entry with appendFailed=true; the next
+					// tick retries only the iptables Append. Symmetric
+					// with the Delete-side retry below -- a transient
+					// iptables error must not silently drop the rule.
+					log.Errorf("/proc/net scanner creating loopback iptable rules for portbinding: %v failed: %s", bindings, appendErr)
+				}
+				added[port] = portState{
+					bindings:     bindings,
+					delegated:    false,
+					appendFailed: appendErr != nil,
 				}
 			}
 
-			// Remove old ports
-			for port, previousBindings := range previousPortMap {
+			// Remove ports we exposed once their listener disappears.
+			for port, state := range added {
+				if _, exists := newPortMap[port]; exists {
+					continue
+				}
+				if state.delegated {
+					// Engine owns the tracker entry and (if present) the
+					// iptables rule. Drop the local marker without touching
+					// either.
+					log.Debugf("/proc/net scanner cleaning up delegated port: %s", port)
+					delete(added, port)
+					continue
+				}
+				log.Infof("/proc/net scanner removed port: %s -> %+v", port, state.bindings)
+				if err := p.tracker.Remove(utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))); err != nil {
+					log.Errorf("/proc/net scanner failed to remove port: %s", err)
+					continue
+				}
+				if err := p.execLoopbackIPtablesRule(state.bindings, port, Delete); err != nil {
+					// Retain the `added` entry so we retry the iptables
+					// Delete on the next tick. Without this, a transient
+					// probe error leaks a real PREROUTING rule (the leak
+					// self-cleans on RD restart, but is a long-lived
+					// artifact otherwise).
+					log.Errorf("/proc/net scanner deleting loopback iptable rules for portbinding: %v failed: %s", state.bindings, err)
+					continue
+				}
+				delete(added, port)
+			}
+
+			// Drop log-suppression markers for ports that disappeared
+			// without ever entering `added`. Their next sighting starts a
+			// fresh first-error cycle.
+			for port := range addErrorLogged {
 				if _, exists := newPortMap[port]; !exists {
-					log.Infof("/proc/net scanner removed port: %s -> %+v", port, previousBindings)
-					err := p.tracker.Remove(utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port())))
-					if err != nil {
-						log.Errorf("/proc/net scanner failed to remove port: %s", err)
-						continue
-					}
-
-					if err = p.execLoopbackIPtablesRule(previousBindings, port, Delete); err != nil {
-						log.Errorf("/proc/net scanner deleting loopback iptable rules for portbinding: %v failed: %s", previousBindings, err)
-					}
+					delete(addErrorLogged, port)
 				}
 			}
 
-			previousPortMap = newPortMap
+			// newPortMap is rebuilt with make() on the next iteration, so
+			// this alias is safe; do not reuse newPortMap below this line.
+			seenLastScan = newPortMap
 		}
 	}
 }
 
-// execLoopbackIPtablesRule modifies iptables NAT rules to handle loopback traffic for a specified port
-// and protocol. This function is only necessary when the container is using the host network driver
-// (i.e., with --network=host), as in this case the container shares the host's network namespace.
+// engineManagesLoopbackBinding probes container-engine chains for any
+// 127.0.0.1 binding of the port. Returns (true, nil) if any engine chain
+// already manages the port (the caller must skip the procnet Append for
+// that port); (false, nil) if no engine chain does; (false, err) on
+// transient iptables error (the caller is expected to defer the port to
+// the next scan).
+func (p *ProcNetScanner) engineManagesLoopbackBinding(port nat.Port, bindings []nat.PortBinding) (bool, error) {
+	for _, binding := range bindings {
+		if binding.HostIP != "127.0.0.1" {
+			continue
+		}
+		managed, err := engineChainManagesPort(p.context, port.Proto(), binding.HostPort)
+		if err != nil {
+			return false, fmt.Errorf("%s/%s: %w", port.Proto(), binding.HostPort, err)
+		}
+		if managed {
+			log.Debugf("skipping PREROUTING DNAT for %s/%s: port already managed by container engine chain",
+				port.Proto(), binding.HostPort)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// execLoopbackIPtablesRule appends or deletes the loopback PREROUTING
+// DNAT rule for any 127.0.0.1 binding of the port. This function is
+// only meaningful for --network=host containers, where traffic bound to
+// 127.0.0.1 has to be redirected from outside the network namespace.
 //
-// When using the host network driver, network traffic bound to 127.0.0.1 needs to be redirected from
-// outside the network namespace to the localhost (127.0.0.1). This function adds or removes DNAT rules
-// that allow traffic to be forwarded to the specified port on localhost, based on the provided 'action'
-// ('append' or 'delete').
+// The Append path relies on the caller (ForwardPorts, via
+// engineManagesLoopbackBinding) having already verified that no
+// container-engine chain manages the port. On iptables-nft (the
+// default on supported WSL2 kernels) DNAT in PREROUTING terminates
+// the chain, so a procnet rule for an engine-managed port shadows the
+// engine's authoritative rule and hangs external traffic. Both the
+// bug and the fix depend on this chain-terminating behavior; revisit
+// the probes if the kernel default changes.
 //
-// The function iterates over the provided list of port bindings. For each binding where the HostIP is set
-// to 127.0.0.1, it constructs and executes the corresponding iptables command to either add or delete the
-// appropriate DNAT rule.
-//
-// The iptables rule ensures that incoming traffic from outside the network namespace (i.e., from the
-// host machine) on the specified port and protocol is redirected to the same port on localhost, where the
-// container's service can be accessed.
+// Both paths probe preroutingHasLoopbackRule first. The Delete probe
+// avoids logging spurious errors for rules we never wrote. The Append
+// probe is the idempotency gate: when the rule already exists (because
+// a previous tick's iptables call committed the rule but returned
+// non-zero, or an external party wrote the same rule), the second
+// Append would otherwise install a duplicate PREROUTING DNAT, and a
+// later Delete would remove only one of the pair. Both probes return
+// the probe error on transient failure so the caller can defer.
 //
 // Example iptables rule when 'action' is "append":
 //
@@ -150,25 +373,173 @@ func (p *ProcNetScanner) ForwardPorts() error {
 //	iptables -t nat -D PREROUTING -p tcp --dport 8009 -j DNAT --to-destination 127.0.0.1:8009
 func (p *ProcNetScanner) execLoopbackIPtablesRule(bindings []nat.PortBinding, portProto nat.Port, action action) error {
 	for _, binding := range bindings {
-		if binding.HostIP == "127.0.0.1" {
-			// iptables -t nat -D PREROUTING -p tcp --dport 8009 -j DNAT --to-destination 127.0.0.1:8009
-			//nolint:gosec // None of the arguments are user-supplied.
-			iptablesCmd := exec.CommandContext(p.context,
-				"iptables",
-				"--table", "nat",
-				fmt.Sprintf("--%s", action), "PREROUTING",
-				"--protocol", portProto.Proto(),
-				"--dport", binding.HostPort,
-				"--jump", "DNAT",
-				"--to-destination", fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort),
-			)
-			if err := iptablesCmd.Run(); err != nil {
-				return err
-			}
-			log.Debugf("running the following iptables rule [%s] for port bindings: %v", iptablesCmd.String(), binding)
+		if binding.HostIP != "127.0.0.1" {
+			continue
 		}
+		exists, err := preroutingHasLoopbackRule(p.context, portProto.Proto(), binding.HostPort)
+		if err != nil {
+			return fmt.Errorf("iptables --check for %s/%s: %w", portProto.Proto(), binding.HostPort, err)
+		}
+		if action == Delete && !exists {
+			log.Debugf("skipping PREROUTING DNAT delete for %s/%s: rule not present",
+				portProto.Proto(), binding.HostPort)
+			continue
+		}
+		if action == Append && exists {
+			log.Debugf("skipping PREROUTING DNAT append for %s/%s: rule already present",
+				portProto.Proto(), binding.HostPort)
+			continue
+		}
+		// iptables -t nat --wait 2 -<A|D> PREROUTING -p tcp --dport 8009 -j DNAT --to-destination 127.0.0.1:8009
+		//nolint:gosec // None of the arguments are user-supplied.
+		iptablesCmd := exec.CommandContext(p.context,
+			"iptables",
+			"--wait", "2",
+			"--table", "nat",
+			fmt.Sprintf("--%s", action), "PREROUTING",
+			"--protocol", portProto.Proto(),
+			"--dport", binding.HostPort,
+			"--jump", "DNAT",
+			"--to-destination", fmt.Sprintf("%s:%s", binding.HostIP, binding.HostPort),
+		)
+		if err := iptablesCmd.Run(); err != nil {
+			return err
+		}
+		log.Debugf("running the following iptables rule [%s] for port bindings: %v", iptablesCmd.String(), binding)
 	}
 	return nil
+}
+
+// engineChainManagesPort reports whether a container-engine chain
+// already references the port as a DNAT destination for protocol.
+// When true, procnet must not add its own PREROUTING DNAT.
+//
+// The chain list is closed to the two engines Rancher Desktop ships
+// (CNI-HOSTPORT-DNAT for nerdctl/CNI portmap, DOCKER for docker).
+// Revisit (and update this docstring) when adding a third engine;
+// otherwise the helper silently misses its DNAT rules and the original
+// shadow-DNAT bug reappears.
+//
+// Returns (false, nil) when a chain does not exist (the engine has not
+// yet created it). Returns (false, err) on transient iptables failure
+// (xtables lock contention, fork/exec failure) so the caller can defer
+// the port to a later scan; mirrors the precedent at
+// pkg/iptables/iptables.go that treats exit status 4 as transient.
+// Shells out to iptables directly; end-to-end behavior is covered by
+// published-ports.bats. Distinguishing absent from transient errors
+// is unit-tested through isIptablesRuleAbsent.
+func engineChainManagesPort(ctx context.Context, protocol, port string) (bool, error) {
+	for _, chain := range []string{"CNI-HOSTPORT-DNAT", "DOCKER"} {
+		cmd := exec.CommandContext(ctx,
+			"iptables",
+			"--wait", "2",
+			"--table", "nat",
+			"--list", chain,
+			"--numeric")
+		out, err := cmd.Output()
+		if err != nil {
+			if isIptablesRuleAbsent(err) {
+				continue
+			}
+			return false, fmt.Errorf("iptables --list %s: %w", chain, err)
+		}
+		if dnatChainContainsPort(string(out), protocol, port) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// dnatChainContainsPort reports whether `iptables --list <chain>
+// --numeric` output references port as a DNAT destination for protocol.
+// It matches both the single-port form (`tcp dpt:<port>`) and the
+// multiport list form (`tcp multiport dports <port>[,…]`). Word
+// boundaries prevent matching `80` against `8080` or against IP-address
+// octets in `to:` clauses.
+//
+// Limitation: port-range syntax in either form is NOT matched. The
+// standalone single-rule range (`tcp dpts:LO:HI`) is ignored entirely;
+// the multiport-embedded range (`multiport dports 80,1000:2000,3000`)
+// is captured only up to the first colon, so individual ports listed
+// before the colon match while ports inside (or after) the range are
+// missed. The engines Rancher Desktop ships (nerdctl-CNI portmap and
+// docker) emit per-port DNAT rules even for `-p LO-HI:LO-HI`
+// publishes, so both gaps are theoretical for shipped engines but
+// real for hand-rolled iptables setups that target the same chains.
+// The dpts: and embedded-range fixtures in the test file lock the
+// current (intentional) miss.
+func dnatChainContainsPort(out, protocol, port string) bool {
+	for _, m := range dnatRuleRe.FindAllStringSubmatch(out, -1) {
+		if m[1] != protocol {
+			continue
+		}
+		if m[2] != "" && m[2] == port {
+			return true
+		}
+		if m[3] != "" {
+			for _, p := range strings.Split(m[3], ",") {
+				if p == port {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// preroutingHasLoopbackRule reports whether the exact PREROUTING DNAT
+// rule execLoopbackIPtablesRule would Append already exists. Gates the
+// Delete path so we do not log errors for rules we never wrote.
+//
+// Returns (false, nil) when iptables reports the rule is absent (the
+// expected case when the Append was previously skipped or cleaned up
+// out of band). Returns (false, err) on transient iptables failure so
+// the caller can defer the Delete rather than dropping `added` state
+// and leaking the rule until RD restart.
+func preroutingHasLoopbackRule(ctx context.Context, protocol, port string) (bool, error) {
+	cmd := exec.CommandContext(ctx,
+		"iptables",
+		"--wait", "2",
+		"--table", "nat",
+		"--check", "PREROUTING",
+		"--protocol", protocol,
+		"--dport", port,
+		"--jump", "DNAT",
+		"--to-destination", fmt.Sprintf("127.0.0.1:%s", port),
+	)
+	// cmd.Output() so the ExitError carries stderr for isIptablesRuleAbsent.
+	if _, err := cmd.Output(); err != nil {
+		if isIptablesRuleAbsent(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// isIptablesRuleAbsent reports whether an iptables --check or --list
+// failure indicates that the rule or chain does not exist. The
+// canonical iptables stderr messages we treat as "absent" are:
+//
+//	No chain/target/match by that name        -- chain does not exist
+//	Bad rule (does a matching rule exist ...) -- rule does not exist
+//
+// Every other failure mode (exit status 4 from xtables lock
+// contention, fork/exec failure, invalid-argument errors, etc.)
+// returns false so the caller bubbles the error and defers the scan.
+// "Absent" here means a steady-state "no" the caller can act on now;
+// anything else might succeed on the next tick.
+func isIptablesRuleAbsent(err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	stderr := string(exitErr.Stderr)
+	return strings.Contains(stderr, "No chain/target/match by that name") ||
+		strings.Contains(stderr, "does a matching rule exist in that chain")
 }
 
 func addValidProtoEntryToPortMap(entry procnettcp.Entry, portMap nat.PortMap) error {

--- a/src/go/guestagent/pkg/procnet/scanner_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright © 2026 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procnet
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/tracker"
+	guestagentTypes "github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/types"
+)
+
+func TestDnatChainContainsPort(t *testing.T) {
+	const cniSinglePort = `Chain CNI-HOSTPORT-DNAT (1 references)
+target     prot opt source               destination
+CNI-DN-040d482914fc21368006e  tcp  --  0.0.0.0/0            0.0.0.0/0            /* dnat name: "bridge" id: "default-abc" */ multiport dports 8080
+`
+
+	const cniMultiplePorts = `Chain CNI-HOSTPORT-DNAT (1 references)
+target     prot opt source               destination
+CNI-DN-aaaaaaaaaaaaaaaaaaaaaaaa  tcp  --  0.0.0.0/0            0.0.0.0/0            /* dnat name: "bridge" id: "default-aaa" */ multiport dports 80,8080,8443
+`
+
+	const dockerChain = `Chain DOCKER (2 references)
+target     prot opt source               destination
+RETURN     all  --  0.0.0.0/0            0.0.0.0/0
+DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:80 to:172.17.0.2:80
+`
+
+	const onlyHeader = `Chain CNI-HOSTPORT-DNAT (0 references)
+target     prot opt source               destination
+`
+
+	// Pitfall: ports that also appear as IP octets. Searching for 80 must
+	// not match "10.4.0.80", and searching for 8000 must not match
+	// "to:...:8000" -- the regex anchors on dport, not on the destination.
+	const ipOctetLooksLikePort = `Chain DOCKER (1 references)
+target     prot opt source               destination
+DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:9000 to:10.4.0.80:8000
+`
+
+	// UDP rule with the same port number as a TCP probe: must NOT match.
+	// This is the cross-protocol failure mode the engineChainManagesPort
+	// protocol parameter exists to prevent.
+	const udpOnlyChain = `Chain DOCKER (1 references)
+target     prot opt source               destination
+DNAT       udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:53 to:172.17.0.2:53
+`
+
+	// Both TCP and UDP rules on the same port in the same chain. A TCP
+	// probe matches the TCP line; a UDP probe matches the UDP line.
+	const tcpAndUdpSamePort = `Chain DOCKER (2 references)
+target     prot opt source               destination
+DNAT       udp  --  0.0.0.0/0            0.0.0.0/0            udp dpt:53 to:172.17.0.2:53
+DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpt:53 to:172.17.0.3:53
+`
+
+	// Port-range form `tcp dpts:LO:HI` is intentionally not matched; the
+	// engines RD ships emit per-port rules. Lock the current behavior so
+	// any future range-matching support is a deliberate change.
+	const tcpRangeChain = `Chain DOCKER (1 references)
+target     prot opt source               destination
+DNAT       tcp  --  0.0.0.0/0            0.0.0.0/0            tcp dpts:8000:9000 to:127.0.0.1
+`
+
+	// Multiport with an embedded range: `dports 80,1000:2000,3000`.
+	// The regex captures up to the first colon, so 80 and 1000 match but
+	// 1500 (inside the range) and 3000 (after the range) do not.
+	const multiportEmbeddedRange = `Chain CNI-HOSTPORT-DNAT (1 references)
+target     prot opt source               destination
+CNI-DN-aaaaaaaaaaaaaaaaaaaaaaaa  tcp  --  0.0.0.0/0            0.0.0.0/0            multiport dports 80,1000:2000,3000
+`
+
+	tests := []struct {
+		name     string
+		output   string
+		protocol string
+		port     string
+		want     bool
+	}{
+		{"empty output", "", "tcp", "8080", false},
+		{"chain header only", onlyHeader, "tcp", "8080", false},
+
+		{"single CNI dport matches exact", cniSinglePort, "tcp", "8080", true},
+		{"single CNI dport does not match prefix 80", cniSinglePort, "tcp", "80", false},
+		{"single CNI dport does not match unrelated 8081", cniSinglePort, "tcp", "8081", false},
+		{"single CNI dport does not match suffix 080", cniSinglePort, "tcp", "080", false},
+
+		{"multiport list matches first entry", cniMultiplePorts, "tcp", "80", true},
+		{"multiport list matches middle entry", cniMultiplePorts, "tcp", "8080", true},
+		{"multiport list matches last entry", cniMultiplePorts, "tcp", "8443", true},
+		{"multiport list does not match unrelated 8000", cniMultiplePorts, "tcp", "8000", false},
+
+		{"DOCKER dpt: matches", dockerChain, "tcp", "80", true},
+		{"DOCKER dpt: does not match unrelated 8080", dockerChain, "tcp", "8080", false},
+
+		{"IP octet 10.4.0.80 does not match port 80", ipOctetLooksLikePort, "tcp", "80", false},
+		{"destination port :8000 does not match port 8000", ipOctetLooksLikePort, "tcp", "8000", false},
+		{"dpt:9000 still matches port 9000", ipOctetLooksLikePort, "tcp", "9000", true},
+
+		{"udp rule does not match tcp probe on same port", udpOnlyChain, "tcp", "53", false},
+		{"udp rule matches udp probe on same port", udpOnlyChain, "udp", "53", true},
+		{"tcp probe matches tcp line in mixed chain", tcpAndUdpSamePort, "tcp", "53", true},
+		{"udp probe matches udp line in mixed chain", tcpAndUdpSamePort, "udp", "53", true},
+		{"multiport with tcp probe does not match unrelated udp", cniMultiplePorts, "udp", "80", false},
+
+		{"dpts:8000:9000 does not match port 8500 (range form unsupported)", tcpRangeChain, "tcp", "8500", false},
+		{"dpts:8000:9000 does not match port 8000 (range form unsupported)", tcpRangeChain, "tcp", "8000", false},
+
+		{"multiport with embedded range matches pre-range single 80", multiportEmbeddedRange, "tcp", "80", true},
+		{"multiport with embedded range matches pre-range single 1000", multiportEmbeddedRange, "tcp", "1000", true},
+		{"multiport with embedded range does not match port inside range 1500", multiportEmbeddedRange, "tcp", "1500", false},
+		{"multiport with embedded range does not match port after range 3000", multiportEmbeddedRange, "tcp", "3000", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, dnatChainContainsPort(tt.output, tt.protocol, tt.port))
+		})
+	}
+}
+
+func TestIsIptablesRuleAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"non-exit error", errors.New("fork failure"), false},
+		{
+			"missing chain",
+			&exec.ExitError{Stderr: []byte("iptables: No chain/target/match by that name.\n")},
+			true,
+		},
+		{
+			"missing rule",
+			&exec.ExitError{Stderr: []byte("iptables: Bad rule (does a matching rule exist in that chain?).\n")},
+			true,
+		},
+		{
+			"xtables lock contention",
+			&exec.ExitError{Stderr: []byte("Another app is currently holding the xtables lock; still 1s 0us time ahead to have a chance to grab the lock...\n")},
+			false,
+		},
+		{
+			"unrelated stderr",
+			&exec.ExitError{Stderr: []byte("iptables v1.8.11: invalid port/service `99999' specified\n")},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isIptablesRuleAbsent(tt.err))
+		})
+	}
+}
+
+// TestPortAlreadyExposedSubstringIsReachable pins the substring contract
+// that the procnet delegation path depends on. The substring originates
+// in gvisor-tap-vsock's host-port forwarder; the response body passes
+// through forwarder.verifyResponseBody ("%w: %s" wrap of ErrAPI), then
+// through tracker.APITracker.Add ("%w: %+v" wrap of ErrExposeAPI). If
+// either wrap layer ever drops the body, or upstream renames the
+// message, this test fails before the procnet scanner silently regresses.
+func TestPortAlreadyExposedSubstringIsReachable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("host port forwarding: cannot expose 127.0.0.1:8080: proxy already running"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tr := tracker.NewAPITracker(context.Background(), &noopForwarder{}, srv.URL, "192.168.127.2", true)
+
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	addErr := tr.Add("synthetic-tcp-8080", nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "8080"}},
+	})
+	require.Error(t, addErr)
+	require.Contains(t, addErr.Error(), portAlreadyExposedSubstring,
+		"the delegation marker must survive the forwarder/tracker wrap chain")
+}
+
+type noopForwarder struct{}
+
+func (noopForwarder) Send(_ guestagentTypes.PortMapping) error { return nil }


### PR DESCRIPTION
## Summary

The /proc/net scanner (`src/go/guestagent/pkg/procnet/scanner_linux.go`) exposes `--network=host` containers' loopback listeners to the Windows host by appending

```
-A PREROUTING -p tcp --dport <port> -j DNAT --to-destination 127.0.0.1:<port>
```

For bridge-network containers, nerdctl's own OCI `createRuntime` hook (`/usr/local/libexec/nerdctl/nerdctl internal oci-hook createRuntime`) briefly opens a port-reservation socket on `127.0.0.1:<port>` *before* CNI installs its iptables rules. The 3-second scanner poll catches that transient listener and appends the PREROUTING rule, which then **shadows** the `CNI-HOSTPORT-DNAT` chain on kernels where DNAT in PREROUTING terminates the chain (e.g. iptables-nft on current WSL2 kernels). External traffic to the published port hangs at the SYN stage: curl establishes against `host-switch.exe` on the Windows side but never sees a SYN-ACK from the proxied connection, because the rogue DNAT redirects the packet to `127.0.0.1:<port>` in the main netns where nothing is listening.

This reproduces deterministically in `bats/tests/containers/published-ports.bats` ("container published port binding to localhost") and intermittently for end users running `docker run -p 127.0.0.1:<port>:<port> ...` and accessing the port from the Windows host.

## Fix

Three layered guards in front of the iptables Append.

**1. Two-scan stability gate.** A `seenLastScan` map defers each port until it has been observed in two consecutive scans. The OCI-hook reservation socket never lives long enough to be seen twice on a normal-load system, so the rogue rule never reaches the Append path.

**2. Engine-chain delegation.** Before calling `tracker.Add`, probe `CNI-HOSTPORT-DNAT` and `DOCKER` (filtered by protocol) for a DNAT rule referencing the host port. When found, the port is engine-managed: mark the local state `delegated`, skip both `tracker.Add` and the iptables Append, and let the engine's events handler own the gvisor-tap-vsock proxy under its container ID.

**3. Partial-failure-aware "proxy already running" detection.** `APITracker.Add` is not atomic — `apiForwarder.Expose` and `portStorage.add` succeed before `wslProxyForwarder.Send` runs. If wsl-proxy.Send fails, the next-tick retry hits "proxy already running" from gvisor-tap-vsock. Probe `tracker.Get(syntheticID)` to distinguish: if procnet already owns the entry, resume ownership (the wsl-proxy retry will come on the next loop iteration); if not, the engine owns it and we delegate.

Additional hardening:

- **Append-side retry symmetric with Delete-side.** `portState.appendFailed` retains the entry across ticks when `iptables -A` fails transiently, so the next tick reissues just the Append (idempotency-probed against `preroutingHasLoopbackRule` to prevent duplicate rules).
- **`iptables --wait 2`** on every shell-out — bounded retry against xtables lock contention at the source.
- **`isIptablesRuleAbsent` helper** distinguishes "rule absent" (skip) from "iptables errored" (defer to next scan).
- **Log-once for persistent `tracker.Add` failures** — first error logs at Error, subsequent at Debug, preventing a 3-second retry-storm flood when host-switch or wsl-proxy stays down.

`dnatChainContainsPort` is a pure function with 23 table-driven subtests covering single-port, multiport, prefix/suffix-of-port, IP-octet-looks-like-port, cross-protocol, and intentionally-unmatched port-range cases. `isIptablesRuleAbsent` has its own table-driven test for the stderr classifier. A new test pins the gvisor-tap-vsock "proxy already running" substring against the actual forwarder/tracker wrap chain.

## Test plan

- [ ] `go test ./src/go/guestagent/pkg/procnet/...` (unit tests pass)
- [ ] `go vet ./src/go/guestagent/pkg/procnet/...` (clean)
- [ ] `bats bats/tests/containers/published-ports.bats` passes end-to-end on Windows
- [ ] Manual: `nerdctl run -d -p 127.0.0.1:8080:80 nginx` then `curl http://127.0.0.1:8080` from Windows host returns the nginx welcome page (no shadowing)
- [ ] Manual: a `--network=host` container that listens on `127.0.0.1:<port>` is still reachable from the Windows host (no regression in the original procnet purpose)
- [ ] Verify no rogue `iptables -t nat -L PREROUTING` entry of the form `DNAT … --to-destination 127.0.0.1:<port>` appears for bridge-network published ports
