### PR TITLE
Add drift detection and the check gate

### DIFF
--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -284,6 +284,53 @@ Checks include:
 - `@override` placement (leaf keys only)
 - `@source` coverage (every translated key carries a `@source`)
 
+### drift
+
+Detect keys whose English source text changed since last translation.
+Compares current `en-us.yaml` values against the `@source` snapshot on each key.
+
+```sh
+i18n-report drift --locale=de
+```
+
+Exits with code 1 when drift is detected, and also when a translated key
+carries no `@source`.
+
+### check
+
+The command CI runs. It has three forms.
+
+Bare `check` runs the locale-independent source gate: keys defined in
+`en-us.yaml` but referenced nowhere (unused), and keys referenced in source
+but missing from `en-us.yaml` (undefined).
+
+```sh
+i18n-report check
+```
+
+`check --locale=<code>` runs the source gate, the registration checks, and
+the per-locale checks: locale file readable, no stale keys, validate passes.
+Checking the source locale (`en-us`) per-locale is an error.
+
+```sh
+i18n-report check --locale=de
+i18n-report check --locale=de --strict
+```
+
+`check --locale=all` covers every translation file on disk.
+
+```sh
+i18n-report check --locale=all
+```
+
+`--strict` adds the completeness checks — no missing keys, no drifted
+keys — for periodic and pre-release runs, while PR CI uses the default
+structural set. Passing `--strict` without `--locale` is an error.
+
+The registration checks verify that the locale enum in `command-api.yaml`,
+`settingsValidator.ts`, its spec, and the `locale.*` display-name keys in
+`en-us.yaml` agree with the translation files on disk.
+
 ## Common workflows
 
 ### Clean up dead keys
@@ -389,6 +436,8 @@ go test ./src/go/i18n-report/...
 | `report_remove.go` | `remove` subcommand, YAML key removal |
 | `report_source.go` | `source` subcommand |
 | `report_validate.go` | `validate` subcommand, placeholder and structure checks |
+| `report_check.go` | `check` subcommand, CI gate |
+| `report_drift.go` | `drift` subcommand |
 
 All files are in `package main`. The tool has one external dependency:
 `gopkg.in/yaml.v3`.

--- a/src/go/i18n-report/compute.go
+++ b/src/go/i18n-report/compute.go
@@ -4,8 +4,9 @@
 
 package main
 
-// Shared key-set computations. The listers (stale, missing, translate) all
-// derive their findings from these helpers.
+// Shared key-set computations. The gate commands (check, drift) and the
+// listers (stale, missing, translate, unused) all derive their findings from
+// these helpers, so a gate and its matching lister agree by construction.
 //
 // Drift compares the current en-us value against the @source snapshot recorded
 // at translation time; both are decoded scalars, so re-quoting the English
@@ -31,6 +32,17 @@ func computeMissing[V any](enKeys map[string]string, localeKeys map[string]V) []
 		}
 	}
 	return missing
+}
+
+// computeUnused returns en-us keys that no source reference covers, sorted.
+func computeUnused[V any](enKeys map[string]string, refs map[string]V) []string {
+	var unused []string
+	for _, k := range sortedKeys(enKeys) {
+		if _, found := refs[k]; !found {
+			unused = append(unused, k)
+		}
+	}
+	return unused
 }
 
 // computeDrifted returns keys whose English source differs from the @source

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -18,9 +18,9 @@ import (
 )
 
 // errFindings marks an error that reports problems in the data being checked
-// (such as undefined key references) rather than an operational failure (an
-// unreadable file, a bad flag). main exits 1 for findings and 2 for
-// operational errors, so CI can tell them apart.
+// (drifted keys, undefined references, failed check gates) rather than an
+// operational failure (an unreadable file, a bad flag). main exits 1 for
+// findings and 2 for operational errors, so CI can tell them apart.
 var errFindings = errors.New("findings")
 
 // findingsError matches errFindings without wrapping it, so the sentinel
@@ -40,8 +40,10 @@ var subcommands = map[string]func([]string) error{
 	"untranslated": runUntranslated,
 	"references":   runReferences,
 	"dynamic":      runDynamic,
+	"check":        runCheck,
 	"remove":       runRemove,
 	"source":       runSource,
+	"drift":        runDrift,
 	"validate":     runValidate,
 }
 
@@ -86,7 +88,9 @@ Subcommands:
   untranslated  Hardcoded English strings in Vue/TS files (heuristic)
   references    Where each en-us.yaml key is used (file:line)
   dynamic       Template literal patterns that reference keys dynamically
+  check         Source gate (unused + undefined); per-locale checks with --locale
   source        Record the English source text on each translated key
