### PR TITLE
Add validate with a real ICU MessageFormat parser

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -2,6 +2,7 @@ emoji
 github
 https
 passwordless
+selectordinal
 ssh
 ubuntu
 workarounds

--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -26,10 +26,10 @@ go build -o src/go/i18n-report/i18n-report ./src/go/i18n-report
   references.
 - `2` — an operational failure: an unreadable file or an invalid flag.
 
-Gate commands (`undefined`) split exit `1` from exit `2`, so CI can tell
-a real finding from a broken invocation. Lister commands (`unused`, `stale`,
-`translate`, `references`, `dynamic`, `untranslated`) exit `0` even when
-they list results.
+Gate commands (`undefined` and `validate`) split exit `1` from exit `2`,
+so CI can tell a real finding from a broken invocation. Lister commands
+(`unused`, `stale`, `translate`, `references`, `dynamic`, `untranslated`)
+exit `0` even when they list results.
 
 ## Subcommands
 
@@ -136,6 +136,22 @@ i18n-report source --locale=de
 i18n-report source --locale=all
 ```
 
+### validate
+
+Check structural correctness of translations in a locale file.
+
+```sh
+i18n-report validate --locale=de
+```
+
+Checks include:
+- Placeholder parity (`{name}`, `{count}`) between English and locale
+- ICU MessageFormat structure (plural/select branch names)
+- HTML tag preservation (`<a>`, `<b>`, etc.)
+- `data-*` attribute preservation (runtime handlers depend on these)
+- `@override` placement (leaf keys only)
+- `@source` coverage (every translated key carries a `@source`)
+
 ## How it works
 
 ### Source scanning
@@ -195,6 +211,7 @@ go test ./src/go/i18n-report/...
 | `report_references.go` | `references` subcommand |
 | `report_dynamic.go` | `dynamic` subcommand, finds dynamic key patterns |
 | `report_source.go` | `source` subcommand |
+| `report_validate.go` | `validate` subcommand, placeholder and structure checks |
 
 All files are in `package main`. The tool has one external dependency:
 `gopkg.in/yaml.v3`.

--- a/src/go/i18n-report/icu.go
+++ b/src/go/i18n-report/icu.go
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file implements a small recursive-descent parser for the subset of
+// ICU MessageFormat that the app's translation strings use, mirroring the
+// behavior of intl-messageformat 11 (the runtime library). It is used by the
+// validator to compare placeholders and plural/select structure between the
+// English source and a locale translation.
+//
+// Grammar handled:
+//
+//	message   := (text | argument)*
+//	argument  := '{' name '}'
+//	           | '{' name ',' type '}'                       (typed simple arg)
+//	           | '{' name ',' type ',' style '}'             (typed arg, style ignored)
+//	           | '{' name ',' keyword ',' branch+ '}'        (keyword ∈ plural|select|selectordinal)
+//	branch    := label '{' message '}'
+//	label     := '=' digits | identifier                    (=N only for plural/selectordinal)
+//
+// Apostrophe handling follows ICU "lenient" mode as implemented by
+// intl-messageformat: '' is a literal apostrophe; an apostrophe immediately
+// followed by one of { } < > (or # inside a plural/selectordinal branch)
+// starts a quoted literal that runs to the next lone apostrophe, in which
+// { } # are not special; any other apostrophe is a literal character.
+//
+// Inside a plural/selectordinal branch, '#' is the number substitution and is
+// tracked as a reference to the construct's variable.
+
+// icuKind identifies the kind of an AST node.
+type icuKind int
+
+const (
+	icuText   icuKind = iota // literal text
+	icuArg                   // {name} or {name, type[, style]}
+	icuSelect                // {name, plural|select|selectordinal, branches}
+	icuPound                 // '#' number substitution inside a plural branch
+)
+
+// icuNode is a node in the parsed message tree.
+type icuNode struct {
+	kind     icuKind
+	text     string      // icuText: the literal text
+	name     string      // icuArg/icuSelect: variable name; icuPound: the plural variable it references
+	keyword  string      // icuSelect: plural, select, or selectordinal
+	branches []icuBranch // icuSelect: the branches
+}
+
+// icuBranch is one branch of a plural/select/selectordinal construct.
+type icuBranch struct {
+	label string
+	body  []icuNode
+}
+
+const keywordPlural = "plural"
+
+// icuSelectKeywords are the ICU keywords that introduce branching.
+var icuSelectKeywords = map[string]bool{
+	keywordPlural:   true,
+	"select":        true,
+	"selectordinal": true,
+}
+
+// parseICU parses an ICU MessageFormat string into a message tree. Errors
+// carry the byte offset at which parsing failed.
+func parseICU(msg string) ([]icuNode, error) {
+	p := &icuParser{src: msg}
+	nodes, err := p.parseMessage("", false)
+	if err != nil {
+		return nil, err
+	}
+	if p.pos < len(p.src) {
+		// Only a stray '}' can stop parseMessage before EOF at the top level.
+		return nil, p.errf("unexpected %q", string(p.src[p.pos]))
+	}
+	return nodes, nil
+}
+
+type icuParser struct {
+	src string
+	pos int
+}
+
+func (p *icuParser) errf(format string, args ...any) error {
+	return fmt.Errorf("ICU parse error at position %d: %s", p.pos, fmt.Sprintf(format, args...))
+}
+
+// parseMessage parses a sequence of text and arguments. pluralVar is the
+// variable of the nearest enclosing plural/selectordinal (empty if none), which
+// makes '#' significant. When nested is true, an unquoted '}' ends the message.
+func (p *icuParser) parseMessage(pluralVar string, nested bool) ([]icuNode, error) {
+	var nodes []icuNode
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		switch {
+		case c == '{':
+			node, err := p.parseArgument()
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, node)
+		case c == '}':
+			if nested {
+				return nodes, nil
+			}
+			return nil, p.errf("unexpected %q", "}")
+		case c == '#' && pluralVar != "":
+			p.pos++
+			nodes = append(nodes, icuNode{kind: icuPound, name: pluralVar})
+		default:
+			nodes = append(nodes, icuNode{kind: icuText, text: p.parseText(pluralVar)})
+		}
+	}
+	if nested {
+		return nil, p.errf("unterminated branch: expected %q", "}")
+	}
+	return nodes, nil
+}
+
+// isQuoteStart reports whether an apostrophe followed by c starts a quoted
+// literal, matching intl-messageformat's lenient apostrophe mode.
+func isQuoteStart(c byte, pluralVar string) bool {
+	switch c {
+	case '{', '}', '<', '>':
+		return true
+	case '#':
+		return pluralVar != ""
+	}
+	return false
+}
+
+// parseText reads a run of literal text, resolving apostrophe quoting. It
+// stops at an unquoted '{', '}', or (when pluralVar is set) '#'.
+func (p *icuParser) parseText(pluralVar string) string {
+	var b strings.Builder
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		if c == '{' || c == '}' {
+			break
+		}
+		if c == '#' && pluralVar != "" {
+			break
+		}
+		if c == '\'' {
+			// '' is a literal apostrophe.
+			if p.pos+1 < len(p.src) && p.src[p.pos+1] == '\'' {
+				b.WriteByte('\'')
+				p.pos += 2
+				continue
+			}
+			// A quote start begins a literal region ending at the next lone '.
+			if p.pos+1 < len(p.src) && isQuoteStart(p.src[p.pos+1], pluralVar) {
+				p.pos++ // opening apostrophe
+				for p.pos < len(p.src) {
+					if p.src[p.pos] == '\'' {
+						if p.pos+1 < len(p.src) && p.src[p.pos+1] == '\'' {
+							b.WriteByte('\'')
+							p.pos += 2
+							continue
+						}
+						p.pos++ // closing apostrophe
+						break
+					}
+					b.WriteByte(p.src[p.pos])
+					p.pos++
+				}
+				continue
+			}
+			// A lone apostrophe is a literal character.
+			b.WriteByte('\'')
+			p.pos++
+			continue
+		}
+		b.WriteByte(c)
+		p.pos++
+	}
+	return b.String()
+}
+
+// parseArgument parses an argument starting at the opening brace.
+func (p *icuParser) parseArgument() (icuNode, error) {
+	p.pos++ // opening brace
+	p.skipSpaces()
+	name := p.parseIdent()
+	if name == "" {
+		return icuNode{}, p.errf("expected argument name")
+	}
+	p.skipSpaces()
+	if p.pos >= len(p.src) {
+		return icuNode{}, p.errf("unterminated argument")
+	}
+	if p.src[p.pos] == '}' {
+		p.pos++
+		return icuNode{kind: icuArg, name: name}, nil
+	}
+	if p.src[p.pos] != ',' {
+		return icuNode{}, p.errf("expected %q or %q after argument name", ",", "}")
+	}
+	p.pos++ // comma
+	p.skipSpaces()
+	keyword := p.parseIdent()
+	if keyword == "" {
+		return icuNode{}, p.errf("expected argument type")
+	}
+	p.skipSpaces()
+
+	if icuSelectKeywords[keyword] {
+		if p.pos >= len(p.src) || p.src[p.pos] != ',' {
+			return icuNode{}, p.errf("expected %q before %s branches", ",", keyword)
+		}
+		p.pos++ // comma
+		branches, err := p.parseBranches(name, keyword)
+		if err != nil {
+			return icuNode{}, err
+		}
+		if p.pos >= len(p.src) || p.src[p.pos] != '}' {
+			return icuNode{}, p.errf("unterminated %s argument", keyword)
+		}
+		p.pos++ // closing brace
+		return icuNode{kind: icuSelect, name: name, keyword: keyword, branches: branches}, nil
+	}
+
+	// Typed simple argument, e.g. {count, number} or {when, date, short}.
+	if p.pos < len(p.src) && p.src[p.pos] == ',' {
+		p.pos++ // comma
+		if err := p.skipArgStyle(); err != nil {
+			return icuNode{}, err
+		}
+	}
+	if p.pos >= len(p.src) || p.src[p.pos] != '}' {
+		return icuNode{}, p.errf("unterminated argument")
+	}
+	p.pos++ // closing brace
+	return icuNode{kind: icuArg, name: name}, nil
+}
+
+// parseBranches parses the branches of a plural/select/selectordinal, stopping
+// at the closing brace. pluralVar is passed to branch bodies only for
+// plural/selectordinal so that '#' resolves to this construct's variable.
+func (p *icuParser) parseBranches(variable, keyword string) ([]icuBranch, error) {
+	branchPlural := ""
+	if keyword == keywordPlural || keyword == "selectordinal" {
+		branchPlural = variable
+	}
+	var branches []icuBranch
+	for {
+		p.skipSpaces()
+		if p.pos >= len(p.src) {
+			return nil, p.errf("unterminated %s argument", keyword)
+		}
+		if p.src[p.pos] == '}' {
+			break
+		}
+		label := p.parseBranchLabel()
+		if label == "" {
+			return nil, p.errf("expected branch label in %s argument", keyword)
+		}
+		p.skipSpaces()
+		if p.pos >= len(p.src) || p.src[p.pos] != '{' {
+			return nil, p.errf("expected %q after branch label %q", "{", label)
+		}
+		p.pos++ // opening brace of branch body
+		body, err := p.parseMessage(branchPlural, true)
+		if err != nil {
+			return nil, err
+		}
+		if p.pos >= len(p.src) || p.src[p.pos] != '}' {
+			return nil, p.errf("unterminated branch %q", label)
+		}
+		p.pos++ // closing brace of branch body
+		branches = append(branches, icuBranch{label: label, body: body})
+	}
+	if len(branches) == 0 {
+		return nil, p.errf("%s argument has no branches", keyword)
+	}
+	return branches, nil
+}
+
+// skipArgStyle consumes a typed argument's style up to (but not including) the
+// argument's closing brace, honoring nested braces.
+func (p *icuParser) skipArgStyle() error {
+	depth := 0
+	for p.pos < len(p.src) {
+		switch p.src[p.pos] {
+		case '{':
+			depth++
+		case '}':
+			if depth == 0 {
+				return nil
+			}
+			depth--
+		}
+		p.pos++
+	}
+	return p.errf("unterminated argument style")
+}
+
+// parseIdent reads an identifier ([A-Za-z0-9_]+).
+func (p *icuParser) parseIdent() string {
+	start := p.pos
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+			p.pos++
+			continue
+		}
+		break
+	}
+	return p.src[start:p.pos]
+}
+
+// parseBranchLabel reads a branch label: a run up to the next space or brace.
+// This accepts '=N' exact-match labels and arbitrary select keys.
+func (p *icuParser) parseBranchLabel() string {
+	start := p.pos
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '{' || c == '}' {
+			break
+		}
+		p.pos++
+	}
+	return p.src[start:p.pos]
+}
+
+func (p *icuParser) skipSpaces() {
+	for p.pos < len(p.src) {
+		switch p.src[p.pos] {
+		case ' ', '\t', '\n', '\r':
+			p.pos++
+		default:
+			return
+		}
+	}
+}
+
+// icuArgumentNames returns the set of every argument name referenced anywhere
+// in the message, recursively. This includes plural/select variables and '#'
+// references (which resolve to their enclosing plural variable).
+func icuArgumentNames(nodes []icuNode) map[string]bool {
+	result := make(map[string]bool)
+	collectArgumentNames(nodes, result)
+	return result
+}
+
+func collectArgumentNames(nodes []icuNode, result map[string]bool) {
+	for _, n := range nodes {
+		switch n.kind {
+		case icuArg, icuPound:
+			result[n.name] = true
+		case icuSelect:
+			result[n.name] = true
+			for _, b := range n.branches {
+				collectArgumentNames(b.body, result)
+			}
+		}
+	}
+}
+
+// icuConstruct is a structural summary of a plural/select/selectordinal
+// construct and its nested constructs, used for comparing structure between
+// two translations.
+type icuConstruct struct {
+	Variable string
+	Keyword  string
+	Branches []string       // branch labels, sorted
+	Nested   []icuConstruct // nested constructs, sorted
+}
+
+// icuConstructs returns the tree of plural/select/selectordinal constructs in
+// the message. Top-level constructs are returned sorted; nested constructs are
+// attached to their enclosing construct.
+func icuConstructs(nodes []icuNode) []icuConstruct {
+	var constructs []icuConstruct
+	for _, n := range nodes {
+		if n.kind != icuSelect {
+			continue
+		}
+		labels := make([]string, 0, len(n.branches))
+		var nested []icuConstruct
+		for _, b := range n.branches {
+			labels = append(labels, b.label)
+			nested = append(nested, icuConstructs(b.body)...)
+		}
+		sort.Strings(labels)
+		sortConstructs(nested)
+		constructs = append(constructs, icuConstruct{
+			Variable: n.name,
+			Keyword:  n.keyword,
+			Branches: labels,
+			Nested:   nested,
+		})
+	}
+	sortConstructs(constructs)
+	return constructs
+}
+
+func sortConstructs(cs []icuConstruct) {
+	sort.Slice(cs, func(i, j int) bool {
+		if cs[i].Variable != cs[j].Variable {
+			return cs[i].Variable < cs[j].Variable
+		}
+		return cs[i].Keyword < cs[j].Keyword
+	})
+}

--- a/src/go/i18n-report/icu_test.go
+++ b/src/go/i18n-report/icu_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestParseICUArgumentNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "simple placeholder",
+			input: "Hello {name}",
+			want:  []string{"name"},
+		},
+		{
+			name:  "spaced placeholder",
+			input: "Error { action } failed",
+			want:  []string{"action"},
+		},
+		{
+			name:  "typed argument",
+			input: "{count, number}",
+			want:  []string{"count"},
+		},
+		{
+			name:  "plural variable and pound",
+			input: "{count, plural, one {# item} other {# items}}",
+			want:  []string{"count"},
+		},
+		{
+			name:  "nested plural extracts inner placeholders",
+			input: "{pages, plural, =0 {No entries} =1 {{count} {count, plural, =1 {Item} other {Items}}} other {{from} - {to} of {count}}}",
+			want:  []string{"count", "from", "pages", "to"},
+		},
+		{
+			name:  "apostrophe-wrapped placeholder",
+			input: "''{version}''",
+			want:  []string{"version"},
+		},
+		{
+			name:  "fully quoted extracts nothing",
+			input: "'{version}'",
+			want:  nil,
+		},
+		{
+			name:  "quoted tags around placeholder",
+			input: "Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'",
+			want:  []string{"date", "time"},
+		},
+		{
+			name:  "no placeholders",
+			input: "just plain text",
+			want:  nil,
+		},
+		{
+			name:  "lone apostrophe is literal",
+			input: "QEMU's {device} devices",
+			want:  []string{"device"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nodes, err := parseICU(tc.input)
+			if err != nil {
+				t.Fatalf("parseICU(%q) failed: %v", tc.input, err)
+			}
+			got := sortedKeys(icuArgumentNames(nodes))
+			want := append([]string{}, tc.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("argument names = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseICUErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unterminated argument", "Hello {name"},
+		{"stray close brace", "Hello }"},
+		{"unterminated plural", "{count, plural, one {item}"},
+		{"missing branch body", "{count, plural, one other {x}}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseICU(tc.input); err == nil {
+				t.Errorf("parseICU(%q) = nil error, want error", tc.input)
+			}
+		})
+	}
+}
+
+func TestParseICUConstructs(t *testing.T) {
+	nodes, err := parseICU("{count, plural, =0 {none} one {item} other {items}}")
+	if err != nil {
+		t.Fatalf("parseICU failed: %v", err)
+	}
+	got := icuConstructs(nodes)
+	if len(got) != 1 {
+		t.Fatalf("got %d constructs, want 1: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Variable != "count" || c.Keyword != "plural" {
+		t.Errorf("construct = {%s, %s}, want {count, plural}", c.Variable, c.Keyword)
+	}
+	if !reflect.DeepEqual(c.Branches, []string{"=0", "one", "other"}) {
+		t.Errorf("branches = %v, want [=0 one other]", c.Branches)
+	}
+}
+
+func TestParseICUNestedConstructs(t *testing.T) {
+	input := "{pages, plural, =1 {{count, plural, =1 {Item} other {Items}}} other {none}}"
+	nodes, err := parseICU(input)
+	if err != nil {
+		t.Fatalf("parseICU failed: %v", err)
+	}
+	got := icuConstructs(nodes)
+	if len(got) != 1 || got[0].Variable != "pages" {
+		t.Fatalf("top-level construct = %+v, want single pages construct", got)
+	}
+	if len(got[0].Nested) != 1 || got[0].Nested[0].Variable != "count" {
+		t.Errorf("nested construct = %+v, want single count construct", got[0].Nested)
+	}
+}
+
+// TestParseICURealCorpus parses every value in the real en-us.yaml. The runtime
+// (intl-messageformat 11) accepts all of them, so the parser must too.
+func TestParseICURealCorpus(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Skipf("repoRoot: %v", err)
+	}
+	path := filepath.Join(root, "pkg", "rancher-desktop", "assets", "translations", "en-us.yaml")
+	values, err := loadYAMLFlat(path)
+	if err != nil {
+		t.Fatalf("loadYAMLFlat(%s): %v", path, err)
+	}
+	if len(values) < 500 {
+		t.Fatalf("loaded only %d values from en-us.yaml, expected the full corpus", len(values))
+	}
+	for key, value := range values {
+		if _, err := parseICU(value); err != nil {
+			t.Errorf("parseICU failed for %s = %q: %v", key, value, err)
+		}
+	}
+}

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -40,6 +40,7 @@ var subcommands = map[string]func([]string) error{
 	"references":   runReferences,
 	"dynamic":      runDynamic,
 	"source":       runSource,
+	"validate":     runValidate,
 }
 
 func main() {
@@ -82,6 +83,7 @@ Subcommands:
   references    Where each en-us.yaml key is used (file:line)
   dynamic       Template literal patterns that reference keys dynamically
   source        Record the English source text on each translated key
+  validate      Structural checks: placeholders, tags, sources, overrides
 
 Run "i18n-report <subcommand> -h" for subcommand-specific flags.`)
 }

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+)
+
+func runValidate(args []string) error {
+	fs := flag.NewFlagSet("validate", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale code (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *locale == "" {
+		return fmt.Errorf("--locale is required")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return reportValidate(os.Stdout, root, *locale)
+}
+
+// Check categories reported by validate.
+const (
+	catSource      = "source"
+	catOverride    = "override"
+	catPlaceholder = "placeholder"
+	catTag         = "tag"
+	catICU         = "icu"
+	catICUSyntax   = "icu-syntax"
+)
+
+// validationError represents a single validation issue.
+type validationError struct {
+	Key     string
+	Check   string
+	Message string
+}
+
+// validateLocale runs all structural checks on a locale file and returns
+// the errors found.
+func validateLocale(root, locale string) ([]validationError, error) {
+	enPath := translationsPath(root, "en-us.yaml")
+	localePath := translationsPath(root, locale+".yaml")
+
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return nil, err
+	}
+	localeKeys, err := loadYAMLFlat(localePath)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := loadSources(root, locale)
+	if err != nil {
+		return nil, err
+	}
+
+	var errors []validationError
+
+	// Check placeholder parity, ICU structure, and tag parity.
+	for key, enValue := range enKeys {
+		localeValue, exists := localeKeys[key]
+		if !exists {
+			continue
+		}
+		if errs := checkICU(key, enValue, localeValue); len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
+		if errs := checkTags(key, enValue, localeValue); len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
+	}
+
+	// Check override placement.
+	if placement := validateOverridePlacement(doc); len(placement) > 0 {
+		for _, key := range placement {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catOverride,
+				Message: "@override on parent mapping node (must be on leaf keys only)",
+			})
+		}
+	}
+
+	// Check that every translated key carries a @source snapshot. A @source
+	// cannot be orphaned from its translation, since it lives on the key.
+	for key := range localeKeys {
+		if _, inEn := enKeys[key]; !inEn {
+			continue // stale key, reported by stale check
+		}
+		if _, hasSource := meta[key]; !hasSource {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catSource,
+				Message: "translated key has no @source",
+			})
+		}
+	}
+
+	// Sort errors by key for stable output.
+	sort.Slice(errors, func(i, j int) bool {
+		if errors[i].Key == errors[j].Key {
+			return errors[i].Check < errors[j].Check
+		}
+		return errors[i].Key < errors[j].Key
+	})
+
+	return errors, nil
+}
+
+// reportValidate runs structural checks on a locale file.
+func reportValidate(w io.Writer, root, locale string) error {
+	errors, err := validateLocale(root, locale)
+	if err != nil {
+		return err
+	}
+
+	if len(errors) == 0 {
+		fmt.Fprintf(w, "Validation passed for %s.\n", locale)
+		return nil
+	}
+
+	fmt.Fprintf(w, "Found %d validation errors in %s:\n", len(errors), locale)
+	for _, e := range errors {
+		fmt.Fprintf(w, "  [%s] %s: %s\n", e.Check, e.Key, e.Message)
+	}
+	return findingsError(fmt.Sprintf("validation failed with %d errors", len(errors)))
+}
+
+// containsICU reports whether a value has any ICU syntax worth parsing: a
+// placeholder brace or an apostrophe (which may quote literal braces).
+func containsICU(s string) bool {
+	return strings.ContainsAny(s, "{'")
+}
+
+// checkICU runs all ICU-based checks (syntax, placeholder parity, and
+// plural/select structure) on a translation value pair.
+func checkICU(key, enValue, localeValue string) []validationError {
+	if !containsICU(enValue) && !containsICU(localeValue) {
+		return nil
+	}
+
+	var errors []validationError
+	_, enErr := parseICU(enValue)
+	_, localeErr := parseICU(localeValue)
+	if enErr != nil {
+		errors = append(errors, validationError{
+			Key:     key,
+			Check:   catICUSyntax,
+			Message: fmt.Sprintf("English source fails to parse: %v", enErr),
+		})
+	}
+	if localeErr != nil {
+		errors = append(errors, validationError{
+			Key:     key,
+			Check:   catICUSyntax,
+			Message: fmt.Sprintf("translation fails to parse: %v", localeErr),
+		})
+	}
+	if enErr != nil || localeErr != nil {
+		return errors
+	}
+
+	errors = append(errors, checkPlaceholders(key, enValue, localeValue)...)
+	errors = append(errors, checkICUStructure(key, enValue, localeValue)...)
+	return errors
+}
+
+// checkPlaceholders verifies that the locale value references the same set of
+// argument names as the English source, including names nested inside ICU
+// plural/select branches and '#' number substitutions.
+func checkPlaceholders(key, enValue, localeValue string) []validationError {
+	enNodes, err := parseICU(enValue)
+	if err != nil {
+		return nil
+	}
+	localeNodes, err := parseICU(localeValue)
+	if err != nil {
+		return nil
+	}
+
+	enNames := icuArgumentNames(enNodes)
+	localeNames := icuArgumentNames(localeNodes)
+
+	var errors []validationError
+
+	// Argument names in English but missing from the locale.
+	for _, name := range sortedKeys(enNames) {
+		if !localeNames[name] {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catPlaceholder,
+				Message: fmt.Sprintf("missing placeholder {%s}", name),
+			})
+		}
+	}
+
+	// Argument names in the locale that are not in English.
+	for _, name := range sortedKeys(localeNames) {
+		if !enNames[name] {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catPlaceholder,
+				Message: fmt.Sprintf("unexpected placeholder {%s}", name),
+			})
+		}
+	}
+
+	return errors
+}
+
+// tagRe matches the HTML tags a translation may carry: <tag>, </tag>, <tag/>,
+// <tag attr="...">. It is an allowlist so literal angle-bracket prose such as
+// "<Binary Data: {n} bytes>" is not mistaken for markup.
+var tagRe = regexp.MustCompile(`(?i)</?(a|b|br|code|em|i|li|ol|p|pre|span|strong|ul)\b[^>]*/?>`)
+
+// attrRe matches the HTML attributes a translation must preserve verbatim:
+// data-* (runtime click handlers dispatch on them) and href (a translation
+// must not change link targets).
+var attrRe = regexp.MustCompile(`(data-[\w-]+|href)=(?:"([^"]*)"|'([^']*)')`)
+
+// checkTags verifies that the locale value contains the same HTML-like
+// tag names as the English source, and that required data-* attributes
+// are preserved (runtime handlers depend on these).
+func checkTags(key, enValue, localeValue string) []validationError {
+	enTags := extractTagNames(enValue)
+	localeTags := extractTagNames(localeValue)
+
+	var errors []validationError
+
+	for tag, enCount := range enTags {
+		localeCount := localeTags[tag]
+		if localeCount < enCount {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catTag,
+				Message: fmt.Sprintf("missing <%s> tag (expected %d, found %d)", tag, enCount, localeCount),
+			})
+		}
+	}
+
+	for tag, localeCount := range localeTags {
+		enCount := enTags[tag]
+		if localeCount > enCount {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catTag,
+				Message: fmt.Sprintf("unexpected <%s> tag (expected %d, found %d)", tag, enCount, localeCount),
+			})
+		}
+	}
+
+	// Verify that href/data-* attribute values are preserved, comparing the
+	// full multiset of values per name so a changed link in a multi-link
+	// string is not masked by an unchanged one.
+	enAttrs := extractDataAttrs(enValue)
+	localeAttrs := extractDataAttrs(localeValue)
+	for attr, enVals := range enAttrs {
+		localeVals := localeAttrs[attr]
+		if slices.Equal(enVals, localeVals) {
+			continue
+		}
+		if len(localeVals) == 0 {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catTag,
+				Message: fmt.Sprintf("missing %s attribute (expected %q)", attr, enVals),
+			})
+		} else {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catTag,
+				Message: fmt.Sprintf("%s attribute value changed (expected %q, found %q)", attr, enVals, localeVals),
+			})
+		}
+	}
+
+	return errors
+}
+
+// checkICUStructure verifies that ICU plural/select/selectordinal constructs
+// in the locale value match those in the English source: same variable, same
+// keyword, and same branch labels, recursively through nested constructs.
+//
+// The match is intentionally exact, plural branch labels included: every
+// shipping locale mirrors English's structure, so a dropped or renamed branch
+// is a real error. This would wrongly reject a language whose CLDR plural
+// categories differ from English (Polish few/many, or a locale that omits the
+// never-selected one branch). Relax the plural case — not select — if such a
+// locale is added.
+func checkICUStructure(key, enValue, localeValue string) []validationError {
+	enNodes, err := parseICU(enValue)
+	if err != nil {
+		return nil
+	}
+	localeNodes, err := parseICU(localeValue)
+	if err != nil {
+		return nil
+	}
+
+	en := icuConstructs(enNodes)
+	locale := icuConstructs(localeNodes)
+	if len(en) == 0 && len(locale) == 0 {
+		return nil
+	}
+	return compareConstructs(key, en, locale)
+}
+
+// compareConstructs compares two construct trees, reporting missing/unexpected
+// constructs, missing/unexpected branch labels, and recursing into nested
+// constructs of matched pairs.
+func compareConstructs(key string, en, locale []icuConstruct) []validationError {
+	enByKey := make(map[string]icuConstruct)
+	for _, c := range en {
+		enByKey[c.Variable+","+c.Keyword] = c
+	}
+	localeByKey := make(map[string]icuConstruct)
+	for _, c := range locale {
+		localeByKey[c.Variable+","+c.Keyword] = c
+	}
+
+	var errors []validationError
+
+	// Constructs in English, matched against the locale.
+	for _, e := range en {
+		loc, found := localeByKey[e.Variable+","+e.Keyword]
+		if !found {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catICU,
+				Message: fmt.Sprintf("missing {%s, %s, ...} construct", e.Variable, e.Keyword),
+			})
+			continue
+		}
+		errors = append(errors, compareBranchLabels(key, &e, &loc)...)
+		errors = append(errors, compareConstructs(key, e.Nested, loc.Nested)...)
+	}
+
+	// Constructs in the locale but not in English.
+	for _, loc := range locale {
+		if _, found := enByKey[loc.Variable+","+loc.Keyword]; !found {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catICU,
+				Message: fmt.Sprintf("unexpected {%s, %s, ...} construct", loc.Variable, loc.Keyword),
+			})
+		}
+	}
+
+	return errors
+}
+
+// compareBranchLabels reports branch labels present in one construct but not
+// the other.
+func compareBranchLabels(key string, en, locale *icuConstruct) []validationError {
+	enBranches := make(map[string]bool)
+	for _, b := range en.Branches {
+		enBranches[b] = true
+	}
+	localeBranches := make(map[string]bool)
+	for _, b := range locale.Branches {
+		localeBranches[b] = true
+	}
+
+	var errors []validationError
+	for _, b := range en.Branches {
+		if !localeBranches[b] {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catICU,
+				Message: fmt.Sprintf("missing branch %q in {%s, %s, ...}", b, en.Variable, en.Keyword),
+			})
+		}
+	}
+	for _, b := range locale.Branches {
+		if !enBranches[b] {
+			errors = append(errors, validationError{
+				Key:     key,
+				Check:   catICU,
+				Message: fmt.Sprintf("unexpected branch %q in {%s, %s, ...}", b, locale.Variable, locale.Keyword),
+			})
+		}
+	}
+	return errors
+}
+
+// extractTagNames returns a count map of HTML-like tag names in a string.
+func extractTagNames(s string) map[string]int {
+	matches := tagRe.FindAllStringSubmatch(s, -1)
+	result := make(map[string]int)
+	for _, m := range matches {
+		result[m[1]]++
+	}
+	return result
+}
+
+// extractDataAttrs maps each href/data-* attribute name to the sorted list of
+// every value it takes in the string. Keeping all occurrences, not just the
+// last, lets checkTags catch a changed link target when an attribute repeats.
+func extractDataAttrs(s string) map[string][]string {
+	matches := attrRe.FindAllStringSubmatch(s, -1)
+	result := make(map[string][]string)
+	for _, m := range matches {
+		// m[2] is the double-quoted value, m[3] is the single-quoted value.
+		val := m[2]
+		if val == "" {
+			val = m[3]
+		}
+		result[m[1]] = append(result[m[1]], val)
+	}
+	for _, vals := range result {
+		sort.Strings(vals)
+	}
+	return result
+}

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -161,8 +161,8 @@ func checkICU(key, enValue, localeValue string) []validationError {
 	}
 
 	var errors []validationError
