### PR TITLE
guestagent: distinguish "proxy already running" via a typed sentinel

### DIFF
--- a/src/go/guestagent/pkg/iptables/iptables.go
+++ b/src/go/guestagent/pkg/iptables/iptables.go
@@ -16,6 +16,7 @@ package iptables
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"strings"
@@ -120,11 +121,14 @@ func (i *Iptables) ForwardPorts() error {
 				portMap[portMapKey] = []nat.PortBinding{portBinding}
 			}
 			name := entryToString(p)
-			if err := i.apiTracker.Add(utils.GenerateID(name), portMap); err != nil {
+			switch err := i.apiTracker.Add(utils.GenerateID(name), portMap); {
+			case err == nil:
+				log.Infof("iptables scanner forwarded portmap for %s", name)
+			case errors.Is(err, tracker.ErrPortAlreadyExposed):
+				log.Debugf("iptables scanner: portmap for %s already exposed elsewhere", name)
+			default:
 				log.Errorf("iptables scanner failed to forward portmap for %s: %s", name, err)
-				continue
 			}
-			log.Infof("iptables scanner forwarded portmap for %s", name)
 		}
 	}
 }

--- a/src/go/guestagent/pkg/kube/watcher_linux.go
+++ b/src/go/guestagent/pkg/kube/watcher_linux.go
@@ -174,16 +174,20 @@ func WatchForServices(
 
 						continue
 					}
-					if err := portTracker.Add(string(event.UID), portMapping); err != nil {
+					switch err := portTracker.Add(string(event.UID), portMapping); {
+					case err == nil:
+						log.Debugf("kubernetes service: port mapping added %s/%s:%v",
+							event.namespace, event.name, event.portMapping)
+					case errors.Is(err, tracker.ErrPortAlreadyExposed):
+						log.Debugf("kubernetes service: port mapping already exposed elsewhere %s/%s:%v",
+							event.namespace, event.name, event.portMapping)
+					default:
 						log.Errorf("failed to add port mapping: %v from tracker UID: %v namespace: %s name: %s failed: %s",
 							event.portMapping,
 							event.UID,
 							event.namespace,
 							event.name,
 							err)
-					} else {
-						log.Debugf("kubernetes service: port mapping added %s/%s:%v",
-							event.namespace, event.name, event.portMapping)
 					}
 				}
 			}

--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
@@ -289,13 +289,7 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 		// syntheticIDFor(port), so an engine cannot Remove our entry
 		// out from under us between the two calls.
 		if len(pst.tracker.Get(syntheticID)) > 0 {
-			if err := pst.tracker.Remove(syntheticID); err != nil {
-				if removeReportedProxyDestroyed(err) {
-					log.Errorf("/proc/net scanner released prior partial-Add of %s before engine delegation (wsl-proxy notification failed): %s", port, err)
-				} else {
-					log.Errorf("/proc/net scanner failed to release prior partial-Add of %s before engine delegation; host-switch unexpose may have left the proxy bound until RD restart: %s", port, err)
-				}
-			}
+			pst.releaseToEngine(port, "before engine delegation")
 		}
 		// Reconcile any leftover procnet loopback rule before delegating.
 		// Two scenarios produce a stale rule that the delegation path
@@ -424,23 +418,17 @@ func (pst *portStateTracker) retryAppend(port nat.Port, state portState) {
 			log.Debugf("/proc/net scanner retry of iptables Delete for %s after engine takeover still failing: %s", port, err)
 			return
 		}
