### PR TITLE
guestagent: recover stranded proxies via portStorage retention + retryStranded

### DIFF
--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux.go
@@ -82,13 +82,10 @@ import (
 //	    Delete precedes the Remove so a transient Delete failure leaves
 //	    the port appendFailed with its tracker entry intact, to retry
 //	    next tick, rather than stranded with neither proxy nor rule.
-//	    The Remove error is classified the same way retireDisappeared
-//	    classifies it: a wsl-proxy-only failure leaves the proxy gone
-//	    (mark delegated); any other failure is logged and the port is
-//	    still marked delegated, accepting the rare leak that
-//	    retireDisappeared's default branch already accepts -- a retry
-//	    would not recover because APITracker.Remove clears portStorage
-//	    via a leading defer.
+//	    On Remove failure releaseToEngine records the port in
+//	    strandedProxies; retryStranded drives the recovery on later
+//	    ticks (see "Stranded-proxy recovery" below). The port is marked
+//	    delegated either way -- the engine's chain is now authoritative.
 //	    This trusts the engine to expose the port itself. The engine
 //	    chain is installed during container network setup, before the
 //	    engine's portTracker.Add runs, so its presence does not prove
@@ -105,12 +102,13 @@ import (
 //	  Owned: tracker.Remove. On success -- or a wsl-proxy-only
 //	    failure, where every host-switch Unexpose landed and the proxy
 //	    is gone -- delete the loopback rule. On an unexpose failure the
-//	    proxy may still be bound, so keep the rule -- deleting it would
-//	    strand traffic to the proxy, and a retained rule self-cleans on
-//	    RD restart. Either way drop the local marker: APITracker.Remove
-//	    wipes portStorage via a leading defer, so retrying it on a later
-//	    tick is a silent no-op, and retaining the marker deadlocks
-//	    the Add path if the listener reappears.
+//	    proxy may still be bound, so retain the rule (deleting it would
+//	    strand in-WSL traffic to the proxy that may still be serving)
+//	    and record the port in strandedProxies. retryStranded reissues
+//	    Remove on each tick; once it succeeds the strand drops and the
+//	    retained rule is deleted. Either way drop the local marker:
+//	    retaining it deadlocks the Add path if the listener reappears
+//	    (the alreadyAdded fast path would short-circuit it).
 //
 // Bindings refresh (per tick): when an already-tracked port's binding
 // set changes, reconcileBindings applies the iptables transition. A
@@ -120,6 +118,22 @@ import (
 // Delegated ports refresh state.bindings only -- the engine owns the
 // rule. The non-loopback dimension does not drive iptables; loopback
 // bindings carry the rules.
+//
+// Stranded-proxy recovery: a tracker.Remove that returns a non-
+// proxyDestroyed error leaves the gvisor proxy possibly bound under
+// the synthetic ID. releaseToEngine and retireDisappeared's default
+// branch record the port in strandedProxies. APITracker.Remove
+// retains the failing bindings in portStorage so each retry actually
+// reissues the Unexpose call instead of walking an empty map.
+// retryStranded runs at the end of every Tick: when no listener is
+// observable for a stranded port, it retries Remove and -- on success
+// or a wsl-proxy-only failure -- deletes any retained loopback rule
+// (idempotent for engine-takeover sites that already cleared their
+// rule). While a listener IS observable, retryStranded skips: the
+// proxy that may still be bound is now plausibly serving that
+// listener, and an unbind would tear the working path down.
+// Re-acquiring ownership (exposeNew's non-managed success or
+// handleAlreadyExposed's resume path) clears the strand directly.
 //
 // Engine-chain re-probe: addObserved re-probes the engine chain only
 // when appendFailed=true; owned-success and delegated ports skip
@@ -167,8 +181,8 @@ func (r *realIptablesRunner) ApplyLoopbackRule(proto, hostPort string, act actio
 
 // portStateTracker drives the procnet per-port state machine across
 // scan ticks. State (added, seenLastScan, addErrorLogged,
-// probeErrorLogged) outlives a single Tick call. The struct is not
-// safe for concurrent use; callers must serialize Tick.
+// probeErrorLogged, strandedProxies) outlives a single Tick call. The
+// struct is not safe for concurrent use; callers must serialize Tick.
 type portStateTracker struct {
 	tracker          tracker.Tracker
 	iptables         iptablesRunner
@@ -176,6 +190,14 @@ type portStateTracker struct {
 	seenLastScan     nat.PortMap
 	addErrorLogged   map[nat.Port]bool
 	probeErrorLogged map[nat.Port]bool
+	// strandedProxies tracks ports whose host-switch Unexpose failed.
+	// The gvisor proxy may still be bound under the synthetic ID, and
+	// APITracker.Remove retains the failing bindings in portStorage so
+	// a later tracker.Remove can retry them. Each Tick calls
+	// retryStranded to drive the retry; on success the entry drops and
+	// any retained loopback rule is deleted. The map's value carries
+	// the bindings whose loopback rule may still need a Delete.
+	strandedProxies map[nat.Port][]nat.PortBinding
 }
 
 func newPortStateTracker(t tracker.Tracker, ipt iptablesRunner) *portStateTracker {
@@ -188,15 +210,18 @@ func newPortStateTracker(t tracker.Tracker, ipt iptablesRunner) *portStateTracke
 		added:            make(map[nat.Port]portState),
 		addErrorLogged:   make(map[nat.Port]bool),
 		probeErrorLogged: make(map[nat.Port]bool),
+		strandedProxies:  make(map[nat.Port][]nat.PortBinding),
 	}
 }
 
 // Tick runs one scan iteration: expose newly-observed ports, retire
-// ports whose listeners disappeared, and refresh the stability gate.
+// ports whose listeners disappeared, refresh the stability gate, and
+// retry any stranded-proxy cleanup whose previous Remove failed.
 func (pst *portStateTracker) Tick(newPortMap nat.PortMap) {
 	pst.addObserved(newPortMap)
 	pst.retireDisappeared(newPortMap)
 	pst.cleanupErrorLogged(newPortMap)
+	pst.retryStranded(newPortMap)
 	// newPortMap is rebuilt by the caller on the next iteration, so
 	// this alias is safe; the caller must not mutate newPortMap after
 	// passing it in.
@@ -247,14 +272,12 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 		// error (see APITracker.Add's partial-failure block); without
 		// this release the gvisor proxy stays bound under the synthetic
 		// ID and blocks the engine's own Add with "proxy already
-		// running" until RD restart. APITracker.Remove clears
-		// portStorage via a leading defer, so we cannot retry: a
-		// wsl-proxy-only failure means the proxy is gone, and any
-		// other failure leaves the leak retireDisappeared's default
-		// branch already accepts. Mark delegated either way; the
-		// engine's container-start handler is expected to bind its own
-		// proxy under the container ID, and the chain appearing is the
-		// engine's signal that setup is underway.
+		// running" until RD restart. On a non-proxyDestroyed Remove
+		// failure releaseToEngine records the strand and retryStranded
+		// drives the recovery on later ticks. Mark delegated either
+		// way; the engine's container-start handler is expected to
+		// bind its own proxy under the container ID, and the chain
+		// appearing is the engine's signal that setup is underway.
 		//
 		// Known trade-off: when procnet's and the engine's host-switch
 		// Local strings collide, the engine's events handler
@@ -263,29 +286,22 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 		// from gvisor against our binding, logged once, and returned
 		// -- without retrying. The Remove here then tears down the
 		// only host-switch proxy, and Windows-side traffic drops until
-		// RD restart. The collision triggers in two configurations:
-		// any HostIP=127.0.0.1 publish (procnet binds 127.0.0.1 for
+		// the engine's next portTracker.Add or RD restart. The
+		// collision triggers in two configurations: any
+		// HostIP=127.0.0.1 publish (procnet binds 127.0.0.1 for
 		// loopback listeners; the engine's Expose also uses 127.0.0.1
 		// for that publish form), and -- in non-admin install -- any
 		// publish at all, since APITracker.determineHostIP rewrites
-		// every HostIP to 127.0.0.1 when isAdmin is false. The trade-
-		// off is intentional: leaving the synthetic entry in place
-		// would strand the gvisor proxy under the synthetic ID, with
-		// the engine's later Add forever failing with "proxy already
-		// running", so this regression rides along with the existing
-		// rare-leak path retireDisappeared's default branch already
-		// accepts. The trigger still requires
-		// stability-gate bypass under heavy load plus a transient
-		// wsl-proxy.Send failure, and the collision configuration
-		// above. The same trade-off applies in retryAppend's engine-
-		// takeover branch and in retireDisappeared's default branch.
+		// every HostIP to 127.0.0.1 when isAdmin is false. Trigger
+		// requires stability-gate bypass under heavy load plus the
+		// collision configuration above; rare enough to accept.
 		//
 		// The Get+Remove pair is non-atomic but safe: engines key
 		// portStorage on container.ID and procnet keys on
 		// syntheticIDFor(port), so an engine cannot Remove our entry
 		// out from under us between the two calls.
 		if len(pst.tracker.Get(syntheticID)) > 0 {
-			pst.releaseToEngine(port, "before engine delegation")
+			pst.releaseToEngine(port, bindings, "before engine delegation")
 		}
 		// Reconcile any leftover procnet loopback rule before delegating.
 		// Two scenarios produce a stale rule that the delegation path
@@ -343,6 +359,9 @@ func (pst *portStateTracker) exposeNew(port nat.Port, bindings []nat.PortBinding
 		delegated:    false,
 		appendFailed: appendErr != nil,
 	}
+	// Re-acquiring ownership supersedes any prior strand; the live
+	// proxy now serves the active listener.
+	delete(pst.strandedProxies, port)
 }
 
 // handleAlreadyExposed disambiguates the two shapes of
@@ -372,6 +391,8 @@ func (pst *portStateTracker) handleAlreadyExposed(port nat.Port, bindings []nat.
 			appendFailed: appendErr != nil,
 		}
 		delete(pst.addErrorLogged, port)
+		// Resuming ownership supersedes any prior strand.
+		delete(pst.strandedProxies, port)
 		return
 	}
 	// Do not reconcile a leftover loopback rule here. From this branch
@@ -449,7 +470,7 @@ func (pst *portStateTracker) installLateLoopback(port nat.Port, newBindings []na
 		return
 	}
 	if managed {
-		pst.releaseToEngine(port, "on late loopback install")
+		pst.releaseToEngine(port, newBindings, "on late loopback install")
 		pst.added[port] = portState{bindings: newBindings, delegated: true}
 		log.Infof("/proc/net scanner released ownership of %s to engine-managed chain on late loopback install", port)
 		return
@@ -489,17 +510,13 @@ func (pst *portStateTracker) retryAppend(port nat.Port, state portState) {
 			log.Debugf("/proc/net scanner retry of iptables Delete for %s after engine takeover still failing: %s", port, err)
 			return
 		}
-		// APITracker.Remove clears portStorage via a leading defer, so
-		// a next-tick retry would read an empty portMap, skip the
-		// Unexpose loop, and return nil -- hiding the failure rather
-		// than recovering. Accept the rare leak when host-switch
-		// unexpose fails: a stranded gvisor proxy under the synthetic
-		// ID blocks the engine's later Add with "proxy already running"
-		// until RD restart, and on the Local-collision configurations
-		// described in exposeNew's engine-delegation comment,
-		// Windows-side traffic for that host port drops until RD
-		// restart.
-		pst.releaseToEngine(port, "after engine took over")
+		// On a non-proxyDestroyed Remove failure releaseToEngine
+		// records the port in strandedProxies; retryStranded reissues
+		// Remove on later ticks until the proxy unbinds. The port is
+		// marked delegated either way -- the engine's chain is the
+		// authoritative routing surface and the strand carries the
+		// proxy-cleanup obligation independently of pst.added.
+		pst.releaseToEngine(port, state.bindings, "after engine took over")
 		pst.added[port] = portState{bindings: state.bindings, delegated: true}
 		log.Infof("/proc/net scanner released ownership of %s to engine-managed chain after append retry", port)
 		return
@@ -547,15 +564,15 @@ func (pst *portStateTracker) retireDisappeared(newPortMap nat.PortMap) {
 			log.Errorf("/proc/net scanner failed to remove port (wsl-proxy notification failed; loopback rule deleted): %s", removeErr)
 		default:
 			// The host-switch unexpose did not land, or the error is
-			// unclassified, so the proxy may still be bound. Keep the
-			// loopback rule so traffic still reaches the proxy; deleting
-			// it would strand the port. A leaked rule self-cleans on RD
-			// restart. Same trade-off as exposeNew's engine-delegation
-			// path: a stranded gvisor proxy under the synthetic ID can
-			// block a later same-host-port engine Add with "proxy
-			// already running" on the Local-collision configurations
-			// described in that comment.
-			log.Errorf("/proc/net scanner failed to remove port (host-switch unexpose may have left proxy bound; loopback rule retained): %s", removeErr)
+			// unclassified, so the proxy may still be bound. Mark the
+			// port stranded; APITracker.Remove retains the failing
+			// bindings in portStorage, and retryStranded will retry
+			// the Unexpose on each tick. Keep the loopback rule until
+			// the strand recovers (deleting it now would strand
+			// in-WSL traffic to the proxy that may still be bound);
+			// retryStranded deletes the rule once the Unexpose lands.
+			log.Errorf("/proc/net scanner failed to remove port (host-switch unexpose may have left proxy bound; retrying): %s", removeErr)
+			pst.strandedProxies[port] = state.bindings
 			continue
 		}
 		if err := pst.applyLoopbackRules(state.bindings, port, Delete); err != nil {
@@ -636,12 +653,17 @@ func hasLoopbackBinding(bindings []nat.PortBinding) bool {
 
 // releaseToEngine calls tracker.Remove on the synthetic ID for port and
 // logs any failure with classification. It does not mark the port
-// delegated -- callers do that based on their own state. The phase
-// string describes the call site for log clarity; it must complete
-// "released ownership of <port> <phase>" and "failed to release
-// ownership of <port> <phase>". Used when an engine chain has taken
-// over a port procnet currently owns or has a partial-Add for.
-func (pst *portStateTracker) releaseToEngine(port nat.Port, phase string) {
+// delegated -- callers do that based on their own state. On a non-
+// proxyDestroyed failure the gvisor proxy may still be bound under the
+// synthetic ID; releaseToEngine records the port in strandedProxies so
+// retryStranded keeps retrying until the Remove lands. The bindings
+// passed in are used by retryStranded to delete any retained loopback
+// rule once the strand recovers. The phase string describes the call
+// site for log clarity; it must complete "released ownership of <port>
+// <phase>" and "failed to release ownership of <port> <phase>". Used
+// when an engine chain has taken over a port procnet currently owns or
+// has a partial-Add for.
+func (pst *portStateTracker) releaseToEngine(port nat.Port, bindings []nat.PortBinding, phase string) {
 	err := pst.tracker.Remove(syntheticIDFor(port))
 	if err == nil {
 		return
@@ -650,7 +672,45 @@ func (pst *portStateTracker) releaseToEngine(port nat.Port, phase string) {
 		log.Errorf("/proc/net scanner released ownership of %s %s (wsl-proxy notification failed): %s", port, phase, err)
 		return
 	}
-	log.Errorf("/proc/net scanner failed to release ownership of %s %s; host-switch unexpose may have left the proxy bound until RD restart: %s", port, phase, err)
+	log.Errorf("/proc/net scanner failed to release ownership of %s %s; host-switch unexpose may have left the proxy bound -- retrying: %s", port, phase, err)
+	pst.strandedProxies[port] = bindings
+}
+
+// retryStranded retries tracker.Remove for each port whose previous
+// Remove failed with a non-proxyDestroyed error. On success (or a
+// wsl-proxy-only failure where every Unexpose actually landed) the
+// entry drops from strandedProxies and applyLoopbackRules(Delete) runs
+// against the stored bindings. applyLoopbackRules probes for the rule
+// first, so the Delete is a no-op for engine-takeover sites that
+// already cleared their rule before the Remove. APITracker.Remove
+// retains the failing bindings in portStorage so this retry actually
+// reissues the Unexpose call instead of walking an empty map.
+//
+// Ports whose listener has reappeared in newPortMap are skipped: the
+// proxy that may still be bound is now plausibly serving that listener,
+// and an unbind here would tear down a working path. The strand stays
+// in the map for a later gap. exposeNew and handleAlreadyExposed drop
+// the strand once procnet re-acquires ownership of the port.
+func (pst *portStateTracker) retryStranded(newPortMap nat.PortMap) {
+	for port, bindings := range pst.strandedProxies {
+		if _, listenerBack := newPortMap[port]; listenerBack {
+			continue
+		}
+		err := pst.tracker.Remove(syntheticIDFor(port))
+		if err != nil && !removeReportedProxyDestroyed(err) {
+			log.Debugf("/proc/net scanner stranded-proxy retry for %s still failing: %s", port, err)
+			continue
+		}
+		delete(pst.strandedProxies, port)
+		if err != nil {
+			log.Errorf("/proc/net scanner recovered stranded proxy for %s (wsl-proxy notification failed): %s", port, err)
+		} else {
+			log.Infof("/proc/net scanner recovered stranded proxy for %s", port)
+		}
+		if ruleErr := pst.applyLoopbackRules(bindings, port, Delete); ruleErr != nil {
+			log.Errorf("/proc/net scanner deleting retained loopback rule for recovered port %s failed: %s", port, ruleErr)
+		}
+	}
 }
 
 // removeReportedProxyDestroyed reports whether a non-nil tracker.Remove

--- a/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/port_state_tracker_linux_test.go
@@ -34,9 +34,10 @@ type fakeTracker struct {
 	addBehavior []addBehavior
 	addCalls    []addCall
 	removeCalls []string
-	// removeErr, when set, is returned by every Remove call. The
-	// storage entry is still cleared, mirroring APITracker.Remove's
-	// leading `defer a.portStorage.remove`.
+	// removeErr, when set, is returned by every Remove call. Storage
+	// retention mirrors APITracker.Remove: cleared on a successful or
+	// wsl-proxy-only Remove (proxy is gone), retained on a host-switch
+	// unexpose failure so a retry can drive the recovery.
 	removeErr error
 }
 
@@ -77,7 +78,12 @@ func (f *fakeTracker) Add(containerID string, portMap nat.PortMap) error {
 
 func (f *fakeTracker) Remove(containerID string) error {
 	f.removeCalls = append(f.removeCalls, containerID)
-	delete(f.storage, containerID)
+	// Mirror APITracker.Remove: clear storage on success or a
+	// wsl-proxy-only failure (proxy is gone); retain storage on a
+	// host-switch unexpose failure so a retry can recover.
+	if f.removeErr == nil || removeReportedProxyDestroyed(f.removeErr) {
+		delete(f.storage, containerID)
+	}
 	return f.removeErr
 }
 
@@ -337,32 +343,51 @@ func TestCleanupReleasesAddedOnDeleteFailure(t *testing.T) {
 }
 
 // TestCleanupReleasesAddedOnRemoveFailure covers the cleanup-side
-// tracker.Remove failure. APITracker.Remove wipes portStorage via a
-// leading defer even when it returns an error, so a retry is a silent
-// no-op. The local marker must drop anyway, or the listener can never
-// be re-added when it reappears.
+// tracker.Remove failure. The local marker must drop so the listener
+// can be re-added when it reappears (without the drop, the
+// alreadyAdded fast path would short-circuit re-acquisition). The
+// strand mechanism keeps trying to unbind the leaked proxy via
+// retryStranded.
 func TestCleanupReleasesAddedOnRemoveFailure(t *testing.T) {
 	fakeT := newFakeTracker()
 	fakeIPT := newFakeIptables()
 	pst := newPortStateTracker(fakeT, fakeIPT)
 	pm := makePortMap(t)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
 
 	pst.Tick(pm) // 1: defer
 	pst.Tick(pm) // 2: added
 	require.Len(t, fakeT.addCalls, 1)
 
-	// Listener disappears; tracker.Remove fails.
+	// Listener disappears; tracker.Remove fails on both the
+	// retireDisappeared call and the same-tick retryStranded retry.
 	fakeT.removeErr = errors.New("unexpose api error: simulated")
-	pst.Tick(nat.PortMap{}) // 3: cleanup; Remove fails
-	require.Len(t, fakeT.removeCalls, 1)
+	pst.Tick(nat.PortMap{}) // 3: cleanup; Remove fails; strand set
+	require.Len(t, fakeT.removeCalls, 2,
+		"retireDisappeared + retryStranded each issue one Remove in the same tick")
+	_, stillTracked := pst.added[port]
+	require.False(t, stillTracked, "pst.added must drop the entry")
+	require.Contains(t, pst.strandedProxies, port,
+		"failed Remove must record the port in strandedProxies for retry")
 
-	// Remove recovers; listener reappears.
-	fakeT.removeErr = nil
-	pst.Tick(pm) // 4: reappearance, defer
-	pst.Tick(pm) // 5: stability gate passes, re-add
+	// Listener reappears with Remove still failing; retryStranded must
+	// skip while a listener is observable to avoid unbinding a proxy
+	// that may now be serving the new listener.
+	pst.Tick(pm) // 4: reappearance, defer; retryStranded skips
+	require.Len(t, fakeT.removeCalls, 2,
+		"retryStranded must NOT retry while the listener is observable")
+	require.Contains(t, pst.strandedProxies, port,
+		"strand must persist across the deferral tick")
+
+	// Stability gate passes; tracker.Add succeeds (default behavior);
+	// re-acquisition clears the strand.
+	pst.Tick(pm) // 5: re-add
 
 	require.Len(t, fakeT.addCalls, 2,
 		"reappearance after tracker.Remove failure must trigger a fresh tracker.Add")
+	require.NotContains(t, pst.strandedProxies, port,
+		"re-acquiring ownership must clear the strand")
 }
 
 // TestAddErrorLoggedSuppressesLogSpam confirms the first failed
@@ -951,13 +976,15 @@ func TestAppendRetryEngineTakeoverRetriesFailedDelete(t *testing.T) {
 }
 
 // TestRemoveFailureRetainsRuleForReappearance pins the rule-retention
-// path on Remove failure. Scenario: an owned port's listener disappears
-// and tracker.Remove fails -- the host-switch proxy may still be bound.
-// The loopback rule must be retained, not deleted: when the listener
-// reappears, tracker.Add returns "proxy already running" from the stale
-// proxy and (storage having been cleared) the port is delegated with no
-// fresh Append, so only the retained rule keeps it reachable from the
-// host.
+// path during a strand + reappearance sequence. Scenario: an owned
+// port's listener disappears and tracker.Remove fails. The loopback
+// rule must stay installed so traffic from the still-bound proxy
+// continues to reach a listener that reappears. APITracker.Remove
+// retains the failing binding in portStorage, so when the listener
+// reappears tracker.Add returns ErrPortAlreadyExposed and
+// handleAlreadyExposed resumes ownership (Get>0) -- not delegation.
+// retryStranded skips while a listener is observable, so the strand
+// stays in the map across the deferral tick and clears on the resume.
 func TestRemoveFailureRetainsRuleForReappearance(t *testing.T) {
 	fakeT := newFakeTracker()
 	fakeIPT := newFakeIptables()
@@ -969,31 +996,35 @@ func TestRemoveFailureRetainsRuleForReappearance(t *testing.T) {
 	pst.Tick(pm) // 1: defer
 	pst.Tick(pm) // 2: added; loopback rule installed
 	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")])
+	appendsAfterTick2 := countApplyByAction(fakeIPT.applyCalls, Append)
 
 	// Listener disappears; tracker.Remove fails (unexpose API error).
 	fakeT.removeErr = errors.New("unexpose api error: simulated")
-	pst.Tick(nat.PortMap{}) // 3: cleanup; Remove fails → rule retained
-	require.Len(t, fakeT.removeCalls, 1)
+	pst.Tick(nat.PortMap{}) // 3: cleanup; Remove fails on both retireDisappeared and the same-tick retryStranded
 	require.Equal(t, 0, countApplyByAction(fakeIPT.applyCalls, Delete),
 		"a failed Remove must not delete the loopback rule")
 	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")],
 		"the loopback rule must survive a failed Remove")
+	require.Contains(t, pst.strandedProxies, pPort,
+		"failed Remove must record the port in strandedProxies")
 
-	// Listener reappears; tracker.Add returns "proxy already running"
-	// from the stale proxy, with storage empty (cleared by Remove).
+	// Listener reappears; with portStorage retained, tracker.Add
+	// returns ErrPortAlreadyExposed and procnet resumes ownership.
 	fakeT.removeErr = nil
 	fakeT.addBehavior = []addBehavior{
 		{err: tracker.ErrPortAlreadyExposed, seedStorage: false},
 	}
-	pst.Tick(pm) // 4: reappearance, defer
-	pst.Tick(pm) // 5: tracker.Add → "proxy already running", Get==0 → delegate
+	pst.Tick(pm) // 4: reappearance, defer; retryStranded skips (listener observable)
+	pst.Tick(pm) // 5: tracker.Add → ErrPortAlreadyExposed, Get>0 → resume
 
-	require.True(t, pst.added[pPort].delegated,
-		"reappearing port with a stale proxy must delegate")
-	require.Equal(t, 1, countApplyByAction(fakeIPT.applyCalls, Append),
-		"the reappearing port gets no fresh Append")
+	require.False(t, pst.added[pPort].delegated,
+		"reappearing port with retained portStorage must resume ownership, not delegate")
+	require.GreaterOrEqual(t, countApplyByAction(fakeIPT.applyCalls, Append), appendsAfterTick2+1,
+		"the resume path runs a fresh Append (idempotent in production)")
 	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")],
 		"the retained rule keeps the reappearing port reachable")
+	require.NotContains(t, pst.strandedProxies, pPort,
+		"resume must clear the strand")
 }
 
 // TestRemoveFailureClassificationDrivesRuleCleanup confirms retireDisappeared
@@ -1020,7 +1051,11 @@ func TestRemoveFailureClassificationDrivesRuleCleanup(t *testing.T) {
 
 		fakeT.removeErr = removeErr
 		pst.Tick(nat.PortMap{}) // 3: listener gone
-		require.Len(t, fakeT.removeCalls, 1)
+		// removeCalls count varies by error classification:
+		// proxyDestroyed errors take one Remove; default-branch errors
+		// strand the port and the same-tick retryStranded reissues a
+		// Remove, so they take two. The test is about rule retention,
+		// not call counts -- skip that assertion.
 		return fakeIPT.rules[iptKey("tcp", "8080")]
 	}
 
@@ -1095,33 +1130,21 @@ func TestEngineDelegationReleasesPriorPartialAdd(t *testing.T) {
 		"synthetic portStorage entry must be cleared after release")
 }
 
-// TestEngineDelegationAcceptsLeakWhenRemoveFails locks the documented
-// trade-off in exposeNew's engine-delegation branch: when the
-// partial-Add's host-switch unexpose fails (Remove returns an
-// ErrUnexposeAPI-shaped error), the gvisor proxy may still be bound
-// under the synthetic ID. The branch logs at Error and marks the port
-// delegated anyway because APITracker.Remove clears portStorage via a
-// leading defer, so a next-tick retry would see an empty portMap, skip
-// the Unexpose loop, and silently return nil -- hiding the failure
-// rather than recovering. The same trade-off applies in retryAppend's
-// engine-takeover branch and in retireDisappeared's default case.
-//
-// For a HostIP=127.0.0.1 publish this trade-off has a known cost: the
-// engine's events handler may have already attempted its own Add,
-// gotten "proxy already running" from gvisor against our 127.0.0.1
-// binding, and logged once without retrying. The engine then has no
-// proxy; procnet's Remove failed; nothing rebinds. Windows-side
-// traffic drops until RD restart. Triggers require the 127.0.0.1-
-// publish form plus stability-gate bypass plus an unexpose transient
-// -- documented in the if-managed branch comment.
-func TestEngineDelegationAcceptsLeakWhenRemoveFails(t *testing.T) {
+// TestEngineDelegationStrandsAndRecovers covers the engine-delegation
+// branch when the partial-Add release Remove fails with an unexpose-
+// shaped error. The port is marked delegated, the strand is recorded,
+// and retryStranded keeps reissuing tracker.Remove until the proxy
+// unbinds. Without the strand mechanism the gvisor proxy would stay
+// bound under the synthetic ID until RD restart (the engine's events
+// handler does not retry its own Add once it sees ErrPortAlreadyExposed,
+// so no other component would drive the cleanup).
+func TestEngineDelegationStrandsAndRecovers(t *testing.T) {
 	fakeT := newFakeTracker()
 	fakeIPT := newFakeIptables()
 	fakeT.addBehavior = []addBehavior{
 		{err: fmt.Errorf("%w: simulated", tracker.ErrWSLProxy), seedStorage: true},
 	}
-	// The Remove on the next tick fails with an unexpose-shaped error,
-	// signalling that the host-switch proxy may still be bound.
+	// The Remove on tick 3 fails with an unexpose-shaped error.
 	fakeT.removeErr = fmt.Errorf("%w: unexpose api failed: simulated", forwarder.ErrUnexposeAPI)
 	pst := newPortStateTracker(fakeT, fakeIPT)
 	pm := makePortMap(t)
@@ -1135,12 +1158,123 @@ func TestEngineDelegationAcceptsLeakWhenRemoveFails(t *testing.T) {
 
 	fakeIPT.engineManaged[iptKey("tcp", "8080")] = true
 
-	pst.Tick(pm) // 3: engine chain present; Remove called; Remove fails
+	pst.Tick(pm) // 3: engine chain present; Remove called; Remove fails; strand set
 
 	require.Contains(t, fakeT.removeCalls, syntheticID,
 		"engine delegation must call Remove even though it will fail")
 	require.True(t, pst.added[port].delegated,
-		"port must still be marked delegated despite Remove failure -- the documented trade-off")
+		"port must be marked delegated despite Remove failure")
+	require.Contains(t, pst.strandedProxies, port,
+		"engine-delegation Remove failure must record the port in strandedProxies")
+
+	// Unexpose recovers; listener has gone (the engine took over so
+	// this port is no longer observable via /proc/net). retryStranded
+	// reissues the Remove and clears the strand.
+	fakeT.removeErr = nil
+	pst.Tick(nat.PortMap{}) // 4: retireDisappeared drops the delegated marker; retryStranded recovers
+
+	require.NotContains(t, pst.strandedProxies, port,
+		"retryStranded must clear the strand once Remove succeeds")
+	require.NotContains(t, pst.added, port,
+		"the delegated port drops from pst.added when its listener disappears")
+}
+
+// TestAppendRetryEngineTakeoverStrandsOnRemoveFailure covers the
+// retryAppend engine-takeover path when Remove fails with an unexpose-
+// shaped error. The port is marked delegated and recorded in
+// strandedProxies so retryStranded drives the proxy unbind on later
+// ticks. The loopback rule was already Deleted before the Remove, so
+// the strand carries those bindings purely for retryStranded's
+// idempotent rule-Delete probe (a no-op here).
+func TestAppendRetryEngineTakeoverStrandsOnRemoveFailure(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	// Append commits but errors → appendFailed=true with rule installed.
+	fakeIPT.applyErrors[applyKey("tcp", "8080", Append)] = errors.New("iptables exited non-zero")
+	fakeIPT.commitOnError[applyKey("tcp", "8080", Append)] = true
+	// The Remove issued by retryAppend's engine-takeover fails.
+	fakeT.removeErr = fmt.Errorf("%w: unexpose api failed: simulated", forwarder.ErrUnexposeAPI)
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	pm := makePortMap(t)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	pst.Tick(pm) // 1: defer
+	pst.Tick(pm) // 2: tracker.Add ok, Append errors but commits → appendFailed
+	require.True(t, fakeIPT.rules[iptKey("tcp", "8080")])
+
+	// Engine chain lands before tick 3.
+	fakeIPT.engineManaged[iptKey("tcp", "8080")] = true
+
+	pst.Tick(pm) // 3: retry path → engine takeover → Delete then Remove (fails) → strand
+
+	require.True(t, pst.added[port].delegated,
+		"engine-takeover marks the port delegated")
+	require.Contains(t, pst.strandedProxies, port,
+		"engine-takeover Remove failure must record the port in strandedProxies")
+	require.False(t, fakeIPT.rules[iptKey("tcp", "8080")],
+		"the committed procnet rule must be Deleted before the Remove attempt")
+
+	// Listener disappears; Remove recovers; retryStranded drains.
+	fakeT.removeErr = nil
+	pst.Tick(nat.PortMap{}) // 4: retryStranded recovers
+
+	require.NotContains(t, pst.strandedProxies, port,
+		"retryStranded must clear the strand on recovery")
+}
+
+// TestCleanDelegationDoesNotStrand confirms that a port delegated on
+// its first action (engine chain visible at exposeNew) never enters
+// strandedProxies. The engine owns the proxy; procnet has nothing to
+// release.
+func TestCleanDelegationDoesNotStrand(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	fakeIPT.engineManaged[iptKey("tcp", "8080")] = true
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	pm := makePortMap(t)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	pst.Tick(pm)            // 1: defer
+	pst.Tick(pm)            // 2: engine probe true → delegated; no tracker.Add
+	pst.Tick(nat.PortMap{}) // 3: listener disappears
+
+	require.NotContains(t, pst.strandedProxies, port,
+		"cleanly delegated ports must never enter strandedProxies")
+	require.Empty(t, fakeT.removeCalls,
+		"cleanly delegated ports must not call tracker.Remove on cleanup")
+}
+
+// TestStrandSkipsRetryWhileListenerObservable confirms retryStranded
+// holds the strand entry without retrying Remove while a listener is
+// observable in /proc/net. The proxy that may still be bound is now
+// plausibly serving that listener, and an unbind here would tear down
+// a working path.
+func TestStrandSkipsRetryWhileListenerObservable(t *testing.T) {
+	fakeT := newFakeTracker()
+	fakeIPT := newFakeIptables()
+	pst := newPortStateTracker(fakeT, fakeIPT)
+	pm := makePortMap(t)
+	port, err := nat.NewPort("tcp", "8080")
+	require.NoError(t, err)
+
+	pst.Tick(pm) // 1: defer
+	pst.Tick(pm) // 2: added
+
+	// Listener disappears; Remove fails; strand recorded.
+	fakeT.removeErr = errors.New("unexpose api error: simulated")
+	pst.Tick(nat.PortMap{}) // 3: cleanup; strand set; retryStranded retries (still fails)
+	removeCallsAfterStrand := len(fakeT.removeCalls)
+	require.Contains(t, pst.strandedProxies, port)
+
+	// Listener reappears; retryStranded must skip while it is observable.
+	pst.Tick(pm) // 4: defer
+
+	require.Equal(t, removeCallsAfterStrand, len(fakeT.removeCalls),
+		"retryStranded must NOT issue Remove while the listener is observable")
+	require.Contains(t, pst.strandedProxies, port,
+		"the strand must persist across the deferral tick")
 }
 
 // TestRemoveReportedProxyDestroyed pins the shared error-classification

--- a/src/go/guestagent/pkg/tracker/apitracker.go
+++ b/src/go/guestagent/pkg/tracker/apitracker.go
@@ -179,17 +179,30 @@ func (a *APITracker) Get(containerID string) nat.PortMap {
 	return a.portStorage.get(containerID)
 }
 
-// Remove a single entry from the port storage and calls the
-// /services/forwarder/unexpose endpoint to remove the forwarded port mappings.
+// Remove unexposes the bindings stored under containerID and updates
+// portStorage. Bindings whose Unexpose call succeeds drop from storage;
+// bindings whose Unexpose call fails remain in storage so a later
+// Remove(containerID) can retry them. wsl-proxy is notified of the
+// successful unexposes only -- a later retry that succeeds will send a
+// fresh notification for those bindings.
 func (a *APITracker) Remove(containerID string) error {
 	portMap := a.portStorage.get(containerID)
-	defer a.portStorage.remove(containerID)
+	if len(portMap) == 0 {
+		return nil
+	}
 
 	var unexposeErrs []error
+	unexposed := make(nat.PortMap)
+	remaining := make(nat.PortMap)
 
 	for portProto, portBindings := range portMap {
+		var unexposedBindings []nat.PortBinding
+		var remainingBindings []nat.PortBinding
 		for _, portBinding := range portBindings {
-			// The unexpose API only supports IPv4
+			// The unexpose API only supports IPv4. Non-IPv4 entries
+			// were never exposed via the API, so we drop them from
+			// storage rather than retain them -- a retry would skip
+			// them again with the same isIPv4 result.
 			ipv4, err := isIPv4(portBinding.HostIP)
 			if !ipv4 || err != nil {
 				log.Errorf("did not receive IPv4 for HostIP: %s", portBinding.HostIP)
@@ -206,10 +219,25 @@ func (a *APITracker) Remove(containerID string) error {
 			if err != nil {
 				unexposeErrs = append(unexposeErrs,
 					fmt.Errorf("unexposing %+v failed: %w", portBinding, err))
-
+				remainingBindings = append(remainingBindings, portBinding)
 				continue
 			}
+			unexposedBindings = append(unexposedBindings, portBinding)
 		}
+		if len(unexposedBindings) > 0 {
+			unexposed[portProto] = unexposedBindings
+		}
+		if len(remainingBindings) > 0 {
+			remaining[portProto] = remainingBindings
+		}
+	}
+
+	// Update portStorage: retain only the bindings whose Unexpose
+	// failed; drop the entry entirely if everything succeeded.
+	if len(remaining) > 0 {
+		a.portStorage.add(containerID, remaining)
+	} else {
+		a.portStorage.remove(containerID)
 	}
 
 	// Report the host-switch unexpose failures and the wsl-proxy failure
@@ -223,10 +251,10 @@ func (a *APITracker) Remove(containerID string) error {
 		retErr = fmt.Errorf("%w: %+v", forwarder.ErrUnexposeAPI, unexposeErrs)
 	}
 
-	if len(portMap) != 0 {
+	if len(unexposed) > 0 {
 		portMapping := guestagentTypes.PortMapping{
 			Remove: true,
-			Ports:  portMap,
+			Ports:  unexposed,
 		}
 		log.Debugf("forwarding to wsl-proxy to remove port mapping: %+v", portMapping)
 		if err := a.wslProxyForwarder.Send(portMapping); err != nil {

--- a/src/go/guestagent/pkg/tracker/apitracker_test.go
+++ b/src/go/guestagent/pkg/tracker/apitracker_test.go
@@ -463,7 +463,80 @@ func TestRemoveWithError(t *testing.T) {
 	})
 
 	actualPortMapping := apiTracker.Get(containerID)
-	assert.Nil(t, actualPortMapping)
+	require.Len(t, actualPortMapping[protoPort], 1,
+		"failing binding must remain in storage for retry")
+	assert.Equal(t, hostIP2, actualPortMapping[protoPort][0].HostIP)
+}
+
+// TestRemoveRetainsFailedUnexposeInStorage pins the storage-retention
+// path on partial Unexpose failure. Scenario: a containerID has three
+// bindings; the Unexpose call for one binding fails. The entry for the
+// failing binding must remain in portStorage so a later Remove can
+// retry, the successfully-unexposed bindings must drop from storage,
+// and wsl-proxy must be notified only of the successes.
+func TestRemoveRetainsFailedUnexposeInStorage(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/services/forwarder/unexpose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.UnexposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.Local == ipPortBuilder(hostIP2, hostPort) {
+			http.Error(w, "Test API error", http.StatusRequestTimeout)
+			return
+		}
+	})
+
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	wslProxy := &testForwarder{}
+	apiTracker := tracker.NewAPITracker(context.Background(), wslProxy, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	portMapping := nat.PortMap{
+		protoPort: []nat.PortBinding{
+			{HostIP: hostIP, HostPort: hostPort},
+			{HostIP: hostIP2, HostPort: hostPort},
+			{HostIP: hostIP3, HostPort: hostPort},
+		},
+	}
+
+	require.NoError(t, apiTracker.Add(containerID, portMapping))
+
+	// Discard wsl-proxy mappings from Add; we only assert on what Remove sends.
+	wslProxy.receivedPortMappings = nil
+
+	err = apiTracker.Remove(containerID)
+	require.Error(t, err, "Remove must surface the unexpose failure")
+	require.ErrorIs(t, err, forwarder.ErrUnexposeAPI)
+
+	remaining := apiTracker.Get(containerID)
+	require.NotNil(t, remaining,
+		"portStorage must retain the entry when any Unexpose fails")
+	require.Len(t, remaining[protoPort], 1,
+		"storage must contain the failing binding only")
+	require.Equal(t, hostIP2, remaining[protoPort][0].HostIP,
+		"the retained binding must be the one whose Unexpose failed")
+
+	require.Len(t, wslProxy.receivedPortMappings, 1,
+		"wsl-proxy must be notified once, for the successful unexposes")
+	require.True(t, wslProxy.receivedPortMappings[0].Remove)
+	var sentBindings []nat.PortBinding
+	for _, bindings := range wslProxy.receivedPortMappings[0].Ports {
+		sentBindings = append(sentBindings, bindings...)
+	}
+	sentIPs := make([]string, 0, len(sentBindings))
+	for _, b := range sentBindings {
+		sentIPs = append(sentIPs, b.HostIP)
+	}
+	assert.ElementsMatch(t, []string{hostIP, hostIP3}, sentIPs,
+		"wsl-proxy must see only the successfully-unexposed bindings")
 }
 
 // TestRemoveWSLProxyFailureIsDistinguishable confirms that when every


### PR DESCRIPTION
## Summary

When `tracker.Remove` returned a non-proxyDestroyed error, `APITracker` cleared `portStorage` anyway via the leading defer, so any retry walked an empty map and silently returned `nil` -- hiding the failure rather than recovering. The gvisor proxy stayed bound under procnet's synthetic ID, and the Windows host port was leaked until RD restart. Three sites trigger this: `retryAppend`'s engine-takeover, `exposeNew`'s engine-delegation, and `retireDisappeared`'s owned-port default branch.

## Approach

Two changes drive the recovery:

- **`APITracker.Remove`** retains failing bindings in `portStorage`. Successful unexposes drop from storage; bindings whose `Unexpose` call fails remain so a later `Remove(containerID)` can retry. wsl-proxy is notified only of the successfully-unexposed bindings -- a later retry that succeeds sends a fresh notification.
- **`portStateTracker.strandedProxies`** map populated by `releaseToEngine` (the three engine-takeover sites) and `retireDisappeared`'s default branch when `tracker.Remove` fails with a non-proxyDestroyed error. `Tick` calls `retryStranded` at the end of each iteration:
  - Ports with an observable listener are skipped (the proxy may now be serving that listener; an unbind would tear the working path down).
  - Otherwise `Remove` is reissued and, on success, the strand drops and `applyLoopbackRules(Delete)` runs against the stored bindings (idempotent for engine-takeover sites that already cleared their rule).

Re-acquiring ownership (`exposeNew`'s non-managed success and `handleAlreadyExposed`'s resume path) clears the strand directly: the live proxy now serves the active listener, so a `retryStranded` retry would unbind it incorrectly.

## Stacks on #10355

This branch is based on `procnet-bindings-refresh` (#10355), itself stacked on `tracker-already-exposed-sentinel` (#10347), which is stacked on `procnet-portstatetracker` (#10280). Each lower PR needs to land first; this branch rebases down naturally as they do.

## Tests

`pkg/tracker/apitracker_test.go`:
- `TestRemoveRetainsFailedUnexposeInStorage` pins the new retention contract.
- `TestRemoveWithError` updated to assert the failing binding remains in storage.

`pkg/procnet/port_state_tracker_linux_test.go`:
- `TestCleanupReleasesAddedOnRemoveFailure` rewritten to assert strand-set and strand-cleared-on-resume.
- `TestRemoveFailureRetainsRuleForReappearance` rewritten: with `portStorage` retained, reappearance drives `handleAlreadyExposed`'s resume path (not delegation).
- `TestEngineDelegationStrandsAndRecovers` (renamed from `TestEngineDelegationAcceptsLeakWhenRemoveFails`) pins the `exposeNew` engine-delegation strand and the `retryStranded` recovery.
- `TestAppendRetryEngineTakeoverStrandsOnRemoveFailure` pins the `retryAppend` engine-takeover strand.
- `TestCleanDelegationDoesNotStrand` confirms a port delegated on its first action never enters `strandedProxies`.
- `TestStrandSkipsRetryWhileListenerObservable` pins the listener-back gate in `retryStranded`.
- `fakeTracker.Remove` updated to mirror the new `APITracker` behavior (retain storage on host-switch unexpose failure; clear on success or wsl-proxy-only failure).

The three new bug-fix tests (engine-delegation strand, retryAppend engine-takeover strand, retryStranded-skips-while-observable) were each verified to fail against the unchanged mechanism before the fix landed.

## Documentation

- `portState`'s "Append retry" and "Listener disappears" sections rewritten to describe strand recording instead of the prior "rare leak accepted" framing.
- A new **Stranded-proxy recovery** section documents the mechanism end to end.
- The "Known trade-off" paragraph in `exposeNew`'s engine-delegation branch trimmed: the rare-leak framing no longer applies.

## Test plan

- [ ] `go test ./...` in `src/go/guestagent` (passes locally on linux/arm64)
- [ ] `yarn lint:go:nofix` (clean)
- [ ] `bats bats/tests/containers/published-ports.bats` passes on Windows
- [ ] Manual reproduction is hard (requires a transient host-switch outage coincident with container teardown); rely on the test suite for the strand-and-recover paths.
