### PR TITLE
Add the translation data model: @source snapshots and node layer

### DIFF
--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -120,6 +120,22 @@ show which en-us.yaml keys they match.
 i18n-report dynamic [--format=json|text]
 ```
 
+### source
+
+Record the current English source text on each translated key of a locale, or
+`all` locales, as a co-located `# @source` comment. The snapshot lets a later
+drift check tell which translations were made from English that has since
+changed, without a parallel metadata file.
+
+Refreshing an existing `@source` would overwrite the snapshot with the current
+English and erase that record, so when a key has drifted the command refuses
+unless `--force`.
+
+```sh
+i18n-report source --locale=de
+i18n-report source --locale=all
+```
+
 ## How it works
 
 ### Source scanning
@@ -166,10 +182,11 @@ go test ./src/go/i18n-report/...
 |------|----------|
 | `main.go` | Subcommand dispatch, usage text |
 | `repo.go` | Repository root detection, path helpers |
-| `yaml.go` | YAML flattening |
+| `yaml.go` | YAML flattening, scalar formatting, nested writer |
 | `scan.go` | Source file scanning, key reference detection |
 | `output.go` | Shared text/JSON output formatter |
 | `compute.go` | Shared key-set computations |
+| `source.go` | `@source` comment parsing, English snapshot annotation |
 | `report_unused.go` | `unused` subcommand |
 | `report_undefined.go` | `undefined` subcommand |
 | `report_stale.go` | `stale` subcommand |
@@ -177,6 +194,7 @@ go test ./src/go/i18n-report/...
 | `report_untranslated.go` | `untranslated` subcommand, heuristic scanner |
 | `report_references.go` | `references` subcommand |
 | `report_dynamic.go` | `dynamic` subcommand, finds dynamic key patterns |
+| `report_source.go` | `source` subcommand |
 
 All files are in `package main`. The tool has one external dependency:
 `gopkg.in/yaml.v3`.

--- a/src/go/i18n-report/compute.go
+++ b/src/go/i18n-report/compute.go
@@ -6,6 +6,10 @@ package main
 
 // Shared key-set computations. The listers (stale, missing, translate) all
 // derive their findings from these helpers.
+//
+// Drift compares the current en-us value against the @source snapshot recorded
+// at translation time; both are decoded scalars, so re-quoting the English
+// never counts as drift.
 
 // computeStale returns locale keys that no longer exist in en-us, sorted.
 func computeStale[V any](enKeys map[string]string, localeKeys map[string]V) []string {
@@ -27,4 +31,22 @@ func computeMissing[V any](enKeys map[string]string, localeKeys map[string]V) []
 		}
 	}
 	return missing
+}
+
+// computeDrifted returns keys whose English source differs from the @source
+// snapshot, sorted. Only keys present in the locale, en-us, and with a @source
+// are considered; a key without a @source cannot be checked for drift.
+func computeDrifted[V any](enKeys, meta map[string]string, localeKeys map[string]V) []string {
+	var drifted []string
+	for _, k := range sortedKeys(localeKeys) {
+		enValue, inEn := enKeys[k]
+		storedSource, inMeta := meta[k]
+		if !inEn || !inMeta {
+			continue
+		}
+		if enValue != storedSource {
+			drifted = append(drifted, k)
+		}
+	}
+	return drifted
 }

