### PR TITLE
BATS: helm-install-rancher: wait for Available instead of helm --wait

### DIFF
--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -112,9 +112,17 @@ deploy_rancher() {
         --version "$rancher_chart_version" \
         --namespace cattle-system \
         --set hostname="$host" \
-        --wait \
-        --timeout=10m \
+        --set replicas=1 \
         --create-namespace
+
+    # Don't use `helm --wait`: the chart's Deployment relies on the default
+    # `progressDeadlineSeconds` (10m), which is shorter than the initial
+    # rancher image pull on slow networks. Wait on `Available` directly,
+    # since that condition is driven by pod Ready state and is unaffected
+    # by ProgressDeadlineExceeded.
+    kubectl wait --namespace cattle-system \
+        --for=condition=Available --timeout=30m \
+        deployment/rancher
 }
 
 verify_rancher() {


### PR DESCRIPTION
## Summary

- The rancher Deployment uses the default `progressDeadlineSeconds` (10m), which is shorter than the initial `rancher/rancher` image pull (~487 MB) on slow networks (notably WSL2 on Windows). When the deadline lapses Kubernetes marks the Deployment `Failed` with `ProgressDeadlineExceeded`, and `helm --wait` reads that and bails out before its own `--timeout` would have allowed the pull to complete.
- Drop `helm --wait` and wait on the Deployment's `Available` condition directly with `kubectl wait --for=condition=Available --timeout=30m`. `Available` is driven by Ready replica count and is unaffected by `ProgressDeadlineExceeded`, so once the image pull eventually completes and the pod goes Ready the wait succeeds.
- Also `--set replicas=1` since this is a single-node cluster — running three Rancher replicas adds no test coverage and just consumes scarce VM memory.

### Symptom before the fix

On a Windows runner, `deploy_rancher` consistently failed:

```
Release "rancher" does not exist. Installing it now.
Error: resource Deployment/cattle-system/rancher not ready. status: Failed,
  message: Progress deadline exceeded
```

while `k3s.log` showed the `rancher/rancher:v2.11.0` image still downloading at ~700 kB/s; the 487 MB pull took ~11 minutes vs the chart Deployment's 10 minute progress deadline.
