### PR TITLE
Add translate and untranslated reports

### DIFF
--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -1,8 +1,8 @@
 # i18n-report
 
 A CLI tool for maintaining Rancher Desktop's translation files. It scans
-source code and YAML locale files to find unused keys, stale translations,
-and other i18n issues.
+source code and YAML locale files to find unused keys, missing translations,
+hardcoded English strings, and other i18n issues.
 
 ## Quick start
 
@@ -27,8 +27,9 @@ go build -o src/go/i18n-report/i18n-report ./src/go/i18n-report
 - `2` — an operational failure: an unreadable file or an invalid flag.
 
 Gate commands (`undefined`) split exit `1` from exit `2`, so CI can tell
-a real finding from a broken invocation. Lister commands (`unused`,
-`stale`, `references`, `dynamic`) exit `0` even when they list results.
+a real finding from a broken invocation. Lister commands (`unused`, `stale`,
+`translate`, `references`, `dynamic`, `untranslated`) exit `0` even when
+they list results.
 
 ## Subcommands
 
@@ -59,6 +60,48 @@ obsolete and should be removed.
 ```sh
 i18n-report stale --locale=de [--format=json|text]
 ```
+
+### translate
+
+List keys that need translation, with their English values.
+
+Modes:
+- **`missing`** (default) — keys absent from the locale file
+
+```sh
+i18n-report translate --locale=de [--mode=missing] [--format=json|text]
+```
+
+`--format=json` is the machine-readable form: it preserves multiline
+values, unlike the text format. Use it whenever the output feeds another
+tool.
+
+Split the output into parallel batches with `--batch` and `--batches`:
+
+```sh
+i18n-report translate --locale=de --batch=1 --batches=3 > batch1.txt
+i18n-report translate --locale=de --batch=2 --batches=3 > batch2.txt
+i18n-report translate --locale=de --batch=3 --batches=3 > batch3.txt
+```
+
+Each batch outputs `key=value` lines suitable for feeding to a translator
+or saving to a file.
+
+### untranslated
+
+Scan Vue and TypeScript files for hardcoded English strings that should
+use `t()` calls.
+
+```sh
+i18n-report untranslated [--format=json|text] [--include-descriptions]
+```
+
+The `--include-descriptions` flag extends the scan to `description`
+properties, catching diagnostics strings in `main/diagnostics/*.ts`.
+
+This report uses heuristics and may produce false positives. Known gaps
+include `showErrorBox` calls, port forwarding errors, and template-literal
+strings.
 
 ### references
 
@@ -96,6 +139,19 @@ Key references are found by matching several regex patterns:
 
 Full-line comments are ignored; trailing comments on code lines are not.
 
+### Untranslated heuristics
+
+The untranslated scanner checks:
+- Unbound HTML attributes (`label="..."`, `placeholder="..."`, etc.)
+- Text between HTML tags (same line and cross-line)
+- Bound string literal attributes (`:label="'text'"`)
+- Electron dialog properties (`title`, `message`, `detail`)
+- Validation error messages (`errors.push('...')`)
+
+It skips test files, lines already using `t()` or bound attributes, and
+values matching common non-translatable patterns (URLs, CSS classes,
+identifiers).
+
 ## Development
 
 ### Running tests
@@ -117,6 +173,8 @@ go test ./src/go/i18n-report/...
 | `report_unused.go` | `unused` subcommand |
 | `report_undefined.go` | `undefined` subcommand |
 | `report_stale.go` | `stale` subcommand |
+| `report_translate.go` | `translate` subcommand |
+| `report_untranslated.go` | `untranslated` subcommand, heuristic scanner |
 | `report_references.go` | `references` subcommand |
 | `report_dynamic.go` | `dynamic` subcommand, finds dynamic key patterns |
 

--- a/src/go/i18n-report/compute.go
+++ b/src/go/i18n-report/compute.go
@@ -4,7 +4,8 @@
 
 package main
 
-// Shared key-set computations.
+// Shared key-set computations. The listers (stale, missing, translate) all
+// derive their findings from these helpers.
 
 // computeStale returns locale keys that no longer exist in en-us, sorted.
 func computeStale[V any](enKeys map[string]string, localeKeys map[string]V) []string {
@@ -15,4 +16,15 @@ func computeStale[V any](enKeys map[string]string, localeKeys map[string]V) []st
 		}
 	}
 	return stale
