### PR TITLE
update: drive the updater through a simulated upgrade

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -94,6 +94,7 @@ certutil
 cgroupfs
 chartjs
 checkpath
+checkupgrade
 chirico
 cidata
 cidfile

--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -166,7 +166,7 @@ check_directories() {
         # TODO on macOS (not implemented by `rdctl factory-reset`)
         # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
         # this one only exists after an update has been downloaded
-        # ~/Library/Application Support/Caches/rancher-desktop-updater
+        # ~/Library/Caches/rancher-desktop-updater
     fi
 
     if is_windows; then

--- a/bats/tests/containers/reset.bats
+++ b/bats/tests/containers/reset.bats
@@ -215,7 +215,7 @@ check_directories() {
         # TODO on macOS (not implemented by `rdctl factory-reset`)
         # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
         # this one only exists after an update has been downloaded
-        # ~/Library/Application Support/Caches/rancher-desktop-updater
+        # ~/Library/Caches/rancher-desktop-updater
     fi
 
     if is_windows; then

--- a/bats/tests/helpers/vm.bash
+++ b/bats/tests/helpers/vm.bash
@@ -142,7 +142,19 @@ factory_reset() {
         clear_iptables_chain "KUBE"
     fi
     rdctl reset --factory "$@"
+    delete_pending_update
     setup_ramdisk
+}
+
+# An update that finished downloading is staged, and the next launch installs
+# it, so a leak lands in whichever test runs next. electron-updater names the
+# staging directory after the build: a `-updater` sibling of the cache when
+# packaged, the cache itself in dev mode, and the app home on Windows. Factory
+# reset removes only the Windows one.
+delete_pending_update() {
+    rm -rf "$PATH_CACHE/updater-longhorn.json" "$PATH_CACHE/pending" \
+        "$PATH_CACHE/update.zip" "$PATH_CACHE/current.blockmap" \
+        "${PATH_CACHE}-updater" "$PATH_APP_HOME/pending"
 }
 
 # Turn `rdctl start` arguments into `yarn dev` arguments

--- a/bats/tests/updater/update-server.mjs
+++ b/bats/tests/updater/update-server.mjs
@@ -1,0 +1,109 @@
+/**
+ * A stand-in for the Upgrade Responder and the GitHub releases API, so that an
+ * upgrade can be driven end-to-end without publishing a release or downloading
+ * hundreds of megabytes.
+ *
+ * The updater only checks the size and the checksum of the asset it fetches, so
+ * the "installer" this serves is a handful of bytes. Nothing installs it: the
+ * test asserts that the download completed, which is as far as the updater gets
+ * before the user restarts the application.
+ *
+ * Usage: node update-server.mjs <url-file> [<trace-file>]
+ * Prints nothing; writes its base URL to <url-file> once it is listening, and
+ * appends one line per request to <trace-file>, which records how far the
+ * updater got when an assertion fails without one.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+
+/** Higher than any real release, so the running version always wants it. */
+const version = '9.9.9';
+const tag = `v${ version }`;
+
+/**
+ * The updater picks the asset for the platform it runs on. This names the asset
+ * from the architecture of the node running the server, so an x64 node on an
+ * arm64 host offers one the application will not accept.
+ */
+function assetName() {
+  switch (process.platform) {
+  case 'darwin':
+    return `Rancher.Desktop-${ version }-mac.${ process.arch === 'arm64' ? 'aarch64' : 'x86_64' }.zip`;
+  case 'linux':
+    return `rancher-desktop-linux-${ version }.AppImage`;
+  case 'win32':
+    return `Rancher.Desktop.Setup.${ version }.msi`;
+  }
+  throw new Error(`No asset name for platform ${ process.platform }`);
+}
+
+const name = assetName();
+const asset = Buffer.from('Rancher Desktop simulated upgrade');
+const checksum = `${ crypto.createHash('sha512').update(asset).digest('hex') }  ${ name }\n`;
+
+function send(response, status, body, type = 'application/json') {
+  response.writeHead(status, { 'content-type': type, 'content-length': Buffer.byteLength(body) });
+  response.end(body);
+}
+
+const traceFile = process.argv[3];
+
+const server = http.createServer((request, response) => {
+  const base = `http://${ request.headers.host }`;
+  const { pathname } = new URL(request.url, base);
+
+  if (traceFile) {
+    fs.appendFileSync(traceFile, `${ request.method } ${ pathname }\n`);
+  }
+
+  // Drain the body of the Upgrade Responder's POST; we answer the same either way.
+  request.resume();
+
+  if (pathname.endsWith('/checkupgrade')) {
+    return send(response, 200, JSON.stringify({
+      versions:                 [{ Name: version, ReleaseDate: '2038-01-01T00:00:00Z', Supported: true, Tags: ['latest'] }],
+      requestIntervalInMinutes: 60,
+    }));
+  }
+
+  // Answer for whatever owner/repo the update config names.
+  if (pathname.endsWith(`/releases/tags/${ tag }`)) {
+    return send(response, 200, JSON.stringify({
+      url:          `${ base }/releases/1`,
+      id:           1,
+      tag_name:     tag,
+      name:         `Rancher Desktop ${ version }`,
+      body:         'Simulated release.',
+      draft:        false,
+      prerelease:   false,
+      published_at: '2038-01-01T00:00:00Z',
+      assets:       [
+        {
+          url: '', browser_download_url: `${ base }/assets/${ name }`, id: 1, name, label: '', size: asset.length,
+        },
+        {
+          url: '', browser_download_url: `${ base }/assets/${ name }.sha512sum`, id: 2, name: `${ name }.sha512sum`, label: '', size: Buffer.byteLength(checksum),
+        },
+      ],
+    }));
+  }
+
+  if (pathname === `/assets/${ name }`) {
+    return send(response, 200, asset, 'application/octet-stream');
+  }
+  if (pathname === `/assets/${ name }.sha512sum`) {
+    return send(response, 200, checksum, 'text/plain');
+  }
+
+  // electron-updater probes for a differential-download block map; saying no
+  // makes it fall back to fetching the whole asset.
+  send(response, 404, JSON.stringify({ message: `No such path ${ pathname }` }));
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address();
+
+  fs.writeFileSync(process.argv[2], `http://127.0.0.1:${ port }`);
+});

--- a/bats/tests/updater/upgrade.bats
+++ b/bats/tests/updater/upgrade.bats
@@ -1,0 +1,102 @@
+load '../helpers/load'
+
+# Drive the updater through a whole upgrade against a local stand-in for the
+# Upgrade Responder and the GitHub releases API.
+#
+# The main process bundles its own copy of electron-updater, so a packaging
+# mistake can leave the updater unable to fetch anything at all while every
+# other test still passes. Nothing here installs the update; the test follows
+# the updater as far as it gets on its own, which is a verified download.
+
+local_setup_file() {
+    # Assign before skipping: teardown still runs for a skipped file, and would
+    # trip over the unset variables under `set -o nounset`.
+    export UPDATE_SERVER_SCRIPT="$BATS_TEST_DIRNAME/update-server.mjs"
+    export UPDATE_SERVER_URL_FILE="$BATS_FILE_TMPDIR/update-server-url"
+    export UPDATE_SERVER_PID_FILE="$BATS_FILE_TMPDIR/update-server-pid"
+    export UPDATE_LOG="$PATH_LOGS/update.log"
+    # Beside the updater's own log, so log capture collects the request trace.
+    # Not a `.log`: the application deletes every log file it does not own.
+    export UPDATE_SERVER_LOG="$PATH_LOGS/update-server.txt"
+
+    if is_linux; then
+        skip 'the updater only downloads on Linux when the app runs from an AppImage'
+    fi
+    # bats runs inside WSL, where the server would offer the app a Linux asset,
+    # and exported variables never reach a Win32 process.
+    skip_on_windows 'the update server cannot serve the Win32 app from inside WSL'
+}
+
+# The next test file would factory reset anyway, but only this one downloads a
+# release that must never be installed, so it takes the update back out here too.
+local_teardown_file() {
+    if [ -s "$UPDATE_SERVER_PID_FILE" ]; then
+        kill "$(cat "$UPDATE_SERVER_PID_FILE")" || true
+    fi
+    delete_pending_update
+}
+
+assert_update_server_ready() {
+    run -0 cat "$UPDATE_SERVER_URL_FILE"
+    assert_output --partial 'http://127.0.0.1:'
+}
+
+# The updater logs every step it takes, so the log is the record of what it did.
+assert_update_log_contains() { # <pattern>
+    run -0 cat "$UPDATE_LOG"
+    assert_output --partial "$1"
+}
+
+@test 'factory reset' {
+    factory_reset
+    rm -f "$UPDATE_SERVER_URL_FILE" "$UPDATE_LOG" "$UPDATE_SERVER_LOG"
+}
+
+@test 'start the update server' {
+    node "$UPDATE_SERVER_SCRIPT" "$UPDATE_SERVER_URL_FILE" "$UPDATE_SERVER_LOG" &
+    echo "$!" >"$UPDATE_SERVER_PID_FILE"
+    try assert_update_server_ready
+}
+
+@test 'launch the application with updates enabled' {
+    run -0 cat "$UPDATE_SERVER_URL_FILE"
+    url=${output}
+
+    # The update config that ships with the application names the owner and repo;
+    # the update server answers for whichever ones it names.
+    export RD_FORCE_UPDATES_ENABLED=1
+    export RD_UPGRADE_RESPONDER_URL="${url}/v1/checkupgrade"
+    export RD_GITHUB_API_URL="${url}"
+
+    # The updater runs before the backend starts, so this never needs Kubernetes.
+    launch_the_application --application.debug --kubernetes.enabled=false
+}
+
+@test 'the updater offers the simulated release' {
+    # Confirm the updater ran at all before asserting what it found, so a failed
+    # launch reports as one instead of as a missing version.
+    try --max 36 --delay 5 assert_update_log_contains 'Checking for update'
+    try assert_update_log_contains 'Found version v9.9.9'
+}
+
+@test 'the updater downloads the release' {
+    # A bundling mistake breaks exactly here: the download throws before it
+    # transfers a byte, so the update is never offered for install.
+    try assert_update_log_contains 'New version v9.9.9 has been downloaded'
+    # macOS then hands the stub to Squirrel, which rejects it. That error in
+    # update.log is expected, and installs nothing.
+}
+
+@test 'the updater resolved its bundled dependencies' {
+    # `(0 , o.readFile) is not a function`: electron-updater got bundled into the
+    # main process, and its own imports lost the exports Node cannot see.
+    run -0 cat "$UPDATE_LOG"
+    # An empty log would refute the substring without the updater having run at
+    # all, so make sure it did.
+    assert_output --partial 'Checking for update'
+    refute_output --partial 'o.readFile) is not a function'
+}
+
+@test 'shut down' {
+    rdctl shutdown
+}

--- a/docs/development/env.md
+++ b/docs/development/env.md
@@ -12,10 +12,20 @@ Forces debug logging to always be enabled. Useful to debug first-run issues when
 
 When set, it will force auto-update to be enabled even in `yarn dev` mode. Updates will be checked and downloaded, but **not** installed.
 
+## RD_GITHUB_API_URL=http://localhost:8314
+
+Set an alternate GitHub API endpoint, from which the updater fetches the release
+it was told about by the upgrade responder. Takes effect only when
+`RD_FORCE_UPDATES_ENABLED` is also set, because the release names both the asset
+to download and the checksum that verifies it. Together with
+`RD_UPGRADE_RESPONDER_URL` this lets a test serve a whole release of its own.
+
 ## RD_MOCK_MACOS_VERSION=semver
 
 Used for testing compatibility of the app with the OS version, for upgrade responder tests, and for enabling/disabling certain parts of the preferences (related to VZ emulation mode).
 
 ## RD_UPGRADE_RESPONDER_URL=http://localhost:8314/v1/checkupgrade
 
-Set an alternate upgrade responder endpoint for testing.
+Set an alternate upgrade responder endpoint for testing. Takes effect only when
+`RD_FORCE_UPDATES_ENABLED` is also set, because the responder chooses which
+release the updater then goes looking for.

--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -132,6 +132,19 @@ interface LonghornCache {
   /** The minimum time (in Unix epoch) we should next check for an update. */
   nextUpdateTime:             number;
   /**
+   * The GitHub API the release was fetched from. An entry fetched from a test
+   * server names both the download and its checksum, so it must not outlive the
+   * run that asked for it. A cache written before this field existed carries
+   * neither it nor the responder below, so `hasQueuedUpdate` and
+   * `checkForUpdates` both discard the entry.
+   */
+  apiURL?:                    string;
+  /**
+   * The upgrade responder override the release was found through, or the empty
+   * string when the update configuration's own server was used.
+   */
+  upgradeServer?:             string;
+  /**
    * Whether there is an unsupported version of Rancher Desktop that is
    * newer than the latest supported version.
    */
@@ -158,12 +171,46 @@ interface LonghornCache {
   }
 }
 
+/**
+ * Where this run looks for releases. A redirected server names the asset to
+ * download and the checksum that verifies it, so both overrides require the
+ * flag that already marks the run as a test.
+ */
+function updateSources(): Required<Pick<LonghornCache, 'apiURL' | 'upgradeServer'>> {
+  const testing = process.env.RD_FORCE_UPDATES_ENABLED;
+
+  return {
+    apiURL:        (testing && process.env.RD_GITHUB_API_URL) || 'https://api.github.com',
+    upgradeServer: (testing && process.env.RD_UPGRADE_RESPONDER_URL) || '',
+  };
+}
+
+/**
+ * Whether a cached release came from the servers this run would ask. Only the
+ * environment overrides count: a build whose bundled update configuration names
+ * a different responder or repository writes the identity an official build
+ * computes, so its cached release survives into one.
+ */
+function fromCurrentSources(cache: LonghornCache): boolean {
+  const sources = updateSources();
+
+  return cache.apiURL === sources.apiURL && cache.upgradeServer === sources.upgradeServer;
+}
+
 export async function hasQueuedUpdate(): Promise<boolean> {
   try {
     const rawCache = await fs.promises.readFile(gCachePath, 'utf-8');
     const cache: LonghornCache = JSON.parse(rawCache);
 
     if (!cache.isInstallable) {
+      return false;
+    }
+
+    // Every reader of the cache must agree on which releases count, or a test
+    // server's release stays queued for a launch that would refuse to fetch it.
+    if (!fromCurrentSources(cache)) {
+      console.log(`Ignoring update staged from ${ cache.apiURL ?? 'an unrecorded source' }.`);
+
       return false;
     }
 
@@ -376,11 +423,15 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
    * applicable.
    */
   protected async checkForUpdates(): Promise<LonghornCache> {
+    const sources = updateSources();
+
     try {
       const rawCache = await fs.promises.readFile(gCachePath, 'utf-8');
       const cache: LonghornCache = JSON.parse(rawCache);
 
-      if (cache.nextUpdateTime > Date.now()) {
+      // A cached release outlives the process, so a test server's release would
+      // otherwise still be installable once the run that fetched it is over.
+      if (cache.nextUpdateTime > Date.now() && fromCurrentSources(cache)) {
         return cache;
       }
     } catch (error) {
@@ -405,7 +456,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
     // Get release information from GitHub releases.
     const { owner, repo, vPrefixedTagName } = this.configuration;
     const tag = (vPrefixedTagName ? 'v' : '') + latest.Name.replace(/^v/, '');
-    const infoURL = `https://api.github.com/repos/${ owner }/${ repo }/releases/tags/${ tag }`;
+    const infoURL = `${ sources.apiURL }/repos/${ owner }/${ repo }/releases/tags/${ tag }`;
     const releaseInfoRaw = await net.fetch(infoURL,
       { headers: { Accept: 'application/vnd.github.v3+json' } });
     const releaseInfo = await releaseInfoRaw.json() as GitHubReleaseInfo;
@@ -446,6 +497,7 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
 
     const cache: LonghornCache = {
       nextUpdateTime: nextRequestTime.getTime(),
+      ...sources,
       unsupportedUpdateAvailable,
       isInstallable:  false, // Always false, we'll update this later.
       release:        {

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { jest } from '@jest/globals';
 import semver from 'semver';
 
@@ -30,11 +34,27 @@ const standardMockedVersion: WSLVersionInfo = {
   },
 };
 
+// The provider caches update info under `paths.cache` at module load, and
+// logging creates `paths.logs` the same way, so point both somewhere disposable
+// rather than at the developer's own directories.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rd-longhorn-test-'));
+const cacheDir = path.join(tmpDir, 'cache');
+const logsDir = path.join(tmpDir, 'logs');
+
+fs.mkdirSync(cacheDir, { recursive: true });
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
 const modules = mockModules({
   '@pkg/utils/childProcess': { spawnFile: jest.fn<typeof spawnFileType>() },
   '@pkg/utils/osVersion':    { getMacOsVersion: jest.fn(() => new semver.SemVer('12.0.0')) },
+  '@pkg/utils/paths':        { cache: cacheDir, logs: logsDir },
   '@pkg/utils/wslVersion':   { default: jest.fn<typeof getWSLVersionType>() },
   electron:                  {
+    // Older than any release the tests offer, so a staged update looks newer.
+    app: { getVersion: () => '1.0.0' },
     net: {
       // We only return a subset of the values, so we need a complicated type here.
       fetch: jest.fn<(...args: Parameters<typeof fetch>) => Promise<Partial<Awaited<ReturnType<typeof fetch>>>>>(),
@@ -390,5 +410,216 @@ describe('LonghornProvider.getSha512Sum', () => {
 
     await expect(makeProvider()['getSha512Sum']('https://example.test/cs'))
       .rejects.toThrow(/sha512/i);
+  });
+});
+
+describe('LonghornProvider.checkForUpdates', () => {
+  const cacheFile = path.join(cacheDir, 'updater-longhorn.json');
+  const assetName = 'Rancher.Desktop.Setup.9.9.9.msi';
+  const githubURL = 'https://api.github.com/repos/rancher-sandbox/rancher-desktop/releases/tags/v9.9.9';
+  const serverURL = 'http://127.0.0.1:8314';
+  let LonghornProviderClass: typeof import('../LonghornProvider').default;
+
+  beforeAll(async() => {
+    ({ default: LonghornProviderClass } = await import('../LonghornProvider'));
+  });
+  beforeEach(() => {
+    // Documented developer variables, which every test file inherits from the
+    // shell, so clear them before the first test rather than after each one.
+    delete process.env.RD_FORCE_UPDATES_ENABLED;
+    delete process.env.RD_GITHUB_API_URL;
+    delete process.env.RD_UPGRADE_RESPONDER_URL;
+    modules['@pkg/utils/wslVersion'].default.mockResolvedValue(standardMockedVersion);
+  });
+  afterEach(() => {
+    modules.electron.net.fetch.mockReset();
+    fs.rmSync(cacheFile, { force: true });
+  });
+
+  /** Answer the upgrade responder, the release lookup, and the checksum, in that order. */
+  function mockRelease() {
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({
+        requestIntervalInMinutes: 100,
+        versions:                 [{
+          Name: 'v9.9.9', ReleaseDate: '2038-01-01T00:00:00Z', Supported: true, Tags: ['latest'],
+        }],
+      }),
+    });
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve({
+        name:         'Rancher Desktop 9.9.9',
+        body:         'Simulated release.',
+        published_at: '2038-01-01T00:00:00Z',
+        assets:       [
+          { name: assetName, browser_download_url: `${ serverURL }/msi`, size: 1 },
+          { name: `${ assetName }.sha512sum`, browser_download_url: `${ serverURL }/sha512sum`, size: 1 },
+        ],
+      }),
+    });
+    modules.electron.net.fetch.mockResolvedValueOnce({
+      ok:         true,
+      status:     200,
+      statusText: 'OK',
+      text:       () => Promise.resolve(`${ 'a'.repeat(128) }  ${ assetName }\n`),
+    });
+  }
+
+  // `getUpdater` points the provider at the responder override when it honours
+  // one, so a test that sets the variable must configure the same URL here.
+  function makeProvider(upgradeServer = 'https://upgrade.test/v1/checkupgrade') {
+    return new LonghornProviderClass(
+      {
+        owner: 'rancher-sandbox', repo: 'rancher-desktop', vPrefixedTagName: true, upgradeServer,
+      } as any,
+      { currentVersion: new semver.SemVer('1.0.0') } as any,
+      { platform: 'win32' } as any,
+    );
+  }
+
+  /** The release lookup is the request that follows the upgrade responder query. */
+  async function releaseLookupURL() {
+    mockRelease();
+    await makeProvider()['checkForUpdates']();
+
+    return modules.electron.net.fetch.mock.calls[1][0];
+  }
+
+  it('fetches the release from GitHub when no override is set', async() => {
+    await expect(releaseLookupURL()).resolves.toBe(githubURL);
+  });
+
+  it('honours RD_GITHUB_API_URL when updates are forced', async() => {
+    process.env.RD_FORCE_UPDATES_ENABLED = '1';
+    process.env.RD_GITHUB_API_URL = serverURL;
+
+    await expect(releaseLookupURL()).resolves
+      .toBe(`${ serverURL }/repos/rancher-sandbox/rancher-desktop/releases/tags/v9.9.9`);
+  });
+
+  it('ignores RD_GITHUB_API_URL unless updates are forced', async() => {
+    process.env.RD_GITHUB_API_URL = serverURL;
+
+    await expect(releaseLookupURL()).resolves.toBe(githubURL);
+  });
+
+  it('discards a cached release that came from a different API', async() => {
+    // A release cached by a test run names a download and a checksum the test
+    // server chose; a later run must not install it just because it is fresh.
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      apiURL:         serverURL,
+      upgradeServer:  '',
+      file:           { url: `${ serverURL }/msi`, size: 1, checksum: 'cached' },
+    }));
+
+    await expect(releaseLookupURL()).resolves.toBe(githubURL);
+  });
+
+  it('reuses a cached release that came from the same API', async() => {
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      apiURL:         'https://api.github.com',
+      upgradeServer:  '',
+      file:           { url: 'https://example.test/msi', size: 1, checksum: 'cached' },
+    }));
+
+    await makeProvider()['checkForUpdates']();
+    expect(modules.electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it('discards a cached release found through a different upgrade responder', async() => {
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      apiURL:         'https://api.github.com',
+      upgradeServer:  `${ serverURL }/v1/checkupgrade`,
+      file:           { url: 'https://example.test/msi', size: 1, checksum: 'cached' },
+    }));
+
+    await expect(releaseLookupURL()).resolves.toBe(githubURL);
+  });
+
+  it('leaves no update queued from a release the run would refuse to fetch', async() => {
+    const { hasQueuedUpdate } = await import('../LonghornProvider');
+
+    // Written by a run with the test flag set; this run has neither variable.
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      apiURL:         serverURL,
+      upgradeServer:  '',
+      isInstallable:  true,
+      release:        { tag: 'v9.9.9', name: '', notes: '', date: '' },
+      file:           { url: `${ serverURL }/msi`, size: 1, checksum: 'cached' },
+    }));
+
+    await expect(hasQueuedUpdate()).resolves.toBe(false);
+  });
+
+  it('queues an update staged from the servers this run would ask', async() => {
+    const { hasQueuedUpdate } = await import('../LonghornProvider');
+
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      apiURL:         'https://api.github.com',
+      upgradeServer:  '',
+      isInstallable:  true,
+      release:        { tag: 'v9.9.9', name: '', notes: '', date: '' },
+      file:           { url: 'https://example.test/msi', size: 1, checksum: 'cached' },
+    }));
+
+    await expect(hasQueuedUpdate()).resolves.toBe(true);
+  });
+
+  it('reuses the release it just cached', async() => {
+    // The second query would succeed if it happened, so a cache that recorded
+    // no source fails this by fetching again rather than by throwing.
+    mockRelease();
+    mockRelease();
+    await makeProvider()['checkForUpdates']();
+    const afterFirst = modules.electron.net.fetch.mock.calls.length;
+
+    await makeProvider()['checkForUpdates']();
+    expect(modules.electron.net.fetch.mock.calls).toHaveLength(afterFirst);
+  });
+
+  it('records the responder override when updates are forced', async() => {
+    process.env.RD_FORCE_UPDATES_ENABLED = '1';
+    process.env.RD_UPGRADE_RESPONDER_URL = `${ serverURL }/v1/checkupgrade`;
+    mockRelease();
+
+    await makeProvider(`${ serverURL }/v1/checkupgrade`)['checkForUpdates']();
+    expect(JSON.parse(fs.readFileSync(cacheFile, 'utf-8')).upgradeServer)
+      .toBe(`${ serverURL }/v1/checkupgrade`);
+  });
+
+  it('ignores the responder override unless updates are forced', async() => {
+    process.env.RD_UPGRADE_RESPONDER_URL = `${ serverURL }/v1/checkupgrade`;
+    mockRelease();
+
+    await makeProvider()['checkForUpdates']();
+    expect(JSON.parse(fs.readFileSync(cacheFile, 'utf-8')).upgradeServer).toBe('');
+  });
+
+  it('leaves no update queued from a cache that predates recorded sources', async() => {
+    const { hasQueuedUpdate } = await import('../LonghornProvider');
+
+    // The schema every installation carries into its first launch of this build.
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      isInstallable:  true,
+      release:        { tag: 'v9.9.9', name: '', notes: '', date: '' },
+      file:           { url: 'https://example.test/msi', size: 1, checksum: 'cached' },
+    }));
+
+    await expect(hasQueuedUpdate()).resolves.toBe(false);
+  });
+
+  it('discards a cache that predates recorded sources', async() => {
+    fs.writeFileSync(cacheFile, JSON.stringify({
+      nextUpdateTime: Date.now() + 60_000,
+      file:           { url: 'https://example.test/msi', size: 1, checksum: 'cached' },
+    }));
+
+    await expect(releaseLookupURL()).resolves.toBe(githubURL);
   });
 });

