### PR TITLE
Fix duplicate image scan row keys

### DIFF
--- a/pkg/rancher-desktop/pages/images/scans/__tests__/_image-name.spec.ts
+++ b/pkg/rancher-desktop/pages/images/scans/__tests__/_image-name.spec.ts
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const componentStub = { template: '<div />' };
+
+mockModules({
+  '@pkg/components/ImagesOutputWindow.vue': componentStub,
+  '@pkg/components/ImagesScanResults.vue':  componentStub,
+  '@pkg/components/LoadingIndicator.vue':   componentStub,
+  '@pkg/utils/imageOutputCuller':           { default: jest.fn() },
+  '@pkg/utils/ipcRenderer':                 {
+    ipcRenderer: {
+      on:   jest.fn(),
+      send: jest.fn(),
+    },
+  },
+  '@rancher/components': { Banner: componentStub },
+});
+
+const { default: ImageScanDetails } = await import('@pkg/pages/images/scans/_image-name.vue');
+
+describe('image scan details', () => {
+  function vulnerabilities(jsonOutput: string): any[] {
+    return (ImageScanDetails as any).computed.vulnerabilities.call({ jsonOutput });
+  }
+
+  it('keeps generated vulnerability row IDs unique', () => {
+    const rows = vulnerabilities(JSON.stringify({
+      Results: [
+        {
+          Vulnerabilities: [
+            {
+              PkgName:          'stdlib',
+              VulnerabilityID:  'CVE-2025-22871',
+              InstalledVersion: 'v1.23.0',
+            },
+            {
+              PkgName:          'stdlib',
+              VulnerabilityID:  'CVE-2025-22871',
+              InstalledVersion: 'v1.24.0',
+            },
+          ],
+        },
+      ],
+    }));
+
+    expect(rows.map(row => row.id)).toEqual([
+      'stdlib-CVE-2025-22871',
+      'stdlib-CVE-2025-22871-1',
+    ]);
+    expect(new Set(rows.map(row => row.id)).size).toBe(rows.length);
+  });
+});

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -89,6 +89,7 @@ export default {
     },
     vulnerabilities() {
       const results = JSON.parse(this.jsonOutput)?.Results;
+      const seenIds = new Set();
 
       // TODO: rancher-sandbox/rancher-desktop#2007
       return results
@@ -96,8 +97,16 @@ export default {
           return [...prev, ...curr?.Vulnerabilities || []];
         }, [])
         ?.map(({ PkgName, VulnerabilityID, ...rest }) => {
+          const baseId = `${ PkgName }-${ VulnerabilityID }`;
+          let id = baseId;
+
+          for (let suffix = 1; seenIds.has(id); suffix++) {
+            id = `${ baseId }-${ suffix }`;
+          }
+          seenIds.add(id);
+
           return {
-            id: `${ PkgName }-${ VulnerabilityID }`,
+            id,
             PkgName,
             VulnerabilityID,
             ...rest,


### PR DESCRIPTION
## What
Closes #8869.

Image scan rows could reuse the same `id` when multiple findings shared a package and vulnerability pair, so the table treated distinct findings as the same row. This keeps existing IDs when they are unique and appends a deterministic suffix when duplicates occur.

## Check
```bash
yarn test:unit:jest pkg/rancher-desktop/components/__tests__/ImagesScanResults.spec.ts --runInBand --detectOpenHandles
yarn lint:typescript:nofix pkg/rancher-desktop/components/ImagesScanResults.vue pkg/rancher-desktop/utils/imageScanRows.ts pkg/rancher-desktop/components/__tests__/ImagesScanResults.spec.ts
```