### PR TITLE
Fix snapshots for Lima v2 disk-file rename

### DIFF
--- a/bats/tests/snapshots/restore-legacy-snapshot.bats
+++ b/bats/tests/snapshots/restore-legacy-snapshot.bats
@@ -1,0 +1,72 @@
+load '../helpers/load'
+
+# Snapshots created before the Lima v2 disk-layout change store the VM disk
+# under the legacy filenames "basedisk" and "diffdisk". Restoring such a
+# snapshot must still work and preserve the disk contents.
+
+local_setup() {
+    skip_on_windows "Lima manages the VM disk image only on macOS and Linux"
+    SNAPSHOT=legacy-disk-names
+}
+
+@test 'factory reset and delete all the snapshots' {
+    delete_all_snapshots
+    factory_reset
+}
+
+@test 'start the container engine' {
+    start_container_engine
+    wait_for_container_engine
+    wait_for_backend
+}
+
+@test 'pull an image to populate the VM disk' {
+    ctrctl pull "$IMAGE_BUSYBOX"
+    run ctrctl image ls
+    assert_success
+    assert_output --partial busybox
+}
+
+@test 'shut down and create a snapshot' {
+    rdctl shutdown
+    rdctl snapshot create "$SNAPSHOT"
+    run rdctl snapshot list
+    assert_success
+    assert_output --partial "$SNAPSHOT"
+}
+
+@test 'rewrite the snapshot with the legacy disk filenames' {
+    # `snapshot list --json` hides the ID, so find the snapshot by its
+    # directory name; only the one we just created exists at this point.
+    run ls -1 "$PATH_SNAPSHOTS"
+    assert_success
+    refute_output ""
+    local snapshot_dir="$PATH_SNAPSHOTS/${lines[0]}"
+
+    assert_exists "$snapshot_dir/disk"
+    assert_exists "$snapshot_dir/iso"
+    mv "$snapshot_dir/disk" "$snapshot_dir/diffdisk"
+    mv "$snapshot_dir/iso" "$snapshot_dir/basedisk"
+}
+
+@test 'factory reset before restoring' {
+    rdctl factory-reset
+}
+
+@test 'restore the legacy snapshot, restart, and verify the disk survived' {
+    run rdctl snapshot restore "$SNAPSHOT"
+    assert_success
+    refute_output --partial fail
+
+    launch_the_application
+    wait_for_container_engine
+    wait_for_backend
+
+    run ctrctl image ls
+    assert_success
+    assert_output --partial busybox
+}
+
+@test 'delete the snapshot' {
+    rdctl snapshot delete "$SNAPSHOT"
+}

--- a/bats/tests/snapshots/restore-legacy-snapshot.bats
+++ b/bats/tests/snapshots/restore-legacy-snapshot.bats
@@ -40,7 +40,7 @@ local_setup() {
     # directory name; only the one we just created exists at this point.
     run ls -1 "$PATH_SNAPSHOTS"
     assert_success
-    refute_output ""
+    assert_output # the snapshot directory must exist
     local snapshot_dir="$PATH_SNAPSHOTS/${lines[0]}"
 
     assert_exists "$snapshot_dir/disk"

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -527,9 +527,9 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       await this.lima('stop', MACHINE_NAME);
     }
 
-    const diskPath = path.join(paths.lima, MACHINE_NAME, 'basedisk');
+    const imagePath = await this.instanceDiskPath('iso', 'basedisk');
 
-    await fs.promises.copyFile(this.baseDiskImage, diskPath);
+    await fs.promises.copyFile(this.baseDiskImage, imagePath);
     // The config file will be updated in updateConfig() instead; no need to do it here.
     console.log(`Base image successfully updated.`);
   }
@@ -961,6 +961,25 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
         return undefined;
       }
     })();
