### PR TITLE
Add a language picker to Application preferences

### DIFF
--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -375,6 +375,20 @@ application:
         dark:
           label: Dark
           description: Always use dark mode
+  general:
+    adminAccess:
+      legendText: Administrative Access
+      label: Allow administrative credentials (sudo access)
+      legendTooltip: If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+    automaticUpdates:
+      legendText: Automatic Updates
+      label: Check for updates automatically
+    statistics:
+      legendText: Statistics
+      label: Allow collection of anonymous statistics to help improve {appName}
+  locale:
+    legendText: Language
+    disclaimer: Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
 
 virtualMachine:
   networkingTunnel:

--- a/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
+++ b/pkg/rancher-desktop/components/Preferences/ApplicationGeneral.vue
@@ -3,6 +3,7 @@
 import { defineComponent } from 'vue';
 import { mapGetters } from 'vuex';
 
+import RdSelect from '@pkg/components/RdSelect.vue';
 import RdCheckbox from '@pkg/components/form/RdCheckbox.vue';
 import RdFieldset from '@pkg/components/form/RdFieldset.vue';
 import { Settings } from '@pkg/config/settings';
@@ -12,33 +13,29 @@ import type { PropType } from 'vue';
 
 export default defineComponent({
   name:       'preferences-application-general',
-  components: { RdCheckbox, RdFieldset },
+  components: { RdSelect, RdCheckbox, RdFieldset },
   props:      {
     preferences: {
       type:     Object as PropType<Settings>,
       required: true,
     },
   },
-  data() {
-    return {
-      sudoAllowedTooltip: `
-        If checked, Rancher Desktop will attempt to acquire administrative
-        credentials ("sudo access") when starting for some operations.  This
-        allows for enhanced functionality, including bridged networking and
-        default docker socket support.  Changes will only be applied next time
-        Rancher Desktop starts.
-      `,
-      automaticUpdates: true,
-      statistics:       false,
-    };
-  },
   computed: {
     ...mapGetters('preferences', ['isPlatformWindows', 'isPreferenceLocked']),
+    ...mapGetters('i18n', ['availableLocales']),
     isSudoAllowed(): boolean {
       return this.preferences?.application?.adminAccess ?? false;
     },
     canAutoUpdate(): boolean {
       return this.preferences?.application.updater.enabled ?? false;
+    },
+    selectedLocale(): string {
+      const locale = this.preferences?.application?.locale;
+
+      return (!locale || locale === 'none') ? 'en-us' : locale;
+    },
+    showLocaleDisclaimer(): boolean {
+      return this.selectedLocale !== 'en-us';
     },
   },
   methods: {
@@ -52,13 +49,41 @@ export default defineComponent({
 <template>
   <div class="application-general">
     <rd-fieldset
+      data-test="locale"
+      class="width-xs"
+      :legend-text="t('application.locale.legendText')"
+      :is-experimental="true"
+    >
+      <rd-select
+        data-test="localeSelect"
+        :model-value="selectedLocale"
+        :aria-label="t('application.locale.legendText')"
+        :is-locked="isPreferenceLocked('application.locale')"
+        @change="onChange('application.locale', $event.target.value)"
+      >
+        <option
+          v-for="(label, code) in availableLocales"
+          :key="code"
+          :value="code"
+        >
+          {{ label }}
+        </option>
+      </rd-select>
+      <p
+        v-if="showLocaleDisclaimer"
+        class="locale-disclaimer"
+      >
+        {{ t('application.locale.disclaimer') }}
+      </p>
+    </rd-fieldset>
+    <rd-fieldset
       v-if="!isPlatformWindows"
       data-test="administrativeAccess"
-      legend-text="Administrative Access"
-      :legend-tooltip="sudoAllowedTooltip"
+      :legend-text="t('application.general.adminAccess.legendText')"
+      :legend-tooltip="t('application.general.adminAccess.legendTooltip')"
     >
       <rd-checkbox
-        label="Allow to acquire administrative credentials (sudo access)"
+        :label="t('application.general.adminAccess.label')"
         :value="isSudoAllowed"
         :is-locked="isPreferenceLocked('application.adminAccess')"
         @update:value="onChange('application.adminAccess', $event)"
@@ -66,11 +91,11 @@ export default defineComponent({
     </rd-fieldset>
     <rd-fieldset
       data-test="automaticUpdates"
-      legend-text="Automatic Updates"
+      :legend-text="t('application.general.automaticUpdates.legendText')"
     >
       <rd-checkbox
         data-test="automaticUpdatesCheckbox"
-        label="Check for updates automatically"
+        :label="t('application.general.automaticUpdates.label')"
         :value="canAutoUpdate"
         :is-locked="isPreferenceLocked('application.updater.enabled')"
         @update:value="onChange('application.updater.enabled', $event)"
@@ -78,10 +103,10 @@ export default defineComponent({
     </rd-fieldset>
     <rd-fieldset
       data-test="statistics"
-      legend-text="Statistics"
+      :legend-text="t('application.general.statistics.legendText')"
     >
       <rd-checkbox
-        label="Allow collection of anonymous statistics to help us improve Rancher Desktop"
+        :label="t('application.general.statistics.label')"
         :value="preferences.application.telemetry.enabled"
         :is-locked="isPreferenceLocked('application.telemetry.enabled')"
         @update:value="onChange('application.telemetry.enabled', $event)"
@@ -95,5 +120,16 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+
+  .width-xs {
+    max-width: 20rem;
+    min-width: 20rem;
+  }
+
+  .locale-disclaimer {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--input-label);
   }
 </style>

--- a/pkg/rancher-desktop/components/TelemetryOptIn.vue
+++ b/pkg/rancher-desktop/components/TelemetryOptIn.vue
@@ -28,7 +28,7 @@ export default {
       <rd-checkbox
         :value="telemetry"
         :is-locked="isTelemetryLocked"
-        label="Allow collection of anonymous statistics to help us improve Rancher Desktop"
+        :label="t('application.general.statistics.label')"
         @update:value="toggleTelemetry"
       />
       <p class="fineprint">


### PR DESCRIPTION
The picker lists the available locales and writes application.locale; it is experimental and defaults to English ('none'). The same change also localizes the existing labels on that preferences page.