### PR TITLE
Make helm-install-rancher.bats robust to teardown hang and stray repos

### DIFF
--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -143,9 +143,11 @@ verify_rancher() {
 }
 
 uninstall_rancher() {
-    run helm uninstall rancher --namespace cattle-system --wait
+    # Don't use `helm --wait`. Rancher's uninstall leaves a broken ext.cattle.io
+    # aggregated API that hangs helm's post-delete wait; factory_reset handles cleanup.
+    run helm uninstall rancher --namespace cattle-system
     assert_nothing
-    run helm uninstall cert-manager --namespace cert-manager --wait
+    run helm uninstall cert-manager --namespace cert-manager
     assert_nothing
 }
 

--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -154,7 +154,9 @@ uninstall_rancher() {
 @test 'add helm repo' {
     helm repo add jetstack https://charts.jetstack.io
     helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-    helm repo update
+    # Update only the repos this test adds; the shared global config may hold
+    # unrelated stale repos that would fail a bare `helm repo update`.
+    helm repo update jetstack rancher-latest
 }
 
 foreach_k3s_version \


### PR DESCRIPTION
**Drop `helm --wait` from the rancher uninstall teardown.** `helm uninstall ... --wait` hangs indefinitely: rancher's uninstall leaves a broken `ext.cattle.io` aggregated API (its `imperative-api-extension` Service loses its endpoints once the rancher pod is deleted), and that 503 trips helm's post-delete wait even though every release resource is already gone. The teardown is best-effort (`assert_nothing`) and each iteration starts with `factory_reset`, so it never needed to wait.

**Update only the repos this test manages.** `helm repo update` with no arguments refreshes every repo in the shared global helm config, so one unrelated stale repo (a developer's leftover) fails the whole command and the test. The update now names `jetstack` and `rancher-latest`.
