### PR TITLE
Add merge and remove, and the translate improve/drift modes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,8 +32,9 @@ linters:
       # "error" is the conventional log-field key, "--" is the POSIX
       # end-of-options marker, "eth0" shares a platform-interface table
       # with other literal names, and "--address" is a wsl.exe / nerdctl
-      # flag inlined in command-line slices.
-      ignore-string-values: ^(error|--|eth0|--address)$
+      # flag inlined in command-line slices, and '' plays three distinct
+      # YAML-quoting roles in i18n-report (empty scalar, escape, unescape).
+      ignore-string-values: ^(error|--|eth0|--address|'')$
     gocritic:
       disabled-checks:
         - dupImport # https://github.com/go-critic/go-critic/issues/845

--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -31,6 +31,86 @@ so CI can tell a real finding from a broken invocation. Lister commands
 (`unused`, `stale`, `translate`, `references`, `dynamic`, `untranslated`)
 exit `0` even when they list results.
 
+## Annotation conventions
+
+Translation files use YAML comments to carry annotations that the tool reads
+and preserves during merge operations.
+
+### `@reason`
+
+Explains why a particular translation was chosen. Place on the line before
+the key:
+
+```yaml
+# @reason "Checking" is clearer than "Verifying" in this context
+product.networkStatus.checking: Checking...
+```
+
+Multi-line reasons use `#` continuation lines:
+
+```yaml
+# @reason Matches the label used in Kubernetes documentation;
+#   kept short to fit the status bar
+product.networkStatus.online: Online
+```
+
+The `merge` command preserves `@reason` comments on existing keys and
+attaches them to new keys when present in the input.
+
+### `@override`
+
+Marks a translation as intentionally different from what an automated
+translator would produce. Place on the line before the key:
+
+```yaml
+# @override
+product.networkStatus.checking: Verifying...
+```
+
+`@override` affects three subcommands:
+
+- **`translate --mode=improve`** skips `@override` keys (they need no
+  improvement). Pass `--include-overrides` to include them anyway.
+- **`merge --mode=drift`** warns before overwriting `@override` keys,
+  since the translator chose that wording deliberately.
+- **`merge --mode=improve`** skips `@override` keys by default.
+  Pass `--include-overrides` to overwrite them.
+
+`@override` must appear on leaf keys only.
+
+A key can have both annotations:
+
+```yaml
+# @override
+# @reason human-reviewed; "Settings" preferred over "Preferences" for this locale
+preferences.title: Settings
+```
+
+### `@source`
+
+Records the English source text a translation was made from, so a later
+`drift` check can tell when the English has changed. Place it on the line
+before the key:
+
+```yaml
+# @source Checking...
+product.networkStatus.checking: Wird geprüft…
+```
+
+A multi-line source repeats the marker, one line per line of English:
+
+```yaml
+# @source {count, plural,
+# @source   one {# item}
+# @source   other {# items}
+# @source }
+sortableTable.rows: …
+```
+
+Unlike `@reason` and `@override`, `@source` is machine-managed: the `source`
+command writes it and `merge` refreshes it as it writes each translation, so
+do not edit it by hand.
+
 ## Subcommands
 
 ### unused
@@ -67,14 +147,17 @@ List keys that need translation, with their English values.
 
 Modes:
 - **`missing`** (default) — keys absent from the locale file
+- **`improve`** — keys already translated but eligible for quality review
+  (skips `@override` keys unless `--include-overrides` is set)
+- **`drift`** — keys whose English source changed since last translation
 
 ```sh
 i18n-report translate --locale=de [--mode=missing] [--format=json|text]
 ```
 
-`--format=json` is the machine-readable form: it preserves multiline
-values, unlike the text format. Use it whenever the output feeds another
-tool.
+`--format=json` is the machine-readable form: it round-trips through `merge`
+without losing multiline values, unlike the text format. Use it whenever the
+output feeds another tool.
 
 Split the output into parallel batches with `--batch` and `--batches`:
 
@@ -86,6 +169,34 @@ i18n-report translate --locale=de --batch=3 --batches=3 > batch3.txt
 
 Each batch outputs `key=value` lines suitable for feeding to a translator
 or saving to a file.
+
+### merge
+
+Read flat translations and write (or update) a nested YAML locale file.
+Accepts file arguments or reads from stdin.
+
+```sh
+i18n-report merge --locale=de batch1.out batch2.out batch3.out
+i18n-report merge --locale=de < translations.txt
+i18n-report merge --locale=de --dry-run batch1.out   # preview without writing
+```
+
+Input formats detected automatically:
+- **JSON array** — `translate --format=json` output; the lossless path
+  for multiline values
+- **JSONL** — agent transcripts; extracts text from assistant messages
+- **Markdown with `` ```yaml `` fences** — extracts content between fences
+- **Raw flat text** — `key=value` or `key: value` lines passed through
+
+Merge modes control how `@override` keys are handled:
+- **`normal`** (default) — overwrite everything
+- **`drift`** — warn before overwriting `@override` keys
+- **`improve`** — skip `@override` keys (pass `--include-overrides` to
+  overwrite them)
+
+The merge command preserves existing translations, adds new keys, and
+maintains `@reason` comments. Use `--dry-run` to preview changes without
+writing.
 
 ### untranslated
 
@@ -120,6 +231,27 @@ show which en-us.yaml keys they match.
 i18n-report dynamic [--format=json|text]
 ```
 
+### remove
+
+Remove keys from translation files. Two modes:
+
+**Pipe mode** — reads dotted keys from stdin and removes them from all
+translation files (en-us.yaml and every locale):
+
+```sh
+i18n-report unused | i18n-report remove
+```
+
+Non-key lines (headers, blank lines) are filtered out automatically, so
+the output of `unused` or `stale` can be piped directly.
+
+**Stale mode** — removes keys from each locale file that do not exist in
+en-us.yaml:
+
+```sh
+i18n-report remove --stale
+```
+
 ### source
 
 Record the current English source text on each translated key of a locale, or
@@ -151,6 +283,39 @@ Checks include:
 - `data-*` attribute preservation (runtime handlers depend on these)
 - `@override` placement (leaf keys only)
 - `@source` coverage (every translated key carries a `@source`)
+
+## Common workflows
+
+### Clean up dead keys
+
+```sh
+i18n-report unused | i18n-report remove   # remove from all files
+i18n-report remove --stale                # remove locale-only leftovers
+```
+
+### Translate missing keys
+
+```sh
+# Generate key=value output for translators.
+i18n-report translate --locale=de --batch=1 --batches=3 > batch1.txt
+i18n-report translate --locale=de --batch=2 --batches=3 > batch2.txt
+i18n-report translate --locale=de --batch=3 --batches=3 > batch3.txt
+
+# Merge translated output back into the locale file.
+i18n-report merge --locale=de batch1.out batch2.out batch3.out
+```
+
+### Retranslate drifted keys
+
+```sh
+i18n-report translate --mode=drift --locale=de > drifted.txt
+# Translate the output, then merge:
+i18n-report merge --mode=drift --locale=de drifted.out
+```
+
+Merge records the new English source for the merged keys itself; do not
+run `source` here, since refreshing every `@source` would clear the drift
+markers of keys that still await retranslation.
 
 ## How it works
 
@@ -184,6 +349,16 @@ It skips test files, lines already using `t()` or bound attributes, and
 values matching common non-translatable patterns (URLs, CSS classes,
 identifiers).
 
+### Merge pipeline
+
+The merge command:
+1. Reads the existing locale file (which must already exist)
+2. Parses each input source (JSON array, JSONL, markdown, or raw flat
+   `key=value` / `key: value` lines with `@reason` comments)
+3. Merges new entries with existing ones (new overrides old)
+4. Writes sorted, nested YAML
+5. Records each merged key's English source as a co-located `@source` comment
+
 ## Development
 
 ### Running tests
@@ -207,9 +382,11 @@ go test ./src/go/i18n-report/...
 | `report_undefined.go` | `undefined` subcommand |
 | `report_stale.go` | `stale` subcommand |
 | `report_translate.go` | `translate` subcommand |
+| `report_merge.go` | `merge` subcommand, input parsing, extraction |
 | `report_untranslated.go` | `untranslated` subcommand, heuristic scanner |
 | `report_references.go` | `references` subcommand |
 | `report_dynamic.go` | `dynamic` subcommand, finds dynamic key patterns |
+| `report_remove.go` | `remove` subcommand, YAML key removal |
 | `report_source.go` | `source` subcommand |
 | `report_validate.go` | `validate` subcommand, placeholder and structure checks |
 

--- a/src/go/i18n-report/fixtures_test.go
+++ b/src/go/i18n-report/fixtures_test.go
@@ -11,6 +11,14 @@ import (
 	"testing"
 )
 
+// bootstrapSource records @source snapshots on de.yaml, as `source` would.
+func bootstrapSource(t *testing.T, dir string) {
+	t.Helper()
+	if err := annotateSource(io.Discard, dir, "de", false); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // setupLocaleTestRepo builds a repo fixture with en-us.yaml and de.yaml. When
 // withSource is set, de.yaml is annotated with @source snapshots of the current
 // English, as a real bootstrap would leave it.
@@ -24,9 +32,7 @@ func setupLocaleTestRepo(t *testing.T, enUS, locale string, withSource bool) str
 	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
 
 	if withSource {
-		if err := annotateSource(io.Discard, dir, "de", false); err != nil {
-			t.Fatal(err)
-		}
+		bootstrapSource(t, dir)
 	}
 	return dir
 }

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -36,9 +36,11 @@ var subcommands = map[string]func([]string) error{
 	"undefined":    runUndefined,
 	"stale":        runStale,
 	"translate":    runTranslate,
+	"merge":        runMerge,
 	"untranslated": runUntranslated,
 	"references":   runReferences,
 	"dynamic":      runDynamic,
+	"remove":       runRemove,
 	"source":       runSource,
 	"validate":     runValidate,
 }
@@ -79,6 +81,8 @@ Subcommands:
   undefined     Keys referenced in source code but missing from en-us.yaml
   stale         Keys in a locale file absent from en-us.yaml
   translate     Keys missing from a locale, with English values
+  merge         Read flat translations, write nested YAML locale file
+  remove        Remove keys from translation files (stdin or --stale)
   untranslated  Hardcoded English strings in Vue/TS files (heuristic)
   references    Where each en-us.yaml key is used (file:line)
   dynamic       Template literal patterns that reference keys dynamically

