### PR TITLE
Skip stopped WSL distros during integration sync

### DIFF
--- a/pkg/rancher-desktop/integrations/__tests__/windowsIntegrationManager.spec.ts
+++ b/pkg/rancher-desktop/integrations/__tests__/windowsIntegrationManager.spec.ts
@@ -57,6 +57,50 @@ describe('WindowsIntegrationManager', () => {
     });
   });
 
+  describe('runningDistros', () => {
+    it('should return a set of running distro names', async() => {
+      captureCommandMock.mockImplementation((_opts: any, ...args: string[]) => {
+        if (args.includes('--running')) {
+          return 'Ubuntu\r\nMyDistro\r\n';
+        }
+
+        return wslOutput;
+      });
+
+      const running = await integrationManager['runningDistros'];
+
+      expect(running).toEqual(new Set(['Ubuntu', 'MyDistro']));
+    });
+
+    it('should return an empty set when no distros are running', async() => {
+      captureCommandMock.mockImplementation((_opts: any, ...args: string[]) => {
+        if (args.includes('--running')) {
+          return '';
+        }
+
+        return wslOutput;
+      });
+
+      const running = await integrationManager['runningDistros'];
+
+      expect(running).toEqual(new Set());
+    });
+
+    it('should return an empty set when the command fails', async() => {
+      captureCommandMock.mockImplementation((_opts: any, ...args: string[]) => {
+        if (args.includes('--running')) {
+          throw new Error('wsl.exe not found');
+        }
+
+        return wslOutput;
+      });
+
+      const running = await integrationManager['runningDistros'];
+
+      expect(running).toEqual(new Set());
+    });
+  });
+
   describe('getStateForIntegration', () => {
     it('should return a string explaining that only v2 distros are supported', async() => {
       const distro = new WSLDistro('Ubuntu', 1);
@@ -65,6 +109,44 @@ describe('WindowsIntegrationManager', () => {
       expect(state).toEqual(
         expect.stringMatching(`Rancher Desktop can only integrate with v2 WSL distributions.*`),
       );
+    });
+
+    it('should return the settings value for a stopped v2 distro without running wsl --exec', async() => {
+      captureCommandMock.mockImplementation((_opts: any, ...args: string[]) => {
+        if (args.includes('--running')) {
+          return ''; // no distros running
+        }
+
+        return wslOutput;
+      });
+
+      // Set integration enabled in settings for Ubuntu
+      (integrationManager as any).settings = { WSL: { integrations: { Ubuntu: true } } };
+
+      const distro = new WSLDistro('Ubuntu', 2);
+      const state = await integrationManager['getStateForIntegration'](distro);
+
+      expect(state).toBe(true);
+      // Verify captureCommand was never called with --distribution (i.e., never ran wsl --exec)
+      expect(captureCommandMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ distro: 'Ubuntu' }),
+        expect.anything(),
+      );
+    });
+
+    it('should return false for a stopped v2 distro with no settings entry', async() => {
+      captureCommandMock.mockImplementation((_opts: any, ...args: string[]) => {
+        if (args.includes('--running')) {
+          return '';
+        }
+
+        return wslOutput;
+      });
+
+      const distro = new WSLDistro('Ubuntu', 2);
+      const state = await integrationManager['getStateForIntegration'](distro);
+
+      expect(state).toBe(false);
     });
   });
 });

--- a/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
+++ b/pkg/rancher-desktop/integrations/windowsIntegrationManager.ts
@@ -199,10 +199,20 @@ export default class WindowsIntegrationManager implements IntegrationManager {
         kubeconfigPath = undefined;
       }
 