+  }
+
+  /**
+   * Resolve a Lima instance disk file, preferring the legacy filename when it
+   * still exists. Lima renamed basedisk→iso and diffdisk→disk and migrates
+   * existing instances on start; this runs before that migration, so a
+   * just-upgraded instance still has only the legacy name.
+   */
+  protected async instanceDiskPath(current: string, legacy: string): Promise<string> {
+    const instanceDir = path.join(paths.lima, MACHINE_NAME);
+    const legacyPath = path.join(instanceDir, legacy);
+
+    try {
+      await fs.promises.access(legacyPath);
+
+      return legacyPath;
+    } catch {
+      return path.join(instanceDir, current);
+    }
   }
 
   protected async imageInfo(fileName: string): Promise<QEMUImageInfo> {
@@ -1858,15 +1877,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
         // Virtualization Framework only supports RAW disks
         if (vmStatus && config.virtualMachine.type === VMType.VZ) {
-          const diffdisk = path.join(paths.lima, MACHINE_NAME, 'diffdisk');
-          const { format } = await this.imageInfo(diffdisk);
+          const disk = await this.instanceDiskPath('disk', 'diffdisk');
+          const { format } = await this.imageInfo(disk);
 
           if (format === ImageFormat.QCOW2) {
             if (isVMAlreadyRunning) {
               await this.lima('stop', MACHINE_NAME);
               isVMAlreadyRunning = false;
             }
-            await this.convertToRaw(diffdisk);
+            await this.convertToRaw(disk);
           }
         }
         // Start the VM; if it's already running, this does nothing.

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -964,22 +964,28 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   /**
-   * Resolve a Lima instance disk file, preferring the legacy filename when it
-   * still exists. Lima renamed basedisk→iso and diffdisk→disk and migrates
-   * existing instances on start; this runs before that migration, so a
-   * just-upgraded instance still has only the legacy name.
+   * Resolve a Lima instance disk file, returning the first of `names` that
+   * exists, or the first name when none do. Lima renamed basedisk→iso and
+   * diffdisk→disk and migrates existing instances on start; passing the new
+   * name first uses it when present and falls back to the legacy name on an
+   * instance Lima has not migrated yet.
    */
-  protected async instanceDiskPath(current: string, legacy: string): Promise<string> {
+  protected async instanceDiskPath(...names: string[]): Promise<string> {
     const instanceDir = path.join(paths.lima, MACHINE_NAME);
-    const legacyPath = path.join(instanceDir, legacy);
 
-    try {
-      await fs.promises.access(legacyPath);
+    for (const name of names) {
+      const candidate = path.join(instanceDir, name);
 
-      return legacyPath;
-    } catch {
-      return path.join(instanceDir, current);
+      try {
+        await fs.promises.access(candidate);
+
+        return candidate;
+      } catch {
+        // Not this name; try the next one.
+      }
     }
+
+    return path.join(instanceDir, names[0]);
   }
 
   protected async imageInfo(fileName: string): Promise<QEMUImageInfo> {
@@ -1877,15 +1883,15 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
         // Virtualization Framework only supports RAW disks
         if (vmStatus && config.virtualMachine.type === VMType.VZ) {
-          const disk = await this.instanceDiskPath('disk', 'diffdisk');
-          const { format } = await this.imageInfo(disk);
+          const diskPath = await this.instanceDiskPath('disk', 'diffdisk');
+          const { format } = await this.imageInfo(diskPath);
 
           if (format === ImageFormat.QCOW2) {
             if (isVMAlreadyRunning) {
               await this.lima('stop', MACHINE_NAME);
               isVMAlreadyRunning = false;
             }
-            await this.convertToRaw(disk);
+            await this.convertToRaw(diskPath);
           }
         }
         // Start the VM; if it's already running, this does nothing.

--- a/src/go/rdctl/pkg/snapshot/manager_unix_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_unix_test.go
@@ -178,7 +178,11 @@ func TestManagerUnix(t *testing.T) {
 		// Rewrite the snapshot to use Lima's legacy disk filenames, as a
 		// snapshot created by an older version of Rancher Desktop would.
 		snapshotDir := manager.SnapshotDirectory(snapshot)
-		for current, legacy := range map[string]string{"disk": "diffdisk", "iso": "basedisk"} {
+		nameMapping := map[string]string{
+			"disk": "diffdisk",
+			"iso":  "basedisk",
+		}
+		for current, legacy := range nameMapping {
 			if err := os.Rename(filepath.Join(snapshotDir, current), filepath.Join(snapshotDir, legacy)); err != nil {
 				t.Fatalf("failed to rename %q to %q in snapshot: %s", current, legacy, err)
 			}

--- a/src/go/rdctl/pkg/snapshot/manager_unix_test.go
+++ b/src/go/rdctl/pkg/snapshot/manager_unix_test.go
@@ -27,13 +27,13 @@ func populateFiles(t *testing.T, includeOverrideYaml bool) (*paths.Paths, map[st
 			Path:     filepath.Join(appPaths.Config, "settings.json"),
 			Contents: `{"test": "settings.json"}`,
 		},
-		"basedisk": {
-			Path:     filepath.Join(appPaths.Lima, "0", "basedisk"),
-			Contents: "basedisk contents",
+		"iso": {
+			Path:     filepath.Join(appPaths.Lima, "0", "iso"),
+			Contents: "iso contents",
 		},
-		"diffdisk": {
-			Path:     filepath.Join(appPaths.Lima, "0", "diffdisk"),
-			Contents: "diffdisk contents",
+		"disk": {
+			Path:     filepath.Join(appPaths.Lima, "0", "disk"),
+			Contents: "disk contents",
 		},
 		"user": {
 			Path:     filepath.Join(appPaths.Lima, "_config", "user"),
@@ -91,8 +91,8 @@ func TestManagerUnix(t *testing.T) {
 			snapshotDir := testManager.SnapshotDirectory(snapshot)
 			snapshotFiles := []string{
 				filepath.Join(snapshotDir, "settings.json"),
-				filepath.Join(snapshotDir, "basedisk"),
-				filepath.Join(snapshotDir, "diffdisk"),
+				filepath.Join(snapshotDir, "iso"),
+				filepath.Join(snapshotDir, "disk"),
 				filepath.Join(snapshotDir, "metadata.json"),
 			}
 			if includeOverrideYaml {
@@ -165,6 +165,40 @@ func TestManagerUnix(t *testing.T) {
 		}
 		if _, err := os.Stat(overrideYamlPath); !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("override.yaml appears to not have been removed in restore")
+		}
+	})
+
+	t.Run("Restore should map a legacy basedisk/diffdisk snapshot to disk/iso", func(t *testing.T) {
+		appPaths, testFiles := populateFiles(t, true)
+		manager := newTestManager(appPaths)
+		snapshot, err := manager.Create(context.Background(), "test-snapshot", "")
+		if err != nil {
+			t.Fatalf("failed to create snapshot: %s", err)
+		}
+		// Rewrite the snapshot to use Lima's legacy disk filenames, as a
+		// snapshot created by an older version of Rancher Desktop would.
+		snapshotDir := manager.SnapshotDirectory(snapshot)
+		for current, legacy := range map[string]string{"disk": "diffdisk", "iso": "basedisk"} {
+			if err := os.Rename(filepath.Join(snapshotDir, current), filepath.Join(snapshotDir, legacy)); err != nil {
+				t.Fatalf("failed to rename %q to %q in snapshot: %s", current, legacy, err)
+			}
+		}
+		for testFileName, testFile := range testFiles {
+			if err := os.WriteFile(testFile.Path, []byte(`{"something": "different"}`), 0o644); err != nil {
+				t.Fatalf("failed to modify %s: %s", testFileName, err)
+			}
+		}
+		if err := manager.Restore(context.Background(), snapshot.Name); err != nil {
+			t.Fatalf("failed to restore snapshot: %s", err)
+		}
+		for testFileName, testFile := range testFiles {
+			contents, err := os.ReadFile(testFile.Path)
+			if err != nil {
+				t.Fatalf("failed to read contents of %s: %s", testFileName, err)
+			}
+			if string(contents) != testFile.Contents {
+				t.Errorf("contents of %s appear to have not been restored", testFileName)
+			}
 		}
 	})
 

--- a/src/go/rdctl/pkg/snapshot/snapshotter_unix.go
+++ b/src/go/rdctl/pkg/snapshot/snapshotter_unix.go
@@ -19,6 +19,9 @@ type snapshotFile struct {
 	WorkingPath string
 	// The path that the file is put at in a snapshot.
 	SnapshotPath string
+	// Fallback path for restoring snapshots written by older versions of
+	// Rancher Desktop, which used different filenames. Empty if unchanged.
+	LegacySnapshotPath string
 	// Whether clonefile (macOS) or ioctl_ficlone (Linux) should be used
 	// when copying the file around.
 	CopyOnWrite bool
@@ -53,18 +56,20 @@ func (snapshotter SnapshotterImpl) Files(appPaths *paths.Paths, snapshotDir stri
 			FileMode:     0o644,
 		},
 		{
-			WorkingPath:  filepath.Join(appPaths.Lima, "0", "basedisk"),
-			SnapshotPath: filepath.Join(snapshotDir, "basedisk"),
-			CopyOnWrite:  true,
-			MissingOk:    false,
-			FileMode:     0o644,
+			WorkingPath:        filepath.Join(appPaths.Lima, "0", "iso"),
+			SnapshotPath:       filepath.Join(snapshotDir, "iso"),
+			LegacySnapshotPath: filepath.Join(snapshotDir, "basedisk"),
+			CopyOnWrite:        true,
+			MissingOk:          false,
+			FileMode:           0o644,
 		},
 		{
-			WorkingPath:  filepath.Join(appPaths.Lima, "0", "diffdisk"),
-			SnapshotPath: filepath.Join(snapshotDir, "diffdisk"),
-			CopyOnWrite:  true,
-			MissingOk:    false,
-			FileMode:     0o644,
+			WorkingPath:        filepath.Join(appPaths.Lima, "0", "disk"),
+			SnapshotPath:       filepath.Join(snapshotDir, "disk"),
+			LegacySnapshotPath: filepath.Join(snapshotDir, "diffdisk"),
+			CopyOnWrite:        true,
+			MissingOk:          false,
+			FileMode:           0o644,
 		},
 		{
 			WorkingPath:  filepath.Join(appPaths.Lima, "_config", "user"),
@@ -127,7 +132,15 @@ func (snapshotter SnapshotterImpl) RestoreFiles(ctx context.Context, appPaths *p
 	for _, file := range files {
 		taskRunner.Add(func() error {
 			filename := filepath.Base(file.WorkingPath)
-			err := copyFile(file.WorkingPath, file.SnapshotPath, file.CopyOnWrite, file.FileMode)
+			snapshotPath := file.SnapshotPath
+			// Older snapshots stored the VM disk under Lima's legacy filenames;
+			// fall back to them so those snapshots stay restorable.
+			if file.LegacySnapshotPath != "" {
+				if _, statErr := os.Stat(snapshotPath); errors.Is(statErr, os.ErrNotExist) {
+					snapshotPath = file.LegacySnapshotPath
+				}
+			}
+			err := copyFile(file.WorkingPath, snapshotPath, file.CopyOnWrite, file.FileMode)
 			if errors.Is(err, os.ErrNotExist) && file.MissingOk {
 				if err := os.RemoveAll(file.WorkingPath); err != nil {
 					return fmt.Errorf("failed to remove %q: %w", filename, err)


### PR DESCRIPTION
Lima v2 renamed the instance disk files (`basedisk`→`iso`, `diffdisk`→`disk`), but the rdctl snapshotter and the Lima backend still used the old names, so snapshot creation failed on fresh macOS/Linux instances with "failed to copy basedisk: ... no such file or directory". Windows uses WSL tar exports and was unaffected.

- `snapshotter_unix.go`: create/restore use `disk`/`iso`; restore falls back to the legacy names so snapshots from older releases stay restorable, mapped onto the new working-file names independently of Lima's symlink migration.

- `lima.ts`: `updateBaseDisk` and the VZ `qcow2`→`raw` conversion run before Lima migrates an upgraded instance, so they target whichever filename is present.

- Added a bats test that restores a snapshot rewritten with the legacy filenames and confirms the disk survives.