--- a/src/go/i18n-report/report_merge.go
+++ b/src/go/i18n-report/report_merge.go
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// modeNormal is merge-only; the shared modes live with translate.
+const modeNormal = "normal"
+
+// looksLikeEntry matches lines that were probably meant as key-value
+// entries, so their silent loss can be reported. Report header lines
+// ("Found 15 keys ...") contain spaces before the separator and stay quiet.
+var looksLikeEntry = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]*\s*[:=]`)
+
+func runMerge(args []string) error {
+	fs := flag.NewFlagSet("merge", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale code (required)")
+	dryRun := fs.Bool("dry-run", false, "Show what would change without writing")
+	mode := fs.String("mode", modeNormal, "Merge mode: normal, drift, improve")
+	includeOverrides := fs.Bool("include-overrides", false, "In improve mode, also overwrite @override keys")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *locale == "" {
+		return fmt.Errorf("--locale is required")
+	}
+
+	validModes := map[string]bool{modeNormal: true, modeDrift: true, modeImprove: true}
+	if !validModes[*mode] {
+		return fmt.Errorf("--mode must be normal, drift, or improve")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return reportMerge(os.Stdout, root, *locale, fs.Args(), *dryRun, *mode, *includeOverrides)
+}
+
+// reportMerge reads translated entries and updates a nested YAML locale
+// file. It operates on the yaml.Node tree directly, preserving all existing
+// leaf comments. File arguments and stdin accept the same auto-detected
+// formats (see parseInputData).
+//
+// Merge modes control how @override keys are handled:
+//   - normal: write everything unconditionally
+//   - drift: write everything, warn when overwriting @override keys
+//   - improve: skip @override keys unless includeOverrides is set
+func reportMerge(w io.Writer, root, locale string, files []string, dryRun bool, mode string, includeOverrides bool) error {
+	localePath := translationsPath(root, locale+".yaml")
+
+	// A missing locale file is a mistyped --locale until proven otherwise;
+	// adding a language starts by creating the empty file (see README).
+	if _, err := os.Stat(localePath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("locale file %s does not exist; create it first (see the translations README)", localePath)
+		}
+		return err
+	}
+
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		return fmt.Errorf("loading existing %s: %w", localePath, err)
+	}
+	treeRoot := documentRoot(doc)
+	if err := validateNoAliases(treeRoot); err != nil {
+		return fmt.Errorf("%s: %w", localePath, err)
+	}
+
+	// Parse new entries from file arguments or stdin.
+	var newEntries []mergeEntry
+	if len(files) > 0 {
+		for _, path := range files {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+			entries, err := parseInputData(data)
+			if err != nil {
+				return fmt.Errorf("parsing %s: %w", path, err)
+			}
+			newEntries = append(newEntries, entries...)
+		}
+	} else {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("reading stdin: %w", err)
+		}
+		newEntries, err = parseInputData(data)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(newEntries) == 0 {
+		return fmt.Errorf("no translation entries found in input")
+	}
+
+	// Reject conflicting duplicate keys in input.
+	seen := make(map[string]string, len(newEntries))
+	for _, e := range newEntries {
+		if prev, exists := seen[e.key]; exists && prev != e.value {
+			return fmt.Errorf("conflicting values for key %q in input:\n  first:  %s\n  second: %s", e.key, prev, e.value)
+		}
+		seen[e.key] = e.value
+	}
+
+	// Reject keys not present in the English source.
+	enPath := translationsPath(root, "en-us.yaml")
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return fmt.Errorf("loading source keys: %w", err)
+	}
+	var unknown []string
+	for _, e := range newEntries {
+		if _, exists := enKeys[e.key]; !exists {
+			unknown = append(unknown, e.key)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("input contains %d keys not in en-us.yaml: %s", len(unknown), strings.Join(unknown, ", "))
+	}
+
+	// Apply new entries to the tree, respecting mode.
+	var added, overwritten, skipped, warned int
+	var applied []string
+	for _, e := range newEntries {
+		existingVal, _, found := nodeGetLeaf(treeRoot, e.key)
+		if found {
+			hasOverride := nodeHasOverride(treeRoot, e.key)
+
+			// In improve mode, skip @override keys unless --include-overrides.
+			if mode == modeImprove && hasOverride && !includeOverrides {
+				skipped++
+				if dryRun {
+					fmt.Fprintf(w, "skip %s (@override)\n", e.key)
+				}
+				continue
+			}
+
+			if existingVal != e.value {
+				overwritten++
+				if dryRun {
+					fmt.Fprintf(w, "overwrite %s\n  old: %s\n  new: %s\n", e.key, existingVal, e.value)
+				}
+				// In drift mode, warn when overwriting @override keys.
+				if mode == modeDrift && hasOverride {
+					warned++
+					fmt.Fprintf(os.Stderr, "Warning: overwriting @override key %s\n", e.key)
+				}
+			}
+		} else {
+			added++
+			if dryRun {
+				fmt.Fprintf(w, "add %s: %s\n", e.key, e.value)
+			}
+		}
+		applied = append(applied, e.key)
+		if !dryRun {
+			if err := nodeSetLeaf(treeRoot, e.key, e.value, e.comment); err != nil {
+				return fmt.Errorf("setting %s: %w", e.key, err)
+			}
+		}
+	}
+
+	if dryRun {
+		total := len(nodeAllLeaves(treeRoot)) + added
+		fmt.Fprintf(os.Stderr, "Dry run: %d new, %d overwritten", added, overwritten)
+		if skipped > 0 {
+			fmt.Fprintf(os.Stderr, ", %d skipped (@override)", skipped)
+		}
+		if warned > 0 {
+			fmt.Fprintf(os.Stderr, ", %d @override warnings", warned)
+		}
+		fmt.Fprintf(os.Stderr, ", %d total\n", total)
+		return nil
+	}
+
+	// Record the English source each applied key was translated from, as a
+	// co-located @source comment. Only applied keys are touched; refreshing
+	// @source on keys this merge skipped would erase their drift markers.
+	for _, key := range applied {
+		en, ok := enKeys[key]
+		if !ok {
+			continue
+		}
+		val, comment, found := nodeGetLeaf(treeRoot, key)
+		if !found {
+			continue
+		}
+		if err := nodeSetLeaf(treeRoot, key, val, setSourceComment(comment, en)); err != nil {
+			return fmt.Errorf("recording @source for %s: %w", key, err)
+		}
+	}
+
+	// Serialize before writing, so a serialization failure leaves the file
+	// untouched. @source lives in the same file, so one atomic write keeps a
+	// translation and its snapshot in sync.
+	var buf strings.Builder
+	serializeYAMLNode(&buf, doc)
+	localeData := []byte(buf.String())
+
+	total := len(nodeAllLeaves(treeRoot))
+
+	if err := writeFileAtomic(localePath, localeData); err != nil {
+		return fmt.Errorf("writing %s: %w", localePath, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Merged %d new keys into %s (%d overwritten", added, localePath, overwritten)
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, ", %d skipped", skipped)
+	}
+	if warned > 0 {
+		fmt.Fprintf(os.Stderr, ", %d @override warnings", warned)
+	}
+	fmt.Fprintf(os.Stderr, ", %d total)\n", total)
+	return nil
+}
+
+// parseInputData converts one input source (file or stdin) into merge
+// entries. A JSON array in the `translate --format=json` shape is the
+// lossless path for multiline values; everything else goes through the
+// line-based text formats.
+func parseInputData(data []byte) ([]mergeEntry, error) {
+	data = bytes.TrimPrefix(data, []byte("\xef\xbb\xbf"))
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var pairs []struct {
+			Key     string `json:"key"`
+			Value   string `json:"value"`
+			Comment string `json:"comment"`
+		}
+		if err := json.Unmarshal(trimmed, &pairs); err != nil {
+			return nil, fmt.Errorf("parsing JSON array input: %w", err)
+		}
+		entries := make([]mergeEntry, 0, len(pairs))
+		for _, p := range pairs {
+			entries = append(entries, mergeEntry{key: p.Key, value: p.Value, comment: localeCommentLines(p.Comment)})
+		}
+		return entries, nil
+	}
+	return parseMergeInput(strings.NewReader(extractTranslationText(data)))
+}
+
+// localeCommentLines keeps only comment lines that belong on the locale key
+// (@reason and @override), matching the flat parser. The translate report
+// carries en-us annotations (@context, @meaning) whose home is the source
+// file, not the locale file.
+func localeCommentLines(comment string) string {
+	var kept []string
+	for _, line := range strings.Split(comment, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# @reason") || strings.HasPrefix(trimmed, "# @override") {
+			kept = append(kept, trimmed)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+// extractTranslationText extracts flat translation content from raw bytes.
+// It handles three input formats:
+//  1. JSONL agent output — parses JSON, extracts text from assistant messages
+//  2. Markdown with ```yaml fences — extracts content between fences
+//  3. Raw flat key-value text — passed through unchanged
+func extractTranslationText(data []byte) string {
+	content := string(data)
+
+	// Detect JSONL by checking whether the first non-whitespace character is '{'.
+	// Sufficient for the agent output formats we consume.
+	firstLine := ""
+	for _, line := range strings.Split(content, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			firstLine = trimmed
+			break
+		}
+	}
+	if firstLine != "" && firstLine[0] == '{' && json.Valid([]byte(firstLine)) {
+		var extracted strings.Builder
+		for _, line := range strings.Split(content, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || line[0] != '{' {
+				continue
+			}
+			var msg struct {
+				Message struct {
+					Role    string          `json:"role"`
+					Content json.RawMessage `json:"content"`
+				} `json:"message"`
+			}
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				continue
+			}
+			if msg.Message.Role != "assistant" {
+				continue
+			}
+			// Content may be a string or an array of content blocks.
+			var text string
+			if err := json.Unmarshal(msg.Message.Content, &text); err == nil {
+				extracted.WriteString(text)
+				extracted.WriteString("\n")
+			} else {
+				var blocks []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}
+				if err := json.Unmarshal(msg.Message.Content, &blocks); err == nil {
+					for _, b := range blocks {
+						if b.Type == "text" {
+							extracted.WriteString(b.Text)
+							extracted.WriteString("\n")
+						}
+					}
+				}
+			}
+		}
+		content = extracted.String()
+	}
+
+	// Extract content from ```yaml fences if present.
+	if strings.Contains(content, "```yaml") {
+		var extracted strings.Builder
+		inFence := false
+		for _, line := range strings.Split(content, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "```yaml" {
+				inFence = true
+				continue
+			}
+			if trimmed == "```" && inFence {
+				inFence = false
+				continue
+			}
+			if inFence {
+				extracted.WriteString(line)
+				extracted.WriteString("\n")
+			}
+		}
+		if extracted.Len() > 0 {
+			content = extracted.String()
+		}
+	}
+
+	return content
+}
+
+// parseMergeInput reads flat key=value or key: value lines from a reader,
+// collecting @reason comments and associating them with the next key.
+// Blank lines and non-@reason comments are skipped.
+// maxLineBytes bounds a single input line; agent transcripts embed whole
+// documents on one JSONL line.
+const maxLineBytes = 1024 * 1024
+
+func parseMergeInput(r io.Reader) ([]mergeEntry, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, maxLineBytes), maxLineBytes)
+
+	var entries []mergeEntry
+	var pendingComment strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Skip blank lines.
+		if trimmed == "" || trimmed == "---" {
+			pendingComment.Reset()
+			continue
+		}
+
+		// Accumulate @reason and @override comments; both belong on the
+		// locale key. An input @override marks the key as hand-tuned so
+		// later improve/merge passes leave it alone.
+		if strings.HasPrefix(trimmed, "# @reason") || strings.HasPrefix(trimmed, "# @override") {
+			if pendingComment.Len() > 0 {
+				pendingComment.WriteString("\n")
+			}
+			pendingComment.WriteString(trimmed)
+			continue
+		}
+		// Accumulate continuation lines for multi-line @reason comments.
+		if strings.HasPrefix(trimmed, "#   ") && pendingComment.Len() > 0 {
+			pendingComment.WriteString("\n")
+			pendingComment.WriteString(trimmed)
+			continue
+		}
+
+		// Skip other comment lines.
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Parse key-value pair: try "key: value" then "key=value".
+		var key, value string
+		if idx := strings.Index(trimmed, ": "); idx > 0 {
+			candidate := trimmed[:idx]
+			if isValidDottedKey(candidate) {
+				key = candidate
+				value = stripYAMLQuotes(trimmed[idx+2:])
+			}
+		}
+		if key == "" {
+			if idx := strings.Index(trimmed, "="); idx > 0 {
+				candidate := trimmed[:idx]
+				if isValidDottedKey(candidate) {
+					key = candidate
+					value = stripYAMLQuotes(trimmed[idx+1:])
+				}
+			}
+		}
+
+		if key == "" {
+			if looksLikeEntry.MatchString(trimmed) {
+				fmt.Fprintf(os.Stderr, "Warning: ignoring unparseable input line: %s\n", trimmed)
+			}
+			pendingComment.Reset()
+			continue
+		}
+
+		entries = append(entries, mergeEntry{
+			key:     key,
+			value:   value,
+			comment: pendingComment.String(),
+		})
+		pendingComment.Reset()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+	return entries, nil
+}

