### PR TITLE
fix: wait for the Windows certificate stream to close

### DIFF
--- a/pkg/rancher-desktop/main/networking/__tests__/win-ca.spec.ts
+++ b/pkg/rancher-desktop/main/networking/__tests__/win-ca.spec.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from 'events';
+
+import { jest } from '@jest/globals';
+
+import type { spawn } from '@pkg/utils/childProcess';
+
+const logMock = {
+  fdStream: Promise.resolve(2),
+  log:      jest.fn(),
+  error:    jest.fn(),
+  info:     jest.fn(),
+  warn:     jest.fn(),
+  debug:    jest.fn(),
+  debugE:   jest.fn(),
+};
+
+const spawnMock = jest.fn<typeof spawn>();
+const executableMock = jest.fn(() => 'wsl-helper');
+
+jest.unstable_mockModule('@pkg/utils/childProcess', () => ({
+  __esModule: true,
+  spawn:      spawnMock,
+}));
+jest.unstable_mockModule('@pkg/utils/logging', () => ({
+  __esModule: true,
+  Log:        class {},
+  default:    new Proxy({}, { get: () => logMock }),
+}));
+jest.unstable_mockModule('@pkg/utils/resources', () => ({
+  __esModule: true,
+  executable: executableMock,
+}));
+jest.unstable_mockModule('tls', () => ({
+  __esModule:       true,
+  default:          { rootCertificates: ['node-root-cert'] },
+  rootCertificates: ['node-root-cert'],
+}));
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+}
+
+test('getWinCertificates waits for close before ending and does not emit an empty tail', async() => {
+  const { default: getWinCertificates } = await import('../win-ca');
+  const proc = new FakeChildProcess();
+  const cert1 = '-----BEGIN CERTIFICATE-----\nfirst\n-----END CERTIFICATE-----\n';
+  const cert2 = '-----BEGIN CERTIFICATE-----\nsecond\n-----END CERTIFICATE-----\n';
+  const actual: string[] = [];
+
+  spawnMock.mockReturnValue(proc as any);
+
+  const collecting = (async() => {
+    for await (const cert of getWinCertificates()) {
+      actual.push(cert);
+    }
+  })();
+
+  // The generator suspends at `await fdStream` before registering its event
+  // listeners; one microtask tick lets it resume and attach them.
+  await Promise.resolve();
+
+  proc.stdout.emit('data', cert1);
+  proc.emit('exit', 0, null);
+  proc.stdout.emit('data', cert2);
+  proc.emit('close', 0, null);
+
+  await collecting;
+
+  expect(actual).toEqual([cert1, cert2, 'node-root-cert']);
+  expect(actual).not.toContain('');
+  expect(executableMock).toHaveBeenCalledWith('wsl-helper');
+});

--- a/pkg/rancher-desktop/main/networking/win-ca.ts
+++ b/pkg/rancher-desktop/main/networking/win-ca.ts
@@ -38,8 +38,24 @@ export default async function * getWinCertificates(): AsyncIterable<string> {
     windowsHide: true,
   });
   const iterator = new AsyncCallbackIterator<string>();
+  let emissions = Promise.resolve();
 
-  proc.stdout.on('data', async(chunk: string | Buffer) => {
+  function queueEmit(cert: string) {
+    emissions = emissions.then(async() => {
+      if (cert) {
+        await iterator.emit(cert);
+      }
+    });
+  }
+
+  function queueError(reason: any) {
+    emissions = emissions.then(
+      () => iterator.error(reason),
+      () => iterator.error(reason),
+    );
+  }
+
+  proc.stdout.on('data', (chunk: string | Buffer) => {
     try {
       if (Buffer.isBuffer(chunk)) {
         buffer += chunk.toString('utf-8');
@@ -53,22 +69,24 @@ export default async function * getWinCertificates(): AsyncIterable<string> {
           break;
         }
         buffer = buffer.substring(match.length);
-        await iterator.emit(match);
+        queueEmit(match);
       }
     } catch (ex) {
-      await iterator.error(ex);
+      queueError(ex);
     }
   });
-  proc.on('exit', async(code, signal) => {
+  proc.on('close', (code, signal) => {
     if (!(code === 0 || signal === 'SIGTERM')) {
-      iterator.error(code || signal);
+      queueError(code || signal);
     } else {
-      try {
-        await iterator.emit(buffer);
+      emissions = emissions.then(async() => {
+        if (buffer) {
+          await iterator.emit(buffer);
+        }
         iterator.end();
-      } catch (ex) {
+      }, async(ex) => {
         await iterator.error(ex);
-      }
+      });
     }
   });
 


### PR DESCRIPTION
fix win-ca to wait for `close` before ending the iterator.

Node can fire `exit` while stdout is still open, so the last cert chunk can land late. That makes this path a bit sketchy bc we can finish early and even yield an empty tail.

This switches the Windows cert path to `close`, queues cert emits so they stay ordered, and skips the empty tail. Added a regression test for the `data`, `exit`, `data`, `close` sequence.

Repro
1. Emit one PEM chunk on `stdout`
2. Fire `exit`
3. Emit another PEM chunk
4. Fire `close`

Before: only the first cert is yielded, and `''` can be yielded too.
After: both certs are yielded, no empty tail.