### PR TITLE
update: validate sha512 checksum fetched from release server

### DIFF
--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -348,10 +348,27 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
    * @returns Base64-encoded checksum.
    */
   protected async getSha512Sum(checksumURL: string): Promise<string> {
-    const contents = await (await net.fetch(checksumURL)).text();
-    const buffer = Buffer.from(contents.split(/\s+/)[0], 'hex');
+    const response = await net.fetch(checksumURL);
 
-    return buffer.toString('base64');
+    if (!response.ok) {
+      throw newError(
+        `Failed to fetch checksum from ${ checksumURL }: ${ response.status } ${ response.statusText }`,
+        'ERR_UPDATER_CHECKSUM_FETCH_FAILED',
+      );
+    }
+    const hex = (await response.text()).split(/\s+/)[0];
+
+    // Buffer.from(..., 'hex') silently truncates on non-hex input, so an HTML
+    // error page or redirect body would otherwise cache as an empty checksum.
+    // Require the digest to be 128 hex characters before decoding.
+    if (!/^[0-9a-f]{128}$/i.test(hex)) {
+      throw newError(
+        `Invalid sha512 checksum from ${ checksumURL }: ${ JSON.stringify(hex) }`,
+        'ERR_UPDATER_CHECKSUM_INVALID',
+      );
+    }
+
+    return Buffer.from(hex, 'hex').toString('base64');
   }
 
   /**

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -335,3 +335,62 @@ describe('queryUpgradeResponder', () => {
     expect(body.extraInfo.wslVersion).toBe(undefined);
   });
 });
+
+describe('LonghornProvider.getSha512Sum', () => {
+  let LonghornProviderClass: typeof import('../LonghornProvider').default;
+
+  beforeAll(async() => {
+    ({ default: LonghornProviderClass } = await import('../LonghornProvider'));
+  });
+  afterEach(() => {
+    modules.electron.net.fetch.mockReset();
+  });
+
+  function makeProvider() {
+    const provider = new LonghornProviderClass(
+      {} as any,
+      {} as any,
+      { platform: 'win32' } as any,
+    );
+
+    return provider as unknown as { getSha512Sum(url: string): Promise<string> };
+  }
+
+  it('decodes the hex checksum and returns it as base64', async() => {
+    const hex = 'a'.repeat(128);
+
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      ok:         true,
+      status:     200,
+      statusText: 'OK',
+      text:       () => Promise.resolve(`${ hex }  rancher-desktop.msi\n`),
+    });
+
+    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+      .resolves.toBe(Buffer.from(hex, 'hex').toString('base64'));
+  });
+
+  it('rejects when the server returns a non-OK status', async() => {
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      ok:         false,
+      status:     503,
+      statusText: 'Service Unavailable',
+      text:       () => Promise.resolve('<html>oops</html>'),
+    });
+
+    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+      .rejects.toThrow(/503/);
+  });
+
+  it('rejects when the response is not a valid sha512 hex string', async() => {
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      ok:         true,
+      status:     200,
+      statusText: 'OK',
+      text:       () => Promise.resolve('<html>oops</html>'),
+    });
+
+    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+      .rejects.toThrow(/sha512/i);
+  });
+});

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -347,13 +347,11 @@ describe('LonghornProvider.getSha512Sum', () => {
   });
 
   function makeProvider() {
-    const provider = new LonghornProviderClass(
+    return new LonghornProviderClass(
       {} as any,
       {} as any,
       { platform: 'win32' } as any,
     );
-
-    return provider as unknown as { getSha512Sum(url: string): Promise<string> };
   }
 
   it('decodes the hex checksum and returns it as base64', async() => {
@@ -366,7 +364,7 @@ describe('LonghornProvider.getSha512Sum', () => {
       text:       () => Promise.resolve(`${ hex }  rancher-desktop.msi\n`),
     });
 
-    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+    await expect(makeProvider()['getSha512Sum']('https://example.test/cs'))
       .resolves.toBe(Buffer.from(hex, 'hex').toString('base64'));
   });
 
@@ -378,7 +376,7 @@ describe('LonghornProvider.getSha512Sum', () => {
       text:       () => Promise.resolve('<html>oops</html>'),
     });
 
-    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+    await expect(makeProvider()['getSha512Sum']('https://example.test/cs'))
       .rejects.toThrow(/503/);
   });
 
@@ -390,7 +388,7 @@ describe('LonghornProvider.getSha512Sum', () => {
       text:       () => Promise.resolve('<html>oops</html>'),
     });
 
-    await expect(makeProvider().getSha512Sum('https://example.test/cs'))
+    await expect(makeProvider()['getSha512Sum']('https://example.test/cs'))
       .rejects.toThrow(/sha512/i);
   });
 });


### PR DESCRIPTION
Updating failed with `sha512 checksum mismatch, expected , got ...` because getSha512Sum silently returned an empty string when the checksum URL responded with a non-2xx status or with non-hex content: Buffer.from(x, 'hex') truncates silently on bad input. The empty result was cached for ~24h, so every retry compared against it.

Reject non-OK responses and require a 128-hex-char digest before decoding.

Fixes #10359