+}
+
+// computeMissing returns en-us keys absent from the locale, sorted.
+func computeMissing[V any](enKeys map[string]string, localeKeys map[string]V) []string {
+	var missing []string
+	for _, k := range sortedKeys(enKeys) {
+		if _, found := localeKeys[k]; !found {
+			missing = append(missing, k)
+		}
+	}
+	return missing
 }

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -32,11 +32,13 @@ func (e findingsError) Error() string { return string(e) }
 func (findingsError) Is(target error) bool { return target == errFindings }
 
 var subcommands = map[string]func([]string) error{
-	"unused":     runUnused,
-	"undefined":  runUndefined,
-	"stale":      runStale,
-	"references": runReferences,
-	"dynamic":    runDynamic,
+	"unused":       runUnused,
+	"undefined":    runUndefined,
+	"stale":        runStale,
+	"translate":    runTranslate,
+	"untranslated": runUntranslated,
+	"references":   runReferences,
+	"dynamic":      runDynamic,
 }
 
 func main() {
@@ -74,6 +76,8 @@ Subcommands:
   unused        Keys in en-us.yaml not referenced in source code
   undefined     Keys referenced in source code but missing from en-us.yaml
   stale         Keys in a locale file absent from en-us.yaml
+  translate     Keys missing from a locale, with English values
+  untranslated  Hardcoded English strings in Vue/TS files (heuristic)
   references    Where each en-us.yaml key is used (file:line)
   dynamic       Template literal patterns that reference keys dynamically
 

--- a/src/go/i18n-report/report_translate.go
+++ b/src/go/i18n-report/report_translate.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// normalizeWhitespace collapses newlines and surrounding whitespace into
+// single spaces so that multiline values fit on one key=value output line.
+// This makes the text format lossy for multiline values; use --format json
+// for a lossless round-trip through translate and merge.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// Translate modes; merge reuses improve and drift for @override handling.
+const (
+	modeMissing = "missing"
+	modeImprove = "improve"
+	modeDrift   = "drift"
+)
+
+func runTranslate(args []string) error {
+	fs := flag.NewFlagSet("translate", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale code (required)")
+	mode := fs.String("mode", "missing", "Translate mode: missing")
+	format := fs.String("format", formatText, "Output format: text, json")
+	batch := fs.Int("batch", 0, "Batch number (1-indexed); requires --batches")
+	batches := fs.Int("batches", 0, "Total number of batches")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateFormat(*format); err != nil {
+		return err
+	}
+
+	if *locale == "" {
+		return fmt.Errorf("--locale is required")
+	}
+
+	validModes := map[string]bool{modeMissing: true}
+	if !validModes[*mode] {
+		return fmt.Errorf("--mode must be one of: missing")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return reportTranslate(os.Stdout, root, *locale, *mode, *format, *batch, *batches, false)
+}
+
+// reportTranslate outputs key=value pairs for translation. The mode controls
+// which keys are included:
+//   - missing: keys in en-us.yaml absent from the locale
+//
+//nolint:unparam,gocritic // includeOverrides and the single-case switch scaffold the improve and drift modes
+func reportTranslate(w io.Writer, root, locale, mode, format string, batch, batches int, includeOverrides bool) error {
+	enPath := translationsPath(root, "en-us.yaml")
+	localePath := translationsPath(root, locale+".yaml")
+
+	enEntries, err := loadYAMLWithComments(enPath)
+	if err != nil {
+		return err
+	}
+
+	// Build a flat key map for sorting.
+	enKeyMap := make(map[string]string, len(enEntries))
+	for k, e := range enEntries {
+		enKeyMap[k] = e.value
+	}
+
+	type kv struct {
+		Key     string `json:"key"`
+		Value   string `json:"value"`
+		Comment string `json:"comment,omitempty"`
+	}
+	var pairs []kv
+
+	switch mode {
+	case modeMissing:
+		localeKeys, err := loadYAMLFlat(localePath)
+		if err != nil {
+			return err
+		}
+		for _, k := range computeMissing(enKeyMap, localeKeys) {
+			pairs = append(pairs, kv{k, enEntries[k].value, enEntries[k].comment})
+		}
+	}
+
+	// Apply batch slicing if requested.
+	if batch != 0 || batches != 0 {
+		if batches < 1 {
+			return fmt.Errorf("--batches must be at least 1")
+		}
+		if batch < 1 || batch > batches {
+			return fmt.Errorf("--batch must be between 1 and %d", batches)
+		}
+		total := len(pairs)
+		size := (total + batches - 1) / batches
+		start := (batch - 1) * size
+		end := start + size
+		if start > total {
+			start = total
+		}
+		if end > total {
+			end = total
+		}
+		pairs = pairs[start:end]
+	}
+
+	if format == formatJSON {
+		if pairs == nil {
+			pairs = []kv{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(pairs)
+	}
+
+	modeLabel := map[string]string{
+		modeMissing: "missing from",
+		modeImprove: "eligible for improvement in",
+		modeDrift:   "drifted in",
+	}[mode]
+
+	if len(pairs) == 0 && batches == 0 {
+		fmt.Fprintf(w, "No keys %s %s.\n", modeLabel, locale)
+		return nil
+	}
+
+	label := fmt.Sprintf("Found %d keys %s %s", len(pairs), modeLabel, locale)
+	if batches > 0 {
+		label += fmt.Sprintf(" (batch %d of %d)", batch, batches)
+	}
+	fmt.Fprintf(w, "%s:\n\n", label)
+	for _, p := range pairs {
+		if p.Comment != "" {
+			fmt.Fprintln(w, p.Comment)
+		}
+		fmt.Fprintf(w, "%s=%s\n", p.Key, normalizeWhitespace(p.Value))
+	}
+	return nil
+}

--- a/src/go/i18n-report/report_translate_test.go
+++ b/src/go/i18n-report/report_translate_test.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReportTranslateIncludesAnnotations(t *testing.T) {
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0755)
+
+	enUS := `tray:
+  # @context System tray menu, shows active container runtime
+  # @no-translate containerd, moby
+  containerEngine: "Container engine: {name}"
+  preferences: Preferences
+locale:
+  name: English
+`
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+
+	// de.yaml has "preferences" but is missing "containerEngine" and "locale.name".
+	de := `tray:
+  preferences: Einstellungen
+`
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(de), 0o644)
+
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", "missing", "text", 0, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	// The annotation from en-us.yaml should appear in the output.
+	if !strings.Contains(output, "@context System tray menu") {
+		t.Errorf("missing @context annotation in output:\n%s", output)
+	}
+	if !strings.Contains(output, "@no-translate containerd") {
+		t.Errorf("missing @no-translate annotation in output:\n%s", output)
+	}
+	// The key itself should be present.
+	if !strings.Contains(output, "tray.containerEngine=") {
+		t.Errorf("missing tray.containerEngine key in output:\n%s", output)
+	}
+	// Keys without annotations should still appear.
+	if !strings.Contains(output, "locale.name=English") {
+		t.Errorf("missing locale.name key in output:\n%s", output)
+	}
+}
+
+func TestReportTranslateJSON(t *testing.T) {
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0755)
+
+	enUS := `tray:
+  # @context System tray tooltip
+  status: Running
+`
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(""), 0o644)
+
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", "missing", "json", 0, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	// JSON output should include the comment field.
+	if !strings.Contains(output, `"comment"`) {
+		t.Errorf("JSON output missing comment field:\n%s", output)
+	}
+	if !strings.Contains(output, "@context System tray tooltip") {
+		t.Errorf("JSON output missing annotation:\n%s", output)
+	}
+}
+
+func TestTranslateRejectsInvalidBatchCounts(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	dir := setupTranslateTestRepo(t, enUS, "{}\n")
+
+	// Negative batch counts must error, not silently disable batching.
+	err := reportTranslate(io.Discard, dir, "de", "missing", "text", 1, -2, false)
+	if err == nil {
+		t.Error("expected an error for --batches=-2, got nil")
+	}
+
+	err = reportTranslate(io.Discard, dir, "de", "missing", "text", -1, 3, false)
+	if err == nil {
+		t.Error("expected an error for --batch=-1, got nil")
+	}
+}
+
+// TestTranslateBatchesPartitionAllKeys proves the batch slices reproduce the
+// unbatched key set exactly: every key appears in exactly one batch, including
+// when the batch count exceeds the key count and leaves trailing batches empty.
+func TestTranslateBatchesPartitionAllKeys(t *testing.T) {
+	enUS := "one: A\ntwo: B\nthree: C\nfour: D\n"
+	dir := setupTranslateTestRepo(t, enUS, "{}\n")
+
+	type kv struct {
+		Key string `json:"key"`
+	}
+	collect := func(batch, batches int) []kv {
+		var buf bytes.Buffer
+		if err := reportTranslate(&buf, dir, "de", "missing", "json", batch, batches, false); err != nil {
+			t.Fatalf("batch %d of %d: %v", batch, batches, err)
+		}
+		var pairs []kv
+		if err := json.Unmarshal(buf.Bytes(), &pairs); err != nil {
+			t.Fatalf("unmarshal batch %d of %d: %v", batch, batches, err)
+		}
+		return pairs
+	}
+
+	want := collect(0, 0)
+	if len(want) != 4 {
+		t.Fatalf("unbatched run has %d keys, want 4", len(want))
+	}
+
+	// 5 > 4 exercises a batch count larger than the key set.
+	for _, batches := range []int{1, 2, 3, 5} {
+		seen := map[string]bool{}
+		for b := 1; b <= batches; b++ {
+			for _, p := range collect(b, batches) {
+				if seen[p.Key] {
+					t.Errorf("batches=%d: key %q appears in more than one batch", batches, p.Key)
+				}
+				seen[p.Key] = true
+			}
+		}
+		if len(seen) != len(want) {
+			t.Errorf("batches=%d: union has %d keys, want %d", batches, len(seen), len(want))
+		}
+		for _, p := range want {
+			if !seen[p.Key] {
+				t.Errorf("batches=%d: key %q missing from every batch", batches, p.Key)
+			}
+		}
+	}
+}
+
+// TestTranslateEmptyBatchKeepsHeader verifies that an empty trailing batch
+// still reports its batch position instead of the "No keys missing" message,
+// which would imply the locale is complete.
+func TestTranslateEmptyBatchKeepsHeader(t *testing.T) {
+	// One missing key across three batches leaves batch 3 empty.
+	dir := setupTranslateTestRepo(t, "only: A\n", "{}\n")
+
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", "missing", "text", 3, 3, false); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "(batch 3 of 3)") {
+		t.Errorf("empty batch dropped the batch header:\n%s", out)
+	}
+	if strings.Contains(out, "No keys") {
+		t.Errorf("empty batch printed the completeness message:\n%s", out)
+	}
+}
+
+// TestTranslateCompleteLocaleMessage verifies the unbatched path still reports
+// a complete locale plainly.
+func TestTranslateCompleteLocaleMessage(t *testing.T) {
+	dir := setupTranslateTestRepo(t, "only: A\n", "only: B\n")
+
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", "missing", "text", 0, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if out := buf.String(); !strings.Contains(out, "No keys missing from de") {
+		t.Errorf("want the completeness message for a fully translated locale, got:\n%s", out)
+	}
+}
+
+func setupTranslateTestRepo(t *testing.T, enUS, locale string) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0755)
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
+	return dir
+}

