### PR TITLE
Fix update restart button disappearing after a re-check

### DIFF
--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -1,0 +1,247 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+import type { LonghornUpdateInfo } from '../LonghornProvider';
+import type { UpdateState } from '../index';
+
+/**
+ * A stand-in for electron-updater's platform updater. setupUpdate() attaches all
+ * of its event handlers to this object; each test then emits the same events that
+ * electron-updater would, to drive the update state machine directly.
+ */
+const updaterInstances: FakeUpdater[] = [];
+
+class FakeUpdater extends EventEmitter {
+  logger: unknown;
+  autoDownload = false;
+  autoInstallOnAppQuit = false;
+  forceDevUpdateConfig = false;
+
+  constructor(public options?: unknown) {
+    super();
+    updaterInstances.push(this);
+  }
+
+  isUpdaterActive(): boolean {
+    return true;
+  }
+
+  checkForUpdates = jest.fn(() => Promise.resolve({ updateInfo: { nextUpdateTime: Date.now() + 100_000 } }));
+  quitAndInstall = jest.fn();
+}
+
+const appUpdateConfigPath = path.join(os.tmpdir(), 'rd-update-state-machine-test.yaml');
+
+class FakeElectronAppAdapter {
+  get appUpdateConfigPath(): string {
+    return appUpdateConfigPath;
+  }
+}
+
+const sentStates: UpdateState[] = [];
+const send = jest.fn((_channel: string, state: UpdateState) => {
+  sentStates.push({ ...state });
+});
+const setHasQueuedUpdate = jest.fn<(isQueued: boolean) => Promise<void>>();
+const hasQueuedUpdate = jest.fn<() => Promise<boolean>>(() => Promise.resolve(false));
+const timersMock = { setTimeout: jest.fn(() => 0), clearTimeout: jest.fn() };
+const logStub = {
+  log: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn(), debugE: jest.fn(),
+};
+
+mockModules({
+  electron:                                  { ipcMain: { on: jest.fn() } },
+  'electron-updater/out/MacUpdater':         { MacUpdater: FakeUpdater },
+  'electron-updater/out/AppImageUpdater':    { AppImageUpdater: FakeUpdater },
+  'electron-updater/out/ElectronAppAdapter': { ElectronAppAdapter: FakeElectronAppAdapter },
+  '@pkg/main/update/MSIUpdater':             { default: FakeUpdater },
+  '@pkg/main/update/LonghornProvider':       { default: class {}, hasQueuedUpdate, setHasQueuedUpdate },
+  '@pkg/window':                             { send },
+  '@pkg/main/mainEvents':                    { on: jest.fn() },
+  '@pkg/utils/logging':                      { default: new Proxy({}, { get: () => logStub }) },
+  timers:                                    timersMock,
+});
+
+function makeInfo(version: string): LonghornUpdateInfo {
+  return {
+    version,
+    files:                      [],
+    path:                       '',
+    sha512:                     '',
+    releaseDate:                '',
+    nextUpdateTime:             Date.now() + 100_000,
+    unsupportedUpdateAvailable: false,
+  };
+}
+
+function lastState(): UpdateState {
+  return sentStates[sentStates.length - 1];
+}
+
+/** Let detached promises (checkForUpdates, the install path) settle. */
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('setupUpdate state machine', () => {
+  let setupUpdate: typeof import('../index').default;
+  let updater: FakeUpdater;
+
+  beforeAll(async() => {
+    fs.writeFileSync(appUpdateConfigPath, '{}');
+    ({ default: setupUpdate } = await import('../index'));
+
+    await setupUpdate(true);
+    await flush();
+    updater = updaterInstances[updaterInstances.length - 1];
+  });
+
+  afterAll(() => {
+    fs.rmSync(appUpdateConfigPath, { force: true });
+  });
+
+  beforeEach(() => {
+    // Reset to a clean slate: error cleared, no staged version, updater re-armed.
+    updater.emit('checking-for-update');
+    updater.emit('update-not-available', makeInfo('v0.0.0'));
+    updater.autoDownload = true;
+    sentStates.length = 0;
+    updater.checkForUpdates.mockClear();
+    updater.quitAndInstall.mockClear();
+    hasQueuedUpdate.mockClear();
+    setHasQueuedUpdate.mockClear();
+    timersMock.setTimeout.mockClear();
+  });
+
+  it('keeps the staged update installable when a re-check finds the same version', () => {
+    const info = makeInfo('v1.22.3');
+
+    // First check after a restart: the update is already in the pending cache,
+    // so electron-updater skips the download and emits update-downloaded with no
+    // preceding download-progress event.
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    expect(lastState()).toMatchObject({ available: true, downloaded: true });
+
+    // A later scheduled check finds the same version still available. The
+    // restart button must remain.
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+
+    expect(lastState()).toMatchObject({ available: true, downloaded: true });
+  });
+
+  it('discards the staged update and downloads a newer version when one appears', () => {
+    const older = makeInfo('v1.22.2');
+    const newer = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', older);
+    updater.emit('update-downloaded', older);
+
+    expect(lastState()).toMatchObject({ downloaded: true, info: expect.objectContaining({ version: 'v1.22.2' }) });
+    expect(updater.autoDownload).toBe(false);
+
+    // A newer version shows up. We must stop offering the stale download and
+    // re-arm autoDownload so the updater fetches the new one.
+    updater.emit('checking-for-update');
+    updater.emit('update-available', newer);
+
+    expect(updater.autoDownload).toBe(true);
+    expect(lastState()).toMatchObject({ downloaded: false, info: expect.objectContaining({ version: 'v1.22.3' }) });
+
+    // The newer download completes.
+    updater.emit('download-progress', {
+      total: 2, delta: 1, transferred: 1, percent: 50, bytesPerSecond: 1000,
+    });
+    updater.emit('update-downloaded', newer);
+
+    expect(lastState()).toMatchObject({ downloaded: true, info: expect.objectContaining({ version: 'v1.22.3' }) });
+    expect(updater.autoDownload).toBe(false);
+  });
+
+  it('does not re-download a version that is already staged', () => {
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    expect(updater.autoDownload).toBe(false);
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+
+    expect(updater.autoDownload).toBe(false);
+    expect(lastState()).toMatchObject({ downloaded: true });
+  });
+
+  it('forwards download progress to the renderer', () => {
+    const progress = {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    };
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', progress);
+
+    expect(lastState()).toMatchObject({ available: true, downloaded: false, progress });
+  });
+
+  it('reports an updater error and clears the downloaded flag', () => {
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    expect(lastState().downloaded).toBe(true);
+
+    updater.emit('error', new Error('download failed'));
+
+    expect(lastState().downloaded).toBe(false);
+    expect(lastState().error).toBeInstanceOf(Error);
+  });
+
+  it('clears a previous error once a later check succeeds', () => {
+    updater.emit('error', new Error('boom'));
+
+    expect(lastState().error).toBeInstanceOf(Error);
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+
+    expect(lastState().error).toBeUndefined();
+  });
+
+  it('installs a queued update at launch instead of checking for a new one', async() => {
+    hasQueuedUpdate.mockResolvedValueOnce(true);
+
+    const installing = setupUpdate(true, true);
+
+    // The install path waits for update-downloaded before quitting to install.
+    await flush();
+    updater.emit('update-downloaded', makeInfo('v1.22.3'));
+
+    await expect(installing).resolves.toBe(true);
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true);
+  });
+
+  it('schedules the next check even when a check fails', async() => {
+    updater.checkForUpdates.mockRejectedValueOnce(new Error('network blip'));
+
+    await setupUpdate(true);
+    // triggerUpdateCheck runs detached; let its rejection and catch settle.
+    await flush();
+
+    expect(timersMock.setTimeout).toHaveBeenCalled();
+  });
+});