--- a/src/go/i18n-report/report_merge.go
+++ b/src/go/i18n-report/report_merge.go
@@ -22,7 +22,9 @@ const modeNormal = "normal"
 // looksLikeEntry matches lines that were probably meant as key-value
 // entries, so their silent loss can be reported. Report header lines
 // ("Found 15 keys ...") contain spaces before the separator and stay quiet.
-var looksLikeEntry = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.-]*\s*[:=]`)
+// The key run admits quotes and slashes, so a key rejected for a stray quote
+// still matches here.
+var looksLikeEntry = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_.'"/-]*\s*[:=]`)
 
 func runMerge(args []string) error {
 	fs := flag.NewFlagSet("merge", flag.ExitOnError)

--- a/src/go/i18n-report/report_merge_fix_test.go
+++ b/src/go/i18n-report/report_merge_fix_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// writeMergeFixture creates a repo with the given en-us and locale content.
+// meta, if non-empty, is a flat "key: source" map injected inline as @source
+// comments on de.yaml, as the co-located model stores it.
+func writeMergeFixture(t *testing.T, enUS, locale, meta string) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	if err := os.MkdirAll(transDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	localePath := filepath.Join(transDir, "de.yaml")
+	os.WriteFile(localePath, []byte(locale), 0o644)
+	if meta == "" {
+		return dir
+	}
+
+	sources := map[string]string{}
+	if err := yaml.Unmarshal([]byte(meta), &sources); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := documentRoot(doc)
+	for key, src := range sources {
+		val, comment, found := nodeGetLeaf(root, key)
+		if !found {
+			t.Fatalf("meta key %q absent from locale", key)
+		}
+		if err := nodeSetLeaf(root, key, val, setSourceComment(comment, src)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf strings.Builder
+	serializeYAMLNode(&buf, doc)
+	os.WriteFile(localePath, []byte(buf.String()), 0o644)
+	return dir
+}
+
+func mergeInputFile(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "input.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMergeUpdatesMetadataOnlyForMergedKeys(t *testing.T) {
+	enUS := "a:\n  b: New English text\n  c: Third key\n"
+	locale := "a:\n  b: Alte Übersetzung\n"
+	// a.b has drifted; meta still records the old English source.
+	meta := "a.b: Old English text\n"
+	dir := writeMergeFixture(t, enUS, locale, meta)
+	input := mergeInputFile(t, dir, "a.c=Dritter Schlüssel\n")
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadSources(dir, "de")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["a.b"] != "Old English text" {
+		t.Errorf("merge of a.c erased the drift marker for a.b: meta[a.b] = %q, want %q",
+			got["a.b"], "Old English text")
+	}
+	if got["a.c"] != "Third key" {
+		t.Errorf("meta[a.c] = %q, want %q", got["a.c"], "Third key")
+	}
+}
+
+func TestMergeRefusesToOverwriteMapping(t *testing.T) {
+	enUS := "a:\n  b: Leaf in English\n"
+	// The locale has diverged; a.b is a mapping with children.
+	locale := "a:\n  b:\n    nested: Wert\n    other: Mehr\n"
+	dir := writeMergeFixture(t, enUS, locale, "")
+	input := mergeInputFile(t, dir, "a.b=Neu\n")
+
+	err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false)
+	if err == nil {
+		t.Fatal("expected an error overwriting a mapping with a leaf, got nil")
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+	if !strings.Contains(string(data), "nested: Wert") {
+		t.Errorf("locale file was modified despite the error:\n%s", data)
+	}
+}
+
+func TestMergeReadsTranslateJSONArray(t *testing.T) {
+	enUS := "a:\n  multi: |-\n    Line one: {error}\n\n    Line two\n"
+	locale := "{}\n"
+	dir := writeMergeFixture(t, enUS, locale, "")
+	input := mergeInputFile(t, dir,
+		`[{"key": "a.multi", "value": "Zeile eins: {error}\n\nZeile zwei"}]`)
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadYAMLFlat(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "Zeile eins: {error}\n\nZeile zwei"
+	if got["a.multi"] != want {
+		t.Errorf("multiline value lost through JSON merge:\ngot:  %q\nwant: %q", got["a.multi"], want)
+	}
+}
+
+func TestLoadYAMLFlatPreservesScalarText(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	content := "a:\n  octal: 0755\n  float: 1.10\n  tilde: ~\n  word: no\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadYAMLFlat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"a.octal": "0755",
+		"a.float": "1.10",
+		"a.tilde": "~",
+		"a.word":  "no",
+	} {
+		if got[key] != want {
+			t.Errorf("loadYAMLFlat resolved %s to %q, want raw text %q", key, got[key], want)
+		}
+	}
+}
+
+func TestParseInputDataFormats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "BOM before first entry",
+			input: "\ufeffa.b=Wert eins\na.c=Wert zwei\n",
+			want:  map[string]string{"a.b": "Wert eins", "a.c": "Wert zwei"},
+		},
+		{
+			name:  "JSON array",
+			input: `[{"key": "a.b", "value": "Wert"}]`,
+			want:  map[string]string{"a.b": "Wert"},
+		},
+		{
+			name:  "JSONL assistant message",
+			input: `{"message": {"role": "assistant", "content": "a.b=Wert\n"}}`,
+			want:  map[string]string{"a.b": "Wert"},
+		},
+		{
+			name:  "flat text",
+			input: "a.b: Wert\n",
+			want:  map[string]string{"a.b": "Wert"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entries, err := parseInputData([]byte(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := make(map[string]string, len(entries))
+			for _, e := range entries {
+				got[e.key] = e.value
+			}
+			for k, want := range tc.want {
+				if got[k] != want {
+					t.Errorf("entry %s = %q, want %q (all: %v)", k, got[k], want, got)
+				}
+			}
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d entries, want %d", len(got), len(tc.want))
+			}
+		})
+	}
+}
+
+func TestMergeErrorsOnMissingLocaleFile(t *testing.T) {
+	enUS := "a:\n  b: Text\n"
+	dir := writeMergeFixture(t, enUS, "{}\n", "")
+	input := mergeInputFile(t, dir, "a.b=Wert\n")
+
+	err := reportMerge(io.Discard, dir, "de-DE", []string{input}, false, "normal", false)
+	if err == nil {
+		t.Fatal("expected an error for a locale without a translation file, got nil")
+	}
+
+	typoPath := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de-DE.yaml")
+	if _, statErr := os.Stat(typoPath); statErr == nil {
+		t.Error("merge created a locale file for an unknown locale")
+	}
+}
+
+func TestMergeStripsStaleOverrideMarker(t *testing.T) {
+	enUS := "a:\n  b: English text\n"
+	locale := "a:\n  # @override\n  # hand-tuned wording\n  b: Handgemachte Übersetzung\n"
+	dir := writeMergeFixture(t, enUS, locale, "")
+	input := mergeInputFile(t, dir, "a.b=Maschinelle Übersetzung\n")
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+	if strings.Contains(string(data), "@override") {
+		t.Errorf("stale @override marker survived a machine overwrite:\n%s", data)
+	}
+}
+
+func TestMergeRejectsAliases(t *testing.T) {
+	enUS := "a:\n  b: Text\n  c: More\n"
+	locale := "a:\n  b: &shared Wert\n  c: *shared\n"
+	dir := writeMergeFixture(t, enUS, locale, "")
+	input := mergeInputFile(t, dir, "a.b=Neu\n")
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err == nil {
+		t.Fatal("expected an error for a locale file containing aliases, got nil")
+	}
+}

--- a/src/go/i18n-report/report_merge_fix_test.go
+++ b/src/go/i18n-report/report_merge_fix_test.go
@@ -244,3 +244,28 @@ func TestMergeRejectsAliases(t *testing.T) {
 		t.Fatal("expected an error for a locale file containing aliases, got nil")
 	}
 }
+
+func TestMergeTextRoundTripsDottedSegmentKey(t *testing.T) {
+	// translate/stale/unused emit secret-type keys whose own segment holds a
+	// dot in the quoted form secret.types."kubernetes.io/service-account-token".
+	// The text merge path must accept that form, not silently drop the key.
+	enUS := "secret:\n" +
+		"  plain: Plain\n" +
+		"  types:\n" +
+		"    'kubernetes.io/service-account-token': Svc Acct Token\n"
+	dir := writeMergeFixture(t, enUS, "{}\n", "")
+	key := `secret.types."kubernetes.io/service-account-token"`
+	input := mergeInputFile(t, dir, "secret.plain=Einfach\n"+key+"=Dienstkonto-Token\n")
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadYAMLFlat(translationsPath(dir, "de.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[key] != "Dienstkonto-Token" {
+		t.Errorf("dotted-segment key dropped by text merge: got %q for %s (all: %v)", got[key], key, got)
+	}
+}

--- a/src/go/i18n-report/report_merge_test.go
+++ b/src/go/i18n-report/report_merge_test.go
@@ -141,6 +141,39 @@ a.b=hello
 	}
 }
 
