### PR TITLE
Keep go-openapi/swag submodules as direct deps

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -315,6 +315,7 @@ jsmith
 JSONOr
 jsontable
 JSONTo
+jsonutils
 julianb
 karl
 Kaspersky
@@ -680,6 +681,7 @@ trivy
 TStr
 TVar
 tvf
+typeutils
 ucmonitor
 udhcpc
 UEFI

--- a/src/go/wsl-helper/pkg/dockerproxy/generate.go
+++ b/src/go/wsl-helper/pkg/dockerproxy/generate.go
@@ -17,6 +17,14 @@ limitations under the License.
 package dockerproxy
 
 import (
+	// Blank imports keeping modules that only generated code uses as direct
+	// requirements. The swagger code under pkg/dockerproxy/models imports the
+	// swag packages and is generated at build time, not checked in; go:generate
+	// below runs the go-swagger tool. Without these, `go mod tidy` demotes the
+	// modules to indirect when the generated code is absent — as it is in
+	// dependabot's tree — breaking its update PRs.
+	_ "github.com/go-openapi/swag/jsonutils"
+	_ "github.com/go-openapi/swag/typeutils"
 	_ "github.com/go-swagger/go-swagger"
 )
 


### PR DESCRIPTION
The swagger-generated models in `src/go/wsl-helper/pkg/dockerproxy/models` import `go-openapi/swag/jsonutils` and `go-openapi/swag/typeutils`, but those models are generated at build time and not checked in. dependabot regenerates `go.mod` without them and demotes the two modules to indirect. CI then runs `go generate` and `go mod tidy` (`scripts/lint-go.ts`), which restores them to direct, producing a diff that fails the lint job on every dependabot PR touching this module.

Blank-import both packages in `generate.go`, as `go-swagger` already is, so `go mod tidy` keeps them direct even when the generated code is absent.

This unblocks #10425, #10426, and #10427, which all fail for this reason.