### PR TITLE
wsl-helper: Also munge /containers/{id}/archive API endpoint

### DIFF
--- a/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/mungers/containers_create_linux.go
@@ -332,6 +332,9 @@ func (b *bindManager) mungeContainersCreateResponse(resp *http.Response, context
 // munge incoming request to activate the mount, on
 // POST /containers/{id}/start
 // POST /containers/{id}/restart
+// HEAD /containers/{id}/archive
+// GET /containers/{id}/archive
+// PUT /containers/{id}/archive
 func (b *bindManager) mungeContainersStartRequest(req *http.Request, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
 	// Look up all the mappings this container needs
 	mapping := make(map[string]string)
@@ -375,6 +378,9 @@ func (b *bindManager) mungeContainersStartRequest(req *http.Request, contextValu
 // munge outgoing response to deactivate the mount, on
 // POST /containers/{id}/start
 // POST /containers/{id}/restart
+// HEAD /containers/{id}/archive
+// GET /containers/{id}/archive
+// PUT /containers/{id}/archive
 func (b *bindManager) mungeContainersStartResponse(req *http.Response, contextValue *dockerproxy.RequestContextValue, templates map[string]string) error {
 	binds, ok := (*contextValue)[contextKey].(*map[string]string)
 	if !ok {
@@ -442,4 +448,11 @@ func init() {
 	dockerproxy.RegisterResponseMunger(http.MethodPost, "/containers/{id}/start", b.mungeContainersStartResponse)
 	dockerproxy.RegisterResponseMunger(http.MethodPost, "/containers/{id}/restart", b.mungeContainersStartResponse)
 	dockerproxy.RegisterResponseMunger(http.MethodDelete, "/containers/{id}", b.mungeContainersDeleteResponse)
+
+	dockerproxy.RegisterRequestMunger(http.MethodHead, "/containers/{id}/archive", b.mungeContainersStartRequest)
+	dockerproxy.RegisterResponseMunger(http.MethodHead, "/containers/{id}/archive", b.mungeContainersStartResponse)
+	dockerproxy.RegisterRequestMunger(http.MethodGet, "/containers/{id}/archive", b.mungeContainersStartRequest)
+	dockerproxy.RegisterResponseMunger(http.MethodGet, "/containers/{id}/archive", b.mungeContainersStartResponse)
+	dockerproxy.RegisterRequestMunger(http.MethodPut, "/containers/{id}/archive", b.mungeContainersStartRequest)
+	dockerproxy.RegisterResponseMunger(http.MethodPut, "/containers/{id}/archive", b.mungeContainersStartResponse)
 }


### PR DESCRIPTION
This ensures that API calls making direct access to a container's files after it is created, but before it is started for the first time, are correctly intercepted.

Fixes #1544, fixes #9787

Disclaimer - I haven't been able to build a working Wix installer MSI locally for a while, for reasons I haven't worked out, but I've been running this patch locally on a built version of `1.20.0-227-g<hash>` for about 8 months with no ill effect.