### PR TITLE
nerdctl-stub: fix compose down volumes flags

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -355,6 +355,7 @@ mcapps
 mediaselect
 messageformat
 metainfo
+metavar
 metricsection
 mikey
 milli

--- a/src/go/nerdctl-stub/parse_args.go
+++ b/src/go/nerdctl-stub/parse_args.go
@@ -347,6 +347,10 @@ func init() {
 	registerArgHandler("compose", "-f", argHandlers.filePathArgHandler)
 	registerArgHandler("compose", "--project-directory", argHandlers.filePathArgHandler)
 	registerArgHandler("compose", "--env-file", argHandlers.filePathArgHandler)
+	// nerdctl's help text renders these with a metavar because the
+	// description quotes the "volumes" Compose section, but they are booleans.
+	registerArgHandler("compose down", "--volumes", nil)
+	registerArgHandler("compose down", "-v", nil)
 	registerArgHandler("compose run", "--volume", argHandlers.volumeArgHandler)
 	registerArgHandler("compose run", "-v", argHandlers.volumeArgHandler)
 	registerArgHandler("container create", "--cidfile", argHandlers.outputPathArgHandler)

--- a/src/go/nerdctl-stub/parse_args_test.go
+++ b/src/go/nerdctl-stub/parse_args_test.go
@@ -290,4 +290,23 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, []string{"subcommand", "--foo", "FOO"}, result.args)
 		}
 	})
+	t.Run("compose down volumes flag is boolean", func(t *testing.T) {
+		t.Parallel()
+		for _, flag := range []string{"--volumes", "-v"} {
+			t.Run(flag, func(t *testing.T) {
+				t.Parallel()
+				result, err := commands[""].parse([]string{"compose", "down", flag})
+				if assert.NoError(t, err) {
+					assert.Equal(t, []string{"compose", "down", flag}, result.args)
+				}
+			})
+		}
+		t.Run("--volumes=false", func(t *testing.T) {
+			t.Parallel()
+			result, err := commands[""].parse([]string{"compose", "down", "--volumes=false"})
+			if assert.NoError(t, err) {
+				assert.Equal(t, []string{"compose", "down", "--volumes=false"}, result.args)
+			}
+		})
+	})
 }


### PR DESCRIPTION
## What
Closes #10096.

`nerdctl compose down --volumes` and `-v` are boolean flags, but the generated stub metadata treated them as value-taking flags because of nerdctl's help text. This targeted override keeps the Windows stub from forwarding an empty argument to nerdctl.

## Check
```bash
cd src/go/nerdctl-stub
go test ./...
```