### PR TITLE
Restore leading slash on container names in extension API

### DIFF
--- a/pkg/rancher-desktop/preload/__tests__/extensions.spec.ts
+++ b/pkg/rancher-desktop/preload/__tests__/extensions.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment-options {"url": "app://index.html"}
+ */
+
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+mockModules({
+  electron:                 undefined,
+  '@pkg/utils/ipcRenderer': {
+    ipcRenderer: { on: jest.fn(), send: jest.fn(), invoke: jest.fn() },
+  },
+});
+
+const { RDXClient } = await import('../extensions');
+
+describe('RDXClient', () => {
+  describe('docker.listContainers', () => {
+    it('restores the leading slash that the Docker Engine API puts on container names', async() => {
+      const client = new RDXClient();
+      const lsResult = {
+        code:           0,
+        parseJsonLines: () => [{
+          ID:        'abcdef123456',
+          Names:     'web', // The CLI strips the leading slash that the Engine API includes.
+          Image:     'nginx',
+          Command:   '"nginx -g daemon off;"',
+          Status:    'Up 5 minutes',
+          CreatedAt: '2024-01-01T00:00:00Z',
+        }],
+      };
+      const inspectResult = {
+        code:           0,
+        parseJsonLines: () => [{
+          Id:              'abcdef1234567890',
+          Name:            '/web',
+          Image:           'nginx',
+          ImageID:         'sha256:deadbeef',
+          NetworkSettings: { Ports: {} },
+          Mounts:          [],
+          HostConfig:      {},
+          SizeRootFs:      0,
+          SizeRw:          0,
+          Config:          { Labels: {} },
+          State:           { Status: 'running', State: 'running', StartedAt: '2024-01-01T00:00:00Z' },
+        }],
+      };
+
+      client.docker.cli.exec = jest.fn()
+        .mockResolvedValueOnce(lsResult)
+        .mockResolvedValueOnce(inspectResult) as any;
+
+      const [container] = await client.docker.listContainers();
+
+      expect(container.Names).toEqual(['/web']);
+    });
+  });
+});

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -548,6 +548,11 @@ export class RDXClient implements v1.DockerDesktopClient {
           return result as any;
         }
 
+        // The Docker Engine API prefixes container names with '/'; the CLI
+        // output we parse strips it, so restore it to match the Engine API.
+        const names = (typeof c.Names === 'string' ? c.Names.split(/\s+/g) : Array.from(c.Names))
+          .map((name: string) => (name.startsWith('/') ? name : `/${ name }`));
+
         return {
           ...pick(c, 'Image', 'Command', 'Status'),
           ...pick(details, 'Id', 'NetworkSettings', 'Mounts'),
@@ -558,7 +563,7 @@ export class RDXClient implements v1.DockerDesktopClient {
           Ports:      details.NetworkSettings?.Ports ?? {},
           ...pick(details.Config, 'Labels'),
           ...pick(details.State, ['Status', 'State'] as const),
-          Names:      typeof c.Names === 'string' ? c.Names.split(/\s+/g) : Array.from(c.Names),
+          Names:      names,
           Created:    Date.parse(c.CreatedAt).valueOf(),
           Started:    Date.parse(details.State.StartedAt).valueOf(),
         };


### PR DESCRIPTION
`ddClient.docker.listContainers()` returned container `Names` without the leading `/` that the Docker Engine API includes, because Rancher Desktop builds the list from `docker container ls` output, which strips it. Extensions that remove the expected slash (e.g. with `slice(1)`) then drop the first real character: the Logs Explorer extension showed every container name missing its first letter, while Docker Desktop rendered them correctly.

Restore the leading slash in `listContainers` to match the Engine API.

Fixes #6453