+      const runningDistros = await this.runningDistros;
+      const enabledDistros = new Set(
+        Object.entries(this.settings.WSL?.integrations ?? {})
+          .filter(([_, enabled]) => enabled === true)
+          .map(([name]) => name),
+      );
+      const canKeepStoppedDistroAlive = !this.dockerSocketProxyReason;
       await Promise.all([
         this.syncHostSocketProxy(),
         this.syncHostDockerPluginConfig(),
-        ...(await this.supportedDistros).map(distro => this.syncDistro(distro.name, kubeconfigPath)),
+        ...(await this.supportedDistros)
+          .filter(distro => runningDistros.has(distro.name) ||
+            (canKeepStoppedDistroAlive && enabledDistros.has(distro.name)))
+          .map(distro => this.syncDistro(distro.name, kubeconfigPath)),
       ]);
     } catch (ex) {
       console.error(`Integration sync: Error: ${ ex }`);
@@ -515,10 +525,11 @@ export default class WindowsIntegrationManager implements IntegrationManager {
    */
   async verifyAllDistrosKubeConfig() {
     const distros = await this.supportedDistros;
+    const running = await this.runningDistros;
 
-    await Promise.all(distros.map(async(distro) => {
-      await this.verifyDistroKubeConfig(distro.name);
-    }));
+    await Promise.all(distros
+      .filter(distro => running.has(distro.name))
+      .map(distro => this.verifyDistroKubeConfig(distro.name)));
   }
 
   /**
@@ -615,7 +626,7 @@ export default class WindowsIntegrationManager implements IntegrationManager {
       let wslOutput: string;
 
       try {
-        wslOutput = await this.captureCommand({ encoding: 'utf16le' }, '--list', '--verbose');
+        wslOutput = await this.captureCommand({ env: { WSL_UTF8: '1' } }, '--list', '--verbose');
       } catch (error: any) {
         console.error(`Error listing distros: ${ error }`);
 
@@ -643,6 +654,29 @@ export default class WindowsIntegrationManager implements IntegrationManager {
     })();
   }
 
+  /**
+   * Returns a set of WSL distro names that are currently in Running state.
+   * Used to avoid starting stopped distros just to query or sync them,
+   * which would trigger WSL's idle-termination and clear binfmt_misc entries.
+   */
+  protected get runningDistros(): Promise<Set<string>> {
+    return (async() => {
+      try {
+        const output = await this.captureCommand({ env: { WSL_UTF8: '1' } }, '--list', '--running', '--quiet');
+        const names = output
+          .split(/\r?\n/g)
+          .map(x => x.trim())
+          .filter(x => x);
+
+        return new Set(names);
+      } catch (error) {
+        console.error(`Error listing running distros: ${ error }`);
+
+        return new Set<string>();
+      }
+    })();
+  }
+
   protected async markIntegration(distro: string, state: boolean): Promise<void> {
     try {
       const exe = await this.getLinuxToolPath(distro, executable('wsl-helper-linux'));
@@ -657,7 +691,9 @@ export default class WindowsIntegrationManager implements IntegrationManager {
   async listIntegrations(): Promise<Record<string, boolean | string>> {
     // Get the results in parallel
     const distros = await this.nonBlacklistedDistros;
-    const states = distros.map(d => (async() => [d.name, await this.getStateForIntegration(d)] as const)());
+    const running = await this.runningDistros;
+    const states = distros.map(async(d) =>
+      [d.name, await this.getStateForIntegration(d, running)] as const);
 
     return Object.fromEntries(await Promise.all(states));
   }
@@ -666,11 +702,18 @@ export default class WindowsIntegrationManager implements IntegrationManager {
    * Tells the caller what the state of a distro is. For more information see
    * the comment on `IntegrationManager.listIntegrations`.
    */
-  protected async getStateForIntegration(distro: WSLDistro): Promise<boolean | string> {
+  protected async getStateForIntegration(distro: WSLDistro, runningDistros?: Set<string>): Promise<boolean | string> {
     if (distro.version !== 2) {
       console.log(`WSL distro "${ distro.name }": is version ${ distro.version }`);
 
       return `Rancher Desktop can only integrate with v2 WSL distributions (this is v${ distro.version }).`;
+    }
+    // Skip starting stopped distros just to read their state; return the
+    // settings value directly instead (the UI will reflect it correctly).
+    const running = runningDistros ?? await this.runningDistros;
+
+    if (!running.has(distro.name)) {
+      return this.settings.WSL?.integrations?.[distro.name] ?? false;
     }
     try {
       const exe = await this.getLinuxToolPath(distro.name, executable('wsl-helper-linux'));


### PR DESCRIPTION
Running `wsl.exe --exec` in a stopped systemd-enabled distro starts it; WSL auto-terminates it ~30s later, globally clearing all `binfmt_misc` entries, including WSLInterop in every running distro.

This fix adds a runningDistros getter that calls `wsl --list --running --quiet` (never starts a distro), and filters `sync()` and `getStateForIntegration()` to skip distros that are stopped and not explicitly integration-enabled.

Fixes [#10049](https://github.com/rancher-sandbox/rancher-desktop/issues/10049)