### PR TITLE
Fix indefinite startup hang when a queued update check fails

### DIFF
--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -193,6 +193,21 @@ describe('setupUpdate state machine', () => {
     expect(lastState()).toMatchObject({ available: true, downloaded: false, progress });
   });
 
+  it('clears stale download progress when a new check starts', () => {
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    });
+
+    expect(lastState().progress).toBeDefined();
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.4'));
+
+    expect(lastState().progress).toBeUndefined();
+  });
+
   it('reports an updater error and clears the downloaded flag', () => {
     const info = makeInfo('v1.22.3');
 

--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -32,7 +32,7 @@ class FakeUpdater extends EventEmitter {
     return true;
   }
 
-  checkForUpdates = jest.fn<() => Promise<{ updateInfo: { nextUpdateTime: number } }>>()
+  checkForUpdates = jest.fn<() => Promise<{ updateInfo: { nextUpdateTime: number } } | null>>()
     .mockResolvedValue({ updateInfo: { nextUpdateTime: Date.now() + 100_000 } });
 
   quitAndInstall = jest.fn();
@@ -234,6 +234,61 @@ describe('setupUpdate state machine', () => {
 
     await expect(installing).resolves.toBe(true);
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true);
+  });
+
+  it('continues startup instead of hanging when the queued-install check fails', async() => {
+    hasQueuedUpdate.mockResolvedValueOnce(true);
+    updater.checkForUpdates.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(setupUpdate(true, true)).resolves.toBe(false);
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+
+    // The failed install must still schedule the periodic checks.
+    await flush();
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+  });
+
+  it('continues startup when the queued update is no longer offered', async() => {
+    hasQueuedUpdate.mockResolvedValueOnce(true);
+
+    const installing = setupUpdate(true, true);
+
+    await flush();
+    updater.emit('update-not-available', makeInfo('v1.22.3'));
+
+    await expect(installing).resolves.toBe(false);
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('continues startup when update checks are disabled during the queued install', async() => {
+    hasQueuedUpdate.mockResolvedValueOnce(true);
+    // A falsy check result means updates are disabled: no events fire, so the
+    // install path must settle on the result alone rather than wait forever.
+    updater.checkForUpdates.mockResolvedValueOnce(null);
+
+    await expect(setupUpdate(true, true)).resolves.toBe(false);
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+
+    // Falling through still schedules the periodic checks.
+    await flush();
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+  });
+
+  it('does not install on a later download once the queued install has settled', async() => {
+    hasQueuedUpdate.mockResolvedValueOnce(true);
+
+    const installing = setupUpdate(true, true);
+
+    await flush();
+    updater.emit('update-not-available', makeInfo('v1.22.3'));
+
+    await expect(installing).resolves.toBe(false);
+
+    // The install path removed its one-shot listeners on the way out, so a
+    // later periodic check's download must not fire a stale quitAndInstall.
+    updater.emit('update-downloaded', makeInfo('v1.22.4'));
+
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
   });
 
   it('schedules the next check even when a check fails', async() => {

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -279,22 +279,52 @@ async function doInitialUpdateCheck(doInstall = false): Promise<boolean> {
   if (doInstall && await hasQueuedUpdate() && !process.env.RD_FORCE_UPDATES_ENABLED) {
     console.log('Update is cached; forcing re-check to install.');
 
-    return await new Promise((resolve) => {
-      let hasError = false;
-
-      autoUpdater.once('error', (e) => {
+    const installing = await new Promise<boolean>((resolve) => {
+      // Every terminal event must settle this promise: startup awaits it
+      // before starting the backend, so a check that fails without emitting
+      // update-downloaded (offline, or the release was pulled) would hang the
+      // app forever. Remove the listeners on the way out so a later periodic
+      // check's update-downloaded can't fire a stale quitAndInstall.
+      const finish = (installing: boolean) => {
+        autoUpdater.removeListener('error', onError);
+        autoUpdater.removeListener('update-not-available', onNotAvailable);
+        autoUpdater.removeListener('update-downloaded', onDownloaded);
+        resolve(installing);
+      };
+      const onError = (e: Error) => {
         console.error('Updater got error', e);
-        hasError = true;
-      });
-      autoUpdater.once('update-downloaded', () => {
+        finish(false);
+      };
+      const onNotAvailable = () => {
+        console.log('Cached update is no longer offered; continuing startup.');
+        finish(false);
+      };
+      const onDownloaded = () => {
         console.log('Update download complete; restarting app');
-        setHasQueuedUpdate(true);
+        // The persistent update-downloaded handler already recorded the staged
+        // version and set the queued flag; here we only need to install.
         autoUpdater.quitAndInstall(true, true);
-        console.log(`Install complete, result: ${ !hasError }`);
-        resolve(!hasError);
-      });
-      autoUpdater.checkForUpdates();
+        finish(true);
+      };
+
+      autoUpdater.once('error', onError);
+      autoUpdater.once('update-not-available', onNotAvailable);
+      autoUpdater.once('update-downloaded', onDownloaded);
+      autoUpdater.checkForUpdates().then((result) => {
+        // A falsy result means update checks are disabled, so none of the
+        // events above will fire; settle here rather than wait forever.
+        if (!result) {
+          finish(false);
+        }
+      }).catch(onError);
     });
+
+    if (installing) {
+      return true;
+    }
+    // The cached update could not be installed (offline, the release was
+    // pulled, or checks are disabled); fall through to schedule periodic
+    // checks so the session keeps looking for updates.
   }
 
   triggerUpdateCheck();

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -147,6 +147,9 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
     updateState.error = undefined;
     updateState.available = false;
     updateState.downloaded = false;
+    // Drop stale progress so a newer offer doesn't show the previous
+    // download's percentage.
+    updateState.progress = undefined;
     setHasQueuedUpdate(false);
   });
   updater.on('update-available', (info) => {


### PR DESCRIPTION
Potential hang discovered by AI while working on #10419.

The queued-install path at startup returned a promise that resolved only on `update-downloaded`. An error event merely set a flag, an `update-not-available` event was unhandled, and the `checkForUpdates()` rejection was neither awaited nor caught. `setupUpdate(enabled, true)` is awaited before the backend starts, so a queued update plus a launch-time check failure (offline, or the release was pulled) left the promise pending and hung the app before startup finished.

Settle the promise on every outcome: resolve `false` on error, `update-not-available`, and a `disabled-checks` result; resolve true on `update-downloaded`. Remove the listeners on the way out so a later periodic check's `update-downloaded` cannot fire a stale `quitAndInstall`. When no install happens, fall through to schedule the periodic checks so the session keeps looking for updates.