### PR TITLE
RDX: show installed extension metadata

### DIFF
--- a/pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts
+++ b/pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const componentStub = { template: '<div />' };
+
+mockModules({
+  '@pkg/components/EmptyState.vue':             componentStub,
+  '@pkg/components/LoadingIndicator.vue':       componentStub,
+  '@pkg/components/NavIconExtension.vue':       componentStub,
+  '@pkg/components/SortableTable/index.vue':    componentStub,
+  '@pkg/hocs/withCredentials':                  { default: jest.fn() },
+  '@pkg/utils/ipcRenderer':                    {
+    ipcRenderer: {
+      on: jest.fn(),
+    },
+  },
+});
+
+const { default: InstalledExtensions } = await import('@pkg/pages/extensions/installed.vue');
+const methods = (InstalledExtensions as any).methods;
+
+describe('extensions metadata', () => {
+  it('builds installed extension metadata from OCI labels', () => {
+    const extension = {
+      id:     'publisher/sample-extension',
+      labels: {
+        'org.opencontainers.image.title':        'Sample Extension',
+        'org.opencontainers.image.vendor':       'Example Publisher',
+        'org.opencontainers.image.description':  'Adds sample tools.',
+        'io.rancherdesktop.extension.more-info': 'https://docs.example.test/sample-extension',
+      },
+    };
+
+    expect(methods.extensionTitle(extension)).toBe('Sample Extension');
+    expect(methods.extensionVendor(extension)).toBe('Example Publisher');
+    expect(methods.extensionDescription(extension)).toBe('Adds sample tools.');
+    expect(methods.extensionLink(extension)).toBe('https://docs.example.test/sample-extension');
+  });
+
+  it('uses useful fallbacks for installed extensions without metadata labels', () => {
+    const extension = {
+      id:     'publisher/sample-extension',
+      labels: {},
+    };
+
+    expect(methods.extensionTitle(extension)).toBe('publisher/sample-extension');
+    expect(methods.extensionVendor(extension)).toBe('');
+    expect(methods.extensionDescription(extension)).toBe('');
+    expect(methods.extensionLink(extension)).toBe(
+      'https://hub.docker.com/extensions/publisher/sample-extension',
+    );
+  });
+
+  it('links non-Docker-Hub extension IDs as host names', () => {
+    const extension = {
+      id:     'extensions.example.test/sample-extension',
+      labels: {},
+    };
+
+    expect(methods.extensionLink(extension)).toBe(
+      'https://extensions.example.test/sample-extension',
+    );
+  });
+});

--- a/pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts
+++ b/pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts
@@ -1,14 +1,29 @@
 import { jest } from '@jest/globals';
+import { shallowMount } from '@vue/test-utils';
 
 import mockModules from '@pkg/utils/testUtils/mockModules';
 
 const componentStub = { template: '<div />' };