+// A rejected key must be reported — dropping it quietly would lose a
+// translation from a long piped batch.
+func TestParseMergeInputRejectsMalformedKey(t *testing.T) {
+	lines := []string{
+		`a"b.c=Läuft`,
+		`secret.types."kubernetes.io/service-account-token=Svc Acct Token`,
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			oldStderr := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+
+			got, err := parseMergeInput(strings.NewReader(line + "\n"))
+			w.Close()
+			os.Stderr = oldStderr
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 0 {
+				t.Errorf("parseMergeInput(%q) = %+v, want no entries", line, got)
+			}
+
+			stderr, _ := io.ReadAll(r)
+			if !strings.Contains(string(stderr), "Warning: ignoring unparseable input line") {
+				t.Errorf("line %q was dropped without a warning; stderr: %q", line, stderr)
+			}
+		})
+	}
+}
+
 func TestMergePreservesExistingComments(t *testing.T) {
 	dir := t.TempDir()
 

--- a/src/go/i18n-report/report_merge_test.go
+++ b/src/go/i18n-report/report_merge_test.go
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseMergeInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []mergeEntry
+		wantErr bool
+	}{
+		{
+			name:  "key=value format",
+			input: "a.b=hello\nc.d=world\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+				{key: "c.d", value: "world"},
+			},
+		},
+		{
+			name:  "key: value format",
+			input: "a.b: hello\nc.d: world\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+				{key: "c.d", value: "world"},
+			},
+		},
+		{
+			name:  "key: value with YAML quotes",
+			input: "a.b: 'quoted value'\nc.d: \"double quoted\"\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "quoted value"},
+				{key: "c.d", value: "double quoted"},
+			},
+		},
+		{
+			name: "@reason comment attached to next key",
+			input: `# @reason Standard translation
+a.b=hello
+`,
+			want: []mergeEntry{
+				{key: "a.b", value: "hello", comment: "# @reason Standard translation"},
+			},
+		},
+		{
+			name: "multi-line @reason comment",
+			input: `# @reason Standard translation for admin access;
+#   kept "sudo" as-is since it's a Unix command
+a.b=hello
+`,
+			want: []mergeEntry{
+				{key: "a.b", value: "hello", comment: "# @reason Standard translation for admin access;\n#   kept \"sudo\" as-is since it's a Unix command"},
+			},
+		},
+		{
+			name:  "@override comment attached to next key",
+			input: "# @override\na.b=hello\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello", comment: "# @override"},
+			},
+		},
+		{
+			name:  "blank lines reset pending comment",
+			input: "# @reason this gets discarded\n\na.b=hello\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+			},
+		},
+		{
+			name:  "non-@reason comments are skipped",
+			input: "# just a comment\na.b=hello\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+			},
+		},
+		{
+			name:  "YAML separator skipped",
+			input: "---\na.b=hello\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+			},
+		},
+		{
+			name:  "invalid key lines ignored",
+			input: "not a valid line\na.b=hello\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "hello"},
+			},
+		},
+		{
+			name:  "mixed formats",
+			input: "a.b=one\nc.d: two\ne.f: 'three'\n",
+			want: []mergeEntry{
+				{key: "a.b", value: "one"},
+				{key: "c.d", value: "two"},
+				{key: "e.f", value: "three"},
+			},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMergeInput(strings.NewReader(tc.input))
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d entries, want %d", len(got), len(tc.want))
+			}
+			for i := range tc.want {
+				if got[i].key != tc.want[i].key {
+					t.Errorf("[%d] key = %q, want %q", i, got[i].key, tc.want[i].key)
+				}
+				if got[i].value != tc.want[i].value {
+					t.Errorf("[%d] value = %q, want %q", i, got[i].value, tc.want[i].value)
+				}
+				if got[i].comment != tc.want[i].comment {
+					t.Errorf("[%d] comment = %q, want %q", i, got[i].comment, tc.want[i].comment)
+				}
+			}
+		})
+	}
+}
+
+func TestMergePreservesExistingComments(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a repo structure: translations dir with en-us.yaml and de.yaml.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+
+	enUS := `status:
+  checking: Checking...
+  updating: Updating...
+  done: Done
+`
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+
+	// Existing de.yaml with @reason comments.
+	existingDE := `status:
+  # @reason "wird geprüft" = standard German
+  checking: Wird geprüft…
+  updating: Aktualisieren…
+`
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(existingDE), 0o644)
+
+	// Merge new input that adds "done" but doesn't touch "checking".
+	newInput := `# @reason Standard completion message
+status.done=Fertig
+`
+	inputFile := filepath.Join(dir, "input.txt")
+	os.WriteFile(inputFile, []byte(newInput), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "normal", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the result and verify comments are preserved.
+	result, err := loadYAMLWithComments(filepath.Join(transDir, "de.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Existing comment preserved.
+	if e := result["status.checking"]; e.comment != `# @reason "wird geprüft" = standard German` {
+		t.Errorf("existing comment lost: got %q", e.comment)
+	}
+
+	// New comment applied, with @source recorded from the English source.
+	if e := result["status.done"]; e.comment != "# @reason Standard completion message\n# @source Done" {
+		t.Errorf("new comment missing: got %q", e.comment)
+	}
+
+	// Uncommented key has no comment.
+	if e := result["status.updating"]; e.comment != "" {
+		t.Errorf("unexpected comment on updating: got %q", e.comment)
+	}
+}
+
+func TestMergeDryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+
+	existingDE := "status:\n  checking: Wird geprüft…\n"
+	dePath := filepath.Join(transDir, "de.yaml")
+	os.WriteFile(dePath, []byte(existingDE), 0o644)
+
+	// Input adds "done" and overwrites "checking".
+	newInput := "status.checking=Prüfe…\nstatus.done=Fertig\n"
+	inputFile := filepath.Join(dir, "input.txt")
+	os.WriteFile(inputFile, []byte(newInput), 0o644)
+
+	// Capture file state before dry run.
+	before, _ := os.ReadFile(dePath)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, true, "normal", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File must be unchanged.
+	after, _ := os.ReadFile(dePath)
+	if string(after) != string(before) {
+		t.Error("dry run modified the locale file")
+	}
+}
+
+func setupMergeTestRepo(t *testing.T, existingLocale string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(existingLocale), 0o644)
+
+	inputFile := filepath.Join(dir, "input.txt")
+	return dir, inputFile
+}
+
+func TestMergeInputOverrideMarksKeyAndImproveSkips(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Alt\n"
+	dir := writeMergeFixture(t, enUS, de, "")
+	input := mergeInputFile(t, dir, "# @override\nstatus.checking=Handgemacht\n")
+
+	if err := reportMerge(io.Discard, dir, "de", []string{input}, false, "normal", false); err != nil {
+		t.Fatal(err)
+	}
+
+	// The merged key carries the @override marker.
+	dePath := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml")
+	data, _ := os.ReadFile(dePath)
+	if !strings.Contains(string(data), "@override") {
+		t.Fatalf("merge input @override did not set the marker:\n%s", data)
+	}
+
+	// translate --mode=improve now skips the @override key.
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", "improve", "text", 0, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No keys eligible for improvement") {
+		t.Errorf("improve should skip the @override key, got:\n%s", buf.String())
+	}
+}
+
+func TestMergeModeDrift(t *testing.T) {
+	existing := `status:
+  # @override
+  checking: Manuelle Übersetzung
+  done: Fertig
+`
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	// Input overwrites both keys.
+	os.WriteFile(inputFile, []byte("status.checking=Wird geprüft…\nstatus.done=Erledigt\n"), 0o644)
+
+	// Capture stderr for the warning.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "drift", false)
+	w.Close()
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stderrOut, _ := io.ReadAll(r)
+	stderr := string(stderrOut)
+
+	// Should warn about overwriting the @override key.
+	if !strings.Contains(stderr, "Warning: overwriting @override key status.checking") {
+		t.Errorf("expected @override warning, got: %s", stderr)
+	}
+
+	// Both keys should be overwritten (drift mode writes everything).
+	result, _ := loadYAMLWithComments(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+	if result["status.checking"].value != "Wird geprüft…" {
+		t.Errorf("override key not overwritten in drift mode: got %q", result["status.checking"].value)
+	}
+	if result["status.done"].value != "Erledigt" {
+		t.Errorf("non-override key not overwritten: got %q", result["status.done"].value)
+	}
+}
+
+func TestMergeModeImprove(t *testing.T) {
+	existing := `status:
+  # @override
+  checking: Manuelle Übersetzung
+  done: Fertig
+`
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	os.WriteFile(inputFile, []byte("status.checking=Wird geprüft…\nstatus.done=Erledigt\n"), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "improve", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := loadYAMLWithComments(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+
+	// @override key should be skipped.
+	if result["status.checking"].value != "Manuelle Übersetzung" {
+		t.Errorf("override key should be preserved in improve mode: got %q", result["status.checking"].value)
+	}
+	// Non-override key should be overwritten.
+	if result["status.done"].value != "Erledigt" {
+		t.Errorf("non-override key not overwritten: got %q", result["status.done"].value)
+	}
+}
+
+func TestMergeModeImproveIncludeOverrides(t *testing.T) {
+	existing := `status:
+  # @override
+  checking: Manuelle Übersetzung
+`
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	os.WriteFile(inputFile, []byte("status.checking=Wird geprüft…\n"), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "improve", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := loadYAMLWithComments(filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+
+	// With --include-overrides, even @override keys should be overwritten.
+	if result["status.checking"].value != "Wird geprüft…" {
+		t.Errorf("override key should be overwritten with --include-overrides: got %q", result["status.checking"].value)
+	}
+}
+
+func TestMergeModeImproveSkipDryRun(t *testing.T) {
+	existing := `status:
+  # @override
+  checking: Manuelle Übersetzung
+  done: Fertig
+`
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	os.WriteFile(inputFile, []byte("status.checking=Wird geprüft…\nstatus.done=Erledigt\n"), 0o644)
+
+	// Capture the dry-run output.
+	var buf bytes.Buffer
+	if err := reportMerge(&buf, dir, "de", []string{inputFile}, true, "improve", false); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	// Dry run should report the skip.
+	if !strings.Contains(output, "skip status.checking (@override)") {
+		t.Errorf("dry-run should show skip, got: %s", output)
+	}
+	// Non-override key should show overwrite.
+	if !strings.Contains(output, "overwrite status.done") {
+		t.Errorf("dry-run should show overwrite for non-override key, got: %s", output)
+	}
+}
+
+func TestMergeRejectsDuplicateKeys(t *testing.T) {
+	existing := "status:\n  checking: Wird geprüft…\n"
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	// Two entries for the same key with different values.
+	os.WriteFile(inputFile, []byte("status.checking=Prüfe…\nstatus.checking=Wird geprüft…\n"), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "normal", false)
+	if err == nil {
+		t.Error("merge should reject conflicting duplicate keys")
+	}
+	if err != nil && !strings.Contains(err.Error(), "conflicting values") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeRejectsUnknownKeys(t *testing.T) {
+	existing := "status:\n  checking: Wird geprüft…\n"
+	dir, inputFile := setupMergeTestRepo(t, existing)
+	// Key not in en-us.yaml.
+	os.WriteFile(inputFile, []byte("status.nonexistent=Hallo\n"), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "normal", false)
+	if err == nil {
+		t.Error("merge should reject unknown keys not in en-us.yaml")
+	}
+	if err != nil && !strings.Contains(err.Error(), "not in en-us.yaml") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeRejectsNonMappingRoot(t *testing.T) {
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+
+	enUS := "status:\n  checking: Checking...\n"
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	// Write a scalar root (not a mapping).
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte("just a string\n"), 0o644)
+
+	inputFile := filepath.Join(dir, "input.txt")
+	os.WriteFile(inputFile, []byte("status.checking=Wird geprüft…\n"), 0o644)
+
+	err := reportMerge(io.Discard, dir, "de", []string{inputFile}, false, "normal", false)
+	if err == nil {
+		t.Error("merge should reject non-mapping root")
+	}
+	if err != nil && !strings.Contains(err.Error(), "not a mapping") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractTranslationText(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "raw flat text passes through",
+			input: "a.b=hello\nc.d=world\n",
+			want:  "a.b=hello\nc.d=world\n",
+		},
+		{
+			name: "markdown yaml fence",
+			input: `Some text before
+
+` + "```yaml" + `
+a.b=hello
+c.d=world
+` + "```" + `
+
+Some text after
+`,
+			want: "a.b=hello\nc.d=world\n",
+		},
+		{
+			name: "JSONL agent output",
+			input: `{"message":{"role":"user","content":"translate"}}
+{"message":{"role":"assistant","content":[{"type":"text","text":"a.b=hello\nc.d=world"}]}}
+`,
+			// After JSONL extraction, the markdown fence check runs but finds none.
+			want: "a.b=hello\nc.d=world\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractTranslationText([]byte(tc.input))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/go/i18n-report/report_remove.go
+++ b/src/go/i18n-report/report_remove.go
@@ -165,7 +165,11 @@ func removeKeysFromFile(path string, keys map[string]bool) (int, error) {
 
 	removed := 0
 	for key := range keys {
-		if removeKeyFromNode(root, splitKeyPath(key)) {
+		parts, err := splitKeyPath(key)
+		if err != nil {
+			return 0, fmt.Errorf("%s: invalid key %q: %w", path, key, err)
+		}
+		if removeKeyFromNode(root, parts) {
 			removed++
 		}
 	}

--- a/src/go/i18n-report/report_remove.go
+++ b/src/go/i18n-report/report_remove.go
@@ -165,7 +165,7 @@ func removeKeysFromFile(path string, keys map[string]bool) (int, error) {
 
 	removed := 0
 	for key := range keys {
-		if removeKeyFromNode(root, strings.Split(key, ".")) {
+		if removeKeyFromNode(root, splitKeyPath(key)) {
 			removed++
 		}
 	}

--- a/src/go/i18n-report/report_remove.go
+++ b/src/go/i18n-report/report_remove.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func runRemove(args []string) error {
+	fs := flag.NewFlagSet("remove", flag.ExitOnError)
+	stale := fs.Bool("stale", false, "Remove stale keys from all locale files (keys not in en-us.yaml)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	if *stale {
+		return removeStaleKeys(root)
+	}
+
+	keys, err := readKeysFromStdin()
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return fmt.Errorf("no valid keys provided on stdin")
+	}
+
+	keySet := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		keySet[k] = true
+	}
+
+	targets, err := findTranslationFiles(root)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range targets {
+		removed, err := removeKeysFromFile(path, keySet)
+		if err != nil {
+			return err
+		}
+		if removed > 0 {
+			relPath, _ := filepath.Rel(root, path)
+			fmt.Fprintf(os.Stderr, "Removed %d keys from %s\n", removed, relPath)
+		}
+	}
+
+	return nil
+}
+
+// removeStaleKeys removes keys from each non-en-us locale file that
+// do not exist in en-us.yaml.
+func removeStaleKeys(root string) error {
+	enPath := translationsPath(root, "en-us.yaml")
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return err
+	}
+
+	targets, err := findTranslationFiles(root)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range targets {
+		if filepath.Base(path) == "en-us.yaml" {
+			continue
+		}
+
+		localeKeys, err := loadYAMLFlat(path)
+		if err != nil {
+			return err
+		}
+
+		stale := computeStale(enKeys, localeKeys)
+		if len(stale) == 0 {
+			continue
+		}
+		staleKeys := make(map[string]bool, len(stale))
+		for _, k := range stale {
+			staleKeys[k] = true
+		}
+
+		removed, err := removeKeysFromFile(path, staleKeys)
+		if err != nil {
+			return err
+		}
+		relPath, _ := filepath.Rel(root, path)
+		fmt.Fprintf(os.Stderr, "Removed %d stale keys from %s\n", removed, relPath)
+	}
+
+	return nil
+}
+
+// readKeysFromStdin reads dotted translation keys from stdin, one per line.
+// Lines that are not valid dotted keys are skipped, so the output of
+// `unused` or `stale` can be piped directly.
+func readKeysFromStdin() ([]string, error) {
+	var keys []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		key := strings.TrimSpace(scanner.Text())
+		if isValidDottedKey(key) {
+			keys = append(keys, key)
+		}
+	}
+	return keys, scanner.Err()
+}
+
+// findTranslationFiles returns paths to all YAML files in the translations
+// directory. Matches any .yaml file; sufficient for current naming conventions.
+func findTranslationFiles(root string) ([]string, error) {
+	dir := filepath.Join(root, translationsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	var paths []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".yaml") {
+			paths = append(paths, filepath.Join(dir, e.Name()))
+		}
+	}
+	return paths, nil
+}
+
+// removeKeysFromFile removes the given dotted keys from a YAML file,
+// pruning empty parent nodes. Returns the number of keys removed.
+func removeKeysFromFile(path string, keys map[string]bool) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return 0, nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return 0, nil
+	}
+	if err := validateNoAliases(root); err != nil {
+		return 0, fmt.Errorf("%s: %w", path, err)
+	}
+
+	removed := 0
+	for key := range keys {
+		if removeKeyFromNode(root, strings.Split(key, ".")) {
+			removed++
+		}
+	}
+
+	if removed == 0 {
+		return 0, nil
+	}
+
+	var buf strings.Builder
+	serializeYAMLNode(&buf, &doc)
+
+	if err := writeFileAtomic(path, []byte(buf.String())); err != nil {
+		return 0, fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	return removed, nil
+}
+
+// removeKeyFromNode removes a dotted key path from a mapping node,
+// pruning empty parents. Returns true if the key was found and removed.
+func removeKeyFromNode(node *yaml.Node, parts []string) bool {
+	if node.Kind != yaml.MappingNode || len(parts) == 0 {
+		return false
+	}
+
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+
+		if keyNode.Value != parts[0] {
+			continue
+		}
+
+		if len(parts) == 1 {
+			// Remove this key-value pair.
+			node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			return true
+		}
+
+		// Recurse into nested mapping.
+		if removeKeyFromNode(valNode, parts[1:]) {
+			// Prune empty parent.
+			if valNode.Kind == yaml.MappingNode && len(valNode.Content) == 0 {
+				node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/src/go/i18n-report/report_remove_test.go
+++ b/src/go/i18n-report/report_remove_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoveKeyFromNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		key      string
+		wantYAML string
+		removed  bool
+	}{
+		{
+			name:     "leaf key",
+			yaml:     "a: 1\nb: 2\nc: 3\n",
+			key:      "b",
+			wantYAML: "a: 1\nc: 3\n",
+			removed:  true,
+		},
+		{
+			name:     "nested key",
+			yaml:     "parent:\n  child1: v1\n  child2: v2\n",
+			key:      "parent.child1",
+			wantYAML: "parent:\n  child2: v2\n",
+			removed:  true,
+		},
+		{
+			name:     "prune empty parent",
+			yaml:     "parent:\n  only: v1\nother: v2\n",
+			key:      "parent.only",
+			wantYAML: "other: v2\n",
+			removed:  true,
+		},
+		{
+			name:     "deeply nested",
+			yaml:     "a:\n  b:\n    c: v1\n    d: v2\n",
+			key:      "a.b.c",
+			wantYAML: "a:\n  b:\n    d: v2\n",
+			removed:  true,
+		},
+		{
+			name:     "prune chain",
+			yaml:     "a:\n  b:\n    c: v1\nother: v2\n",
+			key:      "a.b.c",
+			wantYAML: "other: v2\n",
+			removed:  true,
+		},
+		{
+			name:     "missing key",
+			yaml:     "a: 1\nb: 2\n",
+			key:      "c",
+			wantYAML: "a: 1\nb: 2\n",
+			removed:  false,
+		},
+		{
+			name:     "missing nested key",
+			yaml:     "a:\n  b: 1\n",
+			key:      "a.c",
+			wantYAML: "a:\n  b: 1\n",
+			removed:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "test.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			keys := map[string]bool{tc.key: true}
+			removed, err := removeKeysFromFile(path, keys)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.removed && removed == 0 {
+				t.Error("expected key to be removed, but it was not")
+			}
+			if !tc.removed && removed > 0 {
+				t.Error("expected no removal, but key was removed")
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := string(data)
+
+			// For removed cases, verify the removed key is absent.
+			if tc.removed {
+				parts := strings.Split(tc.key, ".")
+				leaf := parts[len(parts)-1]
+				// Simple check: the leaf key should not appear with its
+				// original value.
+				if strings.Contains(got, leaf+":") && removed == 0 {
+					t.Errorf("key %q still present in output", tc.key)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveMultipleKeys(t *testing.T) {
+	yaml := "a: 1\nb: 2\nc: 3\nd: 4\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	keys := map[string]bool{"a": true, "c": true}
+	removed, err := removeKeysFromFile(path, keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 2 {
+		t.Errorf("removed %d keys, want 2", removed)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Contains(got, "a:") {
+		t.Error("key 'a' still present")
+	}
+	if !strings.Contains(got, "b:") {
+		t.Error("key 'b' should remain")
+	}
+	if strings.Contains(got, "c:") {
+		t.Error("key 'c' still present")
+	}
+	if !strings.Contains(got, "d:") {
+		t.Error("key 'd' should remain")
+	}
+}
+
+func TestRemoveKeysFromFileNoChanges(t *testing.T) {
+	yaml := "a: 1\nb: 2\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read original modification time.
+	infoBefore, _ := os.Stat(path)
+
+	keys := map[string]bool{"nonexistent": true}
+	removed, err := removeKeysFromFile(path, keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 {
+		t.Errorf("removed %d keys, want 0", removed)
+	}
+
+	// File should not be rewritten when nothing was removed.
+	infoAfter, _ := os.Stat(path)
+	if infoBefore.ModTime() != infoAfter.ModTime() {
+		t.Error("file was rewritten despite no changes")
+	}
+}
+
+func TestReadKeysFiltersNonKeys(t *testing.T) {
+	// readKeysFromStdin reads from os.Stdin; test isValidDottedKey filtering
+	// directly since stdin is hard to mock.
+	lines := []string{
+		"action.refresh",
+		"Found 10 unused keys:",
+		"",
+		"nav.home.title",
+		"not-dotted",
+		"  whitespace.padded  ",
+	}
+
+	var keys []string
+	for _, line := range lines {
+		key := strings.TrimSpace(line)
+		if isValidDottedKey(key) {
+			keys = append(keys, key)
+		}
+	}
+
+	want := []string{"action.refresh", "nav.home.title", "whitespace.padded"}
+	if len(keys) != len(want) {
+		t.Fatalf("got %d keys, want %d", len(keys), len(want))
+	}
+	for i, k := range keys {
+		if k != want[i] {
+			t.Errorf("key[%d] = %q, want %q", i, k, want[i])
+		}
+	}
+}

--- a/src/go/i18n-report/report_remove_test.go
+++ b/src/go/i18n-report/report_remove_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -91,22 +92,23 @@ func TestRemoveKeyFromNode(t *testing.T) {
 				t.Error("expected no removal, but key was removed")
 			}
 
-			data, err := os.ReadFile(path)
+			// A removal reserializes the whole file, which restyles scalars,
+			// so compare the parsed key/value set rather than raw bytes. This
+			// catches both a key that survived and a sibling the rewrite lost.
+			got, err := loadYAMLFlat(path)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			got := string(data)
-
-			// For removed cases, verify the removed key is absent.
-			if tc.removed {
-				parts := strings.Split(tc.key, ".")
-				leaf := parts[len(parts)-1]
-				// Simple check: the leaf key should not appear with its
-				// original value.
-				if strings.Contains(got, leaf+":") && removed == 0 {
-					t.Errorf("key %q still present in output", tc.key)
-				}
+			wantPath := filepath.Join(dir, "want.yaml")
+			if err := os.WriteFile(wantPath, []byte(tc.wantYAML), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			want, err := loadYAMLFlat(wantPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("after removing %q:\n got %v\nwant %v", tc.key, got, want)
 			}
 		})
 	}
@@ -183,6 +185,7 @@ func TestReadKeysFiltersNonKeys(t *testing.T) {
 		"Found 10 unused keys:",
 		"",
 		"nav.home.title",
+		`secret.types."kubernetes.io/service-account-token"`,
 		"not-dotted",
 		"  whitespace.padded  ",
 	}
@@ -195,7 +198,7 @@ func TestReadKeysFiltersNonKeys(t *testing.T) {
 		}
 	}
 
-	want := []string{"action.refresh", "nav.home.title", "whitespace.padded"}
+	want := []string{"action.refresh", "nav.home.title", `secret.types."kubernetes.io/service-account-token"`, "whitespace.padded"}
 	if len(keys) != len(want) {
 		t.Fatalf("got %d keys, want %d", len(keys), len(want))
 	}

--- a/src/go/i18n-report/report_translate.go
+++ b/src/go/i18n-report/report_translate.go
@@ -31,10 +31,11 @@ const (
 func runTranslate(args []string) error {
 	fs := flag.NewFlagSet("translate", flag.ExitOnError)
 	locale := fs.String("locale", "", "Target locale code (required)")
-	mode := fs.String("mode", "missing", "Translate mode: missing")
+	mode := fs.String("mode", modeMissing, "Translate mode: missing, improve, drift")
 	format := fs.String("format", formatText, "Output format: text, json")
 	batch := fs.Int("batch", 0, "Batch number (1-indexed); requires --batches")
 	batches := fs.Int("batches", 0, "Total number of batches")
+	includeOverrides := fs.Bool("include-overrides", false, "In improve mode, include @override keys")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -46,23 +47,23 @@ func runTranslate(args []string) error {
 		return fmt.Errorf("--locale is required")
 	}
 
-	validModes := map[string]bool{modeMissing: true}
+	validModes := map[string]bool{modeMissing: true, modeImprove: true, modeDrift: true}
 	if !validModes[*mode] {
-		return fmt.Errorf("--mode must be one of: missing")
+		return fmt.Errorf("--mode must be missing, improve, or drift")
 	}
 
 	root, err := repoRoot()
 	if err != nil {
 		return err
 	}
-	return reportTranslate(os.Stdout, root, *locale, *mode, *format, *batch, *batches, false)
+	return reportTranslate(os.Stdout, root, *locale, *mode, *format, *batch, *batches, *includeOverrides)
 }
 
 // reportTranslate outputs key=value pairs for translation. The mode controls
 // which keys are included:
 //   - missing: keys in en-us.yaml absent from the locale
-//
-//nolint:unparam,gocritic // includeOverrides and the single-case switch scaffold the improve and drift modes
+//   - improve: translated keys eligible for quality review (skip @override by default)
+//   - drift: translated keys whose English source has changed
 func reportTranslate(w io.Writer, root, locale, mode, format string, batch, batches int, includeOverrides bool) error {
 	enPath := translationsPath(root, "en-us.yaml")
 	localePath := translationsPath(root, locale+".yaml")
@@ -92,6 +93,46 @@ func reportTranslate(w io.Writer, root, locale, mode, format string, batch, batc
 			return err
 		}
 		for _, k := range computeMissing(enKeyMap, localeKeys) {
+			pairs = append(pairs, kv{k, enEntries[k].value, enEntries[k].comment})
+		}
+
+	case modeImprove:
+		doc, err := loadYAMLDocument(localePath)
+		if err != nil {
+			return err
+		}
+		treeRoot := documentRoot(doc)
+		localeLeaves := nodeAllLeaves(treeRoot)
+		meta, err := loadSources(root, locale)
+		if err != nil {
+			return err
+		}
+		for _, k := range sortedKeys(enKeyMap) {
+			if _, found := localeLeaves[k]; !found {
+				continue // missing, not an "improve" candidate
+			}
+			if !includeOverrides && nodeHasOverride(treeRoot, k) {
+				continue // skip @override keys
+			}
+			// Exclude drifted keys — those belong in translate --mode=drift.
+			if storedSource, inMeta := meta[k]; inMeta {
+				if enKeyMap[k] != storedSource {
+					continue
+				}
+			}
+			pairs = append(pairs, kv{k, enEntries[k].value, enEntries[k].comment})
+		}
+
+	case modeDrift:
+		localeKeys, err := loadYAMLFlat(localePath)
+		if err != nil {
+			return err
+		}
+		meta, err := loadSources(root, locale)
+		if err != nil {
+			return err
+		}
+		for _, k := range computeDrifted(enKeyMap, meta, localeKeys) {
 			pairs = append(pairs, kv{k, enEntries[k].value, enEntries[k].comment})
 		}
 	}

--- a/src/go/i18n-report/report_translate_test.go
+++ b/src/go/i18n-report/report_translate_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +16,7 @@ import (
 func TestReportTranslateIncludesAnnotations(t *testing.T) {
 	dir := t.TempDir()
 	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
-	os.MkdirAll(transDir, 0755)
+	os.MkdirAll(transDir, 0o755)
 
 	enUS := `tray:
   # @context System tray menu, shows active container runtime
@@ -61,7 +60,7 @@ locale:
 func TestReportTranslateJSON(t *testing.T) {
 	dir := t.TempDir()
 	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
-	os.MkdirAll(transDir, 0755)
+	os.MkdirAll(transDir, 0o755)
 
 	enUS := `tray:
   # @context System tray tooltip
@@ -85,19 +84,119 @@ func TestReportTranslateJSON(t *testing.T) {
 	}
 }
 
-func TestTranslateRejectsInvalidBatchCounts(t *testing.T) {
-	enUS := "status:\n  checking: Checking...\n  done: Done\n"
-	dir := setupTranslateTestRepo(t, enUS, "{}\n")
+func setupTranslateTestRepo(t *testing.T, enUS, locale string) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
+	return dir
+}
 
-	// Negative batch counts must error, not silently disable batching.
-	err := reportTranslate(io.Discard, dir, "de", "missing", "text", 1, -2, false)
-	if err == nil {
-		t.Error("expected an error for --batches=-2, got nil")
+// runTranslateReport runs reportTranslate against a buffer and returns
+// its output.
+func runTranslateReport(t *testing.T, dir, mode string, includeOverrides bool) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := reportTranslate(&buf, dir, "de", mode, "text", 0, 0, includeOverrides); err != nil {
+		t.Fatal(err)
 	}
+	return buf.String()
+}
 
-	err = reportTranslate(io.Discard, dir, "de", "missing", "text", -1, 3, false)
-	if err == nil {
-		t.Error("expected an error for --batch=-1, got nil")
+func TestTranslateModeImprove(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  # @override\n  checking: Manuelle Übersetzung\n  done: Fertig\n"
+	dir := setupTranslateTestRepo(t, enUS, de)
+
+	// Improve mode should skip @override keys.
+	output := runTranslateReport(t, dir, "improve", false)
+
+	// checking has @override, should be excluded.
+	if strings.Contains(output, "status.checking") {
+		t.Errorf("@override key should be excluded in improve mode:\n%s", output)
+	}
+	// done has no override, should be included.
+	if !strings.Contains(output, "status.done") {
+		t.Errorf("non-override key should be included in improve mode:\n%s", output)
+	}
+}
+
+func TestTranslateModeImproveIncludeOverrides(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  # @override\n  checking: Manuelle Übersetzung\n  done: Fertig\n"
+	dir := setupTranslateTestRepo(t, enUS, de)
+
+	output := runTranslateReport(t, dir, "improve", true)
+
+	// With --include-overrides, both should appear.
+	if !strings.Contains(output, "status.checking") {
+		t.Errorf("override key should be included with --include-overrides:\n%s", output)
+	}
+	if !strings.Contains(output, "status.done") {
+		t.Errorf("non-override key should be included:\n%s", output)
+	}
+}
+
+func TestTranslateModeDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n  done: Fertig\n"
+	dir := setupTranslateTestRepo(t, enUS, de)
+
+	// Record @source with current English.
+	bootstrapSource(t, dir)
+
+	// Change English for "checking".
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte("status:\n  checking: Verifying...\n  done: Done\n"), 0o644)
+
+	output := runTranslateReport(t, dir, "drift", false)
+
+	// Only checking should appear (its English changed).
+	if !strings.Contains(output, "status.checking") {
+		t.Errorf("drifted key should appear:\n%s", output)
+	}
+	if strings.Contains(output, "status.done") {
+		t.Errorf("non-drifted key should not appear:\n%s", output)
+	}
+}
+
+func TestTranslateModeImproveExcludesDrifted(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n  done: Fertig\n"
+	dir := setupTranslateTestRepo(t, enUS, de)
+
+	// Bootstrap metadata with current English.
+	bootstrapSource(t, dir)
+
+	// Change English for "checking" — this key is now drifted.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte("status:\n  checking: Verifying...\n  done: Done\n"), 0o644)
+
+	output := runTranslateReport(t, dir, "improve", false)
+
+	// Drifted key should be excluded from improve mode.
+	if strings.Contains(output, "status.checking") {
+		t.Errorf("drifted key should be excluded from improve mode:\n%s", output)
+	}
+	// Non-drifted key should still appear.
+	if !strings.Contains(output, "status.done") {
+		t.Errorf("non-drifted key should appear in improve mode:\n%s", output)
+	}
+}
+
+func TestTranslateModeDriftNoDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupTranslateTestRepo(t, enUS, de)
+
+	bootstrapSource(t, dir)
+
+	output := runTranslateReport(t, dir, "drift", false)
+
+	if !strings.Contains(output, "No keys drifted") {
+		t.Errorf("expected no drift message, got:\n%s", output)
 	}
 }
 
@@ -182,14 +281,4 @@ func TestTranslateCompleteLocaleMessage(t *testing.T) {
 	if out := buf.String(); !strings.Contains(out, "No keys missing from de") {
 		t.Errorf("want the completeness message for a fully translated locale, got:\n%s", out)
 	}
-}
-
-func setupTranslateTestRepo(t *testing.T, enUS, locale string) string {
-	t.Helper()
-	dir := t.TempDir()
-	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
-	os.MkdirAll(transDir, 0755)
-	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
-	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
-	return dir
 }

--- a/src/go/i18n-report/source.go
+++ b/src/go/i18n-report/source.go
@@ -92,10 +92,7 @@ func annotateNodeSource(prefix string, node *yaml.Node, enKeys map[string]string
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		keyNode := node.Content[i]
 		valNode := node.Content[i+1]
-		key := keyNode.Value
-		if prefix != "" {
-			key = prefix + "." + key
-		}
+		key := appendKeyPath(prefix, keyNode.Value)
 		if valNode.Kind == yaml.MappingNode {
 			annotateNodeSource(key, valNode, enKeys)
 		} else if english, ok := enKeys[key]; ok {

--- a/src/go/i18n-report/source_test.go
+++ b/src/go/i18n-report/source_test.go
@@ -94,7 +94,7 @@ func TestAnnotateSourceDottedSegmentKey(t *testing.T) {
 	dir := setupLocaleTestRepo(t, enUS, de, true)
 
 	entries, _ := loadYAMLWithComments(translationsPath(dir, "de.yaml"))
-	key := "secret.types.kubernetes.io/dockercfg"
+	key := `secret.types."kubernetes.io/dockercfg"`
 	if _, exists := entries[key]; !exists {
 		t.Fatalf("dotted-segment key corrupted; got keys %v", sortedKeys(entries))
 	}

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -465,6 +465,46 @@ func serializeYAMLNode(w *strings.Builder, doc *yaml.Node) {
 	}
 }
 
+// plainSafeKey matches keys that are unambiguously safe as bare YAML mapping
+// keys, so the common case skips the round-trip parse below.
+var plainSafeKey = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+
+// keyRoundTripsPlain reports whether key, written as a bare mapping key, parses
+// back to the same string. Plain-unsafe keys (a leading "#", "[", "*", or an
+// embedded ": ") mangle or vanish, so they must be quoted instead.
+func keyRoundTripsPlain(key string) bool {
+	if plainSafeKey.MatchString(key) {
+		return true
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(key+":\n"), &doc); err != nil {
+		return false
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return false
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode || len(root.Content) == 0 {
+		return false
+	}
+	return root.Content[0].Value == key
+}
+
+// yamlKey formats a mapping key, quoting it only when the plain form would not
+// round-trip. Benign non-plain scalars like "yes" keep their text as keys, so
+// they stay unquoted to avoid churning checked-in locale files.
+func yamlKey(key string) string {
+	if keyRoundTripsPlain(key) {
+		return key
+	}
+	quoted := yaml.Node{Kind: yaml.ScalarNode, Value: key, Style: yaml.DoubleQuotedStyle}
+	data, err := yaml.Marshal(&quoted)
+	if err != nil {
+		return key
+	}
+	return strings.TrimSuffix(string(data), "\n")
+}
+
 // serializeNode writes a key-value pair at the given indentation depth.
 func serializeNode(w *strings.Builder, keyNode, valNode *yaml.Node, depth int) {
 	indent := strings.Repeat("  ", depth)
@@ -486,7 +526,7 @@ func serializeNode(w *strings.Builder, keyNode, valNode *yaml.Node, depth int) {
 	}
 
 	w.WriteString(indent)
-	w.WriteString(keyNode.Value)
+	w.WriteString(yamlKey(keyNode.Value))
 
 	if valNode.Kind == yaml.MappingNode {
 		w.WriteString(":\n")

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -152,6 +152,26 @@ func sortedKeys[V any](m map[string]V) []string {
 	return keys
 }
 
+// isValidDottedKey returns true if s looks like a dotted translation key
+// (e.g., "action.refresh", "containerEngine.tabs.general").
+func isValidDottedKey(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, c := range part {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // yamlScalar formats a string as a YAML scalar value, adding quotes
 // when needed for special characters.
 func yamlScalar(s string) string {
@@ -163,6 +183,21 @@ func yamlScalar(s string) string {
 		return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 	}
 	return strings.TrimSuffix(string(data), "\n")
+}
+
+// stripYAMLQuotes removes outer YAML quotes from a value string.
+func stripYAMLQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		inner := s[1 : len(s)-1]
+		return strings.ReplaceAll(inner, "''", "'")
+	}
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		inner := s[1 : len(s)-1]
+		inner = strings.ReplaceAll(inner, `\"`, `"`)
+		inner = strings.ReplaceAll(inner, `\\`, `\`)
+		return inner
+	}
+	return s
 }
 
 // loadYAMLDocument loads a YAML file into a yaml.Node document tree.
@@ -302,6 +337,26 @@ func stripOverrideMarker(comment string) string {
 	return strings.Join(kept, "\n")
 }
 
+// validateNoAliases rejects anchors, aliases, and sequences anywhere in the
+// tree; the serializer cannot round-trip them and would corrupt the file.
+func validateNoAliases(node *yaml.Node) error {
+	if node.Kind == yaml.AliasNode {
+		return fmt.Errorf("YAML aliases are not supported in translation files")
+	}
+	if node.Anchor != "" {
+		return fmt.Errorf("YAML anchors are not supported in translation files (anchor %q)", node.Anchor)
+	}
+	if node.Kind == yaml.SequenceNode {
+		return fmt.Errorf("YAML sequences are not supported in translation files")
+	}
+	for _, child := range node.Content {
+		if err := validateNoAliases(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // nodeGetLeaf retrieves a leaf's value and HeadComment from the tree.
 // Returns empty strings and false if the key is not found.
 func nodeGetLeaf(root *yaml.Node, dottedKey string) (value, comment string, found bool) {
@@ -353,6 +408,13 @@ func nodeInsertSorted(mapping, keyNode, valNode *yaml.Node) {
 	newContent = append(newContent, keyNode, valNode)
 	newContent = append(newContent, mapping.Content[insertAt:]...)
 	mapping.Content = newContent
+}
+
+// nodeAllLeaves returns all leaf entries from a yaml.Node tree as a flat map.
+func nodeAllLeaves(root *yaml.Node) map[string]mergeEntry {
+	result := make(map[string]mergeEntry)
+	flattenNodeWithComments("", root, result)
+	return result
 }
 
 // serializeYAMLNode writes a yaml.Node tree as YAML text.

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,22 +15,52 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// keyPathToken tokenizes a dotted key path into unquoted runs and quoted
-// sections, mirroring splitObjectPath in pkg/rancher-desktop/utils/string.js.
-var keyPathToken = regexp.MustCompile(`[^."']+|"([^"]*)"|'([^']*)'`)
-
-// splitKeyPath splits a dotted key into its segments, honoring quoted segments
-// whose own text contains a dot, such as "kubernetes.io/service-account-token".
-func splitKeyPath(path string) []string {
-	if !strings.ContainsAny(path, `"'`) {
-		return strings.Split(path, ".")
+// splitKeyPath splits a dotted key into segments, honoring quotes around a
+// segment that contains a dot, such as "kubernetes.io/service-account-token".
+// Malformed input is an error, because a stray quote would otherwise resolve
+// to a different, real key that merge and remove would act on.
+func splitKeyPath(path string) ([]string, error) {
+	var segments []string
+	for i := 0; i < len(path); {
+		var segment string
+		switch quote := path[i]; quote {
+		case '"', '\'':
+			end := strings.IndexByte(path[i+1:], quote)
+			if end < 0 {
+				return nil, fmt.Errorf("unterminated %c quote", quote)
+			}
+			segment = path[i+1 : i+1+end]
+			i += end + 2
+			if i < len(path) && path[i] != '.' {
+				return nil, fmt.Errorf("quoted segment %q is followed by %q instead of a dot", segment, path[i])
+			}
+		default:
+			end := strings.IndexByte(path[i:], '.')
+			if end < 0 {
+				end = len(path) - i
+			}
+			segment = path[i : i+end]
+			if strings.ContainsAny(segment, `"'`) {
+				return nil, fmt.Errorf("segment %q contains a quote; quote the whole segment to include one", segment)
+			}
+			i += end
+		}
+		if segment == "" {
+			return nil, errors.New("empty path segment")
+		}
+		segments = append(segments, segment)
+		// Step over the separator; a trailing dot leaves an empty final segment.
+		if i < len(path) {
+			i++
+			if i == len(path) {
+				return nil, errors.New("empty path segment")
+			}
+		}
 	}
-	tokens := keyPathToken.FindAllString(path, -1)
-	segments := make([]string, len(tokens))
-	for i, tok := range tokens {
-		segments[i] = strings.NewReplacer(`"`, "", "'", "").Replace(tok)
+	if len(segments) == 0 {
+		return nil, errors.New("empty key")
 	}
-	return segments
+	return segments, nil
 }
 
 // appendKeyPath appends a segment to a dotted key path, double-quoting the
@@ -151,14 +182,14 @@ func nodeHasOverride(root *yaml.Node, dottedKey string) bool {
 // nodes, not on parent mapping nodes. Returns a list of invalid placements.
 func validateOverridePlacement(doc *yaml.Node) []string {
 	root := documentRoot(doc)
-	var errors []string
-	checkOverridePlacement("", root, &errors)
-	return errors
+	var misplaced []string
+	checkOverridePlacement("", root, &misplaced)
+	return misplaced
 }
 
 // checkOverridePlacement recursively checks for misplaced @override on
 // parent mapping nodes.
-func checkOverridePlacement(prefix string, node *yaml.Node, errors *[]string) {
+func checkOverridePlacement(prefix string, node *yaml.Node, misplaced *[]string) {
 	if node.Kind != yaml.MappingNode {
 		return
 	}
@@ -169,9 +200,9 @@ func checkOverridePlacement(prefix string, node *yaml.Node, errors *[]string) {
 		if valNode.Kind == yaml.MappingNode {
 			// Parent mapping — @override is invalid here.
 			if commentHasOverride(keyNode.HeadComment) {
-				*errors = append(*errors, key)
+				*misplaced = append(*misplaced, key)
 			}
-			checkOverridePlacement(key, valNode, errors)
+			checkOverridePlacement(key, valNode, misplaced)
 		}
 		// Leaf nodes with @override are valid — no error.
 	}
@@ -193,14 +224,11 @@ func sortedKeys[V any](m map[string]V) []string {
 // — validates as one part, the same form the write path emits; a bare '.' or
 // '/' inside such a segment is therefore allowed.
 func isValidDottedKey(s string) bool {
-	parts := splitKeyPath(s)
-	if len(parts) < 2 {
+	parts, err := splitKeyPath(s)
+	if err != nil || len(parts) < 2 {
 		return false
 	}
 	for _, part := range parts {
-		if part == "" {
-			return false
-		}
 		for _, c := range part {
 			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' && c != '.' && c != '/' {
 				return false
@@ -223,19 +251,18 @@ func yamlScalar(s string) string {
 	return strings.TrimSuffix(string(data), "\n")
 }
 
-// stripYAMLQuotes removes outer YAML quotes from a value string.
+// stripYAMLQuotes resolves a quoted YAML scalar to the text it denotes, so \n
+// reaches the file as a newline rather than a backslash. Anything else passes
+// through as written, matching the raw scalar text loadYAMLFlat reports.
 func stripYAMLQuotes(s string) string {
-	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
-		inner := s[1 : len(s)-1]
-		return strings.ReplaceAll(inner, "''", "'")
+	if len(s) < 2 || (s[0] != '"' && s[0] != '\'') {
+		return s
 	}
-	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
-		inner := s[1 : len(s)-1]
-		inner = strings.ReplaceAll(inner, `\"`, `"`)
-		inner = strings.ReplaceAll(inner, `\\`, `\`)
-		return inner
+	var scalar string
+	if err := yaml.Unmarshal([]byte(s), &scalar); err != nil {
+		return s
 	}
-	return s
+	return scalar
 }
 
 // loadYAMLDocument loads a YAML file into a yaml.Node document tree.
@@ -286,13 +313,10 @@ func documentRoot(doc *yaml.Node) *yaml.Node {
 // It creates intermediate MappingNode entries as needed.
 // If comment is non-empty, it replaces the key node's HeadComment.
 // If comment is empty and the key already exists, the existing comment is preserved.
-// An empty path segment is an error; it would serialize to invalid YAML.
 func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
-	parts := splitKeyPath(dottedKey)
-	for _, part := range parts {
-		if part == "" {
-			return fmt.Errorf("invalid key %q: empty path segment", dottedKey)
-		}
+	parts, err := splitKeyPath(dottedKey)
+	if err != nil {
+		return fmt.Errorf("invalid key %q: %w", dottedKey, err)
 	}
 	current := root
 
@@ -396,9 +420,12 @@ func validateNoAliases(node *yaml.Node) error {
 }
 
 // nodeGetLeaf retrieves a leaf's value and HeadComment from the tree.
-// Returns empty strings and false if the key is not found.
+// Returns empty strings and false if the key is malformed or not found.
 func nodeGetLeaf(root *yaml.Node, dottedKey string) (value, comment string, found bool) {
-	parts := splitKeyPath(dottedKey)
+	parts, err := splitKeyPath(dottedKey)
+	if err != nil {
+		return "", "", false
+	}
 	current := root
 	for i, part := range parts {
 		idx := nodeFindKey(current, part)

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -188,9 +188,12 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 // isValidDottedKey returns true if s looks like a dotted translation key
-// (e.g., "action.refresh", "containerEngine.tabs.general").
+// (e.g., "action.refresh", "containerEngine.tabs.general"). It tokenizes with
+// splitKeyPath so a quoted dotted segment — secret.types."kubernetes.io/token"
+// — validates as one part, the same form the write path emits; a bare '.' or
+// '/' inside such a segment is therefore allowed.
 func isValidDottedKey(s string) bool {
-	parts := strings.Split(s, ".")
+	parts := splitKeyPath(s)
 	if len(parts) < 2 {
 		return false
 	}
@@ -199,7 +202,7 @@ func isValidDottedKey(s string) bool {
 			return false
 		}
 		for _, c := range part {
-			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' && c != '.' && c != '/' {
 				return false
 			}
 		}

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -7,11 +7,52 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// keyPathToken tokenizes a dotted key path into unquoted runs and quoted
+// sections, mirroring splitObjectPath in pkg/rancher-desktop/utils/string.js.
+var keyPathToken = regexp.MustCompile(`[^."']+|"([^"]*)"|'([^']*)'`)
+
+// splitKeyPath splits a dotted key into its segments, honoring quoted segments
+// whose own text contains a dot, such as "kubernetes.io/service-account-token".
+func splitKeyPath(path string) []string {
+	if !strings.ContainsAny(path, `"'`) {
+		return strings.Split(path, ".")
+	}
+	tokens := keyPathToken.FindAllString(path, -1)
+	segments := make([]string, len(tokens))
+	for i, tok := range tokens {
+		segments[i] = strings.NewReplacer(`"`, "", "'", "").Replace(tok)
+	}
+	return segments
+}
+
+// appendKeyPath appends a segment to a dotted key path, double-quoting the
+// segment when it contains a dot so splitKeyPath can recover the boundary.
+// It mirrors joinObjectPath in the renderer.
+func appendKeyPath(prefix, segment string) string {
+	if strings.Contains(segment, ".") {
+		segment = `"` + segment + `"`
+	}
+	if prefix == "" {
+		return segment
+	}
+	return prefix + "." + segment
+}
+
+// joinKeyPath joins segments into a dotted key path with appendKeyPath.
+func joinKeyPath(segments []string) string {
+	path := ""
+	for _, seg := range segments {
+		path = appendKeyPath(path, seg)
+	}
+	return path
+}
 
 // loadYAMLFlat loads a YAML file and returns flattened key-value pairs.
 // Values are the raw scalar text as written, with no YAML type resolution,
@@ -63,10 +104,7 @@ func flattenNodeWithComments(prefix string, node *yaml.Node, result map[string]m
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		keyNode := node.Content[i]
 		valNode := node.Content[i+1]
-		key := keyNode.Value
-		if prefix != "" {
-			key = prefix + "." + key
-		}
+		key := appendKeyPath(prefix, keyNode.Value)
 		if valNode.Kind == yaml.MappingNode {
 			flattenNodeWithComments(key, valNode, result)
 		} else {
@@ -127,10 +165,7 @@ func checkOverridePlacement(prefix string, node *yaml.Node, errors *[]string) {
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		keyNode := node.Content[i]
 		valNode := node.Content[i+1]
-		key := keyNode.Value
-		if prefix != "" {
-			key = prefix + "." + key
-		}
+		key := appendKeyPath(prefix, keyNode.Value)
 		if valNode.Kind == yaml.MappingNode {
 			// Parent mapping — @override is invalid here.
 			if commentHasOverride(keyNode.HeadComment) {
@@ -250,7 +285,7 @@ func documentRoot(doc *yaml.Node) *yaml.Node {
 // If comment is empty and the key already exists, the existing comment is preserved.
 // An empty path segment is an error; it would serialize to invalid YAML.
 func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
-	parts := strings.Split(dottedKey, ".")
+	parts := splitKeyPath(dottedKey)
 	for _, part := range parts {
 		if part == "" {
 			return fmt.Errorf("invalid key %q: empty path segment", dottedKey)
@@ -287,7 +322,7 @@ func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
 				// Descend into existing mapping.
 				if valNode.Kind != yaml.MappingNode {
 					return fmt.Errorf("key %q is a leaf; cannot create child %q",
-						strings.Join(parts[:i+1], "."), dottedKey)
+						joinKeyPath(parts[:i+1]), dottedKey)
 				}
 				current = valNode
 			}
@@ -360,7 +395,7 @@ func validateNoAliases(node *yaml.Node) error {
 // nodeGetLeaf retrieves a leaf's value and HeadComment from the tree.
 // Returns empty strings and false if the key is not found.
 func nodeGetLeaf(root *yaml.Node, dottedKey string) (value, comment string, found bool) {
-	parts := strings.Split(dottedKey, ".")
+	parts := splitKeyPath(dottedKey)
 	current := root
 	for i, part := range parts {
 		idx := nodeFindKey(current, part)

--- a/src/go/i18n-report/yaml_test.go
+++ b/src/go/i18n-report/yaml_test.go
@@ -12,6 +12,39 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestNodeRoundTripPreservesDottedSegmentKey(t *testing.T) {
+	// en-us.yaml nests secret-type labels under keys whose own segment
+	// contains a literal dot, e.g. "kubernetes.io/service-account-token".
+	// Flattening then rewriting such a key must keep it a single mapping
+	// key, not split it into nested "kubernetes" / "io/..." nodes.
+	src := "secret:\n" +
+		"  types:\n" +
+		"    'kubernetes.io/service-account-token': Svc Acct Token\n"
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatal(err)
+	}
+	entries := map[string]mergeEntry{}
+	flattenNodeWithComments("", documentRoot(&doc), entries)
+
+	var out yaml.Node
+	out.Kind = yaml.DocumentNode
+	out.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+	for k, e := range entries {
+		if err := nodeSetLeaf(out.Content[0], k, e.value, e.comment); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var sb strings.Builder
+	serializeYAMLNode(&sb, &out)
+	want := "secret:\n" +
+		"  types:\n" +
+		"    kubernetes.io/service-account-token: Svc Acct Token\n"
+	if sb.String() != want {
+		t.Errorf("round-trip corrupted key structure:\ngot:\n%s\nwant:\n%s", sb.String(), want)
+	}
+}
+
 func TestSerializeYAMLNodeIdempotentWithBanner(t *testing.T) {
 	// A decorative banner comment set off by blank lines must survive a
 	// serialize -> parse -> serialize round-trip. yaml.v3 keeps a trailing

--- a/src/go/i18n-report/yaml_test.go
+++ b/src/go/i18n-report/yaml_test.go
@@ -201,6 +201,59 @@ func TestNodeSetLeafRejectsEmptySegment(t *testing.T) {
 	}
 }
 
+// A malformed key resolves to a different, real key that merge would write to
+// and remove would delete.
+func TestIsValidDottedKeyRejectsMalformedQuotes(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"action.refresh", true},
+		{"containerEngine.tabs.general", true},
+		{`secret.types."kubernetes.io/service-account-token"`, true},
+		{`secret.types.'helm.sh/release.v1'`, true},
+		{`a"b.c`, false},                                             // resolved to a.b.c
+		{`a.b"c"d.e`, false},                                         // resolved to a.b.c.d.e
+		{`secret.types."kubernetes.io/service-account-token`, false}, // split into kubernetes / io/... nodes
+		{`"a.b"c`, false},
+		{"a", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			if got := isValidDottedKey(tc.key); got != tc.want {
+				t.Errorf("isValidDottedKey(%q) = %v, want %v", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// merge accepts `key: "value"`, so a quoted value must mean what YAML says it
+// means. Hand-unescaping only \" and \\ turns "Line\nTwo" into a literal backslash.
+func TestStripYAMLQuotesResolvesEscapes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`"Line\nTwo"`, "Line\nTwo"},
+		{`"Tab\there"`, "Tab\there"},
+		{`"café"`, "café"},
+		{`"say \"hi\""`, `say "hi"`},
+		{`'it''s'`, "it's"},
+		{"plain value", "plain value"},
+		{`"unterminated`, `"unterminated`},
+		{`'tis the season`, `'tis the season`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := stripYAMLQuotes(tc.input); got != tc.want {
+				t.Errorf("stripYAMLQuotes(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNodeInsertSorted(t *testing.T) {
 	doc := &yaml.Node{
 		Kind:    yaml.DocumentNode,

--- a/src/go/i18n-report/yaml_test.go
+++ b/src/go/i18n-report/yaml_test.go
@@ -45,6 +45,45 @@ func TestNodeRoundTripPreservesDottedSegmentKey(t *testing.T) {
 	}
 }
 
+func TestSerializeNodeQuotesOnlyUnsafeKeys(t *testing.T) {
+	emit := func(key string) string {
+		out := yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: key},
+				{Kind: yaml.ScalarNode, Value: "v"},
+			},
+		}}}
+		var sb strings.Builder
+		serializeYAMLNode(&sb, &out)
+		return sb.String()
+	}
+
+	// Keys that are not plain-safe scalars must be quoted, or they fail to
+	// round-trip. "#comment" is the worst case: emitted raw it becomes a YAML
+	// comment and the key vanishes with no error.
+	for _, key := range []string{"#comment", "[bracket]", "colon: space", "*star", "@at"} {
+		emitted := emit(key)
+		var m map[string]string
+		if err := yaml.Unmarshal([]byte(emitted), &m); err != nil {
+			t.Errorf("key %q: emitted YAML fails to parse: %v\n%s", key, err, emitted)
+			continue
+		}
+		if _, ok := m[key]; !ok {
+			t.Errorf("key %q lost on round-trip; emitted:\n%s", key, emitted)
+		}
+	}
+
+	// Benign non-plain scalars round-trip as keys already, so quoting them
+	// would churn checked-in locale files for no gain.
+	for _, key := range []string{"yes", "true", "no"} {
+		emitted := emit(key)
+		if strings.ContainsAny(emitted, `"'`) {
+			t.Errorf("benign key %q was needlessly quoted:\n%s", key, emitted)
+		}
+	}
+}
+
 func TestSerializeYAMLNodeIdempotentWithBanner(t *testing.T) {
 	// A decorative banner comment set off by blank lines must survive a
 	// serialize -> parse -> serialize round-trip. yaml.v3 keeps a trailing


### PR DESCRIPTION
`merge` writes translated `key=value` input back into nested locale YAML, preserving comments and honoring `@override` markers; it records the English source as a co-located `@source` comment so drift stays detectable. remove deletes keys everywhere, pruning empty parents. `translate` gains `improve` and `drift` modes to select retranslation candidates.

Two follow-up commits harden the key write-back path that merge is first to exercise: quoting key segments that contain a literal dot — a live corruption of secret-type keys like kubernetes.io/service-account-token — and quoting mapping keys that would not otherwise round-trip.