### PR TITLE
build: stop bundling electron-updater into the main process

### DIFF
--- a/scripts/lib/__tests__/build-utils.spec.ts
+++ b/scripts/lib/__tests__/build-utils.spec.ts
@@ -20,14 +20,14 @@ describe('build-utils', () => {
 
     it.each([
       // Bare dependencies keep their own resolution.
-      ['electron-updater', 'module-import electron-updater'],
-      ['@napi-rs/xattr', 'module-import @napi-rs/xattr'],
+      ['electron-updater', 'electron-updater'],
+      ['@napi-rs/xattr', '@napi-rs/xattr'],
       // Subpaths need the extension spelled out for Node's ESM loader.
-      ['electron-updater/out/MacUpdater', 'module-import electron-updater/out/MacUpdater.js'],
-      ['lodash/merge', 'module-import lodash/merge.js'],
-      ['lodash/isEqual.js', 'module-import lodash/isEqual.js'],
+      ['electron-updater/out/MacUpdater', 'electron-updater/out/MacUpdater.js'],
+      ['lodash/merge', 'lodash/merge.js'],
+      ['lodash/isEqual.js', 'lodash/isEqual.js'],
       // Optional dependencies ship with the app, so they are external too.
-      ['posix-node', 'module-import posix-node'],
+      ['posix-node', 'posix-node'],
       // Everything else is bundled.
       ['@pkg/utils/logging', undefined],
       ['./relative', undefined],
@@ -35,9 +35,16 @@ describe('build-utils', () => {
       await expect(classify(buildUtils.webpackConfig, request)).resolves.toBe(expected);
     });
 
+    it('externalizes the main process as module-import, so dynamic imports stay dynamic', async() => {
+      await expect(buildUtils.webpackConfig.then(config => config.externalsType)).resolves.toBe('module-import');
+    });
+
     it('should bundle everything into the preload script', async() => {
-      // A sandboxed renderer loading it from outside the asar can resolve nothing.
-      await expect(buildUtils.webpackPreloadConfig.then(config => config.externals)).resolves.toEqual([]);
+      // A sandboxed renderer loading it from outside the asar cannot resolve anything.
+      const config = await buildUtils.webpackPreloadConfig;
+
+      expect(config.externals).toEqual([]);
+      expect(config.externalsType).toBe('commonjs2');
     });
 
     it.each([

--- a/scripts/lib/__tests__/build-utils.spec.ts
+++ b/scripts/lib/__tests__/build-utils.spec.ts
@@ -5,7 +5,50 @@ import semver from 'semver';
 
 import buildUtils from '../build-utils';
 
+import type webpack from 'webpack';
+
 describe('build-utils', () => {
+  describe('externals', () => {
+    /** Ask a config's externals handler how it would treat a request. */
+    async function classify(config: Promise<webpack.Configuration>, request: string): Promise<string | undefined> {
+      const [handler] = (await config).externals as any[];
+
+      return new Promise((resolve) => {
+        handler({ request }, (_error: unknown, result?: string) => resolve(result));
+      });
+    }
+
+    it.each([
+      // Bare dependencies keep their own resolution.
+      ['electron-updater', 'module-import electron-updater'],
+      ['@napi-rs/xattr', 'module-import @napi-rs/xattr'],
+      // Subpaths need the extension spelled out for Node's ESM loader.
+      ['electron-updater/out/MacUpdater', 'module-import electron-updater/out/MacUpdater.js'],
+      ['lodash/merge', 'module-import lodash/merge.js'],
+      ['lodash/isEqual.js', 'module-import lodash/isEqual.js'],
+      // Optional dependencies ship with the app, so they are external too.
+      ['posix-node', 'module-import posix-node'],
+      // Everything else is bundled.
+      ['@pkg/utils/logging', undefined],
+      ['./relative', undefined],
+    ])('externalizes %s', async(request, expected) => {
+      await expect(classify(buildUtils.webpackConfig, request)).resolves.toBe(expected);
+    });
+
+    it('should bundle everything into the preload script', async() => {
+      // A sandboxed renderer loading it from outside the asar can resolve nothing.
+      await expect(buildUtils.webpackPreloadConfig.then(config => config.externals)).resolves.toEqual([]);
+    });
+
+    it.each([
+      'lodash/no-such-module',
+      'electron-updater/out/DoesNotExist.js',
+    ])('rejects %s, which would only fail once packaged', async(request) => {
+      await expect(classify(buildUtils.webpackConfig, request))
+        .rejects.toThrow(`Cannot resolve external "${ request }"`);
+    });
+  });
+
   describe('docsUrl', () => {
     it.each([
       ['1.9.0', 'https://docs.rancherdesktop.io/1.9'],

--- a/scripts/lib/__tests__/build-utils.spec.ts
+++ b/scripts/lib/__tests__/build-utils.spec.ts
@@ -36,15 +36,13 @@ describe('build-utils', () => {
     });
 
     it('externalizes the main process as module-import, so dynamic imports stay dynamic', async() => {
-      await expect(buildUtils.webpackConfig.then(config => config.externalsType)).resolves.toBe('module-import');
+      await expect(buildUtils.webpackConfig).resolves.toHaveProperty('externalsType', 'module-import');
     });
 
     it('should bundle everything into the preload script', async() => {
       // A sandboxed renderer loading it from outside the asar cannot resolve anything.
-      const config = await buildUtils.webpackPreloadConfig;
-
-      expect(config.externals).toEqual([]);
-      expect(config.externalsType).toBe('commonjs2');
+      await expect(buildUtils.webpackPreloadConfig).resolves.toHaveProperty('externals', []);
+      await expect(buildUtils.webpackPreloadConfig).resolves.toHaveProperty('externalsType', 'commonjs2');
     });
 
     it.each([

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -2,7 +2,9 @@
  * This module is a helper for the build & dev scripts.
  */
 
+import fs from 'fs';
 import childProcess from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import util from 'util';
 
@@ -13,6 +15,68 @@ import webpack from 'webpack';
 
 import babelConfig from '@/babel.config.cjs';
 import packageJson from '@/package.json' with { type: 'json' };
+
+/**
+ * Resolve the way the bundle will at runtime: a subpath can be exported to
+ * `import` but not to `require`, so `require.resolve` would reject specifiers
+ * Node accepts.  `import.meta.resolve` only maps the specifier to a URL and
+ * reports a missing file for an absent package alone, so stat the target too.
+ *
+ * This catches a missing or renamed file, not every specifier Node will reject.
+ * We run under tsx, whose resolver still walks a directory to its `index.js`
+ * where the ESM loader raises ERR_UNSUPPORTED_DIR_IMPORT.  Telling that apart
+ * from an `exports` map pointing somewhere else means resolving the map
+ * ourselves, which is not worth it while no dependency imports a directory.
+ */
+function canResolve(specifier: string): boolean {
+  try {
+    return fs.statSync(fileURLToPath(import.meta.resolve(specifier))).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Spell out the file a subpath import refers to, because Node's ESM loader does
+ * no extension resolution.  Packages that publish an `exports` map resolve
+ * their own subpaths, so try the request unchanged as well.  A request that
+ * resolves no way at all would fail once packaged, so fail the build instead.
+ */
+function externalSpecifier(request: string): string {
+  const candidates = path.extname(request) ? [request] : [`${ request }.js`, request];
+
+  for (const candidate of candidates) {
+    if (canResolve(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(`Cannot resolve external "${ request }"; Node will not resolve it at runtime either.`);
+}
+
+/**
+ * Keep runtime dependencies out of the bundle.  A string external only matches
+ * the request as a whole, so a subpath import such as
+ * `electron-updater/out/MacUpdater` misses the package name and gets bundled.
+ * Bundling a runtime dependency is worse than wasteful: its own `require()` of
+ * another external becomes an ESM namespace import, which carries only the named
+ * exports Node can find by static analysis.  fs-extra assembles its exports in a
+ * loop, so electron-updater called an undefined `readFile` and auto-update died.
+ *
+ * `module-import` leaves a dynamic import dynamic, where plain `module` hoists it
+ * to the top of the bundle; @napi-rs/xattr ships no Windows binding, so it must
+ * stay behind its `import()`.
+ */
+function externalsEntry(dependencies: Record<string, string>) {
+  return ({ request }: { request?: string }, callback: (error?: null, result?: string) => void) => {
+    const packageName = /^(?:@[^/]+\/)?[^/]+/.exec(request ?? '')?.[0];
+
+    if (!packageName || !Object.hasOwn(dependencies, packageName)) {
+      return callback();
+    }
+
+    return callback(null, `module-import ${ externalSpecifier(request ?? '') }`);
+  };
+}
 
 /**
  * A promise that is resolved when the child exits.
@@ -63,6 +127,15 @@ export default {
   /** The package.json metadata. */
   get packageMeta() {
     return packageJson;
+  },
+
+  /**
+   * Packages resolved from node_modules at runtime rather than bundled.
+   * electron-builder ships optional dependencies too, and background.ts loads
+   * one of them (posix-node) on Linux.
+   */
+  get runtimeDependencies(): Record<string, string> {
+    return { ...this.packageMeta.dependencies, ...this.packageMeta.optionalDependencies };
   },
 
   /**
@@ -210,7 +283,7 @@ export default {
         },
         entry:       { background: path.resolve(this.rootDir, 'background') },
         experiments: { outputModule: true },
-        externals:   [...Object.keys(this.packageMeta.dependencies)],
+        externals:   [externalsEntry(this.runtimeDependencies)],
         devtool:     this.isDevelopment ? 'source-map' : false,
         resolve:     {
           alias:      { '@pkg': path.resolve(this.rootDir, 'pkg', 'rancher-desktop') },
@@ -287,6 +360,12 @@ export default {
       };
 
       const result = _.merge({}, await this.webpackConfig, overrides);
+
+      // The preload script is loaded into a sandboxed renderer, from outside the
+      // asar, so it can resolve neither npm packages nor the app's node_modules.
+      // Bundle everything.  Assigned after the merge because lodash merges
+      // arrays element-wise, which would keep the main process's entry.
+      result.externals = [];
       const rules = (result.module?.rules ?? []).filter(
         (rule): rule is webpack.RuleSetRule => !!rule && typeof rule === 'object',
       );

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -17,19 +17,18 @@ import babelConfig from '@/babel.config.cjs';
 import packageJson from '@/package.json' with { type: 'json' };
 
 /**
- * Resolve the way the bundle will at runtime: a subpath can be exported to
- * `import` but not to `require`, so `require.resolve` would reject specifiers
- * Node accepts.  `import.meta.resolve` only maps the specifier to a URL and
- * reports a missing file for an absent package alone, so stat the target too.
- *
- * This catches a missing or renamed file, not every specifier Node will reject.
- * We run under tsx, whose resolver still walks a directory to its `index.js`
- * where the ESM loader raises ERR_UNSUPPORTED_DIR_IMPORT.  Telling that apart
- * from an `exports` map pointing somewhere else means resolving the map
- * ourselves, which is not worth it while no dependency imports a directory.
+ * Determine whether a specifier is likely to be resolvable at run time.  This
+ * also catches missing files; however, it is possible that it may allow imports
+ * that Node will reject at run time.
  */
 function canResolve(specifier: string): boolean {
   try {
+    // Because a `package.json` can declare conditional imports [1] that vary
+    // between `import` and `require`, we must use `import.meta.resolve` to do the
+    // resolution instead of `require.resolve`.  However, `import.meta.resolve`
+    // only determines the path, not whether the file exists; we therefore must
+    // also do a `stat` to make sure that is valid.
+    // [1]: https://nodejs.org/api/packages.html#conditional-exports
     return fs.statSync(fileURLToPath(import.meta.resolve(specifier))).isFile();
   } catch {
     return false;
@@ -38,12 +37,12 @@ function canResolve(specifier: string): boolean {
 
 /**
  * Spell out the file a subpath import refers to, because Node's ESM loader does
- * no extension resolution.  Packages that publish an `exports` map resolve
+ * not do extension resolution.  Packages that publish an `exports` map resolve
  * their own subpaths, so try the request unchanged as well.  A request that
  * resolves no way at all would fail once packaged, so fail the build instead.
  */
 function externalSpecifier(request: string): string {
-  const candidates = path.extname(request) ? [request] : [`${ request }.js`, request];
+  const candidates = [`${ request }.js`, request];
 
   for (const candidate of candidates) {
     if (canResolve(candidate)) {
@@ -54,26 +53,30 @@ function externalSpecifier(request: string): string {
 }
 
 /**
- * Keep runtime dependencies out of the bundle.  A string external only matches
- * the request as a whole, so a subpath import such as
- * `electron-updater/out/MacUpdater` misses the package name and gets bundled.
- * Bundling a runtime dependency is worse than wasteful: its own `require()` of
- * another external becomes an ESM namespace import, which carries only the named
- * exports Node can find by static analysis.  fs-extra assembles its exports in a
- * loop, so electron-updater called an undefined `readFile` and auto-update died.
+ * externalsEntry returns a function for webpack's `externals` configuration [1]
+ * to avoid bundling our listed dependencies.  This is needed as we sometimes
+ * import files by reaching into the package directly, instead of simply
+ * importing the top-level entry point, likely because the desired exports are
+ * not available at the top level; for example, `electron-updater/out/MacUpdater`.
+ * Bundling those dependencies causes issues as it is done via static analysis,
+ * and `electron-updater` does `require('fs-extra')` which produces dynamic
+ * exports that could not be detected via that static analysis.
  *
- * `module-import` leaves a dynamic import dynamic, where plain `module` hoists it
- * to the top of the bundle; @napi-rs/xattr ships no Windows binding, so it must
- * stay behind its `import()`.
+ * @param dependencies The npm packages to avoid bundling.
+ *
+ * [1]: https://webpack.js.org/configuration/externals/#function
  */
-function externalsEntry(dependencies: Record<string, string>) {
-  return ({ request }: { request?: string }, callback: (error?: null, result?: string) => void) => {
+function externalsEntry(dependencies: Set<string>) {
+  return ({ request }: webpack.ExternalItemFunctionData, callback: (error?: null, result?: webpack.ExternalItemValue) => void) => {
     const packageName = /^(?:@[^/]+\/)?[^/]+/.exec(request ?? '')?.[0];
 
-    if (!packageName || !Object.hasOwn(dependencies, packageName)) {
+    if (!packageName || !dependencies.has(packageName)) {
       return callback();
     }
 
+    // `module-import` leaves a dynamic import dynamic, where plain `module`
+    // hoists it to the top of the bundle; @napi-rs/xattr ships no Windows
+    // binding, so it must stay behind its `import()`.
     return callback(null, `module-import ${ externalSpecifier(request ?? '') }`);
   };
 }
@@ -134,8 +137,11 @@ export default {
    * electron-builder ships optional dependencies too, and background.ts loads
    * one of them (posix-node) on Linux.
    */
-  get runtimeDependencies(): Record<string, string> {
-    return { ...this.packageMeta.dependencies, ...this.packageMeta.optionalDependencies };
+  get runtimeDependencies(): Set<string> {
+    return new Set([
+      ...Object.keys(this.packageMeta.dependencies),
+      ...Object.keys(this.packageMeta.optionalDependencies),
+    ]);
   },
 
   /**

--- a/scripts/lib/build-utils.ts
+++ b/scripts/lib/build-utils.ts
@@ -2,8 +2,8 @@
  * This module is a helper for the build & dev scripts.
  */
 
-import fs from 'fs';
 import childProcess from 'node:child_process';
+import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
 import util from 'util';
@@ -43,13 +43,13 @@ function canResolve(specifier: string): boolean {
  */
 function externalSpecifier(request: string): string {
   const candidates = [`${ request }.js`, request];
+  const resolved = candidates.find(canResolve);
 
-  for (const candidate of candidates) {
-    if (canResolve(candidate)) {
-      return candidate;
-    }
+  if (!resolved) {
+    throw new Error(`Cannot resolve external "${ request }"; Node will not resolve it at runtime either.`);
   }
-  throw new Error(`Cannot resolve external "${ request }"; Node will not resolve it at runtime either.`);
+
+  return resolved;
 }
 
 /**
@@ -74,10 +74,7 @@ function externalsEntry(dependencies: Set<string>) {
       return callback();
     }
 
-    // `module-import` leaves a dynamic import dynamic, where plain `module`
-    // hoists it to the top of the bundle; @napi-rs/xattr ships no Windows
-    // binding, so it must stay behind its `import()`.
-    return callback(null, `module-import ${ externalSpecifier(request ?? '') }`);
+    return callback(null, externalSpecifier(request ?? ''));
   };
 }
 
@@ -287,11 +284,15 @@ export default {
           __dirname:  false,
           __filename: false,
         },
-        entry:       { background: path.resolve(this.rootDir, 'background') },
-        experiments: { outputModule: true },
-        externals:   [externalsEntry(this.runtimeDependencies)],
-        devtool:     this.isDevelopment ? 'source-map' : false,
-        resolve:     {
+        entry:         { background: path.resolve(this.rootDir, 'background') },
+        experiments:   { outputModule: true },
+        // `module-import` leaves a dynamic import dynamic, where plain `module`
+        // hoists it to the top of the bundle; @napi-rs/xattr ships no Windows
+        // binding, so it must stay behind its `import()`.
+        externalsType: 'module-import',
+        externals:     [externalsEntry(this.runtimeDependencies)],
+        devtool:       this.isDevelopment ? 'source-map' : false,
+        resolve:       {
           alias:      { '@pkg': path.resolve(this.rootDir, 'pkg', 'rancher-desktop') },
           extensions: ['.ts', '.js', '.json', '.node'],
           modules:    ['node_modules'],
@@ -362,7 +363,8 @@ export default {
           library:  { type: 'commonjs2' },
           path:     path.join(this.rootDir, 'resources'),
         },
-        experiments: { outputModule: false },
+        experiments:   { outputModule: false },
+        externalsType: 'commonjs2',
       };
 
       const result = _.merge({}, await this.webpackConfig, overrides);


### PR DESCRIPTION
Auto-update is broken for every 1.23.x user: the updater throws "(0 , o.readFile) is not a function" the moment it starts a download, so nothing is ever fetched and no retry helps. Only 1.23.x is affected, because the download runs in the updater of the version already installed.

A string in webpack's `externals` matches the request as a whole, so the subpath imports added in 3b537a453 stopped matching `electron-updater` and dragged it into the bundle. Its own `require("fs-extra")` then became an ESM namespace import, and Node cannot see the exports that fs-extra builds in a loop, so `readFile` was undefined.
