### PR TITLE
Add restart action to Containers page

### DIFF
--- a/e2e/pages/containers-page.ts
+++ b/e2e/pages/containers-page.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
-type ActionString = 'info' | 'stop' | 'start' | 'delete';
+type ActionString = 'info' | 'stop' | 'restart' | 'start' | 'delete';
 
 export class ContainersPage {
   readonly page:              Page;
@@ -31,10 +31,11 @@ export class ContainersPage {
 
     // Wait for the action menu to appear and click the action by text
     const actionText = {
-      info:   'Info',
-      stop:   'Stop',
-      start:  'Start',
-      delete: 'Delete',
+      info:    'Info',
+      stop:    'Stop',
+      restart: 'Restart',
+      start:   'Start',
+      delete:  'Delete',
     }[action];
 
     const actionLocator = this.page
@@ -50,6 +51,10 @@ export class ContainersPage {
 
   async stopContainer(containerId: string) {
     await this.clickContainerAction(containerId, 'stop');
+  }
+
+  async restartContainer(containerId: string) {
+    await this.clickContainerAction(containerId, 'restart');
   }
 
   async startContainer(containerId: string) {

--- a/pkg/rancher-desktop/pages/Containers.vue
+++ b/pkg/rancher-desktop/pages/Containers.vue
@@ -154,13 +154,14 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
  * @property { string } action
  * @property { boolean } enabled
  * @property { boolean } bulkable
- * @property { boolean } [bulkAction]
+ * @property { string } [bulkAction]
  */
 
 /**
  * @typedef { Container } RowItem An item in the table row
  * @property { Action[] } [availableActions]
  * @property { (this: Container, containers?: Container[]) => void } [stopContainer]
+ * @property { (this: Container, containers?: Container[]) => void } [restartContainer]
  * @property { (this: Container, containers?: Container[]) => void } [startContainer]
  * @property { (this: Container, containers?: Container[]) => void } [deleteContainer]
  * @property { (this: Container) => void } [viewInfo]
@@ -239,43 +240,18 @@ export default defineComponent({
         })
         .map(container => merge({}, container, {
           uptime:           container.started && dayjs(container.started).toNow(true),
-          availableActions: [
-            {
-              label:      'Info',
-              action:     'viewInfo',
-              enabled:    true,
-              bulkable:   false,
-            },
-            {
-              label:      'Stop',
-              action:     'stopContainer',
-              enabled:    this.isRunning(container),
-              bulkable:   true,
-              bulkAction: 'stopContainer',
-            },
-            {
-              label:      'Start',
-              action:     'startContainer',
-              enabled:    this.isStopped(container),
-              bulkable:   true,
-              bulkAction: 'startContainer',
-            },
-            {
-              label:      this.t('images.manager.table.action.delete'),
-              action:     'deleteContainer',
-              enabled:    this.isStopped(container),
-              bulkable:   true,
-              bulkAction: 'deleteContainer',
-            },
-          ],
-          stopContainer:   (args) => {
-            this.execCommand('stop', args?.length ? args : container);
+          availableActions: this.getContainerActions(container),
+          stopContainer:    (args) => {
+            this.execCommand('stop', this.containerCommandTarget(container, args));
+          },
+          restartContainer:   (args) => {
+            this.execCommand('restart', this.containerCommandTarget(container, args));
           },
           startContainer:   (args) => {
-            this.execCommand('start', args?.length ? args : container);
+            this.execCommand('start', this.containerCommandTarget(container, args));
           },
           deleteContainer:   (args) => {
-            this.execCommand('rm', args?.length ? args : container);
+            this.execCommand('rm', this.containerCommandTarget(container, args));
           },
           viewInfo: () => {
             this.viewInfo(container);
@@ -320,6 +296,47 @@ export default defineComponent({
     clearTimeout(this.subscribeTimer);
   },
   methods: {
+    containerCommandTarget(container, args) {
+      return args?.length ? args : container;
+    },
+    getContainerActions(container) {
+      return [
+        {
+          label:      'Info',
+          action:     'viewInfo',
+          enabled:    true,
+          bulkable:   false,
+        },
+        {
+          label:      'Stop',
+          action:     'stopContainer',
+          enabled:    this.isRunning(container),
+          bulkable:   true,
+          bulkAction: 'stopContainer',
+        },
+        {
+          label:      'Restart',
+          action:     'restartContainer',
+          enabled:    this.isRunning(container),
+          bulkable:   true,
+          bulkAction: 'restartContainer',
+        },
+        {
+          label:      'Start',
+          action:     'startContainer',
+          enabled:    this.isStopped(container),
+          bulkable:   true,
+          bulkAction: 'startContainer',
+        },
+        {
+          label:      this.t('images.manager.table.action.delete'),
+          action:     'deleteContainer',
+          enabled:    this.isStopped(container),
+          bulkable:   true,
+          bulkAction: 'deleteContainer',
+        },
+      ];
+    },
     async subscribe() {
       clearTimeout(this.subscribeTimer);
       try {

--- a/pkg/rancher-desktop/pages/__tests__/Containers.spec.ts
+++ b/pkg/rancher-desktop/pages/__tests__/Containers.spec.ts
@@ -1,0 +1,81 @@
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const componentStub = { template: '<div />' };
+
+mockModules({
+  '@pkg/components/SortableTable': componentStub,
+  '@pkg/entry/store':              {
+    mapTypedGetters: jest.fn(() => ({})),
+    mapTypedState:   jest.fn(() => ({})),
+  },
+  '@pkg/utils/ipcRenderer': {
+    ipcRenderer: {
+      on:             jest.fn(),
+      send:           jest.fn(),
+      invoke:         jest.fn(),
+      removeListener: jest.fn(),
+    },
+  },
+  '@rancher/components': {
+    BadgeState: componentStub,
+    Banner:     componentStub,
+  },
+  electron: { shell: { openExternal: jest.fn() } },
+});
+
+const { default: Containers } = await import('@pkg/pages/Containers.vue');
+const methods = (Containers as any).methods;
+
+describe('Containers methods', () => {
+  function container(id: string, state: string, status: string): any {
+    return {
+      id,
+      containerName: id,
+      imageName:     'alpine',
+      state,
+      status,
+      started:       undefined,
+      labels:        {},
+      ports:         {},
+      projectGroup:  'Standalone Containers',
+    };
+  }
+
+  const helpers = {
+    isRunning: (candidate: any) => candidate.state === 'running' || candidate.status === 'Up',
+    isStopped: (candidate: any) => candidate.state === 'created' || candidate.state === 'exited',
+    t:         (key: string) => key,
+  };
+
+  it('adds restart actions for running containers', () => {
+    const running = container('running-container', 'running', 'Up');
+    const stopped = container('stopped-container', 'exited', 'Exited');
+    const runningRestart = methods.getContainerActions.call(helpers, running)
+      .find((action: any) => action.action === 'restartContainer');
+    const stoppedRestart = methods.getContainerActions.call(helpers, stopped)
+      .find((action: any) => action.action === 'restartContainer');
+
+    expect(runningRestart).toMatchObject({
+      label:      'Restart',
+      enabled:    true,
+      bulkable:   true,
+      bulkAction: 'restartContainer',
+    });
+    expect(stoppedRestart).toMatchObject({
+      label:   'Restart',
+      enabled: false,
+    });
+  });
+
+  it('targets a single row unless a bulk selection is passed', () => {
+    const running = container('running-container', 'running', 'Up');
+    const stopped = container('stopped-container', 'exited', 'Exited');
+    const bulkSelection = [running, stopped];
+
+    expect(methods.containerCommandTarget(running)).toBe(running);
+    expect(methods.containerCommandTarget(running, [])).toBe(running);
+    expect(methods.containerCommandTarget(running, bulkSelection)).toBe(bulkSelection);
+  });
+});

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -104,7 +104,7 @@ class MobyContainerSubscriber extends Subscriber {
       {
         filters: {
           type:  ['container'],
-          event: ['create', 'start', 'stop', 'die', 'kill', 'pause', 'unpause', 'rename', 'update', 'destroy', 'remove'],
+          event: ['create', 'start', 'restart', 'stop', 'die', 'kill', 'pause', 'unpause', 'rename', 'update', 'destroy', 'remove'],
         },
       });
   }


### PR DESCRIPTION
## What
Closes #10224.

Adds a Restart action for running containers on the Containers page, including bulk selections. Moby container subscriptions now refresh on restart events so the table updates after a restart completes.

## Check
```bash
yarn test:unit:jest pkg/rancher-desktop/pages/__tests__/Containers.spec.ts --runInBand --detectOpenHandles
yarn lint:typescript:nofix pkg/rancher-desktop/pages/Containers.vue pkg/rancher-desktop/pages/containersActions.ts pkg/rancher-desktop/pages/__tests__/Containers.spec.ts e2e/pages/containers-page.ts pkg/rancher-desktop/store/container-engine.ts
```