### PR TITLE
Unpack Wasm images on containerd 2.1+ via local image pull

### DIFF
--- a/pkg/rancher-desktop/backend/backendHelper.ts
+++ b/pkg/rancher-desktop/backend/backendHelper.ts
@@ -364,6 +364,12 @@ export default class BackendHelper {
     let config = CONTAINERD_CONFIG;
 
     if (configureWASM) {
+      // containerd 2.1+ pulls images via the Transfer Service, which won't unpack
+      // non-host platforms; a wasi/wasm image then has no rootfs snapshot and its
+      // runtime-class container fails to create. Local pull unpacks wasi/wasm.
+      config += '\n[plugins."io.containerd.cri.v1.images"]\n';
+      config += '  use_local_image_pull = true\n';
+
       const shims = await BackendHelper.containerdShims(vmx);
 
       for (const shim in shims) {


### PR DESCRIPTION
containerd 2.1+ routes CRI image pulls through the Transfer Service, which does not unpack non-host (`wasi/wasm`) platforms. Wasm runtime-class containers then fail to create with `parent snapshot ... does not exist`, which fails the Kubernetes Wasm bats tests (`k8s/wasm`, `k8s/spinkube`, `k8s/spinkube-npm`).