### PR TITLE
npm: Bump node-abi

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "jest-environment-jsdom": "30.4.1",
     "js-yaml-loader": "1.2.2",
     "mustache": "4.2.0",
+    "node-abi": "^4.32.0",
     "node-addon-api": "8",
     "node-gyp": "13.0.0",
     "node-gyp-build": "4.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4988,19 +4988,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.5.38":
-  version: 3.5.38
-  resolution: "@vue/compiler-core@npm:3.5.38"
-  dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/shared": "npm:3.5.38"
-    entities: "npm:^7.0.1"
-    estree-walker: "npm:^2.0.2"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/b2adafbed0cb15d22dc7aa875cf1701dd5d56bfdcdf83e2ff8beb75c101f993ed350c053f9e246a20db592d04447b07a7d41229987314ba88fe656977ed0a0fb
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-core@npm:3.5.39":
   version: 3.5.39
   resolution: "@vue/compiler-core@npm:3.5.39"
@@ -5014,16 +5001,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-dom@npm:3.5.38":
-  version: 3.5.38
-  resolution: "@vue/compiler-dom@npm:3.5.38"
-  dependencies:
-    "@vue/compiler-core": "npm:3.5.38"
-    "@vue/shared": "npm:3.5.38"
-  checksum: 10c0/ed16a0beeba511581d89c08a70b5dfd3f4732e02ea7483a9bc6e8e3149249522d60a86a03502dab23f1b341765deb6227ea8f48daae7adeaa9881173a0b3a869
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-dom@npm:3.5.39":
   version: 3.5.39
   resolution: "@vue/compiler-dom@npm:3.5.39"
@@ -5034,7 +5011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-sfc@npm:3.5.39":
+"@vue/compiler-sfc@npm:3.5.39, @vue/compiler-sfc@npm:^3.5.13, @vue/compiler-sfc@npm:^3.5.22":
   version: 3.5.39
   resolution: "@vue/compiler-sfc@npm:3.5.39"
   dependencies:
@@ -5048,33 +5025,6 @@ __metadata:
     postcss: "npm:^8.5.15"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/1361005ef5b66622c2762211c6a9c96c53a106894b8ac9f7ff4dc9fa99453010ab48cafce45f5f799a599ac0b56abffb4232391abd87397c1a2c16514321fe8f
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-sfc@npm:^3.5.13, @vue/compiler-sfc@npm:^3.5.22":
-  version: 3.5.38
-  resolution: "@vue/compiler-sfc@npm:3.5.38"
-  dependencies:
-    "@babel/parser": "npm:^7.29.7"
-    "@vue/compiler-core": "npm:3.5.38"
-    "@vue/compiler-dom": "npm:3.5.38"
-    "@vue/compiler-ssr": "npm:3.5.38"
-    "@vue/shared": "npm:3.5.38"
-    estree-walker: "npm:^2.0.2"
-    magic-string: "npm:^0.30.21"
-    postcss: "npm:^8.5.15"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/acb7fd11d999848f9dbd499ed5cdd8624bdce245e44ffc8bede7d13899887699c612ee93a35e445b03678f13a5b557c5fe239add87407bb8d0f266ecf6b19a47
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-ssr@npm:3.5.38":
-  version: 3.5.38
-  resolution: "@vue/compiler-ssr@npm:3.5.38"
-  dependencies:
-    "@vue/compiler-dom": "npm:3.5.38"
-    "@vue/shared": "npm:3.5.38"
-  checksum: 10c0/a1400d4c69bb2a19d6505c7cbe89e17fc1c7df7893b149694a10eb8ff2225ca1cf4b8e33b757e00680e8017ab72f30cb53d917f679d14feda5ebf925aad208a4
   languageName: node
   linkType: hard
 
@@ -5245,14 +5195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.5.38, @vue/shared@npm:^3.5.13":
-  version: 3.5.38
-  resolution: "@vue/shared@npm:3.5.38"
-  checksum: 10c0/42c6b2118d5632920d97f06c4883ac611f300e5158cbdef6c2b87962c4b8b89121c726cc2ff6fe1894a2266370c91c1664d0956026d27874491b2c4a213af8e8
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.5.39":
+"@vue/shared@npm:3.5.39, @vue/shared@npm:^3.5.13":
   version: 3.5.39
   resolution: "@vue/shared@npm:3.5.39"
   checksum: 10c0/2b8b008ab8c22c84a37d231f47133721ae3469e6054d1aa77eea972440657b344ace1e508ea0e025aa132cb5236dee8a5db8284d0c811fd413b25d43c78dad2f
@@ -9865,7 +9808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:11.3.6":
+"fs-extra@npm:11.3.6, fs-extra@npm:^11.1.1, fs-extra@npm:^11.2.0":
   version: 11.3.6
   resolution: "fs-extra@npm:11.3.6"
   dependencies:
@@ -9884,17 +9827,6 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^11.1.1, fs-extra@npm:^11.2.0":
-  version: 11.3.5
-  resolution: "fs-extra@npm:11.3.5"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 
@@ -12842,16 +12774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abi@npm:^4.2.0":
-  version: 4.28.0
-  resolution: "node-abi@npm:4.28.0"
-  dependencies:
-    semver: "npm:^7.6.3"
-  checksum: 10c0/d734dc7d25247fdd7bba7f1f12ddadc23c6ada9c639cf2cd2b11a6e568591c82f609e41bf740077b838f2eb88ff4d9489eb111eef4e530c8dbdb41355e6f0343
-  languageName: node
-  linkType: hard
-
-"node-abi@npm:^4.32.0":
+"node-abi@npm:^4.2.0, node-abi@npm:^4.32.0":
   version: 4.32.0
   resolution: "node-abi@npm:4.32.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12851,6 +12851,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-abi@npm:^4.32.0":
+  version: 4.32.0
+  resolution: "node-abi@npm:4.32.0"
+  dependencies:
+    semver: "npm:^7.6.3"
+  checksum: 10c0/d5247681d7823b4387376da6b5586ddf3e721f9144b6e67b03bdd12b9bbde1cb70bffafe207a0927c598e80566a1a0349d9e4c4fbacdec559ddfeb709cda99d6
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:8":
   version: 8.9.0
   resolution: "node-addon-api@npm:8.9.0"
@@ -14571,6 +14580,7 @@ __metadata:
     marked: "npm:18.0.5"
     mustache: "npm:4.2.0"
     native-reg: "npm:1.1.1"
+    node-abi: "npm:^4.32.0"
     node-addon-api: "npm:8"
     node-forge: "npm:1.4.0"
     node-gyp: "npm:13.0.0"


### PR DESCRIPTION
#10584 appears to be failing because the version of `node-abi` we have is too old.  Add `node-abi` as an explicit dependency so @dependabot will update it in the future; we will need to do so for newer versions of Electron.

Also run `yarn dedupe` so that the dependency change is actually picked up; otherwise, yarn's default behaviour is to keep using whichever version it has picked previously.

Post-change:
```
$ yarn why node-abi
├─ @electron/rebuild@npm:4.0.3
│  └─ node-abi@npm:4.32.0 (via npm:^4.2.0)
│
└─ rancher-desktop@workspace:.
   └─ node-abi@npm:4.32.0 (via npm:^4.32.0)
```