### PR TITLE
Enforce @reason on identical translations and clean up deferred i18n items

### DIFF
--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -211,9 +211,9 @@ needed.
 
 CI runs `i18n-report check --locale=all` on every pull request: the
 source gate (unused and undefined keys), the locale registration
-checks, and each locale's structural checks. Periodic and pre-release
-runs add `--strict`, which also requires complete translations (no
-missing or drifted keys). Findings exit 1; operational errors exit 2.
+checks, and each locale's structural checks. Run `--strict` by hand before
+a release to also require complete translations (no missing or drifted
+keys); no configured job adds it. Findings exit 1; operational errors exit 2.
 
 ## Locale switching
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -66,6 +66,9 @@ Add these comments directly above the key they describe.
 | `@no-translate` | en-us.yaml | Terms that should stay in English by default |
 | `@reason` | locale files | Why a particular translation was chosen |
 
+A translation left identical to its English source must carry a `@reason`
+(or `@override`) comment; `validate` flags unmarked identical values.
+
 ### Examples in en-us.yaml
 
 ```yaml
@@ -170,7 +173,11 @@ needed.
    ```
 3. Run `i18n-report translate --locale=<code>` to find keys that need
    translation, then merge the results with `i18n-report merge`.
-4. Run `i18n-report untranslated` to find hardcoded English strings in
+4. Review `validate --locale=<code>` findings. An `[identical]` finding
+   is a translation that matches a current `@source` without a `@reason`:
+   either translate the key or mark the keep with a `@reason`, then
+   merge with `merge --mode=improve`.
+5. Run `i18n-report untranslated` to find hardcoded English strings in
    Vue/TS files that should be externalized.
 
 CI runs `i18n-report check --locale=all` on every pull request: the

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -55,6 +55,27 @@ The `v-t` directive always renders innerHTML (or sets an attribute with
 A missing key renders as a visible `%some.key%` placeholder in every
 process; run `i18n-report undefined` to find such references.
 
+## Writing source strings
+
+en-us.yaml is the source every locale translates from, so its phrasing sets the
+ceiling on translation quality.
+
+- **Name the subject.** A subjectless passive like "Locked due to organization's
+  policy" gives a gendered language nothing to agree with, so each translator
+  invents a referent and they disagree. Spanish and French were left with a bare
+  participle agreeing with nothing.
+- **Keep a sentence in one key.** `images.add` assembles one from `{action}` plus
+  its `gerund`/`infinitive`/`pastTense` sub-keys, which forces English word order
+  onto every language; German and Brazilian Portuguese had to rephrase around it.
+- **Headings are noun phrases.** English tolerates a fragment like "From the
+  blog" because the layout supplies the missing noun. Chinese, Japanese, and
+  Korean headings have no such affordance, so a fragment forces every translator
+  to invent a head noun, and invention is where locales diverge.
+
+Changing an en-us value after locales exist invalidates their `@source`
+snapshots and forces a drift pass across every locale, so phrasing is far
+cheaper to get right before the string ships.
+
 ## YAML comment conventions
 
 Add these comments directly above the key they describe.

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -140,13 +140,20 @@ Without file arguments, it reads from stdin.
 ## Adding a new language
 
 1. Create an empty locale file `{code}.yaml` in this directory.
-2. Register the locale code in four places: en-us.yaml locale names,
-   `command-api.yaml` enum, `settingsValidator.ts` `checkEnum`, and
-   `settingsValidator.spec.ts` error string.
-3. Run `yarn postinstall` to regenerate Go CLI code from the API spec.
-4. Run `go tool i18n-report translate --locale={code}` to get keys
+2. Register the locale code in three places: the `locale.` display names
+   in en-us.yaml, the `application.locale` enum in `command-api.yaml`,
+   and the `Locale` type in `config/settings.ts`. The settings validator
+   builds its enum from the translation files at build time and needs no
+   edit.
+3. Add the new locale's display name to every other locale file,
+   translated into that file's language: `merge` a one-entry
+   `locale.{code}` translation into each.
+4. Run `yarn postinstall` to regenerate Go CLI code from the API spec.
+5. Run `go tool i18n-report translate --locale={code}` to get keys
    that need translation; translate them and merge with
    `go tool i18n-report merge --locale={code}`.
+6. Run `go tool i18n-report check --locale=all` to verify the
+   registration.
 
 Webpack discovers new YAML files automatically — no other code changes are
 needed.
@@ -206,10 +213,11 @@ leaking callbacks.
 
 ### i18n-report tool
 
-- **Registration cross-validation is string-based** for
-  settingsValidator.ts and its spec test. Generating those registrations
-  from the translation file list would make drift impossible; revisit
-  when the next locale is added.
+- **The `Locale` type in `config/settings.ts` is synced by hand.**
+  `check` cross-validates the `command-api.yaml` enum and the
+  validator's dynamic `...availableLocales` pattern against the
+  translation files, but nothing checks the TypeScript union; a
+  forgotten entry surfaces only where a locale literal meets the type.
 
 ### Scanner gaps
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -64,10 +64,18 @@ Add these comments directly above the key they describe.
 | `@context` | en-us.yaml | Where in the UI the string appears |
 | `@meaning` | en-us.yaml | Domain-specific meaning when English is ambiguous |
 | `@no-translate` | en-us.yaml | Terms that should stay in English by default |
-| `@reason` | locale files | Why a particular translation was chosen |
+| `@reason` | locale files | Why a wording was chosen, or why English was kept |
 
-A translation left identical to its English source must carry a `@reason`
-(or `@override`) comment; `validate` flags unmarked identical values.
+`@reason` carries two meanings. It records why a wording was chosen, and it
+marks a value left identical to its English source as a deliberate keep
+rather than a missed translation. When the `@source` snapshot still matches
+current English, `validate` flags an unmarked identical value and accepts
+either `@reason` or `@override`; a stale snapshot belongs to `drift`.
+
+`merge` preserves a `@reason` across a value change and strips only
+`@override`, so a note written for an earlier wording can outlive it and
+still satisfy the identical-value check. Re-read the note whenever you
+change the value it describes.
 
 ### Examples in en-us.yaml
 
@@ -122,7 +130,7 @@ A Go CLI at `src/go/i18n-report/` for translation maintenance. See
 | `check` | source checks, plus per-locale checks with `--locale` |
 | `source` | Record each translated key's English source as a `@source` comment |
 | `drift` | Detect translated keys whose English source changed |
-| `validate` | Structural checks: placeholders, tags, metadata, overrides |
+| `validate` | Structural checks: placeholders, tags, metadata, overrides, deliberate identity |
 
 Run from the repository root:
 

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -718,9 +718,9 @@ images:
       # @reason tab label on the Add Image page; matches its submit button images.manager.input.pull.button 'Abrufen'
       # @source Pull
       pull: Abrufen
-    # @reason Restructured to the "Fehler beim ... von" pattern already used by images.scan.errorText; en dash matches file convention
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: Fehler beim { action } von ''{ image }'' – siehe Konsolenausgabe für weitere Informationen
+    # @reason Restructured to the "Fehler beim ... von" pattern already used by images.scan.errorText
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: Fehler beim { action } von ''{ image }''. Siehe Konsolenausgabe für weitere Informationen.
     # @reason Restructured as passive; composes to "Image wird erstellt..." / "Image wird abgerufen..."
     # @source {action} image...
     loadingText: Image wird {action}...
@@ -793,8 +793,8 @@ images:
       primaryUrl: Primäre URL
       # @source References
       references: Referenzen
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: Fehler beim Scannen von ''{ image }'' – siehe Konsolenausgabe für weitere Informationen
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: Fehler beim Scannen von ''{ image }''. Siehe Konsolenausgabe für weitere Informationen.
     labels:
       # @source CRITICAL
       critical: KRITISCH

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -513,6 +513,8 @@ diagnostics:
   failedCount: '{count} fehlgeschlagen plus {muted} stummgeschaltet'
   # @source Last run:
   lastRun: 'Letzter Lauf:'
+  # @source (Never)
+  never: (Nie)
   # @source (No fixes available)
   noFixes: (Keine Korrekturen verfügbar)
   results:
@@ -1223,6 +1225,8 @@ progress:
   deletingVirtualMachine: Virtuelle Maschine wird gelöscht
   # @source DNS configuration
   dnsConfiguration: DNS-Konfiguration
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Kubernetes-Komponenten werden heruntergeladen
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: Kompatibles kubectl wird sichergestellt
   # @source Ensuring virtualization is supported
@@ -1267,6 +1271,9 @@ progress:
   proxyConfigSetup: Proxy-Konfiguration wird eingerichtet
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop-Gast-Agent
+  # @reason 'repariert' not 'wiederhergestellt'; this file reserves 'Wiederherstellen' for snapshot restore
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Defekte virtuelle Maschine wird repariert
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Konfiguration wird aufgrund fehlender Berechtigungen neu generiert
   # @source Registering WSL distribution
@@ -1593,6 +1600,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Debug-Modus aktivieren
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Kann nicht geändert werden, da die Umgebungsvariable RD_DEBUG_ENABLED gesetzt ist.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -1097,8 +1097,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: Diese Option erfordert, dass
   locked:
-    # @source Locked due to organization's policy
-    tooltip: Gesperrt aufgrund der Unternehmensrichtlinie
+    # @source This setting is locked by organization policy.
+    tooltip: Diese Einstellung ist durch eine Unternehmensrichtlinie gesperrt.
   nav:
     # @source Application
     application: Anwendung
@@ -1272,8 +1272,8 @@ progress:
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop-Gast-Agent
   # @reason 'repariert' not 'wiederhergestellt'; this file reserves 'Wiederherstellen' for snapshot restore
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: Defekte virtuelle Maschine wird repariert
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: Virtuelle Maschine wird repariert
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Konfiguration wird aufgrund fehlender Berechtigungen neu generiert
   # @source Registering WSL distribution
@@ -1600,8 +1600,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Debug-Modus aktivieren
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: Kann nicht geändert werden, da die Umgebungsvariable RD_DEBUG_ENABLED gesetzt ist.
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Der Debug-Modus kann nicht geändert werden, da die Umgebungsvariable RD_DEBUG_ENABLED gesetzt ist.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -720,7 +720,7 @@ troubleshooting:
         cancel: Cancel
   needHelp: Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
   debugMode: Enable debug mode
-  debugModeLockedTooltip: Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
 diagnostics:
   title: Diagnostics
   results:
@@ -779,7 +779,7 @@ preferences:
       restart: Kubernetes will restart after applying changes.
       error: There's a problem with the preferences selection.
   locked:
-    tooltip: Locked due to organization's policy
+    tooltip: This setting is locked by organization policy.
   incompatibleTypeWarningPre: The option requires
   incompatibleTypeWarningPostSelected: to be selected.
   incompatibleTypeWarningPostDisabled: to be unselected.
@@ -972,7 +972,7 @@ progress:
   preparingToStart: Preparing to start
   proxyConfigSetup: Proxy Config Setup
   rancherDesktopGuestAgent: Rancher Desktop guest agent
-  recoveringBrokenVirtualMachine: Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Recovering virtual machine
   regeneratingConfiguration: Regenerating configuration to account for lack of permissions
   registeringWslDistribution: Registering WSL distribution
   removingExistingCertificates: Removing existing certificates

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -237,11 +237,11 @@ images:
         pull: Pulled
     loadingText: '{action} image...'
     successText: '{action} image'
-    errorText: Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Error trying to { action } ''{ image }''. See console output for more information.
   scan:
     title: Scan details for ''{ image }''
     loadingText: Scanning ''{ image }''
-    errorText: Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Error trying to scan ''{ image }''. See console output for more information.
     results:
       headers:
         severity: Severity

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -68,18 +68,27 @@ mainMenu:
   showAll: Show All
   quit: Quit {appName}
 tray:
+  # @no-translate Rancher Desktop
   tooltip: Rancher Desktop
   state:
+    # @no-translate Kubernetes
     stopped: Kubernetes is stopped
+    # @no-translate Kubernetes
     starting: Kubernetes is starting
+    # @no-translate Kubernetes
     started: Kubernetes is running
+    # @no-translate Kubernetes
     stopping: Kubernetes is shutting down
+    # @no-translate Kubernetes
     error: Kubernetes has encountered an error
+    # @no-translate Kubernetes
     disabled: Kubernetes is disabled
   openMainWindow: Open main window
   openPreferences: Open preferences dialog
   openDashboard: Open cluster dashboard
+  # @no-translate Kubernetes
   kubernetesContexts: Kubernetes Contexts
+  # @no-translate Rancher Desktop
   quitRancherDesktop: Quit Rancher Desktop
   containerEngine: 'Container engine: {name}'
   networkStatus: 'Network status: {status}'
@@ -91,6 +100,7 @@ imageEvents:
      {error}
   deleteBatchError: Error trying to delete images {ids}
   buildTitle: Pick the build directory
+  # @no-translate Dockerfile
   buildMessage: Please select the Dockerfile to use (could have a different name)
   scanError: |-
     Error trying to scan {name}:
@@ -107,6 +117,7 @@ product:
     online: online
   version: Version
   networkStatus: Network status
+  # @no-translate Kubernetes
   kubernetesVersion: Kubernetes
   containerEngine:
     fullName: Container Engine
@@ -114,12 +125,15 @@ product:
   deactivated: deactivated
 firstRun:
   kubernetesVersion:
+    # @no-translate Kubernetes
     legend: Kubernetes Version
     cachedOnly: (cached versions only)
     otherVersions: Other Versions
     recommendedVersions: Recommended Versions
   ok: OK
+  # @no-translate Kubernetes
   enableKubernetes: Enable Kubernetes
+  # @no-translate Rancher Desktop, SUSE
   welcome: Welcome to Rancher Desktop by SUSE
 marketplace:
   title: Extensions
@@ -267,6 +281,7 @@ images:
   sortableTables:
     noRows: There are no images to show
 portForwarding:
+  # @no-translate Kubernetes
   includeKubernetesServices: Include Kubernetes services
   title: Port Forwarding
   manage:
@@ -280,7 +295,9 @@ portForwarding:
     noRows: There are no port forwarding entries to show
 general:
   navLabel: General
+  # @no-translate Rancher Desktop, SUSE
   title: Welcome to Rancher Desktop by SUSE
+  # @no-translate Rancher Desktop, Kubernetes
   description: Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
   homepage: Homepage
   issues: Issues
@@ -338,6 +355,7 @@ virtualMachine:
           description: Exposes the filesystem by running an SFTP server.
         9p:
           label: 9p
+          # @no-translate QEMU
           description: Exposes the filesystem by using QEMU's virtio-9p-pci devices.
           options:
             cacheMode:
@@ -367,9 +385,11 @@ virtualMachine:
                 mapped-file: mapped-file
                 none: none
         virtiofs:
+          # @no-translate virtiofs
           label: virtiofs
           description: Exposes the filesystem by using an Apple Virtualization framework shared directory device.
   proxy:
+    # @no-translate WSL
     legend: WSL Proxy
     label: Enable the proxy used by rancher-desktop
     addressTitle: Proxy address
@@ -387,7 +407,9 @@ virtualMachine:
     legend: Virtual Machine Type
     options:
       qemu:
+        # @no-translate QEMU
         label: QEMU
+        # @no-translate QEMU
         description: Use the QEMU emulator.
       vz:
         label: VZ
@@ -399,14 +421,20 @@ containerEngine:
   label: Container Engine
   options:
     moby:
+      # @no-translate dockerd, moby
       label: dockerd (moby)
+      # @no-translate Docker
       description: Docker API; use with Docker CLI.
     containerd:
+      # @no-translate containerd
       label: containerd
+      # @no-translate nerdctl
       description: Namespaces for container images; use with nerdctl.
 webAssembly:
+  # @no-translate WebAssembly, Wasm
   label: WebAssembly (Wasm)
   enabled: Enabled
+  # @no-translate WebAssembly
   description: Please read the documentation before enabling the experimental WebAssembly feature!
 allowedImages:
   label: Allowed Image Patterns
@@ -418,31 +446,41 @@ allowedImages:
   alert: The image name needs to match one of the patterns defined in the Allowed Images preference tab.
 pathManagement:
   label: Configure PATH
+  # @no-translate Rancher Desktop, kubectl, nerdctl, helm, docker
   tooltip: Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
   options:
     rcFiles:
       label: Automatic
+      # @no-translate Rancher Desktop
       description: Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
     manual:
       label: Manual
+      # @no-translate Rancher Desktop
       description: Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
 sudoPrompt:
   title: Administrative Access Required
+  # @no-translate Rancher Desktop
   message: 'Rancher Desktop requires administrative access ("sudo access") for the following reasons:'
+  # @no-translate Rancher Desktop, docker, rancher-desktop
   messageSecondPart: The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
   explanation: 'This will modify the following paths:'
   buttonText: OK
   alwaysRunWithout: Always run without administrative access
   reasons:
     dockerSocket:
+      # @no-translate docker
       description: Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      # @no-translate docker
       title: Set up default docker socket
     networking:
       description: Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
       title: Configure networking
 unmetPrerequisites:
+  # @no-translate Rancher Desktop
   title: Rancher Desktop is unable to start
+  # @no-translate Rancher Desktop
   message: 'Rancher Desktop cannot start because requirements are missing or not configured:'
+  # @no-translate Rancher Desktop
   action: Please ensure all requirements are met and try again. Rancher Desktop will now close.
   buttonText: OK
 asyncButton:
@@ -585,8 +623,11 @@ sortableTable:
     show: Show
 validation:
   cannotDecrease: Cannot decrease "{field}" from {from} to {to}
+  # @no-translate WebAssembly, moby
   cannotEnableWasmClassic: Cannot enable WebAssembly with classic storage for moby.
+  # @no-translate WebAssembly, moby
   cannotSwitchClassicWasm: Cannot switch to classic storage for moby when WebAssembly is enabled.
+  # @no-translate WebAssembly, moby
   cannotSwitchMobyClassicWasm: Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
   duplicateEntries: 'field "{field}" has duplicate entries: "{duplicates}"'
   errorsInProposedSettings: 'Errors in proposed settings:'
@@ -600,6 +641,7 @@ validation:
   invalidTag: '{field}: "{name}" has invalid tag "{tag}"'
   invalidValue: 'Invalid value for "{field}": <{value}>'
   invalidValueEnum: 'Invalid value for "{field}": <{value}>; must be one of {validValues}'
+  # @no-translate Kubernetes
   kubernetesVersionNotFound: Kubernetes version "{version}" not found.
   nonStringTag: '{field}: "{name}" has non-string tag "{tag}"'
   notSupported: Changing field "{field}" via the API isn't supported.
@@ -638,6 +680,7 @@ snapshots:
     actions:
       submit: Create
       back: Cancel
+    # @no-translate Rancher Desktop
     info: Rancher Desktop will be temporarily unavailable while creating a new Snapshot
   empty:
     icon: icon-search
@@ -652,7 +695,9 @@ snapshots:
         cancel: Cancel
       error:
         header: Error restoring snapshot
+        # @no-translate Rancher Desktop
         description: Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        # @no-translate Rancher Desktop
         buttonText: Quit Rancher Desktop
     delete:
       header: Permanently delete snapshot?
@@ -662,11 +707,13 @@ snapshots:
         cancel: Cancel
     restoring:
       header: Restoring {snapshot}
+      # @no-translate Rancher Desktop
       message: Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
       actions:
         cancel: Cancel
     creating:
       header: Creating {snapshot}
+      # @no-translate Rancher Desktop
       message: Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
       actions:
         cancel: Cancel
@@ -674,6 +721,7 @@ snapshots:
       error: Close
     generic:
       header: Snapshot operation in progress
+      # @no-translate Rancher Desktop
       message: Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
     showLogs: Show logs
   info:
@@ -693,11 +741,16 @@ troubleshooting:
   title: Troubleshooting
   kubernetes:
     resetKubernetes:
+      # @no-translate Kubernetes
       title: Reset Kubernetes
+      # @no-translate Kubernetes
       description: Resetting Kubernetes will delete all workloads and configuration.
+      # @no-translate Kubernetes
       buttonText: Reset Kubernetes
       messageBox:
+        # @no-translate Rancher Desktop, Kubernetes
         title: Rancher Desktop - Reset Kubernetes
+        # @no-translate Kubernetes
         message: Reset Kubernetes?
         checkboxLabel: Delete container images
         ok: Reset
@@ -705,16 +758,21 @@ troubleshooting:
   general:
     logs:
       title: Logs
+      # @no-translate Rancher Desktop
       description: Show Rancher Desktop logs
       buttonText: Show Logs
     factoryReset:
       title: Factory Reset
+      # @no-translate Rancher Desktop
       description: Factory Reset will remove all Rancher Desktop Configurations.
       buttonText: Factory Reset
       messageBox:
+        # @no-translate Rancher Desktop
         title: Rancher Desktop - Factory Reset
         message: Perform a factory reset?
+        # @no-translate Rancher Desktop
         detail: <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        # @no-translate Kubernetes
         checkboxLabel: Keep cached Kubernetes images
         ok: Factory Reset
         cancel: Cancel
@@ -731,6 +789,7 @@ diagnostics:
     success:
       icon: icon-checkmark
       heading: No problems detected
+      # @no-translate Rancher Desktop
       body: Rancher Desktop appears to be functioning correctly.
   failedCount: '{count} failed plus {muted} muted'
   lastRun: 'Last run:'
@@ -755,13 +814,16 @@ extensions:
   view:
     emptyState:
       heading: Extension removed
+      # @no-translate Rancher Desktop
       body: '{extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.'
 preferences:
   nav:
     application: Application
     virtualMachine: Virtual Machine
+    # @no-translate WSL
     wsl: WSL
     containerEngine: Container Engine
+    # @no-translate Kubernetes
     kubernetes: Kubernetes
   tabs:
     general: General
@@ -775,7 +837,9 @@ preferences:
     allowedImages: Allowed Images
   actions:
     banner:
+      # @no-translate Kubernetes
       reset: Kubernetes will reset after applying changes.
+      # @no-translate Kubernetes
       restart: Kubernetes will restart after applying changes.
       error: There's a problem with the preferences selection.
   locked:
@@ -786,6 +850,7 @@ preferences:
   incompatiblePrefWarningOr: or
   containerEngine:
     webAssembly:
+      # @no-translate WebAssembly, Kubernetes, Spin
       # Translators: preserve the <a> tag and its data-navigate attribute exactly.
       # The application code uses data-navigate to handle click navigation.
       warning: WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
@@ -796,11 +861,15 @@ preferences:
   header: Preferences
   resetDialog:
     apply: Apply and reset
+    # @no-translate Kubernetes
     detail: These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    # @no-translate Kubernetes
     message: Apply preferences and reset Kubernetes?
+    # @no-translate Rancher Desktop, Kubernetes
     title: Rancher Desktop - Reset Kubernetes
 integrations:
   windows:
+    # @no-translate Rancher Desktop, Kubernetes, WSL, Docker
     description: Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
 containerInfo:
   fallbackTitle: Container Info
@@ -855,6 +924,7 @@ containerInspect:
     dropped: Dropped
 containerStats:
   notRunning: Stats are only available for running containers.
+  # @no-translate Docker, Moby
   mobyOnly: Stats are currently only available for the Docker (Moby) engine.
   # @context Label of the dropdown selecting the stats refresh interval
   refresh: Refresh
@@ -885,6 +955,7 @@ deploymentProfile:
   noVersion: 'Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).'
   noVersionRegistry: 'Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).'
 denyRoot:
+  # @no-translate Rancher Desktop
   message: Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
   title: Cannot run as Root
 dialog:
@@ -894,14 +965,18 @@ dialog:
     title: Bridged network did not get an IP address.
   confirmMigration:
     delete: Delete Workloads
+    # @no-translate Kubernetes
     message: Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
     title: Confirming migration
   invalidK8sVersion:
     detail: Falling back to recommended minimum upgrade version of {version}
+    # @no-translate Kubernetes
     message: Requested Kubernetes version ''{version}'' is not a supported version.
+    # @no-translate Kubernetes
     title: Invalid Kubernetes Version
   networkFailure:
     detail: Please acquire a version in the range {range} and install in ''{path}''
+    # @no-translate kubectl
     message: Can't download a compatible version of kubectl in offline-mode
     title: Network failure
 kubernetesError:
@@ -913,19 +988,27 @@ kubernetesError:
   logLines: 'Some recent <a href="#" data-action="showLogs">logfile</a> lines:'
 kubernetesPrefs:
   kubernetes:
+    # @no-translate Kubernetes
     label: Enable Kubernetes
+    # @no-translate Kubernetes
     legendText: Kubernetes
   options:
     legendText: Options
+    # @no-translate Spin
     spinkube: Install Spin Operator
+    # @no-translate WebAssembly, Spin
     # Translators: preserve the <a> tag and its data-navigate attribute exactly.
     # The application code uses data-navigate to handle click navigation.
     spinkubeWarning: 'Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.'
+    # @no-translate Traefik
     traefik: Enable Traefik
   port:
+    # @no-translate Kubernetes
     legendText: Kubernetes Port
   version:
+    # @no-translate Kubernetes
     legendText: Kubernetes version
+    # @no-translate Kubernetes
     legendTextCached: Kubernetes version (cached versions only)
     otherVersions: Other Versions
     recommendedVersions: Recommended Versions
@@ -934,80 +1017,115 @@ preferencesWindow:
     detail: There are preferences with changes that have not been applied. All unsaved preferences will be lost.
     discardChanges: Discard changes
     message: Close preferences without applying?
+    # @no-translate Rancher Desktop
     title: Rancher Desktop - Close Preferences
+  # @no-translate Rancher Desktop
   title: Rancher Desktop - Preferences
 progress:
   askingPermission: Asking for permission to run tasks as administrator
   bundlingCertificates: Bundling certificates
+  # @no-translate k3s
   checkingK3sImages: Checking k3s images
   configuringContainerEngine: Configuring container engine
   configuringImageProxy: Configuring image proxy
   configuringLogrotate: Configuring logrotate
   containerEngineComponents: Container engine components
   copyingCertificates: Copying certificates
+  # @no-translate Kubernetes
   deletingIncompatibleState: Deleting incompatible Kubernetes state
+  # @no-translate Kubernetes
   deletingKubernetes: Deleting Kubernetes
   deletingVirtualMachine: Deleting virtual machine
   dnsConfiguration: DNS configuration
+  # @no-translate Kubernetes
   downloadingKubernetesComponents: Downloading Kubernetes components
+  # @no-translate kubectl
   ensuringCompatibleKubectl: Ensuring compatible kubectl
   ensuringVirtualizationSupported: Ensuring virtualization is supported
   expectingPermission: Expecting user permission to continue
   extractingCertificates: Extracting certificates
   fetchingCertificates: Fetching certificates
+  # @no-translate Rancher Desktop
   initializingRancherDesktop: Initializing Rancher Desktop
+  # @no-translate WSL
   initializingWslData: Initializing WSL data
+  # @no-translate Buildkit
   installingBuildkit: Installing Buildkit
   installingCaCertificates: Installing CA certificates
   installingContainerEngine: Installing container engine
   installingCredentialHelper: Installing credential helper
+  # @no-translate docker-credential
   installingDockerCredentialHelper: Installing the docker-credential helper
   installingHelpers: Installing helpers
   installingImageScanner: Installing image scanner
+  # @no-translate k3s
   installingK3s: Installing k3s
+  # @no-translate Kubernetes
   installingKubernetes: Installing Kubernetes
+  # @no-translate Kubernetes
   kubernetesComponents: Kubernetes components
+  # @no-translate Kubernetes, dockerd
   kubernetesDockerCompatibility: Kubernetes dockerd compatibility
+  # @no-translate WSL
   mountingWslData: Mounting WSL data
   preparingToStart: Preparing to start
   proxyConfigSetup: Proxy Config Setup
+  # @no-translate Rancher Desktop
   rancherDesktopGuestAgent: Rancher Desktop guest agent
   recoveringBrokenVirtualMachine: Recovering virtual machine
   regeneratingConfiguration: Regenerating configuration to account for lack of permissions
+  # @no-translate WSL
   registeringWslDistribution: Registering WSL distribution
   removingExistingCertificates: Removing existing certificates
+  # @no-translate spinkube
   removingSpinkubeOperator: Removing spinkube operator
   removingStaleState: Removing stale state
+  # @no-translate Traefik
   removingTraefik: Removing Traefik
+  # @no-translate Kubernetes
   resettingKubernetes: Resetting Kubernetes
   runningProvisioningScripts: Running provisioning scripts
+  # @no-translate update-ca-certificates
   runningUpdateCaCertificates: Running update-ca-certificates
+  # @no-translate docker
   settingDockerContext: Setting docker context
+  # @no-translate Lima
   settingLimaPermissions: Setting Lima permissions
+  # @no-translate Docker
   settingUpDockerSocket: Setting up Docker socket
   settingUpVirtualEthernet: Setting up virtual ethernet
   shuttingDown: Shutting down
+  # @no-translate flannel
   skippingNodeChecksFlannel: Skipping node checks, flannel is disabled
   startingBackend: Starting Backend
+  # @no-translate buildkit
   startingBuildkit: Starting buildkit
   startingContainerEngine: Starting container engine
   startingImageProxy: Starting image proxy
+  # @no-translate k3s
   startingK3s: Starting k3s
+  # @no-translate Kubernetes
   startingKubernetes: Starting Kubernetes
   startingProxy: Starting proxy
   startingService: Starting {service}
   startingVirtualMachine: Starting virtual machine
+  # @no-translate WSL
   startingWslEnvironment: Starting WSL environment
   stoppingExistingInstance: Stopping existing instance
   stoppingMockBackend: Stopping mock backend
   stoppingServices: Stopping services
   updatingClusterConfiguration: Updating cluster configuration
+  # @no-translate /etc/hosts
   updatingEtcHosts: Updating /etc/hosts
+  # @no-translate kubeconfig
   updatingKubeconfig: Updating kubeconfig
   updatingOutdatedVm: Updating outdated virtual machine
+  # @no-translate WSL
   updatingWslData: Updating WSL data
+  # @no-translate WSL
   upgradingWslDistribution: Upgrading WSL distribution
   waitingForContainerEngine: Waiting for container engine to be ready
+  # @no-translate Kubernetes
   waitingForKubernetesApi: Waiting for Kubernetes API
   waitingForNodes: Waiting for nodes
   waitingForServices: Waiting for services
@@ -1016,6 +1134,7 @@ systemPreferences:
   cpus: '# CPUs'
   memory: Memory (GB)
 telemetryOptIn:
+  # @no-translate Rancher Desktop
   fineprint: Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
 updateStatus:
   applyingUpdate: Applying update...
@@ -1027,6 +1146,7 @@ updateStatus:
   restartNow: Restart Now
   restartToApply: Restart the application to apply the update.
   unsupported:
+    # @no-translate Rancher Desktop
     message: A newer version of Rancher Desktop is available, but not supported on your system.
     seeDocumentation: 'For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.'
     title: Latest Version Not Supported

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -459,6 +459,8 @@ diagnostics:
   failedCount: '{count} fallidos más {muted} silenciados'
   # @source Last run:
   lastRun: 'Última ejecución:'
+  # @source (Never)
+  never: (Nunca)
   # @source (No fixes available)
   noFixes: (No hay correcciones disponibles)
   results:
@@ -1166,6 +1168,8 @@ progress:
   deletingVirtualMachine: Eliminando la máquina virtual
   # @source DNS configuration
   dnsConfiguration: Configuración de DNS
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Descargando los componentes de Kubernetes
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: Comprobando que kubectl sea compatible
   # @source Ensuring virtualization is supported
@@ -1212,6 +1216,8 @@ progress:
   proxyConfigSetup: Configuración del proxy
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agente invitado de Rancher Desktop
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Recuperando la máquina virtual dañada
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Regenerando la configuración para tener en cuenta la falta de permisos
   # @source Registering WSL distribution
@@ -1524,6 +1530,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Habilitar el modo de depuración
+  # @reason "definida" is the idiomatic Spanish predicate for an environment variable being set; the file's "establecida" is reserved for settings fields.
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: No se puede modificar porque la variable de entorno RD_DEBUG_ENABLED está definida.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -668,8 +668,8 @@ images:
       # @reason Infinitive so it composes with images.add.errorText ("Error al intentar {action}..."); "descargar" is the common Spanish for pulling an image.
       # @source Pull
       pull: Descargar
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: Error al intentar { action } ''{ image }'' - consulte la salida de la consola para obtener más información
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: Error al intentar { action } ''{ image }''. Consulte la salida de la consola para obtener más información.
     # @reason No article before "imagen", matching the terse en-us style; composes as "Construyendo imagen..." / "Descargando imagen...".
     # @source {action} image...
     loadingText: '{action} imagen...'
@@ -738,8 +738,8 @@ images:
       primaryUrl: URL principal
       # @source References
       references: Referencias
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: Error al intentar analizar ''{ image }'' - consulte la salida de la consola para obtener más información
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: Error al intentar analizar ''{ image }''. Consulte la salida de la consola para obtener más información.
     labels:
       # @reason Severity labels take feminine forms, agreeing with "gravedad".
       # @source CRITICAL

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -1050,8 +1050,9 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: La opción requiere que
   locked:
-    # @source Locked due to organization's policy
-    tooltip: Bloqueado por la política de la organización
+    # @reason "Esta opción" is the file's rendering of "This setting" (see prefs.onlyFromVentura_*) and stays neutral across the input, select, checkbox and fieldset controls that share this tooltip; "Este campo" would misread next to a checkbox or fieldset.
+    # @source This setting is locked by organization policy.
+    tooltip: Esta opción está bloqueada por la política de la organización.
   nav:
     # @source Application
     application: Aplicación
@@ -1216,8 +1217,8 @@ progress:
   proxyConfigSetup: Configuración del proxy
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agente invitado de Rancher Desktop
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: Recuperando la máquina virtual dañada
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: Recuperando la máquina virtual
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Regenerando la configuración para tener en cuenta la falta de permisos
   # @source Registering WSL distribution
@@ -1531,8 +1532,8 @@ troubleshooting:
   # @source Enable debug mode
   debugMode: Habilitar el modo de depuración
   # @reason "definida" is the idiomatic Spanish predicate for an environment variable being set; the file's "establecida" is reserved for settings fields.
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: No se puede modificar porque la variable de entorno RD_DEBUG_ENABLED está definida.
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: El modo de depuración no se puede modificar porque la variable de entorno RD_DEBUG_ENABLED está definida.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -1067,8 +1067,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: Cette option nécessite que
   locked:
-    # @source Locked due to organization's policy
-    tooltip: Verrouillé par la politique de l'organisation
+    # @source This setting is locked by organization policy.
+    tooltip: Ce paramètre est verrouillé par la politique de l'organisation.
   nav:
     # @reason 'Application' is the same word in French
     # @source Application
@@ -1234,8 +1234,8 @@ progress:
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agent invité de Rancher Desktop
   # @reason "recovering" rendered as « réparation »: the step repairs a VM stuck in Lima's Broken state, whereas « récupération » would read as retrieval.
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: Réparation de la machine virtuelle défectueuse
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: Réparation de la machine virtuelle
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Régénération de la configuration pour tenir compte de l'absence d'autorisations
   # @source Registering WSL distribution
@@ -1550,9 +1550,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Activer le mode débogage
-  # @reason Masculine agreement (modifié): the tooltip describes « le mode débogage » toggle.
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: Ne peut pas être modifié car la variable d'environnement RD_DEBUG_ENABLED est définie.
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Le mode débogage ne peut pas être modifié car la variable d'environnement RD_DEBUG_ENABLED est définie.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -676,8 +676,8 @@ images:
       # @source Pull
       pull: Télécharger
     # @reason Guillemets replace the ICU-escaped apostrophes, matching images.scan.errorText; « en tentant de » takes the infinitive { action }.
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: Erreur en tentant de { action } « { image } » - consultez la sortie de la console pour plus d'informations
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: Erreur en tentant de { action } « { image } ». Consultez la sortie de la console pour plus d'informations.
     # @reason Restructured: {action} receives an action noun (Construction/Téléchargement); « en cours » conveys the progressive aspect, as in the previous translation.
     # @source {action} image...
     loadingText: '{action} de l''image en cours...'
@@ -749,8 +749,8 @@ images:
       primaryUrl: URL principale
       # @source References
       references: Références
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: Erreur lors de l'analyse de « { image } » - consultez la sortie de la console pour plus d'informations
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: Erreur lors de l'analyse de « { image } ». Consultez la sortie de la console pour plus d'informations.
     labels:
       # @source CRITICAL
       critical: CRITIQUE

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -468,6 +468,8 @@ diagnostics:
   failedCount: '{count} en échec et {muted} ignorés'
   # @source Last run:
   lastRun: 'Dernière exécution :'
+  # @source (Never)
+  never: (Jamais)
   # @source (No fixes available)
   noFixes: (Aucun correctif disponible)
   results:
@@ -1183,6 +1185,8 @@ progress:
   deletingVirtualMachine: Suppression de la machine virtuelle
   # @source DNS configuration
   dnsConfiguration: Configuration DNS
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Téléchargement des composants Kubernetes
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: Vérification de la compatibilité de kubectl
   # @source Ensuring virtualization is supported
@@ -1229,6 +1233,9 @@ progress:
   proxyConfigSetup: Mise en place de la configuration du proxy
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agent invité de Rancher Desktop
+  # @reason "recovering" rendered as « réparation »: the step repairs a VM stuck in Lima's Broken state, whereas « récupération » would read as retrieval.
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Réparation de la machine virtuelle défectueuse
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Régénération de la configuration pour tenir compte de l'absence d'autorisations
   # @source Registering WSL distribution
@@ -1543,6 +1550,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Activer le mode débogage
+  # @reason Masculine agreement (modifié): the tooltip describes « le mode débogage » toggle.
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Ne peut pas être modifié car la variable d'environnement RD_DEBUG_ENABLED est définie.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -465,6 +465,8 @@ diagnostics:
   failedCount: '{count} falliti più {muted} silenziati'
   # @source Last run:
   lastRun: 'Ultima esecuzione:'
+  # @source (Never)
+  never: (Mai)
   # @source (No fixes available)
   noFixes: (Nessuna correzione disponibile)
   results:
@@ -1189,6 +1191,8 @@ progress:
   deletingVirtualMachine: Eliminazione della macchina virtuale
   # @source DNS configuration
   dnsConfiguration: Configurazione DNS
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Scaricamento dei componenti di Kubernetes
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: Verifica della compatibilità di kubectl
   # @source Ensuring virtualization is supported
@@ -1235,6 +1239,9 @@ progress:
   # @reason 'guest agent' kept English: it names the rancher-desktop-guestagent component.
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Guest agent di Rancher Desktop
+  # @reason 'Ripristino' (restoring to working order) rather than 'Recupero', which this section already uses for 'Fetching'.
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Ripristino della macchina virtuale danneggiata
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Rigenerazione della configurazione per tenere conto della mancanza di autorizzazioni
   # @source Registering WSL distribution
@@ -1551,6 +1558,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Abilita la modalità di debug
+  # @reason Added the subject 'l'impostazione'; Italian cannot render subjectless 'Cannot be modified' without a gender-agreeing participle. Follows the same fix as preferences locked.tooltip.
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Impossibile modificare l'impostazione perché è definita la variabile d'ambiente RD_DEBUG_ENABLED.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -1069,9 +1069,9 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: L'opzione richiede che
   locked:
-    # @reason Added the subject 'Impostazione' to fix gender agreement; 'criteri' is the standard Italian rendering of 'policy'.
-    # @source Locked due to organization's policy
-    tooltip: Impostazione bloccata dai criteri dell'organizzazione
+    # @reason 'criteri' is the standard Italian rendering of an administrative 'policy', consistent with 'Criterio di caching' elsewhere in this file.
+    # @source This setting is locked by organization policy.
+    tooltip: Questa impostazione è bloccata dai criteri dell'organizzazione.
   nav:
     # @source Application
     application: Applicazione
@@ -1240,8 +1240,8 @@ progress:
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Guest agent di Rancher Desktop
   # @reason 'Ripristino' (restoring to working order) rather than 'Recupero', which this section already uses for 'Fetching'.
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: Ripristino della macchina virtuale danneggiata
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: Ripristino della macchina virtuale
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Rigenerazione della configurazione per tenere conto della mancanza di autorizzazioni
   # @source Registering WSL distribution
@@ -1558,9 +1558,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Abilita la modalità di debug
-  # @reason Added the subject 'l'impostazione'; Italian cannot render subjectless 'Cannot be modified' without a gender-agreeing participle. Follows the same fix as preferences locked.tooltip.
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: Impossibile modificare l'impostazione perché è definita la variabile d'ambiente RD_DEBUG_ENABLED.
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: La modalità di debug non può essere modificata perché è definita la variabile d'ambiente RD_DEBUG_ENABLED.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -679,8 +679,8 @@ images:
       # @source Pull
       pull: Pull
     # @reason { action } is used as a noun ('l'operazione di pull'); an Italian infinitive after 'trying to' would not compose with the loanword verbs.
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: Errore durante l'operazione di { action } su ''{ image }'' - consulta l'output della console per maggiori informazioni
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: Errore durante l'operazione di { action } su ''{ image }''. Consulta l'output della console per maggiori informazioni.
     # @reason Restructured: Italian has no progressive suffix, so the gerund value acts as a noun and 'in corso' carries the ongoing sense, as in scan.loadingText.
     # @source {action} image...
     loadingText: '{action} dell''immagine in corso...'
@@ -751,8 +751,8 @@ images:
       primaryUrl: URL principale
       # @source References
       references: Riferimenti
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: Errore durante la scansione di ''{ image }'' - consulta l'output della console per maggiori informazioni
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: Errore durante la scansione di ''{ image }''. Consulta l'output della console per maggiori informazioni.
     labels:
       # @reason Severity labels use feminine forms, agreeing with 'gravità'.
       # @source CRITICAL

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -1046,8 +1046,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: このオプションには
   locked:
-    # @source Locked due to organization's policy
-    tooltip: 組織のポリシーによりロックされています
+    # @source This setting is locked by organization policy.
+    tooltip: この設定は組織のポリシーによりロックされています。
   nav:
     # @source Application
     application: アプリケーション
@@ -1208,8 +1208,8 @@ progress:
   proxyConfigSetup: プロキシ設定のセットアップ
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop ゲストエージェント
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: 破損した仮想マシンを復旧しています
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: 仮想マシンを復旧しています
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 権限がないため設定を再生成しています
   # @source Registering WSL distribution
@@ -1525,8 +1525,8 @@ troubleshooting:
   # @source Enable debug mode
   debugMode: デバッグモードを有効にする
   # @reason RD_DEBUG_ENABLED is an environment variable name, kept verbatim.
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: RD_DEBUG_ENABLED 環境変数が設定されているため、変更できません。
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: RD_DEBUG_ENABLED 環境変数が設定されているため、デバッグモードは変更できません。
   general:
     factoryReset:
       # @reason ファクトリーリセット is the common katakana rendering of Factory Reset; used consistently.

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -457,6 +457,9 @@ diagnostics:
   failedCount: '{count}件が失敗、さらに{muted}件がミュートされています'
   # @source Last run:
   lastRun: 最終実行：
+  # @reason English "Never" is elliptical for "never run"; Japanese needs the verb, so 未実行 (not yet run). Full-width parentheses match diagnostics.noFixes.
+  # @source (Never)
+  never: （未実行）
   # @source (No fixes available)
   noFixes: （利用可能な修正はありません）
   results:
@@ -1158,6 +1161,8 @@ progress:
   deletingVirtualMachine: 仮想マシンを削除しています
   # @source DNS configuration
   dnsConfiguration: DNS 設定
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Kubernetes コンポーネントをダウンロードしています
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: 互換性のある kubectl を準備しています
   # @source Ensuring virtualization is supported
@@ -1203,6 +1208,8 @@ progress:
   proxyConfigSetup: プロキシ設定のセットアップ
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop ゲストエージェント
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: 破損した仮想マシンを復旧しています
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 権限がないため設定を再生成しています
   # @source Registering WSL distribution
@@ -1517,6 +1524,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: デバッグモードを有効にする
+  # @reason RD_DEBUG_ENABLED is an environment variable name, kept verbatim.
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: RD_DEBUG_ENABLED 環境変数が設定されているため、変更できません。
   general:
     factoryReset:
       # @reason ファクトリーリセット is the common katakana rendering of Factory Reset; used consistently.

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -667,8 +667,8 @@ images:
         pull: プル
       # @source Pull
       pull: プル
-    # @reason Restructured for Japanese word order: image before verb, error clause and console hint as full sentences per the file's scan.errorText.
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    # @reason Restructured for Japanese word order: image before verb.
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
     errorText: '''''{ image }'''' を{ action }しようとしてエラーが発生しました。詳細はコンソール出力を確認してください。'
     # @reason Japanese puts the verb last; the template conjugates the action noun, composing to イメージをビルドしています... like the file's other progressive messages.
     # @source {action} image...
@@ -737,7 +737,7 @@ images:
       primaryUrl: プライマリ URL
       # @source References
       references: 参考情報
-    # @source Error trying to scan ''{ image }'' — see console output for more information
+    # @source Error trying to scan ''{ image }''. See console output for more information.
     errorText: '''''{ image }'''' のスキャン中にエラーが発生しました。詳細はコンソール出力を確認してください。'
     labels:
       # @reason Vulnerability severity scale rendered as 致命的/高/中/低, the common Japanese mapping for CRITICAL/HIGH/MEDIUM/LOW in security scanners.

--- a/pkg/rancher-desktop/assets/translations/ko.yaml
+++ b/pkg/rancher-desktop/assets/translations/ko.yaml
@@ -454,6 +454,9 @@ diagnostics:
   failedCount: '{count}개 실패 및 {muted}개 무시됨'
   # @source Last run:
   lastRun: '마지막 실행:'
+  # @reason A bare adverb cannot stand alone as a Korean label; expanded to "never run" so it reads as a value after 마지막 실행:
+  # @source (Never)
+  never: (실행된 적 없음)
   # @source (No fixes available)
   noFixes: (사용 가능한 수정 없음)
   results:
@@ -1143,6 +1146,8 @@ progress:
   deletingVirtualMachine: 가상 머신 삭제 중
   # @source DNS configuration
   dnsConfiguration: DNS 구성
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Kubernetes 구성 요소 다운로드 중
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: 호환되는 kubectl 확인 중
   # @source Ensuring virtualization is supported
@@ -1187,6 +1192,8 @@ progress:
   proxyConfigSetup: 프록시 구성 설정
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop 게스트 에이전트
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: 손상된 가상 머신 복구 중
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 권한 부족을 반영하여 구성 다시 생성 중
   # @source Registering WSL distribution
@@ -1496,6 +1503,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: 디버그 모드 활성화
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: RD_DEBUG_ENABLED 환경 변수가 설정되어 있어 수정할 수 없습니다.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/ko.yaml
+++ b/pkg/rancher-desktop/assets/translations/ko.yaml
@@ -1032,8 +1032,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: 이 옵션을 사용하려면
   locked:
-    # @source Locked due to organization's policy
-    tooltip: 조직의 정책에 따라 잠겨 있습니다
+    # @source This setting is locked by organization policy.
+    tooltip: 이 설정은 조직의 정책에 따라 잠겨 있습니다.
   nav:
     # @source Application
     application: 애플리케이션
@@ -1192,8 +1192,8 @@ progress:
   proxyConfigSetup: 프록시 구성 설정
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop 게스트 에이전트
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: 손상된 가상 머신 복구 중
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: 가상 머신 복구 중
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 권한 부족을 반영하여 구성 다시 생성 중
   # @source Registering WSL distribution
@@ -1503,8 +1503,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: 디버그 모드 활성화
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: RD_DEBUG_ENABLED 환경 변수가 설정되어 있어 수정할 수 없습니다.
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: 디버그 모드는 RD_DEBUG_ENABLED 환경 변수가 설정되어 있어 수정할 수 없습니다.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/ko.yaml
+++ b/pkg/rancher-desktop/assets/translations/ko.yaml
@@ -659,7 +659,7 @@ images:
       # @source Pull
       pull: 풀
     # @reason rephrased so the action noun (풀/빌드) composes grammatically
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
     errorText: '''''{ image }'''' 이미지 { action } 중 오류가 발생했습니다. 자세한 내용은 콘솔 출력을 확인하십시오.'
     # @reason rephrased around noun-form action; gerund keys must also be noun forms (풀/빌드)
     # @source {action} image...
@@ -729,7 +729,7 @@ images:
       primaryUrl: 기본 URL
       # @source References
       references: 참조
-    # @source Error trying to scan ''{ image }'' — see console output for more information
+    # @source Error trying to scan ''{ image }''. See console output for more information.
     errorText: '''''{ image }'''' 스캔 중 오류가 발생했습니다. 자세한 내용은 콘솔 출력을 확인하십시오.'
     labels:
       # @reason Korean has no letter case; standard severity terms used instead of all-caps

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -677,8 +677,8 @@ images:
       # @source Pull
       pull: Pull
     # @reason { action } receives the pt-br infinitive (construir/baixar), so "ao tentar" composes directly without the old "executar" wrapper
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: Erro ao tentar { action } ''{ image }'' - consulte a saída do console para mais informações
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: Erro ao tentar { action } ''{ image }''. Consulte a saída do console para mais informações.
     # @reason {action} receives the pt-br gerund (Construindo/Baixando), which starts the sentence, so the gerund values are capitalized
     # @source {action} image...
     loadingText: '{action} imagem...'
@@ -749,8 +749,8 @@ images:
       primaryUrl: URL principal
       # @source References
       references: Referências
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: Erro ao tentar escanear ''{ image }'' - consulte a saída do console para mais informações
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: Erro ao tentar escanear ''{ image }''. Consulte a saída do console para mais informações.
     labels:
       # @reason Severity labels use the feminine form, agreeing with "vulnerabilidade"/"severidade"
       # @source CRITICAL

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -1063,8 +1063,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: A opção requer que
   locked:
-    # @source Locked due to organization's policy
-    tooltip: Bloqueado pela política da organização
+    # @source This setting is locked by organization policy.
+    tooltip: Esta configuração está bloqueada pela política da organização.
   nav:
     # @source Application
     application: Aplicativo
@@ -1232,9 +1232,8 @@ progress:
   proxyConfigSetup: Configuração do proxy
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agente convidado do Rancher Desktop
-  # @reason 'com problemas' rather than 'corrompida/quebrada': the source tracks Lima's 'Broken' status (orphaned driver/host agent after an unclean shutdown), not a damaged disk
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: Recuperando máquina virtual com problemas
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: Recuperando máquina virtual
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Regenerando a configuração devido à falta de permissões
   # @source Registering WSL distribution
@@ -1549,9 +1548,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Ativar modo de depuração
-  # @reason The English subject is implicit; masculine 'alterado' agrees with 'o modo de depuração', the control this tooltip is attached to
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: Não pode ser alterado porque a variável de ambiente RD_DEBUG_ENABLED está definida.
+  # @reason Masculine 'alterado' agrees with the now-explicit subject 'O modo de depuração'; the term matches troubleshooting.debugMode
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: O modo de depuração não pode ser alterado porque a variável de ambiente RD_DEBUG_ENABLED está definida.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -464,6 +464,8 @@ diagnostics:
   failedCount: '{count} com falha, mais {muted} silenciados'
   # @source Last run:
   lastRun: 'Última execução:'
+  # @source (Never)
+  never: (Nunca)
   # @source (No fixes available)
   noFixes: (Nenhuma correção disponível)
   results:
@@ -1182,6 +1184,8 @@ progress:
   deletingVirtualMachine: Excluindo a máquina virtual
   # @source DNS configuration
   dnsConfiguration: Configuração de DNS
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: Baixando componentes do Kubernetes
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: Garantindo um kubectl compatível
   # @source Ensuring virtualization is supported
@@ -1228,6 +1232,9 @@ progress:
   proxyConfigSetup: Configuração do proxy
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Agente convidado do Rancher Desktop
+  # @reason 'com problemas' rather than 'corrompida/quebrada': the source tracks Lima's 'Broken' status (orphaned driver/host agent after an unclean shutdown), not a damaged disk
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: Recuperando máquina virtual com problemas
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: Regenerando a configuração devido à falta de permissões
   # @source Registering WSL distribution
@@ -1542,6 +1549,9 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: Ativar modo de depuração
+  # @reason The English subject is implicit; masculine 'alterado' agrees with 'o modo de depuração', the control this tooltip is attached to
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: Não pode ser alterado porque a variável de ambiente RD_DEBUG_ENABLED está definida.
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -522,6 +522,9 @@ diagnostics:
   failedCount: '{count} 项失败，{muted} 项已静音'
   # @source Last run:
   lastRun: 上次运行：
+  # @reason "从未" is an adverb and cannot stand alone in Chinese; the verb 运行 echoes the adjacent "上次运行：" label
+  # @source (Never)
+  never: （从未运行）
   # @source (No fixes available)
   noFixes: （无可用修复）
   results:
@@ -1203,6 +1206,8 @@ progress:
   deletingVirtualMachine: 正在删除虚拟机
   # @source DNS configuration
   dnsConfiguration: DNS 配置
+  # @source Downloading Kubernetes components
+  downloadingKubernetesComponents: 正在下载 Kubernetes 组件
   # @source Ensuring compatible kubectl
   ensuringCompatibleKubectl: 正在确保 kubectl 兼容
   # @source Ensuring virtualization is supported
@@ -1247,6 +1252,8 @@ progress:
   proxyConfigSetup: 代理配置设置
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop 来宾代理
+  # @source Recovering broken virtual machine
+  recoveringBrokenVirtualMachine: 正在恢复损坏的虚拟机
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 正在重新生成配置以适应权限不足的情况
   # @source Registering WSL distribution
@@ -1575,6 +1582,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: 启用调试模式
+  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: 无法修改，因为已设置 RD_DEBUG_ENABLED 环境变量。
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -712,8 +712,8 @@ images:
       # @source Pull
       pull: 拉取
     # @reason dropped the space before { action } since the substituted verb is now Chinese; parallels images.scan.errorText 尝试扫描
-    # @source Error trying to { action } ''{ image }'' — see console output for more information
-    errorText: 尝试{ action } ''{ image }'' 时出错 - 详情请查看控制台输出
+    # @source Error trying to { action } ''{ image }''. See console output for more information.
+    errorText: 尝试{ action } ''{ image }'' 时出错。详情请查看控制台输出。
     # @reason 正在 moved into the gerund values; composed text 正在构建镜像... matches the previous translation
     # @source {action} image...
     loadingText: '{action}镜像...'
@@ -783,8 +783,8 @@ images:
       primaryUrl: 主要 URL
       # @source References
       references: 参考
-    # @source Error trying to scan ''{ image }'' — see console output for more information
-    errorText: 尝试扫描 ''{ image }'' 时出错 - 详情请查看控制台输出
+    # @source Error trying to scan ''{ image }''. See console output for more information.
+    errorText: 尝试扫描 ''{ image }'' 时出错。详情请查看控制台输出。
     labels:
       # @source CRITICAL
       critical: 严重

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -1085,8 +1085,8 @@ preferences:
   # @source The option requires
   incompatibleTypeWarningPre: 该选项要求
   locked:
-    # @source Locked due to organization's policy
-    tooltip: 已被组织策略锁定
+    # @source This setting is locked by organization policy.
+    tooltip: 此设置已被组织策略锁定。
   nav:
     # @source Application
     application: 应用程序
@@ -1252,8 +1252,8 @@ progress:
   proxyConfigSetup: 代理配置设置
   # @source Rancher Desktop guest agent
   rancherDesktopGuestAgent: Rancher Desktop 来宾代理
-  # @source Recovering broken virtual machine
-  recoveringBrokenVirtualMachine: 正在恢复损坏的虚拟机
+  # @source Recovering virtual machine
+  recoveringBrokenVirtualMachine: 正在恢复虚拟机
   # @source Regenerating configuration to account for lack of permissions
   regeneratingConfiguration: 正在重新生成配置以适应权限不足的情况
   # @source Registering WSL distribution
@@ -1582,8 +1582,8 @@ tray:
 troubleshooting:
   # @source Enable debug mode
   debugMode: 启用调试模式
-  # @source Cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
-  debugModeLockedTooltip: 无法修改，因为已设置 RD_DEBUG_ENABLED 环境变量。
+  # @source Debug mode cannot be modified because the RD_DEBUG_ENABLED environment variable is set.
+  debugModeLockedTooltip: 调试模式无法修改，因为已设置 RD_DEBUG_ENABLED 环境变量。
   general:
     factoryReset:
       # @source Factory Reset

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -282,6 +282,10 @@ export default class SettingsValidator {
         errors.push(this.notSupported(fqname));
       }
       if (changeNeededHere) {
+        // At the root prefix is empty, so `${ prefix }.${ k }` would yield a
+        // leading dot, and lodash resolves that against `lockedSettings['']`
+        // instead of the lock. No test covers this today, because `version` is
+        // the only root-level leaf and its validator never reports a change.
         const isLocked = _.get(this.lockedSettings, fqname);
 
         if (isLocked) {

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -282,13 +282,13 @@ export default class SettingsValidator {
         errors.push(this.notSupported(fqname));
       }
       if (changeNeededHere) {
-        const isLocked = _.get(this.lockedSettings, `${ prefix }.${ k }`);
+        const isLocked = _.get(this.lockedSettings, fqname);
 
         if (isLocked) {
           // A delayed error condition, raised only if we try to change a field in a locked object.
           // Callers check hasLockedFieldError to detect this condition without
           // parsing the translated error message.
-          errors.push(t('validation.fieldLocked', { field: `${ prefix }.${ k }` }));
+          errors.push(t('validation.fieldLocked', { field: fqname }));
           this.isFatal = true;
           this.hasLockedFieldError = true;
         } else {

--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -61,6 +61,12 @@ A translation left identical to its English source must carry a `@reason`
 (or `@override`): `validate` flags unmarked identical values, since they
 are indistinguishable from missed translations.
 
+`merge` preserves a `@reason` even when it replaces the value, and strips
+only `@override`. So a note written for an earlier wording can outlive it
+and still satisfy that check. Re-read the note whenever you change the
+value it describes. Clearing one takes a hand edit, because `merge` only
+ever overwrites a comment with another `@reason` or `@override` line.
+
 ### `@override`
 
 Marks a translation as intentionally different from what an automated

--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -57,6 +57,10 @@ product.networkStatus.online: Online
 The `merge` command preserves `@reason` comments on existing keys and
 attaches them to new keys when present in the input.
 
+A translation left identical to its English source must carry a `@reason`
+(or `@override`): `validate` flags unmarked identical values, since they
+are indistinguishable from missed translations.
+
 ### `@override`
 
 Marks a translation as intentionally different from what an automated
@@ -283,6 +287,8 @@ Checks include:
 - `data-*` attribute preservation (runtime handlers depend on these)
 - `@override` placement (leaf keys only)
 - `@source` coverage (every translated key carries a `@source`)
+- Deliberate identity (a translation identical to a current `@source` carries
+  a `@reason` or `@override`; a stale snapshot is left to `drift`)
 
 ### drift
 

--- a/src/go/i18n-report/README.md
+++ b/src/go/i18n-report/README.md
@@ -335,9 +335,10 @@ i18n-report check --locale=de --strict
 i18n-report check --locale=all
 ```
 
-`--strict` adds the completeness checks — no missing keys, no drifted
-keys — for periodic and pre-release runs, while PR CI uses the default
-structural set. Passing `--strict` without `--locale` is an error.
+`--strict` adds the completeness checks (no missing keys, no drifted
+keys). PR CI runs the default structural set and no configured job passes
+`--strict`, so run it by hand before a release. Passing `--strict` without
+`--locale` is an error.
 
 The registration checks verify that the locale enum in `command-api.yaml`,
 `settingsValidator.ts`, its spec, and the `locale.*` display-name keys in

--- a/src/go/i18n-report/main.go
+++ b/src/go/i18n-report/main.go
@@ -91,7 +91,8 @@ Subcommands:
   check         Source gate (unused + undefined); per-locale checks with --locale
   source        Record the English source text on each translated key
   drift         Detect translated keys whose English source has changed
-  validate      Structural checks: placeholders, tags, sources, overrides
+  validate      Structural checks: placeholders, tags, sources, overrides,
+                deliberate identity
 
 Run "i18n-report <subcommand> -h" for subcommand-specific flags.`)
 }

--- a/src/go/i18n-report/output.go
+++ b/src/go/i18n-report/output.go
@@ -48,7 +48,9 @@ func outputStrings(w io.Writer, items []string, format, noun, suffix string) err
 	}
 
 	if len(items) == 0 {
-		fmt.Fprintf(w, "No %s%s found.\n", plural(0, noun), suffix)
+		// suffix trails "found" here, unlike the header below: "No stale keys
+		// found in de" reads naturally where "No stale keys in de found" does not.
+		fmt.Fprintf(w, "No %s found%s.\n", plural(0, noun), suffix)
 		return nil
 	}
 

--- a/src/go/i18n-report/output.go
+++ b/src/go/i18n-report/output.go
@@ -25,8 +25,19 @@ func validateFormat(format string) error {
 	return nil
 }
 
-// outputStrings prints a list of strings in text or JSON format.
-func outputStrings(w io.Writer, items []string, format, label string) error {
+// plural returns noun for a count of one and its regular plural (noun+"s")
+// otherwise, so a formatted count reads naturally: "1 key", "0 keys", "2 keys".
+func plural(n int, noun string) string {
+	if n == 1 {
+		return noun
+	}
+	return noun + "s"
+}
+
+// outputStrings prints a list of strings in text or JSON format. In text mode
+// the header pluralizes noun to match the count and appends suffix, a trailing
+// phrase such as " in de" (empty for none).
+func outputStrings(w io.Writer, items []string, format, noun, suffix string) error {
 	if format == formatJSON {
 		if items == nil {
 			items = []string{}
@@ -37,11 +48,11 @@ func outputStrings(w io.Writer, items []string, format, label string) error {
 	}
 
 	if len(items) == 0 {
-		fmt.Fprintf(w, "No %s found.\n", label)
+		fmt.Fprintf(w, "No %s%s found.\n", plural(0, noun), suffix)
 		return nil
 	}
 
-	fmt.Fprintf(w, "Found %d %s:\n", len(items), label)
+	fmt.Fprintf(w, "Found %d %s%s:\n", len(items), plural(len(items), noun), suffix)
 	for _, item := range items {
 		fmt.Fprintf(w, "  %s\n", item)
 	}

--- a/src/go/i18n-report/output_fix_test.go
+++ b/src/go/i18n-report/output_fix_test.go
@@ -22,10 +22,45 @@ func TestValidateFormat(t *testing.T) {
 
 func TestOutputStringsEmptyJSON(t *testing.T) {
 	var buf strings.Builder
-	if err := outputStrings(&buf, nil, "json", "unused keys"); err != nil {
+	if err := outputStrings(&buf, nil, "json", "unused key", ""); err != nil {
 		t.Fatal(err)
 	}
 	if got := strings.TrimSpace(buf.String()); got != "[]" {
 		t.Errorf("empty list encoded as %q, want []", got)
+	}
+}
+
+func TestPlural(t *testing.T) {
+	for _, c := range []struct {
+		n    int
+		want string
+	}{{0, "keys"}, {1, "key"}, {2, "keys"}} {
+		if got := plural(c.n, "key"); got != c.want {
+			t.Errorf("plural(%d, \"key\") = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestOutputStringsTextPluralizes(t *testing.T) {
+	for _, c := range []struct {
+		name         string
+		items        []string
+		noun, suffix string
+		want         string
+	}{
+		{"zero", nil, "unused key", "", "No unused keys found.\n"},
+		{"one", []string{"a.b"}, "unused key", "", "Found 1 unused key:\n  a.b\n"},
+		{"many", []string{"a.b", "c.d"}, "unused key", "", "Found 2 unused keys:\n  a.b\n  c.d\n"},
+		{"suffix", []string{"a.b"}, "stale key", " in de", "Found 1 stale key in de:\n  a.b\n"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := outputStrings(&buf, c.items, formatText, c.noun, c.suffix); err != nil {
+				t.Fatal(err)
+			}
+			if got := buf.String(); got != c.want {
+				t.Errorf("outputStrings = %q, want %q", got, c.want)
+			}
+		})
 	}
 }

--- a/src/go/i18n-report/output_fix_test.go
+++ b/src/go/i18n-report/output_fix_test.go
@@ -49,6 +49,7 @@ func TestOutputStringsTextPluralizes(t *testing.T) {
 		want         string
 	}{
 		{"zero", nil, "unused key", "", "No unused keys found.\n"},
+		{"zero suffix", nil, "stale key", " in de", "No stale keys found in de.\n"},
 		{"one", []string{"a.b"}, "unused key", "", "Found 1 unused key:\n  a.b\n"},
 		{"many", []string{"a.b", "c.d"}, "unused key", "", "Found 2 unused keys:\n  a.b\n  c.d\n"},
 		{"suffix", []string{"a.b"}, "stale key", " in de", "Found 1 stale key in de:\n  a.b\n"},

--- a/src/go/i18n-report/report_check.go
+++ b/src/go/i18n-report/report_check.go
@@ -23,8 +23,8 @@ import (
 // gate (unused + undefined keys). With --locale it also verifies the locale
 // registration surfaces and runs the per-locale checks; --locale=all covers
 // every translation file on disk. --strict adds the completeness checks
-// (no missing, no drifted keys) for periodic and pre-release runs, while
-// PR CI uses the default structural set.
+// (no missing, no drifted keys). No configured job passes it; PR CI runs
+// the default structural set.
 func runCheck(args []string) error {
 	fs := flag.NewFlagSet("check", flag.ExitOnError)
 	locale := fs.String("locale", "", "Target locale, or 'all' (omit for the source-only gate)")

--- a/src/go/i18n-report/report_check.go
+++ b/src/go/i18n-report/report_check.go
@@ -322,7 +322,8 @@ func crossValidateSpec(specContent string, knownLocales map[string]bool) []strin
 // reportCheckLocale runs the per-locale checks:
 //   - locale file present
 //   - no stale keys
-//   - validate passes (placeholders, ICU structure, tags, metadata)
+//   - validate passes (placeholders, ICU structure, tags, metadata,
+//     deliberate identity)
 //
 // With strict, the locale must also be complete:
 //   - no missing keys

--- a/src/go/i18n-report/report_check.go
+++ b/src/go/i18n-report/report_check.go
@@ -404,7 +404,7 @@ func reportValidateQuiet(root, locale string) error {
 		return err
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%d validation errors", len(errs))
+		return fmt.Errorf("%d validation %s", len(errs), plural(len(errs), "error"))
 	}
 	return nil
 }

--- a/src/go/i18n-report/report_drift.go
+++ b/src/go/i18n-report/report_drift.go
@@ -94,7 +94,7 @@ func reportDrift(w io.Writer, root, locale string) error {
 	sort.Strings(missingSource)
 
 	if len(drifted) > 0 {
-		fmt.Fprintf(w, "Found %d drifted keys in %s:\n", len(drifted), locale)
+		fmt.Fprintf(w, "Found %d drifted %s in %s:\n", len(drifted), plural(len(drifted), "key"), locale)
 		for _, d := range drifted {
 			suffix := ""
 			if d.Override {
@@ -105,7 +105,7 @@ func reportDrift(w io.Writer, root, locale string) error {
 	}
 
 	if len(missingSource) > 0 {
-		fmt.Fprintf(w, "\n%d keys missing @source:\n", len(missingSource))
+		fmt.Fprintf(w, "\n%d %s missing @source:\n", len(missingSource), plural(len(missingSource), "key"))
 		for _, key := range missingSource {
 			fmt.Fprintf(w, "  %s\n", key)
 		}

--- a/src/go/i18n-report/report_dynamic.go
+++ b/src/go/i18n-report/report_dynamic.go
@@ -92,11 +92,11 @@ func reportDynamic(w io.Writer, root, format string) error {
 		return nil
 	}
 
-	fmt.Fprintf(w, "Found %d dynamic key patterns:\n\n", len(entries))
+	fmt.Fprintf(w, "Found %d dynamic key %s:\n\n", len(entries), plural(len(entries), "pattern"))
 	for _, e := range entries {
 		fmt.Fprintf(w, "  %s\n", e.Pattern)
 		fmt.Fprintf(w, "    source:  %s\n", e.Source)
-		fmt.Fprintf(w, "    matches: %d keys\n", len(e.Matches))
+		fmt.Fprintf(w, "    matches: %d %s\n", len(e.Matches), plural(len(e.Matches), "key"))
 		for _, k := range e.Matches {
 			fmt.Fprintf(w, "      %s\n", k)
 		}

--- a/src/go/i18n-report/report_merge.go
+++ b/src/go/i18n-report/report_merge.go
@@ -133,7 +133,7 @@ func reportMerge(w io.Writer, root, locale string, files []string, dryRun bool, 
 		}
 	}
 	if len(unknown) > 0 {
-		return fmt.Errorf("input contains %d keys not in en-us.yaml: %s", len(unknown), strings.Join(unknown, ", "))
+		return fmt.Errorf("input contains %d %s not in en-us.yaml: %s", len(unknown), plural(len(unknown), "key"), strings.Join(unknown, ", "))
 	}
 
 	// Apply new entries to the tree, respecting mode.
@@ -185,7 +185,7 @@ func reportMerge(w io.Writer, root, locale string, files []string, dryRun bool, 
 			fmt.Fprintf(os.Stderr, ", %d skipped (@override)", skipped)
 		}
 		if warned > 0 {
-			fmt.Fprintf(os.Stderr, ", %d @override warnings", warned)
+			fmt.Fprintf(os.Stderr, ", %d @override %s", warned, plural(warned, "warning"))
 		}
 		fmt.Fprintf(os.Stderr, ", %d total\n", total)
 		return nil
@@ -221,12 +221,12 @@ func reportMerge(w io.Writer, root, locale string, files []string, dryRun bool, 
 		return fmt.Errorf("writing %s: %w", localePath, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Merged %d new keys into %s (%d overwritten", added, localePath, overwritten)
+	fmt.Fprintf(os.Stderr, "Merged %d new %s into %s (%d overwritten", added, plural(added, "key"), localePath, overwritten)
 	if skipped > 0 {
 		fmt.Fprintf(os.Stderr, ", %d skipped", skipped)
 	}
 	if warned > 0 {
-		fmt.Fprintf(os.Stderr, ", %d @override warnings", warned)
+		fmt.Fprintf(os.Stderr, ", %d @override %s", warned, plural(warned, "warning"))
 	}
 	fmt.Fprintf(os.Stderr, ", %d total)\n", total)
 	return nil

--- a/src/go/i18n-report/report_remove.go
+++ b/src/go/i18n-report/report_remove.go
@@ -56,7 +56,7 @@ func runRemove(args []string) error {
 		}
 		if removed > 0 {
 			relPath, _ := filepath.Rel(root, path)
-			fmt.Fprintf(os.Stderr, "Removed %d keys from %s\n", removed, relPath)
+			fmt.Fprintf(os.Stderr, "Removed %d %s from %s\n", removed, plural(removed, "key"), relPath)
 		}
 	}
 
@@ -101,7 +101,7 @@ func removeStaleKeys(root string) error {
 			return err
 		}
 		relPath, _ := filepath.Rel(root, path)
-		fmt.Fprintf(os.Stderr, "Removed %d stale keys from %s\n", removed, relPath)
+		fmt.Fprintf(os.Stderr, "Removed %d stale %s from %s\n", removed, plural(removed, "key"), relPath)
 	}
 
 	return nil

--- a/src/go/i18n-report/report_source.go
+++ b/src/go/i18n-report/report_source.go
@@ -89,7 +89,7 @@ func annotateSource(w io.Writer, root, locale string, force bool) error {
 		flattenNodeWithComments("", localeRoot, entries)
 		drifted := computeDrifted(enKeys, collectSources(entries), entries)
 		if len(drifted) > 0 {
-			fmt.Fprintf(w, "%d drifted keys in %s would lose their drift marker:\n", len(drifted), locale)
+			fmt.Fprintf(w, "%d drifted %s in %s would lose their drift marker:\n", len(drifted), plural(len(drifted), "key"), locale)
 			for _, k := range drifted {
 				fmt.Fprintf(w, "  %s\n", k)
 			}

--- a/src/go/i18n-report/report_source.go
+++ b/src/go/i18n-report/report_source.go
@@ -89,13 +89,15 @@ func annotateSource(w io.Writer, root, locale string, force bool) error {
 		flattenNodeWithComments("", localeRoot, entries)
 		drifted := computeDrifted(enKeys, collectSources(entries), entries)
 		if len(drifted) > 0 {
-			fmt.Fprintf(w, "%d drifted %s in %s would lose their drift marker:\n", len(drifted), plural(len(drifted), "key"), locale)
+			fmt.Fprintf(w, "%d drifted %s in %s would lose the drift %s:\n",
+				len(drifted), plural(len(drifted), "key"), locale, plural(len(drifted), "marker"))
 			for _, k := range drifted {
 				fmt.Fprintf(w, "  %s\n", k)
 			}
 			fmt.Fprintf(os.Stderr, "Retranslate the drift (translate --mode=drift then merge --mode=drift) "+
 				"or pass --force to overwrite the @source markers anyway.\n")
-			return findingsError(fmt.Sprintf("refusing to erase %d outstanding drift markers in %s", len(drifted), locale))
+			return findingsError(fmt.Sprintf("refusing to erase %d outstanding drift %s in %s",
+				len(drifted), plural(len(drifted), "marker"), locale))
 		}
 	}
 

--- a/src/go/i18n-report/report_stale.go
+++ b/src/go/i18n-report/report_stale.go
@@ -47,5 +47,5 @@ func reportStale(root, locale, format string) error {
 
 	stale := computeStale(enKeys, localeKeys)
 
-	return outputStrings(os.Stdout, stale, format, "stale keys in "+locale)
+	return outputStrings(os.Stdout, stale, format, "stale key", " in "+locale)
 }

--- a/src/go/i18n-report/report_translate.go
+++ b/src/go/i18n-report/report_translate.go
@@ -178,7 +178,7 @@ func reportTranslate(w io.Writer, root, locale, mode, format string, batch, batc
 		return nil
 	}
 
-	label := fmt.Sprintf("Found %d keys %s %s", len(pairs), modeLabel, locale)
+	label := fmt.Sprintf("Found %d %s %s %s", len(pairs), plural(len(pairs), "key"), modeLabel, locale)
 	if batches > 0 {
 		label += fmt.Sprintf(" (batch %d of %d)", batch, batches)
 	}

--- a/src/go/i18n-report/report_undefined.go
+++ b/src/go/i18n-report/report_undefined.go
@@ -53,7 +53,7 @@ func reportUndefined(w io.Writer, root, format string) error {
 	} else if len(undefined) == 0 {
 		fmt.Fprintln(w, "No undefined keys found.")
 	} else {
-		fmt.Fprintf(w, "Found %d undefined keys (referenced in code, missing from en-us.yaml):\n", len(undefined))
+		fmt.Fprintf(w, "Found %d undefined %s (referenced in code, missing from en-us.yaml):\n", len(undefined), plural(len(undefined), "key"))
 		for _, k := range sortedKeys(undefined) {
 			fmt.Fprintf(w, "  %s\n", k)
 			for _, ref := range undefined[k] {
@@ -63,7 +63,7 @@ func reportUndefined(w io.Writer, root, format string) error {
 	}
 
 	if len(undefined) > 0 {
-		return findingsError(fmt.Sprintf("%d undefined keys found", len(undefined)))
+		return findingsError(fmt.Sprintf("%d undefined %s found", len(undefined), plural(len(undefined), "key")))
 	}
 	return nil
 }

--- a/src/go/i18n-report/report_untranslated.go
+++ b/src/go/i18n-report/report_untranslated.go
@@ -84,7 +84,7 @@ func reportUntranslated(w io.Writer, root, format string, includeDescriptions bo
 		return nil
 	}
 
-	fmt.Fprintf(w, "Found %d potential untranslated strings:\n\n", len(hits))
+	fmt.Fprintf(w, "Found %d potential untranslated %s:\n\n", len(hits), plural(len(hits), "string"))
 	for _, h := range hits {
 		fmt.Fprintf(w, "  %s:%d\n    %s\n\n", h.File, h.Line, h.Context)
 	}

--- a/src/go/i18n-report/report_unused.go
+++ b/src/go/i18n-report/report_unused.go
@@ -40,5 +40,5 @@ func reportUnused(root, format string) error {
 
 	unused := computeUnused(keys, refs)
 
-	return outputStrings(os.Stdout, unused, format, "unused keys")
+	return outputStrings(os.Stdout, unused, format, "unused key", "")
 }

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -41,6 +41,7 @@ const (
 	catTag         = "tag"
 	catICU         = "icu"
 	catICUSyntax   = "icu-syntax"
+	catIdentical   = "identical"
 )
 
 // validationError represents a single validation issue.
@@ -70,10 +71,11 @@ func validateLocale(root, locale string) ([]validationError, error) {
 		return nil, err
 	}
 
-	meta, err := loadSources(root, locale)
+	entries, err := loadYAMLWithComments(localePath)
 	if err != nil {
 		return nil, err
 	}
+	meta := collectSources(entries)
 
 	var errors []validationError
 
@@ -115,6 +117,29 @@ func validateLocale(root, locale string) ([]validationError, error) {
 				Message: "translated key has no @source",
 			})
 		}
+	}
+
+	// A translation left identical to its English source must be marked as
+	// deliberate with a @reason (or @override) comment; without one it is
+	// indistinguishable from a missed translation.
+	for key, e := range entries {
+		if _, inEn := enKeys[key]; !inEn {
+			continue // stale key, reported by stale check
+		}
+		if e.value == "" {
+			continue // an empty source stays empty; nothing to explain
+		}
+		if storedSource, hasSource := meta[key]; !hasSource || e.value != storedSource {
+			continue // no snapshot or drifted, reported by other checks
+		}
+		if e.override || commentHasReason(e.comment) {
+			continue
+		}
+		errors = append(errors, validationError{
+			Key:     key,
+			Check:   catIdentical,
+			Message: "translation identical to source without @reason",
+		})
 	}
 
 	// Sort errors by key for stable output.

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -61,11 +61,6 @@ func validateLocale(root, locale string) ([]validationError, error) {
 	if err != nil {
 		return nil, err
 	}
-	localeKeys, err := loadYAMLFlat(localePath)
-	if err != nil {
-		return nil, err
-	}
-
 	doc, err := loadYAMLDocument(localePath)
 	if err != nil {
 		return nil, err
@@ -81,10 +76,11 @@ func validateLocale(root, locale string) ([]validationError, error) {
 
 	// Check placeholder parity, ICU structure, and tag parity.
 	for key, enValue := range enKeys {
-		localeValue, exists := localeKeys[key]
+		localeEntry, exists := entries[key]
 		if !exists {
 			continue
 		}
+		localeValue := localeEntry.value
 		if errs := checkICU(key, enValue, localeValue); len(errs) > 0 {
 			errors = append(errors, errs...)
 		}
@@ -106,7 +102,7 @@ func validateLocale(root, locale string) ([]validationError, error) {
 
 	// Check that every translated key carries a @source snapshot. A @source
 	// cannot be orphaned from its translation, since it lives on the key.
-	for key := range localeKeys {
+	for key := range entries {
 		if _, inEn := enKeys[key]; !inEn {
 			continue // stale key, reported by stale check
 		}
@@ -130,7 +126,7 @@ func validateLocale(root, locale string) ([]validationError, error) {
 			continue // an empty source stays empty; nothing to explain
 		}
 		if storedSource, hasSource := meta[key]; !hasSource || e.value != storedSource {
-			continue // no snapshot or drifted, reported by other checks
+			continue // no snapshot (reported above), or translated, or drifted
 		}
 		if e.override || commentHasReason(e.comment) {
 			continue

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -165,11 +165,11 @@ func reportValidate(w io.Writer, root, locale string) error {
 		return nil
 	}
 
-	fmt.Fprintf(w, "Found %d validation errors in %s:\n", len(errors), locale)
+	fmt.Fprintf(w, "Found %d validation %s in %s:\n", len(errors), plural(len(errors), "error"), locale)
 	for _, e := range errors {
 		fmt.Fprintf(w, "  [%s] %s: %s\n", e.Check, e.Key, e.Message)
 	}
-	return findingsError(fmt.Sprintf("validation failed with %d errors", len(errors)))
+	return findingsError(fmt.Sprintf("validation failed with %d %s", len(errors), plural(len(errors), "error")))
 }
 
 // containsICU reports whether a value has any ICU syntax worth parsing: a

--- a/src/go/i18n-report/report_validate.go
+++ b/src/go/i18n-report/report_validate.go
@@ -119,14 +119,22 @@ func validateLocale(root, locale string) ([]validationError, error) {
 	// deliberate with a @reason (or @override) comment; without one it is
 	// indistinguishable from a missed translation.
 	for key, e := range entries {
-		if _, inEn := enKeys[key]; !inEn {
+		enValue, inEn := enKeys[key]
+		if !inEn {
 			continue // stale key, reported by stale check
 		}
 		if e.value == "" {
 			continue // an empty source stays empty; nothing to explain
 		}
-		if storedSource, hasSource := meta[key]; !hasSource || e.value != storedSource {
-			continue // no snapshot (reported above), or translated, or drifted
+		storedSource, hasSource := meta[key]
+		if !hasSource || e.value != storedSource {
+			continue // no snapshot (reported above), or translated
+		}
+		if storedSource != enValue {
+			// The snapshot is stale, so "identical to source" would misdescribe
+			// a value that matches superseded English. drift owns the case, and
+			// a default check run skips drift unless --strict is set.
+			continue
 		}
 		if e.override || commentHasReason(e.comment) {
 			continue

--- a/src/go/i18n-report/report_validate_test.go
+++ b/src/go/i18n-report/report_validate_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -374,5 +375,76 @@ func TestValidateLocaleEndToEnd(t *testing.T) {
 	}
 	if got[catPlaceholder] != 1 || got[catSource] != 1 {
 		t.Fatalf("bad locale: want 1 placeholder + 1 source, got %v: %v", got, errs)
+	}
+}
+
+func TestValidateIdenticalNeedsReason(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(translationsPath(root, "en-us.yaml")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(locale, content string) {
+		t.Helper()
+		if err := os.WriteFile(translationsPath(root, locale+".yaml"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("en-us", `title: Volumes
+farewell: Bye
+empty: ""
+secret:
+  types:
+    kubernetes.io/basic-auth: Opaque
+`)
+	// Identical values that are deliberate (@reason or @override), translated
+	// values, and empty values produce no findings.
+	write("annotated", `# @reason standard term in this language
+# @source Volumes
+title: Volumes
+# @source Bye
+farewell: Tschüss
+# @source
+empty: ""
+secret:
+  types:
+    # @override
+    # @source Opaque
+    kubernetes.io/basic-auth: Opaque
+`)
+	// Identical values with only a @source are flagged, including keys whose
+	// segments need quoting in the dotted representation.
+	write("bare", `# @source Volumes
+title: Volumes
+# @source Bye
+farewell: Tschüss
+# @source
+empty: ""
+secret:
+  types:
+    # @source Opaque
+    kubernetes.io/basic-auth: Opaque
+`)
+
+	identical := func(locale string) []string {
+		t.Helper()
+		errs, err := validateLocale(root, locale)
+		if err != nil {
+			t.Fatalf("%s locale: unexpected err %v", locale, err)
+		}
+		var keys []string
+		for _, e := range errs {
+			if e.Check == "identical" {
+				keys = append(keys, e.Key)
+			}
+		}
+		return keys
+	}
+
+	if keys := identical("annotated"); len(keys) != 0 {
+		t.Errorf("annotated locale: want no identical findings, got %v", keys)
+	}
+	want := []string{`secret.types."kubernetes.io/basic-auth"`, "title"}
+	if keys := identical("bare"); !slices.Equal(keys, want) {
+		t.Errorf("bare locale: want identical findings %v, got %v", want, keys)
 	}
 }

--- a/src/go/i18n-report/report_validate_test.go
+++ b/src/go/i18n-report/report_validate_test.go
@@ -392,12 +392,15 @@ func TestValidateIdenticalNeedsReason(t *testing.T) {
 	write("en-us", `title: Volumes
 farewell: Bye
 empty: ""
+renamed: Current
 secret:
   types:
     kubernetes.io/basic-auth: Opaque
 `)
 	// Identical values that are deliberate (@reason or @override), translated
-	// values, and empty values produce no findings.
+	// values, and empty values produce no findings. The check also skips a
+	// value whose @source has drifted from the current English, which the
+	// drift check owns, and a key absent from en-us, which the stale check owns.
 	write("annotated", `# @reason standard term in this language
 # @source Volumes
 title: Volumes
@@ -405,6 +408,10 @@ title: Volumes
 farewell: Tschüss
 # @source
 empty: ""
+# @source Superseded
+renamed: Current
+# @source Gone
+withdrawn: Gone
 secret:
   types:
     # @override
@@ -433,7 +440,7 @@ secret:
 		}
 		var keys []string
 		for _, e := range errs {
-			if e.Check == "identical" {
+			if e.Check == catIdentical {
 				keys = append(keys, e.Key)
 			}
 		}

--- a/src/go/i18n-report/report_validate_test.go
+++ b/src/go/i18n-report/report_validate_test.go
@@ -393,14 +393,18 @@ func TestValidateIdenticalNeedsReason(t *testing.T) {
 farewell: Bye
 empty: ""
 renamed: Current
+moved: Updated
 secret:
   types:
     kubernetes.io/basic-auth: Opaque
 `)
 	// Identical values that are deliberate (@reason or @override), translated
-	// values, and empty values produce no findings. The check also skips a
-	// value whose @source has drifted from the current English, which the
-	// drift check owns, and a key absent from en-us, which the stale check owns.
+	// values, and empty values produce no findings. The check also skips two
+	// kinds of key the drift check owns, whose @source no longer matches the
+	// current English: one already retranslated, one still matching its stale
+	// snapshot. A key absent from en-us belongs to the stale check. Removing the
+	// !inEn guard leaves this fixture green: the stale-snapshot comparison
+	// skips the key too.
 	write("annotated", `# @reason standard term in this language
 # @source Volumes
 title: Volumes
@@ -410,6 +414,8 @@ farewell: Tschüss
 empty: ""
 # @source Superseded
 renamed: Current
+# @source Original
+moved: Original
 # @source Gone
 withdrawn: Gone
 secret:

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -152,42 +152,34 @@ func flattenNodeWithComments(prefix string, node *yaml.Node, result map[string]m
 // overrideMarker is the comment line that protects a hand-tuned translation.
 const overrideMarker = "# @override"
 
-// lineIsOverrideMarker reports whether a single comment line is the @override
-// marker: the bare marker or the marker followed by a note.
-func lineIsOverrideMarker(line string) bool {
-	trimmed := strings.TrimSpace(line)
-	return trimmed == overrideMarker || strings.HasPrefix(trimmed, overrideMarker+" ")
-}
-
-// commentHasOverride returns true if any line of a comment is the @override marker.
-func commentHasOverride(comment string) bool {
-	for _, line := range strings.Split(comment, "\n") {
-		if lineIsOverrideMarker(line) {
-			return true
-		}
-	}
-	return false
-}
-
 // reasonMarker is the comment line that documents a translation choice.
 const reasonMarker = "# @reason"
 
-// lineIsReasonMarker reports whether a single comment line is the @reason
-// marker: the bare marker or the marker followed by a note.
-func lineIsReasonMarker(line string) bool {
+// lineIsMarker reports whether a comment line matches marker, either bare or
+// followed by a space and a note.
+func lineIsMarker(line, marker string) bool {
 	trimmed := strings.TrimSpace(line)
-	return trimmed == reasonMarker || strings.HasPrefix(trimmed, reasonMarker+" ")
+	return trimmed == marker || strings.HasPrefix(trimmed, marker+" ")
 }
 
-// commentHasReason returns true if any line of a comment is the @reason marker.
-func commentHasReason(comment string) bool {
+// commentHasMarker returns true if any line of a comment matches marker.
+func commentHasMarker(comment, marker string) bool {
 	for _, line := range strings.Split(comment, "\n") {
-		if lineIsReasonMarker(line) {
+		if lineIsMarker(line, marker) {
 			return true
 		}
 	}
 	return false
 }
+
+// lineIsOverrideMarker reports whether a comment line is the @override marker.
+func lineIsOverrideMarker(line string) bool { return lineIsMarker(line, overrideMarker) }
+
+// commentHasOverride returns true if any line of a comment is the @override marker.
+func commentHasOverride(comment string) bool { return commentHasMarker(comment, overrideMarker) }
+
+// commentHasReason returns true if any line of a comment is the @reason marker.
+func commentHasReason(comment string) bool { return commentHasMarker(comment, reasonMarker) }
 
 // nodeHasOverride returns true if a leaf key's HeadComment contains @override.
 func nodeHasOverride(root *yaml.Node, dottedKey string) bool {
@@ -358,6 +350,8 @@ func nodeSetLeaf(root *yaml.Node, dottedKey, value, comment string) error {
 				} else if valNode.Value != value {
 					// The value is machine-replaced; a retained @override
 					// marker would falsely claim it is still hand-tuned.
+					// A @reason survives. Only its author can tell whether
+					// it still applies, so review it by hand after a merge.
 					current.Content[keyIdx].HeadComment = stripOverrideMarker(current.Content[keyIdx].HeadComment)
 				}
 				// Update leaf value. Style is irrelevant; serializeYAMLNode

--- a/src/go/i18n-report/yaml.go
+++ b/src/go/i18n-report/yaml.go
@@ -169,6 +169,26 @@ func commentHasOverride(comment string) bool {
 	return false
 }
 
+// reasonMarker is the comment line that documents a translation choice.
+const reasonMarker = "# @reason"
+
+// lineIsReasonMarker reports whether a single comment line is the @reason
+// marker: the bare marker or the marker followed by a note.
+func lineIsReasonMarker(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed == reasonMarker || strings.HasPrefix(trimmed, reasonMarker+" ")
+}
+
+// commentHasReason returns true if any line of a comment is the @reason marker.
+func commentHasReason(comment string) bool {
+	for _, line := range strings.Split(comment, "\n") {
+		if lineIsReasonMarker(line) {
+			return true
+		}
+	}
+	return false
+}
+
 // nodeHasOverride returns true if a leaf key's HeadComment contains @override.
 func nodeHasOverride(root *yaml.Node, dottedKey string) bool {
 	_, comment, found := nodeGetLeaf(root, dottedKey)


### PR DESCRIPTION
The final sweep-up PR in the i18n series bundles low-priority items deferred while the larger PRs went through review. It targets `main`. The earlier i18n PRs have merged, so all twelve commits here are its own.

- **Require a @reason on identical translations.** A translation byte-identical to its `@source` is either a deliberate keep or a missed translation, and nothing distinguishes the two. `validate` now flags identical values that carry neither `@reason` nor `@override`, and `check --locale=all` runs `validate`, so CI rejects unmarked ones. The eight shipping locales in this branch exercise the check.
- **Fix the locale-addition steps in the translations README.** The old steps pointed at `settingsValidator.ts`, whose enum is generated from the translation files at build time. Correct the registration list and add the missing display-name and `Locale`-type steps.
- **Document the identical-value review step** in the maintenance workflow.
- **Fix plural agreement in count messages.** Commands printed a fixed plural noun after a count, so a count of one read "Found 1 drifted keys" or "Merged 1 new keys". The reporting commands, merge, and remove now agree the noun with the count.
- **Lock root-level settings by their qualified name.** A leading dot in the lock path bypassed a lock on a root-level setting. Latent today: `version` is the only root-level leaf and it never reports a change, so that code path never runs.

### Added since the first review

- **Translate the last four untranslated keys.** `diagnostics.never` and two startup progress labels shipped English-only in all eight locales. Two sit on the startup path, so every non-English user met them on every launch.
- **Name the subject in the lock tooltips.** "Cannot be modified because…" and "Locked due to organization's policy" carried no grammatical subject, so each gendered language had to invent one and they disagreed. Spanish and French were left with a bare participle agreeing with nothing. Both English strings now name the subject, retranslated across the eight locales.
- **Split the image error messages into two sentences.** They joined their clauses with a dash, which house style bars from user-facing text.
- **Scope the identity check to a current `@source`.** A translation matching a stale snapshot was reported by both `validate` and `drift`, and the identity message was misleading because the value no longer matched current English. It now fires only when the snapshot is current. Thanks @Nino-K for catching this one, and the empty-result wording next to it.
- **Document the @reason overload, and tidy the tool.** `@reason` marks both a wording choice and a deliberate keep, and `merge` carries one across a value change, so a stale note can satisfy the identity check. Both READMEs and the strip site now say so. Also deduplicates the marker helpers, drops a redundant parse, and adds two `validate` test cases.
- **Annotate fixed product names with `@no-translate`.** 108 comment-only lines in en-us. They cause no drift, and `translate` passes them to whoever writes the next locale, so the guidance arrives up front rather than being re-derived per language.
- **Document how to write source strings.** A README section on phrasing the English that every locale translates from. The tooltip and image-message fixes above were both source problems, and each rule cites a string that already cost a re-translation.


### Added since the second review

- **Restore the non-breaking spaces in two French error messages.** Rewording them for house style retyped the values, which replaced the U+00A0 inside `« »` with ordinary spaces. Nothing catches that, since `validate` checks placeholders, tags and ICU structure but never whitespace.
- **Complete the `@no-translate` annotations.** Several lists named only some of the fixed terms in their value, and a few product names carried no annotation at all. The most consequential is a literal `docker` context and the `rancher-desktop` context name, where translating either would break the instruction.
- **Say that the identity check needs a current `@source`.** Both READMEs still described the check without the precondition the previous commit gave it.
- **Correct the docs on when `--strict` runs.** Both READMEs and the `runCheck` doc comment said periodic and pre-release runs add it. No configured job passes it, so the completeness checks stay ungated until someone runs them by hand.