-		if err := pst.tracker.Remove(syntheticIDFor(port)); err != nil {
-			// APITracker.Remove clears portStorage via a leading defer,
-			// so a next-tick retry would read an empty portMap, skip
-			// the Unexpose loop, and return nil -- hiding the failure
-			// rather than recovering. Accept the rare leak when
-			// host-switch unexpose fails: a stranded gvisor proxy
-			// under the synthetic ID blocks the engine's later Add
-			// with "proxy already running" until RD restart, and on
-			// the Local-collision configurations described in
-			// exposeNew's engine-delegation comment, Windows-side
-			// traffic for that host port drops until RD restart.
-			if removeReportedProxyDestroyed(err) {
-				log.Errorf("/proc/net scanner released ownership of %s after engine took over (wsl-proxy notification failed): %s", port, err)
-			} else {
-				log.Errorf("/proc/net scanner failed to release ownership of %s after engine took over; host-switch unexpose may have left the proxy bound until RD restart: %s", port, err)
-			}
-		}
+		// APITracker.Remove clears portStorage via a leading defer, so
+		// a next-tick retry would read an empty portMap, skip the
+		// Unexpose loop, and return nil -- hiding the failure rather
+		// than recovering. Accept the rare leak when host-switch
+		// unexpose fails: a stranded gvisor proxy under the synthetic
+		// ID blocks the engine's later Add with "proxy already running"
+		// until RD restart, and on the Local-collision configurations
+		// described in exposeNew's engine-delegation comment,
+		// Windows-side traffic for that host port drops until RD
+		// restart.
+		pst.releaseToEngine(port, "after engine took over")
 		pst.added[port] = portState{bindings: state.bindings, delegated: true}
 		log.Infof("/proc/net scanner released ownership of %s to engine-managed chain after append retry", port)
 		return
@@ -563,6 +551,25 @@ func (pst *portStateTracker) applyLoopbackRules(bindings []nat.PortBinding, port
 
 func syntheticIDFor(port nat.Port) string {
 	return utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))
+}
+
+// releaseToEngine calls tracker.Remove on the synthetic ID for port and
+// logs any failure with classification. It does not mark the port
+// delegated -- callers do that based on their own state. The phase
+// string describes the call site for log clarity; it must complete
+// "released ownership of <port> <phase>" and "failed to release
+// ownership of <port> <phase>". Used when an engine chain has taken
+// over a port procnet currently owns or has a partial-Add for.
+func (pst *portStateTracker) releaseToEngine(port nat.Port, phase string) {
+	err := pst.tracker.Remove(syntheticIDFor(port))
+	if err == nil {
+		return
+	}
+	if removeReportedProxyDestroyed(err) {
+		log.Errorf("/proc/net scanner released ownership of %s %s (wsl-proxy notification failed): %s", port, phase, err)
+		return
+	}
+	log.Errorf("/proc/net scanner failed to release ownership of %s %s; host-switch unexpose may have left the proxy bound until RD restart: %s", port, phase, err)
 }
 
 // removeReportedProxyDestroyed reports whether a non-nil tracker.Remove

--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Masterminds/log-go"
 	"github.com/docker/go-connections/nat"
