### PR TITLE
Add runtime i18n translation layer

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -109,3 +109,5 @@ ignore$
 ^screenshots/test-data/
 # i18n tool tests use German sample translations
 ^src/go/i18n-report/.*_test\.go$
+# i18n runtime tests use German sample translations
+^\Qpkg/rancher-desktop/store/__tests__/i18n.spec.ts\E$

--- a/background.ts
+++ b/background.ts
@@ -31,7 +31,7 @@ import { HttpCredentialHelperServer } from '@pkg/main/credentialServer/httpCrede
 import { DeploymentProfileError, readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
 import { DiagnosticsManager, DiagnosticsResultCollection } from '@pkg/main/diagnostics/diagnostics';
 import { ExtensionErrorCode, isExtensionError } from '@pkg/main/extensions';
-import { initMainI18n, t } from '@pkg/main/i18n';
+import { initMainI18n } from '@pkg/main/i18n';
 import { ImageEventHandler } from '@pkg/main/imageEvents';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import mainEvents from '@pkg/main/mainEvents';

--- a/background.ts
+++ b/background.ts
@@ -31,6 +31,7 @@ import { HttpCredentialHelperServer } from '@pkg/main/credentialServer/httpCrede
 import { DeploymentProfileError, readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
 import { DiagnosticsManager, DiagnosticsResultCollection } from '@pkg/main/diagnostics/diagnostics';
 import { ExtensionErrorCode, isExtensionError } from '@pkg/main/extensions';
+import { initMainI18n, t } from '@pkg/main/i18n';
 import { ImageEventHandler } from '@pkg/main/imageEvents';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import mainEvents from '@pkg/main/mainEvents';
@@ -284,6 +285,7 @@ Electron.app.whenReady().then(async() => {
     await httpCommandServer.init();
     await httpCredentialHelperServer.init();
 
+    await initMainI18n();
     await initUI();
     await checkForBackendLock();
     await setPathManager(cfg.application.pathManagementStrategy);

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,10 +24,10 @@ export default {
     '<rootDir>/screenshots',
   ],
   moduleNameMapper: {
-    '\\.css$':       '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
-    '^@pkg/assets/': '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
-    '^@pkg/(.*)$':   '<rootDir>/pkg/rancher-desktop/$1',
-    '^@/(.*)$':      '<rootDir>/$1',
+    '\\.css$':                        '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
+    '^@pkg/assets/':                  '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
+    '^@pkg/(.*)$':                    '<rootDir>/pkg/rancher-desktop/$1',
+    '^@/(.*)$':                       '<rootDir>/$1',
   },
   setupFiles: [
     '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupVue.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,10 +24,10 @@ export default {
     '<rootDir>/screenshots',
   ],
   moduleNameMapper: {
-    '\\.css$':                        '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
-    '^@pkg/assets/':                  '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
-    '^@pkg/(.*)$':                    '<rootDir>/pkg/rancher-desktop/$1',
-    '^@/(.*)$':                       '<rootDir>/$1',
+    '\\.css$':       '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
+    '^@pkg/assets/': '<rootDir>/pkg/rancher-desktop/config/emptyStubForJSLinter.js',
+    '^@pkg/(.*)$':   '<rootDir>/pkg/rancher-desktop/$1',
+    '^@/(.*)$':      '<rootDir>/$1',
   },
   setupFiles: [
     '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupVue.ts',

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -595,6 +595,12 @@ components:
                 quitOnClose:
                   type: boolean
                   x-rd-usage: terminate app when the main window is closed
+            locale:
+              type: string
+              # Keep in sync with the translation files and settingsValidator.ts;
+              # run `i18n-report check --locale=all` to catch mismatches.
+              enum: [none, en-us]
+              x-rd-usage: set the UI language
             theme:
               type: string
               enum: [system, light, dark]

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -50,8 +50,7 @@ process; run `i18n-report undefined` to find such references.
 
 ## YAML comment conventions
 
-Add these comments directly above the key they describe. The `js-yaml-loader`
-strips all comments at build time, so they cost nothing at runtime.
+Add these comments directly above the key they describe.
 
 | Comment | Where | Purpose |
 |---------|-------|---------|
@@ -63,34 +62,34 @@ strips all comments at build time, so they cost nothing at runtime.
 ### Examples in en-us.yaml
 
 ```yaml
-# @context Preferences > Application > General, checkbox label
-# @meaning Administrative privilege escalation for bridged networking and docker socket
 application:
   adminAccess:
+    # @context Preferences > Application > General, checkbox label
+    # @meaning Administrative privilege escalation for bridged networking and docker socket
     label: Allow to acquire administrative credentials (sudo access)
 
-# @context Preferences > Container Engine > General, dropdown label
-# @meaning The OCI runtime (containerd or moby/dockerd), not a JavaScript engine
 containerEngine:
+  # @context Preferences > Container Engine > General, dropdown label
+  # @meaning The OCI runtime (containerd or moby/dockerd), not a JavaScript engine
   label: Container Engine
 
-# @no-translate — Unix command name
 resetKubernetes:
+  # @no-translate Kubernetes
   description: "Run {command} to reset Kubernetes"
 ```
 
 ### Examples in locale files
 
 ```yaml
-# @reason "Administratorzugriff" is the standard German term for admin access
-#   in software UIs; "sudo" kept untranslated as a Unix command name
 application:
   adminAccess:
+    # @reason "Administratorzugriff" is the standard German term for admin access
+    #   in software UIs; "sudo" kept untranslated as a Unix command name
     label: Administratorzugriff erlauben (sudo-Zugriff)
 
-# @reason "Container-Laufzeit" (container runtime) is more common in German
-#   than a literal translation of "container engine"
 containerEngine:
+  # @reason "Container-Laufzeit" (container runtime) is more common in German
+  #   than a literal translation of "container engine"
   label: Container-Laufzeit
 ```
 
@@ -110,7 +109,7 @@ A Go CLI at `src/go/i18n-report/` for translation maintenance. See
 | `untranslated` | Hardcoded English strings in Vue/TS files (heuristic) |
 | `references` | Where each en-us.yaml key is used (file:line) |
 | `dynamic` | Template literal patterns that reference keys dynamically |
-| `check` | CI gate: source checks, plus per-locale checks with `--locale` |
+| `check` | source checks, plus per-locale checks with `--locale` |
 | `source` | Record each translated key's English source as a `@source` comment |
 | `drift` | Detect translated keys whose English source changed |
 | `validate` | Structural checks: placeholders, tags, metadata, overrides |
@@ -125,9 +124,11 @@ go tool i18n-report unused --format=json
 go tool i18n-report check --locale=de
 ```
 
-The `merge` subcommand accepts agent output files (JSONL), markdown with YAML
-fences, or raw flat `key=value` text. Without file arguments, it reads from
-stdin.
+The `merge` subcommand reads flat `key: value` or `key=value` lines, one full
+dotted key per line, from plain text, JSON, or agent JSONL transcripts. A YAML
+code fence around the lines is stripped as a convenience, but the content
+inside must still be flat — nested YAML is not supported, fenced or not.
+Without file arguments, it reads from stdin.
 
 ## Adding a new language
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -1,0 +1,218 @@
+# Translations
+
+This directory holds the YAML translation files for Rancher Desktop.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `en-us.yaml` | Canonical English strings (source of truth) |
+| `zh-hans.yaml` | Simplified Chinese translation |
+
+## Architecture
+
+The renderer (Vuex store `store/i18n.js`) and the main process
+(`main/i18n.ts`) both format through `intl-messageformat`, so every key
+speaks the same ICU MessageFormat dialect. Both load YAML through
+webpack's `js-yaml-loader` at build time via the shared
+`utils/translationLoader.ts`.
+
+Webpack auto-discovers locale YAML files in this directory (one file per
+locale, named `{code}.yaml`).
+
+The `application.locale` setting controls language selection; the main process
+and renderer sync it over IPC.
+
+### Template `t()` function
+
+The i18n plugin (`plugins/i18n.js`) injects a global `t(key, args)`
+function into all Vue components. It returns the raw translation;
+escaping is the sink's job:
+
+- `{{ t('some.key') }}` — Vue text interpolation escapes itself.
+- `v-clean-html="t('some.key')"` — HTML sinks render translator-controlled
+  markup; use `v-clean-html` (DOMPurify) when interpolated arguments carry
+  data from outside the translation files, and HTML-escape such arguments
+  at the call site.
+
+The `<t>` component renders a text child by default; `raw` switches to
+innerHTML for strings with entities or markup:
+
+```html
+<t k="some.key" raw />
+```
+
+The `v-t` directive always renders innerHTML (or sets an attribute with
+`v-t:title="'some.key'"`).
+
+A missing key renders as a visible `%some.key%` placeholder in every
+process; run `i18n-report undefined` to find such references.
+
+## YAML comment conventions
+
+Add these comments directly above the key they describe. The `js-yaml-loader`
+strips all comments at build time, so they cost nothing at runtime.
+
+| Comment | Where | Purpose |
+|---------|-------|---------|
+| `@context` | en-us.yaml | Where in the UI the string appears |
+| `@meaning` | en-us.yaml | Domain-specific meaning when English is ambiguous |
+| `@no-translate` | en-us.yaml | Terms that should stay in English by default |
+| `@reason` | locale files | Why a particular translation was chosen |
+
+### Examples in en-us.yaml
+
+```yaml
+# @context Preferences > Application > General, checkbox label
+# @meaning Administrative privilege escalation for bridged networking and docker socket
+application:
+  adminAccess:
+    label: Allow to acquire administrative credentials (sudo access)
+
+# @context Preferences > Container Engine > General, dropdown label
+# @meaning The OCI runtime (containerd or moby/dockerd), not a JavaScript engine
+containerEngine:
+  label: Container Engine
+
+# @no-translate — Unix command name
+resetKubernetes:
+  description: "Run {command} to reset Kubernetes"
+```
+
+### Examples in locale files
+
+```yaml
+# @reason "Administratorzugriff" is the standard German term for admin access
+#   in software UIs; "sudo" kept untranslated as a Unix command name
+application:
+  adminAccess:
+    label: Administratorzugriff erlauben (sudo-Zugriff)
+
+# @reason "Container-Laufzeit" (container runtime) is more common in German
+#   than a literal translation of "container engine"
+containerEngine:
+  label: Container-Laufzeit
+```
+
+## The i18n-report tool
+
+A Go CLI at `src/go/i18n-report/` for translation maintenance. See
+`src/go/i18n-report/README.md` for full documentation.
+
+| Subcommand | Description |
+|------------|-------------|
+| `unused` | Keys in en-us.yaml not referenced in source code |
+| `undefined` | Keys referenced in source code but missing from en-us.yaml |
+| `stale` | Keys in a locale file absent from en-us.yaml |
+| `translate` | Keys missing from a locale, with English values |
+| `merge` | Read flat translations, write nested YAML locale file |
+| `remove` | Remove keys from translation files (stdin or `--stale`) |
+| `untranslated` | Hardcoded English strings in Vue/TS files (heuristic) |
+| `references` | Where each en-us.yaml key is used (file:line) |
+| `dynamic` | Template literal patterns that reference keys dynamically |
+| `check` | CI gate: source checks, plus per-locale checks with `--locale` |
+| `source` | Record each translated key's English source as a `@source` comment |
+| `drift` | Detect translated keys whose English source changed |
+| `validate` | Structural checks: placeholders, tags, metadata, overrides |
+
+Run from the repository root:
+
+```sh
+go tool i18n-report translate --locale=fa
+go tool i18n-report translate --locale=fa --batch=1 --batches=3
+go tool i18n-report merge --locale=fa agent1.output agent2.output
+go tool i18n-report unused --format=json
+go tool i18n-report check --locale=de
+```
+
+The `merge` subcommand accepts agent output files (JSONL), markdown with YAML
+fences, or raw flat `key=value` text. Without file arguments, it reads from
+stdin.
+
+## Adding a new language
+
+1. Create an empty locale file `{code}.yaml` in this directory.
+2. Register the locale code in four places: en-us.yaml locale names,
+   `command-api.yaml` enum, `settingsValidator.ts` `checkEnum`, and
+   `settingsValidator.spec.ts` error string.
+3. Run `yarn postinstall` to regenerate Go CLI code from the API spec.
+4. Run `go tool i18n-report translate --locale={code}` to get keys
+   that need translation; translate them and merge with
+   `go tool i18n-report merge --locale={code}`.
+
+Webpack discovers new YAML files automatically — no other code changes are
+needed.
+
+## Maintenance workflow
+
+1. Remove dead keys from all translation files:
+   ```sh
+   go tool i18n-report unused | go tool i18n-report remove
+   ```
+2. Remove stale keys from locale files (keys not in en-us.yaml):
+   ```sh
+   go tool i18n-report remove --stale
+   ```
+3. Run `i18n-report translate --locale=<code>` to find keys that need
+   translation, then merge the results with `i18n-report merge`.
+4. Run `i18n-report untranslated` to find hardcoded English strings in
+   Vue/TS files that should be externalized.
+
+CI runs `i18n-report check --locale=all` on every pull request: the
+source gate (unused and undefined keys), the locale registration
+checks, and each locale's structural checks. Periodic and pre-release
+runs add `--strict`, which also requires complete translations (no
+missing or drifted keys). Findings exit 1; operational errors exit 2.
+
+## Locale switching
+
+Most UI text updates live when the locale changes (store-driven
+templates, application and tray menus, window titles). Labels captured
+in a component's `data()` — table headers and row actions — refresh
+when navigation remounts the page; this is the accepted pattern, so
+prefer `data()` capture over reactive plumbing for new tables.
+
+## Known limitations and deferred work
+
+### Validation messages
+
+`settingsValidator.ts` emits localized error strings, and the CLI and
+HTTP API return them directly, so scripts must not parse message text.
+In-process callers classify errors through structured flags
+(`hasLockedFieldError`); add a flag rather than string matching when a
+new category needs classification.
+
+### HTML in translation strings
+
+Several keys embed `<a>` tags with `data-action` or `data-navigate`
+attributes that application code relies on. `validate` enforces tag,
+`data-*`, and `href` parity, but restructuring these to component
+slots would remove the coupling.
+
+### Callback lifecycle
+
+`onLocaleChange()` in `main/i18n.ts` returns an unregister function.
+Callers that register during a lifecycle (e.g., tray show) must call
+the returned function during teardown (e.g., tray hide) to avoid
+leaking callbacks.
+
+### i18n-report tool
+
+- **Registration cross-validation is string-based** for
+  settingsValidator.ts and its spec test. Generating those registrations
+  from the translation file list would make drift impossible; revisit
+  when the next locale is added.
+
+### Scanner gaps
+
+The source scanner (`scan.go`) does not detect translation candidates
+in `showErrorBox` calls (`tray.ts`, `settingsImpl.ts`) or port
+forwarding error messages (`backend/kube/client.ts`). It also skips
+`__tests__` directories, so the `references` report omits test-only
+key usage.
+
+### Navigation identifiers
+
+`transientSettings.ts` uses English nav item names as internal
+identifiers. These are no longer displayed directly (preference tabs
+use `labelKey`), but the internal/display split remains unresolved.

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -3896,7 +3896,6 @@ validation:
   cannotSwitchClassicWasm: Cannot switch to classic storage for moby when WebAssembly is enabled.
   cannotSwitchMobyClassicWasm: Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
   duplicateEntries: 'field "{field}" has duplicate entries: "{duplicates}"'
-  errorsInProposedSettings: 'Errors in proposed settings:'
   fieldLocked: field "{field}" is locked
   invalidImageReference: '{field}: "{pattern}" does not describe an image reference'
   invalidMapping: '{field}: "{value}" is not a valid mapping'
@@ -3910,9 +3909,6 @@ validation:
   kubernetesVersionNotFound: Kubernetes version "{version}" not found.
   nonStringTag: '{field}: "{name}" has non-string tag "{tag}"'
   notSupported: Changing field "{field}" via the API isn't supported.
-  profileExpectedArray: 'Error for field ''''{field}'''': expecting value of type array, got ''''{value}'''''
-  profileExpectedType: 'Error for field ''''{field}'''': expecting value of type {expectedType}, got ''''{value}'''''
-  profileExpectedTypeGotArray: 'Error for field ''''{field}'''': expecting value of type {expectedType}, got an array {value}'
   proposedShouldBeObject: Proposed field "{field}" should be an object, got <{value}>.
   requiresArm: Setting {field} can only be enabled on aarch64 systems.
   requiresNineP: Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -3891,6 +3891,39 @@ validation:
     route:
       match: At least one Match or Match Regex must be selected
       interval: '"{key}" must be of a format with digits followed by a unit i.e. 1h, 2m, 30s'
+  cannotDecrease: Cannot decrease "{field}" from {from} to {to}
+  cannotEnableWasmClassic: Cannot enable WebAssembly with classic storage for moby.
+  cannotSwitchClassicWasm: Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  duplicateEntries: 'field "{field}" has duplicate entries: "{duplicates}"'
+  errorsInProposedSettings: 'Errors in proposed settings:'
+  fieldLocked: field "{field}" is locked
+  invalidImageReference: '{field}: "{pattern}" does not describe an image reference'
+  invalidMapping: '{field}: "{value}" is not a valid mapping'
+  invalidName: '{field}: "{name}" is an invalid name'
+  invalidNoproxyEntries: 'field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"'
+  invalidPageName: '{field}: "{value}" is not a valid page name for Preferences Dialog'
+  invalidTabName: '{field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page'
+  invalidTag: '{field}: "{name}" has invalid tag "{tag}"'
+  invalidValue: 'Invalid value for "{field}": <{value}>'
+  invalidValueEnum: 'Invalid value for "{field}": <{value}>; must be one of {validValues}'
+  kubernetesVersionNotFound: Kubernetes version "{version}" not found.
+  nonStringTag: '{field}: "{name}" has non-string tag "{tag}"'
+  notSupported: Changing field "{field}" via the API isn't supported.
+  profileExpectedArray: 'Error for field ''''{field}'''': expecting value of type array, got ''''{value}'''''
+  profileExpectedType: 'Error for field ''''{field}'''': expecting value of type {expectedType}, got ''''{value}'''''
+  profileExpectedTypeGotArray: 'Error for field ''''{field}'''': expecting value of type {expectedType}, got an array {value}'
+  proposedShouldBeObject: Proposed field "{field}" should be an object, got <{value}>.
+  requiresArm: Setting {field} can only be enabled on aarch64 systems.
+  requiresNineP: Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresVz: Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresWebAssembly: Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  settingRequires: Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequiresEither: Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  shouldBeObject: Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeSimple: Setting "{field}" should be a simple value, but got <{value}>.
+  vzArmMacOs: Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzIntelMacOs: Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
 
 wizard:
   previous: Previous

--- a/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
+++ b/pkg/rancher-desktop/components/ExtensionsUninstalled.vue
@@ -23,7 +23,6 @@ export default defineComponent({
       return this.t(
         'extensions.view.emptyState.body',
         { extensionId: `<code>${ this.extensionId }</code>` },
-        true,
       );
     },
   },

--- a/pkg/rancher-desktop/components/ImagesOutputWindow.vue
+++ b/pkg/rancher-desktop/components/ImagesOutputWindow.vue
@@ -71,7 +71,7 @@ export default defineComponent({
       return this.t('images.add.successText', { action: pastTense });
     },
     errorText(): string {
-      return this.t('images.add.errorText', { action: this.action, image: this.imageToPull }, true);
+      return this.t('images.add.errorText', { action: this.action, image: this.imageToPull });
     },
   },
 

--- a/pkg/rancher-desktop/components/MountTypeSelector.vue
+++ b/pkg/rancher-desktop/components/MountTypeSelector.vue
@@ -55,7 +55,7 @@ export default defineComponent({
           return {
             label:           this.t(`virtualMachine.mount.type.options.${ x }.label`),
             value:           x,
-            description:     this.t(`virtualMachine.mount.type.options.${ x }.description`, {}, true),
+            description:     this.t(`virtualMachine.mount.type.options.${ x }.description`),
             experimental:    x === MountType.NINEP,
             disabled:        x === MountType.VIRTIOFS && this.virtIoFsDisabled,
             compatiblePrefs: this.getCompatiblePrefs(x),
@@ -115,7 +115,7 @@ export default defineComponent({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t(`prefs.onlyWithVZ_${ this.arch }`, undefined, true) };
+        tooltip = { content: this.t(`prefs.onlyWithVZ_${ this.arch }`) };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/components/Nav.vue
+++ b/pkg/rancher-desktop/components/Nav.vue
@@ -20,7 +20,7 @@
           <i
             v-if="item.experimental"
             v-tooltip="{
-              content: t('prefs.experimental', undefined, true),
+              content: t('prefs.experimental'),
               placement: 'right',
             }"
             :class="`icon icon-flask`"

--- a/pkg/rancher-desktop/components/PathManagementSelector.vue
+++ b/pkg/rancher-desktop/components/PathManagementSelector.vue
@@ -41,12 +41,12 @@ export default defineComponent({
         {
           label:       this.t('pathManagement.options.rcFiles.label'),
           value:       PathManagementStrategy.RcFiles,
-          description: this.t('pathManagement.options.rcFiles.description', { }, true),
+          description: this.t('pathManagement.options.rcFiles.description'),
         },
         {
           label:       this.t('pathManagement.options.manual.label'),
           value:       PathManagementStrategy.Manual,
-          description: this.t('pathManagement.options.manual.description', { }, true),
+          description: this.t('pathManagement.options.manual.description'),
         },
       ];
     },
@@ -57,7 +57,7 @@ export default defineComponent({
       return this.showLabel ? this.t('pathManagement.label') : '';
     },
     tooltip(): string {
-      return this.showLabel ? this.t('pathManagement.tooltip', { }, true) : '';
+      return this.showLabel ? this.t('pathManagement.tooltip') : '';
     },
   },
   methods: {

--- a/pkg/rancher-desktop/components/Preferences/Alert.vue
+++ b/pkg/rancher-desktop/components/Preferences/Alert.vue
@@ -42,7 +42,7 @@ export default defineComponent({
       }
 
       if (this.alert) {
-        return this.t(this.alert, { }, true);
+        return this.t(this.alert);
       }
 
       return null;

--- a/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationEnvironment.vue
@@ -42,7 +42,7 @@ export default defineComponent({
   <rd-fieldset
     data-test="pathManagement"
     :legend-text="t('pathManagement.label')"
-    :legend-tooltip="t('pathManagement.tooltip', { }, true)"
+    :legend-tooltip="t('pathManagement.tooltip')"
     :is-locked="isPreferenceLocked('application.pathManagementStrategy')"
   >
     <template #default="{ isLocked }">

--- a/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
+++ b/pkg/rancher-desktop/components/Preferences/VirtualMachineEmulation.vue
@@ -43,7 +43,7 @@ export default defineComponent({
           return {
             label:           this.t(`virtualMachine.type.options.${ x }.label`),
             value:           x,
-            description:     this.t(`virtualMachine.type.options.${ x }.description`, {}, true),
+            description:     this.t(`virtualMachine.type.options.${ x }.description`),
             disabled:        x === VMType.VZ && this.vzDisabled,
             compatiblePrefs: this.getCompatiblePrefs(x),
           };
@@ -73,7 +73,7 @@ export default defineComponent({
       let tooltip = {};
 
       if (disabled) {
-        tooltip = { content: this.t(`prefs.onlyFromVentura_${ this.arch }`, undefined, true) };
+        tooltip = { content: this.t(`prefs.onlyFromVentura_${ this.arch }`) };
       }
 
       return tooltip;

--- a/pkg/rancher-desktop/components/Preferences/WslIntegrations.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslIntegrations.vue
@@ -35,7 +35,7 @@ export default defineComponent({
   <div class="wsl-integrations">
     <rd-fieldset
       data-test="wslIntegrations"
-      :legend-text="t('integrations.windows.description', { }, true)"
+      :legend-text="t('integrations.windows.description')"
     >
       <wsl-integration
         data-test-id="wsl-integration-list"

--- a/pkg/rancher-desktop/components/Preferences/WslProxy.vue
+++ b/pkg/rancher-desktop/components/Preferences/WslProxy.vue
@@ -60,7 +60,7 @@ export default defineComponent({
       :is-experimental="true"
     >
       <rd-checkbox
-        :label="t('virtualMachine.proxy.label', { }, true)"
+        :label="t('virtualMachine.proxy.label')"
         :value="preferences.experimental.virtualMachine.proxy.enabled"
         :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.enabled')"
         @update:value="onChange('experimental.virtualMachine.proxy.enabled', $event)"
@@ -72,10 +72,10 @@ export default defineComponent({
         <rd-fieldset
           data-test="addressTitle"
           class="wsl-proxy-fieldset"
-          :legend-text="t('virtualMachine.proxy.addressTitle', { }, true)"
+          :legend-text="t('virtualMachine.proxy.addressTitle')"
         >
           <rd-input
-            :placeholder="t('virtualMachine.proxy.address', { }, true)"
+            :placeholder="t('virtualMachine.proxy.address')"
             :disabled="isFieldDisabled"
             :value="preferences.experimental.virtualMachine.proxy.address"
             :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.address')"
@@ -83,7 +83,7 @@ export default defineComponent({
           />
           <rd-input
             type="number"
-            :placeholder="t('virtualMachine.proxy.port', { }, true)"
+            :placeholder="t('virtualMachine.proxy.port')"
             :disabled="isFieldDisabled"
             :value="preferences.experimental.virtualMachine.proxy.port"
             :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.port')"
@@ -92,10 +92,10 @@ export default defineComponent({
         </rd-fieldset>
         <rd-fieldset
           class="wsl-proxy-fieldset"
-          :legend-text="t('virtualMachine.proxy.authTitle', { }, true)"
+          :legend-text="t('virtualMachine.proxy.authTitle')"
         >
           <rd-input
-            :placeholder="t('virtualMachine.proxy.username', { }, true)"
+            :placeholder="t('virtualMachine.proxy.username')"
             :disabled="isFieldDisabled"
             :value="preferences.experimental.virtualMachine.proxy.username"
             :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.username')"
@@ -103,7 +103,7 @@ export default defineComponent({
           />
           <rd-input
             type="password"
-            :placeholder="t('virtualMachine.proxy.password', { }, true)"
+            :placeholder="t('virtualMachine.proxy.password')"
             :disabled="isFieldDisabled"
             :value="preferences.experimental.virtualMachine.proxy.password"
             :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.password')"
@@ -113,11 +113,11 @@ export default defineComponent({
       </div>
       <div class="proxy-col">
         <rd-fieldset
-          :legend-text="t('virtualMachine.proxy.noproxy.legend', { }, true)"
+          :legend-text="t('virtualMachine.proxy.noproxy.legend')"
           :is-locked="isPreferenceLocked('experimental.virtualMachine.proxy.noproxy')"
         >
           <string-list
-            :placeholder="t('virtualMachine.proxy.noproxy.placeholder', { }, true)"
+            :placeholder="t('virtualMachine.proxy.noproxy.placeholder')"
             :readonly="isNoProxyFieldReadOnly"
             :actions-position="'left'"
             :items="preferences.experimental.virtualMachine.proxy.noproxy"

--- a/pkg/rancher-desktop/components/RdInput.vue
+++ b/pkg/rancher-desktop/components/RdInput.vue
@@ -36,7 +36,7 @@ export default defineComponent({
       <i
         v-if="isLocked"
         v-tooltip="{
-          content: tooltip || t('preferences.locked.tooltip', undefined, true),
+          content: tooltip || t('preferences.locked.tooltip'),
           placement: 'right',
         }"
         class="icon icon-lock"

--- a/pkg/rancher-desktop/components/RdSelect.vue
+++ b/pkg/rancher-desktop/components/RdSelect.vue
@@ -62,7 +62,7 @@ export default defineComponent({
       <i
         v-if="isLocked"
         v-tooltip="{
-          content: tooltip || t('preferences.locked.tooltip', undefined, true),
+          content: tooltip || t('preferences.locked.tooltip'),
           placement: 'right',
         }"
         class="icon icon-lock"

--- a/pkg/rancher-desktop/components/SnapshotCard.vue
+++ b/pkg/rancher-desktop/components/SnapshotCard.vue
@@ -81,7 +81,7 @@ export default defineComponent({
                 dialog:           'SnapshotsDialog',
                 error,
                 errorTitle:       this.t('snapshots.dialog.restore.error.header'),
-                errorDescription: this.t('snapshots.dialog.restore.error.description', { snapshot: this.snapshot.name }, true),
+                errorDescription: this.t('snapshots.dialog.restore.error.description', { snapshot: this.snapshot.name }),
                 errorButton:      this.t('snapshots.dialog.restore.error.buttonText'),
               });
           } else {
@@ -136,7 +136,7 @@ export default defineComponent({
           format: {
             header:            this.t(`snapshots.dialog.${ type }.header`, { snapshot: this.snapshot.name }),
             snapshot:          this.snapshot,
-            message:           type === 'restore' ? this.t(`snapshots.dialog.${ type }.info`, { }, true) : '',
+            message:           type === 'restore' ? this.t(`snapshots.dialog.${ type }.info`) : '',
             showProgressBar:   false,
             snapshotEventType: 'confirm',
           },
@@ -160,7 +160,7 @@ export default defineComponent({
           },
           format: {
             header:            this.t('snapshots.dialog.restoring.header', { snapshot }),
-            message:           this.t('snapshots.dialog.restoring.message', { snapshot }, true),
+            message:           this.t('snapshots.dialog.restoring.message', { snapshot }),
             showProgressBar:   true,
             snapshotEventType: 'restore',
           },
@@ -185,7 +185,7 @@ export default defineComponent({
         <div class="created">
           <span
             v-if="snapshot.formattedCreateDate"
-            v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
+            v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time })"
             class="value"
           />
         </div>

--- a/pkg/rancher-desktop/components/Snapshots.vue
+++ b/pkg/rancher-desktop/components/Snapshots.vue
@@ -93,7 +93,7 @@ export default defineComponent({
       >
         <span
           v-clean-html="t(`snapshots.info.${snapshotEvent.type}.${snapshotEvent.result}`,
-                          { snapshot: escapeHtml(snapshotEvent.snapshotName), error: snapshotEvent.error }, true)"
+                          { snapshot: escapeHtml(snapshotEvent.snapshotName), error: snapshotEvent.error })"
           class="event-message"
         />
         <span

--- a/pkg/rancher-desktop/components/SortableTable/index.vue
+++ b/pkg/rancher-desktop/components/SortableTable/index.vue
@@ -813,7 +813,7 @@ export default {
 
     labelFor(col) {
       if ( col.labelKey ) {
-        return this.t(col.labelKey, undefined, true);
+        return this.t(col.labelKey);
       } else if ( col.label ) {
         return col.label;
       }

--- a/pkg/rancher-desktop/components/form/LabeledSelect.vue
+++ b/pkg/rancher-desktop/components/form/LabeledSelect.vue
@@ -185,7 +185,9 @@ export default {
         if (this.localizedLabel) {
           const label = get(option, this.optionLabel);
 
-          return this.$store.getters['i18n/t'](label) || label;
+          // The `i18n/t` getter returns a `%key%` placeholder for missing
+          // keys, so test with `i18n/exists` to fall back to the raw label.
+          return this.$store.getters['i18n/exists'](label) ? this.$store.getters['i18n/t'](label) : label;
         } else {
           return get(option, this.optionLabel);
         }

--- a/pkg/rancher-desktop/components/form/RdCheckbox.vue
+++ b/pkg/rancher-desktop/components/form/RdCheckbox.vue
@@ -75,7 +75,7 @@ export default defineComponent({
           <i
             v-if="isLocked"
             v-tooltip="{
-              content: tooltip || t('preferences.locked.tooltip', undefined, true),
+              content: tooltip || t('preferences.locked.tooltip'),
               placement: 'right',
             }"
             class="icon icon-lock"

--- a/pkg/rancher-desktop/components/form/TooltipIcon.vue
+++ b/pkg/rancher-desktop/components/form/TooltipIcon.vue
@@ -20,7 +20,7 @@ export default {
 <template>
   <i
     v-tooltip="{
-      content: t(tooltipText, undefined, true),
+      content: t(tooltipText),
       placement: tooltipPlacement,
     }"
     :class="`icon ${icon}`"

--- a/pkg/rancher-desktop/config/commandLineOptions.ts
+++ b/pkg/rancher-desktop/config/commandLineOptions.ts
@@ -139,7 +139,7 @@ export function updateFromCommandLine(cfg: Settings, lockedFields: LockedSetting
   if (errors.length > 0) {
     const errorString = `Error in command-line options:\n${ errors.join('\n') }`;
 
-    if (errors.some(error => /field ".+?" is locked/.test(error))) {
+    if (settingsValidator.hasLockedFieldError) {
       throw new LockedFieldError(errorString);
     }
     if (isFatal) {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import { RecursivePartial } from '@pkg/utils/typeUtils';
 
-export const CURRENT_SETTINGS_VERSION = 18 as const;
+export const CURRENT_SETTINGS_VERSION = 19 as const;
 
 export enum VMType {
   QEMU = 'qemu',
@@ -84,6 +84,7 @@ export const defaultSettings = {
     autoStart:              false,
     startInBackground:      false,
     hideNotificationIcon:   false,
+    locale:                 'none',
     window:                 { quitOnClose: false },
     theme:                  Theme.SYSTEM,
   },

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -517,6 +517,7 @@ export const updateTable: Record<number, (settings: any, locked : boolean) => vo
       _.set(settings, 'containerEngine.mobyStorageDriver', 'auto');
     }
   },
+  // v19 added application.locale (defaults filled by _.defaultsDeep).
 };
 
 function migrateSettingsToCurrentVersion(settings: Record<string, any>): Settings {

--- a/pkg/rancher-desktop/layouts/default.vue
+++ b/pkg/rancher-desktop/layouts/default.vue
@@ -195,9 +195,9 @@ export default {
             cancelId: 1,
           },
           format: {
-            header:            action || this.t('snapshots.dialog.generic.header', {}, true),
+            header:            action || this.t('snapshots.dialog.generic.header'),
             /** TODO: put here operation type information from 'state' */
-            message:           this.t('snapshots.dialog.generic.message', {}, true),
+            message:           this.t('snapshots.dialog.generic.message'),
             showProgressBar:   true,
             snapshotEventType: 'backend-lock',
           },

--- a/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+import mainEvents from '@pkg/main/mainEvents';
+
+// Relative import bypasses any module mapping so the real module is tested.
+const i18n = await import('../i18n');
+
+describe('main-process i18n', () => {
+  it('translates from the default locale', () => {
+    expect(i18n.t('generic.cancel')).toEqual('Cancel');
+  });
+
+  it('returns a visible %key% placeholder for a missing key', () => {
+    expect(i18n.t('no.such.key')).toEqual('%no.such.key%');
+  });
+
+  it('formats ICU plurals', () => {
+    expect(i18n.t('sortableTable.paging.generic', { pages: 0 })).toEqual('No Items');
+  });
+
+  it('degrades to the raw pattern when an argument is missing', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(i18n.t('sortableTable.paging.generic', {})).toContain('{pages,');
+    spy.mockRestore();
+  });
+
+  it('lists the bundled locales', () => {
+    expect(i18n.availableLocales).toEqual(expect.arrayContaining(['en-us']));
+  });
+});

--- a/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
@@ -1,31 +1,28 @@
 import { jest } from '@jest/globals';
 
-import mainEvents from '@pkg/main/mainEvents';
-
-// Relative import bypasses any module mapping so the real module is tested.
-const i18n = await import('../i18n');
+import { availableLocales, t } from '@pkg/main/i18n';
 
 describe('main-process i18n', () => {
   it('translates from the default locale', () => {
-    expect(i18n.t('generic.cancel')).toEqual('Cancel');
+    expect(t('generic.cancel')).toEqual('Cancel');
   });
 
   it('returns a visible %key% placeholder for a missing key', () => {
-    expect(i18n.t('no.such.key')).toEqual('%no.such.key%');
+    expect(t('no.such.key')).toEqual('%no.such.key%');
   });
 
   it('formats ICU plurals', () => {
-    expect(i18n.t('sortableTable.paging.generic', { pages: 0 })).toEqual('No Items');
+    expect(t('sortableTable.paging.generic', { pages: 0 })).toEqual('No Items');
   });
 
   it('degrades to the raw pattern when an argument is missing', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(i18n.t('sortableTable.paging.generic', {})).toContain('{pages,');
+    expect(t('sortableTable.paging.generic', {})).toContain('{pages,');
     spy.mockRestore();
   });
 
   it('lists the bundled locales', () => {
-    expect(i18n.availableLocales).toEqual(expect.arrayContaining(['en-us']));
+    expect(availableLocales).toEqual(expect.arrayContaining(['en-us']));
   });
 });

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -78,6 +78,7 @@ describe('SettingsValidator', () => {
     // Special fields that cannot be checked here; this includes enums and maps.
     const specialFields = [
       ['application', 'pathManagementStrategy'],
+      ['application', 'locale'],
       ['application', 'theme'],
       ['containerEngine', 'allowedImages', 'locked'],
       ['containerEngine', 'mobyStorageDriver'],
@@ -464,6 +465,40 @@ describe('SettingsValidator', () => {
     });
   });
 
+  describe('application.locale', () => {
+    it('should accept valid locales', () => {
+      const [needToUpdate, errors] = subject.validateSettings({
+        ...cfg,
+        application: { ...cfg.application, locale: 'en-us' },
+      }, { application: { locale: 'none' } });
+
+      expect({ needToUpdate, errors }).toEqual({
+        needToUpdate: true,
+        errors:       [],
+      });
+    });
+
+    it('should accept no-op changes', () => {
+      const [needToUpdate, errors] = subject.validateSettings(cfg,
+        { application: { locale: 'none' } });
+
+      expect({ needToUpdate, errors }).toEqual({
+        needToUpdate: false,
+        errors:       [],
+      });
+    });
+
+    it('should reject invalid values', () => {
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg,
+        { application: { locale: 'invalid' } });
+
+      expect(needToUpdate).toBe(false);
+      expect(isFatal).toBe(true);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Invalid value for "application.locale"');
+    });
+  });
+
   describe('pathManagementStrategy', () => {
     beforeEach(() => {
       modules.os.platform.mockReturnValue('linux');
@@ -592,6 +627,7 @@ describe('SettingsValidator', () => {
               errors:       ['field "containerEngine.allowedImages.enabled" is locked'],
               isFatal:      true,
             });
+            expect(subject.hasLockedFieldError).toBe(true);
           });
           it('can be set to the same value', () => {
             const currentEnabled = allowedImageListConfig.containerEngine.allowedImages.enabled;
@@ -602,6 +638,7 @@ describe('SettingsValidator', () => {
               needToUpdate: false,
               errors:       [],
             });
+            expect(subject.hasLockedFieldError).toBe(false);
           });
         });
 

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -17,6 +17,7 @@ import {
 } from '@pkg/config/settings';
 import { NavItemName, navItemNames, TransientSettings } from '@pkg/config/transientSettings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
+import { availableLocales, t } from '@pkg/main/i18n';
 import { parseImageReference, validateImageName, validateImageTag } from '@pkg/utils/dockerUtils';
 import { stripNoproxyPrefix } from '@pkg/utils/networks';
 import { getMacOsVersion } from '@pkg/utils/osVersion';
@@ -71,6 +72,7 @@ export default class SettingsValidator {
   synonymsTable:            settingsLike | null = null;
   lockedSettings:           LockedSettingsType = { };
   protected isFatal = false;
+  hasLockedFieldError = false;
 
   validateSettings(
     currentSettings: Settings,
@@ -79,6 +81,7 @@ export default class SettingsValidator {
   ): [boolean, string[], boolean] {
     this.lockedSettings = lockedSettings;
     this.isFatal = false;
+    this.hasLockedFieldError = false;
     this.allowedSettings ||= {
       version:     this.checkUnchanged,
       application: {
@@ -98,6 +101,7 @@ export default class SettingsValidator {
         autoStart:              this.checkBoolean,
         startInBackground:      this.checkBoolean,
         hideNotificationIcon:   this.checkBoolean,
+        locale:                 this.checkEnum('none', ...availableLocales),
         window:                 { quitOnClose: this.checkBoolean },
         theme:                  this.checkEnum('system', 'light', 'dark'),
       },
@@ -257,7 +261,7 @@ export default class SettingsValidator {
         if (typeof (newSettings[k]) === 'object') {
           changeNeeded = this.checkProposedSettings(mergedSettings, allowedSettings[k], currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
         } else {
-          errors.push(`Setting "${ fqname }" should wrap an inner object, but got <${ newSettings[k] }>.`);
+          errors.push(t('validation.shouldBeObject', { field: fqname, value: newSettings[k] }));
         }
       } else if (typeof (newSettings[k]) === 'object') {
         if (typeof allowedSettings[k] === 'function') {
@@ -268,7 +272,7 @@ export default class SettingsValidator {
         } else {
           // newSettings[k] should be valid JSON because it came from `JSON.parse(incoming-payload)`.
           // It's an internal error (HTTP Status 500) if it isn't.
-          errors.push(`Setting "${ fqname }" should be a simple value, but got <${ JSON.stringify(newSettings[k]) }>.`);
+          errors.push(t('validation.shouldBeSimple', { field: fqname, value: JSON.stringify(newSettings[k]) }));
         }
       } else if (typeof allowedSettings[k] === 'function') {
         const validator: ValidatorFunc<S, any, any, any> = allowedSettings[k];
@@ -281,9 +285,12 @@ export default class SettingsValidator {
         const isLocked = _.get(this.lockedSettings, `${ prefix }.${ k }`);
 
         if (isLocked) {
-          // A delayed error condition, raised only if we try to change a field in a locked object
-          errors.push(`field "${ prefix }.${ k }" is locked`);
+          // A delayed error condition, raised only if we try to change a field in a locked object.
+          // Callers check hasLockedFieldError to detect this condition without
+          // parsing the translated error message.
+          errors.push(t('validation.fieldLocked', { field: `${ prefix }.${ k }` }));
           this.isFatal = true;
+          this.hasLockedFieldError = true;
         } else {
           changeNeeded = true;
         }
@@ -293,8 +300,11 @@ export default class SettingsValidator {
     return changeNeeded;
   }
 
+  // Validation messages are locale-dependent. The CLI and HTTP API return
+  // these strings directly, so callers must not parse them; classification
+  // uses structured flags like hasLockedFieldError.
   protected invalidSettingMessage(fqname: string, desiredValue: any): string {
-    return `Invalid value for "${ fqname }": <${ JSON.stringify(desiredValue) }>`;
+    return t('validation.invalidValue', { field: fqname, value: JSON.stringify(desiredValue) });
   }
 
   /**
@@ -319,13 +329,13 @@ export default class SettingsValidator {
   protected checkRosetta(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
     if (desiredValue && !currentValue) {
       if (mergedSettings.virtualMachine.type !== VMType.VZ) {
-        errors.push(`Setting ${ fqname } can only be enabled when virtual-machine.type is "${ VMType.VZ }".`);
+        errors.push(t('validation.requiresVz', { field: fqname, vmType: VMType.VZ }));
         this.isFatal = true;
 
         return false;
       }
       if (process.arch !== 'arm64') {
-        errors.push(`Setting ${ fqname } can only be enabled on aarch64 systems.`);
+        errors.push(t('validation.requiresArm', { field: fqname }));
         this.isFatal = true;
 
         return false;
@@ -339,19 +349,24 @@ export default class SettingsValidator {
     if (desiredValue === VMType.VZ) {
       if (os.arch() === 'arm64' && semver.gt('13.3.0', getMacOsVersion())) {
         this.isFatal = true;
-        errors.push(`Setting ${ fqname } to "${ VMType.VZ }" on ARM requires macOS 13.3 (Ventura) or later.`);
+        errors.push(t('validation.vzArmMacOs', { field: fqname, vmType: VMType.VZ }));
 
         return false;
       } else if (semver.gt('13.0.0', getMacOsVersion())) {
         this.isFatal = true;
-        errors.push(`Setting ${ fqname } to "${ VMType.VZ }" on Intel requires macOS 13.0 (Ventura) or later.`);
+        errors.push(t('validation.vzIntelMacOs', { field: fqname, vmType: VMType.VZ }));
 
         return false;
       }
       if (mergedSettings.virtualMachine.mount.type === MountType.NINEP) {
         errors.push(
-          `Setting ${ fqname } to "${ VMType.VZ }" requires that virtual-machine.mount.type is ` +
-          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.VIRTIOFS }".`);
+          t('validation.settingRequiresEither', {
+            field:      fqname,
+            value:      VMType.VZ,
+            otherField: 'virtual-machine.mount.type',
+            option1:    MountType.REVERSE_SSHFS,
+            option2:    MountType.VIRTIOFS,
+          }));
 
         return false;
       }
@@ -359,8 +374,13 @@ export default class SettingsValidator {
     if (desiredValue === VMType.QEMU) {
       if (mergedSettings.virtualMachine.mount.type === MountType.VIRTIOFS && os.platform() === 'darwin') {
         errors.push(
-          `Setting ${ fqname } to "${ VMType.QEMU }" requires that virtual-machine.mount.type is ` +
-          `"${ MountType.REVERSE_SSHFS }" or "${ MountType.NINEP }".`);
+          t('validation.settingRequiresEither', {
+            field:      fqname,
+            value:      VMType.QEMU,
+            otherField: 'virtual-machine.mount.type',
+            option1:    MountType.REVERSE_SSHFS,
+            option2:    MountType.NINEP,
+          }));
 
         return false;
       }
@@ -371,19 +391,19 @@ export default class SettingsValidator {
 
   protected checkMountType(mergedSettings: Settings, currentValue: string, desiredValue: string, errors: string[], fqname: string): boolean {
     if (desiredValue === MountType.VIRTIOFS && mergedSettings.virtualMachine.type !== VMType.VZ && os.platform() === 'darwin') {
-      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that virtual-machine.type is "${ VMType.VZ }".`);
+      errors.push(t('validation.settingRequires', { field: fqname, value: MountType.VIRTIOFS, otherField: 'virtual-machine.type', required: VMType.VZ }));
       this.isFatal = true;
 
       return false;
     }
     if (desiredValue === MountType.VIRTIOFS && mergedSettings.virtualMachine.type !== VMType.QEMU && os.platform() === 'linux') {
-      errors.push(`Setting ${ fqname } to "${ MountType.VIRTIOFS }" requires that virtual-machine.type is "${ VMType.QEMU }".`);
+      errors.push(t('validation.settingRequires', { field: fqname, value: MountType.VIRTIOFS, otherField: 'virtual-machine.type', required: VMType.QEMU }));
       this.isFatal = true;
 
       return false;
     }
     if (desiredValue === MountType.NINEP && mergedSettings.virtualMachine.type !== VMType.QEMU) {
-      errors.push(`Setting ${ fqname } to "${ MountType.NINEP }" requires that virtual-machine.type is "${ VMType.QEMU }".`);
+      errors.push(t('validation.settingRequires', { field: fqname, value: MountType.NINEP, otherField: 'virtual-machine.type', required: VMType.QEMU }));
       this.isFatal = true;
 
       return false;
@@ -395,7 +415,7 @@ export default class SettingsValidator {
   protected checkSpinkube(mergedSettings: Settings, currentValue: boolean, desiredValue: boolean, errors: string[], fqname: string): boolean {
     if (mergedSettings.kubernetes.enabled && desiredValue) {
       if (!mergedSettings.experimental.containerEngine.webAssembly.enabled) {
-        errors.push(`Setting ${ fqname } can only be set when experimental.container-engine.web-assembly.enabled is set as well.`);
+        errors.push(t('validation.requiresWebAssembly', { field: fqname }));
         this.isFatal = true;
 
         return false;
@@ -416,9 +436,9 @@ export default class SettingsValidator {
         mergedSettings.containerEngine.mobyStorageDriver === 'classic'
     ) {
       const message: string = {
-        'containerEngine.name':                             'Cannot switch to moby container engine with classic storage when WebAssembly is enabled.',
-        'experimental.containerEngine.webAssembly.enabled': 'Cannot enable WebAssembly with classic storage for moby.',
-        'containerEngine.mobyStorageDriver':                'Cannot switch to classic storage for moby when WebAssembly is enabled.',
+        'containerEngine.name':                             t('validation.cannotSwitchMobyClassicWasm'),
+        'experimental.containerEngine.webAssembly.enabled': t('validation.cannotEnableWasmClassic'),
+        'containerEngine.mobyStorageDriver':                t('validation.cannotSwitchClassicWasm'),
       }[fqname];
 
       if (currentValue !== desiredValue) {
@@ -448,7 +468,7 @@ export default class SettingsValidator {
     return (mergedSettings: Settings, currentValue: C, desiredValue: D, errors: string[], fqname: N) => {
       if (mergedSettings.virtualMachine.mount.type !== MountType.NINEP) {
         if (!_.isEqual(currentValue, desiredValue)) {
-          errors.push(`Setting ${ fqname } can only be changed when virtualMachine.mount.type is "${ MountType.NINEP }".`);
+          errors.push(t('validation.requiresNineP', { field: fqname, mountType: MountType.NINEP }));
           this.isFatal = true;
         }
 
@@ -506,15 +526,17 @@ export default class SettingsValidator {
 
   protected checkEnum(...validValues: string[]) {
     return <S>(mergedSettings: S, currentValue: string, desiredValue: string, errors: string[], fqname: string) => {
-      const explanation = `must be one of ${ JSON.stringify(validValues) }`;
-
       if (typeof desiredValue !== 'string') {
-        errors.push(`${ this.invalidSettingMessage(fqname, desiredValue) }; ${ explanation }`);
+        errors.push(t('validation.invalidValueEnum', {
+          field: fqname, value: JSON.stringify(desiredValue), validValues: JSON.stringify(validValues),
+        }));
 
         return false;
       }
       if (!validValues.includes(desiredValue)) {
-        errors.push(`Invalid value for "${ fqname }": <${ JSON.stringify(desiredValue) }>; ${ explanation }`);
+        errors.push(t('validation.invalidValueEnum', {
+          field: fqname, value: JSON.stringify(desiredValue), validValues: JSON.stringify(validValues),
+        }));
         this.isFatal = true;
 
         return false;
@@ -566,7 +588,7 @@ export default class SettingsValidator {
     if (typeof desired === 'undefined') {
       errors.push(this.invalidSettingMessage(fqname, desiredValue));
     } else if (typeof current !== 'undefined' && desired < current) {
-      errors.push(`Cannot decrease "${ fqname }" from ${ currentValue } to ${ desiredValue }`);
+      errors.push(t('validation.cannotDecrease', { field: fqname, from: currentValue, to: desiredValue }));
     } else {
       return currentValue !== desiredValue;
     }
@@ -579,7 +601,7 @@ export default class SettingsValidator {
      * desiredVersion can be an empty string when Kubernetes is disabled, but otherwise it must be a valid version.
     */
     if ((mergedSettings.kubernetes.enabled || desiredVersion !== '') && !this.k8sVersions.includes(desiredVersion)) {
-      errors.push(`Kubernetes version "${ desiredVersion }" not found.`);
+      errors.push(t('validation.kubernetesVersionNotFound', { version: desiredVersion }));
 
       return false;
     }
@@ -588,7 +610,7 @@ export default class SettingsValidator {
   }
 
   protected notSupported(fqname: string) {
-    return `Changing field "${ fqname }" via the API isn't supported.`;
+    return t('validation.notSupported', { field: fqname });
   }
 
   protected checkUnchanged<S>(mergedSettings: S, currentValue: any, desiredValue: any, errors: string[], fqname: string): boolean {
@@ -607,7 +629,7 @@ export default class SettingsValidator {
    */
   protected checkBooleanMapping<S>(mergedSettings: S, currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
     if (typeof (desiredValue) !== 'object') {
-      errors.push(`Proposed field "${ fqname }" should be an object, got <${ desiredValue }>.`);
+      errors.push(t('validation.proposedShouldBeObject', { field: fqname, value: desiredValue }));
 
       return false;
     }
@@ -635,7 +657,7 @@ export default class SettingsValidator {
 
     if (duplicateValues.length > 0) {
       duplicateValues.sort(Intl.Collator().compare);
-      errors.push(`field "${ fqname }" has duplicate entries: "${ duplicateValues.join('", "') }"`);
+      errors.push(t('validation.duplicateEntries', { field: fqname, duplicates: duplicateValues.join('", "') }));
 
       return false;
     }
@@ -725,14 +747,14 @@ export default class SettingsValidator {
 
     if (duplicateValues.length > 0) {
       duplicateValues.sort(Intl.Collator().compare);
-      errors.push(`field "${ fqname }" has duplicate entries: "${ duplicateValues.join('", "') }"`);
+      errors.push(t('validation.duplicateEntries', { field: fqname, duplicates: duplicateValues.join('", "') }));
 
       return false;
     }
     const invalidEntries = desiredValue.filter(entry => !SettingsValidator.isIPAddressOrCIDR(entry) && !SettingsValidator.isDomainName(entry));
 
     if (invalidEntries.length > 0) {
-      errors.push(`field "${ fqname }" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "${ invalidEntries.join('", "') }"`);
+      errors.push(t('validation.invalidNoproxyEntries', { field: fqname, entries: invalidEntries.join('", "') }));
 
       return false;
     }
@@ -753,19 +775,19 @@ export default class SettingsValidator {
     }
 
     if (typeof desiredValue !== 'object' || !desiredValue) {
-      errors.push(`${ fqname }: "${ desiredValue }" is not a valid mapping`);
+      errors.push(t('validation.invalidMapping', { field: fqname, value: desiredValue }));
 
       return false;
     }
 
     for (const [name, tag] of Object.entries(desiredValue)) {
       if (!validateImageName(name)) {
-        errors.push(`${ fqname }: "${ name }" is an invalid name`);
+        errors.push(t('validation.invalidName', { field: fqname, name }));
       }
       if (typeof tag !== 'string') {
-        errors.push(`${ fqname }: "${ name }" has non-string tag "${ tag }"`);
+        errors.push(t('validation.nonStringTag', { field: fqname, name, tag: String(tag) }));
       } else if (!validateImageTag(tag)) {
-        errors.push(`${ fqname }: "${ name }" has invalid tag "${ tag }"`);
+        errors.push(t('validation.invalidTag', { field: fqname, name, tag }));
       }
     }
 
@@ -792,7 +814,7 @@ export default class SettingsValidator {
 
     for (const pattern of desiredValue as string[]) {
       if (!parseImageReference(pattern, true)) {
-        errors.push(`${ fqname }: "${ pattern }" does not describe an image reference`);
+        errors.push(t('validation.invalidImageReference', { field: fqname, pattern }));
       }
     }
 
@@ -807,7 +829,7 @@ export default class SettingsValidator {
     fqname: string,
   ): boolean {
     if (!desiredValue || !navItemNames.includes(desiredValue)) {
-      errors.push(`${ fqname }: "${ desiredValue }" is not a valid page name for Preferences Dialog`);
+      errors.push(t('validation.invalidPageName', { field: fqname, value: desiredValue }));
 
       return false;
     }
@@ -824,7 +846,7 @@ export default class SettingsValidator {
   ): boolean {
     for (const k of Object.keys(desiredValue)) {
       if (!navItemNames.includes(k as NavItemName)) {
-        errors.push(`${ fqname }: "${ k }" is not a valid page name for Preferences Dialog`);
+        errors.push(t('validation.invalidPageName', { field: fqname, value: k }));
 
         return false;
       }
@@ -838,7 +860,7 @@ export default class SettingsValidator {
       const navItem = preferencesNavItems.find(item => item.name === k);
 
       if (!navItem?.tabs?.includes(desiredValue[k])) {
-        errors.push(`${ fqname }: tab name "${ desiredValue[k] }" is not a valid tab name for "${ k }" Preference page`);
+        errors.push(t('validation.invalidTabName', { field: fqname, tabName: desiredValue[k], page: k }));
 
         return false;
       }

--- a/pkg/rancher-desktop/main/i18n.ts
+++ b/pkg/rancher-desktop/main/i18n.ts
@@ -1,0 +1,162 @@
+/**
+ * i18n for the main process: the same YAML translation files and ICU
+ * MessageFormat engine as the renderer, without the Vuex store.
+ */
+
+import { IntlMessageFormat } from 'intl-messageformat';
+
+import mainEvents from '@pkg/main/mainEvents';
+import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader';
+
+export { availableLocales } from '@pkg/utils/translationLoader';
+
+type TranslationMap = Record<string, unknown>;
+
+let currentLocale = 'en-us';
+const translations: Record<string, TranslationMap> = { 'en-us': loadTranslations('en-us') };
+const localeChangeCallbacks: (() => void)[] = [];
+
+/**
+ * Traverse a nested object by dotted key path.
+ */
+function getByPath(obj: TranslationMap, path: string): string | undefined {
+  let current: unknown = obj;
+
+  for (const segment of path.split('.')) {
+    if (current == null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return typeof current === 'string' ? current : undefined;
+}
+
+/**
+ * Load a locale's translations if not already loaded.
+ */
+function loadLocale(locale: string): boolean {
+  if (translations[locale]) {
+    return true;
+  }
+  try {
+    translations[locale] = loadTranslations(locale);
+
+    return true;
+  } catch {
+    console.error(`i18n: failed to load locale "${ locale }"`);
+
+    return false;
+  }
+}
+
+// Formatter instances are cached per locale and key; the locale prefix
+// makes entries from a previous locale unreachable after a switch.
+const intlCache: Record<string, IntlMessageFormat | string> = {};
+
+/**
+ * Translate a key with ICU MessageFormat interpolation.
+ * Falls back to en-us if the key is missing in the current locale, and
+ * to a visible %key% placeholder if it is missing entirely.
+ */
+export function t(key: string, args?: Record<string, string | number>): string {
+  const cacheKey = `${ currentLocale }/${ key }`;
+  let formatter = intlCache[cacheKey];
+
+  if (formatter === undefined) {
+    const msg = getByPath(translations[currentLocale], key) ??
+           getByPath(translations['en-us'], key);
+
+    if (msg === undefined) {
+      return `%${ key }%`;
+    }
+
+    if (msg.includes('{') || msg.includes("'")) {
+      try {
+        formatter = new IntlMessageFormat(msg, currentLocale);
+      } catch (e) {
+        console.error(`Malformed ICU pattern for key "${ key }":`, e);
+        formatter = msg;
+      }
+    } else {
+      formatter = msg;
+    }
+    intlCache[cacheKey] = formatter;
+  }
+
+  if (typeof formatter === 'string') {
+    return formatter;
+  }
+  // Numbers stay numbers for plural rules; everything else formats as a
+  // string, so a non-primitive value cannot make ICU emit an array of parts.
+  const stringArgs = args && Object.fromEntries(Object.entries(args)
+    .map(([name, value]) => [name, typeof value === 'number' ? value : String(value)]));
+
+  try {
+    return formatter.format(stringArgs) as string;
+  } catch (e) {
+    // A missing argument must not break the caller; degrade to the raw
+    // pattern like the renderer does.
+    console.error(`Cannot format translation for key "${ key }":`, e);
+
+    return getByPath(translations[currentLocale], key) ??
+        getByPath(translations['en-us'], key) ?? `%${ key }%`;
+  }
+}
+
+/**
+ * Register a callback to run after the locale has been loaded.
+ * Use this instead of listening to settings-update directly, which
+ * would race against the locale loading.
+ * Returns a function that removes the callback.
+ */
+export function onLocaleChange(callback: () => void): () => void {
+  localeChangeCallbacks.push(callback);
+
+  return () => {
+    const idx = localeChangeCallbacks.indexOf(callback);
+
+    if (idx >= 0) {
+      localeChangeCallbacks.splice(idx, 1);
+    }
+  };
+}
+
+/**
+ * Initialize main-process i18n: read current locale from settings and
+ * listen for changes.
+ */
+export async function initMainI18n(): Promise<void> {
+  try {
+    const settings = await mainEvents.invoke('settings-fetch');
+    // 'none' means the language selector is disabled; use English.
+    const raw = settings?.application?.locale;
+    const locale = (!raw || raw === 'none') ? 'en-us' : raw;
+
+    if (locale !== currentLocale && loadLocale(locale)) {
+      currentLocale = locale;
+    }
+  } catch (err) {
+    // settings-fetch handler may not be registered yet during early startup.
+    console.debug('initMainI18n: could not read initial settings:', err);
+  }
+
+  mainEvents.on('settings-update', (settings) => {
+    const raw = settings?.application?.locale;
+    const locale = (!raw || raw === 'none') ? 'en-us' : raw;
+
+    if (locale !== currentLocale) {
+      if (!loadLocale(locale)) {
+        return; // load failed, stay on current locale
+      }
+      currentLocale = locale;
+      for (const callback of [...localeChangeCallbacks]) {
+        try {
+          callback();
+        } catch (err) {
+          console.error('Locale change callback failed:', err);
+        }
+      }
+    }
+  });
+}

--- a/pkg/rancher-desktop/main/i18n.ts
+++ b/pkg/rancher-desktop/main/i18n.ts
@@ -4,6 +4,7 @@
  */
 
 import { IntlMessageFormat } from 'intl-messageformat';
+import get from 'lodash/get.js';
 
 import mainEvents from '@pkg/main/mainEvents';
 import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader';
@@ -17,19 +18,13 @@ const translations: Record<string, TranslationMap> = { 'en-us': loadTranslations
 const localeChangeCallbacks: (() => void)[] = [];
 
 /**
- * Traverse a nested object by dotted key path.
+ * Look up a dotted key path, returning the value only when it is a string;
+ * a key that resolves to a subtree counts as missing.
  */
 function getByPath(obj: TranslationMap, path: string): string | undefined {
-  let current: unknown = obj;
+  const value = get(obj, path);
 
-  for (const segment of path.split('.')) {
-    if (current == null || typeof current !== 'object') {
-      return undefined;
-    }
-    current = (current as Record<string, unknown>)[segment];
-  }
-
-  return typeof current === 'string' ? current : undefined;
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**

--- a/pkg/rancher-desktop/main/i18n.ts
+++ b/pkg/rancher-desktop/main/i18n.ts
@@ -100,6 +100,13 @@ export function t(key: string, args?: Record<string, string | number>): string {
 }
 
 /**
+ * The locale currently in effect.
+ */
+export function getLocale(): string {
+  return currentLocale;
+}
+
+/**
  * Register a callback to run after the locale has been loaded.
  * Use this instead of listening to settings-update directly, which
  * would race against the locale loading.

--- a/pkg/rancher-desktop/pages/FirstRun.vue
+++ b/pkg/rancher-desktop/pages/FirstRun.vue
@@ -64,7 +64,7 @@
     <rd-fieldset
       v-if="pathManagementRelevant"
       :legend-text="t('pathManagement.label')"
-      :legend-tooltip="t('pathManagement.tooltip', { }, true)"
+      :legend-tooltip="t('pathManagement.tooltip')"
       :is-locked="pathManagementSelectorLocked"
     >
       <path-management-selector

--- a/pkg/rancher-desktop/pages/SudoPrompt.vue
+++ b/pkg/rancher-desktop/pages/SudoPrompt.vue
@@ -6,7 +6,7 @@
 <template>
   <div class="contents">
     <h2>{{ t('sudoPrompt.title') }}</h2>
-    <p>{{ t('sudoPrompt.message', { }, true) }}</p>
+    <p>{{ t('sudoPrompt.message') }}</p>
     <ul class="reasons">
       <li
         v-for="(paths, reason) in explanations"

--- a/pkg/rancher-desktop/pages/Troubleshooting.vue
+++ b/pkg/rancher-desktop/pages/Troubleshooting.vue
@@ -76,7 +76,7 @@
       <hr>
       <span
         class="description"
-        v-html="t('troubleshooting.needHelp', { }, true)"
+        v-html="t('troubleshooting.needHelp')"
       />
     </div>
   </div>
@@ -138,7 +138,7 @@ export default {
     async factoryReset() {
       const cancelPosition = 1;
       const message = this.t('troubleshooting.general.factoryReset.messageBox.message');
-      const detail = this.t('troubleshooting.general.factoryReset.messageBox.detail', { }, true);
+      const detail = this.t('troubleshooting.general.factoryReset.messageBox.detail');
 
       const confirm = await ipcRenderer.invoke(
         'show-message-box-rd',

--- a/pkg/rancher-desktop/pages/extensions/installed.vue
+++ b/pkg/rancher-desktop/pages/extensions/installed.vue
@@ -83,7 +83,7 @@ export default defineComponent({
       return this.t('extensions.installed.emptyState.heading');
     },
     emptyStateBody(): string {
-      return this.t('extensions.installed.emptyState.body', { }, true);
+      return this.t('extensions.installed.emptyState.body');
     },
     installedExtensionRows(): InstalledExtensionRow[] {
       return this.installedExtensions.map(extension => ({

--- a/pkg/rancher-desktop/pages/images/scans/_image-name.vue
+++ b/pkg/rancher-desktop/pages/images/scans/_image-name.vue
@@ -114,17 +114,17 @@ export default {
         });
     },
     loadingText() {
-      return this.t('images.scan.loadingText', { image: this.image }, true);
+      return this.t('images.scan.loadingText', { image: this.image });
     },
     errorText() {
-      return this.t('images.scan.errorText', { image: this.image }, true);
+      return this.t('images.scan.errorText', { image: this.image });
     },
   },
 
   mounted() {
     this.$store.dispatch(
       'page/setHeader',
-      { title: this.t('images.scan.title', { image: this.$route.params.image }, true) },
+      { title: this.t('images.scan.title', { image: this.$route.params.image }) },
     );
 
     ipcRenderer.on('ok:images-process-output', (_event, data) => {

--- a/pkg/rancher-desktop/pages/snapshots/create.vue
+++ b/pkg/rancher-desktop/pages/snapshots/create.vue
@@ -114,7 +114,7 @@ export default defineComponent({
           format: {
             header:            this.t('snapshots.dialog.creating.header', { snapshot: name }),
             showProgressBar:   true,
-            message:           this.t('snapshots.dialog.creating.message', { snapshot: escapeHtml(name) }, true),
+            message:           this.t('snapshots.dialog.creating.message', { snapshot: escapeHtml(name) }),
             snapshotEventType: 'create',
           },
         },

--- a/pkg/rancher-desktop/pages/snapshots/dialog.vue
+++ b/pkg/rancher-desktop/pages/snapshots/dialog.vue
@@ -50,7 +50,7 @@ export default defineComponent({
     });
 
     ipcRenderer.on('dialog/info', (_event, args) => {
-      this.info = this.t(args.infoKey, {}, true);
+      this.info = this.t(args.infoKey);
     });
 
     ipcRenderer.on('dialog/options', (_event, { window, format }) => {
@@ -178,7 +178,7 @@ export default defineComponent({
               <div class="created">
                 <span
                   v-if="snapshot.formattedCreateDate"
-                  v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time }, true)"
+                  v-clean-html="t('snapshots.card.created', { date: snapshot.formattedCreateDate.date, time: snapshot.formattedCreateDate.time })"
                   class="value"
                 />
               </div>

--- a/pkg/rancher-desktop/plugins/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/plugins/__tests__/i18n.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 
-import i18nPlugin, { stringFor } from '@pkg/plugins/i18n';
+import i18nPlugin from '@pkg/plugins/i18n';
 
 const translations: Record<string, string> = {
   'test.plain':   'Plain text',
@@ -23,16 +23,6 @@ function makeStore() {
     },
   });
 }
-
-describe('stringFor', () => {
-  it('returns the translation without HTML-escaping', () => {
-    expect(stringFor(makeStore(), 'test.special')).toEqual('Command & "Args"');
-  });
-
-  it('passes the %key% placeholder through for missing keys', () => {
-    expect(stringFor(makeStore(), 'no.such.key')).toEqual('%no.such.key%');
-  });
-});
 
 describe('t component', () => {
   function mountT(template: string) {

--- a/pkg/rancher-desktop/plugins/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/plugins/__tests__/i18n.spec.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+
+import i18nPlugin, { stringFor } from '@pkg/plugins/i18n';
+
+const translations: Record<string, string> = {
+  'test.plain':   'Plain text',
+  'test.special': 'Command & "Args"',
+  'test.entity':  'Loading&hellip;',
+  'test.html':    'See <a href="https://example.com/">docs</a>',
+};
+
+function makeStore() {
+  return createStore({
+    modules: {
+      i18n: {
+        namespaced: true,
+        getters:    {
+          t:      () => (key: string) => translations[key] ?? `%${ key }%`,
+          exists: () => (key: string) => key in translations,
+        },
+      },
+    },
+  });
+}
+
+describe('stringFor', () => {
+  it('returns the translation without HTML-escaping', () => {
+    expect(stringFor(makeStore(), 'test.special')).toEqual('Command & "Args"');
+  });
+
+  it('passes the %key% placeholder through for missing keys', () => {
+    expect(stringFor(makeStore(), 'no.such.key')).toEqual('%no.such.key%');
+  });
+});
+
+describe('t component', () => {
+  function mountT(template: string) {
+    const store = makeStore();
+
+    return mount({ template }, { global: { plugins: [store, i18nPlugin] } });
+  }
+
+  it('renders text children unescaped; the text sink escapes', () => {
+    const wrapper = mountT('<t k="test.special" />');
+
+    expect(wrapper.text()).toEqual('Command & "Args"');
+  });
+
+  it('renders HTML entities when raw', () => {
+    const wrapper = mountT('<t k="test.entity" raw />');
+
+    expect(wrapper.element.textContent).toEqual('Loading…');
+  });
+
+  it('renders markup when raw', () => {
+    const wrapper = mountT('<t k="test.html" raw />');
+
+    expect(wrapper.find('a').attributes('href')).toEqual('https://example.com/');
+  });
+});
+
+describe('v-t directive', () => {
+  function mountDirective(template: string) {
+    const store = makeStore();
+
+    return mount({ template }, { global: { plugins: [store, i18nPlugin] } });
+  }
+
+  it('renders the raw translation as innerHTML', () => {
+    const wrapper = mountDirective(`<span v-t="'test.entity'" />`);
+
+    expect(wrapper.element.textContent).toEqual('Loading…');
+  });
+
+  it('sets attributes to the raw translation', () => {
+    const wrapper = mountDirective(`<span v-t:title="'test.special'" />`);
+
+    expect(wrapper.attributes('title')).toEqual('Command & "Args"');
+  });
+});

--- a/pkg/rancher-desktop/plugins/i18n.js
+++ b/pkg/rancher-desktop/plugins/i18n.js
@@ -1,17 +1,14 @@
 import { watchEffect, ref, h } from 'vue';
 import { useStore } from 'vuex';
 
-// stringFor returns the raw translation; escaping is the sink's job.
+// The i18n/t getter returns the raw translation; escaping is the sink's job.
 // Text sinks ({{ }}, textContent) escape themselves; HTML sinks render
 // translator-controlled markup and sanitize via v-clean-html where the
 // content warrants it.
-export function stringFor(store, key, args) {
-  return store.getters['i18n/t'](key, args);
-}
 
 function directive(el, binding, vnode /*, oldVnode */) {
   const { instance } = binding;
-  const str = stringFor(instance.$store, binding.value, {});
+  const str = instance.$store.getters['i18n/t'](binding.value, {});
 
   if ( binding.arg ) {
     el.setAttribute(binding.arg, str);
@@ -28,7 +25,7 @@ const i18n = {
     }
 
     vueApp.config.globalProperties.t = function(key, args) {
-      return stringFor(this.$store, key, args);
+      return this.$store.getters['i18n/t'](key, args);
     };
 
     // InnerHTML: <some-tag v-t="'some.key'" />
@@ -66,7 +63,7 @@ const i18n = {
         const store = useStore();
 
         watchEffect(() => {
-          msg.value = stringFor(store, props.k, ctx.attrs);
+          msg.value = store.getters['i18n/t'](props.k, ctx.attrs);
         });
 
         return { msg };

--- a/pkg/rancher-desktop/plugins/i18n.js
+++ b/pkg/rancher-desktop/plugins/i18n.js
@@ -1,56 +1,22 @@
 import { watchEffect, ref, h } from 'vue';
 import { useStore } from 'vuex';
 
-import { escapeHtml } from '../utils/string';
-
-export function stringFor(store, key, args, raw = false, escapehtml = true) {
-  const translation = store.getters['i18n/t'](key, args);
-
-  let out;
-
-  if ( translation !== undefined ) {
-    out = translation;
-  } else if ( args && Object.keys(args).length ) {
-    const argStr = Object.keys(args).map(k => `${ k }: ${ args[k] }`).join(', ');
-
-    out = `%${ key }(${ argStr })%`;
-    raw = true;
-  } else {
-    out = `%${ key }%`;
-  }
-
-  if ( raw ) {
-    return out;
-  } else if (escapehtml) {
-    return escapeHtml(out);
-  } else {
-    return out;
-  }
+// stringFor returns the raw translation; escaping is the sink's job.
+// Text sinks ({{ }}, textContent) escape themselves; HTML sinks render
+// translator-controlled markup and sanitize via v-clean-html where the
+// content warrants it.
+export function stringFor(store, key, args) {
+  return store.getters['i18n/t'](key, args);
 }
 
 function directive(el, binding, vnode /*, oldVnode */) {
   const { instance } = binding;
-  const raw = binding.modifiers && binding.modifiers.raw === true;
-  const str = stringFor(instance.$store, binding.value, {}, raw);
+  const str = stringFor(instance.$store, binding.value, {});
 
   if ( binding.arg ) {
     el.setAttribute(binding.arg, str);
   } else {
     el.innerHTML = str;
-  }
-}
-
-export function directiveSsr(vnode, binding) {
-  console.warn('Function `directiveSsr` is deprecated. Please install i18n as a vue plugin: `vueApp.use(i18n)`');
-
-  const { context } = vnode;
-  const raw = binding.modifiers && binding.modifiers.raw === true;
-  const str = stringFor(context.$store, binding.value, {}, raw);
-
-  if ( binding.arg ) {
-    vnode.data.attrs[binding.arg] = str;
-  } else {
-    vnode.data.domProps = { innerHTML: str };
   }
 }
 
@@ -61,8 +27,8 @@ const i18n = {
       console.debug('Skipping i18n install. Directive, component, and option already exist.');
     }
 
-    vueApp.config.globalProperties.t = function(key, args, raw) {
-      return stringFor(this.$store, key, args, raw);
+    vueApp.config.globalProperties.t = function(key, args) {
+      return stringFor(this.$store, key, args);
     };
 
     // InnerHTML: <some-tag v-t="'some.key'" />
@@ -78,6 +44,7 @@ const i18n = {
 
     // Basic (but you might want the directive above): <t k="some.key" />
     // With interpolation: <t k="some.key" count="1" :foo="bar" />
+    // raw renders the translation as innerHTML instead of a text child.
     vueApp.component('t', {
       inheritAttrs: false,
       props:        {
@@ -93,18 +60,13 @@ const i18n = {
           type:    [String, Object],
           default: 'span',
         },
-        escapehtml: {
-          type:    Boolean,
-          default: true,
-        },
       },
       setup(props, ctx) {
         const msg = ref('');
         const store = useStore();
 
-        // Update msg whenever k, $attrs, raw, or escapehtml changes
         watchEffect(() => {
-          msg.value = stringFor(store, props.k, ctx.attrs, props.raw, props.escapehtml);
+          msg.value = stringFor(store, props.k, ctx.attrs);
         });
 
         return { msg };

--- a/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
@@ -1,0 +1,94 @@
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+mockModules({
+  '@pkg/utils/ipcRenderer': {
+    ipcRenderer: {
+      on:   jest.fn(),
+      once: jest.fn(),
+      send: jest.fn(),
+    },
+  },
+});
+
+const i18n = await import('@pkg/store/i18n');
+
+// Builds a minimal state shape for exercising the getters directly.
+function makeState(translations: Record<string, unknown>, selected = 'de') {
+  return {
+    default:   'en-us',
+    selected,
+    available: Object.keys(translations),
+    translations,
+  };
+}
+
+const en = {
+  simple:  'Plain text',
+  nested:  { child: 'Nested value' },
+  greet:   'Hello {name}',
+  plural:  '{count, plural, one {# item} other {# items}}',
+  invalid: 'Unbalanced {brace',
+  special: 'Command & "Args"',
+};
+const de = {
+  simple: 'Einfacher Text',
+  greet:  'Hallo {name}',
+};
+
+describe('i18n store getters', () => {
+  let state: ReturnType<typeof makeState>;
+
+  beforeEach(() => {
+    state = makeState({ 'en-us': en, de });
+  });
+
+  const t = (key: string, args?: Record<string, unknown>) => (i18n.getters as any).t(state)(key, args);
+
+  it('returns the selected locale translation', () => {
+    expect(t('simple')).toEqual('Einfacher Text');
+  });
+
+  it('falls back to en-us per key', () => {
+    expect(t('nested.child')).toEqual('Nested value');
+  });
+
+  it('returns a visible %key% placeholder for a missing key', () => {
+    expect(t('no.such.key')).toEqual('%no.such.key%');
+  });
+
+  it('formats ICU plurals', () => {
+    expect(t('plural', { count: 1 })).toEqual('1 item');
+    expect(t('plural', { count: 3 })).toEqual('3 items');
+  });
+
+  it('interpolates arguments', () => {
+    expect(t('greet', { name: 'Jan' })).toEqual('Hallo Jan');
+  });
+
+  it('degrades to the raw pattern when an argument is missing', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(t('plural', {})).toEqual(en.plural);
+    spy.mockRestore();
+  });
+
+  it('degrades to the raw text for malformed ICU patterns', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(t('invalid')).toEqual('Unbalanced {brace');
+    spy.mockRestore();
+  });
+
+  it("does not HTML-escape; escaping is the sink's responsibility", () => {
+    expect(t('special')).toEqual('Command & "Args"');
+  });
+
+  it('reports key existence', () => {
+    const exists = (key: string) => (i18n.getters as any).exists(state)(key);
+
+    expect(exists('simple')).toBe(true);
+    expect(exists('no.such.key')).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/store/i18n.js
+++ b/pkg/rancher-desktop/store/i18n.js
@@ -170,8 +170,11 @@ export const actions = {
         .map(locale => dispatch('load', locale)),
     );
 
-    // Use the cookie for fast initial render.
-    let selected = this.$cookies.get(LOCALE, { parseJSON: false });
+    // The main process passes the resolved locale as a URL param, so the first
+    // paint is already localized; the cookie is a fallback for a window opened
+    // without one. Later changes arrive via settings-update below.
+    const urlLocale = new URLSearchParams(window.location.search).get('locale');
+    let selected = urlLocale || this.$cookies.get(LOCALE, { parseJSON: false });
 
     if ( !selected ) {
       selected = state.default;
@@ -190,19 +193,6 @@ export const actions = {
           dispatch('switchTo', locale);
         }
       });
-
-      // Read initial settings to sync with the persisted locale.
-      // May briefly flash if the cookie and settings disagree; acceptable because
-      // both are set together during normal operation.
-      ipcRenderer.once('settings-read', (_, settings) => {
-        const raw = settings?.application?.locale;
-        const locale = (!raw || raw === 'none') ? state.default : raw;
-
-        if ( locale !== state.selected ) {
-          dispatch('switchTo', locale);
-        }
-      });
-      ipcRenderer.send('settings-read');
     }
 
     return dispatch('switchTo', selected);

--- a/pkg/rancher-desktop/store/i18n.js
+++ b/pkg/rancher-desktop/store/i18n.js
@@ -1,52 +1,39 @@
 import { IntlMessageFormat } from 'intl-messageformat';
 
-import en from '@pkg/assets/translations/en-us.yaml';
 import { LOCALE } from '@pkg/config/cookies';
 import { getProduct, getVendor } from '@pkg/config/private-label';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { get } from '@pkg/utils/object';
-
-const translationContext = import.meta.webpackContext('@pkg/assets/translations', { recursive: true, regExp: /.*/ });
-
-const NONE = 'none';
+import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader';
 
 // Formatters can't be serialized into state
 const intlCache = {};
+let ipcListenersBound = false;
 
 export const state = function() {
-  const available = translationContext.keys().map(path => path.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1'));
-
   const out = {
     default:      'en-us',
     selected:     null,
-    previous:     null,
-    available,
-    translations: { 'en-us': en },
+    available:    [...availableLocales],
+    translations: { 'en-us': loadTranslations('en-us') },
   };
 
   return out;
 };
 
 export const getters = {
-  selectedLocaleLabel(state) {
-    const key = `locale.${ state.selected }`;
-
-    if ( state.selected === NONE ) {
-      return `%${ key }%`;
-    } else {
-      return get(state.translations[state.default], key);
-    }
-  },
-
-  availableLocales(state, getters) {
+  availableLocales(state) {
     const out = {};
 
     for ( const locale of state.available ) {
-      const key = `locale.${ locale }`;
+      const nativeName = get(state.translations[locale], `locale.${ locale }`);
+      const translatedName = get(state.translations[state.selected], `locale.${ locale }`) ??
+                          get(state.translations[state.default], `locale.${ locale }`);
 
-      if ( state.selected === NONE ) {
-        out[locale] = `%${ key }%`;
+      if ( !nativeName || !translatedName || nativeName === translatedName ) {
+        out[locale] = nativeName ?? translatedName ?? locale;
       } else {
-        out[locale] = get(state.translations[state.default], key);
+        out[locale] = `${ nativeName } (${ translatedName })`;
       }
     }
 
@@ -54,10 +41,6 @@ export const getters = {
   },
 
   t: state => (key, args) => {
-    if (state.selected === NONE ) {
-      return `%${ key }%`;
-    }
-
     const cacheKey = `${ state.selected }/${ key }`;
     let formatter = intlCache[cacheKey];
 
@@ -69,17 +52,27 @@ export const getters = {
       }
 
       if ( !msg ) {
-        return undefined;
+        // Visible placeholder, matching the main process; missing keys
+        // must be debuggable, not silently blank.
+        return `%${ key }%`;
       }
 
       if ( typeof msg === 'object' ) {
         console.error('Translation for', cacheKey, 'is an object');
 
-        return undefined;
+        return `%${ key }%`;
       }
 
       if ( msg?.includes('{')) {
-        formatter = new IntlMessageFormat(msg, state.selected);
+        try {
+          // Uses the selected locale for formatting even when falling back to
+          // English text. Acceptable: plural rules rarely diverge for the
+          // strings used here.
+          formatter = new IntlMessageFormat(msg, state.selected);
+        } catch (e) {
+          console.error(`Malformed ICU pattern for key "${ key }":`, e);
+          formatter = msg;
+        }
       } else {
         formatter = msg;
       }
@@ -97,7 +90,15 @@ export const getters = {
         ...args,
       };
 
-      return formatter.format(moreArgs);
+      try {
+        return formatter.format(moreArgs);
+      } catch (e) {
+        // A missing argument must not abort the component render;
+        // degrade to the raw pattern like the main-process interpolator.
+        console.error(`Cannot format translation for key "${ key }":`, e);
+
+        return get(state.translations[state.selected], key) ?? get(state.translations[state.default], key);
+      }
     } else {
       return '?';
     }
@@ -112,7 +113,7 @@ export const getters = {
 
     let msg = get(state.translations[state.default], key);
 
-    if ( !msg && state.selected && state.selected !== NONE ) {
+    if ( !msg && state.selected ) {
       msg = get(state.translations[state.selected], key);
     }
 
@@ -159,18 +160,56 @@ export const mutations = {
 };
 
 export const actions = {
-  init({ state, commit, dispatch }) {
+  async init({ state, commit, dispatch }) {
+    // Load all translation files so availableLocales can show native names.
+    // Acceptable overhead with a small number of locales; revisit if locale
+    // count grows significantly.
+    await Promise.allSettled(
+      state.available
+        .filter(locale => !state.translations[locale])
+        .map(locale => dispatch('load', locale)),
+    );
+
+    // Use the cookie for fast initial render.
     let selected = this.$cookies.get(LOCALE, { parseJSON: false });
 
     if ( !selected ) {
       selected = state.default;
     }
 
+    if (!ipcListenersBound) {
+      ipcListenersBound = true;
+
+      // Listen for settings changes (from preferences UI or rdctl) to sync locale.
+      // 'none' means the language selector is disabled; use the default locale.
+      ipcRenderer.on('settings-update', (_, settings) => {
+        const raw = settings?.application?.locale;
+        const locale = (!raw || raw === 'none') ? state.default : raw;
+
+        if ( locale !== state.selected ) {
+          dispatch('switchTo', locale);
+        }
+      });
+
+      // Read initial settings to sync with the persisted locale.
+      // May briefly flash if the cookie and settings disagree; acceptable because
+      // both are set together during normal operation.
+      ipcRenderer.once('settings-read', (_, settings) => {
+        const raw = settings?.application?.locale;
+        const locale = (!raw || raw === 'none') ? state.default : raw;
+
+        if ( locale !== state.selected ) {
+          dispatch('switchTo', locale);
+        }
+      });
+      ipcRenderer.send('settings-read');
+    }
+
     return dispatch('switchTo', selected);
   },
 
   async load({ commit }, locale) {
-    const translations = await translationContext(`./${ locale }.yaml`);
+    const translations = loadTranslations(locale);
 
     commit('loadTranslations', { locale, translations });
 
@@ -178,11 +217,8 @@ export const actions = {
   },
 
   async switchTo({ state, commit, dispatch }, locale) {
-    if ( locale === NONE ) {
-      commit('setSelected', locale);
-
-      // Don't remember into cookie
-      return;
+    if ( !locale || locale === 'none' ) {
+      locale = state.default;
     }
 
     if ( !state.translations[locale] ) {
@@ -199,6 +235,10 @@ export const actions = {
       }
     }
 
+    for (const key of Object.keys(intlCache)) {
+      delete intlCache[key];
+    }
+
     commit('setSelected', locale);
     this.$cookies.set(LOCALE, locale, {
       encode: x => x,
@@ -208,11 +248,4 @@ export const actions = {
     });
   },
 
-  toggleNone({ state, dispatch }) {
-    if ( state.selected === NONE ) {
-      return dispatch('switchTo', state.previous || state.default);
-    } else {
-      return dispatch('switchTo', NONE);
-    }
-  },
 };

--- a/pkg/rancher-desktop/utils/testUtils/translations.ts
+++ b/pkg/rancher-desktop/utils/testUtils/translations.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared translation helper for tests and mocks.
+ *
+ * Loads the English YAML once and provides a t() function using the same
+ * ICU MessageFormat engine as the renderer and the main process.
+ */
+
+import { IntlMessageFormat } from 'intl-messageformat';
+
+import { availableLocales, loadTranslations } from '../translationLoader';
+
+type TranslationMap = Record<string, unknown>;
+
+const en = loadTranslations('en-us') as TranslationMap;
+
+export { availableLocales };
+
+function getByPath(obj: TranslationMap, keyPath: string): string | undefined {
+  let current: unknown = obj;
+
+  for (const segment of keyPath.split('.')) {
+    if (current == null || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return typeof current === 'string' ? current : undefined;
+}
+
+export function t(key: string, args?: Record<string, string | number>): string {
+  const msg = getByPath(en, key);
+
+  if (msg === undefined) {
+    return `%${ key }%`;
+  }
+
+  try {
+    return new IntlMessageFormat(msg, 'en-us').format(args) as string;
+  } catch {
+    return msg;
+  }
+}

--- a/pkg/rancher-desktop/utils/translationLoader.ts
+++ b/pkg/rancher-desktop/utils/translationLoader.ts
@@ -1,0 +1,51 @@
+/**
+ * Access to the bundled translation YAML files, shared by the renderer
+ * store and the main process. Under webpack the locale files are bundled
+ * at build time; other runtimes (jest, tsx-run scripts) read the same
+ * files from disk.
+ */
+
+/// <reference types="webpack/module" />
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import yaml from 'js-yaml';
+
+interface TranslationSource {
+  locales: string[];
+  load(locale: string): Record<string, unknown>;
+}
+
+function webpackSource(): TranslationSource {
+  // All locale YAML files are bundled at build time (default 'sync' mode;
+  // nothing is loaded lazily).
+  const context = import.meta.webpackContext(
+    '@pkg/assets/translations', { recursive: false, regExp: /\.yaml$/ },
+  );
+
+  return {
+    locales: context.keys().map(p => p.replace(/^.*\/([^\/]+)\.[^.]+$/, '$1')),
+    load:    locale => context(`./${ locale }.yaml`) as Record<string, unknown>,
+  };
+}
+
+function filesystemSource(): TranslationSource {
+  const dir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'assets', 'translations');
+
+  return {
+    locales: fs.readdirSync(dir).filter(f => f.endsWith('.yaml')).map(f => f.replace(/\.yaml$/, '')),
+    load:    locale => yaml.load(fs.readFileSync(path.join(dir, `${ locale }.yaml`), 'utf8')) as Record<string, unknown>,
+  };
+}
+
+const source = import.meta.webpack ? webpackSource() : filesystemSource();
+
+/** Locale codes derived from the bundled translation files. */
+export const availableLocales: string[] = source.locales;
+
+/** Returns the parsed translations for a bundled locale. */
+export function loadTranslations(locale: string): Record<string, unknown> {
+  return source.load(locale);
+}

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -7,6 +7,7 @@ import Electron, {
 
 import * as K8s from '@pkg/backend/k8s';
 import { getSettings } from '@pkg/config/settingsImpl';
+import { getLocale } from '@pkg/main/i18n';
 import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import { isDevBuild } from '@pkg/utils/environment';
 import Logging from '@pkg/utils/logging';
@@ -96,7 +97,12 @@ export function createWindow(name: string, url: string, options: Electron.Browse
     console.log(`Failed to load ${ url }: ${ errorCode } (${ errorDescription })`, event);
   });
   console.debug('createWindow() name:', name, ' url:', url);
-  window.loadURL(url);
+  // Give the renderer its locale in the URL so the first paint is already
+  // localized, without waiting on a settings roundtrip.
+  const localizedUrl = new URL(url);
+
+  localizedUrl.searchParams.set('locale', getLocale());
+  window.loadURL(localizedUrl.toString());
   windowMapping[name] = window.id;
 
   return window;


### PR DESCRIPTION
The renderer store and the main process translate through the same YAML files and ICU MessageFormat engine, with English fallback and a visible %key% placeholder for missing keys. The application.locale setting selects the language and can be set through rdctl or a deployment profile, so translation works before any UI exists. Validator errors become translation keys so the CLI and HTTP API return localized messages; callers classify errors via hasLockedFieldError instead of parsing text.
