### PR TITLE
fix: recover Lima VM from broken state on startup

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1835,7 +1835,21 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           return;
         }
 
-        const vmStatus = await this.status;
+        let vmStatus = await this.status;
+
+        // Recover from an orphaned driver or host agent after an unclean
+        // shutdown; otherwise `limactl start` would fail.
+        // https://github.com/rancher-sandbox/rancher-desktop/issues/7760
+        if (vmStatus?.status === 'Broken') {
+          const orphanError = vmStatus.errors?.find(e => /(driver|host agent) is running but/.test(e));
+
+          if (orphanError) {
+            console.log(`Lima instance is broken (${ orphanError }); cleaning up before restart.`);
+            await this.progressTracker.action('Recovering broken virtual machine', 100,
+              this.lima('stop', '--force', MACHINE_NAME));
+            vmStatus = await this.status;
+          }
+        }
         let isVMAlreadyRunning = vmStatus?.status === 'Running';
 
         // Virtualization Framework only supports RAW disks


### PR DESCRIPTION
Lima reports the VM as "Broken" when one of the host agent or driver processes is alive while the other is dead -- typically an orphaned vz driver after an unclean shutdown. `limactl start` then fails. Detect this state and run `limactl stop --force` to clean up the orphan and stale pid files before starting.

Fixes #7760