### PR TITLE
build(deps-dev): replace @eslint/compat with @eslint/config-helpers

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { includeIgnoreFile } from '@eslint/compat';
+import { includeIgnoreFile } from '@eslint/config-helpers';
 import eslint from '@eslint/js';
 import { standardTypeChecked } from '@vue/eslint-config-standard-with-typescript';
 import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript';

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@electron/asar": "4.2.0",
     "@electron/fuses": "^2.1.1",
     "@electron/notarize": "3.1.1",
-    "@eslint/compat": "2.0.5",
+    "@eslint/config-helpers": "0.6.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
     "@types/cross-spawn": "6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,20 +2092,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:2.0.5":
-  version: 2.0.5
-  resolution: "@eslint/compat@npm:2.0.5"
-  dependencies:
-    "@eslint/core": "npm:^1.2.1"
-  peerDependencies:
-    eslint: ^8.40 || 9 || 10
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10c0/c6e16c5bd826535dc84b6dfd4cfa8079ac564f6dc614b164e2f2e708e940d6efa9f3754fa6ddaace04b43d296c190aabbad4231c074f6269afab88d7e7b005a8
-  languageName: node
-  linkType: hard
-
 "@eslint/config-array@npm:^0.23.5":
   version: 0.23.5
   resolution: "@eslint/config-array@npm:0.23.5"
@@ -2114,6 +2100,15 @@ __metadata:
     debug: "npm:^4.3.1"
     minimatch: "npm:^10.2.4"
   checksum: 10c0/b24833c4c76e78ee075d306cd3f095db46b2db0f90cc13a6ee6e4275f9889731c05bf5403ab5fefb79c756e07ac9184ed0e04570341382f9eccbccc80e6d1a0c
+  languageName: node
+  linkType: hard
+
+"@eslint/config-helpers@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@eslint/config-helpers@npm:0.6.0"
+  dependencies:
+    "@eslint/core": "npm:^1.2.1"
+  checksum: 10c0/f9af20e8b60b0ba27edb74b8eb40c0c5d51a9bf9baf9e053bb57833a87cb0a1c49b4dfaad88fc24d49c907ad1324c8a0b668684fa9c321351dac4bc9155ec10a
   languageName: node
   linkType: hard
 
@@ -14637,7 +14632,7 @@ __metadata:
     "@electron/asar": "npm:4.2.0"
     "@electron/fuses": "npm:^2.1.1"
     "@electron/notarize": "npm:3.1.1"
-    "@eslint/compat": "npm:2.0.5"
+    "@eslint/config-helpers": "npm:0.6.0"
     "@eslint/js": "npm:10.0.1"
     "@kubernetes/client-node": "npm:1.4.0"
     "@napi-rs/xattr": "npm:^1.0.3"


### PR DESCRIPTION
The repo's only use of @eslint/compat is includeIgnoreFile() in eslint.config.mts. @eslint/compat 2.1.0 marks that re-export @deprecated and points users at @eslint/config-helpers (0.6.0+), so drop the compat shim and import directly from the new home.