### PR TITLE
dependabot: group codeql-action updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     default-days: 7
   open-pull-requests-limit: 12
   labels: ["component/dependencies"]
+  groups:
+    # init and analyze share a config file and abort when their versions differ.
+    codeql-action:
+      patterns: ["github/codeql-action/*"]
 
 # Maintain dependencies for npm
 - package-ecosystem: "npm"


### PR DESCRIPTION
init and analyze share a config file and abort when their versions differ, but Dependabot opens a separate PR for each subpath. #10592 and #10593 split the 4.36.3 bump that way, and each failed CodeQL with a version mismatch.

`github/codeql-action` is the only action here referenced by subpath.