@@ -34,8 +33,8 @@ import (
 //	  on (its second sighting -- the first only defers).
 //	delegated: an engine owns the proxy. Set when an engine chain
 //	  (CNI-HOSTPORT-DNAT or DOCKER) already references the port, OR
-//	  when tracker.Add returns portAlreadyExposedSubstring against an
-//	  ID procnet does not already own. The cleanup path must skip
+//	  when tracker.Add returns tracker.ErrPortAlreadyExposed against
+//	  an ID procnet does not already own. The cleanup path must skip
 //	  tracker.Remove in this case -- the engine owns the tracker entry
 //	  under its container ID, and our synthetic ID would walk an empty
 //	  portStorage entry.
@@ -68,7 +67,7 @@ import (
 //	  Not engine-managed: tracker.Add.
 //	    Succeeds: Append iptables rule; record success or
 //	      appendFailed=true on transient error.
-//	    "proxy already running": classify via tracker.Get(synthetic).
+//	    tracker.ErrPortAlreadyExposed: classify via tracker.Get(synthetic).
 //	      We own it: install the iptables rule that the partial-failure
 //	        path skipped, mark delegated=false. apiForwarder.Expose
 //	        succeeded on an earlier tick but wsl-proxy.Send failed,
@@ -94,7 +93,7 @@ import (
 //	    chain is installed during container network setup, before the
 //	    engine's portTracker.Add runs, so its presence does not prove
 //	    the engine holds a host-switch proxy. If the engine's Add raced
-//	    procnet's and lost, it got portAlreadyExposedSubstring and
+//	    procnet's and lost, it got tracker.ErrPortAlreadyExposed and
 //	    recorded nothing, and the port keeps no host-switch proxy until
 //	    RD restart. The retry path only runs once the stability gate
 //	    was bypassed under heavy load, so this rides along with that
@@ -328,7 +327,7 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 		return
 	}
 	if err := pst.tracker.Add(syntheticID, nat.PortMap{port: bindings}); err != nil {
-		if strings.Contains(err.Error(), portAlreadyExposedSubstring) {
+		if errors.Is(err, tracker.ErrPortAlreadyExposed) {
 			pst.handleAlreadyExposed(port, bindings, syntheticID)
 			return
 		}
@@ -357,7 +356,7 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 }
 
 // handleAlreadyExposed disambiguates the two shapes of
-// portAlreadyExposedSubstring from tracker.Add:
+// tracker.ErrPortAlreadyExposed from tracker.Add:
 //
 //	Genuine engine delegation: the engine's events handler called
 //	  tracker.Add first under its container ID. gvisor-tap-vsock has
@@ -367,7 +366,7 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 //	Partial-failure retry: a prior tick succeeded at apiForwarder.Expose
 //	  (so gvisor-tap-vsock has the proxy and portStorage[synthetic] is
 //	  populated) but failed downstream (typically wsl-proxy.Send).
-//	  The substring is the same, but we own the entry; install the
+//	  The sentinel is the same, but we own the entry; install the
 //	  iptables rule that the partial-failure path skipped and resume
 //	  ownership.
 func (pst *portStateTracker) handleAlreadyExposed(port nat.Port, bindings []nat.PortBinding, syntheticID string) {

--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
@@ -254,7 +254,7 @@ func TestResumeOwnershipInstallsAppend(t *testing.T) {
 		{err: fmt.Errorf("%w: simulated", tracker.ErrWSLProxy), seedStorage: true},
 		// Tick 3: apiForwarder.Expose returns "proxy already running"
 		// (gvisor-tap-vsock still holds the proxy from tick 2).
-		{err: fmt.Errorf("expose api error: %s", portAlreadyExposedSubstring), seedStorage: false},
+		{err: tracker.ErrPortAlreadyExposed, seedStorage: false},
 	}
 	pst := newPortStateTracker(fakeT, fakeIPT)
 	pm := makePortMap(t)
@@ -496,7 +496,7 @@ func TestProxyAlreadyRunningWithoutOwnershipDelegates(t *testing.T) {
 	// container ID; our synthetic Add loses the race and portStorage
 	// is NOT seeded for the synthetic ID.
 	fakeT.addBehavior = []addBehavior{
-		{err: fmt.Errorf("expose api error: %s", portAlreadyExposedSubstring), seedStorage: false},
+		{err: tracker.ErrPortAlreadyExposed, seedStorage: false},
 	}
 	pst := newPortStateTracker(fakeT, fakeIPT)
 	pm := makePortMap(t)
@@ -790,7 +790,7 @@ func TestRemoveFailureRetainsRuleForReappearance(t *testing.T) {
 	// from the stale proxy, with storage empty (cleared by Remove).
 	fakeT.removeErr = nil
 	fakeT.addBehavior = []addBehavior{
-		{err: fmt.Errorf("expose api error: %s", portAlreadyExposedSubstring), seedStorage: false},
+		{err: tracker.ErrPortAlreadyExposed, seedStorage: false},
 	}
 	pst.Tick(pm) // 4: reappearance, defer
 	pst.Tick(pm) // 5: tracker.Add → "proxy already running", Get==0 → delegate

--- a/src/go/guestagent/pkg/procnet/scanner_linux.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux.go
@@ -61,16 +61,6 @@ const loopbackIP = "127.0.0.1"
 // startup so a support-bundle reader sees what procnet considered.
 var engineDNATChains = []string{"CNI-HOSTPORT-DNAT", "DOCKER"}
 
-// portAlreadyExposedSubstring is the substring tracker.Add returns when
-// another component has already exposed the port (typically the
-// containerd or docker events handler on /tasks/start). The string
-// originates in the /services/forwarder/expose API response and survives
-// the tracker's wrapping. handleAlreadyExposed disambiguates the two
-// cases it covers: an engine owns the proxy (delegate), or procnet owns
-// it after a partial-failure retry (resume ownership and install the
-// loopback rule the partial-failure path skipped).
-const portAlreadyExposedSubstring = "proxy already running"
-
 // dnatRuleRe matches a single DNAT rule line in `iptables --list <chain>
 // --numeric` output. Capture groups: (1) protocol (tcp|udp), then ONE of
 // (2) single-port `dpt:N` or (3) multiport list `dports N[,N…]`. The

--- a/src/go/guestagent/pkg/procnet/scanner_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux_test.go
@@ -217,16 +217,17 @@ func TestWrapExitError(t *testing.T) {
 	require.NoError(t, wrapExitError(nil))
 }
 
-// TestPortAlreadyExposedSubstringIsReachable pins the substring contract
-// that the procnet delegation path depends on. The substring originates
-// in gvisor-tap-vsock's host-port forwarder; the response body passes
-// through forwarder.verifyResponseBody ("%w: %s" wrap of ErrAPI), then
-// through tracker.APITracker.Add ("%w: %+v" wrap of ErrExposeAPI). If
-// either wrap layer ever drops the body, this test fails before the
-// procnet scanner silently regresses. An upstream rename of the message
-// is an unguarded risk: the handler below hardcodes the string, and the
-// upstream constant is not an exported symbol to assert against.
-func TestPortAlreadyExposedSubstringIsReachable(t *testing.T) {
+// TestPortAlreadyExposedSentinelIsReachable pins the wire contract that
+// the procnet delegation path depends on. The "proxy already running"
+// substring originates in gvisor-tap-vsock's host-port forwarder; the
+// response body passes through forwarder.verifyResponseBody ("%w: %s"
+// wrap of ErrAPI) and tracker.APITracker.Add must recognise it and
+// surface tracker.ErrPortAlreadyExposed. If either the substring match
+// in Add or the wire shape from gvisor-tap-vsock changes, this test
+// fails before procnet silently regresses. An upstream rename of the
+// message is an unguarded risk: the handler below hardcodes the string,
+// and the upstream constant is not an exported symbol to assert against.
+func TestPortAlreadyExposedSentinelIsReachable(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -242,9 +243,8 @@ func TestPortAlreadyExposedSubstringIsReachable(t *testing.T) {
 	addErr := tr.Add("synthetic-tcp-8080", nat.PortMap{
 		port: []nat.PortBinding{{HostIP: loopbackIP, HostPort: "8080"}},
 	})
-	require.Error(t, addErr)
-	require.Contains(t, addErr.Error(), portAlreadyExposedSubstring,
-		"the delegation marker must survive the forwarder/tracker wrap chain")
+	require.ErrorIs(t, addErr, tracker.ErrPortAlreadyExposed,
+		"the delegation sentinel must survive the forwarder/tracker wrap chain")
 }
 
 type noopForwarder struct{}

--- a/src/go/guestagent/pkg/tracker/apitracker.go
+++ b/src/go/guestagent/pkg/tracker/apitracker.go
@@ -38,7 +38,20 @@ var (
 	ErrAPI         = errors.New("error from API")
 	ErrInvalidIPv4 = errors.New("not an IPv4 address")
 	ErrWSLProxy    = errors.New("error from Rancher Desktop WSL Proxy")
+	// ErrPortAlreadyExposed signals that Add was a no-op because another
+	// component had already exposed every port in the request. Callers
+	// that scan for ports another actor may own (kube watcher, iptables
+	// scanner, /proc/net scanner) should treat this as successful
+	// delegation rather than a failure to retry.
+	ErrPortAlreadyExposed = errors.New("port already exposed by another component")
 )
+
+// portAlreadyExposedSubstring is the substring host-switch's
+// /services/forwarder/expose response carries when the port is already
+// bound. The string is the host-switch wire contract; matching it here
+// lets callers rely on errors.Is(err, ErrPortAlreadyExposed) instead of
+// inspecting message text.
+const portAlreadyExposedSubstring = "proxy already running"
 
 // APITracker keeps track of the port mappings and calls the
 // corresponding API endpoints that is responsible for exposing
@@ -80,8 +93,14 @@ func NewAPITracker(ctx context.Context, wslProxyForwarder forwarder.Forwarder, b
 
 // Add a container ID and port mapping to the tracker and calls the
 // /services/forwarder/expose endpoint to forward the port mappings.
+//
+// If the expose API returns portAlreadyExposedSubstring for every port
+// in the request and no other failures occurred, Add returns
+// ErrPortAlreadyExposed so callers can treat the call as successful
+// delegation rather than a failure to retry.
 func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 	var errs []error
+	var alreadyExposed int
 
 	successfullyForwarded := make(nat.PortMap)
 
@@ -107,6 +126,10 @@ func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 					Protocol: types.TransportProtocol(strings.ToLower(portProto.Proto())),
 				})
 			if err != nil {
+				if strings.Contains(err.Error(), portAlreadyExposedSubstring) {
+					alreadyExposed++
+					continue
+				}
 				errs = append(errs, fmt.Errorf("exposing %+v failed: %w", portBinding, err))
 
 				continue
@@ -138,6 +161,14 @@ func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 		if err := a.wslProxyForwarder.Send(portMapping); err != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("%w: %w", ErrWSLProxy, err))
 		}
+	}
+
+	// If every Expose call that ran reported the port as already
+	// exposed -- no successful forwards, no other failures, no
+	// wsl-proxy error -- surface the sentinel so callers downgrade
+	// the result from an error to a delegation no-op.
+	if retErr == nil && alreadyExposed > 0 && len(successfullyForwarded) == 0 {
+		retErr = ErrPortAlreadyExposed
 	}
 
 	return retErr

--- a/src/go/guestagent/pkg/tracker/apitracker_test.go
+++ b/src/go/guestagent/pkg/tracker/apitracker_test.go
@@ -865,6 +865,112 @@ func TestNonAdminInstall(t *testing.T) {
 	assert.Nil(t, portMapping)
 }
 
+// TestAddReturnsPortAlreadyExposedSentinel verifies that when host-switch
+// rejects every Expose with the "proxy already running" body, Add returns
+// the typed sentinel so callers can downgrade the result to a delegation
+// no-op.
+func TestAddReturnsPortAlreadyExposedSentinel(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "host port forwarding: cannot expose 127.0.0.1:80: proxy already running", http.StatusInternalServerError)
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{{HostIP: hostIP, HostPort: hostPort}},
+	})
+	require.ErrorIs(t, err, tracker.ErrPortAlreadyExposed)
+	require.NotErrorIs(t, err, forwarder.ErrExposeAPI,
+		"the sentinel must replace the generic ErrExposeAPI wrap, not be joined with it")
+
+	// portStorage stays empty: no port was successfully forwarded.
+	assert.Empty(t, apiTracker.Get(containerID))
+}
+
+// TestAddPartialAlreadyExposedReturnsNil verifies that when some ports
+// succeed and others are already exposed elsewhere, Add returns nil --
+// the call did real work and the sentinel only applies when nothing was
+// forwarded.
+func TestAddPartialAlreadyExposedReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.ExposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.Local == ipPortBuilder(hostIP2, hostPort) {
+			http.Error(w, "proxy already running", http.StatusInternalServerError)
+		}
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{
+			{HostIP: hostIP, HostPort: hostPort},  // succeeds
+			{HostIP: hostIP2, HostPort: hostPort}, // already exposed
+		},
+	})
+	require.NoError(t, err)
+
+	// Only the successful binding lands in storage.
+	stored := apiTracker.Get(containerID)
+	require.Len(t, stored[protoPort], 1)
+	assert.Equal(t, hostIP, stored[protoPort][0].HostIP)
+}
+
+// TestAddAlreadyExposedPlusRealFailureReturnsRealFailure verifies that a
+// real Expose failure beats the "already exposed" signal: callers must
+// see the genuine ErrExposeAPI wrap so they retry, not the sentinel that
+// would have them treat the call as delegation.
+func TestAddAlreadyExposedPlusRealFailureReturnsRealFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.ExposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		switch req.Local {
+		case ipPortBuilder(hostIP, hostPort):
+			http.Error(w, "proxy already running", http.StatusInternalServerError)
+		case ipPortBuilder(hostIP2, hostPort):
+			http.Error(w, "transient backend error", http.StatusInternalServerError)
+		}
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{
+			{HostIP: hostIP, HostPort: hostPort},  // already exposed
+			{HostIP: hostIP2, HostPort: hostPort}, // real failure
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forwarder.ErrExposeAPI,
+		"a real Expose failure must surface, not be masked by the sentinel")
+	require.NotErrorIs(t, err, tracker.ErrPortAlreadyExposed,
+		"the sentinel only applies when every port was already exposed")
+}
+
 func ipPortBuilder(ip, port string) string {
 	return ip + ":" + port
 }