--- a/src/go/i18n-report/fixtures_test.go
+++ b/src/go/i18n-report/fixtures_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupLocaleTestRepo builds a repo fixture with en-us.yaml and de.yaml. When
+// withSource is set, de.yaml is annotated with @source snapshots of the current
+// English, as a real bootstrap would leave it.
+func setupLocaleTestRepo(t *testing.T, enUS, locale string, withSource bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644)
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
+
+	if withSource {
+		if err := annotateSource(io.Discard, dir, "de", false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -39,6 +39,7 @@ var subcommands = map[string]func([]string) error{
 	"untranslated": runUntranslated,
 	"references":   runReferences,
 	"dynamic":      runDynamic,
+	"source":       runSource,
 }
 
 func main() {
@@ -80,6 +81,7 @@ Subcommands:
   untranslated  Hardcoded English strings in Vue/TS files (heuristic)
   references    Where each en-us.yaml key is used (file:line)
   dynamic       Template literal patterns that reference keys dynamically
+  source        Record the English source text on each translated key
 
 Run "i18n-report <subcommand> -h" for subcommand-specific flags.`)
 }

--- a/src/go/i18n-report/repo.go
+++ b/src/go/i18n-report/repo.go
@@ -8,9 +8,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const translationsDir = "pkg/rancher-desktop/assets/translations"
+
+// sourceLocale is the locale every translation derives from.
+const sourceLocale = "en-us"
 
 // repoRoot returns the repository root by walking up from the current
 // directory looking for the translations directory. Nested package.json
@@ -35,4 +39,58 @@ func repoRoot() (string, error) {
 // translationsPath returns the absolute path to a file in the translations directory.
 func translationsPath(root, filename string) string {
 	return filepath.Join(root, translationsDir, filename)
+}
+
+// translationLocales returns the locale codes that have a translation file,
+// derived from the *.yaml files in the translations directory. en-us is the
+// source of all translations, not a translation itself, so it is excluded.
+func translationLocales(root string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, translationsDir))
+	if err != nil {
+		return nil, err
+	}
+	var locales []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		if locale := strings.TrimSuffix(name, ".yaml"); locale != sourceLocale {
+			locales = append(locales, locale)
+		}
+	}
+	return locales, nil
+}
+
+// filePerm is the mode for every file the tool writes.
+const filePerm = 0o644
+
+// writeFileAtomic writes data to a temp file in the target directory and
+// renames it into place, so an interrupted write cannot truncate the target.
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func(err error) error {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return cleanup(err)
+	}
+	if err := tmp.Chmod(filePerm); err != nil {
+		return cleanup(err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }

--- a/src/go/i18n-report/report_source.go
+++ b/src/go/i18n-report/report_source.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func runSource(args []string) error {
+	fs := flag.NewFlagSet("source", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale code (required, or 'all')")
+	force := fs.Bool("force", false, "Refresh @source even when outstanding drift would be erased")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *locale == "" {
+		return fmt.Errorf("--locale is required (use 'all' for every locale)")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	if *locale == "all" {
+		locales, err := translationLocales(root)
+		if err != nil {
+			return err
+		}
+		hadDrift := false
+		for _, loc := range locales {
+			if err := annotateSource(os.Stdout, root, loc, *force); err != nil {
+				if !errors.Is(err, errFindings) {
+					return err
+				}
+				hadDrift = true
+				continue
+			}
+			fmt.Printf("Annotated @source for %s\n", loc)
+		}
+		if hadDrift {
+			return findingsError("some locales have outstanding drift; resolve it or pass --force")
+		}
+		return nil
+	}
+
+	if err := annotateSource(os.Stdout, root, *locale, *force); err != nil {
+		return err
+	}
+	fmt.Printf("Annotated @source for %s\n", *locale)
+	return nil
+}
+
+// annotateSource records the current English source text on every translated
+// key of a locale file, as a co-located @source comment. Refreshing an
+// existing @source rewrites it to the current English and so erases the record
+// of which keys drifted since translation. Guard against that: if any key's
+// @source differs from the current English and --force was not given, print
+// the drifted keys and return a findings error. Bootstrapping a locale with no
+// @source yet is unaffected.
+func annotateSource(w io.Writer, root, locale string, force bool) error {
+	enKeys, err := loadYAMLFlat(translationsPath(root, sourceLocale+".yaml"))
+	if err != nil {
+		return err
+	}
+	localePath := translationsPath(root, locale+".yaml")
+	// loadYAMLDocument treats a missing file as empty, so a mistyped
+	// locale name would become a new locale file.
+	if _, err := os.Stat(localePath); err != nil {
+		return err
+	}
+
+	if !force {
+		entries, err := loadYAMLWithComments(localePath)
+		if err != nil {
+			return err
+		}
+		localeKeys := make(map[string]string, len(entries))
+		for k, e := range entries {
+			localeKeys[k] = e.value
+		}
+		drifted := computeDrifted(enKeys, collectSources(entries), localeKeys)
+		if len(drifted) > 0 {
+			fmt.Fprintf(w, "%d drifted keys in %s would lose their drift marker:\n", len(drifted), locale)
+			for _, k := range drifted {
+				fmt.Fprintf(w, "  %s\n", k)
+			}
+			fmt.Fprintf(os.Stderr, "Retranslate the drift (translate --mode=drift then merge --mode=drift) "+
+				"or pass --force to overwrite the @source markers anyway.\n")
+			return findingsError(fmt.Sprintf("refusing to erase %d outstanding drift markers in %s", len(drifted), locale))
+		}
+	}
+
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		return err
+	}
+	annotateNodeSource("", documentRoot(doc), enKeys)
+
+	var buf strings.Builder
+	serializeYAMLNode(&buf, doc)
+	if err := writeFileAtomic(localePath, []byte(buf.String())); err != nil {
+		return fmt.Errorf("writing %s: %w", localePath, err)
+	}
+	return nil
+}

--- a/src/go/i18n-report/report_source.go
+++ b/src/go/i18n-report/report_source.go
@@ -78,16 +78,16 @@ func annotateSource(w io.Writer, root, locale string, force bool) error {
 		return err
 	}
 
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		return err
+	}
+	localeRoot := documentRoot(doc)
+
 	if !force {
-		entries, err := loadYAMLWithComments(localePath)
-		if err != nil {
-			return err
-		}
-		localeKeys := make(map[string]string, len(entries))
-		for k, e := range entries {
-			localeKeys[k] = e.value
-		}
-		drifted := computeDrifted(enKeys, collectSources(entries), localeKeys)
+		entries := make(map[string]mergeEntry)
+		flattenNodeWithComments("", localeRoot, entries)
+		drifted := computeDrifted(enKeys, collectSources(entries), entries)
 		if len(drifted) > 0 {
 			fmt.Fprintf(w, "%d drifted keys in %s would lose their drift marker:\n", len(drifted), locale)
 			for _, k := range drifted {
@@ -99,11 +99,7 @@ func annotateSource(w io.Writer, root, locale string, force bool) error {
 		}
 	}
 
-	doc, err := loadYAMLDocument(localePath)
-	if err != nil {
-		return err
-	}
-	annotateNodeSource("", documentRoot(doc), enKeys)
+	annotateNodeSource("", localeRoot, enKeys)
 
 	var buf strings.Builder
 	serializeYAMLNode(&buf, doc)

--- a/src/go/i18n-report/report_source_test.go
+++ b/src/go/i18n-report/report_source_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+)
+
+func driftEnUS(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(translationsPath(dir, "en-us.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSourceGuardBlocksOutstandingDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	// withSource=true records @source: Checking... on the translated key.
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	// The English moves on after the snapshot.
+	driftEnUS(t, dir, "status:\n  checking: Verifying...\n")
+
+	if err := annotateSource(io.Discard, dir, "de", false); !errors.Is(err, errFindings) {
+		t.Fatalf("expected a findings error for outstanding drift, got: %v", err)
+	}
+	// The @source must survive so the drift marker is not erased.
+	if got, _ := sourceOf(t, dir, "status.checking"); got != "Checking..." {
+		t.Errorf("@source overwritten despite drift: got %q", got)
+	}
+}
+
+func TestSourceForceOverwritesDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	driftEnUS(t, dir, "status:\n  checking: Verifying...\n")
+
+	if err := annotateSource(io.Discard, dir, "de", true); err != nil {
+		t.Fatalf("--force should annotate despite drift, got: %v", err)
+	}
+	if got, _ := sourceOf(t, dir, "status.checking"); got != "Verifying..." {
+		t.Errorf("--force did not refresh @source: got %q", got)
+	}
+}
+
+func TestSourceBootstrapIgnoresGuard(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	// withSource=false: no @source recorded yet.
+	dir := setupLocaleTestRepo(t, enUS, de, false)
+
+	if err := annotateSource(io.Discard, dir, "de", false); err != nil {
+		t.Fatalf("bootstrap should succeed without --force, got: %v", err)
+	}
+	if got, ok := sourceOf(t, dir, "status.checking"); !ok || got != "Checking..." {
+		t.Errorf("bootstrap did not record @source: got (%q, %v)", got, ok)
+	}
+}
+
+func TestSourceRejectsNonMappingFile(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "just a scalar\n"
+	dir := setupLocaleTestRepo(t, enUS, de, false)
+
+	if err := annotateSource(io.Discard, dir, "de", false); err == nil {
+		t.Fatal("expected an error for a non-mapping locale file")
+	}
+	data, err := os.ReadFile(translationsPath(dir, "de.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != de {
+		t.Errorf("locale file rewritten: got %q, want %q", data, de)
+	}
+}
+
+func TestSourceForceRequiresLocaleFile(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, false)
+
+	if err := annotateSource(io.Discard, dir, "xx", true); err == nil {
+		t.Fatal("expected an error for a missing locale file")
+	}
+	if _, err := os.Stat(translationsPath(dir, "xx.yaml")); !os.IsNotExist(err) {
+		t.Errorf("xx.yaml should not be created, stat: %v", err)
+	}
+}

--- a/src/go/i18n-report/source.go
+++ b/src/go/i18n-report/source.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// sourceMarker records the English text a translation was made from. It lives
+// in the translated key's comment, so the snapshot travels with the
+// translation and a later drift check needs no parallel file.
+const sourceMarker = "# @source"
+
+// sourceFromComment extracts the English snapshot from a key's HeadComment.
+// A multi-line source repeats the marker, one physical line each, and the
+// lines rejoin in order. Returns false when the key carries no @source.
+func sourceFromComment(comment string) (string, bool) {
+	var lines []string
+	found := false
+	for _, line := range strings.Split(comment, "\n") {
+		// Strip only indentation; a value's own trailing spaces must survive.
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == sourceMarker {
+			lines = append(lines, "")
+			found = true
+		} else if rest, ok := strings.CutPrefix(trimmed, sourceMarker+" "); ok {
+			lines = append(lines, rest)
+			found = true
+		}
+	}
+	if !found {
+		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// setSourceComment replaces a comment's @source lines with english, preserving
+// every other line (e.g. @override, @reason) and its order. The fresh @source
+// lines follow, one per physical line of the English text.
+func setSourceComment(comment, english string) string {
+	var kept []string
+	for _, line := range strings.Split(comment, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == "" || trimmed == sourceMarker || strings.HasPrefix(trimmed, sourceMarker+" ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	for _, l := range strings.Split(english, "\n") {
+		if l == "" {
+			kept = append(kept, sourceMarker)
+		} else {
+			kept = append(kept, sourceMarker+" "+l)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// collectSources maps each key that carries an @source comment to its snapshot.
+func collectSources(entries map[string]mergeEntry) map[string]string {
+	sources := make(map[string]string)
+	for key, e := range entries {
+		if src, ok := sourceFromComment(e.comment); ok {
+			sources[key] = src
+		}
+	}
+	return sources
+}
+
+// annotateNodeSource walks the mapping tree and sets @source on every leaf key
+// whose dotted path exists in enKeys, to the current English value. It mutates
+// the visited key node's HeadComment directly, so keys whose own segments
+// contain dots are annotated correctly without re-splitting a dotted path.
+func annotateNodeSource(prefix string, node *yaml.Node, enKeys map[string]string) {
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		key := keyNode.Value
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		if valNode.Kind == yaml.MappingNode {
+			annotateNodeSource(key, valNode, enKeys)
+		} else if english, ok := enKeys[key]; ok {
+			keyNode.HeadComment = setSourceComment(keyNode.HeadComment, english)
+		}
+	}
+}

--- a/src/go/i18n-report/source_test.go
+++ b/src/go/i18n-report/source_test.go
@@ -129,11 +129,19 @@ func TestAnnotateSourcePreservesOverride(t *testing.T) {
 }
 
 func TestAnnotateSourceIdempotent(t *testing.T) {
-	enUS := "a:\n  b: Hello\n  c: World\n"
-	de := "a:\n  b: Hallo\n  c: Welt\n"
-	dir := setupLocaleTestRepo(t, enUS, de, true)
+	enUS := "a:\n  b: Hello\n  c: World\n  n: |-\n    {n, plural,\n      one {item}\n      other {items}\n    }\n"
+	de := "a:\n  b: Hallo\n  c: Welt\n  n: |-\n    {n, plural,\n      one {Element}\n      other {Elemente}\n    }\n"
+	dir := setupLocaleTestRepo(t, enUS, de, false)
 	path := translationsPath(dir, "de.yaml")
 
+	pristine, err := loadYAMLFlat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := annotateSource(io.Discard, dir, "de", false); err != nil {
+		t.Fatal(err)
+	}
 	first, _ := os.ReadFile(path)
 	if err := annotateSource(io.Discard, dir, "de", false); err != nil {
 		t.Fatal(err)
@@ -141,5 +149,16 @@ func TestAnnotateSourceIdempotent(t *testing.T) {
 	second, _ := os.ReadFile(path)
 	if string(first) != string(second) {
 		t.Errorf("annotate not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	// Indentation inside a block scalar is part of the translated value.
+	annotated, err := loadYAMLFlat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"a.b", "a.c", "a.n"} {
+		if annotated[key] != pristine[key] {
+			t.Errorf("value of %s changed: %q -> %q", key, pristine[key], annotated[key])
+		}
 	}
 }

--- a/src/go/i18n-report/source_test.go
+++ b/src/go/i18n-report/source_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestSourceFromComment(t *testing.T) {
+	tests := []struct {
+		comment string
+		want    string
+		ok      bool
+	}{
+		{"# @source Hello", "Hello", true},
+		{"# @override\n# @source Hello", "Hello", true},
+		{"# @reason term\n# @source Line one\n# @source Line two", "Line one\nLine two", true},
+		{"# @override", "", false},
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		got, ok := sourceFromComment(tc.comment)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("sourceFromComment(%q) = (%q, %v), want (%q, %v)", tc.comment, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestSetSourceComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		english  string
+		want     string
+	}{
+		{"bootstrap", "", "Hello", "# @source Hello"},
+		{"preserve markers", "# @override\n# @reason term", "Hello", "# @override\n# @reason term\n# @source Hello"},
+		{"replace existing", "# @override\n# @source Old", "New", "# @override\n# @source New"},
+		{"multiline", "", "Line one\nLine two", "# @source Line one\n# @source Line two"},
+	}
+	for _, tc := range tests {
+		if got := setSourceComment(tc.existing, tc.english); got != tc.want {
+			t.Errorf("%s: setSourceComment(%q, %q) = %q, want %q", tc.name, tc.existing, tc.english, got, tc.want)
+		}
+	}
+}
+
+func sourceOf(t *testing.T, dir, key string) (string, bool) {
+	t.Helper()
+	entries, err := loadYAMLWithComments(translationsPath(dir, "de.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sourceFromComment(entries[key].comment)
+}
+
+func TestAnnotateSourceBootstrap(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n" // only checking translated
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	if src, ok := sourceOf(t, dir, "status.checking"); !ok || src != "Checking..." {
+		t.Errorf("status.checking @source = (%q, %v), want Checking...", src, ok)
+	}
+	// status.done is in en-us but not translated, so it never appears in de.yaml.
+	entries, _ := loadYAMLWithComments(translationsPath(dir, "de.yaml"))
+	if _, exists := entries["status.done"]; exists {
+		t.Error("status.done should not appear in de.yaml")
+	}
+}
+
+func TestAnnotateSourceSkipsStaleKeys(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n  gone: Veraltet\n" // gone absent from en-us
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	if _, ok := sourceOf(t, dir, "status.gone"); ok {
+		t.Error("stale key status.gone should not get @source")
+	}
+	if src, ok := sourceOf(t, dir, "status.checking"); !ok || src != "Checking..." {
+		t.Errorf("status.checking @source = (%q, %v)", src, ok)
+	}
+}
+
+func TestAnnotateSourceDottedSegmentKey(t *testing.T) {
+	// A leaf key that itself contains dots must be annotated in place, not
+	// split into nested mappings.
+	enUS := "secret:\n  types:\n    'kubernetes.io/dockercfg': Registry\n"
+	de := "secret:\n  types:\n    'kubernetes.io/dockercfg': 注册表\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	entries, _ := loadYAMLWithComments(translationsPath(dir, "de.yaml"))
+	key := "secret.types.kubernetes.io/dockercfg"
+	if _, exists := entries[key]; !exists {
+		t.Fatalf("dotted-segment key corrupted; got keys %v", sortedKeys(entries))
+	}
+	if src, ok := sourceFromComment(entries[key].comment); !ok || src != "Registry" {
+		t.Errorf("@source for dotted-segment key = (%q, %v), want Registry", src, ok)
+	}
+}
+
+func TestAnnotateSourceMultilineEnglish(t *testing.T) {
+	enUS := "count: |-\n  {n, plural,\n  one {item}\n  other {items}\n  }\n"
+	de := "count: |-\n  {n, plural,\n  one {元素}\n  other {元素}\n  }\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	want := "{n, plural,\none {item}\nother {items}\n}"
+	if src, ok := sourceOf(t, dir, "count"); !ok || src != want {
+		t.Errorf("multiline @source = (%q, %v), want %q", src, ok, want)
+	}
+}
+
+func TestAnnotateSourcePreservesOverride(t *testing.T) {
+	enUS := "a:\n  b: Hello\n"
+	de := "a:\n  # @override\n  # @reason hand-tuned\n  b: Hallo\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	entries, _ := loadYAMLWithComments(translationsPath(dir, "de.yaml"))
+	if !commentHasOverride(entries["a.b"].comment) {
+		t.Error("@override lost after annotation")
+	}
+	if src, ok := sourceFromComment(entries["a.b"].comment); !ok || src != "Hello" {
+		t.Errorf("@source = (%q, %v) after annotation, want Hello", src, ok)
+	}
+}
+
+func TestAnnotateSourceIdempotent(t *testing.T) {
+	enUS := "a:\n  b: Hello\n  c: World\n"
+	de := "a:\n  b: Hallo\n  c: Welt\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+	path := translationsPath(dir, "de.yaml")
+
+	first, _ := os.ReadFile(path)
+	if err := annotateSource(io.Discard, dir, "de", false); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Errorf("annotate not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -213,8 +213,14 @@ func documentRoot(doc *yaml.Node) *yaml.Node {
 // It creates intermediate MappingNode entries as needed.
 // If comment is non-empty, it replaces the key node's HeadComment.
 // If comment is empty and the key already exists, the existing comment is preserved.
+// An empty path segment is an error; it would serialize to invalid YAML.
 func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
 	parts := strings.Split(dottedKey, ".")
+	for _, part := range parts {
+		if part == "" {
+			return fmt.Errorf("invalid key %q: empty path segment", dottedKey)
+		}
+	}
 	current := root
 
 	// Navigate or create intermediate mapping nodes.

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -83,15 +83,63 @@ func flattenNodeWithComments(prefix string, node *yaml.Node, result map[string]m
 // overrideMarker is the comment line that protects a hand-tuned translation.
 const overrideMarker = "# @override"
 
-// commentHasOverride returns true if a comment string contains @override.
+// lineIsOverrideMarker reports whether a single comment line is the @override
+// marker: the bare marker or the marker followed by a note.
+func lineIsOverrideMarker(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed == overrideMarker || strings.HasPrefix(trimmed, overrideMarker+" ")
+}
+
+// commentHasOverride returns true if any line of a comment is the @override marker.
 func commentHasOverride(comment string) bool {
 	for _, line := range strings.Split(comment, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == overrideMarker || strings.HasPrefix(trimmed, overrideMarker+" ") {
+		if lineIsOverrideMarker(line) {
 			return true
 		}
 	}
 	return false
+}
+
+// nodeHasOverride returns true if a leaf key's HeadComment contains @override.
+func nodeHasOverride(root *yaml.Node, dottedKey string) bool {
+	_, comment, found := nodeGetLeaf(root, dottedKey)
+	if !found {
+		return false
+	}
+	return commentHasOverride(comment)
+}
+
+// validateOverridePlacement checks that @override only appears on leaf key
+// nodes, not on parent mapping nodes. Returns a list of invalid placements.
+func validateOverridePlacement(doc *yaml.Node) []string {
+	root := documentRoot(doc)
+	var errors []string
+	checkOverridePlacement("", root, &errors)
+	return errors
+}
+
+// checkOverridePlacement recursively checks for misplaced @override on
+// parent mapping nodes.
+func checkOverridePlacement(prefix string, node *yaml.Node, errors *[]string) {
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+		key := keyNode.Value
+		if prefix != "" {
+			key = prefix + "." + key
+		}
+		if valNode.Kind == yaml.MappingNode {
+			// Parent mapping — @override is invalid here.
+			if commentHasOverride(keyNode.HeadComment) {
+				*errors = append(*errors, key)
+			}
+			checkOverridePlacement(key, valNode, errors)
+		}
+		// Leaf nodes with @override are valid — no error.
+	}
 }
 
 // sortedKeys returns sorted keys of a string-keyed map.
@@ -102,4 +150,267 @@ func sortedKeys[V any](m map[string]V) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// yamlScalar formats a string as a YAML scalar value, adding quotes
+// when needed for special characters.
+func yamlScalar(s string) string {
+	if s == "" {
+		return "''"
+	}
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+	}
+	return strings.TrimSuffix(string(data), "\n")
+}
+
+// loadYAMLDocument loads a YAML file into a yaml.Node document tree.
+// Returns a DocumentNode wrapping a MappingNode root; any other top level
+// is an error, since serializing it would erase the file.
+// If the file does not exist, returns an empty document.
+func loadYAMLDocument(path string) (*yaml.Node, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		// Return an empty document with an empty mapping root.
+		return &yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.MappingNode},
+			},
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return &yaml.Node{
+			Kind: yaml.DocumentNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.MappingNode},
+			},
+		}, nil
+	}
+	if doc.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("parsing %s: top level is not a mapping", path)
+	}
+	return &doc, nil
+}
+
+// documentRoot returns the root MappingNode from a DocumentNode.
+func documentRoot(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+// nodeSetLeaf sets a leaf value in a yaml.Node tree by dotted key path.
+// It creates intermediate MappingNode entries as needed.
+// If comment is non-empty, it replaces the key node's HeadComment.
+// If comment is empty and the key already exists, the existing comment is preserved.
+func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
+	parts := strings.Split(dottedKey, ".")
+	current := root
+
+	// Navigate or create intermediate mapping nodes.
+	for i, part := range parts {
+		isLeaf := i == len(parts)-1
+		keyIdx := nodeFindKey(current, part)
+
+		if keyIdx >= 0 {
+			// Key exists.
+			valNode := current.Content[keyIdx+1]
+			if isLeaf {
+				if valNode.Kind == yaml.MappingNode {
+					return fmt.Errorf("key %q is a mapping with %d children; refusing to replace it with a leaf value",
+						dottedKey, len(valNode.Content)/2)
+				}
+				if comment != "" {
+					current.Content[keyIdx].HeadComment = comment
+				} else if valNode.Value != value {
+					// The value is machine-replaced; a retained @override
+					// marker would falsely claim it is still hand-tuned.
+					current.Content[keyIdx].HeadComment = stripOverrideMarker(current.Content[keyIdx].HeadComment)
+				}
+				// Update leaf value. Style is irrelevant; serializeYAMLNode
+				// formats scalars via yamlScalar().
+				valNode.Kind = yaml.ScalarNode
+				valNode.Tag = ""
+				valNode.Value = value
+			} else {
+				// Descend into existing mapping.
+				if valNode.Kind != yaml.MappingNode {
+					return fmt.Errorf("key %q is a leaf; cannot create child %q",
+						strings.Join(parts[:i+1], "."), dottedKey)
+				}
+				current = valNode
+			}
+		} else {
+			// Key does not exist — insert in sorted position.
+			if isLeaf {
+				keyNode := &yaml.Node{
+					Kind:  yaml.ScalarNode,
+					Value: part,
+				}
+				if comment != "" {
+					keyNode.HeadComment = comment
+				}
+				valNode := &yaml.Node{
+					Kind:  yaml.ScalarNode,
+					Value: value,
+				}
+				nodeInsertSorted(current, keyNode, valNode)
+			} else {
+				keyNode := &yaml.Node{
+					Kind:  yaml.ScalarNode,
+					Value: part,
+				}
+				valNode := &yaml.Node{
+					Kind: yaml.MappingNode,
+				}
+				nodeInsertSorted(current, keyNode, valNode)
+				current = valNode
+			}
+		}
+	}
+	return nil
+}
+
+// stripOverrideMarker removes @override lines from a comment, keeping any
+// other comment lines.
+func stripOverrideMarker(comment string) string {
+	if !commentHasOverride(comment) {
+		return comment
+	}
+	var kept []string
+	for _, line := range strings.Split(comment, "\n") {
+		if !lineIsOverrideMarker(line) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// nodeGetLeaf retrieves a leaf's value and HeadComment from the tree.
+// Returns empty strings and false if the key is not found.
+func nodeGetLeaf(root *yaml.Node, dottedKey string) (value, comment string, found bool) {
+	parts := strings.Split(dottedKey, ".")
+	current := root
+	for i, part := range parts {
+		idx := nodeFindKey(current, part)
+		if idx < 0 {
+			return "", "", false
+		}
+		if i == len(parts)-1 {
+			return current.Content[idx+1].Value, current.Content[idx].HeadComment, true
+		}
+		valNode := current.Content[idx+1]
+		if valNode.Kind != yaml.MappingNode {
+			return "", "", false
+		}
+		current = valNode
+	}
+	return "", "", false
+}
+
+// nodeFindKey finds a key in a MappingNode's Content, returning its index
+// or -1 if not found.
+func nodeFindKey(mapping *yaml.Node, key string) int {
+	if mapping.Kind != yaml.MappingNode {
+		return -1
+	}
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		if mapping.Content[i].Value == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// nodeInsertSorted inserts a key-value pair into a MappingNode
+// in alphabetically sorted position.
+func nodeInsertSorted(mapping, keyNode, valNode *yaml.Node) {
+	insertAt := len(mapping.Content)
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		if mapping.Content[i].Value > keyNode.Value {
+			insertAt = i
+			break
+		}
+	}
+	newContent := make([]*yaml.Node, 0, len(mapping.Content)+2)
+	newContent = append(newContent, mapping.Content[:insertAt]...)
+	newContent = append(newContent, keyNode, valNode)
+	newContent = append(newContent, mapping.Content[insertAt:]...)
+	mapping.Content = newContent
+}
+
+// serializeYAMLNode writes a yaml.Node tree as YAML text.
+// It does not insert blank lines between top-level groups, which keeps
+// round-trips stable regardless of the original file's formatting.
+func serializeYAMLNode(w *strings.Builder, doc *yaml.Node) {
+	root := documentRoot(doc)
+	if root.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		serializeNode(w, root.Content[i], root.Content[i+1], 0)
+	}
+}
+
+// serializeNode writes a key-value pair at the given indentation depth.
+func serializeNode(w *strings.Builder, keyNode, valNode *yaml.Node, depth int) {
+	indent := strings.Repeat("  ", depth)
+
+	// Write HeadComment from the key node. yaml.v3 keeps a trailing newline on
+	// the comment; emitting it as a blank line would detach the comment from
+	// its key on the next parse (re-attaching it as a dropped FootComment), so
+	// strip trailing newlines to keep serialization idempotent.
+	if comment := strings.TrimRight(keyNode.HeadComment, "\n"); comment != "" {
+		for _, line := range strings.Split(comment, "\n") {
+			if line == "" {
+				w.WriteString("\n")
+				continue
+			}
+			w.WriteString(indent)
+			w.WriteString(line)
+			w.WriteString("\n")
+		}
+	}
+
+	w.WriteString(indent)
+	w.WriteString(keyNode.Value)
+
+	if valNode.Kind == yaml.MappingNode {
+		w.WriteString(":\n")
+		for i := 0; i < len(valNode.Content)-1; i += 2 {
+			serializeNode(w, valNode.Content[i], valNode.Content[i+1], depth+1)
+		}
+	} else {
+		w.WriteString(": ")
+		scalar := yamlScalar(valNode.Value)
+		if strings.Contains(scalar, "\n") {
+			lines := strings.Split(scalar, "\n")
+			w.WriteString(lines[0])
+			w.WriteString("\n")
+			bodyIndent := indent + "  "
+			for _, line := range lines[1:] {
+				trimmed := strings.TrimPrefix(line, "  ")
+				if trimmed == "" {
+					w.WriteString("\n")
+				} else {
+					w.WriteString(bodyIndent)
+					w.WriteString(trimmed)
+					w.WriteString("\n")
+				}
+			}
+		} else {
+			w.WriteString(scalar)
+			w.WriteString("\n")
+		}
+	}
 }

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -400,19 +400,19 @@ func serializeNode(w *strings.Builder, keyNode, valNode *yaml.Node, depth int) {
 		w.WriteString(": ")
 		scalar := yamlScalar(valNode.Value)
 		if strings.Contains(scalar, "\n") {
+			// Leading whitespace inside a block scalar body is part of the value, so
+			// shift whole lines; trimming them per line would rewrite the translation.
 			lines := strings.Split(scalar, "\n")
 			w.WriteString(lines[0])
 			w.WriteString("\n")
-			bodyIndent := indent + "  "
 			for _, line := range lines[1:] {
-				trimmed := strings.TrimPrefix(line, "  ")
-				if trimmed == "" {
+				if line == "" {
 					w.WriteString("\n")
-				} else {
-					w.WriteString(bodyIndent)
-					w.WriteString(trimmed)
-					w.WriteString("\n")
+					continue
 				}
+				w.WriteString(indent)
+				w.WriteString(line)
+				w.WriteString("\n")
 			}
 		} else {
 			w.WriteString(scalar)

--- a/src/go/i18n-report/yaml_test.go
+++ b/src/go/i18n-report/yaml_test.go
@@ -113,6 +113,22 @@ func TestNodeSetAndGetLeaf(t *testing.T) {
 	}
 }
 
+// An empty path segment names no key. Accepting one would emit ": value",
+// which is not valid YAML, silently corrupting the locale file.
+func TestNodeSetLeafRejectsEmptySegment(t *testing.T) {
+	for _, key := range []string{"", "a.", ".a", "a..b"} {
+		doc := &yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+		}
+		if err := nodeSetLeaf(documentRoot(doc), key, "value", ""); err == nil {
+			var buf strings.Builder
+			serializeYAMLNode(&buf, doc)
+			t.Errorf("nodeSetLeaf(%q) = nil, want error; emitted %q", key, buf.String())
+		}
+	}
+}
+
 func TestNodeInsertSorted(t *testing.T) {
 	doc := &yaml.Node{
 		Kind:    yaml.DocumentNode,

--- a/src/go/i18n-report/yaml_test.go
+++ b/src/go/i18n-report/yaml_test.go
@@ -6,8 +6,197 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
+
+func TestSerializeYAMLNodeIdempotentWithBanner(t *testing.T) {
+	// A decorative banner comment set off by blank lines must survive a
+	// serialize -> parse -> serialize round-trip. yaml.v3 keeps a trailing
+	// newline on the HeadComment; emitting it as a blank line detached the
+	// banner on re-parse, so the second serialize dropped it.
+	src := "root:\n  a: one\n\n  ### Section\n\n  b: two\n"
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatal(err)
+	}
+	var buf1 strings.Builder
+	serializeYAMLNode(&buf1, &doc)
+	if !strings.Contains(buf1.String(), "### Section") {
+		t.Fatalf("banner dropped on first serialize:\n%s", buf1.String())
+	}
+
+	var doc2 yaml.Node
+	if err := yaml.Unmarshal([]byte(buf1.String()), &doc2); err != nil {
+		t.Fatal(err)
+	}
+	var buf2 strings.Builder
+	serializeYAMLNode(&buf2, &doc2)
+	if buf1.String() != buf2.String() {
+		t.Errorf("serialize not idempotent:\n--- first ---\n%s\n--- second ---\n%s", buf1.String(), buf2.String())
+	}
+}
+
+func TestYamlScalar(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "''"},
+		{"hello", "hello"},
+		{"hello world", "hello world"},
+		{"it's here", "it's here"},
+		{"yes", `"yes"`},   // YAML boolean
+		{"true", `"true"`}, // YAML boolean
+		{"null", `"null"`}, // YAML null
+		{"123", `"123"`},   // YAML number
+		{"key: value", "'key: value'"},
+		{"has {var}", "has {var}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := yamlScalar(tc.input)
+			if got != tc.want {
+				t.Errorf("yamlScalar(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNodeSetAndGetLeaf(t *testing.T) {
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+	}
+	root := documentRoot(doc)
+
+	// Insert a new leaf.
+	nodeSetLeaf(root, "a.b.c", "hello", "# @reason test")
+	val, comment, found := nodeGetLeaf(root, "a.b.c")
+	if !found {
+		t.Fatal("a.b.c not found after insert")
+	}
+	if val != "hello" {
+		t.Errorf("value = %q, want %q", val, "hello")
+	}
+	if comment != "# @reason test" {
+		t.Errorf("comment = %q, want %q", comment, "# @reason test")
+	}
+
+	// Update value, preserve existing comment.
+	nodeSetLeaf(root, "a.b.c", "world", "")
+	val, comment, found = nodeGetLeaf(root, "a.b.c")
+	if !found {
+		t.Fatal("a.b.c not found after update")
+	}
+	if val != "world" {
+		t.Errorf("value = %q, want %q", val, "world")
+	}
+	if comment != "# @reason test" {
+		t.Errorf("comment lost after update: got %q", comment)
+	}
+
+	// Update with new comment replaces old.
+	nodeSetLeaf(root, "a.b.c", "world", "# @reason new")
+	_, comment, _ = nodeGetLeaf(root, "a.b.c")
+	if comment != "# @reason new" {
+		t.Errorf("comment = %q, want %q", comment, "# @reason new")
+	}
+
+	// Non-existent key.
+	_, _, found = nodeGetLeaf(root, "x.y.z")
+	if found {
+		t.Error("x.y.z should not be found")
+	}
+}
+
+func TestNodeInsertSorted(t *testing.T) {
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+	}
+	root := documentRoot(doc)
+
+	// Insert keys out of order.
+	nodeSetLeaf(root, "c.x", "3", "")
+	nodeSetLeaf(root, "a.x", "1", "")
+	nodeSetLeaf(root, "b.x", "2", "")
+
+	// Top-level keys should be sorted.
+	if len(root.Content) != 6 {
+		t.Fatalf("expected 6 Content entries (3 key-value pairs), got %d", len(root.Content))
+	}
+	keys := []string{root.Content[0].Value, root.Content[2].Value, root.Content[4].Value}
+	if keys[0] != "a" || keys[1] != "b" || keys[2] != "c" {
+		t.Errorf("top-level keys = %v, want [a b c]", keys)
+	}
+}
+
+func TestSerializeYAMLNode(t *testing.T) {
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+	}
+	root := documentRoot(doc)
+
+	nodeSetLeaf(root, "action.refresh", "Refresh", "")
+	nodeSetLeaf(root, "status.checking", "Checking...", "# @reason standard term")
+	nodeSetLeaf(root, "status.done", "Done", "")
+
+	var buf strings.Builder
+	serializeYAMLNode(&buf, doc)
+	got := buf.String()
+
+	want := `action:
+  refresh: Refresh
+status:
+  # @reason standard term
+  checking: Checking...
+  done: Done
+`
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestSerializeYAMLNodePreservesRoundTrip(t *testing.T) {
+	// Load a YAML file, serialize it, verify comments survive.
+	input := `status:
+  # @reason "checking" = standard term
+  versionChecking: Checking...
+  updating: Updating...
+`
+	tmpFile := t.TempDir() + "/test.yaml"
+	os.WriteFile(tmpFile, []byte(input), 0644)
+
+	doc, err := loadYAMLDocument(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a new key.
+	nodeSetLeaf(documentRoot(doc), "status.done", "Done", "")
+
+	var buf strings.Builder
+	serializeYAMLNode(&buf, doc)
+	got := buf.String()
+
+	// Original comment must survive.
+	if !strings.Contains(got, `# @reason "checking" = standard term`) {
+		t.Errorf("comment lost in round-trip:\n%s", got)
+	}
+	// New key must appear.
+	if !strings.Contains(got, "done: Done") {
+		t.Errorf("new key missing:\n%s", got)
+	}
+	// Existing values must survive.
+	if !strings.Contains(got, "updating: Updating...") {
+		t.Errorf("existing value lost:\n%s", got)
+	}
+}
 
 func TestCommentHasOverride(t *testing.T) {
 	tests := []struct {
@@ -27,6 +216,74 @@ func TestCommentHasOverride(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("commentHasOverride(%q) = %v, want %v", tc.comment, got, tc.want)
 		}
+	}
+}
+
+func TestStripOverrideMarker(t *testing.T) {
+	tests := []struct {
+		comment string
+		want    string
+	}{
+		{"# @override", ""},
+		{"# @override human-reviewed", ""},
+		{"# @reason standard term\n# @override", "# @reason standard term"},
+		{"# @reason no override here", "# @reason no override here"},
+		// A note that only contains @override as a substring is not a marker; strip only exact marker lines.
+		{"# do not @override casually", "# do not @override casually"},
+		{"# @override\n# @override-note keep me", "# @override-note keep me"},
+	}
+	for _, tc := range tests {
+		got := stripOverrideMarker(tc.comment)
+		if got != tc.want {
+			t.Errorf("stripOverrideMarker(%q) = %q, want %q", tc.comment, got, tc.want)
+		}
+	}
+}
+
+func TestNodeHasOverride(t *testing.T) {
+	doc := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+	}
+	root := documentRoot(doc)
+	nodeSetLeaf(root, "a.b", "value", "# @override")
+	nodeSetLeaf(root, "a.c", "value", "# @reason something")
+
+	if !nodeHasOverride(root, "a.b") {
+		t.Error("a.b should have @override")
+	}
+	if nodeHasOverride(root, "a.c") {
+		t.Error("a.c should not have @override")
+	}
+	if nodeHasOverride(root, "a.d") {
+		t.Error("non-existent key should not have @override")
+	}
+}
+
+func TestValidateOverridePlacement(t *testing.T) {
+	// Valid: @override on a leaf node.
+	validYAML := `status:
+  # @override
+  checking: Checking...
+`
+	tmpFile := t.TempDir() + "/valid.yaml"
+	os.WriteFile(tmpFile, []byte(validYAML), 0644)
+	doc, _ := loadYAMLDocument(tmpFile)
+	if errors := validateOverridePlacement(doc); len(errors) > 0 {
+		t.Errorf("expected no errors for valid placement, got %v", errors)
+	}
+
+	// Invalid: @override on a parent mapping node.
+	invalidYAML := `# @override
+status:
+  checking: Checking...
+`
+	tmpFile2 := t.TempDir() + "/invalid.yaml"
+	os.WriteFile(tmpFile2, []byte(invalidYAML), 0644)
+	doc2, _ := loadYAMLDocument(tmpFile2)
+	errors := validateOverridePlacement(doc2)
+	if len(errors) != 1 || errors[0] != "status" {
+		t.Errorf("expected [status], got %v", errors)
 	}
 }
 


### PR DESCRIPTION
Each translated key records the English text it was made from as a co-located `# @source` comment, so a later drift check can tell which translations have fallen behind their source without a parallel metadata file. The `yaml.Node` layer reads and writes locale files while preserving comments and key order; the `source` command writes the snapshots, and merge, validate, and drift build on both.
