### PR TITLE
spelling: ignore Python string prefixes

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -251,3 +251,6 @@ DNAT\s+.*\s+anywhere anywhere
 
 # Image names
 \bghcr\.io/[A-Za-z0-9_/.-]+(?::[A-Za-z0-9_.-]+)?\b
+
+# Python string prefix / binary prefix
+(?<!['"])\b(?:B|BR|Br|F|FR|Fr|R|RB|RF|Rb|Rf|U|UR|Ur|b|bR|br|f|fR|fr|r|rB|rF|rb|rf|u|uR|ur)['"](?=[A-Z]{3,}|[A-Z][a-z]{2,}|[a-z]{3,})


### PR DESCRIPTION
check-spelling emits "candidate-pattern" notices on bats/tests/security/cve-2026-31431-copy-fail-exploit.py and cve-2026-43284-dirtyfrag-probe.py for `b"..."` and `f"..."` strings whose contents look like English words.

Promote the Python string prefix pattern from candidate.patterns to patterns.txt -- the documented promotion path for accepted candidates.