--- a/src/go/i18n-report/report_untranslated.go
+++ b/src/go/i18n-report/report_untranslated.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// untranslatedHit records a hardcoded string found in a source file.
+type untranslatedHit struct {
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Context string `json:"context"`
+}
+
+// Patterns for detecting hardcoded English strings in Vue/TS files.
+var (
+	// Attributes that should use t() instead of hardcoded strings.
+	// Excludes Vue directives (v-tooltip, v-clean-tooltip) since their values are expressions.
+	attrPattern = regexp.MustCompile(`(?i)(?:^|\s)(label|legend-text|placeholder|tooltip|description)="([^"]{3,})"`)
+	// Skip attributes that are clearly not translatable.
+	skipPattern = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*$|^\d|^http|^/|^#|^\$|^@|^:|^\{`)
+	// Single-word Title Case values (e.g., "Environment", "General").
+	singleWordTitleCase = regexp.MustCompile(`^[A-Z][a-z]{2,}$`)
+	// Text between an HTML closing ">" and an opening "</" on the same line.
+	htmlTextPattern = regexp.MustCompile(`>\s*([A-Z][a-zA-Z ]{2,}?)\s*</`)
+	// Bare text between tags split across lines (e.g., ">\n Cancel\n </button>").
+	bareTextPattern = regexp.MustCompile(`^[A-Z][a-zA-Z]{2,}(?: [a-zA-Z]+)*$`)
+	// Bound string literal attributes, e.g. :label="'Include Kubernetes services'".
+	boundLiteralPattern = regexp.MustCompile(`:(label|placeholder)="'([^']{3,})'"`)
+	// Validation error messages pushed to an errors array.
+	errorPushPattern = regexp.MustCompile(`errors\.push\(\s*['"\x60]`)
+	// Object-literal UI labels in script code, e.g. SortableTable headers
+	// (`label: 'Local Port'`).
+	objectLabelPattern = regexp.MustCompile(`^(label|text|tooltip|placeholder):\s+['"]([A-Z][^'"]{2,})['"],?$`)
+	// A t() call anywhere on the line; such lines are already translated.
+	tCallPattern = regexp.MustCompile(`(?:^|[^a-zA-Z])t\(`)
+)
+
+func runUntranslated(args []string) error {
+	fs := flag.NewFlagSet("untranslated", flag.ExitOnError)
+	format := fs.String("format", formatText, "Output format: text, json")
+	includeDescriptions := fs.Bool("include-descriptions", false, "Include 'description' fields (catches diagnostics strings)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateFormat(*format); err != nil {
+		return err
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return reportUntranslated(os.Stdout, root, *format, *includeDescriptions)
+}
+
+func reportUntranslated(w io.Writer, root, format string, includeDescriptions bool) error {
+	hits, err := findUntranslated(root, includeDescriptions)
+	if err != nil {
+		return err
+	}
+
+	if format == formatJSON {
+		if hits == nil {
+			hits = []untranslatedHit{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(hits)
+	}
+
+	if len(hits) == 0 {
+		fmt.Fprintln(w, "No untranslated strings found.")
+		return nil
+	}
+
+	fmt.Fprintf(w, "Found %d potential untranslated strings:\n\n", len(hits))
+	for _, h := range hits {
+		fmt.Fprintf(w, "  %s:%d\n    %s\n\n", h.File, h.Line, h.Context)
+	}
+	return nil
+}
+
+// findUntranslated uses heuristics to find hardcoded English strings in Vue/TS files.
+// When includeDescriptions is true, the dialog pattern also matches "description" properties
+// (catches diagnostics strings in main/diagnostics/*.ts).
+//
+// Known gaps: error dialog calls (showErrorBox in tray.ts, settingsImpl.ts),
+// port forwarding error messages (backend/kube/client.ts), and template-literal
+// strings lack a reliable structural pattern to scan for without drowning in
+// false positives.
+func findUntranslated(root string, includeDescriptions bool) ([]untranslatedHit, error) {
+	files, err := scanRepoSourceFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var hits []untranslatedHit
+
+	// Electron dialog strings: title/message/detail with hardcoded English.
+	dialogFields := "title|message|detail"
+	if includeDescriptions {
+		dialogFields = "title|message|detail|description"
+	}
+	dialogPattern := regexp.MustCompile(`(` + dialogFields + `):\s+['"]([A-Z][^'"]{5,})['"]`)
+
+	for _, file := range files {
+		base := filepath.Base(file)
+		if strings.Contains(base, ".spec.") || strings.Contains(base, ".test.") {
+			continue
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", file, err)
+		}
+		relPath, _ := filepath.Rel(root, file)
+		lines := strings.Split(string(data), "\n")
+		isVue := strings.HasSuffix(file, ".vue")
+		isTS := strings.HasSuffix(file, ".ts")
+		inTemplate := false
+
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+
+			// Track top-level Vue <template> sections (not nested slot templates).
+			if isVue {
+				if trimmed == "<template>" || strings.HasPrefix(trimmed, "<template ") {
+					if !inTemplate && (i == 0 || len(line)-len(strings.TrimLeft(line, " \t")) == 0) {
+						inTemplate = true
+					}
+				} else if trimmed == "</template>" && inTemplate {
+					if len(line)-len(strings.TrimLeft(line, " \t")) == 0 {
+						inTemplate = false
+					}
+				}
+			}
+
+			// Skip lines that already use binding (:attr) or t()
+			if strings.Contains(trimmed, ":label=") || strings.Contains(trimmed, ":legend-text=") {
+				continue
+			}
+			if tCallPattern.MatchString(trimmed) {
+				continue
+			}
+
+			found := false
+
+			if isVue {
+				// Check unbound attribute values.
+				matches := attrPattern.FindAllStringSubmatch(trimmed, -1)
+				for _, m := range matches {
+					value := m[2]
+					if skipPattern.MatchString(value) {
+						continue
+					}
+					if strings.Contains(value, " ") || singleWordTitleCase.MatchString(value) {
+						found = true
+						break
+					}
+				}
+
+				// Check text between HTML tags on the same line.
+				// Skip <slot> default content — it's fallback text overridden by parents.
+				if !found && !strings.Contains(trimmed, "<slot>") {
+					tagMatches := htmlTextPattern.FindAllStringSubmatch(trimmed, -1)
+					for _, m := range tagMatches {
+						value := strings.TrimSpace(m[1])
+						if skipPattern.MatchString(value) {
+							continue
+						}
+						found = true
+						break
+					}
+				}
+
+				// Check bare text between tags across lines: previous line
+				// ends with ">", this line is bare text, next line starts
+				// with "</" or "<".
+				if !found && inTemplate && bareTextPattern.MatchString(trimmed) {
+					prevEndsWithTag := i > 0 && strings.HasSuffix(strings.TrimSpace(lines[i-1]), ">")
+					nextStartsWithTag := i+1 < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i+1]), "<")
+					if prevEndsWithTag && nextStartsWithTag {
+						found = true
+					}
+				}
+
+				// Check bound string literal attributes.
+				if !found && boundLiteralPattern.MatchString(trimmed) {
+					found = true
+				}
+			}
+
+			if !found && isTS {
+				// Validation error messages.
+				if errorPushPattern.MatchString(trimmed) {
+					found = true
+				}
+			}
+
+			// Object-literal UI labels in script code (not in templates,
+			// where attrPattern already covers attributes).
+			if !found && !inTemplate {
+				if m := objectLabelPattern.FindStringSubmatch(trimmed); m != nil {
+					value := m[2]
+					if !skipPattern.MatchString(value) &&
+						(strings.Contains(value, " ") || singleWordTitleCase.MatchString(value)) {
+						found = true
+					}
+				}
+			}
+
+			// Dialog strings in both .vue and .ts files.
+			if !found && dialogPattern.MatchString(trimmed) {
+				found = true
+			}
+
+			if found {
+				hits = append(hits, untranslatedHit{
+					File:    relPath,
+					Line:    i + 1,
+					Context: trimmed,
+				})
+			}
+		}
+	}
+	return hits, nil
+}

