### PR TITLE
Add screenshot spec for Container Inspect page

### DIFF
--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, ElectronApplication, Page } from '@playwright/test';
 
-import { ContainerInfoPage } from './pages/container-info-page';
+import { ContainerInspectPage } from './pages/container-inspect-page';
 import { ContainerLogsPage } from './pages/container-logs-page';
 import { ContainerShellPage } from './pages/container-shell-page';
 import { ContainersPage } from './pages/containers-page';
@@ -146,7 +146,7 @@ test.describe.serial('Containers Tests', () => {
 
   test('should handle terminal scrolling', async() => {
     const scrollTestContainerName = `test-scroll-container-${ Date.now() }`;
-    let scrollTestContainerId: string;
+    let scrollTestContainerId = '';
 
     try {
       const output = await tool(
@@ -207,7 +207,7 @@ test.describe.serial('Containers Tests', () => {
 
   test('should output logs if container not exited', async() => {
     const longRunningContainerName = `test-not-exited-logs-${ Date.now() }`;
-    let longRunningContainerId: string;
+    let longRunningContainerId = '';
 
     try {
       const output = await tool(
@@ -457,13 +457,13 @@ test.describe.serial('Container Info Tab', () => {
   });
 
   test('Info tab is the default and active tab', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     await expect(infoPage.tab).toHaveClass(/\bactive\b/);
   });
 
   test('summary table shows key container fields', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     await infoPage.waitForData();
 
@@ -484,7 +484,7 @@ test.describe.serial('Container Info Tab', () => {
   });
 
   test('summary table shows IP address', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     // IP row is always rendered; value is either an IP or '—'.
     const ip = await infoPage.getSummaryValue('info-row-ip');
@@ -493,7 +493,7 @@ test.describe.serial('Container Info Tab', () => {
   });
 
   test('ports section is always visible', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     // The alpine container has no published ports, but the section must still render.
     await expect(infoPage.portsSection).toBeVisible();
@@ -503,7 +503,7 @@ test.describe.serial('Container Info Tab', () => {
   });
 
   test('mounts section can be expanded', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     await infoPage.mountsSection.locator('summary').click();
     // After opening the <details>, the section body should appear.
@@ -511,7 +511,7 @@ test.describe.serial('Container Info Tab', () => {
   });
 
   test('switching to Logs tab and back preserves Info data', async() => {
-    const infoPage = new ContainerInfoPage(page);
+    const infoPage = new ContainerInspectPage(page);
 
     await page.getByTestId('tab-logs').click();
     await infoPage.clickTab();

--- a/e2e/pages/container-info-page.ts
+++ b/e2e/pages/container-info-page.ts
@@ -1,50 +1,29 @@
-import { expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
-import type { Locator, Page } from '@playwright/test';
+import { ContainerInspectPage } from './container-inspect-page';
+import { ContainerLogsPage } from './container-logs-page';
+import { ContainerShellPage } from './container-shell-page';
+
+type tabNames = 'info' | 'logs' | 'shell';
 
 export class ContainerInfoPage {
-  readonly page:           Page;
-  readonly tab:            Locator;
-  readonly summaryTable:   Locator;
-  readonly loadingSpinner: Locator;
-  readonly errorMessage:   Locator;
-  readonly mountsSection:  Locator;
-  readonly envSection:     Locator;
-  readonly commandSection: Locator;
-  readonly capsSection:    Locator;
-  readonly portsSection:   Locator;
-  readonly labelsSection:  Locator;
+  readonly page: Page;
+  readonly tab:  Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.tab = page.getByTestId('tab-info');
-    this.summaryTable = page.getByTestId('info-summary-table');
-    this.loadingSpinner = page.getByTestId('info-loading');
-    this.errorMessage = page.getByTestId('info-error');
-    this.mountsSection = page.getByTestId('info-section-mounts');
-    this.envSection = page.getByTestId('info-section-env');
-    this.commandSection = page.getByTestId('info-section-command');
-    this.capsSection = page.getByTestId('info-section-capabilities');
-    this.portsSection = page.getByTestId('info-section-ports');
-    this.labelsSection = page.getByTestId('info-section-labels');
   }
 
-  async clickTab() {
-    await this.tab.click();
-  }
-
-  async waitForData(timeout = 15_000) {
-    await expect(this.loadingSpinner).toBeHidden({ timeout });
-    await expect(this.summaryTable).toBeVisible({ timeout });
-  }
-
-  /**
-   * Read the value cell of a summary row by its data-testid.
-   * E.g. getSummaryValue('info-row-name') returns the container name.
-   */
-  async getSummaryValue(rowTestId: string): Promise<string> {
-    const td = this.page.getByTestId(rowTestId).locator('td');
-
-    return (await td.textContent())?.trim() ?? '';
+  navigateToTab(tabName: 'info'): Promise<ContainerInspectPage>;
+  navigateToTab(tabName: 'logs'): Promise<ContainerLogsPage>;
+  navigateToTab(tabName: 'shell'): Promise<ContainerShellPage>;
+  async navigateToTab(tabName: tabNames) {
+    await this.page.getByTestId(`tab-${ tabName }`).click();
+    return new ({
+      info:  ContainerInspectPage,
+      logs:    ContainerLogsPage,
+      shell:   ContainerShellPage,
+    }[tabName])(this.page);
   }
 }

--- a/e2e/pages/container-inspect-page.ts
+++ b/e2e/pages/container-inspect-page.ts
@@ -1,0 +1,50 @@
+import { expect } from '@playwright/test';
+
+import type { Locator, Page } from '@playwright/test';
+
+export class ContainerInspectPage {
+  readonly page:           Page;
+  readonly tab:            Locator;
+  readonly summaryTable:   Locator;
+  readonly loadingSpinner: Locator;
+  readonly errorMessage:   Locator;
+  readonly mountsSection:  Locator;
+  readonly envSection:     Locator;
+  readonly commandSection: Locator;
+  readonly capsSection:    Locator;
+  readonly portsSection:   Locator;
+  readonly labelsSection:  Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.tab = page.getByTestId('tab-info');
+    this.summaryTable = page.getByTestId('info-summary-table');
+    this.loadingSpinner = page.getByTestId('info-loading');
+    this.errorMessage = page.getByTestId('info-error');
+    this.mountsSection = page.getByTestId('info-section-mounts');
+    this.envSection = page.getByTestId('info-section-env');
+    this.commandSection = page.getByTestId('info-section-command');
+    this.capsSection = page.getByTestId('info-section-capabilities');
+    this.portsSection = page.getByTestId('info-section-ports');
+    this.labelsSection = page.getByTestId('info-section-labels');
+  }
+
+  async clickTab() {
+    await this.tab.click();
+  }
+
+  async waitForData(timeout = 15_000) {
+    await expect(this.loadingSpinner).toBeHidden({ timeout });
+    await expect(this.summaryTable).toBeVisible({ timeout });
+  }
+
+  /**
+   * Read the value cell of a summary row by its data-testid.
+   * E.g. getSummaryValue('info-row-name') returns the container name.
+   */
+  async getSummaryValue(rowTestId: string): Promise<string> {
+    const td = this.page.getByTestId(rowTestId).locator('td');
+
+    return (await td.textContent())?.trim() ?? '';
+  }
+}

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -12,7 +12,6 @@ import { snapshotsList } from './test-data/snapshots';
 import { volumesList } from './test-data/volumes';
 
 import { ContainerInfoPage } from '@/e2e/pages/container-info-page';
-import { ContainerLogsPage } from '@/e2e/pages/container-logs-page';
 import { NavPage } from '@/e2e/pages/nav-page';
 import { PreferencesPage } from '@/e2e/pages/preferences';
 import { clearUserProfile } from '@/e2e/utils/ProfileUtils';
@@ -34,6 +33,15 @@ test.describe.serial('Main App Test', () => {
   let navPage: NavPage;
   let screenshot: MainWindowScreenshots;
   const afterCheckedTimeout = 200;
+
+  const groups = containersList.reduce((set, container) => {
+    const labels: Record<string, string> = container.Labels || {};
+    const group = labels['com.docker.compose.project'] || labels['io.kubernetes.pod.namespace'] + '/' + labels['io.kubernetes.pod.name'];
+    set.add(group);
+
+    return set;
+  }, new Set<string>());
+  const expectedContainerCount = containersList.length + groups.size + 1; // +1 for the header row
 
   test.beforeAll(async({ colorScheme }, testInfo) => {
     createDefaultSettings({
@@ -93,8 +101,7 @@ test.describe.serial('Main App Test', () => {
     test('General Page', async({ colorScheme }) => {
       await screenshot.take('General', navPage);
     });
-
-    test('Containers Page', async() => {
+    test.beforeAll(async() => {
       // Override the containers before the Vuex state is loaded.
       await navPage.page.exposeFunction('listContainersMock', (options?: any) => {
         return Promise.resolve(containersList);
@@ -104,19 +111,18 @@ test.describe.serial('Main App Test', () => {
         ddClient.docker._listContainers = ddClient.docker.listContainers;
         ddClient.docker.listContainers = listContainersMock;
       });
+    });
+    test.afterAll(async() => navPage.page.evaluate(() => {
+      const { ddClient } = window as any;
+      ddClient.docker.listContainers = ddClient.docker._listContainers;
+      delete ddClient.docker._listContainers;
+    }));
 
-      try {
-        const containersPage = await navPage.navigateTo('Containers');
+    test('Containers Page', async() => {
+      const containersPage = await navPage.navigateTo('Containers');
 
-        await expect(containersPage.page.getByRole('row')).toHaveCount(11);
-        await screenshot.take('Containers');
-      } finally {
-        await navPage.page.evaluate(() => {
-          const { ddClient } = window as any;
-          ddClient.docker.listContainers = ddClient.docker._listContainers;
-          delete ddClient.docker._listContainers;
-        });
-      }
+      await expect(containersPage.page.getByRole('row')).toHaveCount(expectedContainerCount);
+      await screenshot.take('Containers');
     });
 
     test('Container Inspect Page', async({ colorScheme }) => {
@@ -148,28 +154,29 @@ test.describe.serial('Main App Test', () => {
         await containersPage.page.waitForURL('**/containers/info/**');
 
         const containerInfoPage = new ContainerInfoPage(containersPage.page);
+        const containerInspectPage = await containerInfoPage.navigateToTab('info');
 
         // Wait for the inspect data to load (with longer timeout for CI)
-        await containerInfoPage.waitForData(30_000);
+        await containerInspectPage.waitForData(30_000);
 
         // Wait for specific summary content to ensure the component has fully rendered
         await expect(containersPage.page.getByTestId('info-row-name').locator('td')).toContainText('webapp-postgres-1');
         await expect(containersPage.page.getByTestId('info-row-image').locator('td')).toContainText('postgres:15');
 
         // Wait for sections to be present and stable
-        await expect(containerInfoPage.mountsSection).toBeVisible();
-        await expect(containerInfoPage.envSection).toBeVisible();
-        await expect(containerInfoPage.portsSection).toBeVisible();
+        await expect(containerInspectPage.mountsSection).toBeVisible();
+        await expect(containerInspectPage.envSection).toBeVisible();
+        await expect(containerInspectPage.portsSection).toBeVisible();
 
         // Open some sections to show their content
-        await containerInfoPage.mountsSection.click();
-        await containerInfoPage.envSection.click();
-        await containerInfoPage.portsSection.click();
+        await containerInspectPage.mountsSection.click();
+        await containerInspectPage.envSection.click();
+        await containerInspectPage.portsSection.click();
 
         // Wait for section content to be visible
-        await expect(containerInfoPage.mountsSection.getByText('/var/lib/postgresql/data')).toBeVisible();
-        await expect(containerInfoPage.envSection.getByText('POSTGRES_USER')).toBeVisible();
-        await expect(containerInfoPage.portsSection.getByText('5432/tcp')).toBeVisible();
+        await expect(containerInspectPage.mountsSection.getByText('/var/lib/postgresql/data')).toBeVisible();
+        await expect(containerInspectPage.envSection.getByText('POSTGRES_USER')).toBeVisible();
+        await expect(containerInspectPage.portsSection.getByText('5432/tcp')).toBeVisible();
 
         await screenshot.take('Container-Inspect');
       } finally {
@@ -187,7 +194,7 @@ test.describe.serial('Main App Test', () => {
       const containersPage = await navPage.navigateTo('Containers');
 
       await containersPage.waitForTableToLoad();
-      await expect(containersPage.page.getByRole('row')).toHaveCount(11);
+      await expect(containersPage.page.getByRole('row')).toHaveCount(expectedContainerCount);
 
       await containersPage.page.evaluate(() => {
         const { ddClient } = window as any;
@@ -226,8 +233,9 @@ test.describe.serial('Main App Test', () => {
         await containersPage.viewContainerInfo(containerId);
 
         await containersPage.page.waitForURL('**/containers/info/**');
+        const containerInfoPage = new ContainerInfoPage(containersPage.page);
+        const containerLogsPage = await containerInfoPage.navigateToTab('logs');
 
-        const containerLogsPage = new ContainerLogsPage(containersPage.page);
         await containerLogsPage.waitForLogsToLoad();
         await expect(containerLogsPage.containerInfo).toBeVisible();
         await expect(containerLogsPage.terminal).toBeVisible();

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -4,12 +4,14 @@ import path from 'path';
 import { test, expect, _electron } from '@playwright/test';
 
 import { MainWindowScreenshots, PreferencesScreenshots } from './Screenshots';
+import { containerInspectData } from './test-data/container-inspect';
 import { containersList } from './test-data/containers';
 import { imagesList } from './test-data/images';
 import { lockedSettings } from './test-data/preferences';
 import { snapshotsList } from './test-data/snapshots';
 import { volumesList } from './test-data/volumes';
 
+import { ContainerInfoPage } from '@/e2e/pages/container-info-page';
 import { ContainerLogsPage } from '@/e2e/pages/container-logs-page';
 import { NavPage } from '@/e2e/pages/nav-page';
 import { PreferencesPage } from '@/e2e/pages/preferences';
@@ -113,6 +115,70 @@ test.describe.serial('Main App Test', () => {
           const { ddClient } = window as any;
           ddClient.docker.listContainers = ddClient.docker._listContainers;
           delete ddClient.docker._listContainers;
+        });
+      }
+    });
+
+    test('Container Inspect Page', async({ colorScheme }) => {
+      const containersPage = await navPage.navigateTo('Containers');
+
+      await containersPage.waitForTableToLoad();
+      await expect(containersPage.page.getByRole('row')).toHaveCount(expectedContainerCount);
+
+      // Mock the docker inspect call to return our test data
+      await containersPage.page.evaluate((inspectData) => {
+        const { ddClient } = window as any;
+        ddClient.docker.cli._exec = ddClient.docker.cli.exec;
+        ddClient.docker.cli.exec = (command, args, options) => {
+          if (command === 'inspect') {
+            return {
+              parseJsonObject: () => [inspectData],
+            };
+          }
+          return ddClient.docker.cli._exec(command, args, options);
+        };
+      }, containerInspectData);
+
+      try {
+        const containerId = containersList[0].Id;
+
+        await containersPage.waitForContainerToAppear(containerId);
+        await containersPage.viewContainerInfo(containerId);
+
+        await containersPage.page.waitForURL('**/containers/info/**');
+
+        const containerInfoPage = new ContainerInfoPage(containersPage.page);
+
+        // Wait for the inspect data to load (with longer timeout for CI)
+        await containerInfoPage.waitForData(30_000);
+
+        // Wait for specific summary content to ensure the component has fully rendered
+        await expect(containersPage.page.getByTestId('info-row-name').locator('td')).toContainText('webapp-postgres-1');
+        await expect(containersPage.page.getByTestId('info-row-image').locator('td')).toContainText('postgres:15');
+
+        // Wait for sections to be present and stable
+        await expect(containerInfoPage.mountsSection).toBeVisible();
+        await expect(containerInfoPage.envSection).toBeVisible();
+        await expect(containerInfoPage.portsSection).toBeVisible();
+
+        // Open some sections to show their content
+        await containerInfoPage.mountsSection.click();
+        await containerInfoPage.envSection.click();
+        await containerInfoPage.portsSection.click();
+
+        // Wait for section content to be visible
+        await expect(containerInfoPage.mountsSection.getByText('/var/lib/postgresql/data')).toBeVisible();
+        await expect(containerInfoPage.envSection.getByText('POSTGRES_USER')).toBeVisible();
+        await expect(containerInfoPage.portsSection.getByText('5432/tcp')).toBeVisible();
+
+        await screenshot.take('Container-Inspect');
+      } finally {
+        await containersPage.page.evaluate(() => {
+          const { ddClient } = window as any;
+          if (ddClient.docker.cli._exec) {
+            ddClient.docker.cli.exec = ddClient.docker.cli._exec;
+            delete ddClient.docker.cli._exec;
+          }
         });
       }
     });

--- a/screenshots/test-data/container-inspect.ts
+++ b/screenshots/test-data/container-inspect.ts
@@ -1,0 +1,69 @@
+import type { ContainerInspectData } from '@pkg/store/container-engine';
+
+/**
+ * Mock inspect data for the first container in containersList
+ * (postgres:15 with ID b253b86ddaca...)
+ */
+export const containerInspectData: ContainerInspectData = {
+  Id:      'b253b86ddaca501c0f542564d086b7535ed015faa323f0f8df8fccc38c0c8ee0',
+  Name:    '/webapp-postgres-1',
+  Created: '2025-01-15T08:08:30.123456789Z',
+  State:   {
+    Status:     'running',
+    StartedAt:  '2025-01-15T08:08:30.987654321Z',
+    FinishedAt: '0001-01-01T00:00:00Z',
+  },
+  Config: {
+    Image: 'postgres:15',
+    Env:   [
+      'POSTGRES_USER=webapp',
+      'POSTGRES_PASSWORD=webapp',
+      'POSTGRES_DB=webapp',
+      'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/15/bin',
+      'GOSU_VERSION=1.17',
+      'LANG=en_US.utf8',
+      'PG_MAJOR=15',
+      'PG_VERSION=15.5-1.pgdg120+1',
+      'PGDATA=/var/lib/postgresql/data',
+    ],
+    Cmd:        ['postgres'],
+    Entrypoint: ['docker-entrypoint.sh'],
+    Labels:     {
+      'com.docker.compose.config-hash':          '6bc84b873e5a54c963a2a5beb0468a9c0739073acccf25087690737d7d620b65',
+      'com.docker.compose.container-number':     '1',
+      'com.docker.compose.depends_on':           '',
+      'com.docker.compose.image':                'sha256:7317fa7ddf4f0870b999784a8ff3f5d8f180fa43e0b894394cc3d8f3aa6cdbd9',
+      'com.docker.compose.oneoff':               'False',
+      'com.docker.compose.project':              'web-compose',
+      'com.docker.compose.project.config_files': '/Users/USER/Desktop/docker-compose.yaml',
+      'com.docker.compose.project.working_dir':  '/Users/USER/Desktop',
+      'com.docker.compose.service':              'webapp-postgres',
+      'com.docker.compose.version':              '2.17.3',
+    },
+  },
+  HostConfig: {
+    CapAdd:  ['SYS_ADMIN', 'NET_ADMIN'],
+    CapDrop: ['MKNOD', 'SYS_CHROOT'],
+  },
+  Mounts: [
+    {
+      Type:        'volume',
+      Source:      '/var/lib/docker/volumes/webapp_postgres_v15/_data',
+      Destination: '/var/lib/postgresql/data',
+      RW:          true,
+      Mode:        'z',
+    },
+  ],
+  NetworkSettings: {
+    IPAddress: '172.18.0.3',
+    Ports:     {
+      '5432/tcp': null,
+    },
+    Networks: {
+      webapp_network: {
+        IPAddress: '172.18.0.3',
+      },
+    },
+  },
+  Args: [],
+};

--- a/screenshots/test-data/containers.ts
+++ b/screenshots/test-data/containers.ts
@@ -7,8 +7,8 @@ export const containersList = [{
   Mounts:  [
     {
       Type:        'volume',
-      Name:        'desktop_penpot_postgres_v15',
-      Source:      '/var/lib/docker/volumes/desktop_penpot_postgres_v15/_data',
+      Name:        'webapp_postgres_v15',
+      Source:      '/var/lib/docker/volumes/webapp_postgres_v15/_data',
       Destination: '/var/lib/postgresql/data',
       Driver:      'local',
       Mode:        'z',
@@ -23,7 +23,7 @@ export const containersList = [{
       Type:   'json-file',
       Config: {},
     },
-    NetworkMode:   'desktop_penpot',
+    NetworkMode:   'webapp_network',
     PortBindings:  {},
     RestartPolicy: {
       Name:              'always',
@@ -39,7 +39,7 @@ export const containersList = [{
     Mounts: [
       {
         Type:          'volume',
-        Source:        'desktop_penpot_postgres_v15',
+        Source:        'webapp_postgres_v15',
         Target:        '/var/lib/postgresql/data',
         VolumeOptions: {},
       },
@@ -57,16 +57,16 @@ export const containersList = [{
     'com.docker.compose.project':              'web-compose',
     'com.docker.compose.project.config_files': '/Users/USER/Desktop/docker-compose.yaml',
     'com.docker.compose.project.working_dir':  '/Users/USER/Desktop',
-    'com.docker.compose.service':              'penpot-postgres',
+    'com.docker.compose.service':              'webapp-postgres',
     'com.docker.compose.version':              '2.17.3',
   },
   State: 'running',
   Names: [
-    'desktop-penpot-postgres-1',
+    'desktop-webapp-postgres-1',
   ],
   Created:          null,
   state:            'running',
-  containerName:    'desktop-penpot-postgres-1',
+  containerName:    'desktop-webapp-postgres-1',
   started:          'Up About 22 minutes ago',
   imageName:        'postgres:15',
   availableActions: [
@@ -118,7 +118,7 @@ export const containersList = [{
       Type:   'json-file',
       Config: {},
     },
-    NetworkMode:   'desktop_penpot',
+    NetworkMode:   'webapp_network',
     PortBindings:  {},
     RestartPolicy: {
       Name:              'always',
@@ -144,16 +144,16 @@ export const containersList = [{
     'com.docker.compose.project':              'web-compose',
     'com.docker.compose.project.config_files': '/Users/USER/Desktop/docker-compose.yaml',
     'com.docker.compose.project.working_dir':  '/Users/USER/Desktop',
-    'com.docker.compose.service':              'penpot-redis',
+    'com.docker.compose.service':              'webapp-redis',
     'com.docker.compose.version':              '2.17.3',
   },
   State: 'running',
   Names: [
-    'desktop-penpot-redis-1',
+    'desktop-webapp-redis-1',
   ],
   Created:          null,
   state:            'running',
-  containerName:    'desktop-penpot-redis-1',
+  containerName:    'desktop-webapp-redis-1',
   started:          'Up About 2 hours ago',
   imageName:        'redis:7',
   availableActions: [
@@ -194,7 +194,7 @@ export const containersList = [{
       Type:   'json-file',
       Config: {},
     },
-    NetworkMode:  'desktop_penpot',
+    NetworkMode:  'webapp_network',
     PortBindings: {
       '1080/tcp': [
         {
@@ -239,16 +239,16 @@ export const containersList = [{
     'com.docker.compose.project':              'web-compose',
     'com.docker.compose.project.config_files': '/Users/USER/Desktop/docker-compose.yaml',
     'com.docker.compose.project.working_dir':  '/Users/USER/Desktop',
-    'com.docker.compose.service':              'penpot-mailcatch',
+    'com.docker.compose.service':              'webapp-mailcatch',
     'com.docker.compose.version':              '2.17.3',
   },
   State: 'running',
   Names: [
-    'desktop-penpot-mailcatch-1',
+    'desktop-webapp-mailcatch-1',
   ],
   Created:          null,
   state:            'running',
-  containerName:    'desktop-penpot-mailcatch-1',
+  containerName:    'desktop-webapp-mailcatch-1',
   started:          'Up About a minute',
   imageName:        'sj26/mailcatcher:latest',
   availableActions: [

--- a/screenshots/test-data/volumes.ts
+++ b/screenshots/test-data/volumes.ts
@@ -1,13 +1,13 @@
 export const volumesList = new Promise((resolve) => {
   resolve([
     {
-      Name:       'desktop_penpot_postgres_v15',
+      Name:       'webapp_postgres_v15',
       Driver:     'local',
-      Mountpoint: '/var/lib/docker/volumes/desktop_penpot_postgres_v15/_data',
+      Mountpoint: '/var/lib/docker/volumes/webapp_postgres_v15/_data',
       CreatedAt:  '2025-01-15T10:30:00Z',
       Labels:     {
         'com.docker.compose.project': 'desktop',
-        'com.docker.compose.service': 'penpot-postgres',
+        'com.docker.compose.service': 'webapp-postgres',
         'com.docker.compose.version': '2.17.3',
       },
       Scope:   'local',


### PR DESCRIPTION
Adds the test asset and the spec to perform the screenshot for the Container Inspect page.

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/10385