-	_, enErr := parseICU(enValue)
-	_, localeErr := parseICU(localeValue)
+	enNodes, enErr := parseICU(enValue)
+	localeNodes, localeErr := parseICU(localeValue)
 	if enErr != nil {
 		errors = append(errors, validationError{
 			Key:     key,
@@ -181,24 +181,15 @@ func checkICU(key, enValue, localeValue string) []validationError {
 		return errors
 	}
 
-	errors = append(errors, checkPlaceholders(key, enValue, localeValue)...)
-	errors = append(errors, checkICUStructure(key, enValue, localeValue)...)
+	errors = append(errors, checkPlaceholders(key, enNodes, localeNodes)...)
+	errors = append(errors, checkICUStructure(key, enNodes, localeNodes)...)
 	return errors
 }
 
-// checkPlaceholders verifies that the locale value references the same set of
+// checkPlaceholders verifies that the locale message references the same set of
 // argument names as the English source, including names nested inside ICU
 // plural/select branches and '#' number substitutions.
-func checkPlaceholders(key, enValue, localeValue string) []validationError {
-	enNodes, err := parseICU(enValue)
-	if err != nil {
-		return nil
-	}
-	localeNodes, err := parseICU(localeValue)
-	if err != nil {
-		return nil
-	}
-
+func checkPlaceholders(key string, enNodes, localeNodes []icuNode) []validationError {
 	enNames := icuArgumentNames(enNodes)
 	localeNames := icuArgumentNames(localeNodes)
 
@@ -237,7 +228,7 @@ var tagRe = regexp.MustCompile(`(?i)</?(a|b|br|code|em|i|li|ol|p|pre|span|strong
 // attrRe matches the HTML attributes a translation must preserve verbatim:
 // data-* (runtime click handlers dispatch on them) and href (a translation
 // must not change link targets).
-var attrRe = regexp.MustCompile(`(data-[\w-]+|href)=(?:"([^"]*)"|'([^']*)')`)
+var attrRe = regexp.MustCompile(`(?i)(data-[\w-]+|href)=(?:"([^"]*)"|'([^']*)')`)
 
 // checkTags verifies that the locale value contains the same HTML-like
 // tag names as the English source, and that required data-* attributes
@@ -308,16 +299,7 @@ func checkTags(key, enValue, localeValue string) []validationError {
 // categories differ from English (Polish few/many, or a locale that omits the
 // never-selected one branch). Relax the plural case — not select — if such a
 // locale is added.
-func checkICUStructure(key, enValue, localeValue string) []validationError {
-	enNodes, err := parseICU(enValue)
-	if err != nil {
-		return nil
-	}
-	localeNodes, err := parseICU(localeValue)
-	if err != nil {
-		return nil
-	}
-
+func checkICUStructure(key string, enNodes, localeNodes []icuNode) []validationError {
 	en := icuConstructs(enNodes)
 	locale := icuConstructs(localeNodes)
 	if len(en) == 0 && len(locale) == 0 {
@@ -404,12 +386,14 @@ func compareBranchLabels(key string, en, locale *icuConstruct) []validationError
 	return errors
 }
 
-// extractTagNames returns a count map of HTML-like tag names in a string.
+// extractTagNames returns a count map of HTML-like tag names in a string. Names
+// are folded to lower case, because HTML tag names are case-insensitive: a
+// translation that writes <B> for English's <b> keeps the same markup.
 func extractTagNames(s string) map[string]int {
 	matches := tagRe.FindAllStringSubmatch(s, -1)
 	result := make(map[string]int)
 	for _, m := range matches {
-		result[m[1]]++
+		result[strings.ToLower(m[1])]++
 	}
 	return result
 }
@@ -417,6 +401,8 @@ func extractTagNames(s string) map[string]int {
 // extractDataAttrs maps each href/data-* attribute name to the sorted list of
 // every value it takes in the string. Keeping all occurrences, not just the
 // last, lets checkTags catch a changed link target when an attribute repeats.
+// Names fold to lower case as in extractTagNames, but values are kept verbatim:
+// URL paths and data-* values are case-sensitive.
 func extractDataAttrs(s string) map[string][]string {
 	matches := attrRe.FindAllStringSubmatch(s, -1)
 	result := make(map[string][]string)
@@ -426,7 +412,8 @@ func extractDataAttrs(s string) map[string][]string {
 		if val == "" {
 			val = m[3]
 		}
-		result[m[1]] = append(result[m[1]], val)
+		name := strings.ToLower(m[1])
+		result[name] = append(result[name], val)
 	}
 	for _, vals := range result {
 		sort.Strings(vals)

--- a/src/go/i18n-report/report_validate_test.go
+++ b/src/go/i18n-report/report_validate_test.go
@@ -10,6 +10,16 @@ import (
 	"testing"
 )
 
+// mustParseICU parses an ICU message, failing the test if it does not parse.
+func mustParseICU(t *testing.T, msg string) []icuNode {
+	t.Helper()
+	nodes, err := parseICU(msg)
+	if err != nil {
+		t.Fatalf("parseICU(%q): %v", msg, err)
+	}
+	return nodes
+}
+
 func TestCheckPlaceholders(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -75,7 +85,7 @@ func TestCheckPlaceholders(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := checkPlaceholders("test.key", tc.enValue, tc.localeValue)
+			errs := checkPlaceholders("test.key", mustParseICU(t, tc.enValue), mustParseICU(t, tc.localeValue))
 			if len(errs) != tc.wantErrors {
 				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
 			}
@@ -162,6 +172,24 @@ func TestCheckTags(t *testing.T) {
 			localeValue: "<二进制数据: {n, number} bytes>",
 			wantErrors:  0,
 		},
+		{
+			name:        "uppercase tag is the same tag",
+			enValue:     "<b>bold</b>",
+			localeValue: "<B>fett</B>",
+			wantErrors:  0, // HTML tag names are case-insensitive
+		},
+		{
+			name:        "uppercase attribute name is the same attribute",
+			enValue:     `<a href="https://docs.example/Guide">docs</a>`,
+			localeValue: `<a HREF="https://docs.example/Guide">Doku</a>`,
+			wantErrors:  0, // HTML attribute names are case-insensitive
+		},
+		{
+			name:        "attribute value case still matters",
+			enValue:     `<a href="https://docs.example/Guide">docs</a>`,
+			localeValue: `<a href="https://docs.example/guide">Doku</a>`,
+			wantErrors:  1, // URL paths are case-sensitive
+		},
 	}
 
 	for _, tc := range tests {
@@ -227,7 +255,7 @@ func TestCheckICUStructure(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := checkICUStructure("test.key", tc.enValue, tc.localeValue)
+			errs := checkICUStructure("test.key", mustParseICU(t, tc.enValue), mustParseICU(t, tc.localeValue))
 			if len(errs) != tc.wantErrors {
 				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
 			}
@@ -295,6 +323,9 @@ func TestExtractTagNames(t *testing.T) {
 		{"<br/>", map[string]int{"br": 1}},
 		{"<code>x</code> and <b>y</b>", map[string]int{"code": 2, "b": 2}},
 		{"no tags", map[string]int{}},
+		{"<B>text</B>", map[string]int{"b": 2}},
+		{"<b>x</b> and <B>y</B>", map[string]int{"b": 4}},
+		{"<BR/>", map[string]int{"br": 1}},
 	}
 
 	for _, tc := range tests {

--- a/src/go/i18n-report/report_validate_test.go
+++ b/src/go/i18n-report/report_validate_test.go
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckPlaceholders(t *testing.T) {
+	tests := []struct {
+		name        string
+		enValue     string
+		localeValue string
+		wantErrors  int
+	}{
+		{
+			name:        "matching placeholders",
+			enValue:     "Hello {name}, you have {count} items",
+			localeValue: "Hallo {name}, Sie haben {count} Artikel",
+			wantErrors:  0,
+		},
+		{
+			name:        "missing placeholder",
+			enValue:     "Hello {name}",
+			localeValue: "Hallo",
+			wantErrors:  1,
+		},
+		{
+			name:        "extra placeholder",
+			enValue:     "Hello",
+			localeValue: "Hallo {name}",
+			wantErrors:  1,
+		},
+		{
+			name:        "ICU plural",
+			enValue:     "{count, plural, one {item} other {items}}",
+			localeValue: "{count, plural, one {Artikel} other {Artikel}}",
+			wantErrors:  0,
+		},
+		{
+			name:        "spaced placeholder",
+			enValue:     "Error { action } failed",
+			localeValue: "Fehler { action } fehlgeschlagen",
+			wantErrors:  0,
+		},
+		{
+			name:        "no placeholders",
+			enValue:     "Simple text",
+			localeValue: "Einfacher Text",
+			wantErrors:  0,
+		},
+		{
+			name:        "nested placeholder dropped",
+			enValue:     "{pages, plural, other {{from} - {to} of {count}}}",
+			localeValue: "{pages, plural, other {{from} - {to}}}",
+			wantErrors:  1, // count is nested and missing in locale
+		},
+		{
+			name:        "quoted literal is not a placeholder",
+			enValue:     "'{version}'",
+			localeValue: "wörtlich",
+			wantErrors:  0, // fully quoted: no placeholder on either side
+		},
+		{
+			name:        "apostrophe-wrapped placeholder",
+			enValue:     "''{version}''",
+			localeValue: "Version",
+			wantErrors:  1, // '' is a literal apostrophe; version is a real placeholder
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := checkPlaceholders("test.key", tc.enValue, tc.localeValue)
+			if len(errs) != tc.wantErrors {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
+			}
+		})
+	}
+}
+
+func TestCheckTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		enValue     string
+		localeValue string
+		wantErrors  int
+	}{
+		{
+			name:        "matching tags",
+			enValue:     "<b>bold</b> and <a href='x'>link</a>",
+			localeValue: "<b>fett</b> und <a href='x'>Link</a>",
+			wantErrors:  0,
+		},
+		{
+			name:        "missing tag",
+			enValue:     "<b>bold</b>",
+			localeValue: "fett",
+			wantErrors:  1, // missing <b>
+		},
+		{
+			name:        "extra tag",
+			enValue:     "plain text",
+			localeValue: "<b>fett</b>",
+			wantErrors:  1,
+		},
+		{
+			name:        "self-closing tag",
+			enValue:     "line1<br/>line2",
+			localeValue: "Zeile1<br/>Zeile2",
+			wantErrors:  0,
+		},
+		{
+			name:        "code tag",
+			enValue:     "use <code>kubectl</code>",
+			localeValue: "benutze <code>kubectl</code>",
+			wantErrors:  0,
+		},
+		{
+			name:        "no tags",
+			enValue:     "plain text",
+			localeValue: "einfacher Text",
+			wantErrors:  0,
+		},
+		{
+			name:        "changed href",
+			enValue:     `see <a href="https://docs.example/">docs</a>`,
+			localeValue: `siehe <a href="https://evil.example/">Doku</a>`,
+			wantErrors:  1,
+		},
+		{
+			name:        "dropped href",
+			enValue:     `see <a href="https://docs.example/">docs</a>`,
+			localeValue: `siehe <a>Doku</a>`,
+			wantErrors:  1,
+		},
+		{
+			name:        "changed first of two links",
+			enValue:     `<a href="https://a.example/">x</a> and <a href="https://b.example/">y</a>`,
+			localeValue: `<a href="https://evil.example/">x</a> und <a href="https://b.example/">y</a>`,
+			wantErrors:  1, // first href changed; must not collapse to the last
+		},
+		{
+			name:        "identical two-link string",
+			enValue:     `<a href="https://a.example/">x</a> <a href="https://b.example/">y</a>`,
+			localeValue: `<a href="https://a.example/">x</a> <a href="https://b.example/">y</a>`,
+			wantErrors:  0,
+		},
+		{
+			name:        "changed hyphenated data attribute",
+			enValue:     `<span data-test-id="alpha">x</span>`,
+			localeValue: `<span data-test-id="beta">x</span>`,
+			wantErrors:  1,
+		},
+		{
+			name:        "literal angle-bracket prose is not a tag",
+			enValue:     "<Binary Data: {n, number} bytes>",
+			localeValue: "<二进制数据: {n, number} bytes>",
+			wantErrors:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := checkTags("test.key", tc.enValue, tc.localeValue)
+			if len(errs) != tc.wantErrors {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
+			}
+		})
+	}
+}
+
+func TestCheckICUStructure(t *testing.T) {
+	tests := []struct {
+		name        string
+		enValue     string
+		localeValue string
+		wantErrors  int
+	}{
+		{
+			name:        "matching plural",
+			enValue:     "Delete {count} {count, plural, one {image} other {images}}?",
+			localeValue: "{count} {count, plural, one {Image} other {Images}} löschen?",
+			wantErrors:  0,
+		},
+		{
+			name:        "missing plural construct",
+			enValue:     "{count, plural, one {item} other {items}}",
+			localeValue: "{count} Artikel",
+			wantErrors:  1,
+		},
+		{
+			name:        "extra plural construct",
+			enValue:     "{count} items",
+			localeValue: "{count, plural, one {Artikel} other {Artikel}}",
+			wantErrors:  1,
+		},
+		{
+			name:        "missing branch",
+			enValue:     "{count, plural, =0 {none} one {item} other {items}}",
+			localeValue: "{count, plural, one {Artikel} other {Artikel}}",
+			wantErrors:  1, // missing =0
+		},
+		{
+			name:        "extra branch",
+			enValue:     "{count, plural, one {item} other {items}}",
+			localeValue: "{count, plural, =0 {keine} one {Artikel} other {Artikel}}",
+			wantErrors:  1, // unexpected =0
+		},
+		{
+			name:        "no ICU in either",
+			enValue:     "Simple text",
+			localeValue: "Einfacher Text",
+			wantErrors:  0,
+		},
+		{
+			name:        "nested plural",
+			enValue:     "{pages, plural, =0 {No entries} =1 {{count} {count, plural, =1 {Item} other {Items}}} other {{from} - {to} of {count}}}",
+			localeValue: "{pages, plural, =0 {Keine Einträge} =1 {{count} {count, plural, =1 {Eintrag} other {Einträge}}} other {{from} - {to} von {count}}}",
+			wantErrors:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := checkICUStructure("test.key", tc.enValue, tc.localeValue)
+			if len(errs) != tc.wantErrors {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
+			}
+		})
+	}
+}
+
+func TestCheckICUSyntax(t *testing.T) {
+	tests := []struct {
+		name        string
+		enValue     string
+		localeValue string
+		wantErrors  int
+		wantCheck   string
+	}{
+		{
+			name:        "balanced both sides",
+			enValue:     "Hello {name}",
+			localeValue: "Hallo {name}",
+			wantErrors:  0,
+		},
+		{
+			name:        "unbalanced brace in locale",
+			enValue:     "Hello {name}",
+			localeValue: "Hallo {name",
+			wantErrors:  1,
+			wantCheck:   "icu-syntax",
+		},
+		{
+			name:        "unbalanced brace in source",
+			enValue:     "Hello {name",
+			localeValue: "Hallo {name}",
+			wantErrors:  1,
+			wantCheck:   "icu-syntax",
+		},
+		{
+			name:        "no ICU in either",
+			enValue:     "plain text",
+			localeValue: "einfacher Text",
+			wantErrors:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := checkICU("test.key", tc.enValue, tc.localeValue)
+			if len(errs) != tc.wantErrors {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tc.wantErrors, errs)
+				return
+			}
+			if tc.wantCheck != "" && errs[0].Check != tc.wantCheck {
+				t.Errorf("check = %q, want %q", errs[0].Check, tc.wantCheck)
+			}
+		})
+	}
+}
+
+func TestExtractTagNames(t *testing.T) {
+	tests := []struct {
+		input string
+		want  map[string]int
+	}{
+		{"<b>text</b>", map[string]int{"b": 2}},
+		{"<a href='x'>link</a>", map[string]int{"a": 2}},
+		{"<br/>", map[string]int{"br": 1}},
+		{"<code>x</code> and <b>y</b>", map[string]int{"code": 2, "b": 2}},
+		{"no tags", map[string]int{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := extractTagNames(tc.input)
+			if len(got) != len(tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+				return
+			}
+			for k, wantCount := range tc.want {
+				if got[k] != wantCount {
+					t.Errorf("tag %q: got %d, want %d", k, got[k], wantCount)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateLocaleEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(translationsPath(root, "en-us.yaml")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(locale, content string) {
+		if err := os.WriteFile(translationsPath(root, locale+".yaml"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("en-us", "greeting: Hello {name}\nfarewell: Bye\n")
+	// Valid: placeholder preserved, both keys carry @source.
+	write("ok", "# @source Hello {name}\ngreeting: Hallo {name}\n# @source Bye\nfarewell: Tschüss\n")
+	// Broken: greeting drops {name}, farewell has no @source.
+	write("bad", "# @source Hello {name}\ngreeting: Hallo\nfarewell: Tschüss\n")
+
+	if errs, err := validateLocale(root, "ok"); err != nil || len(errs) != 0 {
+		t.Fatalf("ok locale: err=%v, errors=%v", err, errs)
+	}
+
+	errs, err := validateLocale(root, "bad")
+	if err != nil {
+		t.Fatalf("bad locale: unexpected err %v", err)
+	}
+	got := map[string]int{}
+	for _, e := range errs {
+		got[e.Check]++
+	}
+	if got[catPlaceholder] != 1 || got[catSource] != 1 {
+		t.Fatalf("bad locale: want 1 placeholder + 1 source, got %v: %v", got, errs)
+	}
+}

--- a/src/go/i18n-report/source.go
+++ b/src/go/i18n-report/source.go
@@ -71,6 +71,16 @@ func collectSources(entries map[string]mergeEntry) map[string]string {
 	return sources
 }
 
+// loadSources reads a locale file and returns each key's @source snapshot,
+// the co-located replacement for a parallel metadata file.
+func loadSources(root, locale string) (map[string]string, error) {
+	entries, err := loadYAMLWithComments(translationsPath(root, locale+".yaml"))
+	if err != nil {
+		return nil, err
+	}
+	return collectSources(entries), nil
+}
+
 // annotateNodeSource walks the mapping tree and sets @source on every leaf key
 // whose dotted path exists in enKeys, to the current English value. It mutates
 // the visited key node's HeadComment directly, so keys whose own segments


### PR DESCRIPTION
`validate` compares each translation against its English source: placeholder parity, plural/select structure, HTML tag and data-* attribute preservation, `@override` placement, and `@source` coverage. The ICU parser mirrors intl-messageformat 11, the renderer's engine, so the gate accepts exactly what the runtime accepts.
