### PR TITLE
update: keep recurring check armed after transient errors

### DIFF
--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -290,22 +290,32 @@ async function doInitialUpdateCheck(doInstall = false): Promise<boolean> {
  */
 async function triggerUpdateCheck() {
   if (state !== State.DOWNLOADING) {
-    const result = await autoUpdater.checkForUpdates();
+    try {
+      const result = await autoUpdater.checkForUpdates();
 
-    if (!result) {
-      // App update is disabled (likely because the app is not packaged).
-      return;
+      if (!result) {
+        // App update is disabled.
+        return;
+      }
+
+      if (!isLonghornUpdateInfo(result.updateInfo)) {
+        throw new Error('result.updateInfo is not of type LonghornUpdateInfo');
+      }
+      const updateInfo = result.updateInfo;
+      const givenTimeDelta = (updateInfo.nextUpdateTime || 0) - Date.now();
+
+      // Enforce at least one minute between checks, even if the server is reporting
+      // bad times.
+      updateInterval = Math.max(givenTimeDelta, 60_000);
+      console.log(`Update check complete; next check at ${ new Date(Date.now() + updateInterval).toISOString() }`);
+    } catch (ex) {
+      // Without catching here, a transient failure (network blip, malformed
+      // server response, missing release asset) would skip the timer rearm
+      // below and silently stop all future checks until the app restarts.
+      // Retry in 10 minutes to recover within a normal session.
+      console.error('Error checking for updates; will retry in 10 minutes:', ex);
+      updateInterval = 10 * 60_000;
     }
-
-    if (!isLonghornUpdateInfo(result.updateInfo)) {
-      throw new Error('result.updateInfo is not of type LonghornUpdateInfo');
-    }
-    const updateInfo = result.updateInfo;
-    const givenTimeDelta = (updateInfo.nextUpdateTime || 0) - Date.now();
-
-    // Enforce at least one minute between checks, even if the server is reporting
-    // bad times.
-    updateInterval = Math.max(givenTimeDelta, 60_000);
   }
 
   // regardless of whether we actually made the check, schedule the next check.


### PR DESCRIPTION
`triggerUpdateCheck()` awaits `autoUpdater.checkForUpdates()` with no try/catch, so a thrown error escapes before the function rearms the timer. A single transient failure silently kills the recurring check until app restart.

Wrap the check in try/catch and schedule the next check for ten minutes later. A short retry recovers from transient failures within a normal session without hammering the server.

The initial check in `setupUpdate()` already has its own try/catch, so this only matters for subsequent recurring checks.

Also log a line on each successful check so the once-daily heartbeat is visible in `update.log`.

Refs: rancher-sandbox/rancher-desktop#10019