+const sortableTableStub = {
+  name:  'SortableTable',
+  props: {
+    defaultSortBy: String,
+    headers:       Array,
+    rows:          Array,
+    loading:       Boolean,
+    search:        Boolean,
+    tableActions:  Boolean,
+    rowActions:    Boolean,
+    keyField:      String,
+  },
+  template: '<table />',
+};
 
 mockModules({
   '@pkg/components/EmptyState.vue':             componentStub,
   '@pkg/components/LoadingIndicator.vue':       componentStub,
   '@pkg/components/NavIconExtension.vue':       componentStub,
-  '@pkg/components/SortableTable/index.vue':    componentStub,
+  '@pkg/components/SortableTable/index.vue':    sortableTableStub,
   '@pkg/hocs/withCredentials':                  { default: jest.fn() },
   '@pkg/utils/ipcRenderer':                    {
     ipcRenderer: {
@@ -19,6 +34,26 @@ mockModules({
 
 const { default: InstalledExtensions } = await import('@pkg/pages/extensions/installed.vue');
 const methods = (InstalledExtensions as any).methods;
+
+describe('extensions installed table', () => {
+  it('sorts installed extensions by displayed name by default', () => {
+    const wrapper = shallowMount(InstalledExtensions, {
+      computed: {
+        ...(InstalledExtensions as any).computed,
+        installedExtensions: () => [],
+      },
+      global: {
+        mocks: {
+          $store: {
+            dispatch: jest.fn(),
+          },
+        },
+      },
+    });
+
+    expect(wrapper.getComponent(sortableTableStub).props('defaultSortBy')).toBe('title');
+  });
+});
 
 describe('extensions metadata', () => {
   it('builds installed extension metadata from OCI labels', () => {

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -170,6 +170,7 @@ export default defineComponent({
       :loading="loading"
       :headers="headers"
       :rows="installedExtensionRows"
+      default-sort-by="title"
       :search="false"
       :table-actions="false"
       :row-actions="false"

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -10,6 +10,23 @@ import useCredentials from '@pkg/hocs/withCredentials';
 import type { ExtensionState } from '@pkg/store/extensions';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
+type InstalledExtensionRow = ExtensionState & {
+  title:       string;
+  vendor:      string;
+  description: string;
+  moreInfo:    string;
+};
+
+interface ExtensionMetadataSource {
+  id:      string;
+  labels?: Record<string, string>;
+}
+
+const LABEL_TITLE = 'org.opencontainers.image.title';
+const LABEL_VENDOR = 'org.opencontainers.image.vendor';
+const LABEL_DESCRIPTION = 'org.opencontainers.image.description';
+const LABEL_MORE_INFO = 'io.rancherdesktop.extension.more-info';
+
 export default defineComponent({
   name:       'extensions-installed',
   components: {
@@ -27,13 +44,30 @@ export default defineComponent({
           width: 35,
         },
         {
-          name:  'id',
+          name:  'title',
           label: 'Name',
+          sort:  ['title', 'id'],
+        },
+        {
+          name:  'vendor',
+          label: 'Vendor',
+          sort:  ['vendor', 'title', 'id'],
+          width: 160,
+        },
+        {
+          name:  'description',
+          label: 'Description',
+          sort:  ['description', 'title', 'id'],
+        },
+        {
+          name:  'moreInfo',
+          label: 'More information',
+          width: 150,
         },
         {
           name:  'actions',
           label: ' ',
-          width: 76,
+          width: 170,
         },
       ],
       loading: true,
@@ -50,6 +84,15 @@ export default defineComponent({
     emptyStateBody(): string {
       return this.t('extensions.installed.emptyState.body', { }, true);
     },
+    installedExtensionRows(): InstalledExtensionRow[] {
+      return this.installedExtensions.map(extension => ({
+        ...extension,
+        title:       this.extensionTitle(extension),
+        vendor:      this.extensionVendor(extension),
+        description: this.extensionDescription(extension),
+        moreInfo:    this.extensionLink(extension),
+      }));
+    },
     ...mapGetters('extensions', ['installedExtensions']) as {
       installedExtensions: () => ExtensionState[],
     },
@@ -62,11 +105,33 @@ export default defineComponent({
     this.loading = false;
   },
   methods: {
+    extensionLabel(ext: { labels?: Record<string, string> }, label: string, fallback = ''): string {
+      return ext.labels?.[label]?.trim() || fallback;
+    },
+    extensionTitle(ext: ExtensionMetadataSource): string {
+      return this.extensionLabel(ext, LABEL_TITLE, ext.id);
+    },
+    extensionVendor(ext: { labels?: Record<string, string> }): string {
+      return this.extensionLabel(ext, LABEL_VENDOR);
+    },
+    extensionDescription(ext: { labels?: Record<string, string> }): string {
+      return this.extensionLabel(ext, LABEL_DESCRIPTION);
+    },
+    extensionLink(ext: ExtensionMetadataSource): string {
+      const preferredURL = this.extensionLabel(ext, LABEL_MORE_INFO);
+
+      if (preferredURL) {
+        return preferredURL;
+      }
+
+      if (!/^[^./]+\//.test(ext.id)) {
+        return `https://${ ext.id }`;
+      }
+
+      return `https://hub.docker.com/extensions/${ ext.id }`;
+    },
     browseExtensions() {
       this.$emit('click:browse');
-    },
-    extensionTitle(ext: { id: string, labels: Record<string, string> }): string {
-      return ext.labels?.['org.opencontainers.image.title'] ?? ext.id;
     },
     async uninstall(installed: ExtensionState) {
       this.busy = { ...this.busy, [installed.id]: true };
@@ -104,7 +169,7 @@ export default defineComponent({
       key-field="id"
       :loading="loading"
       :headers="headers"
-      :rows="installedExtensions"
+      :rows="installedExtensionRows"
       :search="false"
       :table-actions="false"
       :row-actions="false"
@@ -132,9 +197,41 @@ export default defineComponent({
           <nav-icon-extension :extension-id="row.id" />
         </td>
       </template>
-      <template #col:id="{ row }">
+      <template #col:title="{ row }">
         <td>
-          {{ extensionTitle(row) }}
+          {{ row.title }}
+        </td>
+      </template>
+      <template #col:vendor="{ row }">
+        <td>
+          <span v-if="row.vendor">{{ row.vendor }}</span>
+          <span
+            v-else
+            class="empty-cell"
+          >-</span>
+        </td>
+      </template>
+      <template #col:description="{ row }">
+        <td class="description">
+          <span v-if="row.description">{{ row.description }}</span>
+          <span
+            v-else
+            class="empty-cell"
+          >-</span>
+        </td>
+      </template>
+      <template #col:moreInfo="{ row }">
+        <td>
+          <a
+            class="more-info-link"
+            :href="row.moreInfo"
+            :title="row.moreInfo"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ t('marketplace.moreInfo') }}
+            <i class="icon icon-external-link" />
+          </a>
         </td>
       </template>
       <template #col:actions="{ row }">
@@ -177,5 +274,18 @@ export default defineComponent({
   & > * {
     margin-left: 10px;
   }
+}
+
+.description {
+  line-height: 1.35;
+  white-space: normal;
+}
+
+.empty-cell {
+  color: var(--muted);
+}
+
+.more-info-link {
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## What
Closes #8698.

Adds vendor, description, and More information columns to the Installed extensions table using the metadata labels already returned by the extensions backend. The More information link follows the same preferred-label and Docker Hub fallback behavior used by catalog cards.

## Check
```bash
yarn test:unit:jest pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts --runInBand --detectOpenHandles
yarn lint:typescript:nofix pkg/rancher-desktop/pages/extensions/installed.vue pkg/rancher-desktop/pages/extensions/metadata.ts pkg/rancher-desktop/pages/extensions/__tests__/installed.spec.ts
```