### PR TITLE
Revert moby-openapi changes in release-1.22 branch

### DIFF
--- a/scripts/dependencies/moby-openapi.ts
+++ b/scripts/dependencies/moby-openapi.ts
@@ -18,7 +18,8 @@ export class MobyOpenAPISpec extends GlobalDependency(VersionedDependency) {
   readonly releaseFilter = 'custom';
 
   async download(context: DownloadContext): Promise<void> {
-    const baseUrl = `https://raw.githubusercontent.com/${ this.githubOwner }/${ this.githubRepo }/master/api/docs`;
+    const commit = 'b0c8ff7d0c990d28e67d0df3432abcdf6804d847';
+    const baseUrl = `https://raw.githubusercontent.com/${ this.githubOwner }/${ this.githubRepo }/${ commit }/api/docs`;
     const url = `${ baseUrl }/v${ context.versions.mobyOpenAPISpec }.yaml`;
     const outPath = path.join(process.cwd(), 'src', 'go', 'wsl-helper', 'pkg', 'dockerproxy', 'swagger.yaml');
     const modifiedPath = path.join(path.dirname(outPath), 'swagger-modified.yaml');

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -238,7 +238,7 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 
 	for _, mount := range body.HostConfig.Mounts {
 		logEntry := logrus.WithField("mount", fmt.Sprintf("%+v", mount))
-		if mount.Type.MountType != "bind" {
+		if mount.Type != "bind" {
 			logEntry.Trace("skipping mount of unsupported type")
 			continue
 		}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -162,7 +162,7 @@ func TestContainersCreate(t *testing.T) {
 			Consistency: "cached",
 			Source:      bindPath,
 			Target:      "/host",
-			Type:        struct{ models.MountType }{"bind"},
+			Type:        "bind",
 		}
 		buf, err := json.Marshal(&containersCreateRequestBody{
 			HostConfig: models.HostConfig{
@@ -219,7 +219,7 @@ func TestContainersCreate(t *testing.T) {
 				Consistency: "cached",
 				Source:      path.Join(bindManager.mountRoot, mountID),
 				Target:      "/host",
-				Type:        struct{ models.MountType }{"bind"},
+				Type:        "bind",
 			},
 		}, requestBody.HostConfig.Mounts)
 		assert.Equal(t, "hello", responseBody.ID)

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
@@ -68,10 +68,10 @@ func mungeContainersCreate(req *http.Request, contextValue *dockerproxy.RequestC
 		if mount == nil {
 			continue
 		}
-		if mount.Type.MountType == "npipe" {
+		if mount.Type == "npipe" {
 			logrus.WithField("mount", mount).Warn("named pipes are not supported")
 		}
-		if mount.Type.MountType != "bind" {
+		if mount.Type != "bind" {
 			// We only support bind mounts for now
 			continue
 		}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
@@ -72,7 +72,7 @@ func TestContainersCreate(t *testing.T) {
 			Consistency: "cached",
 			Source:      bindPath,
 			Target:      "/host",
-			Type:        struct{ models.MountType }{"bind"},
+			Type:        "bind",
 		}
 		body := containersCreateBody{
 			HostConfig: models.HostConfig{


### PR DESCRIPTION
This reverts moby-openapi related changes on the release-1.22 branch, and pins the moby commit to one around 1.22.0 release.

Fixes #10252

Confirmed by running the reproducer in #10252 in the 1.22.2 release, and then in a locally-built installer with the changes:

```pwsh
docker container run --rm -it --mount type=bind,source=$PWD,target=/workspace alpine:latest /bin/sh
```

---

We will probably need to insert a test to make sure this doesn't regress on `main` (for the 1.23 release).