### PR TITLE
update: import electron-updater submodules directly

### DIFF
--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -6,14 +6,16 @@ import util from 'util';
 
 import { newError, CustomPublishOptions } from 'builder-util-runtime';
 import Electron, { net } from 'electron';
-import { AppUpdater, Provider, ResolvedUpdateFileInfo, UpdateInfo } from 'electron-updater';
-import { ProviderRuntimeOptions, ProviderPlatform } from 'electron-updater/out/providers/Provider';
+import { Provider } from 'electron-updater/out/providers/Provider';
 import semver from 'semver';
 
 import Logging from '@pkg/utils/logging';
 import { getMacOsVersion } from '@pkg/utils/osVersion';
 import paths from '@pkg/utils/paths';
 import getWSLVersion from '@pkg/utils/wslVersion';
+
+import type { AppUpdater, ResolvedUpdateFileInfo, UpdateInfo } from 'electron-updater';
+import type { ProviderRuntimeOptions, ProviderPlatform } from 'electron-updater/out/providers/Provider';
 
 const console = Logging.update;
 const gCachePath = path.join(paths.cache, 'updater-longhorn.json');

--- a/pkg/rancher-desktop/main/update/MSIUpdater.ts
+++ b/pkg/rancher-desktop/main/update/MSIUpdater.ts
@@ -2,8 +2,8 @@ import { spawn } from 'child_process';
 import path from 'path';
 
 import { AllPublishOptions, newError } from 'builder-util-runtime';
-import { NsisUpdater } from 'electron-updater';
 import { InstallOptions } from 'electron-updater/out/BaseUpdater';
+import { NsisUpdater } from 'electron-updater/out/NsisUpdater';
 import { ElectronHttpExecutor } from 'electron-updater/out/electronHttpExecutor';
 import { findFile } from 'electron-updater/out/providers/Provider';
 import { verifySignature } from 'electron-updater/out/windowsExecutableCodeSignatureVerifier';

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -8,10 +8,9 @@ import timers from 'timers';
 
 import { CustomPublishOptions } from 'builder-util-runtime';
 import Electron from 'electron';
-import {
-  AppImageUpdater, MacUpdater, AppUpdater, ProgressInfo, UpdateInfo,
-} from 'electron-updater';
+import { AppImageUpdater } from 'electron-updater/out/AppImageUpdater';
 import { ElectronAppAdapter } from 'electron-updater/out/ElectronAppAdapter';
+import { MacUpdater } from 'electron-updater/out/MacUpdater';
 import yaml from 'yaml';
 
 import LonghornProvider, { hasQueuedUpdate, LonghornUpdateInfo, setHasQueuedUpdate } from './LonghornProvider';
@@ -21,6 +20,8 @@ import { Settings } from '@pkg/config/settings';
 import mainEvent from '@pkg/main/mainEvents';
 import Logging from '@pkg/utils/logging';
 import * as window from '@pkg/window';
+
+import type { AppUpdater, ProgressInfo, UpdateInfo } from 'electron-updater';
 
 const console = Logging.update;
 


### PR DESCRIPTION
Importing from the top-level `electron-updater` barrel triggers an `autoUpdater` getter on the namespace object. When that getter runs it constructs a platform-specific updater whose base class calls `electron.app.getVersion()` at construction time. Tests that mock `electron` without `app.getVersion` will then fail at module-load.

Switch to subpath imports for the runtime needs (`Provider`, `AppImageUpdater`, `MacUpdater`, `NsisUpdater`) and `import type` for the type-only ones, so we never load the barrel and never enumerate that getter.

---

This change will be needed when bumping jest to 30.4.2.