--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -32,7 +32,9 @@ class FakeUpdater extends EventEmitter {
     return true;
   }
 
-  checkForUpdates = jest.fn(() => Promise.resolve({ updateInfo: { nextUpdateTime: Date.now() + 100_000 } }));
+  checkForUpdates = jest.fn<() => Promise<{ updateInfo: { nextUpdateTime: number } }>>()
+    .mockResolvedValue({ updateInfo: { nextUpdateTime: Date.now() + 100_000 } });
+
   quitAndInstall = jest.fn();
 }
 
@@ -45,12 +47,13 @@ class FakeElectronAppAdapter {
 }
 
 const sentStates: UpdateState[] = [];
-const send = jest.fn((_channel: string, state: UpdateState) => {
-  sentStates.push({ ...state });
+const send = jest.fn((channel: string, state: UpdateState) => {
+  if (channel === 'update-state') {
+    sentStates.push({ ...state });
+  }
 });
 const setHasQueuedUpdate = jest.fn<(isQueued: boolean) => Promise<void>>();
-const hasQueuedUpdate = jest.fn<() => Promise<boolean>>(() => Promise.resolve(false));
-const timersMock = { setTimeout: jest.fn(() => 0), clearTimeout: jest.fn() };
+const hasQueuedUpdate = jest.fn<() => Promise<boolean>>().mockResolvedValue(false);
 const logStub = {
   log: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn(), debugE: jest.fn(),
 };
@@ -65,7 +68,12 @@ mockModules({
   '@pkg/window':                             { send },
   '@pkg/main/mainEvents':                    { on: jest.fn() },
   '@pkg/utils/logging':                      { default: new Proxy({}, { get: () => logStub }) },
-  timers:                                    timersMock,
+  // Bridge the timers module to the global setTimeout/clearTimeout so jest's
+  // fake timers (which only patch the globals) control the update scheduler.
+  timers:                                    {
+    setTimeout:   (callback: () => void, ms?: number) => setTimeout(callback, ms),
+    clearTimeout: (handle?: NodeJS.Timeout) => clearTimeout(handle),
+  },
 });
 
 function makeInfo(version: string): LonghornUpdateInfo {
@@ -86,7 +94,7 @@ function lastState(): UpdateState {
 
 /** Let detached promises (checkForUpdates, the install path) settle. */
 function flush(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, 0));
+  return jest.advanceTimersByTimeAsync(0);
 }
 
 describe('setupUpdate state machine', () => {
@@ -94,6 +102,7 @@ describe('setupUpdate state machine', () => {
   let updater: FakeUpdater;
 
   beforeAll(async() => {
+    jest.useFakeTimers();
     fs.writeFileSync(appUpdateConfigPath, '{}');
     ({ default: setupUpdate } = await import('../index'));
 
@@ -103,6 +112,7 @@ describe('setupUpdate state machine', () => {
   });
 
   afterAll(() => {
+    jest.useRealTimers();
     fs.rmSync(appUpdateConfigPath, { force: true });
   });
 
@@ -116,7 +126,7 @@ describe('setupUpdate state machine', () => {
     updater.quitAndInstall.mockClear();
     hasQueuedUpdate.mockClear();
     setHasQueuedUpdate.mockClear();
-    timersMock.setTimeout.mockClear();
+    jest.clearAllTimers();
   });
 
   it('keeps the staged update installable when a re-check finds the same version', () => {
@@ -130,13 +140,16 @@ describe('setupUpdate state machine', () => {
     updater.emit('update-downloaded', info);
 
     expect(lastState()).toMatchObject({ available: true, downloaded: true });
+    expect(updater.autoDownload).toBe(false);
 
     // A later scheduled check finds the same version still available. The
-    // restart button must remain.
+    // restart button must remain, and the updater must keep the staged
+    // download instead of fetching it again.
     updater.emit('checking-for-update');
     updater.emit('update-available', info);
 
     expect(lastState()).toMatchObject({ available: true, downloaded: true });
+    expect(updater.autoDownload).toBe(false);
   });
 
   it('discards the staged update and downloads a newer version when one appears', () => {
@@ -168,22 +181,6 @@ describe('setupUpdate state machine', () => {
     expect(updater.autoDownload).toBe(false);
   });
 
-  it('does not re-download a version that is already staged', () => {
-    const info = makeInfo('v1.22.3');
-
-    updater.emit('checking-for-update');
-    updater.emit('update-available', info);
-    updater.emit('update-downloaded', info);
-
-    expect(updater.autoDownload).toBe(false);
-
-    updater.emit('checking-for-update');
-    updater.emit('update-available', info);
-
-    expect(updater.autoDownload).toBe(false);
-    expect(lastState()).toMatchObject({ downloaded: true });
-  });
-
   it('forwards download progress to the renderer', () => {
     const progress = {
       total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
@@ -205,16 +202,20 @@ describe('setupUpdate state machine', () => {
 
     expect(lastState().downloaded).toBe(true);
 
-    updater.emit('error', new Error('download failed'));
+    const error = new Error('download failed');
+
+    updater.emit('error', error);
 
     expect(lastState().downloaded).toBe(false);
-    expect(lastState().error).toBeInstanceOf(Error);
+    expect(lastState().error).toBe(error);
   });
 
   it('clears a previous error once a later check succeeds', () => {
-    updater.emit('error', new Error('boom'));
+    const error = new Error('boom');
 
-    expect(lastState().error).toBeInstanceOf(Error);
+    updater.emit('error', error);
+
+    expect(lastState().error).toBe(error);
 
     updater.emit('checking-for-update');
     updater.emit('update-available', makeInfo('v1.22.3'));
@@ -242,6 +243,12 @@ describe('setupUpdate state machine', () => {
     // triggerUpdateCheck runs detached; let its rejection and catch settle.
     await flush();
 
-    expect(timersMock.setTimeout).toHaveBeenCalled();
+    // The failed check still armed the retry timer.
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+    // Firing the timer runs the next check, which now succeeds.
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
   });
 });

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -61,6 +61,8 @@ export interface UpdateState {
 const updateState: UpdateState = {
   configured: false, available: false, downloaded: false,
 };
+/** The version of the update that has finished downloading, if any. */
+let stagedVersion: string | undefined;
 
 Electron.ipcMain.on('update-state', () => {
   window.send('update-state', updateState);
@@ -134,13 +136,15 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
   updater.autoDownload = true;
   updater.autoInstallOnAppQuit = false;
   updater.on('error', (error) => {
-    console.debug('update: error:', error);
+    console.error('update: error:', error);
     updateState.error = error;
     updateState.downloaded = false;
     window.send('update-state', updateState);
   });
   updater.on('checking-for-update', () => {
     console.debug('update: checking for update');
+    // Clear any earlier error so a transient failure stops hiding later offers.
+    updateState.error = undefined;
     updateState.available = false;
     updateState.downloaded = false;
     setHasQueuedUpdate(false);
@@ -152,7 +156,18 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
     console.debug('update: update available:', info);
     updateState.available = true;
     updateState.info = info;
-    updateState.downloaded = state === State.UPDATE_PENDING;
+    updateState.downloaded = info.version === stagedVersion;
+    if (updateState.downloaded) {
+      setHasQueuedUpdate(true);
+    } else {
+      // A version other than the staged one is available. Forget the staged
+      // version and re-arm autoDownload so the updater fetches the new one;
+      // electron-updater discards the cached file when its checksum no longer
+      // matches. Clearing stagedVersion keeps a later re-offer of the old
+      // version from reporting it as downloaded once its file is gone.
+      stagedVersion = undefined;
+      updater.autoDownload = true;
+    }
     window.send('update-state', updateState);
   });
   updater.on('update-not-available', (info) => {
@@ -163,6 +178,7 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
     updateState.available = false;
     updateState.info = info;
     updateState.downloaded = false;
+    stagedVersion = undefined;
     setHasQueuedUpdate(false);
     window.send('update-state', updateState);
   });
@@ -181,11 +197,12 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
     if (state === State.DOWNLOADING) {
       state = State.UPDATE_PENDING;
     }
+    stagedVersion = info.version;
     console.debug('update: downloaded:', info);
     updateState.info = info;
     updateState.downloaded = true;
-    // Prevent the updater from downloading the update again; it will clobber
-    // the existing download.
+    // Don't download this same version again on the next check; a newer version
+    // re-arms autoDownload from the update-available handler.
     updater.autoDownload = false;
     setHasQueuedUpdate(true);
     window.send('update-state', updateState);


### PR DESCRIPTION
The "Restart Now" button vanished when an update was restored from the on-disk cache. `update-available` inferred `downloaded` from the download lifecycle `state`, but a cached update emits no `download-progress`, so `state` never reached `UPDATE_PENDING` and a later re-check cleared the button.

Track the staged version instead, and report `downloaded` by comparing the offered version to it. A different (newer) version now re-arms `autoDownload` so the updater discards the stale download and fetches the new one; previously a long-running instance advertised newer releases but never downloaded them.

Also log update errors at `error` level so they appear without debug mode, and clear a stale error on the next check so it stops hiding later offers.

Add tests for the update state machine, which had no coverage.