### PR TITLE
fix: await runCredHelper so the catch block can set ex.helper

### DIFF
--- a/pkg/rancher-desktop/main/credentialServer/credentialUtils.ts
+++ b/pkg/rancher-desktop/main/credentialServer/credentialUtils.ts
@@ -31,7 +31,7 @@ export default async function runCommand(command: string, input?: string): Promi
   const { credsStore } = await getCredentialHelperInfo(command, input ?? '');
 
   try {
-    return runCredHelper(credsStore, command, input);
+    return await runCredHelper(credsStore, command, input);
   } catch (ex: any) {
     ex.helper = credsStore;
     throw ex;


### PR DESCRIPTION
When a credential helper binary fails (e.g. not found, exits non-zero), the error hits `runCommand` in `credentialUtils.ts`. The intent is to tag the error with which helper caused it before rethrowing:

```ts
try {
  return runCredHelper(credsStore, command, input); // no await
} catch (ex: any) {
  ex.helper = credsStore; // dead code - never runs
  throw ex;
}
```

Without `await`, a `try-catch` in an async function doesn't catch Promise rejections. The catch block is dead, `ex.helper` is never set, and the error handler in `httpCredentialHelperServer.ts` always falls back to the `?? '<unknown>'` default:

```ts
const helperName = err.helper ?? '<unknown>'; // always '<unknown>'
console.debug(`FAILURE: Processing request ${commandName} with credential helper ${helperName}`);
```

The fix is one word: `return await runCredHelper(...)`.

Reproduce:

```js
async function withoutAwait() {
  try { return Promise.reject(new Error('fail')); }
  catch (ex) { ex.helper = 'pikachu'; throw ex; }
}
async function withAwait() {
  try { return await Promise.reject(new Error('fail')); }
  catch (ex) { ex.helper = 'pikachu'; throw ex; }
}

try { await withoutAwait(); } catch(e) { console.log(e.helper); } // undefined
try { await withAwait();    } catch(e) { console.log(e.helper); } // 'pikachu'
```

Every other call to `runCredHelper` in the same file already uses `await` - this one was just missed.