### PR TITLE
fix(containers): keep Logs/Shell terminal fitted when zoomed

### DIFF
--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -88,6 +88,26 @@ test.describe.serial('Containers Tests', () => {
     await expect(containerLogsPage.loadingIndicator).not.toBeVisible();
   });
 
+  test('should keep the terminal fitted after zooming out', async() => {
+    const containerLogsPage = new ContainerLogsPage(page);
+
+    await containerLogsPage.waitForLogsToLoad();
+    expect(await containerLogsPage.getTerminalRows()).toBeGreaterThan(5);
+
+    // Zooming out must not collapse the terminal to a single row (#10543).
+    await electronApp.evaluate(({ BrowserWindow }, zoomLevel) => {
+      BrowserWindow.getAllWindows()[0]?.webContents.setZoomLevel(zoomLevel);
+    }, -2);
+
+    try {
+      await expect.poll(() => containerLogsPage.getTerminalRows()).toBeGreaterThan(5);
+    } finally {
+      await electronApp.evaluate(({ BrowserWindow }) => {
+        BrowserWindow.getAllWindows()[0]?.webContents.setZoomLevel(0);
+      });
+    }
+  });
+
   test('should show container information', async() => {
     const containerLogsPage = new ContainerLogsPage(page);
 

--- a/e2e/pages/container-logs-page.ts
+++ b/e2e/pages/container-logs-page.ts
@@ -68,4 +68,13 @@ export class ContainerLogsPage {
       return container?.__xtermTerminal?.buffer.active.viewportY ?? 0;
     });
   }
+
+  /** Number of rows the terminal has fitted itself to. */
+  async getTerminalRows(): Promise<number> {
+    return this.page.evaluate(() => {
+      const el = document.querySelector('[data-testid="terminal"]');
+
+      return (el as any)?.__xtermTerminal?.rows ?? 0;
+    });
+  }
 }

--- a/e2e/pages/container-logs-page.ts
+++ b/e2e/pages/container-logs-page.ts
@@ -47,7 +47,7 @@ export class ContainerLogsPage {
 
   async scrollToBottom() {
     await this.page.evaluate(() => {
-      const container = document.querySelector('[data-testid="terminal"]');
+      const container = document.querySelector('.container-logs-component [data-testid="terminal"]');
 
       container?.__xtermTerminal?.scrollToBottom();
     });
@@ -55,7 +55,7 @@ export class ContainerLogsPage {
 
   async scrollToTop() {
     await this.page.evaluate(() => {
-      const container = document.querySelector('[data-testid="terminal"]');
+      const container = document.querySelector('.container-logs-component [data-testid="terminal"]');
 
       container?.__xtermTerminal?.scrollToTop();
     });
@@ -63,7 +63,7 @@ export class ContainerLogsPage {
 
   async getScrollPosition(): Promise<number> {
     return await this.page.evaluate(() => {
-      const container = document.querySelector('[data-testid="terminal"]');
+      const container = document.querySelector('.container-logs-component [data-testid="terminal"]');
 
       return container?.__xtermTerminal?.buffer.active.viewportY ?? 0;
     });
@@ -72,7 +72,7 @@ export class ContainerLogsPage {
   /** Number of rows the terminal has fitted itself to. */
   async getTerminalRows(): Promise<number> {
     return this.page.evaluate(() => {
-      const el = document.querySelector('[data-testid="terminal"]');
+      const el = document.querySelector('.container-logs-component [data-testid="terminal"]');
 
       return (el as any)?.__xtermTerminal?.rows ?? 0;
     });

--- a/e2e/pages/container-shell-page.ts
+++ b/e2e/pages/container-shell-page.ts
@@ -55,7 +55,7 @@ export class ContainerShellPage {
    */
   async getTerminalText(): Promise<string> {
     return this.page.evaluate(() => {
-      const el = document.querySelector('[data-testid="terminal"]');
+      const el = document.querySelector('.container-shell-component [data-testid="terminal"]');
       const term = (el as any)?.__xtermTerminal;
 
       if (!term) return '';

--- a/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
+++ b/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
@@ -391,6 +391,20 @@ onBeforeUnmount(() => {
   overflow: hidden;
 }
 
+// Stretch the Tabbed wrappers to fill the page; without this the terminal's
+// flex height resolves against content and collapses to a single row.
+:deep(.action-tabs) {
+  flex: 1;
+  min-height: 0;
+}
+
+:deep(.tab-container) {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 :deep(.container-logs-component),
 :deep(.container-shell-component),
 :deep(.container-stats-component) {


### PR DESCRIPTION
The Logs and Shell terminals live inside the shared `Tabbed` component, whose wrappers (`.action-tabs`, `.tab-container`) size to their content instead of filling the page, so the terminals' `flex: 1` had no height to fill. xterm's FitAddon then fitted the terminal to its own content, which makes the height a feedback loop; because `fit()` uses `Math.floor`, each zoom change ratcheted the row count down until it hit the single-row floor and stuck. Zooming out reliably triggered the collapse reported in #10543.

The fix stretches the two `Tabbed` wrappers in `ContainerInfo.vue` so the flex height chain reaches the terminal and the FitAddon measures a real, layout-assigned height. `.container-inspect` and `.container-stats-component` already scroll internally, so constraining `.tab-container` does not clip the Info or Stats tabs.

Verified live against a running build: 1 → 39 rows after the fix, and rows now grow across zoom levels instead of collapsing. Adds an e2e regression test that zooms out and asserts the terminal stays fitted. The e2e suite was not executed in-harness.

Fixes #10543
