### PR TITLE
Provide kubectl in the guest for Kubernetes service forwarding

### DIFF
--- a/pkg/rancher-desktop/assets/scripts/install-k3s
+++ b/pkg/rancher-desktop/assets/scripts/install-k3s
@@ -39,6 +39,9 @@ if [ -f "${IMAGEPATH}.tar" ]; then
 fi
 # Add k3s binary
 ln -s -f "${K3S_DIR}/${K3S}" /usr/local/bin/k3s
+# Lima's guest agent runs `kubectl` to watch Kubernetes services for
+# port forwarding; k3s, a multicall binary, provides kubectl.
+ln -s -f "${K3S_DIR}/${K3S}" /usr/local/bin/kubectl
 # The file system may be readonly (on macOS)
 chmod a+x "${K3S_DIR}/${K3S}" || true
 


### PR DESCRIPTION
Lima's guest agent forwards NodePort and LoadBalancer service ports to the host. Since Lima 2.1 it runs `kubectl` rather than the client-go library ([upstream 9c1252c1](https://github.com/lima-vm/lima/commit/9c1252c1)), but the guest has no `kubectl` on PATH. The watcher fails, so no service ports reach `localhost` on macOS and Linux; `helm-install-rancher` then fails in `verify_rancher`, where `https://localhost` is unreachable.

Symlink k3s, a multicall binary, as `kubectl` so the watcher works.

Fixes #10525 