--- a/src/go/i18n-report/report_untranslated_test.go
+++ b/src/go/i18n-report/report_untranslated_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// setupUntranslatedRepo writes the given files under pkg/rancher-desktop and
+// returns the repo root, so findUntranslated has a source tree to scan.
+func setupUntranslatedRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "pkg", "rancher-desktop")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		path := filepath.Join(srcDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestReportUntranslatedEmptyJSON(t *testing.T) {
+	// A file whose only string sits inside a t() call yields no hits.
+	dir := setupUntranslatedRepo(t, map[string]string{
+		"clean.ts": "const label = t('foo.bar');\n",
+	})
+	var buf bytes.Buffer
+	if err := reportUntranslated(&buf, dir, "json", false); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("empty result encoded as %q, want []", got)
+	}
+}
+
+func TestFindUntranslatedDetectsObjectLabel(t *testing.T) {
+	dir := setupUntranslatedRepo(t, map[string]string{
+		"columns.ts": "const columns = [\n  {\n    label: 'Local Port',\n  },\n];\n",
+	})
+	hits, err := findUntranslated(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("got %d hits, want 1: %+v", len(hits), hits)
+	}
+	if !strings.Contains(hits[0].Context, "Local Port") {
+		t.Errorf("hit context = %q, want it to mention 'Local Port'", hits[0].Context)
+	}
+}
+
+func TestFindUntranslatedUnreadableFileIsAnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file modes cannot make a file unreadable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root can read mode-0 files")
+	}
+	dir := setupUntranslatedRepo(t, nil)
+	broken := filepath.Join(dir, "pkg", "rancher-desktop", "Broken.vue")
+	if err := os.WriteFile(broken, []byte(`label="Reset Kubernetes"`+"\n"), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findUntranslated(dir, false); err == nil {
+		t.Error("expected an error for an unreadable source file")
+	}
+}
+
+func TestValuePatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern *regexp.Regexp
+		group   int
+		line    string
+		wantVal string // empty means no match
+	}{
+		{"attr: label with space", attrPattern, 2, `label="Reset Kubernetes"`, "Reset Kubernetes"},
+		{"attr: placeholder", attrPattern, 2, `placeholder="Enter a value"`, "Enter a value"},
+		{"attr: tooltip", attrPattern, 2, `tooltip="This is helpful"`, "This is helpful"},
+		{"attr: short value skipped", attrPattern, 2, `label="ab"`, ""},
+		{"attr: bound attr not matched", attrPattern, 2, `:label="t('key')"`, ""},
+		{"attr: description attr", attrPattern, 2, `description="Some long text"`, "Some long text"},
+		{"htmlText: text between tags", htmlTextPattern, 1, `<h1>Reset Kubernetes</h1>`, "Reset Kubernetes"},
+		{"htmlText: single word", htmlTextPattern, 1, `<span>Environment</span>`, "Environment"},
+		{"htmlText: lowercase skipped", htmlTextPattern, 1, `<p>not a match</p>`, ""},
+		{"htmlText: short text", htmlTextPattern, 1, `<b>A</b>`, ""},
+		{"boundLiteral: bound label", boundLiteralPattern, 2, `:label="'Include Kubernetes services'"`, "Include Kubernetes services"},
+		{"boundLiteral: bound placeholder", boundLiteralPattern, 2, `:placeholder="'Search...'"`, "Search..."},
+		{"boundLiteral: too short", boundLiteralPattern, 2, `:label="'ab'"`, ""},
+		{"boundLiteral: no match", boundLiteralPattern, 2, `label="plain"`, ""},
+		{"objectLabel: table header label", objectLabelPattern, 2, `label: 'Local Port',`, "Local Port"},
+		{"objectLabel: double quoted", objectLabelPattern, 2, `label: "Namespace",`, "Namespace"},
+		{"objectLabel: tooltip literal", objectLabelPattern, 2, `tooltip: 'Restart the container',`, "Restart the container"},
+		{"objectLabel: t() call not matched", objectLabelPattern, 2, `label: this.t('containers.title'),`, ""},
+		{"objectLabel: lowercase value not matched", objectLabelPattern, 2, `label: 'name',`, ""},
+		{"objectLabel: non-label property not matched", objectLabelPattern, 2, `name: 'Namespace',`, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.pattern.FindStringSubmatch(tc.line)
+			var got string
+			if m != nil {
+				got = m[tc.group]
+			}
+			if tc.wantVal == "" && got != "" {
+				t.Errorf("expected no match, got %q", got)
+			} else if tc.wantVal != "" && got != tc.wantVal {
+				t.Errorf("got %q, want %q", got, tc.wantVal)
+			}
+		})
+	}
+}
+
+func TestSkipPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want bool // true = should skip
+	}{
+		{"camelCase identifier", "containerName", true},
+		{"starts with number", "123abc", true},
+		{"starts with http", "http://example.com", true},
+		{"starts with slash", "/path/to", true},
+		{"starts with hash", "#anchor", true},
+		{"starts with dollar", "$variable", true},
+		{"starts with at", "@slot", true},
+		{"starts with colon", ":bound", true},
+		{"starts with brace", "{expr}", true},
+		{"multi-word text", "Hello World", false},
+		{"Title Case", "Environment", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipPattern.MatchString(tc.val)
+			if got != tc.want {
+				t.Errorf("skipPattern.MatchString(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSingleWordTitleCase(t *testing.T) {
+	tests := []struct {
+		val  string
+		want bool
+	}{
+		{"Environment", true},
+		{"General", true},
+		{"Ab", false},        // too short (< 3 lowercase)
+		{"ABC", false},       // not Title Case
+		{"hello", false},     // lowercase start
+		{"Two Words", false}, // has space
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.val, func(t *testing.T) {
+			got := singleWordTitleCase.MatchString(tc.val)
+			if got != tc.want {
+				t.Errorf("singleWordTitleCase(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBareTextPattern(t *testing.T) {
+	tests := []struct {
+		val  string
+		want bool
+	}{
+		{"Cancel", true},
+		{"Reset Kubernetes", true},
+		{"Two Words Here", true},
+		{"lowercase", false},
+		{"A", false},            // too short
+		{"Ab", false},           // too short
+		{"has123number", false}, // contains digit
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.val, func(t *testing.T) {
+			got := bareTextPattern.MatchString(tc.val)
+			if got != tc.want {
+				t.Errorf("bareTextPattern(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorPushPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"single quote", `errors.push('some error')`, true},
+		{"double quote", `errors.push("some error")`, true},
+		{"backtick", "errors.push(`template error`)", true},
+		{"no match", `errors.push(variable)`, false},
+		{"no match 2", `console.log('test')`, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := errorPushPattern.MatchString(tc.line)
+			if got != tc.want {
+				t.Errorf("errorPushPattern(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTCallPattern(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{`this.t('a.b')`, true},
+		{`t('a.b')`, true},
+		{`:label="t('a.b')"`, true},
+		{`restart('Now')`, false},
+		{`format('Text')`, false},
+	}
+
+	for _, tc := range tests {
+		if got := tCallPattern.MatchString(tc.line); got != tc.want {
+			t.Errorf("tCallPattern(%q) = %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}

--- a/src/go/i18n-report/scan.go
+++ b/src/go/i18n-report/scan.go
@@ -151,6 +151,29 @@ func scanSourceFiles(root string, exts []string) ([]string, error) {
 	return files, err
 }
 
+// scanRepoSourceFiles returns the source files to scan: the recursive
+// pkg/rancher-desktop tree plus root-level files such as background.ts.
+func scanRepoSourceFiles(root string) ([]string, error) {
+	srcDir := filepath.Join(root, "pkg", "rancher-desktop")
+	files, err := scanSourceFiles(srcDir, sourceExtensions)
+	if err != nil {
+		return nil, err
+	}
+
+	extSet := make(map[string]bool, len(sourceExtensions))
+	for _, e := range sourceExtensions {
+		extSet[e] = true
+	}
+	if entries, err := os.ReadDir(root); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() && extSet[filepath.Ext(entry.Name())] {
+				files = append(files, filepath.Join(root, entry.Name()))
+			}
+		}
+	}
+	return files, nil
+}
+
 // scanResult holds everything one pass over the source tree produces.
 type scanResult struct {
 	// refs maps keys to all references, including indirect ones (string
@@ -166,24 +189,9 @@ type scanResult struct {
 // scanFiles reads source files and returns literal key references and
 // dynamic patterns. This shared helper avoids scanning the source tree twice.
 func scanFiles(root string, keys map[string]string) (*scanResult, error) {
-	srcDir := filepath.Join(root, "pkg", "rancher-desktop")
-	exts := sourceExtensions
-	files, err := scanSourceFiles(srcDir, exts)
+	files, err := scanRepoSourceFiles(root)
 	if err != nil {
 		return nil, err
-	}
-
-	// Also scan root-level source files (e.g. background.ts).
-	extSet := make(map[string]bool, len(exts))
-	for _, e := range exts {
-		extSet[e] = true
-	}
-	if entries, err := os.ReadDir(root); err == nil {
-		for _, entry := range entries {
-			if !entry.IsDir() && extSet[filepath.Ext(entry.Name())] {
-				files = append(files, filepath.Join(root, entry.Name()))
-			}
-		}
 	}
 
 	result := &scanResult{


### PR DESCRIPTION
`translate` lists missing keys with their English values and `@context` annotations, in text or JSON, sliceable into batches for parallel translators. `untranslated` heuristically finds hardcoded English strings in Vue/TS files that should use `t()` calls.