### PR TITLE
procnet: refresh bindings each tick and install late loopback DNAT

### DIFF
--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
@@ -112,16 +112,14 @@ import (
 //	    tick is a silent no-op, and retaining the marker deadlocks
 //	    the Add path if the listener reappears.
 //
-// Bindings refresh: state.bindings is captured at the second-sighting
-// tick (or at handleAlreadyExposed's resume path) and is not refreshed
-// when later ticks observe a different binding set for the same
-// nat.Port. Consequence: a --network=host process that opens
-// 127.0.0.1:hostPort AFTER a non-loopback listener on the same hostPort
-// has been acted on misses the PREROUTING DNAT, and external traffic to
-// that loopback-only listener is dropped until the port retires and
-// reappears. The symmetric direction is benign: a loopback rule already
-// in place stays installed, and a 0.0.0.0 listener catches the
-// redirected traffic on its own.
+// Bindings refresh (per tick): when an already-tracked port's binding
+// set changes, reconcileBindings applies the iptables transition. A
+// loopback binding appearing on an owned port runs the engine-probe +
+// Append (or release-to-engine when the chain has taken over); a
+// loopback binding disappearing from an owned port issues the Delete.
+// Delegated ports refresh state.bindings only -- the engine owns the
+// rule. The non-loopback dimension does not drive iptables; loopback
+// bindings carry the rules.
 //
 // Engine-chain re-probe: addObserved re-probes the engine chain only
 // when appendFailed=true; owned-success and delegated ports skip
@@ -208,9 +206,7 @@ func (pst *portStateTracker) Tick(newPortMap nat.PortMap) {
 func (pst *portStateTracker) addObserved(newPortMap nat.PortMap) {
 	for port, bindings := range newPortMap {
 		if state, alreadyAdded := pst.added[port]; alreadyAdded {
-			if state.appendFailed {
-				pst.retryAppend(port, state)
-			}
+			pst.reconcileBindings(port, bindings, state)
 			continue
 		}
 		if _, sawLastScan := pst.seenLastScan[port]; !sawLastScan {
@@ -394,6 +390,81 @@ func (pst *portStateTracker) handleAlreadyExposed(port nat.Port, bindings []nat.
 	delete(pst.addErrorLogged, port)
 }
 
+// reconcileBindings handles a port already in pst.added when a new
+// scan arrives. It refreshes state.bindings, applies any iptables
+// transition driven by a loopback binding appearing or disappearing,
+// and delegates to retryAppend when appendFailed is set. Without
+// this, the snapshot of state.bindings taken at the first action
+// hides any later binding change: a --network=host process that
+// opens 127.0.0.1:hostPort AFTER a non-loopback listener on the same
+// hostPort has been acted on never gets the PREROUTING DNAT, and
+// external traffic to that loopback-only listener is dropped until
+// the port retires and reappears.
+func (pst *portStateTracker) reconcileBindings(port nat.Port, newBindings []nat.PortBinding, state portState) {
+	oldLoopback := hasLoopbackBinding(state.bindings)
+	newLoopback := hasLoopbackBinding(newBindings)
+	switch {
+	case !oldLoopback && newLoopback && !state.delegated:
+		// Loopback binding appeared on an owned port. installLateLoopback
+		// runs the engine-probe + Append (or release-to-engine) and
+		// updates pst.added with the refreshed bindings.
+		pst.installLateLoopback(port, newBindings)
+		return
+	case oldLoopback && !newLoopback && !state.delegated:
+		// Loopback binding vanished from an owned port. Delete the
+		// PREROUTING DNAT we installed earlier so it does not outlive
+		// its listener. applyLoopbackIPtablesRule probes
+		// preroutingHasLoopbackRule first and no-ops the Delete when
+		// no rule exists, so a previous appendFailed (where the rule
+		// may not have been committed) is harmless here.
+		if err := pst.applyLoopbackRules(state.bindings, port, Delete); err != nil {
+			log.Errorf("/proc/net scanner deleting loopback rule for vanished binding %s: %s", port, err)
+		}
+		state.bindings = newBindings
+		state.appendFailed = false
+		pst.added[port] = state
+		return
+	}
+	// No actionable transition (no change in the loopback dimension,
+	// or delegated -- engine owns the rule). Refresh bindings and let
+	// retryAppend run if appendFailed is set.
+	state.bindings = newBindings
+	pst.added[port] = state
+	if state.appendFailed {
+		pst.retryAppend(port, pst.added[port])
+	}
+}
+
+// installLateLoopback handles a loopback binding that appeared on a
+// port already owned by procnet. It mirrors exposeNew's non-delegated
+// path but operates on a port that already has a tracker entry:
+// engine-probe first, release ownership via releaseToEngine when the
+// chain has taken over; otherwise install the iptables Append.
+// Unlike exposeNew, no prior procnet rule exists to Delete -- the
+// first action did not install one for the non-loopback bindings.
+func (pst *portStateTracker) installLateLoopback(port nat.Port, newBindings []nat.PortBinding) {
+	managed, err := pst.anyEngineBinding(port, newBindings)
+	if err != nil {
+		log.Debugf("/proc/net scanner engine-chain probe failed during late-loopback install for %s; deferring: %s", port, err)
+		return
+	}
+	if managed {
+		pst.releaseToEngine(port, "on late loopback install")
+		pst.added[port] = portState{bindings: newBindings, delegated: true}
+		log.Infof("/proc/net scanner released ownership of %s to engine-managed chain on late loopback install", port)
+		return
+	}
+	appendErr := pst.applyLoopbackRules(newBindings, port, Append)
+	if appendErr != nil {
+		log.Errorf("/proc/net scanner installing late loopback rule for %s failed: %s", port, appendErr)
+	}
+	pst.added[port] = portState{
+		bindings:     newBindings,
+		delegated:    false,
+		appendFailed: appendErr != nil,
+	}
+}
+
 // retryAppend reissues the iptables Append for a port whose previous
 // tick succeeded at tracker.Add but failed at Append. Before retrying,
 // re-probe the engine chain: if the engine chain has appeared since the
@@ -551,6 +622,16 @@ func (pst *portStateTracker) applyLoopbackRules(bindings []nat.PortBinding, port
 
 func syntheticIDFor(port nat.Port) string {
 	return utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))
+}
+
+// hasLoopbackBinding reports whether bindings contains a 127.0.0.1 entry.
+func hasLoopbackBinding(bindings []nat.PortBinding) bool {
+	for _, b := range bindings {
+		if b.HostIP == loopbackIP {
+			return true
+		}
+	}
+	return false
 }
 
 // releaseToEngine calls tracker.Remove on the synthetic ID for port and

--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
@@ -678,6 +678,199 @@ func TestMixedBindingsOnlyLoopbackGetsRules(t *testing.T) {
 	require.Equal(t, "8080", fakeIPT.applyCalls[0].hostPort)
 }
 
+// TestLateLoopbackBindingGetsAppend pins the bindings-refresh path.
+// Scenario: a port is first observed with only a non-loopback binding,
+// passes the stability gate, and is acted on without an iptables
+// Append (no loopback binding present). On a later tick a 127.0.0.1
+// binding appears for the same port. The state machine must install
+// the PREROUTING DNAT for the new loopback binding -- otherwise
+// external traffic to that loopback-only listener is dropped until
+// the port retires and reappears.
+func TestLateLoopbackBindingGetsAppend(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	pmNonLoopback := nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8080"}},
+	}
+	pmMixed := nat.PortMap{
+		port: []nat.PortBinding{
+			{HostIP: "0.0.0.0", HostPort: "8080"},
+			{HostIP: loopbackIP, HostPort: "8080"},
+		},
+	}
+
+	pst.Tick(pmNonLoopback) // 1: stability gate defers
+	pst.Tick(pmNonLoopback) // 2: exposeNew; only 0.0.0.0 binding; no Append
+	require.Len(t, fakeT.addCalls, 1)
+	require.Equal(t, 0, countApplyByAction(fakeIPT.applyCalls, Append),
+		"non-loopback-only binding must not trigger an iptables Append")
+
+	pst.Tick(pmMixed) // 3: 127.0.0.1 appears; must install the loopback rule
+
+	require.Equal(t, 1, countApplyByAction(fakeIPT.applyCalls, Append),
+		"late loopback binding must install the PREROUTING DNAT")
+	require.Equal(t, "8080", fakeIPT.applyCalls[len(fakeIPT.applyCalls)-1].hostPort)
+	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")],
+		"the PREROUTING DNAT must end up installed in iptables")
+}
+
+// TestLateLoopbackDelegatesWhenEngineChainPresent pins the late-
+// loopback engine-takeover path. Scenario: a port is acted on with
+// only a non-loopback binding while the engine chain is absent (no
+// loopback to probe), so procnet owns the port. On a later tick a
+// 127.0.0.1 binding appears AND the engine chain is now visible.
+// installLateLoopback's engine-probe must transition the port to
+// delegated via releaseToEngine, not install a procnet PREROUTING DNAT.
+func TestLateLoopbackDelegatesWhenEngineChainPresent(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	pmNonLoopback := nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8080"}},
+	}
+	pmMixed := nat.PortMap{
+		port: []nat.PortBinding{
+			{HostIP: "0.0.0.0", HostPort: "8080"},
+			{HostIP: loopbackIP, HostPort: "8080"},
+		},
+	}
+
+	pst.Tick(pmNonLoopback) // 1: defer
+	pst.Tick(pmNonLoopback) // 2: exposeNew; owned, no Append
+	require.False(t, pst.added[port].delegated)
+	require.Len(t, fakeT.addCalls, 1)
+
+	// Engine chain appears between ticks 2 and 3, alongside the new loopback binding.
+	fakeIPT.engineManaged[iptKey("tcp", "8080")] = true
+
+	pst.Tick(pmMixed) // 3: reconcileBindings → installLateLoopback → engine takeover
+
+	require.True(t, pst.added[port].delegated,
+		"late-loopback with engine chain present must delegate")
+	require.Equal(t, 0, countApplyByAction(fakeIPT.applyCalls, Append),
+		"engine-takeover path must NOT install a procnet rule")
+	require.Len(t, fakeT.removeCalls, 1,
+		"releaseToEngine must call tracker.Remove")
+	require.Nil(t, fakeT.storage[syntheticIDFor(port)],
+		"synthetic portStorage entry must be cleared after release")
+}
+
+// TestLoopbackVanishingTriggersDelete pins the loopback-removed path
+// on an owned port. Scenario: a port is added with a 127.0.0.1 binding
+// (Append installs the PREROUTING DNAT). On a later tick the loopback
+// binding disappears while the port itself remains observable via
+// another listener. reconcileBindings must Delete the rule so it does
+// not outlive its listener.
+func TestLoopbackVanishingTriggersDelete(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	pmLoopback := makePortMap(t)
+	pmNonLoopback := nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8080"}},
+	}
+
+	pst.Tick(pmLoopback) // 1: defer
+	pst.Tick(pmLoopback) // 2: exposeNew installs the loopback Append
+	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")])
+
+	pst.Tick(pmNonLoopback) // 3: loopback binding gone; reconcileBindings deletes
+
+	require.Equal(t, 1, countApplyByAction(fakeIPT.applyCalls, Delete),
+		"vanished loopback binding must trigger an iptables Delete")
+	require.False(t, fakeIPT.rules[iptKey("tcp", "8080")],
+		"the PREROUTING DNAT must be removed when its loopback listener is gone")
+	require.False(t, pst.added[port].delegated,
+		"the port stays owned")
+	require.False(t, pst.added[port].appendFailed,
+		"appendFailed must be cleared once the loopback is gone")
+}
+
+// TestLoopbackVanishingFromDelegatedPortSkipsDelete pins the
+// loopback-removed path on a delegated port. Scenario: a port is
+// delegated at first action (loopback binding + engine chain visible).
+// On a later tick the loopback binding disappears. reconcileBindings
+// must NOT issue an iptables Delete -- the engine owns the rule, and
+// a procnet Delete here would tear down state procnet does not own.
+func TestLoopbackVanishingFromDelegatedPortSkipsDelete(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	fakeIPT.engineManaged[iptKey("tcp", "8080")] = true
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	pmLoopback := makePortMap(t)
+	pmNonLoopback := nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8080"}},
+	}
+
+	pst.Tick(pmLoopback) // 1: defer
+	pst.Tick(pmLoopback) // 2: exposeNew → engine probe true → delegated
+	require.True(t, pst.added[port].delegated)
+	deleteCallsBefore := countApplyByAction(fakeIPT.applyCalls, Delete)
+
+	pst.Tick(pmNonLoopback) // 3: loopback gone, but delegated
+
+	require.Equal(t, deleteCallsBefore, countApplyByAction(fakeIPT.applyCalls, Delete),
+		"delegated port must NOT issue a procnet Delete when its loopback binding vanishes")
+	require.True(t, pst.added[port].delegated,
+		"the port stays delegated")
+}
+
+// TestLateLoopbackDeferOnEngineProbeError pins the engine-probe-
+// failure defer in installLateLoopback. Scenario: a port is acted on
+// with only a non-loopback binding. On a later tick a 127.0.0.1
+// binding appears but the engine-chain probe fails transiently.
+// installLateLoopback must defer without installing a rule and
+// without updating pst.added, so the next tick re-enters the same
+// path. Once the probe recovers, the Append lands.
+func TestLateLoopbackDeferOnEngineProbeError(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+	pmNonLoopback := nat.PortMap{
+		port: []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: "8080"}},
+	}
+	pmMixed := nat.PortMap{
+		port: []nat.PortBinding{
+			{HostIP: "0.0.0.0", HostPort: "8080"},
+			{HostIP: loopbackIP, HostPort: "8080"},
+		},
+	}
+
+	pst.Tick(pmNonLoopback) // 1: defer
+	pst.Tick(pmNonLoopback) // 2: exposeNew; owned, no Append
+
+	// Engine-probe fails transiently before tick 3.
+	fakeIPT.engineErrors[iptKey("tcp", "8080")] = errors.New("xtables lock contention")
+
+	pst.Tick(pmMixed) // 3: late-loopback install probe fails → defer
+
+	require.Equal(t, 0, countApplyByAction(fakeIPT.applyCalls, Append),
+		"probe failure must NOT install a rule")
+	require.False(t, pst.added[port].delegated,
+		"probe failure must NOT mark the port delegated")
+
+	// Probe recovers; the next tick re-enters installLateLoopback.
+	delete(fakeIPT.engineErrors, iptKey("tcp", "8080"))
+
+	pst.Tick(pmMixed) // 4: probe succeeds → Append installed
+
+	require.Equal(t, 1, countApplyByAction(fakeIPT.applyCalls, Append),
+		"recovered probe must let installLateLoopback append the rule")
+	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")],
+		"the PREROUTING DNAT must land after the probe recovers")
+}
+
 // TestAppendRetryEngineTakeoverDeletesCommittedRule covers the
 // committed-rule cleanup on engine takeover. Scenario: tracker.Add
 // succeeds, the iptables Append returns an error but still commits