--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -117,6 +117,10 @@ describe('setupUpdate state machine', () => {
   });
 
   beforeEach(() => {
+    // A shell that exports this sends the queued-install path down its test
+    // branch, so two of these cases fail for reasons outside the change.
+    delete process.env.RD_FORCE_UPDATES_ENABLED;
+    delete process.env.RD_UPGRADE_RESPONDER_URL;
     // Reset to a clean slate: error cleared, no staged version, updater re-armed.
     updater.emit('checking-for-update');
     updater.emit('update-not-available', makeInfo('v0.0.0'));
@@ -320,5 +324,50 @@ describe('setupUpdate state machine', () => {
     await jest.runOnlyPendingTimersAsync();
 
     expect(updater.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('the upgrade responder override', () => {
+  beforeAll(() => {
+    fs.writeFileSync(appUpdateConfigPath, '{}');
+  });
+
+  afterAll(() => {
+    fs.rmSync(appUpdateConfigPath, { force: true });
+  });
+
+  beforeEach(() => {
+    delete process.env.RD_FORCE_UPDATES_ENABLED;
+    delete process.env.RD_UPGRADE_RESPONDER_URL;
+    updaterInstances.length = 0;
+  });
+
+  /**
+   * setupUpdate builds an updater only while it is still unconfigured, so each
+   * case needs its own copy of the module to reach the options it assembles.
+   */
+  async function optionsFromFreshSetup(): Promise<any> {
+    jest.resetModules();
+    const { default: setup } = await import('../index');
+
+    // Configure without enabling: enough to build the updater, and it returns
+    // before scheduling any checks.
+    await setup(false);
+
+    return updaterInstances[updaterInstances.length - 1].options;
+  }
+
+  it('reaches the updater when updates are forced', async() => {
+    process.env.RD_FORCE_UPDATES_ENABLED = '1';
+    process.env.RD_UPGRADE_RESPONDER_URL = 'http://127.0.0.1:8314/v1/checkupgrade';
+
+    await expect(optionsFromFreshSetup()).resolves
+      .toMatchObject({ upgradeServer: 'http://127.0.0.1:8314/v1/checkupgrade' });
+  });
+
+  it('leaves the configured server alone unless updates are forced', async() => {
+    process.env.RD_UPGRADE_RESPONDER_URL = 'http://127.0.0.1:8314/v1/checkupgrade';
+
+    await expect(optionsFromFreshSetup()).resolves.not.toHaveProperty('upgradeServer');
   });
 });

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -104,7 +104,9 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
 
     options.updateProvider = LonghornProvider;
 
-    if (process.env.RD_UPGRADE_RESPONDER_URL) {
+    // A responder chooses which release the updater goes looking for, so it is
+    // gated on the same flag as the API it then fetches that release from.
+    if (process.env.RD_FORCE_UPDATES_ENABLED && process.env.RD_UPGRADE_RESPONDER_URL) {
       console.log(`using custom upgrade responder URL ${ process.env.RD_UPGRADE_RESPONDER_URL }`);
       options.upgradeServer = process.env.RD_UPGRADE_RESPONDER_URL;
     }


### PR DESCRIPTION
The main process bundles its own copy of electron-updater, so a packaging mistake can leave the updater unable to fetch anything at all while every unit test still passes. Nothing caught that, and auto-update shipped broken.

Serve the release from a local stand-in for the upgrade responder and the GitHub API, so the test can follow a real upgrade as far as the updater takes it on its own: found, downloaded, checksum verified. The asset is a few bytes, because the updater only checks its size and its checksum.

Pointing the updater at a local server means an environment variable can choose where a release, its download, and its checksum all come from, so both overrides now require the flag that already marks a run as a test. The cached release records the servers it came from, because it otherwise outlives the run and a later launch would install what a test served.

The suite only runs on macOS. Linux downloads updates only when the app runs from an AppImage, and on Windows bats runs inside WSL while the app runs on Win32.