+  drift         Detect translated keys whose English source has changed
   validate      Structural checks: placeholders, tags, sources, overrides
 
 Run "i18n-report <subcommand> -h" for subcommand-specific flags.`)

--- a/src/go/i18n-report/repo.go
+++ b/src/go/i18n-report/repo.go
@@ -16,6 +16,9 @@ const translationsDir = "pkg/rancher-desktop/assets/translations"
 // sourceLocale is the locale every translation derives from.
 const sourceLocale = "en-us"
 
+// localeAll is the --locale value that selects every translation on disk.
+const localeAll = "all"
+
 // repoRoot returns the repository root by walking up from the current
 // directory looking for the translations directory. Nested package.json
 // files (bats/, sudo-prompt/) make that marker ambiguous.

--- a/src/go/i18n-report/report_check.go
+++ b/src/go/i18n-report/report_check.go
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// runCheck is the CI gate. Bare `check` runs the locale-independent source
+// gate (unused + undefined keys). With --locale it also verifies the locale
+// registration surfaces and runs the per-locale checks; --locale=all covers
+// every translation file on disk. --strict adds the completeness checks
+// (no missing, no drifted keys) for periodic and pre-release runs, while
+// PR CI uses the default structural set.
+func runCheck(args []string) error {
+	fs := flag.NewFlagSet("check", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale, or 'all' (omit for the source-only gate)")
+	strict := fs.Bool("strict", false, "Require complete translations: no missing, no drifted keys (requires --locale)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *strict && *locale == "" {
+		return fmt.Errorf("--strict requires --locale")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	available, err := translationLocales(root)
+	if err != nil {
+		return err
+	}
+
+	// Reject a bad single --locale before the source gate prints, so it is an
+	// operational error like drift's rather than a per-locale finding surfaced
+	// after a partial pass. --locale=all needs no such check.
+	if *locale != "" && *locale != localeAll {
+		if *locale == sourceLocale {
+			return fmt.Errorf("locale %q is the source locale; per-locale checks do not apply", *locale)
+		}
+		if !slices.Contains(available, *locale) {
+			return fmt.Errorf("no translation file for locale %q", *locale)
+		}
+	}
+
+	// The source gate always runs. An operational failure (unreadable file)
+	// aborts immediately; findings are collected and combined with the
+	// per-locale results below.
+	sourceErr := reportCheckSource(os.Stdout, root)
+	if sourceErr != nil && !errors.Is(sourceErr, errFindings) {
+		return sourceErr
+	}
+
+	if *locale == "" {
+		return sourceErr
+	}
+
+	failed := sourceErr != nil
+
+	fmt.Println()
+	if regErr := reportCheckRegistration(os.Stdout, root, available); regErr != nil {
+		if !errors.Is(regErr, errFindings) {
+			return regErr
+		}
+		failed = true
+	}
+
+	locales := available
+	if *locale != localeAll {
+		locales = []string{*locale}
+	}
+
+	for _, loc := range locales {
+		fmt.Println()
+		if err := reportCheckLocale(os.Stdout, root, loc, *strict); err != nil {
+			if !errors.Is(err, errFindings) {
+				return err
+			}
+			failed = true
+		}
+	}
+
+	if failed {
+		return findingsError("check failed")
+	}
+	return nil
+}
+
+// reportCheckSource runs the locale-independent source gate: keys defined in
+// en-us.yaml but referenced nowhere (unused) and keys referenced in source
+// but missing from en-us.yaml (undefined). Undefined keys render as "%key%"
+// placeholders in every locale, so they fail regardless of locale.
+func reportCheckSource(w io.Writer, root string) error {
+	enPath := translationsPath(root, "en-us.yaml")
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return err
+	}
+
+	refs, err := findKeyReferences(root, enKeys)
+	if err != nil {
+		return err
+	}
+	unusedCount := len(computeUnused(enKeys, refs))
+
+	undefined, err := findUndefinedKeys(root, enKeys)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "Source checks:")
+	passed := true
+	printResult := func(label string, count int) {
+		status := "OK"
+		if count > 0 {
+			status = "FAIL"
+			passed = false
+		}
+		fmt.Fprintf(w, "  %-30s %3d  %s\n", label+":", count, status)
+	}
+
+	printResult("unused keys", unusedCount)
+	printResult("undefined keys", len(undefined))
+
+	if passed {
+		fmt.Fprintln(w, "Source checks passed.")
+		return nil
+	}
+	return findingsError("source checks failed")
+}
+
+// reportCheckRegistration checks that every locale registration surface
+// agrees with the translation files on disk: the locale enum in
+// command-api.yaml, the settingsValidator.ts enum construction, the
+// validator spec's test values, and the locale.* display-name keys in
+// en-us.yaml.
+func reportCheckRegistration(w io.Writer, root string, locales []string) error {
+	apiLocales, err := parseAPILocaleEnum(translationsPath(root, "../specs/command-api.yaml"))
+	if err != nil {
+		return err
+	}
+
+	// The expected enum: "none" (no language selected), the source locale,
+	// and every translation file on disk.
+	expected := map[string]bool{"none": true, sourceLocale: true}
+	for _, code := range locales {
+		expected[code] = true
+	}
+
+	apiSet := make(map[string]bool)
+	for _, code := range apiLocales {
+		apiSet[code] = true
+	}
+
+	var problems []string
+
+	for code := range expected {
+		if !apiSet[code] {
+			problems = append(problems, fmt.Sprintf("  locale %q missing from command-api.yaml enum", code))
+		}
+	}
+	for code := range apiSet {
+		if !expected[code] {
+			problems = append(problems, fmt.Sprintf("  command-api.yaml enum has %q with no translation file", code))
+		}
+	}
+
+	// settingsValidator.ts must build its enum from the translation files
+	// instead of a hardcoded list. An unreadable registration file is an
+	// operational failure, like an unreadable command-api.yaml above; only a
+	// present-but-wrong file is a finding.
+	validatorPath := filepath.Join(root, "pkg", "rancher-desktop", "main",
+		"commandServer", "settingsValidator.ts")
+	validatorData, err := os.ReadFile(validatorPath)
+	if err != nil {
+		return fmt.Errorf("reading settingsValidator.ts: %w", err)
+	}
+	if !strings.Contains(string(validatorData), "...availableLocales") {
+		problems = append(problems, "  settingsValidator.ts: locale checkEnum does not use ...availableLocales (hardcoded list?)")
+	}
+
+	// Validate settingsValidator.spec.ts test values.
+	specPath := filepath.Join(root, "pkg", "rancher-desktop", "main",
+		"commandServer", "__tests__", "settingsValidator.spec.ts")
+	specData, err := os.ReadFile(specPath)
+	if err != nil {
+		return fmt.Errorf("reading settingsValidator.spec.ts: %w", err)
+	}
+	problems = append(problems, crossValidateSpec(string(specData), expected)...)
+
+	// Every locale needs a display name for the language picker.
+	enKeys, err := loadYAMLFlat(translationsPath(root, "en-us.yaml"))
+	if err != nil {
+		return fmt.Errorf("reading en-us.yaml: %w", err)
+	}
+	for _, code := range append([]string{sourceLocale}, locales...) {
+		if _, exists := enKeys["locale."+code]; !exists {
+			problems = append(problems, fmt.Sprintf("  en-us.yaml is missing the display-name key %q", "locale."+code))
+		}
+	}
+
+	sort.Strings(problems)
+
+	fmt.Fprintln(w, "Registration checks:")
+	if len(problems) > 0 {
+		for _, p := range problems {
+			fmt.Fprintln(w, p)
+		}
+		return findingsError("registration checks failed")
+	}
+	fmt.Fprintln(w, "Registration checks passed.")
+	return nil
+}
+
+// parseAPILocaleEnum extracts the locale enum values from command-api.yaml
+// by parsing the YAML structure instead of using fragile regex matching.
+func parseAPILocaleEnum(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading command-api.yaml: %w", err)
+	}
+
+	// Parse into a generic structure and navigate to the locale enum.
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing command-api.yaml: %w", err)
+	}
+
+	// Navigate: paths.*.*.properties.application.properties.locale.enum
+	// The locale enum sits deep under application settings; find it by
+	// recursively searching every map for a "locale" property that has an
+	// "enum".
+	locales := findLocaleEnum(doc)
+	if locales == nil {
+		return nil, fmt.Errorf("could not find locale enum in command-api.yaml")
+	}
+	return locales, nil
+}
+
+// findLocaleEnum searches a parsed YAML structure for a "locale" property
+// definition that contains an "enum" list, returning the enum values.
+func findLocaleEnum(v interface{}) []string {
+	switch node := v.(type) {
+	case map[string]interface{}:
+		// If this map has a "locale" key whose value has an "enum", that's it.
+		if locale, found := node["locale"]; found {
+			if localeMap, ok := locale.(map[string]interface{}); ok {
+				if enumVal, hasEnum := localeMap["enum"]; hasEnum {
+					if items, ok := enumVal.([]interface{}); ok {
+						var result []string
+						for _, item := range items {
+							if s, ok := item.(string); ok {
+								result = append(result, s)
+							}
+						}
+						if len(result) > 0 {
+							return result
+						}
+					}
+				}
+			}
+		}
+		// Recurse into all map values.
+		for _, val := range node {
+			if result := findLocaleEnum(val); result != nil {
+				return result
+			}
+		}
+	case []interface{}:
+		for _, val := range node {
+			if result := findLocaleEnum(val); result != nil {
+				return result
+			}
+		}
+	}
+	return nil
+}
+
+// specLocaleRe matches locale string values in test assertions, e.g.:
+//
+//	{ application: { locale: 'de' } }
+var specLocaleRe = regexp.MustCompile(`locale:\s*'([a-z][\w-]*)'`)
+
+// crossValidateSpec checks that locale values used as valid inputs in
+// the settings validator spec correspond to translation files on disk.
+func crossValidateSpec(specContent string, knownLocales map[string]bool) []string {
+	matches := specLocaleRe.FindAllStringSubmatch(specContent, -1)
+	seen := make(map[string]bool)
+	var problems []string
+	for _, m := range matches {
+		code := m[1]
+		if seen[code] {
+			continue
+		}
+		seen[code] = true
+		// "none" and "invalid" are special test values, not real locales.
+		if code == "none" || code == "invalid" {
+			continue
+		}
+		if !knownLocales[code] {
+			problems = append(problems, fmt.Sprintf("  settingsValidator.spec.ts uses locale %q with no translation file", code))
+		}
+	}
+	return problems
+}
+
+// reportCheckLocale runs the per-locale checks:
+//   - locale file present
+//   - no stale keys
+//   - validate passes (placeholders, ICU structure, tags, metadata)
+//
+// With strict, the locale must also be complete:
+//   - no missing keys
+//   - no drifted keys
+func reportCheckLocale(w io.Writer, root, locale string, strict bool) error {
+	passed := true
+	printResult := func(label string, ok bool, detail string) {
+		status := "OK"
+		if !ok {
+			status = "FAIL"
+			passed = false
+		}
+		if detail != "" {
+			fmt.Fprintf(w, "  %-35s %s  %s\n", label+":", status, detail)
+		} else {
+			fmt.Fprintf(w, "  %-35s %s\n", label+":", status)
+		}
+	}
+
+	label := "Checks"
+	if strict {
+		label = "Strict checks"
+	}
+	fmt.Fprintf(w, "%s for %s:\n", label, locale)
+
+	localePath := translationsPath(root, locale+".yaml")
+	enPath := translationsPath(root, "en-us.yaml")
+
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return err
+	}
+
+	localeKeys, localeErr := loadYAMLFlat(localePath)
+	printResult("locale file readable", localeErr == nil, errString(localeErr))
+	if localeErr != nil {
+		localeKeys = make(map[string]string)
+	}
+
+	// No stale keys.
+	staleCount := len(computeStale(enKeys, localeKeys))
+	printResult("no stale keys", staleCount == 0, countDetail(staleCount))
+
+	// Validate passes.
+	validateErr := reportValidateQuiet(root, locale)
+	printResult("validate passes", validateErr == nil, errString(validateErr))
+
+	// Load @source snapshots for the drift check below. Their coherence is
+	// already covered by the "validate passes" check above (validateLocale
+	// checks it).
+	meta, metaErr := loadSources(root, locale)
+	if metaErr != nil {
+		printResult("@source readable", false, errString(metaErr))
+	}
+
+	// Completeness checks.
+	if strict {
+		missingCount := len(computeMissing(enKeys, localeKeys))
+		printResult("no missing keys", missingCount == 0, countDetail(missingCount))
+
+		if meta != nil {
+			driftCount := len(computeDrifted(enKeys, meta, localeKeys))
+			printResult("no drifted keys", driftCount == 0, countDetail(driftCount))
+		}
+	}
+
+	if passed {
+		fmt.Fprintf(w, "All checks passed for %s.\n", locale)
+		return nil
+	}
+	return findingsError(fmt.Sprintf("checks failed for %s", locale))
+}
+
+// reportValidateQuiet runs validate and returns an error summary without
+// printing individual errors.
+func reportValidateQuiet(root, locale string) error {
+	errs, err := validateLocale(root, locale)
+	if err != nil {
+		return err
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%d validation errors", len(errs))
+	}
+	return nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func countDetail(count int) string {
+	if count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d found", count)
+}

--- a/src/go/i18n-report/report_check_test.go
+++ b/src/go/i18n-report/report_check_test.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckSourceReportsUnusedAsFindings(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	// No source file references status.checking, so it is unused.
+	err := reportCheckSource(io.Discard, dir)
+	if err == nil {
+		t.Fatal("expected findings for an unused key")
+	}
+	if !errors.Is(err, errFindings) {
+		t.Errorf("unused key should be a findings error, got: %v", err)
+	}
+}
+
+func TestCheckSourcePassesWhenKeyReferenced(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	srcDir := filepath.Join(dir, "pkg", "rancher-desktop", "components")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	source := "<template>\n  <span v-t=\"'status.checking'\" />\n</template>\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "Sample.vue"), []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reportCheckSource(io.Discard, dir); err != nil {
+		t.Errorf("expected source gate to pass, got: %v", err)
+	}
+}
+
+func TestCheckLocaleFailureIsFindings(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n  removed: Veraltet\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	err := reportCheckLocale(io.Discard, dir, "de", false)
+	if !errors.Is(err, errFindings) {
+		t.Errorf("check failure should be a findings error, got: %v", err)
+	}
+}
+
+func TestCheckLocalePassesWithMissingKeys(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	// de has only 1 key — missing keys are OK for the structural checks.
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	err := reportCheckLocale(io.Discard, dir, "de", false)
+	if err != nil {
+		t.Errorf("structural checks should pass with missing keys, got: %v", err)
+	}
+}
+
+func TestCheckStrictFailsMissing(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	err := reportCheckLocale(io.Discard, dir, "de", true)
+	if err == nil {
+		t.Error("strict should fail with missing keys")
+	}
+}
+
+func TestCheckStrictPasses(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n  done: Fertig\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	err := reportCheckLocale(io.Discard, dir, "de", true)
+	if err != nil {
+		t.Errorf("strict should pass with complete translation, got: %v", err)
+	}
+}
+
+func TestCheckLocaleFailsStale(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	// de has a stale key not in en-us.
+	de := "status:\n  checking: Wird geprüft…\n  removed: Veraltet\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	err := reportCheckLocale(io.Discard, dir, "de", false)
+	if err == nil {
+		t.Error("structural checks should fail with stale keys")
+	}
+}
+
+func TestCheckStrictFailsDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	// Change English after metadata was generated.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte("status:\n  checking: Verifying...\n"), 0644)
+
+	err := reportCheckLocale(io.Discard, dir, "de", true)
+	if err == nil {
+		t.Error("strict should fail with drifted keys")
+	}
+}
+
+// setupRegistrationTestRepo builds a repo fixture with en-us.yaml (including
+// locale display names) and the given locale files.
+func setupRegistrationTestRepo(t *testing.T, localeFiles []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644)
+
+	enUS := "locale:\n  de: German\n  en-us: English\n  fa: Farsi\n"
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+
+	for _, name := range localeFiles {
+		os.WriteFile(filepath.Join(transDir, name), []byte("locale:\n  name: Test\n"), 0o644)
+	}
+	return dir
+}
+
+// writeCrossValidationFiles writes the registration surfaces that
+// reportCheckRegistration inspects into a test repo directory.
+func writeCrossValidationFiles(t *testing.T, dir string, apiEnum string, validatorDynamic bool, specLocales string) {
+	t.Helper()
+
+	// command-api.yaml
+	specsDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "specs")
+	os.MkdirAll(specsDir, 0o755)
+	apiYAML := fmt.Sprintf(`paths:
+  /v1/settings:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  application:
+                    properties:
+                      locale:
+                        type: string
+                        enum: [%s]
+`, apiEnum)
+	os.WriteFile(filepath.Join(specsDir, "command-api.yaml"), []byte(apiYAML), 0o644)
+
+	// settingsValidator.ts
+	validatorDir := filepath.Join(dir, "pkg", "rancher-desktop", "main", "commandServer")
+	os.MkdirAll(validatorDir, 0o755)
+	validatorContent := "locale: this.checkEnum('none', 'de'),\n"
+	if validatorDynamic {
+		validatorContent = "locale: this.checkEnum('none', ...availableLocales),\n"
+	}
+	os.WriteFile(filepath.Join(validatorDir, "settingsValidator.ts"), []byte(validatorContent), 0o644)
+
+	// settingsValidator.spec.ts
+	testDir := filepath.Join(validatorDir, "__tests__")
+	os.MkdirAll(testDir, 0o755)
+	specContent := fmt.Sprintf(`describe('application.locale', () => {
+  it('should accept valid locales', () => {
+    %s
+  });
+  it('should reject invalid values', () => {
+    { application: { locale: 'invalid' } }
+  });
+});
+`, specLocales)
+	os.WriteFile(filepath.Join(testDir, "settingsValidator.spec.ts"), []byte(specContent), 0o644)
+}
+
+// checkRegistration derives the locale list from the fixture directory and
+// runs reportCheckRegistration on it.
+func checkRegistration(t *testing.T, dir string) error {
+	t.Helper()
+	locales, err := translationLocales(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return reportCheckRegistration(io.Discard, dir, locales)
+}
+
+func TestCheckRegistrationMatch(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
+	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+		"{ application: { locale: 'en-us' } }, { application: { locale: 'de' } }")
+
+	if err := checkRegistration(t, dir); err != nil {
+		t.Errorf("registration checks should pass: %v", err)
+	}
+}
+
+func TestCheckRegistrationMissingFromEnum(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml", "fa.yaml"})
+
+	// The API enum is missing "fa".
+	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+		"{ application: { locale: 'de' } }")
+
+	err := checkRegistration(t, dir)
+	if err == nil {
+		t.Fatal("registration checks should fail when the enum is missing a locale")
+	}
+	if !errors.Is(err, errFindings) {
+		t.Errorf("registration mismatch should be a findings error, got: %v", err)
+	}
+}
+
+func TestCheckRegistrationEnumWithoutFile(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
+
+	// The API enum lists "fa", but fa.yaml does not exist.
+	writeCrossValidationFiles(t, dir, "none, de, en-us, fa", true,
+		"{ application: { locale: 'de' } }")
+
+	if err := checkRegistration(t, dir); err == nil {
+		t.Error("registration checks should fail when the enum has a locale with no file")
+	}
+}
+
+func TestCheckRegistrationHardcodedValidator(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
+
+	// settingsValidator.ts uses a hardcoded list instead of ...availableLocales.
+	writeCrossValidationFiles(t, dir, "none, de, en-us", false,
+		"{ application: { locale: 'de' } }")
+
+	if err := checkRegistration(t, dir); err == nil {
+		t.Error("registration checks should fail when settingsValidator.ts uses hardcoded locales")
+	}
+}
+
+func TestCheckRegistrationSpecUnknownLocale(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
+
+	// The spec references 'fr', which has no translation file.
+	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+		"{ application: { locale: 'fr' } }")
+
+	if err := checkRegistration(t, dir); err == nil {
+		t.Error("registration checks should fail when the spec uses a locale with no file")
+	}
+}
+
+func TestCheckRegistrationMissingDisplayName(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml", "pt.yaml"})
+
+	// en-us.yaml has no locale.pt display name.
+	writeCrossValidationFiles(t, dir, "none, de, en-us, pt", true,
+		"{ application: { locale: 'de' } }")
+
+	if err := checkRegistration(t, dir); err == nil {
+		t.Error("registration checks should fail when en-us.yaml lacks a locale display name")
+	}
+}
+
+// withDiscardedStdout runs fn with os.Stdout redirected to the null device, so
+// a command that writes its report to os.Stdout leaves test output clean.
+func withDiscardedStdout(t *testing.T, fn func()) {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = devnull
+	defer func() {
+		os.Stdout = orig
+		devnull.Close()
+	}()
+	fn()
+}
+
+// setupCheckRepo builds a full fixture runCheck can run against: en-us with two
+// display names and a content key, a partial de translation, and the
+// registration surfaces. When referenced is true, a component references every
+// en-us key so the source gate passes; otherwise every key is unused and the
+// source gate reports findings.
+func setupCheckRepo(t *testing.T, referenced bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+	os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644)
+
+	enUS := "locale:\n  de: German\n  en-us: English\nstatus:\n  running: Running\n"
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte("status:\n  running: Läuft\n"), 0o644)
+	bootstrapSource(t, dir)
+
+	if referenced {
+		compDir := filepath.Join(dir, "pkg", "rancher-desktop", "components")
+		os.MkdirAll(compDir, 0o755)
+		src := "<template>\n  <span v-t=\"'locale.de'\" />\n  <span v-t=\"'locale.en-us'\" />\n  <span v-t=\"'status.running'\" />\n</template>\n"
+		os.WriteFile(filepath.Join(compDir, "Sample.vue"), []byte(src), 0o644)
+	}
+
+	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+		"{ application: { locale: 'de' } }")
+	return dir
+}
+
+// TestRunCheckRejectsBadLocaleAsOperational verifies that a misused --locale is
+// an operational error, not a findings error. drift already reports a bad
+// locale operationally; check must agree, so CI can tell a broken invocation
+// from a real translation problem.
+func TestRunCheckRejectsBadLocaleAsOperational(t *testing.T) {
+	dir := setupCheckRepo(t, true)
+	t.Chdir(dir)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"strict without locale", []string{"--strict"}, "--strict requires --locale"},
+		{"source locale", []string{"--locale=en-us"}, "source locale"},
+		{"unknown locale", []string{"--locale=xx"}, "no translation file"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			withDiscardedStdout(t, func() { err = runCheck(tc.args) })
+			if err == nil {
+				t.Fatal("expected an operational error, got nil")
+			}
+			if errors.Is(err, errFindings) {
+				t.Errorf("a misused --locale must be operational, not a finding: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestRunCheckSourceFindingFailsOverall verifies that a source-gate finding
+// fails the whole check even when registration and the per-locale checks pass.
+func TestRunCheckSourceFindingFailsOverall(t *testing.T) {
+	dir := setupCheckRepo(t, false)
+	t.Chdir(dir)
+
+	var err error
+	withDiscardedStdout(t, func() { err = runCheck([]string{"--locale=de"}) })
+	if !errors.Is(err, errFindings) {
+		t.Errorf("a source-gate finding should fail the check as a finding, got: %v", err)
+	}
+}

--- a/src/go/i18n-report/report_drift.go
+++ b/src/go/i18n-report/report_drift.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+// driftEntry describes a single key where English source has changed since
+// the translation was last merged.
+type driftEntry struct {
+	Key      string
+	Override bool
+}
+
+func runDrift(args []string) error {
+	fs := flag.NewFlagSet("drift", flag.ExitOnError)
+	locale := fs.String("locale", "", "Target locale code (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *locale == "" {
+		return fmt.Errorf("--locale is required")
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	return reportDrift(os.Stdout, root, *locale)
+}
+
+// reportDrift reports translated keys whose English source changed since
+// their stored @source snapshot.
+func reportDrift(w io.Writer, root, locale string) error {
+	enPath := translationsPath(root, "en-us.yaml")
+	localePath := translationsPath(root, locale+".yaml")
+
+	if _, err := os.Stat(localePath); os.IsNotExist(err) {
+		return fmt.Errorf("locale file not found: %s", localePath)
+	}
+
+	enKeys, err := loadYAMLFlat(enPath)
+	if err != nil {
+		return err
+	}
+
+	doc, err := loadYAMLDocument(localePath)
+	if err != nil {
+		return err
+	}
+	treeRoot := documentRoot(doc)
+	localeLeaves := nodeAllLeaves(treeRoot)
+
+	meta, err := loadSources(root, locale)
+	if err != nil {
+		return err
+	}
+
+	// Find drifted keys, recording whether each carries an @override.
+	var drifted []driftEntry
+	for _, key := range computeDrifted(enKeys, meta, localeLeaves) {
+		drifted = append(drifted, driftEntry{
+			Key:      key,
+			Override: nodeHasOverride(treeRoot, key),
+		})
+	}
+
+	// Report translated keys that carry no @source snapshot.
+	var missingSource []string
+	for key := range localeLeaves {
+		if _, inEn := enKeys[key]; !inEn {
+			continue
+		}
+		if _, hasSource := meta[key]; !hasSource {
+			missingSource = append(missingSource, key)
+		}
+	}
+
+	// Print results.
+	if len(drifted) == 0 && len(missingSource) == 0 {
+		fmt.Fprintf(w, "No drift detected for %s.\n", locale)
+		return nil
+	}
+
+	sort.Slice(drifted, func(i, j int) bool { return drifted[i].Key < drifted[j].Key })
+	sort.Strings(missingSource)
+
+	if len(drifted) > 0 {
+		fmt.Fprintf(w, "Found %d drifted keys in %s:\n", len(drifted), locale)
+		for _, d := range drifted {
+			suffix := ""
+			if d.Override {
+				suffix = " (@override)"
+			}
+			fmt.Fprintf(w, "  %s%s\n", d.Key, suffix)
+		}
+	}
+
+	if len(missingSource) > 0 {
+		fmt.Fprintf(w, "\n%d keys missing @source:\n", len(missingSource))
+		for _, key := range missingSource {
+			fmt.Fprintf(w, "  %s\n", key)
+		}
+		fmt.Fprintf(os.Stderr, "Run 'i18n-report source --locale=%s' to record the missing @source.\n", locale)
+	}
+
+	return findingsError(fmt.Sprintf("found %d drifted, %d missing @source", len(drifted), len(missingSource)))
+}

--- a/src/go/i18n-report/report_drift_test.go
+++ b/src/go/i18n-report/report_drift_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-FileCopyrightText: The Rancher Desktop Authors
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDriftFindingsVsOperationalError(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupDriftTestRepo(t, enUS, de)
+	bootstrapSource(t, dir)
+
+	// Drift the English so reportDrift reports a finding.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte("status:\n  checking: Verifying...\n"), 0o644)
+
+	findErr := reportDrift(io.Discard, dir, "de")
+	if !errors.Is(findErr, errFindings) {
+		t.Errorf("drift finding should wrap errFindings, got: %v", findErr)
+	}
+
+	// An unreadable locale file is operational, not a finding.
+	dir2 := setupDriftTestRepo(t, enUS, "")
+	os.Remove(filepath.Join(dir2, "pkg", "rancher-desktop", "assets", "translations", "de.yaml"))
+	opErr := reportDrift(io.Discard, dir2, "de")
+	if opErr == nil {
+		t.Fatal("expected an operational error for a missing locale file")
+	}
+	if errors.Is(opErr, errFindings) {
+		t.Errorf("missing-file error must not be a findings error: %v", opErr)
+	}
+}
+
+func setupDriftTestRepo(t *testing.T, enUS, locale string) string {
+	t.Helper()
+	dir := t.TempDir()
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.MkdirAll(transDir, 0o755)
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(enUS), 0o644)
+	os.WriteFile(filepath.Join(transDir, "de.yaml"), []byte(locale), 0o644)
+	return dir
+}
+
+func TestDriftDetectsChangedEnglish(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n  done: Fertig\n"
+	dir := setupDriftTestRepo(t, enUS, de)
+
+	// Generate metadata with current English.
+	bootstrapSource(t, dir)
+
+	// Change English text for "checking".
+	newEnUS := "status:\n  checking: Verifying...\n  done: Done\n"
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte(newEnUS), 0o644)
+
+	var buf bytes.Buffer
+	if err := reportDrift(&buf, dir, "de"); err == nil {
+		t.Fatal("expected non-nil error when drift is detected")
+	}
+	output := buf.String()
+
+	if !strings.Contains(output, "status.checking") {
+		t.Errorf("expected drifted key status.checking in output:\n%s", output)
+	}
+	// "done" did not change, should not appear.
+	if strings.Contains(output, "status.done") {
+		t.Errorf("status.done should not be drifted:\n%s", output)
+	}
+}
+
+func TestDriftNoDrift(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupDriftTestRepo(t, enUS, de)
+
+	bootstrapSource(t, dir)
+
+	var buf bytes.Buffer
+	if err := reportDrift(&buf, dir, "de"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), "No drift detected") {
+		t.Errorf("expected no drift, got:\n%s", buf.String())
+	}
+}
+
+func TestDriftFlagsOverride(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  # @override\n  checking: Manuelle Übersetzung\n"
+	dir := setupDriftTestRepo(t, enUS, de)
+
+	bootstrapSource(t, dir)
+
+	// Change English.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.WriteFile(filepath.Join(transDir, "en-us.yaml"), []byte("status:\n  checking: Verifying...\n"), 0o644)
+
+	var buf bytes.Buffer
+	reportDrift(&buf, dir, "de")
+	output := buf.String()
+
+	if !strings.Contains(output, "(@override)") {
+		t.Errorf("expected @override flag in drift output:\n%s", output)
+	}
+}
+
+func TestDriftMissingLocaleFile(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	dir := setupDriftTestRepo(t, enUS, "")
+
+	// Remove the locale file so only en-us exists.
+	transDir := filepath.Join(dir, "pkg", "rancher-desktop", "assets", "translations")
+	os.Remove(filepath.Join(transDir, "de.yaml"))
+
+	err := reportDrift(io.Discard, dir, "de")
+	if err == nil {
+		t.Fatal("expected error for missing locale file")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestDriftMissingMetadata(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n  done: Done\n"
+	de := "status:\n  checking: Wird geprüft…\n  done: Fertig\n"
+	dir := setupDriftTestRepo(t, enUS, de)
+
+	// No @source recorded — both keys should report as missing @source.
+	var buf bytes.Buffer
+	reportDrift(&buf, dir, "de")
+
+	if !strings.Contains(buf.String(), "missing @source") {
+		t.Errorf("expected missing @source warning:\n%s", buf.String())
+	}
+}

--- a/src/go/i18n-report/report_source.go
+++ b/src/go/i18n-report/report_source.go
@@ -30,7 +30,7 @@ func runSource(args []string) error {
 		return err
 	}
 
-	if *locale == "all" {
+	if *locale == localeAll {
 		locales, err := translationLocales(root)
 		if err != nil {
 			return err

--- a/src/go/i18n-report/report_undefined_test.go
+++ b/src/go/i18n-report/report_undefined_test.go
@@ -7,6 +7,9 @@ package main
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -69,5 +72,26 @@ func TestReportUndefinedFindingsError(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "findings") {
 		t.Errorf("sentinel text leaked into the message: %q", err.Error())
+	}
+}
+
+func TestCheckSourceFailsOnUndefinedKeys(t *testing.T) {
+	enUS := "status:\n  checking: Checking...\n"
+	de := "status:\n  checking: Wird geprüft…\n"
+	dir := setupLocaleTestRepo(t, enUS, de, true)
+
+	srcDir := filepath.Join(dir, "pkg", "rancher-desktop", "components")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// status.checking is referenced so nothing is unused; status.removed is
+	// referenced but not defined, so only the undefined check can fail.
+	source := "<template>\n  <span v-t=\"'status.checking'\" />\n  <span v-t=\"'status.removed'\" />\n</template>\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "Sample.vue"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reportCheckSource(io.Discard, dir); err == nil {
+		t.Error("source gate should fail when a referenced key is missing from en-us.yaml")
 	}
 }

--- a/src/go/i18n-report/report_unused.go
+++ b/src/go/i18n-report/report_unused.go
@@ -38,12 +38,7 @@ func reportUnused(root, format string) error {
 		return err
 	}
 
-	var unused []string
-	for _, k := range sortedKeys(keys) {
-		if _, found := refs[k]; !found {
-			unused = append(unused, k)
-		}
-	}
+	unused := computeUnused(keys, refs)
 
 	return outputStrings(os.Stdout, unused, format, "unused keys")
 }

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -51,7 +51,7 @@ type validationError struct {
 }
 
 // validateLocale runs all structural checks on a locale file and returns
-// the errors found.
+// the errors found. Both reportValidate and reportValidateQuiet use this.
 func validateLocale(root, locale string) ([]validationError, error) {
 	enPath := translationsPath(root, "en-us.yaml")
 	localePath := translationsPath(root, locale+".yaml")


### PR DESCRIPTION
`drift` compares each translated key against the `@source` snapshot recorded when it was translated, so English that has changed since shows up as a key needing retranslation instead of silently shipping a stale string.

`check` is the command CI runs. Its default set is structural, so a PR fails only on breakage a reviewer must act on; `--strict` adds the completeness checks — no missing keys, no drift — for periodic and pre-release runs, where an unfinished locale is what matters.