### PR DESCRIPTION
## Summary

The `/proc/net` scanner's `portStateTracker` snapshots `state.bindings` at the second-sighting tick and never refreshes it. A `--network=host` process that opens a `127.0.0.1:hostPort` listener AFTER a non-loopback listener on the same `hostPort` has already been acted on is invisible to the state machine: no PREROUTING DNAT is installed, and external traffic to that loopback-only listener is dropped until the port retires and reappears.

## Approach

`reconcileBindings` becomes the per-tick entry point for already-tracked ports in `addObserved`. It refreshes `state.bindings` and applies the iptables transition driven by a loopback binding appearing or disappearing:

- **Loopback appears on an owned port:** `installLateLoopback` runs the engine-probe and either Appends the PREROUTING DNAT or releases ownership via `releaseToEngine` when the chain has taken over.
- **Loopback disappears from an owned port:** Delete the PREROUTING DNAT we installed earlier.
- **Delegated ports refresh `state.bindings` only** — the engine owns the rule.

The default path (no change in the loopback dimension, or delegated) still runs `retryAppend` when `appendFailed` is set, now with refreshed bindings.

## Stacks on #10347

This branch is based on `tracker-already-exposed-sentinel` (#10347), itself stacked on `procnet-portstatetracker` (#10280). The bindings-refresh fix uses `releaseToEngine`, the helper #10347 extracts. Both stacked PRs need to land first; this branch will rebase down naturally as they do.

## Documentation

The "Bindings refresh" paragraph in `portState`'s doc block, which previously documented this as a known gap, is rewritten to describe the per-tick reconciliation. The adjacent "Engine-chain re-probe" gap paragraph stays: that gap (no engine re-probe for owned-success or delegated ports when their engine chain status changes mid-lifecycle) is unrelated and still unaddressed.

## Tests

Five new tests in `port_state_tracker_linux_test.go`:

- `TestLateLoopbackBindingGetsAppend` — the primary bug-fix test. Written against the unchanged code first; confirmed to fail before the fix landed.
- `TestLateLoopbackDelegatesWhenEngineChainPresent` — engine chain appears alongside the late loopback binding; port must delegate, not Append.
- `TestLoopbackVanishingTriggersDelete` — owned port loses its loopback binding; rule must be Deleted.
- `TestLoopbackVanishingFromDelegatedPortSkipsDelete` — delegated port loses its loopback binding; procnet must NOT issue a Delete (the engine owns the rule).
- `TestLateLoopbackDeferOnEngineProbeError` — probe failure during late-loopback install defers without partial state; recovers next tick.

Four of the five (all except `TestLoopbackVanishingFromDelegatedPortSkipsDelete`) were verified to fail against the unchanged production code before the fix landed. The fifth is a regression gate for the new code path — the unchanged code happened to do the right thing (nothing) in that case.
