### PR TITLE
update: recover from a failed update download

### DIFF
--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -1672,16 +1672,21 @@ updateStatus:
   available: Ein Update auf Version {version} ist verfügbar
   # @source Check for updates automatically
   checkForUpdates: Automatisch nach Updates suchen
+  # @reason Passive verb clause instead of the noun 'Download'; de.yaml uses the verb 'heruntergeladen' everywhere (updateStatus.downloading, asyncButton.download.waiting)
+  # @source The download of version {version} failed.
+  downloadFailed: Version {version} konnte nicht heruntergeladen werden.
   # @source downloading... ({percent}%, {speed})
   downloading: Wird heruntergeladen... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: Beim Prüfen auf Updates ist ein Fehler aufgetreten.
   # @source Release Notes
   releaseNotes: Versionshinweise
   # @source Restart Now
   restartNow: Jetzt neu starten
   # @source Restart the application to apply the update.
   restartToApply: Starten Sie die Anwendung neu, um das Update anzuwenden.
+  # @source Retry
+  retry: Erneut versuchen
+  # @source Retrying...
+  retrying: Wird erneut versucht...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Eine neuere Version von Rancher Desktop ist verfügbar, wird aber auf Ihrem System nicht unterstützt.

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -1140,11 +1140,13 @@ updateStatus:
   applyingUpdate: Applying update...
   available: An update to version {version} is available
   checkForUpdates: Check for updates automatically
+  downloadFailed: The download of version {version} failed.
   downloading: downloading... ({percent}%, {speed})
-  errorChecking: There was an error checking for updates.
   releaseNotes: Release Notes
   restartNow: Restart Now
   restartToApply: Restart the application to apply the update.
+  retry: Retry
+  retrying: Retrying...
   unsupported:
     # @no-translate Rancher Desktop
     message: A newer version of Rancher Desktop is available, but not supported on your system.

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -1603,17 +1603,21 @@ updateStatus:
   available: Hay disponible una actualización a la versión {version}
   # @source Check for updates automatically
   checkForUpdates: Buscar actualizaciones automáticamente
+  # @source The download of version {version} failed.
+  downloadFailed: Falló la descarga de la versión {version}.
   # @reason Lowercase kept; the source is lowercase because the string is appended inline.
   # @source downloading... ({percent}%, {speed})
   downloading: descargando... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: Se produjo un error al buscar actualizaciones.
   # @source Release Notes
   releaseNotes: Notas de la versión
   # @source Restart Now
   restartNow: Reiniciar ahora
   # @source Restart the application to apply the update.
   restartToApply: Reinicie la aplicación para aplicar la actualización.
+  # @source Retry
+  retry: Reintentar
+  # @source Retrying...
+  retrying: Reintentando...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Hay disponible una versión más reciente de Rancher Desktop, pero no es compatible con su sistema.

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -1622,17 +1622,22 @@ updateStatus:
   available: Une mise à jour vers la version {version} est disponible
   # @source Check for updates automatically
   checkForUpdates: Rechercher automatiquement les mises à jour
