### PR TITLE
moby-openapi: Fix mount type

### DIFF
--- a/scripts/dependencies/moby-openapi.ts
+++ b/scripts/dependencies/moby-openapi.ts
@@ -57,6 +57,19 @@ export class MobyOpenAPISpec extends GlobalDependency(VersionedDependency) {
       delete contents.definitions[key]?.['x-go-name'];
     }
 
+    // The `allOf` here is meant to inherit from the reference and overwrite the
+    // description; however, this actually gets generated as having a property
+    // (named `MountType`) that is then a reference, which is the incorrect
+    // shape.  Since we do not care about descriptions, just override it here.
+    if (contents.definitions.MountPoint?.properties?.Type?.allOf) {
+      contents.definitions.MountPoint.properties.Type['$ref'] = '#/definitions/MountType';
+      delete contents.definitions.MountPoint.properties.Type.allOf;
+    }
+    if (contents.definitions.Mount?.properties?.Type?.allOf) {
+      contents.definitions.Mount.properties.Type['$ref'] = '#/definitions/MountType';
+      delete contents.definitions.Mount.properties.Type.allOf;
+    }
+
     // Moby is starting to add `x-go-type` annotations to the spec; however,
     // none of the types implement validation, and some types are not actually
     // defined in the file.  Override them here.

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -238,7 +238,7 @@ func (b *bindManager) mungeContainersCreateRequest(req *http.Request, contextVal
 
 	for _, mount := range body.HostConfig.Mounts {
 		logEntry := logrus.WithField("mount", fmt.Sprintf("%+v", mount))
-		if mount.Type.MountType != models.MountTypeBind {
+		if mount.Type != models.MountTypeBind {
 			logEntry.Trace("skipping mount of unsupported type")
 			continue
 		}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux_test.go
@@ -162,7 +162,7 @@ func TestContainersCreate(t *testing.T) {
 			Consistency: "cached",
 			Source:      bindPath,
 			Target:      "/host",
-			Type:        struct{ models.MountType }{"bind"},
+			Type:        models.MountTypeBind,
 		}
 		buf, err := json.Marshal(&containersCreateRequestBody{
 			HostConfig: models.HostConfig{
@@ -219,7 +219,7 @@ func TestContainersCreate(t *testing.T) {
 				Consistency: "cached",
 				Source:      path.Join(bindManager.mountRoot, mountID),
 				Target:      "/host",
-				Type:        struct{ models.MountType }{"bind"},
+				Type:        models.MountTypeBind,
 			},
 		}, requestBody.HostConfig.Mounts)
 		assert.Equal(t, "hello", responseBody.ID)

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows.go
@@ -68,10 +68,10 @@ func mungeContainersCreate(req *http.Request, contextValue *dockerproxy.RequestC
 		if mount == nil {
 			continue
 		}
-		if mount.Type.MountType == models.MountTypeNpipe {
+		if mount.Type == models.MountTypeNpipe {
 			logrus.WithField("mount", mount).Warn("named pipes are not supported")
 		}
-		if mount.Type.MountType != models.MountTypeBind {
+		if mount.Type != models.MountTypeBind {
 			// We only support bind mounts for now
 			continue
 		}

--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_windows_test.go
@@ -72,7 +72,7 @@ func TestContainersCreate(t *testing.T) {
 			Consistency: "cached",
 			Source:      bindPath,
 			Target:      "/host",
-			Type:        struct{ models.MountType }{"bind"},
+			Type:        models.MountTypeBind,
 		}
 		body := containersCreateBody{
 			HostConfig: models.HostConfig{


### PR DESCRIPTION
OpenAPI doesn't appear to have a well defined way of doing inheritance (i.e. have a property defined elsewhere, but with some things overridden). Moby uses an `allOf` for this purpose, but our swagger generator treats this as having an object with a single property.  Since we do not actually need any of the other properties, replace the `allOf` with the reference (which causes all the other properties to get ignored).

This is a probably better fix for #10252 than #10264.