### PR DESCRIPTION
## Summary

`tracker.APITracker.Add` forwards every observed port to host-switch via `/services/forwarder/expose`. When another component has already exposed a port, host-switch's response body carries the substring `"proxy already running"`, which surfaces as a wrapped error all the way out to the caller. Until now the wrap chain looked like a generic Expose failure, so two callers retried and logged ERROR on every tick for the lifetime of the cluster:

- `pkg/kube/watcher_linux.go` — Kubernetes service watcher (closes #10337)
- `pkg/iptables/iptables.go` — CNI nat-chain scanner (closes #10338)

## Approach

Promote the detection to a typed sentinel `tracker.ErrPortAlreadyExposed`. `APITracker.Add` inspects each `Expose` error for the host-switch substring and, when every Expose call in the request reported the port as already exposed (with no other failures), returns the sentinel so callers can downgrade the result to a delegation no-op via `errors.Is`. A real Expose failure beats the sentinel: if any port failed for a different reason, callers still see the `ErrExposeAPI` wrap they need to retry.

The `/proc/net` scanner already detected the same substring in `procnet/scanner_linux.go` (`const portAlreadyExposedSubstring`) to drive its delegation path. It now uses the typed sentinel via `errors.Is`; the `handleAlreadyExposed` classifier is unchanged.

## Stacks on #10280

This branch is based on #10280's `procnet-portstatetracker` — the rework relies on the `errors.Join` reshape from that PR. The diff shown here will collapse to just this commit once #10280 lands. Holding draft until then.

## Tests

- `pkg/tracker/apitracker_test.go` — three new integration tests:
  - every Expose `"already exposed"` → sentinel returned
  - mixed success + already-exposed → no error, successful binding stored
  - `"already exposed"` + real failure → real failure wins, sentinel suppressed
- `pkg/procnet/scanner_linux_test.go` — substring-contract test now pins the sentinel via `errors.Is` instead of substring-matching the wrapped error message
- `pkg/procnet/port_state_tracker_linux_test.go` — fake tracker returns the sentinel directly

## Test plan

- [ ] `go test ./...` in `src/go/guestagent` (passes locally)
- [ ] `go vet ./...` in `src/go/guestagent` (clean)
- [ ] BATS suite shows no `proxy already running` ERROR storms in `rancher-desktop-guestagent.log` during a full Kubernetes cluster lifecycle