+  # @source The download of version {version} failed.
+  downloadFailed: Le téléchargement de la version {version} a échoué.
   # @reason no-break space added before % per French typography
   # @source downloading... ({percent}%, {speed})
   downloading: téléchargement... ({percent} %, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: Une erreur s’est produite lors de la recherche de mises à jour.
   # @source Release Notes
   releaseNotes: Notes de version
   # @source Restart Now
   restartNow: Redémarrer maintenant
   # @source Restart the application to apply the update.
   restartToApply: Redémarrez l’application pour appliquer la mise à jour.
+  # @source Retry
+  retry: Réessayer
+  # @reason French has no idiomatic gerund label; back-translates as "new attempt", matching the noun-phrase form of applyingUpdate
+  # @source Retrying...
+  retrying: Nouvelle tentative...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Une version plus récente de Rancher Desktop est disponible, mais elle n’est pas prise en charge sur votre système.

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -1632,17 +1632,22 @@ updateStatus:
   available: È disponibile un aggiornamento alla versione {version}
   # @source Check for updates automatically
   checkForUpdates: Controlla automaticamente la disponibilità di aggiornamenti
+  # @source The download of version {version} failed.
+  downloadFailed: Il download della versione {version} non è riuscito.
   # @reason lowercase kept to match the source's inline status style; 'download' is an established loanword
   # @source downloading... ({percent}%, {speed})
   downloading: download in corso... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: Si è verificato un errore durante il controllo degli aggiornamenti.
   # @source Release Notes
   releaseNotes: Note di rilascio
   # @source Restart Now
   restartNow: Riavvia ora
   # @source Restart the application to apply the update.
   restartToApply: Riavvia l'applicazione per applicare l'aggiornamento.
+  # @source Retry
+  retry: Riprova
+  # @reason riprovare has no idiomatic verbal noun, so the in-progress label drops the shared root with retry and uses a noun phrase, like applyingUpdate
+  # @source Retrying...
+  retrying: Nuovo tentativo...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: È disponibile una versione più recente di Rancher Desktop, ma non è supportata sul tuo sistema.

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -1599,16 +1599,20 @@ updateStatus:
   available: バージョン {version} への更新が利用可能です
   # @source Check for updates automatically
   checkForUpdates: 更新を自動的に確認する
+  # @source The download of version {version} failed.
+  downloadFailed: バージョン {version} のダウンロードに失敗しました。
   # @source downloading... ({percent}%, {speed})
   downloading: ダウンロード中...（{percent}%、{speed}）
-  # @source There was an error checking for updates.
-  errorChecking: 更新の確認中にエラーが発生しました。
   # @source Release Notes
   releaseNotes: リリースノート
   # @source Restart Now
   restartNow: 今すぐ再起動
   # @source Restart the application to apply the update.
   restartToApply: 更新を適用するには、アプリケーションを再起動してください。
+  # @source Retry
+  retry: 再試行
+  # @source Retrying...
+  retrying: 再試行しています...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Rancher Desktop の新しいバージョンが利用可能ですが、お使いのシステムではサポートされていません。

--- a/pkg/rancher-desktop/assets/translations/ko.yaml
+++ b/pkg/rancher-desktop/assets/translations/ko.yaml
@@ -1574,16 +1574,20 @@ updateStatus:
   available: 버전 {version} 업데이트를 사용할 수 있습니다
   # @source Check for updates automatically
   checkForUpdates: 자동으로 업데이트 확인
+  # @source The download of version {version} failed.
+  downloadFailed: 버전 {version} 다운로드에 실패했습니다.
   # @source downloading... ({percent}%, {speed})
   downloading: 다운로드 중... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: 업데이트를 확인하는 동안 오류가 발생했습니다.
   # @source Release Notes
   releaseNotes: 릴리스 노트
   # @source Restart Now
   restartNow: 지금 다시 시작
   # @source Restart the application to apply the update.
   restartToApply: 업데이트를 적용하려면 애플리케이션을 다시 시작하십시오.
+  # @source Retry
+  retry: 다시 시도
+  # @source Retrying...
+  retrying: 다시 시도 중...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: 최신 버전의 Rancher Desktop을 사용할 수 있지만 현재 시스템에서는 지원되지 않습니다.

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -1623,17 +1623,22 @@ updateStatus:
   available: Uma atualização para a versão {version} está disponível
   # @source Check for updates automatically
   checkForUpdates: Verificar atualizações automaticamente
+  # @reason source's noun subject ("The download ... failed") inverted to the "Falha ao <infinitivo>" pattern the file already uses for failures (containerInspect.error.loadFailed), keeping the established verb "baixar" instead of the noun loanword "download"
+  # @source The download of version {version} failed.
+  downloadFailed: Falha ao baixar a versão {version}.
   # @reason lowercase kept to match the source register (appended to a status line)
   # @source downloading... ({percent}%, {speed})
   downloading: baixando... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: Ocorreu um erro ao verificar atualizações.
   # @source Release Notes
   releaseNotes: Notas de versão
   # @source Restart Now
   restartNow: Reiniciar agora
   # @source Restart the application to apply the update.
   restartToApply: Reinicie o aplicativo para aplicar a atualização.
+  # @source Retry
+  retry: Tentar novamente
+  # @source Retrying...
+  retrying: Tentando novamente...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Uma versão mais recente do Rancher Desktop está disponível, mas não é compatível com o seu sistema.

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -1654,16 +1654,20 @@ updateStatus:
   available: 版本 {version} 的更新可用
   # @source Check for updates automatically
   checkForUpdates: 自动检查更新
+  # @source The download of version {version} failed.
+  downloadFailed: 版本 {version} 下载失败。
   # @source downloading... ({percent}%, {speed})
   downloading: 正在下载... ({percent}%, {speed})
-  # @source There was an error checking for updates.
-  errorChecking: 检查更新时出错。
   # @source Release Notes
   releaseNotes: 发行说明
   # @source Restart Now
   restartNow: 立即重启
   # @source Restart the application to apply the update.
   restartToApply: 重启应用程序以应用更新。
+  # @source Retry
+  retry: 重试
+  # @source Retrying...
+  retrying: 正在重试...
   unsupported:
     # @source A newer version of Rancher Desktop is available, but not supported on your system.
     message: Rancher Desktop 有新版本可用，但您的系统不支持该版本。

--- a/pkg/rancher-desktop/components/UpdateStatus.vue
+++ b/pkg/rancher-desktop/components/UpdateStatus.vue
@@ -39,6 +39,15 @@
           >
             {{ applyMessage }}
           </button>
+          <button
+            v-else-if="updateFailed"
+            ref="retryButton"
+            class="btn role-secondary"
+            :disabled="retrying"
+            @click="retryUpdate"
+          >
+            {{ retryMessage }}
+          </button>
           <span v-else />
         </template>
       </card>
@@ -94,7 +103,19 @@ export default defineComponent({
   },
 
   data() {
-    return { applying: false };
+    return { applying: false, retrying: false };
+  },
+
+  watch: {
+    updateState() {
+      // The main process has reported the outcome of the retry.
+      this.retrying = false;
+      if (this.updateState?.error) {
+        // Applying failed. The application is still running and the update is
+        // still on disk, so the button has to come back.
+        this.applying = false;
+      }
+    },
   },
 
   computed: {
@@ -103,23 +124,33 @@ export default defineComponent({
     },
 
     updateReady(): boolean {
-      return this.hasUpdate && !!this.updateState?.downloaded && !this.updateState?.error;
+      // An update that finished downloading stays installable even when a later
+      // check or install attempt fails.
+      return this.hasUpdate && !!this.updateState?.downloaded;
+    },
+
+    updateFailed(): boolean {
+      return this.hasUpdate && !!this.updateState?.error && !this.updateState?.downloaded;
     },
 
     statusMessage(): string {
-      if (this.updateState?.error) {
-        return this.t('updateStatus.errorChecking');
-      }
       if (!this.updateState?.info) {
         return '';
       }
 
       const { info, progress } = this.updateState;
+
+      if (this.updateFailed) {
+        // The card only appears once a check has found an update, so the update
+        // exists and it is the download that failed.
+        return this.t('updateStatus.downloadFailed', { version: info.version });
+      }
+
       // Punctuation is hardcoded here (period, semicolon). Some locales use
       // different punctuation; revisit when locale coverage grows.
       const prefix = this.t('updateStatus.available', { version: info.version });
 
-      if (!progress) {
+      if (this.updateReady || !progress) {
         return `${ prefix }.`;
       }
 
@@ -153,6 +184,10 @@ export default defineComponent({
       return this.applying ? this.t('updateStatus.applyingUpdate') : this.t('updateStatus.restartNow');
     },
 
+    retryMessage(): string {
+      return this.retrying ? this.t('updateStatus.retrying') : this.t('updateStatus.retry');
+    },
+
     unsupportedUpdateAvailable(): boolean {
       return !this.hasUpdate && !!this.updateState?.info?.unsupportedUpdateAvailable;
     },
@@ -162,6 +197,11 @@ export default defineComponent({
     applyUpdate() {
       this.applying = true;
       this.$emit('apply');
+    },
+
+    retryUpdate() {
+      this.retrying = true;
+      this.$emit('retry');
     },
   },
 });

--- a/pkg/rancher-desktop/components/__tests__/UpdateStatus.spec.ts
+++ b/pkg/rancher-desktop/components/__tests__/UpdateStatus.spec.ts
@@ -60,28 +60,84 @@ describe('UpdateStatus.vue', () => {
   });
 
   describe('update status', () => {
-    it('displays error correctly', () => {
+    it('reports a download that failed', () => {
       const wrapper = wrap({
         enabled:     true,
         updateState: {
-          available: true, error: new Error('hello'), downloaded: true,
+          available: true, downloaded: false, error: new Error('hello'), info: { version: 'v1.2.3' },
         } as UpdateState,
       });
 
       expect(wrapper.get({ ref: 'updateStatus' }).text())
-        .toEqual('There was an error checking for updates.');
+        .toEqual('The download of version v1.2.3 failed.');
       expect(wrapper.element.querySelector('.update-notification'))
         .toBeFalsy();
+      expect(wrapper.findComponent({ ref: 'applyButton' }).exists()).toBeFalsy();
     });
 
-    it('hides when there is nothing to display', () => {
+    it('still offers to install an update that was downloaded before an error', () => {
       const wrapper = wrap({
         enabled:     true,
-        updateState: { available: true } as UpdateState,
+        updateState: {
+          available: true, downloaded: true, error: new Error('hello'), info: { version: 'v1.2.3' },
+        } as UpdateState,
       });
 
-      expect(wrapper.get({ ref: 'updateStatus' }).text())
-        .toEqual('');
+      const statusDiv = wrapper.get({ ref: 'updateStatus' });
+
+      expect(statusDiv.find('p').text())
+        .toEqual('An update to version v1.2.3 is available.');
+      expect(statusDiv.find('.update-notification').text())
+        .toEqual('Restart the application to apply the update.');
+      expect(wrapper.get({ ref: 'applyButton' }).attributes()).not.toHaveProperty('disabled');
+      expect(wrapper.findComponent({ ref: 'retryButton' }).exists()).toBeFalsy();
+    });
+
+    it('offers to retry a download that failed', async() => {
+      const failed = {
+        available: true, downloaded: false, error: new Error('hello'), info: { version: 'v1.2.3' },
+      } as UpdateState;
+      const wrapper = wrap({ enabled: true, updateState: failed });
+
+      await wrapper.get({ ref: 'retryButton' }).trigger('click');
+
+      expect(wrapper.emitted('retry')).toHaveLength(1);
+      expect(wrapper.get({ ref: 'retryButton' }).attributes()).toHaveProperty('disabled');
+      expect(wrapper.get({ ref: 'retryButton' }).text()).toEqual('Retrying...');
+
+      // The retry failed too, so the user has to be able to try once more.
+      await wrapper.setProps({ updateState: { ...failed, error: new Error('again') } });
+
+      expect(wrapper.get({ ref: 'retryButton' }).attributes()).not.toHaveProperty('disabled');
+      expect(wrapper.get({ ref: 'retryButton' }).text()).toEqual('Retry');
+    });
+
+    it('lets the user try again when applying an update fails', async() => {
+      const ready = {
+        available: true, downloaded: true, info: { version: 'v1.2.3' },
+      } as UpdateState;
+      const wrapper = wrap({ enabled: true, updateState: ready });
+
+      await wrapper.get({ ref: 'applyButton' }).trigger('click');
+
+      expect(wrapper.get({ ref: 'applyButton' }).attributes()).toHaveProperty('disabled');
+
+      // The install failed, so the button has to come back; the update is still
+      // on disk and a restart is still the way to apply it.
+      await wrapper.setProps({ updateState: { ...ready, error: new Error('install failed') } });
+
+      expect(wrapper.get({ ref: 'applyButton' }).attributes()).not.toHaveProperty('disabled');
+    });
+
+    it('offers no retry when there is no error', () => {
+      const wrapper = wrap({
+        enabled:     true,
+        updateState: {
+          available: true, downloaded: false, info: { version: 'v1.2.3' },
+        } as UpdateState,
+      });
+
+      expect(wrapper.findComponent({ ref: 'retryButton' }).exists()).toBeFalsy();
     });
 
     it('shows when an update is available', () => {

--- a/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/index.spec.ts
@@ -58,8 +58,17 @@ const logStub = {
   log: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn(), debugE: jest.fn(),
 };
 
+/** The IPC handlers the update module registers, by channel. */
+const ipcMainHandlers: Record<string, () => void> = {};
+
 mockModules({
-  electron:                                  { ipcMain: { on: jest.fn() } },
+  electron:                                  {
+    ipcMain: {
+      on: jest.fn((channel: string, handler: () => void) => {
+        ipcMainHandlers[channel] = handler;
+      }),
+    },
+  },
   'electron-updater/out/MacUpdater':         { MacUpdater: FakeUpdater },
   'electron-updater/out/AppImageUpdater':    { AppImageUpdater: FakeUpdater },
   'electron-updater/out/ElectronAppAdapter': { ElectronAppAdapter: FakeElectronAppAdapter },
@@ -117,7 +126,10 @@ describe('setupUpdate state machine', () => {
   });
 
   beforeEach(() => {
-    // Reset to a clean slate: error cleared, no staged version, updater re-armed.
+    // Reset to a clean slate: install latch released, error cleared, no staged
+    // version, updater re-armed. The error clears the install latch a prior
+    // test may have left set; checking-for-update then clears the error.
+    updater.emit('error', new Error('reset'));
     updater.emit('checking-for-update');
     updater.emit('update-not-available', makeInfo('v0.0.0'));
     updater.autoDownload = true;
@@ -208,7 +220,7 @@ describe('setupUpdate state machine', () => {
     expect(lastState().progress).toBeUndefined();
   });
 
-  it('reports an updater error and clears the downloaded flag', () => {
+  it('reports an updater error but keeps a staged update installable', () => {
     const info = makeInfo('v1.22.3');
 
     updater.emit('checking-for-update');
@@ -217,12 +229,68 @@ describe('setupUpdate state machine', () => {
 
     expect(lastState().downloaded).toBe(true);
 
+    const error = new Error('the network is down');
+
+    updater.emit('error', error);
+
+    // The update is on disk, so it can still be installed; only the failure of
+    // whatever ran next is news.
+    expect(lastState().downloaded).toBe(true);
+    expect(lastState().error).toBe(error);
+  });
+
+  it('keeps a staged update on offer when a later check fails', () => {
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+    setHasQueuedUpdate.mockClear();
+
+    // The check never got far enough to retract the offer, so the update the
+    // previous one found is still installable.
+    updater.emit('checking-for-update');
+    updater.emit('error', new Error('the network is down'));
+
+    // Without `available` the renderer hides the whole card, taking the
+    // Restart Now button with it.
+    expect(lastState()).toMatchObject({ available: true, downloaded: true });
+    // The on-disk flag decides whether the next launch installs or re-downloads.
+    expect(setHasQueuedUpdate).toHaveBeenLastCalledWith(true);
+  });
+
+  it('reports a failed download as not downloaded', () => {
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    });
+
     const error = new Error('download failed');
 
     updater.emit('error', error);
 
-    expect(lastState().downloaded).toBe(false);
-    expect(lastState().error).toBe(error);
+    expect(lastState()).toMatchObject({ available: true, downloaded: false, error });
+  });
+
+  it('keeps checking after a failed download', async() => {
+    // A real check arms the timer for the next one, then starts the download.
+    await setupUpdate(true);
+    await flush();
+    updater.checkForUpdates.mockClear();
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    });
+    updater.emit('error', new Error('download failed'));
+
+    // A failed download must not wedge the state machine: the scheduled check
+    // has to keep running so the download gets another chance.
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(updater.checkForUpdates).toHaveBeenCalled();
   });
 
   it('clears a previous error once a later check succeeds', () => {
@@ -304,6 +372,142 @@ describe('setupUpdate state machine', () => {
     updater.emit('update-downloaded', makeInfo('v1.22.4'));
 
     expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('hands the update to only one installer at a time', () => {
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    ipcMainHandlers['update-apply']();
+    ipcMainHandlers['update-apply']();
+
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1);
+
+    // Installing failed and left the application running, so asking again has
+    // to reach the installer.
+    updater.emit('error', new Error('install failed'));
+    ipcMainHandlers['update-apply']();
+
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the install latched when an in-flight check fails', async() => {
+    await setupUpdate(true);
+    await flush();
+
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    // A scheduled check is already in flight when the user installs. When that
+    // check later fails it must not release the latch and re-enable the button
+    // the install already claimed. electron-updater emits 'error' for a failing
+    // check while its promise is still pending.
+    let failCheck!: (reason: Error) => void;
+
+    updater.checkForUpdates.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      failCheck = reject;
+    }));
+    await jest.runOnlyPendingTimersAsync();
+
+    ipcMainHandlers['update-apply']();
+
+    updater.emit('error', new Error('check failed'));
+    failCheck(new Error('check failed'));
+    await flush();
+
+    ipcMainHandlers['update-apply']();
+
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the install latched when one of two overlapping checks fails', async() => {
+    await setupUpdate(true);
+    await flush();
+
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+
+    // A scheduled check is in flight when a manual retry starts a second one.
+    // The retry finishes first; its completion must not conclude that no check
+    // is running while the slow one is still out there to fail.
+    let failSlowCheck!: (reason: Error) => void;
+
+    updater.checkForUpdates.mockReturnValueOnce(new Promise((_resolve, reject) => {
+      failSlowCheck = reject;
+    }));
+    await jest.runOnlyPendingTimersAsync();
+    ipcMainHandlers['update-retry']();
+    await flush();
+
+    ipcMainHandlers['update-apply']();
+
+    updater.emit('error', new Error('slow check failed'));
+    failSlowCheck(new Error('slow check failed'));
+    await flush();
+
+    ipcMainHandlers['update-apply']();
+
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps checking after an install that did not complete', async() => {
+    await setupUpdate(true);
+    await flush();
+
+    const info = makeInfo('v1.22.3');
+
+    updater.emit('checking-for-update');
+    updater.emit('update-available', info);
+    updater.emit('update-downloaded', info);
+    ipcMainHandlers['update-apply']();
+    updater.checkForUpdates.mockClear();
+
+    // A cancelled quit-to-install leaves the latch set, but the scheduled check
+    // still has to run, or the updater wedges until the next restart.
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(updater.checkForUpdates).toHaveBeenCalled();
+  });
+
+  it('checks again when the user retries a failed download', async() => {
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    });
+    updater.emit('error', new Error('download failed'));
+
+    ipcMainHandlers['update-retry']();
+    await flush();
+
+    expect(updater.checkForUpdates).toHaveBeenCalled();
+  });
+
+  it('keeps the failed-download card up when the retry check also fails', () => {
+    updater.emit('checking-for-update');
+    updater.emit('update-available', makeInfo('v1.22.3'));
+    updater.emit('download-progress', {
+      total: 4, delta: 2, transferred: 2, percent: 50, bytesPerSecond: 2048,
+    });
+    updater.emit('error', new Error('download failed'));
+
+    expect(lastState()).toMatchObject({ available: true, downloaded: false });
+
+    // The user hits Retry and the check fails too. The card and its Retry
+    // button have to stay up rather than vanish until the next scheduled check.
+    updater.emit('checking-for-update');
+    updater.emit('error', new Error('still offline'));
+
+    expect(lastState().available).toBe(true);
   });
 
   it('schedules the next check even when a check fails', async() => {

--- a/pkg/rancher-desktop/main/update/index.ts
+++ b/pkg/rancher-desktop/main/update/index.ts
@@ -37,7 +37,7 @@ enum State {
   CHECKED,
   /** An update is being downloaded; suppress checks. */
   DOWNLOADING,
-  /** An update is pending; we should not check again. */
+  /** An update has been downloaded and is waiting to be installed. */
   UPDATE_PENDING,
   /** An error has occurred configuring the updater. */
   ERROR,
@@ -63,6 +63,15 @@ const updateState: UpdateState = {
 };
 /** The version of the update that has finished downloading, if any. */
 let stagedVersion: string | undefined;
+/** Whether an install is under way; a second one must not start a second installer. */
+let installStarted = false;
+/**
+ * How many update checks are in flight. A failing check reports through the same
+ * error handler as a failing install, so a nonzero count tells the two apart: a
+ * check failing must not release the install latch. It is a count, not a flag,
+ * so an overlapping manual retry and scheduled check cannot clear it early.
+ */
+let checksInFlight = 0;
 
 Electron.ipcMain.on('update-state', () => {
   window.send('update-state', updateState);
@@ -72,7 +81,23 @@ Electron.ipcMain.on('update-apply', () => {
   if (!autoUpdater || process.env.RD_FORCE_UPDATES_ENABLED) {
     return;
   }
+  if (installStarted) {
+    // The button that sends this disables itself, but it forgets that when the
+    // user navigates away and back, and a second quitAndInstall() hands the
+    // same update to a second installer process.
+    return;
+  }
+  installStarted = true;
   autoUpdater.quitAndInstall();
+});
+
+Electron.ipcMain.on('update-retry', () => {
+  if (!autoUpdater) {
+    return;
+  }
+  // The next check is not scheduled until some time tomorrow, which is a long
+  // time to leave someone stuck with an update that failed to download.
+  triggerUpdateCheck();
 });
 
 function isLonghornUpdateInfo(info: UpdateInfo | LonghornUpdateInfo): info is LonghornUpdateInfo {
@@ -138,14 +163,37 @@ async function getUpdater(): Promise<AppUpdater | undefined> {
   updater.on('error', (error) => {
     console.error('update: error:', error);
     updateState.error = error;
-    updateState.downloaded = false;
+    if (checksInFlight === 0) {
+      // Installing may be what failed, and the application is still running to
+      // report it, so let the user ask again. A check failing at the same time
+      // must not release the latch, or a second install could start. The rare
+      // cost: an install that fails alongside an in-flight check keeps the latch
+      // until a later error with no check running, or a restart.
+      installStarted = false;
+    }
+    if (state === State.DOWNLOADING) {
+      // The download failed. triggerUpdateCheck() skips every check while we
+      // are DOWNLOADING, so staying here would stop the updater retrying, or
+      // even noticing a newer release, until the application restarts.
+      state = State.CHECKED;
+    }
+    // A failed download or check does not delete an update that already
+    // finished downloading; it stays installable.
+    updateState.downloaded = !!stagedVersion && updateState.info?.version === stagedVersion;
+    if (updateState.downloaded) {
+      // checking-for-update cleared the on-disk flag on the way in; the staged
+      // update outlived the failure, so put it back.
+      setHasQueuedUpdate(true);
+    }
     window.send('update-state', updateState);
   });
   updater.on('checking-for-update', () => {
     console.debug('update: checking for update');
     // Clear any earlier error so a transient failure stops hiding later offers.
     updateState.error = undefined;
-    updateState.available = false;
+    // Leave `available` for update-available/update-not-available to set. A
+    // check that fails before either fires must not retract the card the last
+    // check put up, which the renderer hides entirely without `available`.
     updateState.downloaded = false;
     // Drop stale progress so a newer offer doesn't show the previous
     // download's percentage.
@@ -306,6 +354,7 @@ async function doInitialUpdateCheck(doInstall = false): Promise<boolean> {
         console.log('Update download complete; restarting app');
         // The persistent update-downloaded handler already recorded the staged
         // version and set the queued flag; here we only need to install.
+        installStarted = true;
         autoUpdater.quitAndInstall(true, true);
         finish(true);
       };
@@ -339,7 +388,13 @@ async function doInitialUpdateCheck(doInstall = false): Promise<boolean> {
  * Trigger an update check, and set up the timer to re-check again later.
  */
 async function triggerUpdateCheck() {
+  // Skip only while a download is under way; a fresh check would race it. An
+  // install running at the same time is fine: checksInFlight keeps a failure
+  // here from being read as a failed install, and gating the check on the
+  // install instead would wedge every later check once a quit-to-install is
+  // cancelled and never clears the latch.
   if (state !== State.DOWNLOADING) {
+    checksInFlight += 1;
     try {
       const result = await autoUpdater.checkForUpdates();
 
@@ -365,6 +420,8 @@ async function triggerUpdateCheck() {
       // Retry in 10 minutes to recover within a normal session.
       console.error('Error checking for updates; will retry in 10 minutes:', ex);
       updateInterval = 10 * 60_000;
+    } finally {
+      checksInFlight -= 1;
     }
   }
 

--- a/pkg/rancher-desktop/pages/General.vue
+++ b/pkg/rancher-desktop/pages/General.vue
@@ -16,6 +16,7 @@
       :enabled="settings.application.updater.enabled"
       :update-state="updateState"
       @apply="onUpdateApply"
+      @retry="onUpdateRetry"
     />
     <blog-feed />
   </div>
@@ -68,6 +69,9 @@ export default {
     },
     onUpdateApply() {
       ipcRenderer.send('update-apply');
+    },
+    onUpdateRetry() {
+      ipcRenderer.send('update-retry');
     },
     onUpdateState(event, state) {
       this.$data.updateState = state;

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -33,6 +33,8 @@ export interface IpcMainEvents {
   'update-state': () => void;
   // Quit and apply the update.
   'update-apply': () => void;
+  // Check again, to retry a download that failed.
+  'update-retry': () => void;
   // #endregion
 
   // #region main/containerEvents


### PR DESCRIPTION
A failed download left the "Update Available" card showing an error with no way to act on it, and it stayed that way until the application restarted: the state machine stayed in DOWNLOADING, where every later check is skipped, so nothing ever retried. An error also discarded an update that had already finished downloading, hiding the button that would have installed it.

Say that the download failed rather than blaming the check, and offer a Retry button so nobody has to wait a day for the next scheduled check.

Closes #7516