### PR TITLE
Add eight translated locales (de, zh-hans, fr, es, pt-br, ja, it, ko)

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -110,4 +110,5 @@ ignore$
 # i18n tool tests use German sample translations
 ^src/go/i18n-report/.*_test\.go$
 # i18n runtime tests use German sample translations
+^\Qpkg/rancher-desktop/main/__tests__/i18n.spec.ts\E$
 ^\Qpkg/rancher-desktop/store/__tests__/i18n.spec.ts\E$

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, zh-hans]
+              enum: [de, en-us, fr, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [none, en-us]
+              enum: [de, en-us]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us]
+              enum: [de, en-us, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, es, fr, it, ja, pt-br, zh-hans]
+              enum: [de, en-us, es, fr, it, ja, ko, pt-br, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, es, fr, zh-hans]
+              enum: [de, en-us, es, fr, pt-br, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, fr, zh-hans]
+              enum: [de, en-us, es, fr, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, es, fr, ja, pt-br, zh-hans]
+              enum: [de, en-us, es, fr, it, ja, pt-br, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/specs/command-api.yaml
+++ b/pkg/rancher-desktop/assets/specs/command-api.yaml
@@ -599,7 +599,7 @@ components:
               type: string
               # Keep in sync with the translation files and settingsValidator.ts;
               # run `i18n-report check --locale=all` to catch mismatches.
-              enum: [de, en-us, es, fr, pt-br, zh-hans]
+              enum: [de, en-us, es, fr, ja, pt-br, zh-hans]
               x-rd-usage: set the UI language
             theme:
               type: string

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -10,6 +10,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 | `de.yaml` | German translation |
 | `es.yaml` | Spanish translation |
 | `fr.yaml` | French translation |
+| `it.yaml` | Italian translation |
 | `ja.yaml` | Japanese translation |
 | `pt-br.yaml` | Brazilian Portuguese translation |
 | `zh-hans.yaml` | Simplified Chinese translation |

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -10,6 +10,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 | `de.yaml` | German translation |
 | `es.yaml` | Spanish translation |
 | `fr.yaml` | French translation |
+| `pt-br.yaml` | Brazilian Portuguese translation |
 | `zh-hans.yaml` | Simplified Chinese translation |
 
 ## Architecture

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -8,6 +8,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 |------|---------|
 | `en-us.yaml` | Canonical English strings (source of truth) |
 | `de.yaml` | German translation |
+| `es.yaml` | Spanish translation |
 | `fr.yaml` | French translation |
 | `zh-hans.yaml` | Simplified Chinese translation |
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -12,6 +12,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 | `fr.yaml` | French translation |
 | `it.yaml` | Italian translation |
 | `ja.yaml` | Japanese translation |
+| `ko.yaml` | Korean translation |
 | `pt-br.yaml` | Brazilian Portuguese translation |
 | `zh-hans.yaml` | Simplified Chinese translation |
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -10,6 +10,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 | `de.yaml` | German translation |
 | `es.yaml` | Spanish translation |
 | `fr.yaml` | French translation |
+| `ja.yaml` | Japanese translation |
 | `pt-br.yaml` | Brazilian Portuguese translation |
 | `zh-hans.yaml` | Simplified Chinese translation |
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -8,6 +8,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 |------|---------|
 | `en-us.yaml` | Canonical English strings (source of truth) |
 | `de.yaml` | German translation |
+| `fr.yaml` | French translation |
 | `zh-hans.yaml` | Simplified Chinese translation |
 
 ## Architecture

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -7,6 +7,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 | File | Purpose |
 |------|---------|
 | `en-us.yaml` | Canonical English strings (source of truth) |
+| `de.yaml` | German translation |
 
 ## Architecture
 

--- a/pkg/rancher-desktop/assets/translations/README.md
+++ b/pkg/rancher-desktop/assets/translations/README.md
@@ -8,6 +8,7 @@ This directory holds the YAML translation files for Rancher Desktop.
 |------|---------|
 | `en-us.yaml` | Canonical English strings (source of truth) |
 | `de.yaml` | German translation |
+| `zh-hans.yaml` | Simplified Chinese translation |
 
 ## Architecture
 

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -892,6 +892,8 @@ locale:
   es: Spanisch
   # @source French
   fr: Französisch
+  # @source Japanese
+  ja: Japanisch
   # @source Portuguese (Brazilian)
   pt-br: Portugiesisch (Brasilien)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -896,6 +896,8 @@ locale:
   it: Italienisch
   # @source Japanese
   ja: Japanisch
+  # @source Korean
+  ko: Koreanisch
   # @source Portuguese (Brazilian)
   pt-br: Portugiesisch (Brasilien)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -888,6 +888,8 @@ locale:
   de: Deutsch
   # @source English
   en-us: Englisch
+  # @source Chinese (Simplified)
+  zh-hans: Chinesisch (vereinfacht)
 mainMenu:
   # @source About {appName}
   about: Über {appName}

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -892,6 +892,8 @@ locale:
   es: Spanisch
   # @source French
   fr: Französisch
+  # @source Portuguese (Brazilian)
+  pt-br: Portugiesisch (Brasilien)
   # @source Chinese (Simplified)
   zh-hans: Chinesisch (vereinfacht)
 mainMenu:

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -888,6 +888,8 @@ locale:
   de: Deutsch
   # @source English
   en-us: Englisch
+  # @source Spanish
+  es: Spanisch
   # @source French
   fr: Französisch
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -1,0 +1,1933 @@
+action:
+  # @source Refresh
+  refresh: Aktualisieren
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: Der Image-Name muss einem der in den Einstellungen unter Erlaubte Images definierten Muster entsprechen.
+  # @source Enable
+  enable: Aktivieren
+  errors:
+    # @source This item is a duplicate.
+    duplicate: Dieser Eintrag ist ein Duplikat.
+  # @source Allowed Image Patterns
+  label: Erlaubte Image-Muster
+  patterns:
+    # @source Type the image pattern
+    placeholder: Geben Sie das Image-Muster ein
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: Beim Anmelden automatisch starten
+      # @source Startup
+      legendText: Systemstart
+    background:
+      # @source Background
+      legendText: Hintergrund
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: Das Anwendungsfenster wird ausgeblendet, wenn Rancher Desktop im Hintergrund ausgeführt wird. Es kann über das Benachrichtigungssymbol (falls sichtbar) oder durch Starten von Rancher Desktop aus dem Programmmenü geöffnet werden.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: Benachrichtigungssymbol ausblenden
+      # @source Notification Icon
+      legendText: Benachrichtigungssymbol
+    startInBackground:
+      # @source Start in the background
+      label: Im Hintergrund starten
+    theme:
+      # @source Appearance
+      legendText: Erscheinungsbild
+      options:
+        dark:
+          # @reason Theme option: dark mode - standard German computing term for dark mode is "Dunkel"
+          # @source Always use dark mode
+          description: Dunkelmodus immer verwenden
+          # @source Dark
+          label: Dunkel
+        light:
+          # @reason Theme option: light mode
+          # @source Always use light mode
+          description: Hellmodus immer verwenden
+          # @source Light
+          label: Hell
+        system:
+          # @reason Theme option: follow OS setting - "Systemeinstellung" is the standard German term
+          # @source Follow the operating system setting
+          description: Betriebssystemeinstellung folgen
+          # @reason 'System' is the identical German word; standard theme-option label in German UIs
+          # @source System
+          label: System
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: Beim Schließen des Anwendungsfensters beenden
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: Administratorrechte erlauben (sudo-Zugriff)
+      # @source Administrative Access
+      legendText: Administratorzugriff
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: Wenn aktiviert, fordert {appName} beim Start Administratorrechte ("sudo-Zugriff") an. Dies ermöglicht Bridged-Networking und die Verwendung des Standard-Docker-Sockets. Wird beim nächsten Start wirksam.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: Automatisch nach Aktualisierungen suchen
+      # @source Automatic Updates
+      legendText: Automatische Aktualisierungen
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: Erhebung anonymer Statistiken zur Verbesserung von {appName} erlauben
+      # @source Statistics
+      legendText: Statistiken
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: Übersetzungen werden von der Community und KI-Werkzeugen bereitgestellt. Englisch ist die maßgebliche Sprache. Übersetzungsfehler können auf GitHub gemeldet werden.
+    # @source Language
+    legendText: Sprache
+asyncButton:
+  activate:
+    # @reason Button action label - "Aktivieren" is the standard German infinitive used as imperative in UI
+    # @source Activate
+    action: Aktivieren
+    # @reason Past state after activation
+    # @source Activated
+    success: Aktiviert
+    # @reason In-progress state with ellipsis entity preserved
+    # @source Activating&hellip;
+    waiting: Wird aktiviert&hellip;
+  apply:
+    # @reason Apply button - "Anwenden" is standard in German software UIs
+    # @source Apply
+    action: Anwenden
+    # @source Applied
+    success: Angewendet
+    # @source Applying&hellip;
+    waiting: Wird angewendet&hellip;
+  continue:
+    # @reason Continue/Save - source uses "Saved" as success; "Gespeichert" matches
+    # @source Continue
+    action: Weiter
+    # @source Saved
+    success: Gespeichert
+    # @source Saving&hellip;
+    waiting: Wird gespeichert&hellip;
+  copy:
+    # @reason Copy to clipboard action
+    # @source Click to Copy
+    action: Zum Kopieren klicken
+    # @source Copied!
+    success: Kopiert!
+  create:
+    # @reason Create button
+    # @source Create
+    action: Erstellen
+    # @source Created
+    success: Erstellt
+    # @source Creating&hellip;
+    waiting: Wird erstellt&hellip;
+  deactivate:
+    # @reason Deactivate button
+    # @source Deactivate
+    action: Deaktivieren
+    # @source Deactivated
+    success: Deaktiviert
+    # @source Deactivating&hellip;
+    waiting: Wird deaktiviert&hellip;
+  default:
+    # @reason Generic fallback labels
+    # @source Action
+    action: Aktion
+    # @source Error
+    error: Fehler
+    # @source Success
+    success: Erfolgreich
+    # @source Waiting
+    waiting: Warten
+  delete:
+    # @reason Delete button
+    # @source Delete
+    action: Löschen
+    # @source Deleted
+    success: Gelöscht
+    # @source Deleting&hellip;
+    waiting: Wird gelöscht&hellip;
+  disable:
+    # @reason Disable button
+    # @source Disable
+    action: Deaktivieren
+    # @source Disabled
+    success: Deaktiviert
+    # @source Disabling&hellip;
+    waiting: Wird deaktiviert&hellip;
+  done:
+    # @reason Done/Save - source uses "Saved" as success state
+    # @source Done
+    action: Fertig
+    # @source Saved
+    success: Gespeichert
+    # @source Saving&hellip;
+    waiting: Wird gespeichert&hellip;
+  download:
+    # @reason Download button
+    # @source Download
+    action: Herunterladen
+    # @source Saving
+    success: Wird gespeichert
+    # @source Downloading&hellip;
+    waiting: Wird heruntergeladen&hellip;
+  edit:
+    # @reason Edit/Save button
+    # @source Save
+    action: Speichern
+    # @source Saved
+    success: Gespeichert
+    # @source Saving&hellip;
+    waiting: Wird gespeichert&hellip;
+  enable:
+    # @reason Enable button
+    # @source Enable
+    action: Aktivieren
+    # @source Enabled
+    success: Aktiviert
+    # @source Enabling&hellip;
+    waiting: Wird aktiviert&hellip;
+  finish:
+    # @reason Finish button
+    # @source Finish
+    action: Abschließen
+    # @source Finished
+    success: Abgeschlossen
+    # @source Finishing&hellip;
+    waiting: Wird abgeschlossen&hellip;
+  import:
+    # @reason "Import" as a verb (imperative) for button action
+    # @source Import
+    action: Importieren
+    # @reason Past tense of "Import"
+    # @source Imported
+    success: Importiert
+    # @reason Progressive form with HTML entity preserved
+    # @source Importing&hellip;
+    waiting: Importieren&hellip;
+  install:
+    # @reason "Install" as imperative verb
+    # @source Install
+    action: Installieren
+    # @reason Present progressive
+    # @source Installing
+    success: Wird installiert
+    # @reason "Starting" — engine startup phase
+    # @source Starting&hellip;
+    waiting: Starten&hellip;
+  refresh:
+    # @reason Empty value — preserved as-is
+    # @source
+    action: ''
+    # @reason Icon name — kept in English
+    # @source refresh
+    actionIcon: refresh
+    # @reason Empty value — preserved as-is
+    # @source
+    error: ''
+    # @reason Icon name — kept in English
+    # @source error
+    errorIcon: error
+    # @reason Empty value — preserved as-is
+    # @source
+    success: ''
+    # @reason Icon name — kept in English
+    # @source checkmark
+    successIcon: checkmark
+    # @reason Empty value — preserved as-is
+    # @source
+    waiting: ''
+    # @reason Icon name — kept in English
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @reason "Remove" as imperative verb
+    # @source Remove
+    action: Entfernen
+    # @reason Past tense
+    # @source Removed
+    success: Entfernt
+    # @reason Progressive with HTML entity preserved
+    # @source Removing&hellip;
+    waiting: Wird entfernt&hellip;
+  restore:
+    # @reason "Restore" as imperative verb
+    # @source Restore
+    action: Wiederherstellen
+    # @reason Past tense
+    # @source Restored
+    success: Wiederhergestellt
+    # @reason Progressive
+    # @source Restoring&hellip;
+    waiting: Wiederherstellen&hellip;
+  snapshot:
+    # @reason "Snapshot Now" — imperative with adverb
+    # @source Snapshot Now
+    action: Snapshot erstellen
+    # @reason Snapshot creation in progress
+    # @source Creating Snapshot
+    success: Snapshot wird erstellt
+    # @reason Progressive; "Snapshot" kept in English
+    # @source Snapshotting&hellip;
+    waiting: Snapshot wird erstellt&hellip;
+  uninstall:
+    # @reason "Uninstall" as imperative verb
+    # @source Uninstall
+    action: Deinstallieren
+    # @reason Past tense
+    # @source Uninstalled
+    success: Deinstalliert
+    # @reason Progressive
+    # @source Uninstalling&hellip;
+    waiting: Wird deinstalliert&hellip;
+  update:
+    # @reason "Update" as imperative verb
+    # @source Update
+    action: Aktualisieren
+    # @reason Past tense
+    # @source Updated
+    success: Aktualisiert
+    # @reason Progressive
+    # @source Updating&hellip;
+    waiting: Wird aktualisiert&hellip;
+  upgrade:
+    # @reason "Upgrade" as imperative verb (distinct from Update)
+    # @source Upgrade
+    action: Upgrade durchführen
+    # @reason Present progressive
+    # @source Upgrading
+    success: Upgrade wird durchgeführt
+    # @reason "Starting" — engine startup phase
+    # @source Starting&hellip;
+    waiting: Starten&hellip;
+containerEngine:
+  # @reason German keeps the English "Container Engine" as a loanword (cf. Snapshot, Label, Port); used for the nav entry, this legend, and product.containerEngine.fullName
+  # @source Container Engine
+  label: Container-Engine
+  options:
+    containerd:
+      # @reason "nerdctl" kept in English
+      # @source Namespaces for container images; use with nerdctl.
+      description: Namespaces für Container-Images; Verwendung mit nerdctl.
+      # @reason Product name — kept as-is
+      # @source containerd
+      label: containerd
+    moby:
+      # @reason "Docker API" and "Docker CLI" kept in English
+      # @source Docker API; use with Docker CLI.
+      description: Docker API; Verwendung mit Docker CLI.
+      # @reason Product name — kept as-is
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: Container-Info
+  # @reason 'Info' is standard German (die Info)
+  # @source Info
+  info: Info
+  # @source Logs
+  logs: Protokolle
+  search:
+    # @source Search in logs
+    ariaLabel: In Protokollen suchen
+    # @source Clear search
+    clearSearch: Suche leeren
+    # @source Next match
+    nextMatch: Nächster Treffer
+    # @source Search logs...
+    placeholder: Protokolle durchsuchen...
+    # @source Previous match
+    previousMatch: Vorheriger Treffer
+  # @reason 'Shell' is standard German IT usage (die Shell)
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: Statistiken
+containerInspect:
+  capabilities:
+    # @source Added
+    added: Hinzugefügt
+    # @source Dropped
+    dropped: Entfernt
+  command:
+    # @source Args
+    args: Argumente
+    # @source Command
+    command: Befehl
+    # @reason Dockerfile ENTRYPOINT directive; technical term with no German equivalent
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: Container-Details konnten nicht geladen werden.
+    # @source An unknown error has occurred
+    unknown: Ein unbekannter Fehler ist aufgetreten
+  # @source Loading container details…
+  loading: Container-Details werden geladen…
+  mounts:
+    # @source Destination
+    destination: Ziel
+    # @reason read-only abbreviation, identical in German
+    # @source RO
+    readOnly: RO
+    # @reason read-write abbreviation, identical in German
+    # @source RW
+    readWrite: RW
+    # @reason column header for the RO/RW values, which are also kept as abbreviations
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: Quelle
+    # @source Type
+    type: Typ
+  # @source None
+  none: Keine
+  sections:
+    # @reason Linux capabilities(7); German security literature keeps the term
+    # @source Capabilities
+    capabilities: Capabilities
+    # @source Command & Args
+    commandArgs: Befehl & Argumente
+    # @source Environment
+    environment: Umgebung
+    # @reason Docker label metadata; 'Label' is a German loanword and German container docs keep it
+    # @source Labels
+    labels: Labels
+    # @reason docker inspect 'Mounts' section; 'Mounts'/'Bind Mounts' kept in German Docker literature
+    # @source Mounts
+    mounts: Mounts
+    # @reason 'Port' is a German loanword; plural is identical
+    # @source Ports
+    ports: Ports
+  summary:
+    # @source Created
+    created: Erstellt
+    # @reason identical abbreviation in German
+    # @source ID
+    id: ID
+    # @reason 'Image' is the established container term throughout de.yaml
+    # @source Image
+    image: Image
+    # @source IP Address
+    ipAddress: IP-Adresse
+    # @reason 'Name' is the identical German word
+    # @source Name
+    name: Name
+    # @source Started
+    started: Gestartet
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: Block-I/O (Bytes/s)
+    # @reason abbreviation plus percent sign, identical in German
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: Arbeitsspeicher
+    # @source Network I/O (bytes/s)
+    network: Netzwerk-I/O (Bytes/s)
+  interval:
+    # @source {minutes} min
+    minutes: '{minutes} Min.'
+    # @reason 's' is the SI unit symbol for seconds, identical in German
+    # @source {seconds} s
+    seconds: '{seconds} s'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: Statistiken sind derzeit nur für die Docker-Engine (Moby) verfügbar.
+  # @source No processes found.
+  noProcesses: Keine Prozesse gefunden.
+  # @source Stats are only available for running containers.
+  notRunning: Statistiken sind nur für laufende Container verfügbar.
+  # @source Processes
+  processes: Prozesse
+  # @source Refresh
+  refresh: Aktualisierung
+  series:
+    # @reason 'Limit' is the identical German word (das Limit)
+    # @source Limit
+    limit: Limit
+    # @source Read
+    read: Lesen
+    # @reason network receive abbreviation, identical in German
+    # @source RX
+    rx: RX
+    # @reason network transmit abbreviation, identical in German
+    # @source TX
+    tx: TX
+    # @source Used
+    used: Belegt
+    # @source Write
+    write: Schreiben
+containers:
+  manage:
+    table:
+      action:
+        # @reason 'Info' is standard German (die Info)
+        # @source Info
+        info: Info
+        # @source Restart
+        restart: Neu starten
+        # @source Start
+        start: Starten
+        # @source Stop
+        stop: Stoppen
+      header:
+        # @reason 'Name' is the identical German word
+        # @source Name
+        containerName: Name
+        # @reason 'Image' is the established container term throughout de.yaml
+        # @source Image
+        image: Image
+        # @reason 'Port' is a German loanword; the optional-plural marker works identically
+        # @source Port(s)
+        ports: Port(s)
+        # @source Uptime
+        started: Laufzeit
+        # @source State
+        state: Status
+  sortableTables:
+    # @source There are no containers to show
+    noRows: Es sind keine Container vorhanden
+  # @source Containers
+  title: Container
+dashboard:
+  # @reason @no-translate product name
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop kann nicht mit Root-Rechten ausgeführt werden. Bitte starten Sie die Anwendung erneut als regulärer Benutzer.
+  # @source Cannot run as Root
+  title: Ausführung als Root nicht möglich
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 'Ungültige Bereitstellungsdatei {path}: keine Version angegeben. Fügen Sie ein Versionsfeld hinzu (aktuelle Version ist {version}).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 'Ungültige Bereitstellung: keine Version angegeben unter {path}. Fügen Sie ein Versionsfeld hinzu (aktuelle Version ist {version}).'
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} fehlgeschlagen plus {muted} stummgeschaltet'
+  # @source Last run:
+  lastRun: 'Letzter Lauf:'
+  # @source (No fixes available)
+  noFixes: (Keine Korrekturen verfügbar)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: Versuchen Sie, stummgeschaltete Diagnosen anzuzeigen.
+      # @source No results found
+      heading: Keine Ergebnisse gefunden
+      # @reason icon identifier, not translatable text
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop scheint ordnungsgemäß zu funktionieren.
+      # @source No problems detected
+      heading: Keine Probleme erkannt
+      # @reason icon identifier, not translatable text
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: Stummgeschaltete anzeigen
+  tableHeaders:
+    # @source Mute
+    mute: Stumm
+    # @reason 'Name' is the identical German word
+    # @source Name
+    name: Name
+  # @source Diagnostics
+  title: Diagnose
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: Das gemeinsame Netzwerk ist ebenfalls nicht verfügbar. Netzwerkzugriff ist nur über Port-Weiterleitung zum Host möglich.
+    # @source Using shared network address {ip}
+    sharedFallback: Verwende gemeinsame Netzwerkadresse {ip}
+    # @source Bridged network did not get an IP address.
+    title: Überbrücktes Netzwerk hat keine IP-Adresse erhalten.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: Workloads löschen
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: Ein Downgrade von {from} auf {to} führt zum Verlust bestehender Kubernetes-Workloads. Daten löschen?
+    # @source Confirming migration
+    title: Migration bestätigen
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: Zurückfallen auf empfohlene Mindest-Upgrade-Version {version}
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: Die angeforderte Kubernetes-Version ''{version}'' wird nicht unterstützt.
+    # @source Invalid Kubernetes Version
+    title: Ungültige Kubernetes-Version
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: Bitte beschaffen Sie eine Version im Bereich {range} und installieren Sie sie in ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: Eine kompatible Version von kubectl kann im Offline-Modus nicht heruntergeladen werden
+    # @source Network failure
+    title: Netzwerkfehler
+extensions:
+  # @reason icon identifier, not translatable text
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: Sie haben noch keine Erweiterungen installiert. Durchsuchen Sie den Erweiterungskatalog, um loszulegen.
+      button:
+        # @source Browse Extensions
+        text: Erweiterungen durchsuchen
+      # @source No extensions installed
+      heading: Keine Erweiterungen installiert
+      # @reason icon identifier, not translatable text
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: Entfernen
+      # @source Upgrade
+      upgrade: Aktualisieren
+  view:
+    emptyState:
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId} wurde entfernt. Besuchen Sie den Erweiterungskatalog, um die Erweiterung erneut zu installieren oder nach weiteren Erweiterungen für Rancher Desktop zu stöbern.'
+      # @source Extension removed
+      heading: Erweiterung entfernt
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Kubernetes aktivieren
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (nur zwischengespeicherte Versionen)
+    # @source Kubernetes Version
+    legend: Kubernetes-Version
+    # @source Other Versions
+    otherVersions: Weitere Versionen
+    # @source Recommended Versions
+    recommendedVersions: Empfohlene Versionen
+  # @reason 'OK' is standard German button text
+  # @source OK
+  ok: OK
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Willkommen bei Rancher Desktop von SUSE
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop ermöglicht Kubernetes- und Image-Verwaltung über eine Desktop-Anwendung.
+  # @source Homepage
+  homepage: Startseite
+  # @source Issues
+  issues: Probleme
+  # @source General
+  navLabel: Allgemein
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 'Projektdiskussionen: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack'
+  # @source Project Links:
+  projectLinks: 'Projektlinks:'
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Willkommen bei Rancher Desktop von SUSE
+generic:
+  # @source  and 
+  and: ' und '
+  # @source Apply
+  apply: Anwenden
+  # @source Cancel
+  cancel: Abbrechen
+  # @source Close
+  close: Schließen
+  # @reason list-separator punctuation, identical in German
+  # @source , 
+  comma: ', '
+  # @source Forward
+  forward: Weiterleiten
+  # @source Loading&hellip;
+  loading: Wird geladen&hellip;
+  # @source Namespace
+  namespace: Namensraum
+  # @reason 'OK' is standard German button text
+  # @source OK
+  ok: OK
+  # @source Rerun
+  rerun: Erneut ausführen
+  # @source Search
+  search: Suche
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: Bitte wählen Sie die zu verwendende Dockerfile aus (kann einen anderen Namen haben)
+  # @source Pick the build directory
+  buildTitle: Build-Verzeichnis auswählen
+  # @source Error trying to delete images {ids}
+  deleteBatchError: Fehler beim Löschen der Images {ids}
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      Fehler beim Löschen des Images {name} ({id}):
+
+      {error}
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      Fehler beim Pushen von {name}:
+
+      {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      Fehler beim Scannen von {name}:
+
+      {error}
+images:
+  action:
+    # @source Add Image
+    add: Image hinzufügen
+  add:
+    action:
+      # @reason tab label on the Add Image page; matches its submit button images.manager.input.build.button 'Erstellen'
+      # @source Build
+      build: Erstellen
+      gerund:
+        # @reason Past participle, not a noun — loadingText is restructured as passive "Image wird {action}..."
+        # @source Building
+        build: erstellt
+        # @reason Past participle, not a noun — loadingText is restructured as passive "Image wird {action}..."
+        # @source Pulling
+        pull: abgerufen
+      infinitive:
+        # @reason Nominalized infinitive to compose with "Fehler beim { action } von ..." in errorText
+        # @source build
+        build: Erstellen
+        # @reason Nominalized infinitive to compose with "Fehler beim { action } von ..." in errorText; avoids the separable-verb form "abzurufen"
+        # @source pull
+        pull: Abrufen
+      pastTense:
+        # @reason Nominalized so successText "{action} des Images abgeschlossen" composes; the participle "Erstellt" did not
+        # @source Built
+        build: Erstellen
+        # @reason Nominalized so successText "{action} des Images abgeschlossen" composes; the participle "Abgerufen" did not
+        # @source Pulled
+        pull: Abrufen
+      # @reason tab label on the Add Image page; matches its submit button images.manager.input.pull.button 'Abrufen'
+      # @source Pull
+      pull: Abrufen
+    # @reason Restructured to the "Fehler beim ... von" pattern already used by images.scan.errorText; en dash matches file convention
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Fehler beim { action } von ''{ image }'' – siehe Konsolenausgabe für weitere Informationen
+    # @reason Restructured as passive; composes to "Image wird erstellt..." / "Image wird abgerufen..."
+    # @source {action} image...
+    loadingText: Image wird {action}...
+    # @source {action} image
+    successText: '{action} des Images abgeschlossen'
+    # @source Add Image
+    title: Image hinzufügen
+  confirmDelete:
+    # @source Delete
+    confirm: Löschen
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: '{count} {count, plural, one {Image} other {Images}} löschen?'
+    # @source Delete image {name}:{tag}?
+    single: Image {name}:{tag} löschen?
+    # @source Confirming image deletion
+    title: Image-Löschung bestätigen
+  manager:
+    # @source Close Output to Continue
+    close: Ausgabe schließen zum Fortfahren
+    input:
+      build:
+        # @reason Button label
+        # @source Build
+        button: Erstellen
+        # @reason Field label
+        # @source Name of image to build:
+        label: 'Name des zu erstellenden Images:'
+        # @reason Placeholder — registry path format kept as-is
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @reason Button label
+        # @source Pull
+        button: Abrufen
+        # @reason Field label
+        # @source Name of image to pull:
+        label: 'Name des abzurufenden Images:'
+        # @reason Placeholder — registry path format kept as-is
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: Löschen
+        # @reason kept as loanword; de.yaml already uses 'Pushen' (imageEvents.pushError) and German dev tools such as VS Code keep 'Push'
+        # @source Push
+        push: Push
+        # @source Scan...
+        scan: Scannen...
+      header:
+        # @source Image ID
+        imageId: Image-ID
+        # @reason 'Image' is the established container term throughout de.yaml
+        # @source Image
+        imageName: Image
+        # @source Size
+        size: Größe
+        # @reason Docker image tag; 'Tag' (das Tag) is standard German container usage
+        # @source Tag
+        tag: Tag
+      # @source All images
+      label: Alle Images
+    # @source Image Output
+    title: Image-Ausgabe
+  scan:
+    details:
+      # @source Description
+      description: Beschreibung
+      # @source Primary URL
+      primaryUrl: Primäre URL
+      # @source References
+      references: Referenzen
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Fehler beim Scannen von ''{ image }'' – siehe Konsolenausgabe für weitere Informationen
+    labels:
+      # @source CRITICAL
+      critical: KRITISCH
+      # @source HIGH
+      high: HOCH
+      # @source Issues Found
+      issuesFound: Gefundene Probleme
+      # @source LOW
+      low: NIEDRIG
+      # @source MEDIUM
+      medium: MITTEL
+    # @source Scanning ''{ image }''
+    loadingText: Scanne ''{ image }''
+    results:
+      headers:
+        # @source Fixed
+        fixed: Behoben
+        # @source Installed
+        installed: Installiert
+        # @source Package
+        package: Paket
+        # @source Severity
+        severity: Schweregrad
+        # @source Vulnerability ID
+        vulnerabilityId: Schwachstellen-ID
+    # @source Scan details for ''{ image }''
+    title: Scan-Details für ''{ image }''
+  sortableTables:
+    # @source There are no images to show
+    noRows: Es sind keine Images vorhanden
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: Warten auf Bereitschaft des Image-Managers
+    # @source Error: Unknown state; please reload.
+    unknown: 'Fehler: Unbekannter Status – bitte laden Sie die Seite neu.'
+  # @reason nav page title; 'Image' is the established German container term used throughout de.yaml (e.g. 'Erlaubte Images')
+  # @source Images
+  title: Images
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Kubernetes-Konfiguration und Docker-Socket von Rancher Desktop für Windows Subsystem for Linux (WSL)-Distributionen bereitstellen
+kubernetesError:
+  # @source Context:
+  context: 'Kontext:'
+  # @source Last command run:
+  lastCommand: 'Letzter ausgeführter Befehl:'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 'Einige aktuelle <a href="#" data-action="showLogs">Logdatei</a>-Zeilen:'
+  # @source {appName} Error
+  title: '{appName}-Fehler'
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Kubernetes aktivieren
+    # @reason product name
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: Optionen
+    # @source Install Spin Operator
+    spinkube: Spin Operator installieren
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: <a href="#" data-navigate="Container Engine,general">WebAssembly</a> muss aktiviert sein, damit der Spin Operator installiert werden kann.
+    # @source Enable Traefik
+    traefik: Traefik aktivieren
+  port:
+    # @source Kubernetes Port
+    legendText: Kubernetes-Port
+  version:
+    # @source Kubernetes version
+    legendText: Kubernetes-Version
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Kubernetes-Version (nur zwischengespeicherte Versionen)
+    # @source Other Versions
+    otherVersions: Weitere Versionen
+    # @source Recommended Versions
+    recommendedVersions: Empfohlene Versionen
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: Keine Optionen
+    # @source No matching options
+    noMatch: Keine passenden Optionen
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} Einträge'
+    # @source Load More...
+    more: Mehr laden...
+locale:
+  # @source German
+  de: Deutsch
+  # @source English
+  en-us: Englisch
+mainMenu:
+  # @source About {appName}
+  about: Über {appName}
+  edit:
+    # @source &Copy
+    copy: '&Kopieren'
+    # @source Cu&t
+    cut: Ausschnei&den
+    # @source De&lete
+    delete: '&Löschen'
+    # @source &Edit
+    label: '&Bearbeiten'
+    # @source &Paste
+    paste: '&Einfügen'
+    # @source &Redo
+    redo: '&Wiederholen'
+    # @source Select &All
+    selectAll: Alles &auswählen
+    # @source &Undo
+    undo: '&Rückgängig'
+  file:
+    # @source Close
+    close: Schließen
+    # @source E&xit
+    exit: '&Beenden'
+    # @source &File
+    label: '&Datei'
+  help:
+    # @source &About {appName}
+    about: '&Über {appName}'
+    # @source &Discuss
+    discuss: '&Diskutieren'
+    # @source File a &Bug
+    fileABug: '&Fehler melden'
+    # @source Get &Help
+    getHelp: '&Hilfe erhalten'
+    # @source {appName} &Help
+    help: '{appName}-&Hilfe'
+    # @source &Help
+    label: '&Hilfe'
+    # @source &Project Page
+    projectPage: '&Projektseite'
+  # @source Hide {appName}
+  hide: '{appName} ausblenden'
+  # @source Hide Others
+  hideOthers: Andere ausblenden
+  # @source Preferences
+  preferences: Einstellungen
+  # @source Quit {appName}
+  quit: '{appName} beenden'
+  # @source Services
+  services: Dienste
+  # @source Show All
+  showAll: Alle einblenden
+  view:
+    # @source &Actual Size
+    actualSize: '&Originalgröße'
+    # @source &Force Reload
+    forceReload: Neu laden &erzwingen
+    # @source &View
+    label: '&Ansicht'
+    # @source &Reload
+    reload: Neu &laden
+    # @source Toggle &Developer Tools
+    toggleDevTools: '&Entwicklerwerkzeuge ein/aus'
+    # @source Toggle Full &Screen
+    toggleFullScreen: '&Vollbild ein/aus'
+    # @source Zoom &In
+    zoomIn: Ver&größern
+    # @source Zoom &Out
+    zoomOut: Ver&kleinern
+  window:
+    # @source Bring All to Front
+    front: Alle nach vorne bringen
+    # @source &Window
+    label: '&Fenster'
+    # @source Minimize
+    minimize: Minimieren
+    # @source Zoom
+    zoom: Zoomen
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: Beschreibung
+        # @reason 'Name' is the identical German word
+        # @source Name
+        name: Name
+        # @source Vendor
+        vendor: Anbieter
+  labels:
+    # @source Install
+    install: Installieren
+    # @source Remove
+    uninstall: Entfernen
+    # @source Upgrade
+    upgrade: Aktualisieren
+  loading:
+    # @reason Status message
+    # @source Installing...
+    install: Wird installiert...
+    # @reason Status message
+    # @source Removing...
+    uninstall: Wird entfernt...
+    # @reason Status message
+    # @source Upgrading...
+    upgrade: Upgrade wird durchgeführt...
+  # @source More information
+  moreInfo: Weitere Informationen
+  # @source No extension found for the search criteria
+  noResults: Keine Erweiterung für die Suchkriterien gefunden
+  tabs:
+    # @source Catalog
+    catalog: Katalog
+    # @source Installed
+    installed: Installiert
+  # @source Extensions
+  title: Erweiterungen
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: Cluster-Dashboard
+    # @source Preferences
+    preferences: Einstellungen
+pathManagement:
+  # @source Configure PATH
+  label: PATH konfigurieren
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop ändert Ihre PATH-Konfiguration nicht; fügen Sie <code>$HOME/.rd/bin</code> manuell zu Ihrem PATH hinzu.
+      # @source Manual
+      label: Manuell
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop bearbeitet Ihr Shell-Profil automatisch. Starten Sie geöffnete Shells neu, damit die Änderungen wirksam werden.
+      # @source Automatic
+      label: Automatisch
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop enthält Werkzeuge wie kubectl, nerdctl, helm und docker. Um diese Werkzeuge zu verwenden, muss <code>$HOME/.rd/bin</code> in Ihrem PATH enthalten sein.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Kubernetes-Dienste einbeziehen
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: Lokaler Port
+        # @reason 'Name' is the identical German word
+        # @source Name
+        name: Name
+        # @source Namespace
+        namespace: Namensraum
+        # @reason 'Port' is a German loanword (der Port)
+        # @source Port
+        port: Port
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: Es sind keine Portweiterleitungen vorhanden
+  # @source Port Forwarding
+  title: Portweiterleitung
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: Es gibt ein Problem mit der Auswahl der Einstellungen.
+      # @source Kubernetes will reset after applying changes.
+      reset: Kubernetes wird nach dem Übernehmen der Änderungen zurückgesetzt.
+      # @source Kubernetes will restart after applying changes.
+      restart: Kubernetes wird nach dem Übernehmen der Änderungen neu gestartet.
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: WebAssembly muss aktiviert sein, damit der <a href="#" data-navigate="Kubernetes">Spin Operator</a> installiert werden kann.
+  error:
+    # @source Reload Preferences to try again.
+    body: Laden Sie die Einstellungen erneut, um es noch einmal zu versuchen.
+    # @source Unable to fetch preferences
+    heading: Einstellungen können nicht abgerufen werden
+    # @source Reload preferences
+    reload: Einstellungen neu laden
+  # @source Preferences
+  header: Einstellungen
+  # @source or
+  incompatiblePrefWarningOr: oder
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: deaktiviert sein.
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: aktiviert sein.
+  # @source The option requires
+  incompatibleTypeWarningPre: Diese Option erfordert, dass
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: Gesperrt aufgrund der Unternehmensrichtlinie
+  nav:
+    # @source Application
+    application: Anwendung
+    # @reason English "Container Engine" loanword; see containerEngine.label
+    # @source Container Engine
+    containerEngine: Container-Engine
+    # @reason product name
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: Virtuelle Maschine
+    # @reason product abbreviation (Windows Subsystem for Linux)
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: Anwenden und zurücksetzen
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: Diese Änderungen setzen den Kubernetes-Cluster zurück, was zum Verlust von Workloads und Container-Images führt.
+    # @source Apply preferences and reset Kubernetes?
+    message: Einstellungen anwenden und Kubernetes zurücksetzen?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Kubernetes zurücksetzen
+  tabs:
+    # @source Allowed Images
+    allowedImages: Erlaubte Images
+    # @source Behavior
+    behavior: Verhalten
+    # @reason 'Emulation' is the identical German word (die Emulation)
+    # @source Emulation
+    emulation: Emulation
+    # @source Environment
+    environment: Umgebung
+    # @source General
+    general: Allgemein
+    # @reason 'Hardware' is a German loanword (die Hardware)
+    # @source Hardware
+    hardware: Hardware
+    # @source Integrations
+    integrations: Integrationen
+    # @reason 'Proxy' is a German loanword (der Proxy)
+    # @source Proxy
+    proxy: Proxy
+    # @reason Docker volume term; 'das Volume/Volumes' is standard in German container UIs and used throughout de.yaml
+    # @source Volumes
+    volumes: Volumes
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: Es gibt Einstellungen mit nicht übernommenen Änderungen. Alle nicht gespeicherten Einstellungen gehen verloren.
+    # @source Discard changes
+    discardChanges: Änderungen verwerfen
+    # @source Close preferences without applying?
+    message: Einstellungen schließen ohne zu übernehmen?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - Einstellungen schließen
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - Einstellungen
+prefs:
+  # @source Experimental
+  experimental: Experimentell
+  # @reason macOS version requirement; "Ventura" kept as-is
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: Diese Einstellung erfordert macOS 13.3 (Ventura) oder neuer.
+  # @reason macOS version requirement; "Ventura" kept as-is
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: Diese Einstellung erfordert macOS 13.0 (Ventura) oder neuer.
+  # @reason "This setting requires using the VZ emulation mode" — informational constraint message; formal Sie register
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: Diese Einstellung erfordert die Verwendung des VZ-Emulationsmodus. VZ ist nur unter macOS 13.3 (Ventura) oder neuer verfügbar.
+  # @reason Same message for x64 variant; version number differs
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: Diese Einstellung erfordert die Verwendung des VZ-Emulationsmodus. VZ ist nur unter macOS 13.0 (Ventura) oder neuer verfügbar.
+product:
+  containerEngine:
+    # @reason status-bar abbreviation identifier; no German abbreviation exists
+    # @source CE
+    abbreviation: CE
+    # @reason English "Container Engine" loanword; see containerEngine.label
+    # @source Container Engine
+    fullName: Container-Engine
+  # @source deactivated
+  deactivated: deaktiviert
+  # @reason product name
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: Netzwerkstatus
+  networkStatusValues:
+    # @reason Status indicator; lowercase matches English convention for status labels
+    # @source checking...
+    checking: wird geprüft...
+    # @reason Network status label
+    # @source offline
+    offline: offline
+    # @reason Network status label
+    # @source online
+    online: online
+  # @reason 'Version' is the identical German word (die Version)
+  # @source Version
+  version: Version
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: Berechtigung zum Ausführen von Aufgaben als Administrator wird angefordert
+  # @source Bundling certificates
+  bundlingCertificates: Zertifikate werden gebündelt
+  # @source Checking k3s images
+  checkingK3sImages: k3s-Images werden geprüft
+  # @source Configuring container engine
+  configuringContainerEngine: Container-Engine wird konfiguriert
+  # @source Configuring image proxy
+  configuringImageProxy: Image-Proxy wird konfiguriert
+  # @source Configuring logrotate
+  configuringLogrotate: logrotate wird konfiguriert
+  # @source Container engine components
+  containerEngineComponents: Container-Engine-Komponenten
+  # @source Copying certificates
+  copyingCertificates: Zertifikate werden kopiert
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: Inkompatibler Kubernetes-Zustand wird gelöscht
+  # @source Deleting Kubernetes
+  deletingKubernetes: Kubernetes wird gelöscht
+  # @source Deleting virtual machine
+  deletingVirtualMachine: Virtuelle Maschine wird gelöscht
+  # @source DNS configuration
+  dnsConfiguration: DNS-Konfiguration
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: Kompatibles kubectl wird sichergestellt
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: Virtualisierungsunterstützung wird sichergestellt
+  # @source Expecting user permission to continue
+  expectingPermission: Benutzerberechtigung zum Fortfahren wird erwartet
+  # @source Extracting certificates
+  extractingCertificates: Zertifikate werden extrahiert
+  # @source Fetching certificates
+  fetchingCertificates: Zertifikate werden abgerufen
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Rancher Desktop wird initialisiert
+  # @source Initializing WSL data
+  initializingWslData: WSL-Daten werden initialisiert
+  # @source Installing Buildkit
+  installingBuildkit: Buildkit wird installiert
+  # @source Installing CA certificates
+  installingCaCertificates: CA-Zertifikate werden installiert
+  # @source Installing container engine
+  installingContainerEngine: Container-Engine wird installiert
+  # @source Installing credential helper
+  installingCredentialHelper: Credential-Helper wird installiert
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: docker-credential-Helper wird installiert
+  # @source Installing helpers
+  installingHelpers: Hilfsprogramme werden installiert
+  # @source Installing image scanner
+  installingImageScanner: Image-Scanner wird installiert
+  # @source Installing k3s
+  installingK3s: k3s wird installiert
+  # @source Installing Kubernetes
+  installingKubernetes: Kubernetes wird installiert
+  # @source Kubernetes components
+  kubernetesComponents: Kubernetes-Komponenten
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Kubernetes-dockerd-Kompatibilität
+  # @source Mounting WSL data
+  mountingWslData: WSL-Daten werden eingebunden
+  # @source Preparing to start
+  preparingToStart: Vorbereitung zum Starten
+  # @source Proxy Config Setup
+  proxyConfigSetup: Proxy-Konfiguration wird eingerichtet
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Rancher Desktop-Gast-Agent
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: Konfiguration wird aufgrund fehlender Berechtigungen neu generiert
+  # @source Registering WSL distribution
+  registeringWslDistribution: WSL-Distribution wird registriert
+  # @source Removing existing certificates
+  removingExistingCertificates: Vorhandene Zertifikate werden entfernt
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: spinkube-Operator wird entfernt
+  # @source Removing stale state
+  removingStaleState: Veralteter Zustand wird entfernt
+  # @source Removing Traefik
+  removingTraefik: Traefik wird entfernt
+  # @source Resetting Kubernetes
+  resettingKubernetes: Kubernetes wird zurückgesetzt
+  # @source Running provisioning scripts
+  runningProvisioningScripts: Bereitstellungsskripte werden ausgeführt
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: update-ca-certificates wird ausgeführt
+  # @source Setting docker context
+  settingDockerContext: Docker-Kontext wird gesetzt
+  # @source Setting Lima permissions
+  settingLimaPermissions: Lima-Berechtigungen werden gesetzt
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Docker-Socket wird eingerichtet
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: Virtuelles Ethernet wird eingerichtet
+  # @source Shutting down
+  shuttingDown: Wird heruntergefahren
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: Knotenprüfungen werden übersprungen, flannel ist deaktiviert
+  # @source Starting Backend
+  startingBackend: Backend wird gestartet
+  # @source Starting buildkit
+  startingBuildkit: buildkit wird gestartet
+  # @source Starting container engine
+  startingContainerEngine: Container-Engine wird gestartet
+  # @source Starting image proxy
+  startingImageProxy: Image-Proxy wird gestartet
+  # @source Starting k3s
+  startingK3s: k3s wird gestartet
+  # @source Starting Kubernetes
+  startingKubernetes: Kubernetes wird gestartet
+  # @source Starting proxy
+  startingProxy: Proxy wird gestartet
+  # @source Starting {service}
+  startingService: '{service} wird gestartet'
+  # @source Starting virtual machine
+  startingVirtualMachine: Virtuelle Maschine wird gestartet
+  # @source Starting WSL environment
+  startingWslEnvironment: WSL-Umgebung wird gestartet
+  # @source Stopping existing instance
+  stoppingExistingInstance: Vorhandene Instanz wird gestoppt
+  # @source Stopping mock backend
+  stoppingMockBackend: Mock-Backend wird gestoppt
+  # @source Stopping services
+  stoppingServices: Dienste werden gestoppt
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: Cluster-Konfiguration wird aktualisiert
+  # @source Updating /etc/hosts
+  updatingEtcHosts: /etc/hosts wird aktualisiert
+  # @source Updating kubeconfig
+  updatingKubeconfig: kubeconfig wird aktualisiert
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: Veraltete virtuelle Maschine wird aktualisiert
+  # @source Updating WSL data
+  updatingWslData: WSL-Daten werden aktualisiert
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: WSL-Distribution wird aktualisiert
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: Warten auf Bereitschaft der Container-Engine
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: Warten auf Kubernetes-API
+  # @source Waiting for nodes
+  waitingForNodes: Warten auf Knoten
+  # @source Waiting for services
+  waitingForServices: Warten auf Dienste
+  # @source Writing K3s configuration
+  writingK3sConfiguration: K3s-Konfiguration wird geschrieben
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: Snapshot erstellen
+  card:
+    action:
+      # @source Delete
+      remove: Löschen
+      # @source Restore
+      restore: Wiederherstellen
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: Erstellt am '<b>'{date}'</b>' um '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: Abbrechen
+      # @source Create
+      submit: Erstellen
+    description:
+      # @source Description
+      label: Beschreibung
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: Rancher Desktop ist während der Erstellung eines neuen Snapshots vorübergehend nicht verfügbar
+    name:
+      # @source Snapshot Name
+      label: Snapshot-Name
+    # @source Create a new Snapshot
+    title: Neuen Snapshot erstellen
+  dialog:
+    buttons:
+      # @source Close
+      error: Schließen
+    creating:
+      actions:
+        # @source Cancel
+        cancel: Abbrechen
+      # @source Creating {snapshot}
+      header: '{snapshot} wird erstellt'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: Bitte warten Sie, während der Snapshot '<b>'{snapshot}'</b>' erstellt wird.'<br/>'Dies kann je nach den Ressourcen Ihres Systems einige Zeit dauern.'<br/>'Rancher Desktop ist während dieses Vorgangs vorübergehend nicht verfügbar.'<br/><br/>'Nach Abschluss wird die VM neu gestartet.
+    delete:
+      actions:
+        # @reason Cancel button in delete confirmation dialog
+        # @source Cancel
+        cancel: Abbrechen
+        # @reason Confirm delete button; "Löschen" is the standard German term for delete
+        # @source Delete
+        ok: Löschen
+      # @reason Dialog header asking for confirmation before permanent deletion
+      # @source Permanently delete snapshot?
+      header: Snapshot dauerhaft löschen?
+      # @reason Placeholder value — the English source is literally "text"
+      # @source Deleting a snapshot cannot be undone.
+      info: Das Löschen eines Snapshots kann nicht rückgängig gemacht werden.
+    generic:
+      # @source Snapshot operation in progress
+      header: Snapshot-Vorgang läuft
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: Bitte warten Sie, während der Snapshot-Vorgang aktiv ist.<br/>Dies kann je nach den Ressourcen Ihres Systems einige Zeit dauern.<br/>Rancher Desktop ist während dieses Vorgangs vorübergehend nicht verfügbar.<br/><br/>Nach Abschluss des Snapshot-Vorgangs wird die VM neu gestartet.
+    restore:
+      actions:
+        # @reason Cancel button in restore confirmation dialog
+        # @source Cancel
+        cancel: Abbrechen
+        # @reason Confirm restore button
+        # @source Restore
+        ok: Wiederherstellen
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Rancher Desktop beenden
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: Wiederherstellung des Snapshots '<b>'{snapshot}'</b>' fehlgeschlagen.'<br/><br/>'Rancher Desktop hat einen Werksreset durchgeführt und wird jetzt beendet. Bitte beheben Sie das Problem, das zu diesem Fehler geführt hat, bevor Sie Rancher Desktop neu starten und die Wiederherstellung des Snapshots erneut versuchen.
+        # @source Error restoring snapshot
+        header: Fehler bei der Snapshot-Wiederherstellung
+      # @reason Dialog header for snapshot restore
+      # @source Restore snapshot?
+      header: Snapshot wiederherstellen?
+      # @reason Informational warning that restoring replaces current installation and discards unsaved changes
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: Das Wiederherstellen dieses Snapshots ersetzt Ihre aktuelle Installation einschließlich der Einstellungen. Wenn das Einstellungsfenster geöffnet ist, wird es automatisch geschlossen und alle nicht gespeicherten Änderungen werden verworfen.
+    restoring:
+      actions:
+        # @reason Cancel button shown while restore is in progress
+        # @source Cancel
+        cancel: Abbrechen
+      # @source Restoring {snapshot}
+      header: '{snapshot} wird wiederhergestellt'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: Bitte warten Sie, während der Snapshot '<b>'{snapshot}'</b>' wiederhergestellt wird. Dies kann je nach den Ressourcen Ihres Systems einige Zeit dauern.<br/><br/>Rancher Desktop ist während dieses Vorgangs vorübergehend nicht verfügbar. Nach Abschluss wird die VM mit dem Snapshot {snapshot} neu gestartet.
+    # @source Show logs
+    showLogs: Protokolle anzeigen
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: Klicken Sie auf Snapshot erstellen, um loszulegen
+    # @source No snapshots found
+    heading: Keine Snapshots gefunden
+    # @reason icon identifier, not translatable text
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @reason Notification that snapshot creation was cancelled; {snapshot} is the snapshot name
+      # @source Cancelled creation of {snapshot}
+      cancel: Erstellung von {snapshot} abgebrochen
+      # @reason Success notification; HTML tags and {snapshot} placeholder must be preserved
+      # @source Created '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' erstellt'
+    delete:
+      # @reason Error notification for failed delete; {error} is the error message
+      # @source Delete error: {error}
+      error: 'Fehler beim Löschen: {error}'
+      # @reason Success notification for delete; HTML tags and {snapshot} placeholder preserved
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' gelöscht'
+    lock:
+      # @reason Advisory message about a stale lock file; rdctl command kept in English as a technical identifier
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: Eine Snapshot-Sperrdatei wurde ungewöhnlich lange erkannt. Wenn Sie vermuten, dass dies ein Fehler ist, können Sie versuchen, die Sperrdatei mit <code>rdctl snapshot unlock</code> zu entfernen.
+    restore:
+      # @reason Notification that snapshot restoration was cancelled; {snapshot} is the snapshot name
+      # @source Cancelled restoration of {snapshot}
+      cancel: Wiederherstellung von {snapshot} abgebrochen
+      # @reason Success notification for restore; HTML tags and {snapshot} placeholder preserved
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' wiederhergestellt'
+    # @source  at {time}
+    when: ' um {time}'
+  # @reason 'Snapshot' is the term used throughout de.yaml (Snapshot erstellen, Snapshot-Name); German VM tools like VMware keep it
+  # @source Snapshots
+  title: Snapshots
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: '{actionable} ausgewählt'
+    # @source Available for {actionable} of the {total} selected
+    some: Verfügbar für {actionable} von {total} ausgewählten
+  # @source Add
+  add: Hinzufügen
+  # @source Add Filter
+  addFilter: Filter hinzufügen
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: Aktionen
+  # @source Filter for...
+  filterFor: Filtern nach...
+  # @reason the preposition 'in' is identical in German
+  # @source in
+  in: in
+  # @source No actions available
+  noActions: Keine Aktionen verfügbar
+  # @source There are no rows which match your search query.
+  noData: Es gibt keine Zeilen, die Ihrer Suchanfrage entsprechen.
+  # @source There are no rows to show.
+  noRows: Es gibt keine Zeilen zum Anzeigen.
+  paging:
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: '{pages, plural, =0 {Keine Einträge} =1 {{count} {count, plural, =1 {Eintrag} other {Einträge}}} other {{from} - {to} von {count} Einträgen}}'
+  # @source Reset
+  resetFilters: Zurücksetzen
+  # @reason 'Filter' is the identical German word (der Filter)
+  # @source Filter
+  search: Filter
+  # @source Select a column
+  selectCol: Spalte auswählen
+  tableHeader:
+    # @source Group by
+    groupBy: Gruppieren nach
+    # @source This column cannot be filtered
+    noFilter: Diese Spalte kann nicht gefiltert werden
+    # @source Show
+    show: Anzeigen
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: Immer ohne Administratorzugriff ausführen
+  # @reason 'OK' is standard German button text
+  # @source OK
+  buttonText: OK
+  # @source This will modify the following paths:
+  explanation: 'Folgende Pfade werden geändert:'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'Rancher Desktop benötigt Administratorzugriff ("sudo-Zugriff") aus folgenden Gründen:'
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: Die Eingabeaufforderung wird nach dem Schließen dieses Fensters angezeigt. Wenn Sie die Eingabeaufforderung abbrechen oder den Administratorzugriff deaktivieren, müssen Sie den Docker-Kontext auf rancher-desktop umstellen, um Rancher Desktop weiterhin verwenden zu können.
+  reasons:
+    dockerSocket:
+      # @reason Description of the docker socket sudo prompt reason; "docker" kept as technical term
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: Ermöglicht die Kompatibilität mit Tools, die den Docker-Socket verwenden, ohne die Möglichkeit, Docker-Kontexte zu nutzen.
+      # @reason Title of the docker socket sudo prompt reason
+      # @source Set up default docker socket
+      title: Standard-Docker-Socket einrichten
+    networking:
+      # @reason Description of the networking sudo prompt reason; explains bridged networking benefit
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: Stellt Bridged Networking bereit, damit der Zugriff auf Ihre Container einfacher ist. Wenn dies nicht erlaubt wird, sind Container nur über Port-Weiterleitung zugänglich.
+      # @reason Title of the networking sudo prompt reason
+      # @source Configure networking
+      title: Netzwerk konfigurieren
+  # @source Administrative Access Required
+  title: Administratorzugriff erforderlich
+systemPreferences:
+  # @source # CPUs
+  cpus: Anzahl CPUs
+  # @source Memory (GB)
+  memory: Arbeitsspeicher (GB)
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Senden Sie anonymisierte Nutzungsdaten, Fehlerberichte usw., um Rancher Desktop zu verbessern. Ihre Daten werden nicht an Dritte weitergegeben, und es werden keine Informationen über konkrete Ressourcen oder Endpunkte erfasst, die Sie bereitstellen.
+tray:
+  # @source Container engine: {name}
+  containerEngine: 'Container-Engine: {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Kubernetes-Kontexte
+  # @source Network status: {status}
+  networkStatus: 'Netzwerkstatus: {status}'
+  # @source None found
+  noneFound: Keine gefunden
+  # @source Open cluster dashboard
+  openDashboard: Cluster-Dashboard öffnen
+  # @source Open main window
+  openMainWindow: Hauptfenster öffnen
+  # @source Open preferences dialog
+  openPreferences: Einstellungen öffnen
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Rancher Desktop beenden
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes ist deaktiviert
+    # @source Kubernetes has encountered an error
+    error: Bei Kubernetes ist ein Fehler aufgetreten
+    # @source Kubernetes is running
+    started: Kubernetes wird ausgeführt
+    # @source Kubernetes is starting
+    starting: Kubernetes wird gestartet
+    # @source Kubernetes is stopped
+    stopped: Kubernetes ist gestoppt
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes wird heruntergefahren
+  # @reason product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: Debug-Modus aktivieren
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: Werksreset
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: Der Werksreset entfernt alle Rancher Desktop-Konfigurationen.
+      messageBox:
+        # @source Cancel
+        cancel: Abbrechen
+        # @source Keep cached Kubernetes images
+        checkboxLabel: Zwischengespeicherte Kubernetes-Images behalten
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>Ein Werksreset entfernt Ihren Cluster und alle Rancher Desktop-Einstellungen und beendet Rancher Desktop. Wenn Sie Rancher Desktop weiter verwenden möchten, müssen Sie es manuell starten und die Ersteinrichtung erneut durchführen.</p><p>Möchten Sie wirklich alles zurücksetzen?</p>
+        # @source Perform a factory reset?
+        message: Werksreset durchführen?
+        # @source Factory Reset
+        ok: Werksreset
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - Werksreset
+      # @source Factory Reset
+      title: Werksreset
+    logs:
+      # @source Show Logs
+      buttonText: Protokolle anzeigen
+      # @source Show Rancher Desktop logs
+      description: Rancher Desktop-Protokolle anzeigen
+      # @source Logs
+      title: Protokolle
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Kubernetes zurücksetzen
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: Das Zurücksetzen von Kubernetes löscht alle Workloads und Konfigurationen.
+      messageBox:
+        # @source Cancel
+        cancel: Abbrechen
+        # @source Delete container images
+        checkboxLabel: Container-Images löschen
+        # @source Reset Kubernetes?
+        message: Kubernetes zurücksetzen?
+        # @source Reset
+        ok: Zurücksetzen
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Kubernetes zurücksetzen
+      # @source Reset Kubernetes
+      title: Kubernetes zurücksetzen
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: Haben Sie weiterhin Probleme? Starten Sie eine Diskussion im <b>#rancher-desktop</b>-Kanal auf <a href="https://slack.rancher.io/">Rancher Users Slack</a> oder <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">melden Sie ein Problem</a>.
+  # @source Troubleshooting
+  title: Fehlerbehebung
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: Bitte stellen Sie sicher, dass alle Voraussetzungen erfüllt sind, und versuchen Sie es erneut. Rancher Desktop wird jetzt geschlossen.
+  # @reason 'OK' is standard German button text
+  # @source OK
+  buttonText: OK
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 'Rancher Desktop kann nicht gestartet werden, da Voraussetzungen fehlen oder nicht konfiguriert sind:'
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop kann nicht gestartet werden
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: Update wird angewendet...
+  # @source An update to version {version} is available
+  available: Ein Update auf Version {version} ist verfügbar
+  # @source Check for updates automatically
+  checkForUpdates: Automatisch nach Updates suchen
+  # @source downloading... ({percent}%, {speed})
+  downloading: Wird heruntergeladen... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: Beim Prüfen auf Updates ist ein Fehler aufgetreten.
+  # @source Release Notes
+  releaseNotes: Versionshinweise
+  # @source Restart Now
+  restartNow: Jetzt neu starten
+  # @source Restart the application to apply the update.
+  restartToApply: Starten Sie die Anwendung neu, um das Update anzuwenden.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Eine neuere Version von Rancher Desktop ist verfügbar, wird aber auf Ihrem System nicht unterstützt.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: Weitere Informationen finden Sie in <a href="https://docs.rancherdesktop.io/getting-started/installation">der Installationsdokumentation</a>.
+    # @source Latest Version Not Supported
+    title: Neueste Version nicht unterstützt
+  # @source Update Available
+  updateAvailable: Update verfügbar
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: '"{field}" kann nicht von {from} auf {to} verringert werden.'
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: WebAssembly kann nicht mit klassischem Speicher für moby aktiviert werden.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: Der Wechsel zu klassischem Speicher für moby ist nicht möglich, wenn WebAssembly aktiviert ist.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: Der Wechsel zur moby-Container-Engine mit klassischem Speicher ist nicht möglich, wenn WebAssembly aktiviert ist.
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 'Feld "{field}" enthält doppelte Einträge: "{duplicates}"'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 'Fehler in den vorgeschlagenen Einstellungen:'
+  # @source field "{field}" is locked
+  fieldLocked: Feld "{field}" ist gesperrt.
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: "{pattern}" beschreibt keine Image-Referenz.'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: "{value}" ist keine gültige Zuordnung.'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 'Feld "{field}" enthält ungültige Einträge (erlaubt sind IP-Adressen, CIDR-Subnetze oder Domänennamen): "{entries}"'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: "{name}" ist ein ungültiger Name.'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: "{value}" ist kein gültiger Seitenname für den Einstellungsdialog.'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: Tab-Name "{tabName}" ist kein gültiger Tab-Name für die Einstellungsseite "{page}".'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: "{name}" hat einen ungültigen Tag "{tag}".'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 'Ungültiger Wert für "{field}": <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 'Ungültiger Wert für "{field}": <{value}>; muss einer der folgenden Werte sein: {validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Kubernetes-Version "{version}" nicht gefunden.
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: "{name}" hat einen Tag "{tag}", der nicht vom Typ String ist.'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: Das Ändern von "{field}" über die API wird nicht unterstützt.
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 'Fehler bei Feld ''''{field}'''': Werttyp Array erwartet, ''''{value}'''' erhalten.'
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 'Fehler bei Feld ''''{field}'''': Werttyp {expectedType} erwartet, ''''{value}'''' erhalten.'
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 'Fehler bei Feld ''''{field}'''': Werttyp {expectedType} erwartet, ein Array {value} erhalten.'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: Vorgeschlagenes Feld "{field}" sollte ein Objekt sein, <{value}> erhalten.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: Die Einstellung {field} kann nur auf aarch64-Systemen aktiviert werden.
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: Die Einstellung {field} kann nur geändert werden, wenn virtualMachine.mount.type auf "{mountType}" gesetzt ist.
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: Die Einstellung {field} kann nur aktiviert werden, wenn virtual-machine.type auf "{vmType}" gesetzt ist.
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: Die Einstellung {field} kann nur gesetzt werden, wenn experimental.container-engine.web-assembly.enabled ebenfalls gesetzt ist.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: Die Einstellung {field} auf "{value}" erfordert, dass {otherField} auf "{required}" gesetzt ist.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: Die Einstellung {field} auf "{value}" erfordert, dass {otherField} auf "{option1}" oder "{option2}" gesetzt ist.
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: Die Einstellung "{field}" sollte ein inneres Objekt umschließen, <{value}> erhalten.
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: Die Einstellung "{field}" sollte ein einfacher Wert sein, <{value}> erhalten.
+  # @source One or more fields in this tab contain a form validation error
+  tab: Ein oder mehrere Felder in diesem Tab enthalten einen Validierungsfehler
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: Die Einstellung {field} auf "{vmType}" erfordert auf ARM macOS 13.3 (Ventura) oder neuer.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Die Einstellung {field} auf "{vmType}" erfordert auf Intel macOS 13.0 (Ventura) oder neuer.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: Typ der Dateisystem-Einbindung
+      options:
+        9p:
+          # @reason Description for 9p mount type; QEMU kept as technical term
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: Stellt das Dateisystem über QEMUs virtio-9p-pci-Geräte bereit.
+          # @reason Label for 9p mount type option; technical identifier kept as-is
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: Cache-Modus
+              options:
+                # @reason Technical identifier for cache mode option; kept as-is per rules
+                # @source fscache
+                fscache: fscache
+                # @reason Technical identifier; kept as-is
+                # @source loose
+                loose: loose
+                # @reason Technical identifier; kept as-is
+                # @source mmap
+                mmap: mmap
+                # @reason Technical identifier; kept as-is
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: Zu verwendende Caching-Richtlinie
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: Nachrichtengröße in KiB
+              # @source Maximum message size in KiB
+              tooltip: Maximale Nachrichtengröße in KiB
+            protocolVersion:
+              # @source Protocol Version
+              legend: Protokollversion
+              options:
+                # @reason Technical identifier for protocol version; kept as-is
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason Technical identifier; kept as-is
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason Technical identifier; kept as-is
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: 9P-Protokollversion
+            securityModel:
+              # @source Security Model
+              legend: Sicherheitsmodell
+              options:
+                # @reason Technical identifier for security model option; kept as-is
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason Technical identifier; kept as-is
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason Technical identifier; kept as-is
+                # @source none
+                none: none
+                # @reason Technical identifier; kept as-is
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: Sicherheitsmodell für den Exportpfad
+        reverse-sshfs:
+          # @reason Description for reverse-sshfs mount type; SFTP kept as technical term
+          # @source Exposes the filesystem by running an SFTP server.
+          description: Stellt das Dateisystem bereit, indem ein SFTP-Server ausgeführt wird.
+          # @reason Label for reverse-sshfs mount type; technical identifier kept as-is
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @reason Description for virtiofs mount type; "Apple Virtualization framework" kept as technical term
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Stellt das Dateisystem über ein freigegebenes Verzeichnisgerät des Apple Virtualization Frameworks bereit.
+          # @reason Label for virtiofs mount type; technical identifier kept as-is
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: Adresse
+    # @source Proxy address
+    addressTitle: Proxy-Adresse
+    # @source Authentication information
+    authTitle: Authentifizierungsinformationen
+    # @source Enable the proxy used by rancher-desktop
+    label: Von rancher-desktop verwendeten Proxy aktivieren
+    # @source WSL Proxy
+    legend: WSL-Proxy
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: Dieser Eintrag ist ein Duplikat.
+      # @source Proxy bypass list
+      legend: Liste der Hostnamen ohne Proxy
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: Hostname, der nicht über den Proxy umgeleitet werden soll
+    # @source Password
+    password: Passwort
+    # @reason 'Port' is a German loanword (der Port)
+    # @source Port
+    port: Port
+    # @source Username
+    username: Benutzername
+  type:
+    # @source Virtual Machine Type
+    legend: Typ der virtuellen Maschine
+    options:
+      qemu:
+        # @reason Description for QEMU VM type option; QEMU kept as technical term
+        # @source Use the QEMU emulator.
+        description: Verwendet den QEMU-Emulator.
+        # @reason Label for QEMU VM type option; technical identifier kept as-is
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @reason Description for VZ VM type option; "Apple Virtualization framework" kept as technical term
+        # @source Use the Apple Virtualization framework.
+        description: Verwendet das Apple Virtualization Framework.
+        # @reason Label for VZ VM type option; technical identifier kept as-is
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Rosetta-Unterstützung aktivieren
+    # @source VZ Option
+    legend: VZ-Option
+volumes:
+  files:
+    # @source Available
+    available: Verfügbar
+    # @source Error checking volume status
+    checkError: Fehler beim Prüfen des Volume-Status
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: Ungültiger Volume-Name "{name}"
+    # @source Error listing files: {error}
+    listError: 'Fehler beim Auflisten der Dateien: {error}'
+    # @source Loading volume files...
+    loading: Volume-Dateien werden geladen...
+    # @source This volume is empty
+    noFiles: Dieses Volume ist leer
+    # @source Not Found
+    notFound: Nicht gefunden
+    table:
+      header:
+        # @source Modified
+        modified: Geändert
+        # @reason 'Name' is the identical German word
+        # @source Name
+        name: Name
+        # @source Permissions
+        permissions: Berechtigungen
+        # @source Size
+        size: Größe
+    # @source Volume Files
+    title: Volume-Dateien
+    # @source Volume "{name}" not found
+    volumeNotFound: Volume "{name}" nicht gefunden
+  manage:
+    table:
+      header:
+        # @source Created
+        created: Erstellt
+        # @source Driver
+        driver: Treiber
+        # @source Mount Point
+        mountpoint: Einhängepunkt
+        # @source Volume Name
+        volumeName: Volume-Name
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: Dateien durchsuchen
+        # @source Delete
+        delete: Löschen
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: Es sind keine Volumes vorhanden
+  # @reason nav page title; Docker volume term, standard in German container UIs and used throughout de.yaml (Volume-Name, Volume-Dateien)
+  # @source Volumes
+  title: Volumes
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: Bitte lesen Sie die Dokumentation, bevor Sie die experimentelle WebAssembly-Funktion aktivieren!
+  # @source Enabled
+  enabled: Aktiviert
+  # @reason technology name
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -888,6 +888,8 @@ locale:
   de: Deutsch
   # @source English
   en-us: Englisch
+  # @source French
+  fr: Französisch
   # @source Chinese (Simplified)
   zh-hans: Chinesisch (vereinfacht)
 mainMenu:

--- a/pkg/rancher-desktop/assets/translations/de.yaml
+++ b/pkg/rancher-desktop/assets/translations/de.yaml
@@ -892,6 +892,8 @@ locale:
   es: Spanisch
   # @source French
   fr: Französisch
+  # @source Italian
+  it: Italienisch
   # @source Japanese
   ja: Japanisch
   # @source Portuguese (Brazilian)

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -15,6 +15,7 @@ locale:
   en-us: English
   es: Spanish
   fr: French
+  pt-br: Portuguese (Brazilian)
   zh-hans: Chinese (Simplified)
 nav:
   userMenu:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -15,6 +15,7 @@ locale:
   en-us: English
   es: Spanish
   fr: French
+  ja: Japanese
   pt-br: Portuguese (Brazilian)
   zh-hans: Chinese (Simplified)
 nav:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -17,6 +17,7 @@ locale:
   fr: French
   it: Italian
   ja: Japanese
+  ko: Korean
   pt-br: Portuguese (Brazilian)
   zh-hans: Chinese (Simplified)
 nav:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -13,6 +13,7 @@ generic:
 locale:
   de: German
   en-us: English
+  fr: French
   zh-hans: Chinese (Simplified)
 nav:
   userMenu:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -13,6 +13,7 @@ generic:
 locale:
   de: German
   en-us: English
+  zh-hans: Chinese (Simplified)
 nav:
   userMenu:
     clusterDashboard: Cluster Dashboard

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -15,6 +15,7 @@ locale:
   en-us: English
   es: Spanish
   fr: French
+  it: Italian
   ja: Japanese
   pt-br: Portuguese (Brazilian)
   zh-hans: Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -11,6 +11,7 @@ generic:
   comma: ', '
   loading: Loading&hellip;
 locale:
+  de: German
   en-us: English
 nav:
   userMenu:

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -13,6 +13,7 @@ generic:
 locale:
   de: German
   en-us: English
+  es: Spanish
   fr: French
   zh-hans: Chinese (Simplified)
 nav:

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -840,6 +840,8 @@ locale:
   es: Español
   # @source French
   fr: Francés
+  # @source Japanese
+  ja: Japonés
   # @source Portuguese (Brazilian)
   pt-br: Portugués (Brasil)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -844,6 +844,8 @@ locale:
   it: Italiano
   # @source Japanese
   ja: Japonés
+  # @source Korean
+  ko: Coreano
   # @source Portuguese (Brazilian)
   pt-br: Portugués (Brasil)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -840,6 +840,8 @@ locale:
   es: Español
   # @source French
   fr: Francés
+  # @source Portuguese (Brazilian)
+  pt-br: Portugués (Brasil)
   # @source Chinese (Simplified)
   zh-hans: Chino (simplificado)
 mainMenu:

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -1,0 +1,1867 @@
+action:
+  # @source Refresh
+  refresh: Actualizar
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: El nombre de la imagen debe coincidir con uno de los patrones definidos en la pestaña de configuración Imágenes permitidas.
+  # @source Enable
+  enable: Habilitar
+  errors:
+    # @source This item is a duplicate.
+    duplicate: Este elemento está duplicado.
+  # @source Allowed Image Patterns
+  label: Patrones de imágenes permitidas
+  patterns:
+    # @source Type the image pattern
+    placeholder: Escriba el patrón de imagen
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: Iniciar automáticamente al iniciar sesión
+      # @source Startup
+      legendText: Inicio
+    background:
+      # @source Background
+      legendText: Segundo plano
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Ocultar la ventana de la aplicación cuando Rancher Desktop se ejecuta en segundo plano. Puede abrirse mediante el icono de notificación (si está visible) o ejecutando Rancher Desktop desde el menú de aplicaciones.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: Ocultar el icono de notificación
+      # @source Notification Icon
+      legendText: Icono de notificación
+    startInBackground:
+      # @source Start in the background
+      label: Iniciar en segundo plano
+    theme:
+      # @source Appearance
+      legendText: Apariencia
+      options:
+        dark:
+          # @source Always use dark mode
+          description: Usar siempre el modo oscuro
+          # @source Dark
+          label: Oscuro
+        light:
+          # @source Always use light mode
+          description: Usar siempre el modo claro
+          # @source Light
+          label: Claro
+        system:
+          # @source Follow the operating system setting
+          description: Seguir la configuración del sistema operativo
+          # @source System
+          label: Sistema
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: Salir al cerrar la ventana de la aplicación
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: Permitir credenciales administrativas (acceso sudo)
+      # @source Administrative Access
+      legendText: Acceso administrativo
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: Si está marcada, {appName} obtendrá credenciales administrativas ("acceso sudo") al iniciarse. Esto habilita la red en modo puente y la compatibilidad con el socket predeterminado de docker. Surte efecto en el próximo inicio.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: Buscar actualizaciones automáticamente
+      # @source Automatic Updates
+      legendText: Actualizaciones automáticas
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: Permitir la recopilación de estadísticas anónimas para ayudar a mejorar {appName}
+      # @source Statistics
+      legendText: Estadísticas
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: La comunidad y herramientas de IA proporcionan las traducciones. El inglés es el idioma canónico. Informe de los problemas de traducción en GitHub.
+    # @source Language
+    legendText: Idioma
+asyncButton:
+  activate:
+    # @source Activate
+    action: Activar
+    # @source Activated
+    success: Activado
+    # @source Activating&hellip;
+    waiting: Activando&hellip;
+  apply:
+    # @source Apply
+    action: Aplicar
+    # @source Applied
+    success: Aplicado
+    # @source Applying&hellip;
+    waiting: Aplicando&hellip;
+  continue:
+    # @source Continue
+    action: Continuar
+    # @source Saved
+    success: Guardado
+    # @source Saving&hellip;
+    waiting: Guardando&hellip;
+  copy:
+    # @source Click to Copy
+    action: Haga clic para copiar
+    # @source Copied!
+    success: ¡Copiado!
+  create:
+    # @source Create
+    action: Crear
+    # @source Created
+    success: Creado
+    # @source Creating&hellip;
+    waiting: Creando&hellip;
+  deactivate:
+    # @source Deactivate
+    action: Desactivar
+    # @source Deactivated
+    success: Desactivado
+    # @source Deactivating&hellip;
+    waiting: Desactivando&hellip;
+  default:
+    # @source Action
+    action: Acción
+    # @reason 'Error' is the same word in Spanish.
+    # @source Error
+    error: Error
+    # @source Success
+    success: Éxito
+    # @source Waiting
+    waiting: Esperando
+  delete:
+    # @source Delete
+    action: Eliminar
+    # @source Deleted
+    success: Eliminado
+    # @source Deleting&hellip;
+    waiting: Eliminando&hellip;
+  disable:
+    # @source Disable
+    action: Deshabilitar
+    # @source Disabled
+    success: Deshabilitado
+    # @source Disabling&hellip;
+    waiting: Deshabilitando&hellip;
+  done:
+    # @source Done
+    action: Listo
+    # @source Saved
+    success: Guardado
+    # @source Saving&hellip;
+    waiting: Guardando&hellip;
+  download:
+    # @source Download
+    action: Descargar
+    # @source Saving
+    success: Guardando
+    # @source Downloading&hellip;
+    waiting: Descargando&hellip;
+  edit:
+    # @source Save
+    action: Guardar
+    # @source Saved
+    success: Guardado
+    # @source Saving&hellip;
+    waiting: Guardando&hellip;
+  enable:
+    # @source Enable
+    action: Habilitar
+    # @source Enabled
+    success: Habilitado
+    # @source Enabling&hellip;
+    waiting: Habilitando&hellip;
+  finish:
+    # @source Finish
+    action: Finalizar
+    # @source Finished
+    success: Finalizado
+    # @source Finishing&hellip;
+    waiting: Finalizando&hellip;
+  import:
+    # @source Import
+    action: Importar
+    # @source Imported
+    success: Importado
+    # @source Importing&hellip;
+    waiting: Importando&hellip;
+  install:
+    # @source Install
+    action: Instalar
+    # @source Installing
+    success: Instalando
+    # @source Starting&hellip;
+    waiting: Iniciando&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon identifier, not user-visible text; kept unchanged
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon identifier, not user-visible text; kept unchanged
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon identifier, not user-visible text; kept unchanged
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon identifier, not user-visible text; kept unchanged
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @source Remove
+    action: Quitar
+    # @source Removed
+    success: Quitado
+    # @source Removing&hellip;
+    waiting: Quitando&hellip;
+  restore:
+    # @source Restore
+    action: Restaurar
+    # @source Restored
+    success: Restaurado
+    # @source Restoring&hellip;
+    waiting: Restaurando&hellip;
+  snapshot:
+    # @reason "snapshot" rendered as "instantánea", the established Spanish term for VM/state snapshots
+    # @source Snapshot Now
+    action: Crear instantánea ahora
+    # @source Creating Snapshot
+    success: Creando instantánea
+    # @source Snapshotting&hellip;
+    waiting: Creando instantánea&hellip;
+  uninstall:
+    # @source Uninstall
+    action: Desinstalar
+    # @source Uninstalled
+    success: Desinstalado
+    # @source Uninstalling&hellip;
+    waiting: Desinstalando&hellip;
+  update:
+    # @source Update
+    action: Actualizar
+    # @source Updated
+    success: Actualizado
+    # @source Updating&hellip;
+    waiting: Actualizando&hellip;
+  upgrade:
+    # @reason Spanish uses "actualizar" for both update and upgrade; no distinct common term
+    # @source Upgrade
+    action: Actualizar
+    # @source Upgrading
+    success: Actualizando
+    # @source Starting&hellip;
+    waiting: Iniciando&hellip;
+containerEngine:
+  # @source Container Engine
+  label: Motor de contenedores
+  options:
+    containerd:
+      # @source Namespaces for container images; use with nerdctl.
+      description: Espacios de nombres para las imágenes de contenedores; se usa con nerdctl.
+      # @reason 'containerd' is a product name.
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: API de Docker; se usa con la CLI de Docker.
+      # @reason 'dockerd' and 'moby' are the daemon binary and project names.
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: Información del contenedor
+  # @source Info
+  info: Información
+  # @source Logs
+  logs: Registros
+  search:
+    # @source Search in logs
+    ariaLabel: Buscar en los registros
+    # @source Clear search
+    clearSearch: Borrar búsqueda
+    # @source Next match
+    nextMatch: Coincidencia siguiente
+    # @source Search logs...
+    placeholder: Buscar en los registros...
+    # @source Previous match
+    previousMatch: Coincidencia anterior
+  # @reason Kept in English; standard technical term with no widely used Spanish equivalent
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: Estadísticas
+containerInspect:
+  capabilities:
+    # @reason Feminine plural to agree with "capacidades" (Linux capabilities)
+    # @source Added
+    added: Agregadas
+    # @reason Feminine plural to agree with "capacidades"
+    # @source Dropped
+    dropped: Eliminadas
+  command:
+    # @source Args
+    args: Argumentos
+    # @source Command
+    command: Comando
+    # @reason Kept in English; Dockerfile field name used verbatim in Spanish documentation
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: No se pudieron cargar los detalles del contenedor.
+    # @source An unknown error has occurred
+    unknown: Se ha producido un error desconocido
+  # @source Loading container details…
+  loading: Cargando detalles del contenedor…
+  mounts:
+    # @source Destination
+    destination: Destino
+    # @reason Kept as-is; standard mount-mode abbreviation shown by container tooling
+    # @source RO
+    readOnly: RO
+    # @reason Kept as-is; standard mount-mode abbreviation shown by container tooling
+    # @source RW
+    readWrite: RW
+    # @reason Kept as-is; compact column header matching the RO/RW values below it
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: Origen
+    # @source Type
+    type: Tipo
+  # @reason Masculine default; the placeholder serves sections of mixed grammatical gender
+  # @source None
+  none: Ninguno
+  sections:
+    # @source Capabilities
+    capabilities: Capacidades
+    # @source Command & Args
+    commandArgs: Comando y argumentos
+    # @source Environment
+    environment: Entorno
+    # @source Labels
+    labels: Etiquetas
+    # @source Mounts
+    mounts: Montajes
+    # @source Ports
+    ports: Puertos
+  summary:
+    # @source Created
+    created: Creado
+    # @reason 'ID' is the standard abbreviation in Spanish as well.
+    # @source ID
+    id: ID
+    # @source Image
+    image: Imagen
+    # @source IP Address
+    ipAddress: Dirección IP
+    # @source Name
+    name: Nombre
+    # @source Started
+    started: Iniciado
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: E/S de bloque (bytes/s)
+    # @source CPU %
+    cpu: '% de CPU'
+    # @source Memory
+    memory: Memoria
+    # @source Network I/O (bytes/s)
+    network: E/S de red (bytes/s)
+  interval:
+    # @reason 'min' is also the Spanish abbreviation for minutos.
+    # @source {minutes} min
+    minutes: '{minutes} min'
+    # @reason 's' is the unit symbol for segundos.
+    # @source {seconds} s
+    seconds: '{seconds} s'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: Actualmente, las estadísticas solo están disponibles para el motor Docker (Moby).
+  # @source No processes found.
+  noProcesses: No se encontraron procesos.
+  # @source Stats are only available for running containers.
+  notRunning: Las estadísticas solo están disponibles para los contenedores en ejecución.
+  # @source Processes
+  processes: Procesos
+  # @reason Noun rather than the verb "Actualizar": it labels the interval selector, not an action
+  # @source Refresh
+  refresh: Actualización
+  series:
+    # @source Limit
+    limit: Límite
+    # @source Read
+    read: Lectura
+    # @reason Kept as-is; standard networking abbreviation for receive
+    # @source RX
+    rx: RX
+    # @reason Kept as-is; standard networking abbreviation for transmit
+    # @source TX
+    tx: TX
+    # @reason Feminine to agree with "memoria" (memory chart legend)
+    # @source Used
+    used: Usada
+    # @source Write
+    write: Escritura
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: Información
+        # @source Restart
+        restart: Reiniciar
+        # @source Start
+        start: Iniciar
+        # @source Stop
+        stop: Detener
+      header:
+        # @source Name
+        containerName: Nombre
+        # @source Image
+        image: Imagen
+        # @source Port(s)
+        ports: Puerto(s)
+        # @source Uptime
+        started: Tiempo de actividad
+        # @source State
+        state: Estado
+  sortableTables:
+    # @source There are no containers to show
+    noRows: No hay contenedores que mostrar
+  # @source Containers
+  title: Contenedores
+dashboard:
+  # @reason Product name; kept in English
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop no puede ejecutarse con privilegios de root. Ejecútelo de nuevo como un usuario normal.
+  # @source Cannot run as Root
+  title: No se puede ejecutar como root
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 'Archivo de implementación {path} no válido: no se especificó ninguna versión. Agregue un campo de versión para que sea válido (la versión actual es {version}).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 'Implementación no válida: no se especificó ninguna versión en {path}. Agregue un campo de versión para que sea válida (la versión actual es {version}).'
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} fallidos más {muted} silenciados'
+  # @source Last run:
+  lastRun: 'Última ejecución:'
+  # @source (No fixes available)
+  noFixes: (No hay correcciones disponibles)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: Pruebe a mostrar los diagnósticos silenciados.
+      # @source No results found
+      heading: No se encontraron resultados
+      # @reason Icon identifier, not user-visible text; kept unchanged
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop parece estar funcionando correctamente.
+      # @source No problems detected
+      heading: No se detectaron problemas
+      # @reason Icon identifier, not user-visible text; kept unchanged
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: Mostrar silenciados
+  tableHeaders:
+    # @source Mute
+    mute: Silenciar
+    # @source Name
+    name: Nombre
+  # @source Diagnostics
+  title: Diagnósticos
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: La red compartida tampoco está disponible. El único acceso a la red es mediante el reenvío de puertos al host.
+    # @source Using shared network address {ip}
+    sharedFallback: Usando la dirección de red compartida {ip}
+    # @source Bridged network did not get an IP address.
+    title: La red en modo puente no obtuvo una dirección IP.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: Eliminar cargas de trabajo
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: Bajar de la versión {from} a la {to} hará que se pierdan las cargas de trabajo de Kubernetes existentes. ¿Desea eliminar los datos?
+    # @source Confirming migration
+    title: Confirmación de la migración
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: 'Se usará en su lugar la versión mínima de actualización recomendada: {version}'
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: La versión de Kubernetes solicitada ''{version}'' no es una versión compatible.
+    # @source Invalid Kubernetes Version
+    title: Versión de Kubernetes no válida
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: Obtenga una versión dentro del rango {range} e instálela en ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: No se puede descargar una versión compatible de kubectl en modo sin conexión
+    # @source Network failure
+    title: Fallo de red
+extensions:
+  # @reason Icon identifier, not user-visible text; kept unchanged
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: Parece que aún no tiene ninguna extensión instalada. Explore el catálogo de extensiones para empezar.
+      button:
+        # @source Browse Extensions
+        text: Explorar extensiones
+      # @source No extensions installed
+      heading: No hay extensiones instaladas
+      # @reason Icon identifier, not user-visible text; kept unchanged
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: Quitar
+      # @source Upgrade
+      upgrade: Actualizar
+  view:
+    emptyState:
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: Se ha quitado {extensionId}. Visite el catálogo de extensiones para reinstalar la extensión o busque otras extensiones para mejorar su experiencia con Rancher Desktop.
+      # @reason "Quitar/quitada" for remove (vs "eliminar" for delete), matching the Remove action label
+      # @source Extension removed
+      heading: Extensión quitada
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Habilitar Kubernetes
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (solo versiones en caché)
+    # @source Kubernetes Version
+    legend: Versión de Kubernetes
+    # @source Other Versions
+    otherVersions: Otras versiones
+    # @source Recommended Versions
+    recommendedVersions: Versiones recomendadas
+  # @reason Spanish UI convention: OK buttons are labeled "Aceptar"
+  # @source OK
+  ok: Aceptar
+  # @reason Gender-neutral phrasing instead of "Bienvenido/a"
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Le damos la bienvenida a Rancher Desktop de SUSE
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop proporciona Kubernetes y gestión de imágenes mediante una aplicación de escritorio.
+  # @source Homepage
+  homepage: Página principal
+  # @reason Kept in English; the link goes to the GitHub issue tracker, where the term appears untranslated
+  # @source Issues
+  issues: Issues
+  # @reason 'General' is the same word in Spanish.
+  # @source General
+  navLabel: General
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 'Discusiones del proyecto: <b>#rancher-desktop</b> en el Slack de <a href="https://slack.rancher.io/">Rancher Users</a>'
+  # @source Project Links:
+  projectLinks: 'Enlaces del proyecto:'
+  # @reason Gender-neutral phrasing instead of "Bienvenido/a"
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Le damos la bienvenida a Rancher Desktop de SUSE
+generic:
+  # @source  and 
+  and: ' y '
+  # @source Apply
+  apply: Aplicar
+  # @source Cancel
+  cancel: Cancelar
+  # @source Close
+  close: Cerrar
+  # @reason List separator; Spanish uses the same comma-plus-space.
+  # @source , 
+  comma: ', '
+  # @reason Used as the port-forwarding action button (PortForwarding.vue), so the forwarding sense, not navigation
+  # @source Forward
+  forward: Reenviar
+  # @source Loading&hellip;
+  loading: Cargando&hellip;
+  # @source Namespace
+  namespace: Espacio de nombres
+  # @reason Spanish UI convention: OK buttons are labeled "Aceptar"
+  # @source OK
+  ok: Aceptar
+  # @source Rerun
+  rerun: Volver a ejecutar
+  # @source Search
+  search: Buscar
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: Seleccione el Dockerfile que desea usar (podría tener otro nombre)
+  # @reason "build" of images rendered as "construcción", matching the "Construir" button
+  # @source Pick the build directory
+  buildTitle: Elija el directorio de construcción
+  # @source Error trying to delete images {ids}
+  deleteBatchError: Error al intentar eliminar las imágenes {ids}
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      Error al intentar eliminar la imagen {name} ({id}):
+
+       {error}
+  # @reason "subir" aligns with images.manager.table.action.push (Subir)
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      Error al intentar subir {name}:
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      Error al intentar escanear {name}:
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: Agregar imagen
+  add:
+    action:
+      # @source Build
+      build: Construir
+      gerund:
+        # @source Building
+        build: Construyendo
+        # @reason "Descargando" follows the subtree's pull terminology (Descargar/descargada) instead of the anglicism "pull".
+        # @source Pulling
+        pull: Descargando
+      infinitive:
+        # @source build
+        build: construir
+        # @reason "descargar" follows the subtree's pull terminology (Descargar/descargada) instead of the anglicism "pull".
+        # @source pull
+        pull: descargar
+      pastTense:
+        # @reason Lowercase feminine participle; composed as "Imagen construida" via images.add.successText.
+        # @source Built
+        build: construida
+        # @reason Lowercase feminine participle; composed as "Imagen descargada" via images.add.successText.
+        # @source Pulled
+        pull: descargada
+      # @reason Infinitive so it composes with images.add.errorText ("Error al intentar {action}..."); "descargar" is the common Spanish for pulling an image.
+      # @source Pull
+      pull: Descargar
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Error al intentar { action } ''{ image }'' - consulte la salida de la consola para obtener más información
+    # @reason No article before "imagen", matching the terse en-us style; composes as "Construyendo imagen..." / "Descargando imagen...".
+    # @source {action} image...
+    loadingText: '{action} imagen...'
+    # @reason Reordered: {action} carries a feminine participle (construida/descargada) that follows the noun in Spanish.
+    # @source {action} image
+    successText: Imagen {action}
+    # @source Add Image
+    title: Agregar imagen
+  confirmDelete:
+    # @source Delete
+    confirm: Eliminar
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: ¿Eliminar {count} {count, plural, one {imagen} other {imágenes}}?
+    # @source Delete image {name}:{tag}?
+    single: ¿Eliminar la imagen {name}:{tag}?
+    # @source Confirming image deletion
+    title: Confirmación de eliminación de imágenes
+  manager:
+    # @source Close Output to Continue
+    close: Cerrar la salida para continuar
+    input:
+      build:
+        # @source Build
+        button: Construir
+        # @source Name of image to build:
+        label: 'Nombre de la imagen a construir:'
+        # @reason Example registry reference kept in English; it illustrates the technical format.
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @source Pull
+        button: Descargar
+        # @source Name of image to pull:
+        label: 'Nombre de la imagen a descargar:'
+        # @reason Example registry reference kept in English; it illustrates the technical format.
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: Eliminar
+        # @reason "Subir" (upload to a registry) mirrors "Descargar" for pull; clearer than keeping the anglicism "push".
+        # @source Push
+        push: Subir
+        # @reason "Analizar" is the usual Spanish for vulnerability scanning; avoids the anglicism "escanear".
+        # @source Scan...
+        scan: Analizar...
+      header:
+        # @source Image ID
+        imageId: ID de imagen
+        # @source Image
+        imageName: Imagen
+        # @source Size
+        size: Tamaño
+        # @source Tag
+        tag: Etiqueta
+      # @source All images
+      label: Todas las imágenes
+    # @source Image Output
+    title: Salida de imágenes
+  scan:
+    details:
+      # @source Description
+      description: Descripción
+      # @source Primary URL
+      primaryUrl: URL principal
+      # @source References
+      references: Referencias
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Error al intentar analizar ''{ image }'' - consulte la salida de la consola para obtener más información
+    labels:
+      # @reason Severity labels take feminine forms, agreeing with "gravedad".
+      # @source CRITICAL
+      critical: CRÍTICA
+      # @source HIGH
+      high: ALTA
+      # @source Issues Found
+      issuesFound: Problemas encontrados
+      # @source LOW
+      low: BAJA
+      # @source MEDIUM
+      medium: MEDIA
+    # @source Scanning ''{ image }''
+    loadingText: Analizando ''{ image }''
+    results:
+      headers:
+        # @reason Feminine: the column lists the fixed version ("versión corregida").
+        # @source Fixed
+        fixed: Corregida
+        # @reason Feminine: the column lists the installed version ("versión instalada").
+        # @source Installed
+        installed: Instalada
+        # @source Package
+        package: Paquete
+        # @source Severity
+        severity: Gravedad
+        # @source Vulnerability ID
+        vulnerabilityId: ID de vulnerabilidad
+    # @source Scan details for ''{ image }''
+    title: Detalles del análisis de ''{ image }''
+  sortableTables:
+    # @source There are no images to show
+    noRows: No hay imágenes para mostrar
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: Esperando a que el administrador de imágenes esté listo
+    # @source Error: Unknown state; please reload.
+    unknown: 'Error: estado desconocido; vuelva a cargar.'
+  # @source Images
+  title: Imágenes
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Exponer la configuración de Kubernetes y el socket de Docker de Rancher Desktop a las distribuciones del Subsistema de Windows para Linux (WSL)
+kubernetesError:
+  # @source Context:
+  context: 'Contexto:'
+  # @source Last command run:
+  lastCommand: 'Último comando ejecutado:'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 'Algunas líneas recientes del <a href="#" data-action="showLogs">archivo de registro</a>:'
+  # @source {appName} Error
+  title: Error de {appName}
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Habilitar Kubernetes
+    # @reason 'Kubernetes' is a product name.
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: Opciones
+    # @reason "Spin Operator" kept as a product name.
+    # @source Install Spin Operator
+    spinkube: Instalar Spin Operator
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: El operador Spin requiere que <a href="#" data-navigate="Container Engine,general">WebAssembly</a> esté habilitado.
+    # @source Enable Traefik
+    traefik: Habilitar Traefik
+  port:
+    # @source Kubernetes Port
+    legendText: Puerto de Kubernetes
+  version:
+    # @source Kubernetes version
+    legendText: Versión de Kubernetes
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Versión de Kubernetes (solo versiones en caché)
+    # @source Other Versions
+    otherVersions: Otras versiones
+    # @source Recommended Versions
+    recommendedVersions: Versiones recomendadas
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: Sin opciones
+    # @source No matching options
+    noMatch: No hay opciones coincidentes
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} elementos'
+    # @source Load More...
+    more: Cargar más...
+locale:
+  # @source German
+  de: Alemán
+  # @source English
+  en-us: Inglés
+  # @source Spanish
+  es: Español
+  # @source French
+  fr: Francés
+  # @source Chinese (Simplified)
+  zh-hans: Chino (simplificado)
+mainMenu:
+  # @source About {appName}
+  about: Acerca de {appName}
+  edit:
+    # @source &Copy
+    copy: '&Copiar'
+    # @source Cu&t
+    cut: Cor&tar
+    # @source De&lete
+    delete: '&Eliminar'
+    # @source &Edit
+    label: '&Edición'
+    # @source &Paste
+    paste: '&Pegar'
+    # @source &Redo
+    redo: '&Rehacer'
+    # @reason Accelerator moved to S; T is already taken by "Cor&tar" in the same menu.
+    # @source Select &All
+    selectAll: '&Seleccionar todo'
+    # @source &Undo
+    undo: '&Deshacer'
+  file:
+    # @source Close
+    close: Cerrar
+    # @source E&xit
+    exit: '&Salir'
+    # @source &File
+    label: '&Archivo'
+  help:
+    # @source &About {appName}
+    about: '&Acerca de {appName}'
+    # @reason Noun form; the item links to the community discussion forum, and an imperative would read oddly in Spanish menus.
+    # @source &Discuss
+    discuss: '&Discusiones'
+    # @source File a &Bug
+    fileABug: Informar de un &error
+    # @source Get &Help
+    getHelp: Obtener a&yuda
+    # @source {appName} &Help
+    help: Ay&uda de {appName}
+    # @source &Help
+    label: Ay&uda
+    # @source &Project Page
+    projectPage: '&Página del proyecto'
+  # @source Hide {appName}
+  hide: Ocultar {appName}
+  # @source Hide Others
+  hideOthers: Ocultar los demás
+  # @source Preferences
+  preferences: Configuración
+  # @source Quit {appName}
+  quit: Salir de {appName}
+  # @source Services
+  services: Servicios
+  # @source Show All
+  showAll: Mostrar todo
+  view:
+    # @source &Actual Size
+    actualSize: '&Tamaño real'
+    # @source &Force Reload
+    forceReload: '&Forzar recarga'
+    # @source &View
+    label: '&Ver'
+    # @source &Reload
+    reload: '&Recargar'
+    # @source Toggle &Developer Tools
+    toggleDevTools: Alternar herramientas de &desarrollo
+    # @source Toggle Full &Screen
+    toggleFullScreen: Alternar &pantalla completa
+    # @source Zoom &In
+    zoomIn: '&Acercar'
+    # @source Zoom &Out
+    zoomOut: Ale&jar
+  window:
+    # @source Bring All to Front
+    front: Traer todo al frente
+    # @source &Window
+    label: Ve&ntana
+    # @source Minimize
+    minimize: Minimizar
+    # @reason "Zoom" matches the macOS Spanish Window menu.
+    # @source Zoom
+    zoom: Zoom
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: Descripción
+        # @source Name
+        name: Nombre
+        # @source Vendor
+        vendor: Proveedor
+  labels:
+    # @source Install
+    install: Instalar
+    # @source Remove
+    uninstall: Quitar
+    # @source Upgrade
+    upgrade: Actualizar
+  loading:
+    # @source Installing...
+    install: Instalando...
+    # @source Removing...
+    uninstall: Quitando...
+    # @source Upgrading...
+    upgrade: Actualizando...
+  # @source More information
+  moreInfo: Más información
+  # @source No extension found for the search criteria
+  noResults: No se encontró ninguna extensión para los criterios de búsqueda
+  tabs:
+    # @source Catalog
+    catalog: Catálogo
+    # @reason Feminine plural, agreeing with "extensiones".
+    # @source Installed
+    installed: Instaladas
+  # @source Extensions
+  title: Extensiones
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: Panel del clúster
+    # @source Preferences
+    preferences: Configuración
+pathManagement:
+  # @source Configure PATH
+  label: Configurar PATH
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop no modifica la configuración de su PATH; agregue <code>$HOME/.rd/bin</code> a su PATH manualmente.
+      # @reason 'Manual' is the same word in Spanish.
+      # @source Manual
+      label: Manual
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop edita el perfil de su shell por usted. Reinicie los shells que tenga abiertos para que los cambios surtan efecto.
+      # @source Automatic
+      label: Automático
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop incluye herramientas como kubectl, nerdctl, helm y docker. Para poder usar estas herramientas, <code>$HOME/.rd/bin</code> debe estar en su PATH.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Incluir servicios de Kubernetes
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: Puerto local
+        # @source Name
+        name: Nombre
+        # @reason Kubernetes term; "espacio de nombres" per the Kubernetes Spanish documentation.
+        # @source Namespace
+        namespace: Espacio de nombres
+        # @source Port
+        port: Puerto
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: No hay entradas de reenvío de puertos para mostrar
+  # @source Port Forwarding
+  title: Reenvío de puertos
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: Hay un problema con la configuración seleccionada.
+      # @source Kubernetes will reset after applying changes.
+      reset: Kubernetes se restablecerá después de aplicar los cambios.
+      # @source Kubernetes will restart after applying changes.
+      restart: Kubernetes se reiniciará después de aplicar los cambios.
+  containerEngine:
+    webAssembly:
+      # @reason "Spin Operator" kept as a product name inside the link text.
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: WebAssembly debe estar habilitado para que se pueda instalar el <a href="#" data-navigate="Kubernetes">Spin Operator</a>.
+  error:
+    # @source Reload Preferences to try again.
+    body: Vuelva a cargar la configuración para volver a intentarlo.
+    # @source Unable to fetch preferences
+    heading: No se pudo obtener la configuración
+    # @source Reload preferences
+    reload: Volver a cargar la configuración
+  # @source Preferences
+  header: Configuración
+  # @reason Spanish "o" should become "u" before words starting with o-/ho-; the fragment cannot adapt to what follows at runtime.
+  # @source or
+  incompatiblePrefWarningOr: o
+  # @reason Composed at runtime as Pre + option + Post: "La opción requiere que <X> no esté seleccionado."; the negation must live in this fragment.
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: no esté seleccionado.
+  # @reason Composed at runtime as Pre + option + Post: "La opción requiere que <X> esté seleccionado."
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: esté seleccionado.
+  # @reason Ends with "que" so the runtime-inserted option reads as a subjunctive clause completed by the Post fragments.
+  # @source The option requires
+  incompatibleTypeWarningPre: La opción requiere que
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: Bloqueado por la política de la organización
+  nav:
+    # @source Application
+    application: Aplicación
+    # @source Container Engine
+    containerEngine: Motor de contenedores
+    # @reason 'Kubernetes' is a product name.
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: Máquina virtual
+    # @reason 'WSL' is the product name (Windows Subsystem for Linux).
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: Aplicar y restablecer
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: Estos cambios restablecerán el clúster de Kubernetes, lo que provocará la pérdida de las cargas de trabajo y de las imágenes de contenedores.
+    # @source Apply preferences and reset Kubernetes?
+    message: ¿Aplicar la configuración y restablecer Kubernetes?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Restablecer Kubernetes
+  tabs:
+    # @source Allowed Images
+    allowedImages: Imágenes permitidas
+    # @source Behavior
+    behavior: Comportamiento
+    # @source Emulation
+    emulation: Emulación
+    # @source Environment
+    environment: Entorno
+    # @reason 'General' is the same word in Spanish.
+    # @source General
+    general: General
+    # @reason 'Hardware' is an established loanword in Spanish (RAE), used as-is in Windows/macOS Spanish UIs.
+    # @source Hardware
+    hardware: Hardware
+    # @source Integrations
+    integrations: Integraciones
+    # @reason 'Proxy' is an established loanword in Spanish (RAE), used as-is in Spanish network settings UIs.
+    # @source Proxy
+    proxy: Proxy
+    # @source Volumes
+    volumes: Volúmenes
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: Hay cambios de configuración que no se han aplicado. Se perderán todos los cambios no guardados.
+    # @source Discard changes
+    discardChanges: Descartar cambios
+    # @source Close preferences without applying?
+    message: ¿Cerrar la configuración sin aplicar los cambios?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - Cerrar configuración
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - Configuración
+prefs:
+  # @reason 'Experimental' is the same word in Spanish.
+  # @source Experimental
+  experimental: Experimental
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: Esta opción requiere macOS 13.3 (Ventura) o posterior.
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: Esta opción requiere macOS 13.0 (Ventura) o posterior.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: Esta opción requiere usar el modo de emulación VZ. VZ solo está disponible en macOS 13.3 (Ventura) o posterior.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: Esta opción requiere usar el modo de emulación VZ. VZ solo está disponible en macOS 13.0 (Ventura) o posterior.
+product:
+  containerEngine:
+    # @reason Abbreviation of the English "Container Engine" used across the product; no established Spanish abbreviation.
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: Motor de contenedores
+  # @source deactivated
+  deactivated: desactivado
+  # @reason 'Kubernetes' is a product name.
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: Estado de la red
+  networkStatusValues:
+    # @source checking...
+    checking: comprobando...
+    # @source offline
+    offline: sin conexión
+    # @source online
+    online: en línea
+  # @source Version
+  version: Versión
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: Solicitando permiso para ejecutar tareas como administrador
+  # @source Bundling certificates
+  bundlingCertificates: Empaquetando certificados
+  # @source Checking k3s images
+  checkingK3sImages: Comprobando las imágenes de k3s
+  # @source Configuring container engine
+  configuringContainerEngine: Configurando el motor de contenedores
+  # @source Configuring image proxy
+  configuringImageProxy: Configurando el proxy de imágenes
+  # @source Configuring logrotate
+  configuringLogrotate: Configurando logrotate
+  # @source Container engine components
+  containerEngineComponents: Componentes del motor de contenedores
+  # @source Copying certificates
+  copyingCertificates: Copiando certificados
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: Eliminando el estado incompatible de Kubernetes
+  # @source Deleting Kubernetes
+  deletingKubernetes: Eliminando Kubernetes
+  # @source Deleting virtual machine
+  deletingVirtualMachine: Eliminando la máquina virtual
+  # @source DNS configuration
+  dnsConfiguration: Configuración de DNS
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: Comprobando que kubectl sea compatible
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: Comprobando la compatibilidad con la virtualización
+  # @source Expecting user permission to continue
+  expectingPermission: Esperando el permiso del usuario para continuar
+  # @source Extracting certificates
+  extractingCertificates: Extrayendo certificados
+  # @source Fetching certificates
+  fetchingCertificates: Obteniendo certificados
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Inicializando Rancher Desktop
+  # @source Initializing WSL data
+  initializingWslData: Inicializando los datos de WSL
+  # @source Installing Buildkit
+  installingBuildkit: Instalando Buildkit
+  # @source Installing CA certificates
+  installingCaCertificates: Instalando certificados de CA
+  # @source Installing container engine
+  installingContainerEngine: Instalando el motor de contenedores
+  # @reason "Asistente de credenciales" follows common Spanish documentation usage for "credential helper".
+  # @source Installing credential helper
+  installingCredentialHelper: Instalando el asistente de credenciales
+  # @reason "docker-credential" is the helper binary name prefix; kept verbatim.
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: Instalando el asistente docker-credential
+  # @source Installing helpers
+  installingHelpers: Instalando utilidades auxiliares
+  # @source Installing image scanner
+  installingImageScanner: Instalando el analizador de imágenes
+  # @source Installing k3s
+  installingK3s: Instalando k3s
+  # @source Installing Kubernetes
+  installingKubernetes: Instalando Kubernetes
+  # @source Kubernetes components
+  kubernetesComponents: Componentes de Kubernetes
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Compatibilidad de Kubernetes con dockerd
+  # @source Mounting WSL data
+  mountingWslData: Montando los datos de WSL
+  # @source Preparing to start
+  preparingToStart: Preparándose para iniciar
+  # @source Proxy Config Setup
+  proxyConfigSetup: Configuración del proxy
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Agente invitado de Rancher Desktop
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: Regenerando la configuración para tener en cuenta la falta de permisos
+  # @source Registering WSL distribution
+  registeringWslDistribution: Registrando la distribución de WSL
+  # @source Removing existing certificates
+  removingExistingCertificates: Eliminando los certificados existentes
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: Eliminando el operador spinkube
+  # @source Removing stale state
+  removingStaleState: Eliminando el estado obsoleto
+  # @source Removing Traefik
+  removingTraefik: Eliminando Traefik
+  # @source Resetting Kubernetes
+  resettingKubernetes: Restableciendo Kubernetes
+  # @source Running provisioning scripts
+  runningProvisioningScripts: Ejecutando scripts de aprovisionamiento
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: Ejecutando update-ca-certificates
+  # @source Setting docker context
+  settingDockerContext: Estableciendo el contexto de docker
+  # @source Setting Lima permissions
+  settingLimaPermissions: Estableciendo los permisos de Lima
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Configurando el socket de Docker
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: Configurando la red ethernet virtual
+  # @source Shutting down
+  shuttingDown: Apagando
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: Omitiendo las comprobaciones de nodos; flannel está deshabilitado
+  # @source Starting Backend
+  startingBackend: Iniciando el backend
+  # @source Starting buildkit
+  startingBuildkit: Iniciando buildkit
+  # @source Starting container engine
+  startingContainerEngine: Iniciando el motor de contenedores
+  # @source Starting image proxy
+  startingImageProxy: Iniciando el proxy de imágenes
+  # @source Starting k3s
+  startingK3s: Iniciando k3s
+  # @source Starting Kubernetes
+  startingKubernetes: Iniciando Kubernetes
+  # @source Starting proxy
+  startingProxy: Iniciando el proxy
+  # @source Starting {service}
+  startingService: Iniciando {service}
+  # @source Starting virtual machine
+  startingVirtualMachine: Iniciando la máquina virtual
+  # @source Starting WSL environment
+  startingWslEnvironment: Iniciando el entorno WSL
+  # @source Stopping existing instance
+  stoppingExistingInstance: Deteniendo la instancia existente
+  # @source Stopping mock backend
+  stoppingMockBackend: Deteniendo el backend simulado
+  # @source Stopping services
+  stoppingServices: Deteniendo servicios
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: Actualizando la configuración del clúster
+  # @source Updating /etc/hosts
+  updatingEtcHosts: Actualizando /etc/hosts
+  # @source Updating kubeconfig
+  updatingKubeconfig: Actualizando kubeconfig
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: Actualizando la máquina virtual obsoleta
+  # @source Updating WSL data
+  updatingWslData: Actualizando los datos de WSL
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: Actualizando la distribución de WSL
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: Esperando a que el motor de contenedores esté listo
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: Esperando la API de Kubernetes
+  # @source Waiting for nodes
+  waitingForNodes: Esperando los nodos
+  # @source Waiting for services
+  waitingForServices: Esperando los servicios
+  # @source Writing K3s configuration
+  writingK3sConfiguration: Escribiendo la configuración de K3s
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: Crear instantánea
+  card:
+    action:
+      # @source Delete
+      remove: Eliminar
+      # @source Restore
+      restore: Restaurar
+    # @reason Feminine 'Creada' agrees with 'instantánea' (snapshot).
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: Creada el '<b>'{date}'</b>' a las '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: Cancelar
+      # @source Create
+      submit: Crear
+    description:
+      # @source Description
+      label: Descripción
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: Rancher Desktop no estará disponible temporalmente mientras se crea una nueva instantánea
+    name:
+      # @source Snapshot Name
+      label: Nombre de la instantánea
+    # @source Create a new Snapshot
+    title: Crear una nueva instantánea
+  dialog:
+    buttons:
+      # @source Close
+      error: Cerrar
+    creating:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+      # @source Creating {snapshot}
+      header: Creando {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: Espere mientras se crea la instantánea '<b>'{snapshot}'</b>'.'<br/>'Esto puede tardar algún tiempo según los recursos de su máquina.'<br/>'Rancher Desktop no estará disponible temporalmente durante esta operación.'<br/><br/>'Una vez completada la instantánea, la máquina virtual se reiniciará.
+    delete:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Delete
+        ok: Eliminar
+      # @source Permanently delete snapshot?
+      header: ¿Eliminar la instantánea de forma permanente?
+      # @reason English source is a literal stub ('text'), not a real sentence; kept unchanged until the source gets real content.
+      # @source Deleting a snapshot cannot be undone.
+      info: La eliminación de una instantánea no se puede deshacer.
+    generic:
+      # @source Snapshot operation in progress
+      header: Operación de instantánea en curso
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: Espere mientras la operación de instantánea está activa.<br/>Esto puede tardar algún tiempo según los recursos de su máquina.<br/>Rancher Desktop no estará disponible temporalmente durante esta operación.<br/><br/>Una vez completado el proceso de instantánea, la máquina virtual se reiniciará.
+    restore:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Restore
+        ok: Restaurar
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Salir de Rancher Desktop
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: No se pudo restaurar la instantánea '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop ha realizado un restablecimiento de fábrica y se cerrará ahora. Intente resolver el problema que provocó este error antes de reiniciar Rancher Desktop y volver a intentar restaurar la instantánea.
+        # @source Error restoring snapshot
+        header: Error al restaurar la instantánea
+      # @source Restore snapshot?
+      header: ¿Restaurar la instantánea?
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: Restaurar esta instantánea reemplazará su instalación actual, incluida la configuración. Si la ventana de Configuración está abierta, se cerrará automáticamente y se descartarán los cambios que no haya guardado.
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+      # @source Restoring {snapshot}
+      header: Restaurando {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: Espere mientras se restaura la instantánea '<b>'{snapshot}'</b>'. Esto puede tardar algún tiempo según los recursos de su máquina.<br/><br/>Rancher Desktop no estará disponible temporalmente durante esta operación. Una vez completada, la máquina virtual se reiniciará con la instantánea {snapshot} activa.
+    # @source Show logs
+    showLogs: Mostrar registros
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: Haga clic en Crear instantánea para comenzar
+    # @source No snapshots found
+    heading: No se encontraron instantáneas
+    # @reason Icon identifier, not user-visible text; kept unchanged.
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: Se canceló la creación de {snapshot}
+      # @source Created '<b>'{snapshot}'</b>'
+      success: Se creó '<b>'{snapshot}'</b>'
+    delete:
+      # @source Delete error: {error}
+      error: 'Error al eliminar: {error}'
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: Se eliminó '<b>'{snapshot}'</b>'
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: Se ha detectado un archivo de bloqueo de instantánea durante un tiempo inusualmente largo. Si cree que se trata de un error, puede intentar eliminar el archivo de bloqueo ejecutando <code>rdctl snapshot unlock</code>.
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: Se canceló la restauración de {snapshot}
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: Se restauró '<b>'{snapshot}'</b>'
+    # @source  at {time}
+    when: ' a las {time}'
+  # @reason 'Snapshot' rendered as 'instantánea', the established Spanish term for VM snapshots; the rdctl 'snapshot' command name stays English.
+  # @source Snapshots
+  title: Instantáneas
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: '{actionable} seleccionados'
+    # @source Available for {actionable} of the {total} selected
+    some: Disponible para {actionable} de los {total} seleccionados
+  # @source Add
+  add: Agregar
+  # @source Add Filter
+  addFilter: Agregar filtro
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: Acciones
+  # @source Filter for...
+  filterFor: Filtrar por...
+  # @reason Standalone connector; translated as 'en' assuming the 'filter ... in <column group>' context.
+  # @source in
+  in: en
+  # @source No actions available
+  noActions: No hay acciones disponibles
+  # @source There are no rows which match your search query.
+  noData: No hay filas que coincidan con su búsqueda.
+  # @source There are no rows to show.
+  noRows: No hay filas para mostrar.
+  paging:
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {Sin elementos}
+        =1 {{count} {count, plural, =1 {elemento} other {elementos}}}
+        other {{from} - {to} de {count} elementos}}
+  # @source Reset
+  resetFilters: Restablecer
+  # @source Filter
+  search: Filtrar
+  # @source Select a column
+  selectCol: Seleccionar una columna
+  tableHeader:
+    # @source Group by
+    groupBy: Agrupar por
+    # @source This column cannot be filtered
+    noFilter: No se puede filtrar por esta columna
+    # @source Show
+    show: Mostrar
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: Ejecutar siempre sin acceso administrativo
+  # @source OK
+  buttonText: Aceptar
+  # @source This will modify the following paths:
+  explanation: 'Esto modificará las siguientes rutas:'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'Rancher Desktop requiere acceso administrativo ("acceso sudo") por los siguientes motivos:'
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: La solicitud se mostrará una vez que se cierre esta ventana. Si cancela la solicitud o deshabilita el acceso administrativo, deberá cambiar el contexto de docker a rancher-desktop para seguir usando Rancher Desktop.
+  reasons:
+    dockerSocket:
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: Proporciona compatibilidad con herramientas que usan el socket de docker sin la capacidad de usar contextos de docker.
+      # @source Set up default docker socket
+      title: Configurar el socket de docker predeterminado
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: Proporciona red en modo puente para que sea más fácil acceder a sus contenedores. Si no se permite, los contenedores solo serán accesibles mediante el reenvío de puertos.
+      # @source Configure networking
+      title: Configurar la red
+  # @source Administrative Access Required
+  title: Se requiere acceso administrativo
+systemPreferences:
+  # @reason '#' rendered as 'N.º'; Spanish initialisms like CPU do not take a plural 's'.
+  # @source # CPUs
+  cpus: N.º de CPU
+  # @source Memory (GB)
+  memory: Memoria (GB)
+telemetryOptIn:
+  # @reason 'endpoints' kept in English; it is the common term in Spanish technical usage.
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Envía información de uso anonimizada, informes de errores, etc. para ayudar a mejorar Rancher Desktop. Sus datos no se compartirán con nadie más y no se incluye información sobre los recursos o endpoints específicos que esté desplegando.
+tray:
+  # @source Container engine: {name}
+  containerEngine: 'Motor de contenedores: {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Contextos de Kubernetes
+  # @source Network status: {status}
+  networkStatus: 'Estado de la red: {status}'
+  # @source None found
+  noneFound: No se encontró ninguno
+  # @source Open cluster dashboard
+  openDashboard: Abrir el panel del clúster
+  # @source Open main window
+  openMainWindow: Abrir la ventana principal
+  # @source Open preferences dialog
+  openPreferences: Abrir el diálogo de configuración
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Salir de Rancher Desktop
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes está deshabilitado
+    # @source Kubernetes has encountered an error
+    error: Kubernetes ha encontrado un error
+    # @source Kubernetes is running
+    started: Kubernetes está en ejecución
+    # @source Kubernetes is starting
+    starting: Kubernetes se está iniciando
+    # @source Kubernetes is stopped
+    stopped: Kubernetes está detenido
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes se está deteniendo
+  # @reason 'Rancher Desktop' is the product name.
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: Habilitar el modo de depuración
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: Restablecimiento de fábrica
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: El restablecimiento de fábrica eliminará todas las configuraciones de Rancher Desktop.
+      messageBox:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Keep cached Kubernetes images
+        checkboxLabel: Conservar las imágenes de Kubernetes en caché
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>Realizar un restablecimiento de fábrica eliminará su clúster y toda la configuración de Rancher Desktop, y cerrará Rancher Desktop. Si desea seguir usando Rancher Desktop, deberá iniciarlo manualmente y realizar de nuevo la configuración inicial.</p><p>¿Está seguro de que desea restablecerlo todo?</p>
+        # @source Perform a factory reset?
+        message: ¿Realizar un restablecimiento de fábrica?
+        # @reason Confirm button shortened to the action verb; the dialog text already says 'de fábrica'.
+        # @source Factory Reset
+        ok: Restablecer
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - Restablecimiento de fábrica
+      # @source Factory Reset
+      title: Restablecimiento de fábrica
+    logs:
+      # @source Show Logs
+      buttonText: Mostrar registros
+      # @source Show Rancher Desktop logs
+      description: Mostrar los registros de Rancher Desktop
+      # @source Logs
+      title: Registros
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Restablecer Kubernetes
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: Restablecer Kubernetes eliminará todas las cargas de trabajo y la configuración.
+      messageBox:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Delete container images
+        checkboxLabel: Eliminar las imágenes de contenedor
+        # @source Reset Kubernetes?
+        message: ¿Restablecer Kubernetes?
+        # @source Reset
+        ok: Restablecer
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Restablecer Kubernetes
+      # @source Reset Kubernetes
+      title: Restablecer Kubernetes
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: ¿Sigue teniendo problemas? Inicie una conversación en el canal <b>#rancher-desktop</b> del <a href="https://slack.rancher.io/">Slack de usuarios de Rancher</a> o <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">informe de un problema</a>.
+  # @source Troubleshooting
+  title: Solución de problemas
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: Asegúrese de que se cumplan todos los requisitos y vuelva a intentarlo. Rancher Desktop se cerrará ahora.
+  # @source OK
+  buttonText: Aceptar
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 'Rancher Desktop no puede iniciarse porque faltan requisitos o no están configurados:'
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop no puede iniciarse
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: Aplicando la actualización...
+  # @source An update to version {version} is available
+  available: Hay disponible una actualización a la versión {version}
+  # @source Check for updates automatically
+  checkForUpdates: Buscar actualizaciones automáticamente
+  # @reason Lowercase kept; the source is lowercase because the string is appended inline.
+  # @source downloading... ({percent}%, {speed})
+  downloading: descargando... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: Se produjo un error al buscar actualizaciones.
+  # @source Release Notes
+  releaseNotes: Notas de la versión
+  # @source Restart Now
+  restartNow: Reiniciar ahora
+  # @source Restart the application to apply the update.
+  restartToApply: Reinicie la aplicación para aplicar la actualización.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Hay disponible una versión más reciente de Rancher Desktop, pero no es compatible con su sistema.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: Para obtener más información, consulte <a href="https://docs.rancherdesktop.io/getting-started/installation">la documentación de instalación</a>.
+    # @source Latest Version Not Supported
+    title: La versión más reciente no es compatible
+  # @source Update Available
+  updateAvailable: Actualización disponible
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: No se puede reducir "{field}" de {from} a {to}
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: No se puede habilitar WebAssembly con el almacenamiento clásico para moby.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: No se puede cambiar al almacenamiento clásico para moby cuando WebAssembly está habilitado.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: No se puede cambiar al motor de contenedores moby con almacenamiento clásico cuando WebAssembly está habilitado.
+  # @reason Lowercase start kept to match the source, which is a fragment appended to other error text.
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 'el campo "{field}" tiene entradas duplicadas: "{duplicates}"'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 'Errores en la configuración propuesta:'
+  # @source field "{field}" is locked
+  fieldLocked: el campo "{field}" está bloqueado
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: "{pattern}" no describe una referencia de imagen'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: "{value}" no es una asignación válida'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: "{name}" no es un nombre válido'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 'el campo "{field}" tiene entradas no válidas (deben ser direcciones IP, subredes CIDR o nombres de dominio): "{entries}"'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: "{value}" no es un nombre de página válido para el diálogo de Configuración'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: el nombre de pestaña "{tabName}" no es válido para la página de Configuración "{page}"'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: "{name}" tiene la etiqueta no válida "{tag}"'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 'Valor no válido para "{field}": <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 'Valor no válido para "{field}": <{value}>; debe ser uno de {validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: No se encontró la versión de Kubernetes "{version}".
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: "{name}" tiene una etiqueta que no es una cadena: "{tag}"'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: No se admite cambiar el campo "{field}" mediante la API.
+  # @reason 'array' kept in English; it names the literal JSON type in deployment profiles.
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 'Error en el campo ''''{field}'''': se esperaba un valor de tipo array, se obtuvo ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 'Error en el campo ''''{field}'''': se esperaba un valor de tipo {expectedType}, se obtuvo ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 'Error en el campo ''''{field}'''': se esperaba un valor de tipo {expectedType}, se obtuvo un array {value}'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: El campo propuesto "{field}" debería ser un objeto, se obtuvo <{value}>.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: La opción {field} solo se puede habilitar en sistemas aarch64.
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: La opción {field} solo se puede cambiar cuando virtualMachine.mount.type es "{mountType}".
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: La opción {field} solo se puede habilitar cuando virtual-machine.type es "{vmType}".
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: La opción {field} solo se puede establecer cuando experimental.container-engine.web-assembly.enabled también está establecida.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: Establecer {field} en "{value}" requiere que {otherField} sea "{required}".
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: Establecer {field} en "{value}" requiere que {otherField} sea "{option1}" o "{option2}".
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: La opción "{field}" debería contener un objeto interno, pero se obtuvo <{value}>.
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: La opción "{field}" debería ser un valor simple, pero se obtuvo <{value}>.
+  # @source One or more fields in this tab contain a form validation error
+  tab: Uno o más campos de esta pestaña contienen un error de validación del formulario
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: Establecer {field} en "{vmType}" en ARM requiere macOS 13.3 (Ventura) o posterior.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Establecer {field} en "{vmType}" en Intel requiere macOS 13.0 (Ventura) o posterior.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: Tipo de montaje
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: Expone el sistema de archivos mediante los dispositivos virtio-9p-pci de QEMU.
+          # @reason Literal mount-type value; must match the setting, kept in English.
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: Modo de caché
+              options:
+                # @reason Literal 9p cache-mode value; must match the setting, kept in English.
+                # @source fscache
+                fscache: fscache
+                # @reason Literal 9p cache-mode value; must match the setting, kept in English.
+                # @source loose
+                loose: loose
+                # @reason Literal 9p cache-mode value; must match the setting, kept in English.
+                # @source mmap
+                mmap: mmap
+                # @reason Literal 9p cache-mode value; must match the setting, kept in English.
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: Política de caché que se utilizará
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: Tamaño de mensaje en KiB
+              # @source Maximum message size in KiB
+              tooltip: Tamaño máximo de mensaje en KiB
+            protocolVersion:
+              # @source Protocol Version
+              legend: Versión del protocolo
+              options:
+                # @reason Literal 9p protocol-version value; must match the setting, kept in English.
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason Literal 9p protocol-version value; must match the setting, kept in English.
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason Literal 9p protocol-version value; must match the setting, kept in English.
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: Versión del protocolo 9P
+            securityModel:
+              # @source Security Model
+              legend: Modelo de seguridad
+              options:
+                # @reason Literal 9p security-model value; kept in English.
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason Literal 9p security-model value; kept in English.
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason Literal 9p security-model value; kept in English.
+                # @source none
+                none: none
+                # @reason Literal 9p security-model value; kept in English.
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: Modelo de seguridad usado para la ruta de exportación
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: Expone el sistema de archivos ejecutando un servidor SFTP.
+          # @reason Literal mount-type value; must match the setting, kept in English.
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @reason 'Apple Virtualization' kept as the framework's product name.
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Expone el sistema de archivos mediante un dispositivo de directorio compartido del framework Apple Virtualization.
+          # @reason Literal mount-type value; must match the setting, kept in English.
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: Dirección
+    # @source Proxy address
+    addressTitle: Dirección del proxy
+    # @source Authentication information
+    authTitle: Información de autenticación
+    # @source Enable the proxy used by rancher-desktop
+    label: Habilitar el proxy usado por rancher-desktop
+    # @source WSL Proxy
+    legend: Proxy de WSL
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: Este elemento está duplicado.
+      # @source Proxy bypass list
+      legend: Lista de exclusión del proxy
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: IP, CIDR, dominio o comodín (*.example.com) para omitir el proxy
+    # @source Password
+    password: Contraseña
+    # @source Port
+    port: Puerto
+    # @source Username
+    username: Nombre de usuario
+  type:
+    # @source Virtual Machine Type
+    legend: Tipo de máquina virtual
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: Usar el emulador QEMU.
+        # @reason 'QEMU' is a product name.
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @reason 'Apple Virtualization' kept as the framework's product name.
+        # @source Use the Apple Virtualization framework.
+        description: Usar el framework Apple Virtualization.
+        # @reason 'VZ' is the identifier for the Apple Virtualization framework backend.
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Habilitar la compatibilidad con Rosetta
+    # @source VZ Option
+    legend: Opción de VZ
+volumes:
+  files:
+    # @source Available
+    available: Disponible
+    # @source Error checking volume status
+    checkError: Error al comprobar el estado del volumen
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: 'Nombre de volumen no válido: "{name}"'
+    # @source Error listing files: {error}
+    listError: 'Error al listar los archivos: {error}'
+    # @source Loading volume files...
+    loading: Cargando los archivos del volumen...
+    # @source This volume is empty
+    noFiles: Este volumen está vacío
+    # @source Not Found
+    notFound: No encontrado
+    table:
+      header:
+        # @source Modified
+        modified: Modificado
+        # @source Name
+        name: Nombre
+        # @source Permissions
+        permissions: Permisos
+        # @source Size
+        size: Tamaño
+    # @source Volume Files
+    title: Archivos del volumen
+    # @source Volume "{name}" not found
+    volumeNotFound: No se encontró el volumen "{name}"
+  manage:
+    table:
+      header:
+        # @source Created
+        created: Creado
+        # @source Driver
+        driver: Controlador
+        # @source Mount Point
+        mountpoint: Punto de montaje
+        # @source Volume Name
+        volumeName: Nombre del volumen
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: Explorar archivos
+        # @source Delete
+        delete: Eliminar
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: No hay volúmenes para mostrar
+  # @source Volumes
+  title: Volúmenes
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: ¡Lea la documentación antes de habilitar la función experimental de WebAssembly!
+  # @source Enabled
+  enabled: Habilitado
+  # @reason 'WebAssembly (Wasm)' is a technology name.
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/es.yaml
+++ b/pkg/rancher-desktop/assets/translations/es.yaml
@@ -840,6 +840,8 @@ locale:
   es: Español
   # @source French
   fr: Francés
+  # @source Italian
+  it: Italiano
   # @source Japanese
   ja: Japonés
   # @source Portuguese (Brazilian)

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -857,6 +857,8 @@ locale:
   it: Italien
   # @source Japanese
   ja: Japonais
+  # @source Korean
+  ko: Coréen
   # @source Portuguese (Brazilian)
   pt-br: Portugais (Brésil)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -853,6 +853,8 @@ locale:
   es: Espagnol
   # @source French
   fr: Français
+  # @source Japanese
+  ja: Japonais
   # @source Portuguese (Brazilian)
   pt-br: Portugais (Brésil)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -853,6 +853,8 @@ locale:
   es: Espagnol
   # @source French
   fr: Français
+  # @source Portuguese (Brazilian)
+  pt-br: Portugais (Brésil)
   # @source Chinese (Simplified)
   zh-hans: Chinois (simplifié)
 mainMenu:

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -1,0 +1,1888 @@
+action:
+  # @source Refresh
+  refresh: Actualiser
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: Le nom de l'image doit correspondre à l'un des motifs définis dans l'onglet de préférences « Images autorisées ».
+  # @source Enable
+  enable: Activer
+  errors:
+    # @source This item is a duplicate.
+    duplicate: Cet élément est un doublon.
+  # @source Allowed Image Patterns
+  label: Motifs d'images autorisées
+  patterns:
+    # @source Type the image pattern
+    placeholder: Saisissez le motif d'image
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: Démarrer automatiquement à l'ouverture de session
+      # @source Startup
+      legendText: Démarrage
+    background:
+      # @source Background
+      legendText: Arrière-plan
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Masquer la fenêtre de l'application lorsque Rancher Desktop s'exécute en arrière-plan. Elle peut être rouverte via l'icône de notification (si elle est visible) ou en lançant Rancher Desktop depuis le menu Applications.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: Masquer l'icône de notification
+      # @source Notification Icon
+      legendText: Icône de notification
+    startInBackground:
+      # @source Start in the background
+      label: Démarrer en arrière-plan
+    theme:
+      # @source Appearance
+      legendText: Apparence
+      options:
+        dark:
+          # @source Always use dark mode
+          description: Toujours utiliser le mode sombre
+          # @source Dark
+          label: Sombre
+        light:
+          # @source Always use light mode
+          description: Toujours utiliser le mode clair
+          # @source Light
+          label: Clair
+        system:
+          # @source Follow the operating system setting
+          description: Suivre le réglage du système d'exploitation
+          # @source System
+          label: Système
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: Quitter à la fermeture de la fenêtre de l'application
+  general:
+    adminAccess:
+      # @reason "administrative credentials" rendered as admin privileges; it refers to sudo rights, not login credentials
+      # @source Allow administrative credentials (sudo access)
+      label: Autoriser les privilèges d'administration (accès sudo)
+      # @source Administrative Access
+      legendText: Accès administratif
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: Si cette option est cochée, {appName} obtiendra des privilèges d'administration (« accès sudo ») au démarrage. Cela active le réseau en pont et la prise en charge du socket docker par défaut. Prend effet au prochain démarrage.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: Rechercher automatiquement les mises à jour
+      # @source Automatic Updates
+      legendText: Mises à jour automatiques
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: Autoriser la collecte de statistiques anonymes pour aider à améliorer {appName}
+      # @source Statistics
+      legendText: Statistiques
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: Les traductions sont fournies par la communauté et des outils d'IA. L'anglais est la langue de référence. Signalez les problèmes de traduction sur GitHub.
+    # @source Language
+    legendText: Langue
+asyncButton:
+  activate:
+    # @source Activate
+    action: Activer
+    # @source Activated
+    success: Activé
+    # @source Activating&hellip;
+    waiting: Activation&hellip;
+  apply:
+    # @source Apply
+    action: Appliquer
+    # @source Applied
+    success: Appliqué
+    # @source Applying&hellip;
+    waiting: Application&hellip;
+  continue:
+    # @source Continue
+    action: Continuer
+    # @source Saved
+    success: Enregistré
+    # @source Saving&hellip;
+    waiting: Enregistrement&hellip;
+  copy:
+    # @source Click to Copy
+    action: Cliquer pour copier
+    # @source Copied!
+    success: Copié !
+  create:
+    # @source Create
+    action: Créer
+    # @source Created
+    success: Créé
+    # @source Creating&hellip;
+    waiting: Création&hellip;
+  deactivate:
+    # @source Deactivate
+    action: Désactiver
+    # @source Deactivated
+    success: Désactivé
+    # @source Deactivating&hellip;
+    waiting: Désactivation&hellip;
+  default:
+    # @reason 'Action' is the same word in French
+    # @source Action
+    action: Action
+    # @source Error
+    error: Erreur
+    # @source Success
+    success: Succès
+    # @source Waiting
+    waiting: En attente
+  delete:
+    # @source Delete
+    action: Supprimer
+    # @source Deleted
+    success: Supprimé
+    # @source Deleting&hellip;
+    waiting: Suppression&hellip;
+  disable:
+    # @source Disable
+    action: Désactiver
+    # @source Disabled
+    success: Désactivé
+    # @source Disabling&hellip;
+    waiting: Désactivation&hellip;
+  done:
+    # @source Done
+    action: Terminé
+    # @source Saved
+    success: Enregistré
+    # @source Saving&hellip;
+    waiting: Enregistrement&hellip;
+  download:
+    # @source Download
+    action: Télécharger
+    # @source Saving
+    success: Enregistrement
+    # @source Downloading&hellip;
+    waiting: Téléchargement&hellip;
+  edit:
+    # @source Save
+    action: Enregistrer
+    # @source Saved
+    success: Enregistré
+    # @source Saving&hellip;
+    waiting: Enregistrement&hellip;
+  enable:
+    # @source Enable
+    action: Activer
+    # @source Enabled
+    success: Activé
+    # @source Enabling&hellip;
+    waiting: Activation&hellip;
+  finish:
+    # @source Finish
+    action: Terminer
+    # @source Finished
+    success: Terminé
+    # @source Finishing&hellip;
+    waiting: Finalisation&hellip;
+  import:
+    # @source Import
+    action: Importer
+    # @source Imported
+    success: Importé
+    # @source Importing&hellip;
+    waiting: Importation&hellip;
+  install:
+    # @source Install
+    action: Installer
+    # @source Installing
+    success: Installation
+    # @source Starting&hellip;
+    waiting: Démarrage&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon identifier, not user-visible text
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon identifier, not user-visible text
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon identifier, not user-visible text
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon identifier, not user-visible text
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @reason "Retirer" to distinguish remove from delete = "Supprimer"
+    # @source Remove
+    action: Retirer
+    # @source Removed
+    success: Retiré
+    # @source Removing&hellip;
+    waiting: Retrait&hellip;
+  restore:
+    # @source Restore
+    action: Restaurer
+    # @source Restored
+    success: Restauré
+    # @source Restoring&hellip;
+    waiting: Restauration&hellip;
+  snapshot:
+    # @reason "Snapshot Now" as a concise button label; the immediacy is implied by the action
+    # @source Snapshot Now
+    action: Créer un instantané
+    # @source Creating Snapshot
+    success: Création de l'instantané
+    # @source Snapshotting&hellip;
+    waiting: Création de l'instantané&hellip;
+  uninstall:
+    # @source Uninstall
+    action: Désinstaller
+    # @source Uninstalled
+    success: Désinstallé
+    # @source Uninstalling&hellip;
+    waiting: Désinstallation&hellip;
+  update:
+    # @source Update
+    action: Mettre à jour
+    # @source Updated
+    success: Mis à jour
+    # @source Updating&hellip;
+    waiting: Mise à jour&hellip;
+  upgrade:
+    # @source Upgrade
+    action: Mettre à niveau
+    # @source Upgrading
+    success: Mise à niveau
+    # @source Starting&hellip;
+    waiting: Démarrage&hellip;
+containerEngine:
+  # @source Container Engine
+  label: Moteur de conteneurs
+  options:
+    containerd:
+      # @source Namespaces for container images; use with nerdctl.
+      description: Espaces de noms pour les images de conteneurs ; à utiliser avec nerdctl.
+      # @reason containerd is a product name
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: API Docker ; à utiliser avec la CLI Docker.
+      # @reason dockerd and moby are product names
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: Informations sur le conteneur
+  # @source Info
+  info: Infos
+  # @source Logs
+  logs: Journaux
+  search:
+    # @source Search in logs
+    ariaLabel: Rechercher dans les journaux
+    # @source Clear search
+    clearSearch: Effacer la recherche
+    # @source Next match
+    nextMatch: Correspondance suivante
+    # @source Search logs...
+    placeholder: Rechercher dans les journaux...
+    # @source Previous match
+    previousMatch: Correspondance précédente
+  # @reason Standard technical term in French
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: Statistiques
+containerInspect:
+  capabilities:
+    # @reason Feminine plural, agrees with "capacités"
+    # @source Added
+    added: Ajoutées
+    # @reason Feminine plural, agrees with "capacités"
+    # @source Dropped
+    dropped: Retirées
+  command:
+    # @source Args
+    args: Arguments
+    # @source Command
+    command: Commande
+    # @reason Dockerfile directive name, kept in English
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: Échec du chargement des détails du conteneur.
+    # @source An unknown error has occurred
+    unknown: Une erreur inconnue s'est produite
+  # @source Loading container details…
+  loading: Chargement des détails du conteneur…
+  mounts:
+    # @reason 'Destination' is the same word in French
+    # @source Destination
+    destination: Destination
+    # @reason Kept RO/RW, the mount-mode abbreviations shown by docker itself
+    # @source RO
+    readOnly: RO
+    # @reason Kept RO/RW, the mount-mode abbreviations shown by docker itself
+    # @source RW
+    readWrite: RW
+    # @reason Kept in English to match the RO/RW values displayed in this column
+    # @source R/W
+    rw: R/W
+    # @reason 'Source' is the same word in French
+    # @source Source
+    source: Source
+    # @reason 'Type' is the same word in French
+    # @source Type
+    type: Type
+  # @reason "Aucune entrée" (no entries) avoids gender agreement with the varying section nouns
+  # @source None
+  none: Aucune entrée
+  sections:
+    # @source Capabilities
+    capabilities: Capacités
+    # @source Command & Args
+    commandArgs: Commande et arguments
+    # @source Environment
+    environment: Environnement
+    # @source Labels
+    labels: Étiquettes
+    # @source Mounts
+    mounts: Montages
+    # @reason 'Ports' is the same word in French
+    # @source Ports
+    ports: Ports
+  summary:
+    # @source Created
+    created: Créé
+    # @reason 'ID' is the standard abbreviation in French UIs (cf. « ID de l'image » elsewhere in this file)
+    # @source ID
+    id: ID
+    # @reason 'Image' is the same word in French
+    # @source Image
+    image: Image
+    # @source IP Address
+    ipAddress: Adresse IP
+    # @source Name
+    name: Nom
+    # @source Started
+    started: Démarré
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: E/S de blocs (octets/s)
+    # @source CPU %
+    cpu: '% CPU'
+    # @source Memory
+    memory: Mémoire
+    # @source Network I/O (bytes/s)
+    network: E/S réseau (octets/s)
+  interval:
+    # @reason 'min' is the French abbreviation for minutes as well
+    # @source {minutes} min
+    minutes: '{minutes} min'
+    # @reason 's' is the SI symbol for seconds in French as well
+    # @source {seconds} s
+    seconds: '{seconds} s'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: Les statistiques ne sont actuellement disponibles que pour le moteur Docker (Moby).
+  # @source No processes found.
+  noProcesses: Aucun processus trouvé.
+  # @source Stats are only available for running containers.
+  notRunning: Les statistiques ne sont disponibles que pour les conteneurs en cours d'exécution.
+  # @source Processes
+  processes: Processus
+  # @reason Noun form: labels the refresh-interval selector, not an action button
+  # @source Refresh
+  refresh: Actualisation
+  series:
+    # @source Limit
+    limit: Limite
+    # @source Read
+    read: Lecture
+    # @reason RX/TX are the standard network abbreviations in French as well
+    # @source RX
+    rx: RX
+    # @reason RX/TX are the standard network abbreviations in French as well
+    # @source TX
+    tx: TX
+    # @reason Feminine, agrees with "mémoire"
+    # @source Used
+    used: Utilisée
+    # @source Write
+    write: Écriture
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: Infos
+        # @source Restart
+        restart: Redémarrer
+        # @source Start
+        start: Démarrer
+        # @source Stop
+        stop: Arrêter
+      header:
+        # @source Name
+        containerName: Nom
+        # @reason 'Image' is the same word in French
+        # @source Image
+        image: Image
+        # @reason 'Port(s)' is the same word in French
+        # @source Port(s)
+        ports: Port(s)
+        # @source Uptime
+        started: Durée d'exécution
+        # @source State
+        state: État
+  sortableTables:
+    # @source There are no containers to show
+    noRows: Aucun conteneur à afficher
+  # @source Containers
+  title: Conteneurs
+dashboard:
+  # @reason Product name, kept in English (matches the de locale)
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop ne peut pas être exécuté avec les privilèges root. Veuillez le relancer en tant qu'utilisateur normal.
+  # @source Cannot run as Root
+  title: Exécution en tant que root impossible
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 'Fichier de déploiement {path} non valide : aucune version spécifiée. Ajoutez un champ version pour le rendre valide (la version actuelle est {version}).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 'Déploiement non valide : aucune version spécifiée dans {path}. Ajoutez un champ version pour le rendre valide (la version actuelle est {version}).'
+diagnostics:
+  # @reason "muted" rendered as "ignoré" throughout the diagnostics page
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} en échec et {muted} ignorés'
+  # @source Last run:
+  lastRun: 'Dernière exécution :'
+  # @source (No fixes available)
+  noFixes: (Aucun correctif disponible)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: Essayez d'afficher les diagnostics ignorés.
+      # @source No results found
+      heading: Aucun résultat trouvé
+      # @reason Icon identifier, not user-visible text
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop semble fonctionner correctement.
+      # @source No problems detected
+      heading: Aucun problème détecté
+      # @reason Icon identifier, not user-visible text
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: Afficher les ignorés
+  tableHeaders:
+    # @reason "Ignorer" = mute; hides the diagnostic result from the list
+    # @source Mute
+    mute: Ignorer
+    # @source Name
+    name: Nom
+  # @reason nav page title; 'Diagnostics' is the same word in French (plural of « diagnostic »)
+  # @source Diagnostics
+  title: Diagnostics
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: Le réseau partagé n'est pas disponible non plus. Le seul accès réseau se fait par la redirection de ports vers l'hôte.
+    # @source Using shared network address {ip}
+    sharedFallback: Utilisation de l'adresse du réseau partagé {ip}
+    # @source Bridged network did not get an IP address.
+    title: Le réseau en pont n'a pas obtenu d'adresse IP.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: Supprimer les charges de travail
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: La rétrogradation de {from} vers {to} entraînera la perte des charges de travail Kubernetes existantes. Supprimer les données ?
+    # @source Confirming migration
+    title: Confirmation de la migration
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: Repli sur la version de mise à niveau minimale recommandée {version}
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: La version de Kubernetes demandée ''{version}'' n'est pas une version prise en charge.
+    # @source Invalid Kubernetes Version
+    title: Version de Kubernetes non valide
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: Veuillez obtenir une version dans la plage {range} et l'installer dans ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: Impossible de télécharger une version compatible de kubectl en mode hors ligne
+    # @source Network failure
+    title: Erreur réseau
+extensions:
+  # @reason Icon identifier, not user-visible text
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: Il semble que vous n'ayez encore aucune extension installée. Parcourez le catalogue d'extensions pour commencer.
+      button:
+        # @source Browse Extensions
+        text: Parcourir les extensions
+      # @source No extensions installed
+      heading: Aucune extension installée
+      # @reason Icon identifier, not user-visible text
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: Supprimer
+      # @source Upgrade
+      upgrade: Mettre à niveau
+  view:
+    emptyState:
+      # @reason Feminine agreement (supprimée): {extensionId} names an extension
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId} a été supprimée. Visitez le catalogue d''extensions pour réinstaller l''extension ou parcourez d''autres extensions pour enrichir votre expérience Rancher Desktop.'
+      # @source Extension removed
+      heading: Extension supprimée
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Activer Kubernetes
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (versions en cache uniquement)
+    # @source Kubernetes Version
+    legend: Version de Kubernetes
+    # @source Other Versions
+    otherVersions: Autres versions
+    # @source Recommended Versions
+    recommendedVersions: Versions recommandées
+  # @reason 'OK' is standard on French buttons
+  # @source OK
+  ok: OK
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Bienvenue dans Rancher Desktop par SUSE
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop fournit Kubernetes et la gestion d'images via une application de bureau.
+  # @source Homepage
+  homepage: Page d'accueil
+  # @reason GitHub tab name, kept in English; the link targets the GitHub issue tracker
+  # @source Issues
+  issues: Issues
+  # @source General
+  navLabel: Général
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 'Discussions du projet : <b>#rancher-desktop</b> sur le Slack <a href="https://slack.rancher.io/">Rancher Users</a>'
+  # @source Project Links:
+  projectLinks: 'Liens du projet :'
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Bienvenue dans Rancher Desktop par SUSE
+generic:
+  # @source  and 
+  and: ' et '
+  # @source Apply
+  apply: Appliquer
+  # @source Cancel
+  cancel: Annuler
+  # @source Close
+  close: Fermer
+  # @reason list-separator punctuation, identical in French
+  # @source , 
+  comma: ', '
+  # @reason Port-forwarding action button (PortForwarding.vue); French uses "redirection de ports"
+  # @source Forward
+  forward: Rediriger
+  # @source Loading&hellip;
+  loading: Chargement&hellip;
+  # @source Namespace
+  namespace: Espace de noms
+  # @reason 'OK' is standard on French buttons
+  # @source OK
+  ok: OK
+  # @source Rerun
+  rerun: Réexécuter
+  # @source Search
+  search: Rechercher
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: Veuillez sélectionner le Dockerfile à utiliser (il peut porter un autre nom)
+  # @source Pick the build directory
+  buildTitle: Choisissez le répertoire de construction
+  # @source Error trying to delete images {ids}
+  deleteBatchError: Erreur lors de la suppression des images {ids}
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      Erreur lors de la suppression de l'image {name} ({id}) :
+
+       {error}
+  # @reason "push" kept as the docker CLI operation name
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      Erreur lors du push de {name} :
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      Erreur lors de l'analyse de {name} :
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: Ajouter une image
+  add:
+    action:
+      # @source Build
+      build: Construire
+      gerund:
+        # @reason Action noun rather than a gerund; composes with loadingText as « Construction de l'image en cours... ».
+        # @source Building
+        build: Construction
+        # @reason Action noun rather than a gerund; composes with loadingText as « Téléchargement de l'image en cours... ».
+        # @source Pulling
+        pull: Téléchargement
+      infinitive:
+        # @source build
+        build: construire
+        # @source pull
+        pull: télécharger
+      pastTense:
+        # @reason Lowercase feminine participle; flows into images.add.successText, reordered as "Image {action}".
+        # @source Built
+        build: construite
+        # @reason Lowercase feminine participle, agrees with "image"; see images.add.successText.
+        # @source Pulled
+        pull: téléchargée
+      # @reason Tab label translated as a French verb; the raw "pull"/"build" identifiers only appear where code interpolates them (loadingText/errorText).
+      # @source Pull
+      pull: Télécharger
+    # @reason Guillemets replace the ICU-escaped apostrophes, matching images.scan.errorText; « en tentant de » takes the infinitive { action }.
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Erreur en tentant de { action } « { image } » - consultez la sortie de la console pour plus d'informations
+    # @reason Restructured: {action} receives an action noun (Construction/Téléchargement); « en cours » conveys the progressive aspect, as in the previous translation.
+    # @source {action} image...
+    loadingText: '{action} de l''image en cours...'
+    # @reason Reordered: {action} receives the feminine past participle from images.add.action.pastTense.*.
+    # @source {action} image
+    successText: Image {action}
+    # @source Add Image
+    title: Ajouter une image
+  confirmDelete:
+    # @source Delete
+    confirm: Supprimer
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: Supprimer {count} {count, plural, one {image} other {images}} ?
+    # @source Delete image {name}:{tag}?
+    single: Supprimer l'image {name}:{tag} ?
+    # @source Confirming image deletion
+    title: Confirmation de la suppression d'images
+  manager:
+    # @source Close Output to Continue
+    close: Fermer la sortie pour continuer
+    input:
+      build:
+        # @source Build
+        button: Construire
+        # @source Name of image to build:
+        label: 'Nom de l''image à construire :'
+        # @reason Technical example value, kept verbatim.
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @source Pull
+        button: Télécharger
+        # @source Name of image to pull:
+        label: 'Nom de l''image à télécharger :'
+        # @reason Technical example value, kept verbatim.
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: Supprimer
+        # @reason Accepted French verb for pushing to a registry (as with git push); "Publier" would suggest publishing.
+        # @source Push
+        push: Pousser
+        # @source Scan...
+        scan: Analyser...
+      header:
+        # @source Image ID
+        imageId: ID de l'image
+        # @reason 'Image' is the same word in French
+        # @source Image
+        imageName: Image
+        # @source Size
+        size: Taille
+        # @reason Docker tag; commonly left in English in French container tooling ("étiquette" would be ambiguous).
+        # @source Tag
+        tag: Tag
+      # @source All images
+      label: Toutes les images
+    # @reason Heading over the build/pull console output; literal "Sortie d'image" would read as image export. Matches errorText's "sortie de la console".
+    # @source Image Output
+    title: Sortie de la console
+  scan:
+    details:
+      # @reason 'Description' is the same word in French
+      # @source Description
+      description: Description
+      # @source Primary URL
+      primaryUrl: URL principale
+      # @source References
+      references: Références
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Erreur lors de l'analyse de « { image } » - consultez la sortie de la console pour plus d'informations
+    labels:
+      # @source CRITICAL
+      critical: CRITIQUE
+      # @reason Feminine form, agreeing with "Gravité" (severity); same for MOYENNE.
+      # @source HIGH
+      high: ÉLEVÉE
+      # @source Issues Found
+      issuesFound: Problèmes détectés
+      # @source LOW
+      low: FAIBLE
+      # @source MEDIUM
+      medium: MOYENNE
+    # @source Scanning ''{ image }''
+    loadingText: Analyse de « { image } »
+    results:
+      headers:
+        # @reason Expanded; the bare participle would be ambiguous as a column header.
+        # @source Fixed
+        fixed: Version corrigée
+        # @reason Expanded; the bare participle would be ambiguous as a column header.
+        # @source Installed
+        installed: Version installée
+        # @source Package
+        package: Paquet
+        # @source Severity
+        severity: Gravité
+        # @source Vulnerability ID
+        vulnerabilityId: ID de vulnérabilité
+    # @source Scan details for ''{ image }''
+    title: Détails de l'analyse de « { image } »
+  sortableTables:
+    # @source There are no images to show
+    noRows: Aucune image à afficher
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: En attente de la disponibilité du gestionnaire d'images
+    # @source Error: Unknown state; please reload.
+    unknown: 'Erreur : état inconnu ; veuillez recharger.'
+  # @reason nav page title; 'Images' is the same word in French
+  # @source Images
+  title: Images
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Exposer la configuration Kubernetes et le socket Docker de Rancher Desktop aux distributions WSL (Windows Subsystem for Linux)
+kubernetesError:
+  # @source Context:
+  context: 'Contexte :'
+  # @source Last command run:
+  lastCommand: 'Dernière commande exécutée :'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 'Quelques lignes récentes du <a href="#" data-action="showLogs">fichier journal</a> :'
+  # @source {appName} Error
+  title: Erreur de {appName}
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Activer Kubernetes
+    # @reason Kubernetes is a product name
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @reason 'Options' is the same word in French
+    # @source Options
+    legendText: Options
+    # @reason "Operator" translated (standard Kubernetes term "opérateur"); "Spin" is a product name.
+    # @source Install Spin Operator
+    spinkube: Installer l'opérateur Spin
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: L'opérateur Spin nécessite que <a href="#" data-navigate="Container Engine,general">WebAssembly</a> soit activé.
+    # @source Enable Traefik
+    traefik: Activer Traefik
+  port:
+    # @source Kubernetes Port
+    legendText: Port Kubernetes
+  version:
+    # @source Kubernetes version
+    legendText: Version de Kubernetes
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Version de Kubernetes (versions en cache uniquement)
+    # @source Other Versions
+    otherVersions: Autres versions
+    # @source Recommended Versions
+    recommendedVersions: Versions recommandées
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: Aucune option
+    # @source No matching options
+    noMatch: Aucune option correspondante
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} éléments'
+    # @source Load More...
+    more: Charger plus...
+locale:
+  # @source German
+  de: Allemand
+  # @source English
+  en-us: Anglais
+  # @source French
+  fr: Français
+  # @source Chinese (Simplified)
+  zh-hans: Chinois (simplifié)
+mainMenu:
+  # @source About {appName}
+  about: À propos de {appName}
+  edit:
+    # @source &Copy
+    copy: '&Copier'
+    # @source Cu&t
+    cut: Co&uper
+    # @source De&lete
+    delete: '&Supprimer'
+    # @source &Edit
+    label: '&Édition'
+    # @source &Paste
+    paste: C&oller
+    # @source &Redo
+    redo: '&Rétablir'
+    # @source Select &All
+    selectAll: Sélectionner &tout
+    # @source &Undo
+    undo: '&Annuler'
+  file:
+    # @source Close
+    close: Fermer
+    # @source E&xit
+    exit: '&Quitter'
+    # @source &File
+    label: '&Fichier'
+  help:
+    # @source &About {appName}
+    about: À &propos de {appName}
+    # @source &Discuss
+    discuss: '&Discuter'
+    # @reason "bogue" is the standard French term; "bug" is a common anglicism.
+    # @source File a &Bug
+    fileABug: Signaler un &bogue
+    # @source Get &Help
+    getHelp: Obtenir de l'&aide
+    # @reason Accelerator on "e" to avoid clashing with "Obtenir de l'&aide" in the same menu.
+    # @source {appName} &Help
+    help: Aid&e de {appName}
+    # @reason Accelerator on "d" to avoid clashing with "&Affichage" in the menu bar.
+    # @source &Help
+    label: Ai&de
+    # @reason Accelerator moved to "j" to avoid clashing with "À &propos" in the same menu.
+    # @source &Project Page
+    projectPage: Page du pro&jet
+  # @source Hide {appName}
+  hide: Masquer {appName}
+  # @source Hide Others
+  hideOthers: Masquer les autres
+  # @reason Unified on "Paramètres" for all Preferences UI; native macOS French would use "Réglages"/"Préférences".
+  # @source Preferences
+  preferences: Paramètres
+  # @source Quit {appName}
+  quit: Quitter {appName}
+  # @reason macOS Services menu (role: services); named 'Services' in French macOS as well
+  # @source Services
+  services: Services
+  # @source Show All
+  showAll: Tout afficher
+  view:
+    # @source &Actual Size
+    actualSize: '&Taille réelle'
+    # @source &Force Reload
+    forceReload: '&Forcer le rechargement'
+    # @source &View
+    label: '&Affichage'
+    # @source &Reload
+    reload: '&Recharger'
+    # @source Toggle &Developer Tools
+    toggleDevTools: Afficher/Masquer les outils de &développement
+    # @source Toggle Full &Screen
+    toggleFullScreen: Activer/Désactiver le mode &plein écran
+    # @source Zoom &In
+    zoomIn: Zoom &avant
+    # @source Zoom &Out
+    zoomOut: Zoom arr&ière
+  window:
+    # @source Bring All to Front
+    front: Tout ramener au premier plan
+    # @source &Window
+    label: Fe&nêtre
+    # @source Minimize
+    minimize: Réduire
+    # @reason macOS French convention for the Window > Zoom command.
+    # @source Zoom
+    zoom: Réduire/agrandir
+marketplace:
+  installed:
+    table:
+      header:
+        # @reason 'Description' is the same word in French
+        # @source Description
+        description: Description
+        # @source Name
+        name: Nom
+        # @source Vendor
+        vendor: Éditeur
+  labels:
+    # @source Install
+    install: Installer
+    # @source Remove
+    uninstall: Supprimer
+    # @source Upgrade
+    upgrade: Mettre à jour
+  loading:
+    # @source Installing...
+    install: Installation...
+    # @source Removing...
+    uninstall: Suppression...
+    # @source Upgrading...
+    upgrade: Mise à jour...
+  # @source More information
+  moreInfo: Plus d'informations
+  # @source No extension found for the search criteria
+  noResults: Aucune extension ne correspond aux critères de recherche
+  tabs:
+    # @source Catalog
+    catalog: Catalogue
+    # @reason Feminine plural, agreeing with "extensions".
+    # @source Installed
+    installed: Installées
+  # @reason nav page title; 'Extensions' is the same word in French
+  # @source Extensions
+  title: Extensions
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: Tableau de bord du cluster
+    # @source Preferences
+    preferences: Paramètres
+pathManagement:
+  # @source Configure PATH
+  label: Configurer le PATH
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop ne modifie pas votre configuration du PATH ; ajoutez <code>$HOME/.rd/bin</code> à votre PATH manuellement.
+      # @reason Feminine, agreeing with "configuration" (the PATH configuration method).
+      # @source Manual
+      label: Manuelle
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop modifie votre profil de shell pour vous. Redémarrez tout shell ouvert pour que les modifications prennent effet.
+      # @source Automatic
+      label: Automatique
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop est livré avec des outils tels que kubectl, nerdctl, helm et docker. Pour utiliser ces outils, <code>$HOME/.rd/bin</code> doit figurer dans votre PATH.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Inclure les services Kubernetes
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: Port local
+        # @source Name
+        name: Nom
+        # @source Namespace
+        namespace: Espace de noms
+        # @reason 'Port' is the same word in French
+        # @source Port
+        port: Port
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: Aucune redirection de port à afficher
+  # @source Port Forwarding
+  title: Redirection de ports
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: Il y a un problème avec la sélection des paramètres.
+      # @source Kubernetes will reset after applying changes.
+      reset: Kubernetes sera réinitialisé après l'application des modifications.
+      # @source Kubernetes will restart after applying changes.
+      restart: Kubernetes redémarrera après l'application des modifications.
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: WebAssembly doit être activé pour que l'<a href="#" data-navigate="Kubernetes">opérateur Spin</a> puisse être installé.
+  error:
+    # @source Reload Preferences to try again.
+    body: Rechargez les paramètres pour réessayer.
+    # @source Unable to fetch preferences
+    heading: Impossible de récupérer les paramètres
+    # @source Reload preferences
+    reload: Recharger les paramètres
+  # @source Preferences
+  header: Paramètres
+  # @source or
+  incompatiblePrefWarningOr: ou
+  # @reason Masculine singular default; the gender of the interpolated option name is unknown.
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: soit désélectionné.
+  # @reason Masculine singular default; the gender of the interpolated option name is unknown.
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: soit sélectionné.
+  # @reason Sentence fragment composed in code with an option name and a "...WarningPost*" fragment; "que" makes the assembled French sentence grammatical.
+  # @source The option requires
+  incompatibleTypeWarningPre: Cette option nécessite que
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: Verrouillé par la politique de l'organisation
+  nav:
+    # @reason 'Application' is the same word in French
+    # @source Application
+    application: Application
+    # @source Container Engine
+    containerEngine: Moteur de conteneurs
+    # @reason Kubernetes is a product name
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: Machine virtuelle
+    # @reason WSL (Windows Subsystem for Linux) is a product name
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: Appliquer et réinitialiser
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: Ces modifications réinitialiseront le cluster Kubernetes, ce qui entraînera la perte des charges de travail et des images de conteneurs.
+    # @source Apply preferences and reset Kubernetes?
+    message: Appliquer les paramètres et réinitialiser Kubernetes ?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Réinitialiser Kubernetes
+  tabs:
+    # @source Allowed Images
+    allowedImages: Images autorisées
+    # @source Behavior
+    behavior: Comportement
+    # @source Emulation
+    emulation: Émulation
+    # @source Environment
+    environment: Environnement
+    # @source General
+    general: Général
+    # @source Hardware
+    hardware: Matériel
+    # @source Integrations
+    integrations: Intégrations
+    # @reason 'Proxy' is the same word in French; « proxy » is used throughout this file
+    # @source Proxy
+    proxy: Proxy
+    # @reason 'Volumes' is the same word in French
+    # @source Volumes
+    volumes: Volumes
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: Certains paramètres comportent des modifications non appliquées. Tous les paramètres non enregistrés seront perdus.
+    # @source Discard changes
+    discardChanges: Abandonner les modifications
+    # @source Close preferences without applying?
+    message: Fermer les paramètres sans appliquer ?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - Fermer les paramètres
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - Paramètres
+prefs:
+  # @source Experimental
+  experimental: Expérimental
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: Ce paramètre nécessite macOS 13.3 (Ventura) ou une version ultérieure.
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: Ce paramètre nécessite macOS 13.0 (Ventura) ou une version ultérieure.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: Ce paramètre nécessite l'utilisation du mode d'émulation VZ. VZ n'est disponible que sous macOS 13.3 (Ventura) ou version ultérieure.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: Ce paramètre nécessite l'utilisation du mode d'émulation VZ. VZ n'est disponible que sous macOS 13.0 (Ventura) ou version ultérieure.
+product:
+  containerEngine:
+    # @reason English abbreviation (Container Engine) kept; a French abbreviation would not be recognized.
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: Moteur de conteneurs
+  # @source deactivated
+  deactivated: désactivé
+  # @reason Kubernetes is a product name
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: État du réseau
+  networkStatusValues:
+    # @source checking...
+    checking: vérification...
+    # @source offline
+    offline: hors ligne
+    # @source online
+    online: en ligne
+  # @reason 'Version' is the same word in French
+  # @source Version
+  version: Version
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: Demande d'autorisation pour exécuter des tâches en tant qu'administrateur
+  # @source Bundling certificates
+  bundlingCertificates: Regroupement des certificats
+  # @source Checking k3s images
+  checkingK3sImages: Vérification des images k3s
+  # @source Configuring container engine
+  configuringContainerEngine: Configuration du moteur de conteneurs
+  # @source Configuring image proxy
+  configuringImageProxy: Configuration du proxy d'images
+  # @source Configuring logrotate
+  configuringLogrotate: Configuration de logrotate
+  # @source Container engine components
+  containerEngineComponents: Composants du moteur de conteneurs
+  # @source Copying certificates
+  copyingCertificates: Copie des certificats
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: Suppression de l'état Kubernetes incompatible
+  # @source Deleting Kubernetes
+  deletingKubernetes: Suppression de Kubernetes
+  # @source Deleting virtual machine
+  deletingVirtualMachine: Suppression de la machine virtuelle
+  # @source DNS configuration
+  dnsConfiguration: Configuration DNS
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: Vérification de la compatibilité de kubectl
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: Vérification de la prise en charge de la virtualisation
+  # @source Expecting user permission to continue
+  expectingPermission: En attente de l'autorisation de l'utilisateur pour continuer
+  # @source Extracting certificates
+  extractingCertificates: Extraction des certificats
+  # @source Fetching certificates
+  fetchingCertificates: Récupération des certificats
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Initialisation de Rancher Desktop
+  # @source Initializing WSL data
+  initializingWslData: Initialisation des données WSL
+  # @source Installing Buildkit
+  installingBuildkit: Installation de Buildkit
+  # @source Installing CA certificates
+  installingCaCertificates: Installation des certificats CA
+  # @source Installing container engine
+  installingContainerEngine: Installation du moteur de conteneurs
+  # @reason "credential helper" rendered as "gestionnaire d'identifiants".
+  # @source Installing credential helper
+  installingCredentialHelper: Installation du gestionnaire d'identifiants
+  # @reason docker-credential is the binary name prefix; kept verbatim.
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: Installation du gestionnaire d'identifiants docker-credential
+  # @source Installing helpers
+  installingHelpers: Installation des utilitaires
+  # @source Installing image scanner
+  installingImageScanner: Installation de l'analyseur d'images
+  # @source Installing k3s
+  installingK3s: Installation de k3s
+  # @source Installing Kubernetes
+  installingKubernetes: Installation de Kubernetes
+  # @source Kubernetes components
+  kubernetesComponents: Composants Kubernetes
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Compatibilité de Kubernetes avec dockerd
+  # @source Mounting WSL data
+  mountingWslData: Montage des données WSL
+  # @source Preparing to start
+  preparingToStart: Préparation du démarrage
+  # @source Proxy Config Setup
+  proxyConfigSetup: Mise en place de la configuration du proxy
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Agent invité de Rancher Desktop
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: Régénération de la configuration pour tenir compte de l'absence d'autorisations
+  # @source Registering WSL distribution
+  registeringWslDistribution: Enregistrement de la distribution WSL
+  # @source Removing existing certificates
+  removingExistingCertificates: Suppression des certificats existants
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: Suppression de l'opérateur spinkube
+  # @source Removing stale state
+  removingStaleState: Suppression de l'état obsolète
+  # @source Removing Traefik
+  removingTraefik: Suppression de Traefik
+  # @source Resetting Kubernetes
+  resettingKubernetes: Réinitialisation de Kubernetes
+  # @source Running provisioning scripts
+  runningProvisioningScripts: Exécution des scripts de provisionnement
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: Exécution de update-ca-certificates
+  # @source Setting docker context
+  settingDockerContext: Définition du contexte docker
+  # @source Setting Lima permissions
+  settingLimaPermissions: Définition des permissions Lima
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Configuration du socket Docker
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: Configuration du réseau Ethernet virtuel
+  # @source Shutting down
+  shuttingDown: Arrêt en cours
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: Vérifications du nœud ignorées, flannel est désactivé
+  # @source Starting Backend
+  startingBackend: Démarrage du backend
+  # @source Starting buildkit
+  startingBuildkit: Démarrage de buildkit
+  # @source Starting container engine
+  startingContainerEngine: Démarrage du moteur de conteneurs
+  # @source Starting image proxy
+  startingImageProxy: Démarrage du proxy d'images
+  # @source Starting k3s
+  startingK3s: Démarrage de k3s
+  # @source Starting Kubernetes
+  startingKubernetes: Démarrage de Kubernetes
+  # @source Starting proxy
+  startingProxy: Démarrage du proxy
+  # @source Starting {service}
+  startingService: Démarrage de {service}
+  # @source Starting virtual machine
+  startingVirtualMachine: Démarrage de la machine virtuelle
+  # @source Starting WSL environment
+  startingWslEnvironment: Démarrage de l'environnement WSL
+  # @source Stopping existing instance
+  stoppingExistingInstance: Arrêt de l’instance existante
+  # @source Stopping mock backend
+  stoppingMockBackend: Arrêt du backend simulé
+  # @source Stopping services
+  stoppingServices: Arrêt des services
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: Mise à jour de la configuration du cluster
+  # @source Updating /etc/hosts
+  updatingEtcHosts: Mise à jour de /etc/hosts
+  # @source Updating kubeconfig
+  updatingKubeconfig: Mise à jour du kubeconfig
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: Mise à jour de la machine virtuelle obsolète
+  # @source Updating WSL data
+  updatingWslData: Mise à jour des données WSL
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: Mise à niveau de la distribution WSL
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: En attente de la disponibilité du moteur de conteneurs
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: En attente de l’API Kubernetes
+  # @source Waiting for nodes
+  waitingForNodes: En attente des nœuds
+  # @source Waiting for services
+  waitingForServices: En attente des services
+  # @source Writing K3s configuration
+  writingK3sConfiguration: Écriture de la configuration K3s
+snapshots:
+  action:
+    # @reason snapshot → « instantané », the established French VM-snapshot term (VMware, VirtualBox)
+    # @source Create Snapshot
+    create: Créer un instantané
+  card:
+    action:
+      # @source Delete
+      remove: Supprimer
+      # @source Restore
+      restore: Restaurer
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: Créé le '<b>'{date}'</b>' à '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: Annuler
+      # @source Create
+      submit: Créer
+    description:
+      # @reason 'Description' is the same word in French
+      # @source Description
+      label: Description
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: Rancher Desktop sera temporairement indisponible pendant la création d’un nouvel instantané
+    name:
+      # @source Snapshot Name
+      label: Nom de l’instantané
+    # @source Create a new Snapshot
+    title: Créer un nouvel instantané
+  dialog:
+    buttons:
+      # @source Close
+      error: Fermer
+    creating:
+      actions:
+        # @source Cancel
+        cancel: Annuler
+      # @source Creating {snapshot}
+      header: Création de {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: Veuillez patienter pendant la création de l’instantané '<b>'{snapshot}'</b>'.'<br/>'Cette opération peut prendre un certain temps selon les ressources de votre machine.'<br/>'Rancher Desktop sera temporairement indisponible pendant cette opération.'<br/><br/>'Une fois l’instantané créé, la machine virtuelle redémarrera.
+    delete:
+      actions:
+        # @source Cancel
+        cancel: Annuler
+        # @source Delete
+        ok: Supprimer
+      # @source Permanently delete snapshot?
+      header: Supprimer définitivement l’instantané ?
+      # @reason source value is the placeholder stub « text »; kept unchanged
+      # @source Deleting a snapshot cannot be undone.
+      info: La suppression d'un instantané est irréversible.
+    generic:
+      # @source Snapshot operation in progress
+      header: Opération d’instantané en cours
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: Veuillez patienter pendant l’opération d’instantané.<br/>Cette opération peut prendre un certain temps selon les ressources de votre machine.<br/>Rancher Desktop sera temporairement indisponible pendant cette opération.<br/><br/>Une fois l’opération d’instantané terminée, la machine virtuelle redémarrera.
+    restore:
+      actions:
+        # @source Cancel
+        cancel: Annuler
+        # @source Restore
+        ok: Restaurer
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Quitter Rancher Desktop
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: Échec de la restauration de l’instantané '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop a effectué une réinitialisation d’usine et va maintenant se fermer. Veuillez essayer de corriger le problème à l’origine de cette erreur avant de redémarrer Rancher Desktop et de tenter une nouvelle restauration de l’instantané.
+        # @source Error restoring snapshot
+        header: Erreur lors de la restauration de l’instantané
+      # @source Restore snapshot?
+      header: Restaurer l’instantané ?
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: La restauration de cet instantané remplacera votre installation actuelle, y compris les paramètres. Si la fenêtre des paramètres est ouverte, elle sera automatiquement fermée et toutes les modifications non enregistrées seront perdues.
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: Annuler
+      # @source Restoring {snapshot}
+      header: Restauration de {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: Veuillez patienter pendant la restauration de l’instantané '<b>'{snapshot}'</b>'. Cette opération peut prendre un certain temps selon les ressources de votre machine.<br/><br/>Rancher Desktop sera temporairement indisponible pendant cette opération. Une fois l’opération terminée, la machine virtuelle redémarrera avec l’instantané {snapshot} actif.
+    # @source Show logs
+    showLogs: Afficher les journaux
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: Cliquez sur « Créer un instantané » pour commencer
+    # @source No snapshots found
+    heading: Aucun instantané trouvé
+    # @reason icon identifier, not user-visible text; kept unchanged
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: Création de {snapshot} annulée
+      # @source Created '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' créé'
+    delete:
+      # @source Delete error: {error}
+      error: 'Erreur de suppression : {error}'
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' supprimé'
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: Un fichier de verrouillage d’instantané est détecté depuis un temps anormalement long. Si vous pensez qu’il s’agit d’une erreur, vous pouvez essayer de supprimer le fichier de verrouillage en exécutant <code>rdctl snapshot unlock</code>.
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: Restauration de {snapshot} annulée
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' restauré'
+    # @source  at {time}
+    when: ' à {time}'
+  # @source Snapshots
+  title: Instantanés
+sortableTable:
+  actionAvailability:
+    # @reason count unknown at translation time; parenthetical plural « sélectionné(s) »
+    # @source {actionable} selected
+    selected: '{actionable} sélectionné(s)'
+    # @source Available for {actionable} of the {total} selected
+    some: Disponible pour {actionable} des {total} sélectionnés
+  # @source Add
+  add: Ajouter
+  # @source Add Filter
+  addFilter: Ajouter un filtre
+  bulkActions:
+    collapsed:
+      # @reason 'Actions' is the same word in French
+      # @source Actions
+      label: Actions
+  # @source Filter for...
+  filterFor: Filtrer par...
+  # @reason context-dependent preposition; assumed « filter X in group Y » usage
+  # @source in
+  in: dans
+  # @source No actions available
+  noActions: Aucune action disponible
+  # @source There are no rows which match your search query.
+  noData: Aucune ligne ne correspond à votre recherche.
+  # @source There are no rows to show.
+  noRows: Aucune ligne à afficher.
+  paging:
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {Aucun élément}
+        =1 {{count} {count, plural, =1 {élément} other {éléments}}}
+        other {{from} - {to} sur {count} éléments}}
+  # @source Reset
+  resetFilters: Réinitialiser
+  # @source Filter
+  search: Filtrer
+  # @source Select a column
+  selectCol: Sélectionner une colonne
+  tableHeader:
+    # @source Group by
+    groupBy: Grouper par
+    # @source This column cannot be filtered
+    noFilter: Impossible de filtrer sur cette colonne
+    # @source Show
+    show: Afficher
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: Toujours exécuter sans accès administrateur
+  # @reason 'OK' is standard on French buttons
+  # @source OK
+  buttonText: OK
+  # @source This will modify the following paths:
+  explanation: 'Les chemins suivants seront modifiés :'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'Rancher Desktop nécessite un accès administrateur (« accès sudo ») pour les raisons suivantes :'
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: L’invite s’affichera une fois cette fenêtre fermée. Si vous annulez l’invite ou désactivez l’accès administrateur, vous devrez basculer le contexte docker vers rancher-desktop pour continuer à utiliser Rancher Desktop.
+  reasons:
+    dockerSocket:
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: Assure la compatibilité avec les outils qui utilisent le socket docker sans pouvoir utiliser les contextes docker.
+      # @source Set up default docker socket
+      title: Configurer le socket docker par défaut
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: Fournit un réseau en pont pour faciliter l’accès à vos conteneurs. Si cela n’est pas autorisé, les conteneurs ne seront accessibles que par redirection de ports.
+      # @source Configure networking
+      title: Configurer le réseau
+  # @source Administrative Access Required
+  title: Accès administrateur requis
+systemPreferences:
+  # @source # CPUs
+  cpus: Nombre de CPU
+  # @reason GB rendered as Go per French unit convention
+  # @source Memory (GB)
+  memory: Mémoire (Go)
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Envoyer des informations d’utilisation anonymisées, des rapports d’erreur, etc. pour aider à améliorer Rancher Desktop. Vos données ne seront partagées avec personne d’autre, et aucune information sur les ressources ou points de terminaison spécifiques que vous déployez n’est incluse.
+tray:
+  # @source Container engine: {name}
+  containerEngine: 'Moteur de conteneurs : {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Contextes Kubernetes
+  # @source Network status: {status}
+  networkStatus: 'État du réseau : {status}'
+  # @source None found
+  noneFound: Aucun trouvé
+  # @source Open cluster dashboard
+  openDashboard: Ouvrir le tableau de bord du cluster
+  # @source Open main window
+  openMainWindow: Ouvrir la fenêtre principale
+  # @source Open preferences dialog
+  openPreferences: Ouvrir les paramètres
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Quitter Rancher Desktop
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes est désactivé
+    # @source Kubernetes has encountered an error
+    error: Kubernetes a rencontré une erreur
+    # @source Kubernetes is running
+    started: Kubernetes est en cours d’exécution
+    # @source Kubernetes is starting
+    starting: Kubernetes est en cours de démarrage
+    # @source Kubernetes is stopped
+    stopped: Kubernetes est arrêté
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes est en cours d’arrêt
+  # @reason Rancher Desktop is the product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: Activer le mode débogage
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: Réinitialisation d’usine
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: La réinitialisation d’usine supprimera toutes les configurations de Rancher Desktop.
+      messageBox:
+        # @source Cancel
+        cancel: Annuler
+        # @source Keep cached Kubernetes images
+        checkboxLabel: Conserver les images Kubernetes en cache
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>Une réinitialisation d’usine supprimera votre cluster et tous les paramètres de Rancher Desktop, puis fermera Rancher Desktop. Si vous comptez continuer à utiliser Rancher Desktop, vous devrez le démarrer manuellement et refaire la configuration initiale.</p><p>Voulez-vous vraiment tout réinitialiser ?</p>
+        # @source Perform a factory reset?
+        message: Effectuer une réinitialisation d’usine ?
+        # @source Factory Reset
+        ok: Réinitialisation d’usine
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - Réinitialisation d’usine
+      # @source Factory Reset
+      title: Réinitialisation d’usine
+    logs:
+      # @source Show Logs
+      buttonText: Afficher les journaux
+      # @source Show Rancher Desktop logs
+      description: Afficher les journaux de Rancher Desktop
+      # @source Logs
+      title: Journaux
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Réinitialiser Kubernetes
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: La réinitialisation de Kubernetes supprimera toutes les charges de travail et la configuration.
+      messageBox:
+        # @source Cancel
+        cancel: Annuler
+        # @source Delete container images
+        checkboxLabel: Supprimer les images de conteneurs
+        # @source Reset Kubernetes?
+        message: Réinitialiser Kubernetes ?
+        # @source Reset
+        ok: Réinitialiser
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Réinitialisation de Kubernetes
+      # @source Reset Kubernetes
+      title: Réinitialiser Kubernetes
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: Vous rencontrez encore des problèmes ? Lancez une discussion dans le canal <b>#rancher-desktop</b> du <a href="https://slack.rancher.io/">Slack Rancher Users</a> ou <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">signalez un problème</a>.
+  # @source Troubleshooting
+  title: Dépannage
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: Veuillez vous assurer que toutes les conditions requises sont remplies, puis réessayez. Rancher Desktop va maintenant se fermer.
+  # @reason 'OK' is standard on French buttons
+  # @source OK
+  buttonText: OK
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 'Rancher Desktop ne peut pas démarrer car des prérequis sont manquants ou non configurés :'
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop ne parvient pas à démarrer
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: Application de la mise à jour...
+  # @source An update to version {version} is available
+  available: Une mise à jour vers la version {version} est disponible
+  # @source Check for updates automatically
+  checkForUpdates: Rechercher automatiquement les mises à jour
+  # @reason no-break space added before % per French typography
+  # @source downloading... ({percent}%, {speed})
+  downloading: téléchargement... ({percent} %, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: Une erreur s’est produite lors de la recherche de mises à jour.
+  # @source Release Notes
+  releaseNotes: Notes de version
+  # @source Restart Now
+  restartNow: Redémarrer maintenant
+  # @source Restart the application to apply the update.
+  restartToApply: Redémarrez l’application pour appliquer la mise à jour.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Une version plus récente de Rancher Desktop est disponible, mais elle n’est pas prise en charge sur votre système.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: Pour plus d’informations, veuillez consulter <a href="https://docs.rancherdesktop.io/getting-started/installation">la documentation d’installation</a>.
+    # @source Latest Version Not Supported
+    title: Dernière version non prise en charge
+  # @source Update Available
+  updateAvailable: Mise à jour disponible
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: Impossible de diminuer « {field} » de {from} à {to}
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: Impossible d’activer WebAssembly avec le stockage classique pour moby.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: Impossible de passer au stockage classique pour moby lorsque WebAssembly est activé.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: Impossible de passer au moteur de conteneurs moby avec le stockage classique lorsque WebAssembly est activé.
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 'le champ « {field} » contient des entrées en double : « {duplicates} »'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 'Erreurs dans les paramètres proposés :'
+  # @source field "{field}" is locked
+  fieldLocked: le champ « {field} » est verrouillé
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field} : « {pattern} » ne décrit pas une référence d’image'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field} : « {value} » n’est pas un mappage valide'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field} : « {name} » n’est pas un nom valide'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 'le champ « {field} » contient des entrées invalides (doivent être des adresses IP, des sous-réseaux CIDR ou des noms de domaine) : « {entries} »'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field} : « {value} » n’est pas un nom de page valide pour la fenêtre des paramètres'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field} : le nom d’onglet « {tabName} » n’est pas valide pour la page de paramètres « {page} »'
+  # @reason « tag » kept, the common French term for container image tags
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field} : « {name} » a un tag invalide « {tag} »'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 'Valeur invalide pour « {field} » : <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 'Valeur invalide pour « {field} » : <{value}> ; les valeurs possibles sont {validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Version de Kubernetes « {version} » introuvable.
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field} : « {name} » a un tag « {tag} » qui n’est pas une chaîne de caractères'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: La modification du champ « {field} » via l’API n’est pas prise en charge.
+  # @reason ICU-escaped straight quotes ('') rendered as French guillemets
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 'Erreur pour le champ « {field} » : une valeur de type tableau était attendue, mais « {value} » a été reçu'
+  # @reason ICU-escaped straight quotes ('') rendered as French guillemets
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 'Erreur pour le champ « {field} » : une valeur de type {expectedType} était attendue, mais « {value} » a été reçu'
+  # @reason ICU-escaped straight quotes ('') rendered as French guillemets
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 'Erreur pour le champ « {field} » : une valeur de type {expectedType} était attendue, mais un tableau {value} a été reçu'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: Le champ proposé « {field} » devrait être un objet, mais <{value}> a été reçu.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: Le paramètre {field} ne peut être activé que sur les systèmes aarch64.
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: Le paramètre {field} ne peut être modifié que lorsque virtualMachine.mount.type est « {mountType} ».
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: Le paramètre {field} ne peut être activé que lorsque virtual-machine.type est « {vmType} ».
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: Le paramètre {field} ne peut être défini que si experimental.container-engine.web-assembly.enabled est également défini.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: Définir {field} à « {value} » nécessite que {otherField} soit « {required} ».
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: Définir {field} à « {value} » nécessite que {otherField} soit « {option1} » ou « {option2} ».
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: Le paramètre « {field} » devrait contenir un objet interne, mais <{value}> a été reçu.
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: Le paramètre « {field} » devrait être une valeur simple, mais <{value}> a été reçu.
+  # @source One or more fields in this tab contain a form validation error
+  tab: Un ou plusieurs champs de cet onglet contiennent une erreur de validation
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: Définir {field} à « {vmType} » sur ARM nécessite macOS 13.3 (Ventura) ou une version ultérieure.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Définir {field} à « {vmType} » sur Intel nécessite macOS 13.0 (Ventura) ou une version ultérieure.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: Type de montage
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: Expose le système de fichiers en utilisant les périphériques virtio-9p-pci de QEMU.
+          # @reason literal mount-type config value
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: Mode de cache
+              options:
+                # @reason literal 9p cache-mode config value
+                # @source fscache
+                fscache: fscache
+                # @reason literal 9p cache-mode config value
+                # @source loose
+                loose: loose
+                # @reason literal 9p cache-mode config value
+                # @source mmap
+                mmap: mmap
+                # @reason literal mount option value; kept in English
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: Politique de cache à utiliser
+            mSizeInKib:
+              # @reason KiB rendered as Kio per French unit convention
+              # @source Message Size In KiB
+              legend: Taille des messages en Kio
+              # @source Maximum message size in KiB
+              tooltip: Taille maximale des messages en Kio
+            protocolVersion:
+              # @source Protocol Version
+              legend: Version du protocole
+              options:
+                # @reason literal 9p protocol-version identifier
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason literal 9p protocol-version identifier
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason literal 9p protocol-version identifier
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: Version du protocole 9P
+            securityModel:
+              # @source Security Model
+              legend: Modèle de sécurité
+              options:
+                # @reason literal 9p security-model config value
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason literal 9p security-model config value
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason literal mount option value; kept in English
+                # @source none
+                none: none
+                # @reason literal 9p security-model config value
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: Modèle de sécurité utilisé pour le chemin d’exportation
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: Expose le système de fichiers en exécutant un serveur SFTP.
+          # @reason literal mount-type config value
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Expose le système de fichiers en utilisant un périphérique de répertoire partagé du framework Virtualization d’Apple.
+          # @reason literal mount-type config value
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: Adresse
+    # @source Proxy address
+    addressTitle: Adresse du proxy
+    # @source Authentication information
+    authTitle: Informations d’authentification
+    # @source Enable the proxy used by rancher-desktop
+    label: Activer le proxy utilisé par rancher-desktop
+    # @source WSL Proxy
+    legend: Proxy WSL
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: Cet élément est un doublon.
+      # @source Proxy bypass list
+      legend: Liste de contournement du proxy
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: IP, CIDR, domaine ou caractère générique (*.example.com) pour contourner le proxy
+    # @source Password
+    password: Mot de passe
+    # @reason 'Port' is the same word in French
+    # @source Port
+    port: Port
+    # @source Username
+    username: Nom d’utilisateur
+  type:
+    # @source Virtual Machine Type
+    legend: Type de machine virtuelle
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: Utiliser l’émulateur QEMU.
+        # @reason QEMU is a product name
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @source Use the Apple Virtualization framework.
+        description: Utiliser le framework Virtualization d’Apple.
+        # @reason VZ names Apple's Virtualization framework
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Activer la prise en charge de Rosetta
+    # @source VZ Option
+    legend: Option VZ
+volumes:
+  files:
+    # @source Available
+    available: Disponible
+    # @source Error checking volume status
+    checkError: Erreur lors de la vérification de l’état du volume
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: Nom de volume invalide « {name} »
+    # @source Error listing files: {error}
+    listError: 'Erreur lors du listage des fichiers : {error}'
+    # @source Loading volume files...
+    loading: Chargement des fichiers du volume...
+    # @source This volume is empty
+    noFiles: Ce volume est vide
+    # @source Not Found
+    notFound: Introuvable
+    table:
+      header:
+        # @source Modified
+        modified: Modifié
+        # @source Name
+        name: Nom
+        # @reason 'Permissions' is the same word in French
+        # @source Permissions
+        permissions: Permissions
+        # @source Size
+        size: Taille
+    # @source Volume Files
+    title: Fichiers du volume
+    # @source Volume "{name}" not found
+    volumeNotFound: Volume « {name} » introuvable
+  manage:
+    table:
+      header:
+        # @source Created
+        created: Créé
+        # @source Driver
+        driver: Pilote
+        # @source Mount Point
+        mountpoint: Point de montage
+        # @source Volume Name
+        volumeName: Nom du volume
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: Parcourir les fichiers
+        # @source Delete
+        delete: Supprimer
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: Aucun volume à afficher
+  # @reason nav page title; 'Volumes' is the same word in French
+  # @source Volumes
+  title: Volumes
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: Veuillez lire la documentation avant d’activer la fonctionnalité expérimentale WebAssembly !
+  # @source Enabled
+  enabled: Activé
+  # @reason WebAssembly/Wasm is a technology name
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -853,6 +853,8 @@ locale:
   es: Espagnol
   # @source French
   fr: Français
+  # @source Italian
+  it: Italien
   # @source Japanese
   ja: Japonais
   # @source Portuguese (Brazilian)

--- a/pkg/rancher-desktop/assets/translations/fr.yaml
+++ b/pkg/rancher-desktop/assets/translations/fr.yaml
@@ -849,6 +849,8 @@ locale:
   de: Allemand
   # @source English
   en-us: Anglais
+  # @source Spanish
+  es: Espagnol
   # @source French
   fr: Français
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -856,6 +856,8 @@ locale:
   it: Italiano
   # @source Japanese
   ja: Giapponese
+  # @source Korean
+  ko: Coreano
   # @source Portuguese (Brazilian)
   pt-br: Portoghese (Brasile)
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/it.yaml
+++ b/pkg/rancher-desktop/assets/translations/it.yaml
@@ -1,0 +1,1900 @@
+action:
+  # @source Refresh
+  refresh: Aggiorna
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: Il nome dell'immagine deve corrispondere a uno dei pattern definiti nella scheda Immagini consentite delle Impostazioni.
+  # @source Enable
+  enable: Abilita
+  errors:
+    # @source This item is a duplicate.
+    duplicate: Questo elemento è un duplicato.
+  # @reason Kept "pattern": established loanword in Italian dev usage.
+  # @source Allowed Image Patterns
+  label: Pattern di immagini consentite
+  patterns:
+    # @source Type the image pattern
+    placeholder: Digita il pattern dell'immagine
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: Avvia automaticamente all'accesso
+      # @source Startup
+      legendText: Avvio
+    background:
+      # @reason "Background" is an established loanword in Italian.
+      # @source Background
+      legendText: Background
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Nasconde la finestra dell'app quando Rancher Desktop è in esecuzione in background. Può essere aperta tramite l'icona di notifica (se visibile) o avviando Rancher Desktop dal menu Applicazioni.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: Nascondi l'icona di notifica
+      # @source Notification Icon
+      legendText: Icona di notifica
+    startInBackground:
+      # @source Start in the background
+      label: Avvia in background
+    theme:
+      # @source Appearance
+      legendText: Aspetto
+      options:
+        dark:
+          # @source Always use dark mode
+          description: Usa sempre la modalità scura
+          # @source Dark
+          label: Scuro
+        light:
+          # @source Always use light mode
+          description: Usa sempre la modalità chiara
+          # @source Light
+          label: Chiaro
+        system:
+          # @source Follow the operating system setting
+          description: Segui l'impostazione del sistema operativo
+          # @source System
+          label: Sistema
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: Esci alla chiusura della finestra dell'applicazione
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: Consenti credenziali amministrative (accesso sudo)
+      # @source Administrative Access
+      legendText: Accesso amministrativo
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: Se selezionata, {appName} acquisirà le credenziali amministrative ("accesso sudo") all'avvio. Questo abilita la rete in modalità bridge e il supporto del socket docker predefinito. Ha effetto al prossimo avvio.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: Controlla automaticamente gli aggiornamenti
+      # @source Automatic Updates
+      legendText: Aggiornamenti automatici
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: Consenti la raccolta di statistiche anonime per contribuire a migliorare {appName}
+      # @source Statistics
+      legendText: Statistiche
+  locale:
+    # @reason "canonical" rendered as "di riferimento": more natural than "canonica".
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: Le traduzioni sono fornite dalla community e da strumenti di IA. L'inglese è la lingua di riferimento. Segnala i problemi di traduzione su GitHub.
+    # @source Language
+    legendText: Lingua
+asyncButton:
+  activate:
+    # @source Activate
+    action: Attiva
+    # @source Activated
+    success: Attivato
+    # @source Activating&hellip;
+    waiting: Attivazione&hellip;
+  apply:
+    # @source Apply
+    action: Applica
+    # @source Applied
+    success: Applicato
+    # @source Applying&hellip;
+    waiting: Applicazione&hellip;
+  continue:
+    # @source Continue
+    action: Continua
+    # @source Saved
+    success: Salvato
+    # @source Saving&hellip;
+    waiting: Salvataggio&hellip;
+  copy:
+    # @source Click to Copy
+    action: Fai clic per copiare
+    # @source Copied!
+    success: Copiato!
+  create:
+    # @source Create
+    action: Crea
+    # @source Created
+    success: Creato
+    # @source Creating&hellip;
+    waiting: Creazione&hellip;
+  deactivate:
+    # @source Deactivate
+    action: Disattiva
+    # @source Deactivated
+    success: Disattivato
+    # @source Deactivating&hellip;
+    waiting: Disattivazione&hellip;
+  default:
+    # @source Action
+    action: Azione
+    # @source Error
+    error: Errore
+    # @source Success
+    success: Riuscito
+    # @source Waiting
+    waiting: In attesa
+  delete:
+    # @source Delete
+    action: Elimina
+    # @source Deleted
+    success: Eliminato
+    # @source Deleting&hellip;
+    waiting: Eliminazione&hellip;
+  disable:
+    # @source Disable
+    action: Disabilita
+    # @source Disabled
+    success: Disabilitato
+    # @source Disabling&hellip;
+    waiting: Disabilitazione&hellip;
+  done:
+    # @source Done
+    action: Fatto
+    # @source Saved
+    success: Salvato
+    # @source Saving&hellip;
+    waiting: Salvataggio&hellip;
+  download:
+    # @source Download
+    action: Scarica
+    # @source Saving
+    success: Salvataggio
+    # @source Downloading&hellip;
+    waiting: Scaricamento&hellip;
+  edit:
+    # @source Save
+    action: Salva
+    # @source Saved
+    success: Salvato
+    # @source Saving&hellip;
+    waiting: Salvataggio&hellip;
+  enable:
+    # @source Enable
+    action: Abilita
+    # @source Enabled
+    success: Abilitato
+    # @source Enabling&hellip;
+    waiting: Abilitazione&hellip;
+  finish:
+    # @source Finish
+    action: Fine
+    # @source Finished
+    success: Completato
+    # @source Finishing&hellip;
+    waiting: Completamento&hellip;
+  import:
+    # @source Import
+    action: Importa
+    # @source Imported
+    success: Importato
+    # @source Importing&hellip;
+    waiting: Importazione&hellip;
+  install:
+    # @source Install
+    action: Installa
+    # @source Installing
+    success: Installazione
+    # @source Starting&hellip;
+    waiting: Avvio&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon identifier, not translatable text.
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon identifier, not translatable text.
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon identifier, not translatable text.
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon identifier, not translatable text.
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @source Remove
+    action: Rimuovi
+    # @source Removed
+    success: Rimosso
+    # @source Removing&hellip;
+    waiting: Rimozione&hellip;
+  restore:
+    # @source Restore
+    action: Ripristina
+    # @source Restored
+    success: Ripristinato
+    # @source Restoring&hellip;
+    waiting: Ripristino&hellip;
+  snapshot:
+    # @source Snapshot Now
+    action: Crea snapshot ora
+    # @source Creating Snapshot
+    success: Creazione snapshot
+    # @source Snapshotting&hellip;
+    waiting: Creazione snapshot&hellip;
+  uninstall:
+    # @source Uninstall
+    action: Disinstalla
+    # @source Uninstalled
+    success: Disinstallato
+    # @source Uninstalling&hellip;
+    waiting: Disinstallazione&hellip;
+  update:
+    # @source Update
+    action: Aggiorna
+    # @source Updated
+    success: Aggiornato
+    # @source Updating&hellip;
+    waiting: Aggiornamento&hellip;
+  upgrade:
+    # @reason Kept "upgrade" to distinguish from "Aggiorna" (update).
+    # @source Upgrade
+    action: Esegui upgrade
+    # @source Upgrading
+    success: Upgrade in corso
+    # @source Starting&hellip;
+    waiting: Avvio&hellip;
+containerEngine:
+  # @source Container Engine
+  label: Motore container
+  options:
+    containerd:
+      # @source Namespaces for container images; use with nerdctl.
+      description: Namespace per le immagini container; da usare con nerdctl.
+      # @reason Product name.
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: API Docker; da usare con la CLI Docker.
+      # @reason Product name.
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: Informazioni container
+  # @reason "Info" is standard Italian.
+  # @source Info
+  info: Info
+  # @reason "Log" is the standard term in Italian, invariable in the plural.
+  # @source Logs
+  logs: Log
+  search:
+    # @source Search in logs
+    ariaLabel: Cerca nei log
+    # @source Clear search
+    clearSearch: Cancella la ricerca
+    # @source Next match
+    nextMatch: Corrispondenza successiva
+    # @source Search logs...
+    placeholder: Cerca nei log...
+    # @source Previous match
+    previousMatch: Corrispondenza precedente
+  # @reason Standard technical term in Italian.
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: Statistiche
+containerInspect:
+  capabilities:
+    # @reason Feminine plural, agreeing with "capability" (feminine in Italian technical usage).
+    # @source Added
+    added: Aggiunte
+    # @source Dropped
+    dropped: Rimosse
+  command:
+    # @source Args
+    args: Argomenti
+    # @source Command
+    command: Comando
+    # @reason Docker term, untranslated.
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: Impossibile caricare i dettagli del container.
+    # @source An unknown error has occurred
+    unknown: Si è verificato un errore sconosciuto
+  # @source Loading container details…
+  loading: Caricamento dei dettagli del container…
+  mounts:
+    # @source Destination
+    destination: Destinazione
+    # @reason Standard technical abbreviation, kept.
+    # @source RO
+    readOnly: RO
+    # @reason Standard technical abbreviation, kept.
+    # @source RW
+    readWrite: RW
+    # @reason Standard technical abbreviation, kept.
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: Origine
+    # @source Type
+    type: Tipo
+  # @source None
+  none: Nessuno
+  sections:
+    # @reason Linux "capability" is conventionally left in English; loanwords are invariable in the Italian plural.
+    # @source Capabilities
+    capabilities: Capability
+    # @source Command & Args
+    commandArgs: Comando e argomenti
+    # @source Environment
+    environment: Ambiente
+    # @source Labels
+    labels: Etichette
+    # @reason Docker term, kept; loanwords are invariable in the Italian plural.
+    # @source Mounts
+    mounts: Mount
+    # @source Ports
+    ports: Porte
+  summary:
+    # @source Created
+    created: Creato
+    # @reason 'ID' is the same abbreviation in Italian
+    # @source ID
+    id: ID
+    # @source Image
+    image: Immagine
+    # @source IP Address
+    ipAddress: Indirizzo IP
+    # @source Name
+    name: Nome
+    # @source Started
+    started: Avviato
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: I/O blocchi (byte/s)
+    # @reason 'CPU' acronym and % symbol are identical in Italian
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: Memoria
+    # @source Network I/O (bytes/s)
+    network: I/O rete (byte/s)
+  interval:
+    # @reason 'min' is also the standard Italian abbreviation of 'minuti'
+    # @source {minutes} min
+    minutes: '{minutes} min'
+    # @reason 's' is the SI symbol for seconds, identical in Italian
+    # @source {seconds} s
+    seconds: '{seconds} s'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: Le statistiche sono attualmente disponibili solo per il motore Docker (Moby).
+  # @source No processes found.
+  noProcesses: Nessun processo trovato.
+  # @source Stats are only available for running containers.
+  notRunning: Le statistiche sono disponibili solo per i container in esecuzione.
+  # @source Processes
+  processes: Processi
+  # @reason Noun form: labels the refresh-interval dropdown, not an action button.
+  # @source Refresh
+  refresh: Aggiornamento
+  series:
+    # @source Limit
+    limit: Limite
+    # @source Read
+    read: Lettura
+    # @reason RX (receive) is the universal networking abbreviation, unchanged in Italian
+    # @source RX
+    rx: RX
+    # @reason TX (transmit) is the universal networking abbreviation, unchanged in Italian
+    # @source TX
+    tx: TX
+    # @reason Feminine, agreeing with "memoria" in the memory chart.
+    # @source Used
+    used: Utilizzata
+    # @source Write
+    write: Scrittura
+containers:
+  manage:
+    table:
+      action:
+        # @reason 'Info' is standard Italian shorthand for 'informazioni'; matches containerInfo.info
+        # @source Info
+        info: Info
+        # @source Restart
+        restart: Riavvia
+        # @source Start
+        start: Avvia
+        # @source Stop
+        stop: Arresta
+      header:
+        # @source Name
+        containerName: Nome
+        # @source Image
+        image: Immagine
+        # @source Port(s)
+        ports: Porte
+        # @source Uptime
+        started: Tempo di attività
+        # @source State
+        state: Stato
+  sortableTables:
+    # @source There are no containers to show
+    noRows: Nessun container da mostrare
+  # @source Containers
+  title: Container
+dashboard:
+  # @reason Product name.
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop non può essere eseguito con privilegi di root. Eseguilo di nuovo come utente normale.
+  # @source Cannot run as Root
+  title: Impossibile eseguire come root
+deploymentProfile:
+  # @reason "version" kept as the literal field name; "deployment" is an established loanword.
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 'File di deployment {path} non valido: nessuna versione specificata. Aggiungi un campo version per renderlo valido (la versione corrente è {version}).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 'Deployment non valido: nessuna versione specificata in {path}. Aggiungi un campo version per renderlo valido (la versione corrente è {version}).'
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} falliti più {muted} silenziati'
+  # @source Last run:
+  lastRun: 'Ultima esecuzione:'
+  # @source (No fixes available)
+  noFixes: (Nessuna correzione disponibile)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: Prova a mostrare le diagnostiche silenziate.
+      # @source No results found
+      heading: Nessun risultato trovato
+      # @reason Icon identifier, not translatable text.
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop sembra funzionare correttamente.
+      # @source No problems detected
+      heading: Nessun problema rilevato
+      # @reason Icon identifier, not translatable text.
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: Mostra silenziati
+  tableHeaders:
+    # @source Mute
+    mute: Silenzia
+    # @source Name
+    name: Nome
+  # @source Diagnostics
+  title: Diagnostica
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: Neanche la rete condivisa è disponibile. L'accesso alla rete è possibile solo tramite il port forwarding verso l'host.
+    # @source Using shared network address {ip}
+    sharedFallback: Viene utilizzato l'indirizzo della rete condivisa {ip}
+    # @source Bridged network did not get an IP address.
+    title: La rete in modalità bridge non ha ottenuto un indirizzo IP.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: Elimina i carichi di lavoro
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: Il downgrade da {from} a {to} comporterà la perdita dei carichi di lavoro Kubernetes esistenti. Eliminare i dati?
+    # @source Confirming migration
+    title: Conferma della migrazione
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: 'Verrà utilizzata la versione minima consigliata per l''upgrade: {version}'
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: La versione di Kubernetes richiesta ''{version}'' non è una versione supportata.
+    # @source Invalid Kubernetes Version
+    title: Versione di Kubernetes non valida
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: Procurati una versione nell'intervallo {range} e installala in ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: Impossibile scaricare una versione compatibile di kubectl in modalità offline
+    # @source Network failure
+    title: Errore di rete
+extensions:
+  # @reason Icon identifier, not translatable text.
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: Sembra che tu non abbia ancora installato alcuna estensione. Sfoglia il catalogo delle estensioni per iniziare.
+      button:
+        # @source Browse Extensions
+        text: Sfoglia le estensioni
+      # @source No extensions installed
+      heading: Nessuna estensione installata
+      # @reason Icon identifier, not translatable text.
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: Rimuovi
+      # @reason "Aggiorna" is the conventional Italian for upgrading an installed extension.
+      # @source Upgrade
+      upgrade: Aggiorna
+  view:
+    emptyState:
+      # @reason Feminine agreement: {extensionId} refers to "estensione".
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId} è stata rimossa. Visita il catalogo delle estensioni per reinstallarla o per cercare altre estensioni con cui migliorare la tua esperienza con Rancher Desktop.'
+      # @source Extension removed
+      heading: Estensione rimossa
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Abilita Kubernetes
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (solo versioni in cache)
+    # @source Kubernetes Version
+    legend: Versione di Kubernetes
+    # @source Other Versions
+    otherVersions: Altre versioni
+    # @source Recommended Versions
+    recommendedVersions: Versioni consigliate
+  # @reason 'OK' is the standard confirmation button label in Italian dialogs
+  # @source OK
+  ok: OK
+  # @reason "Ti diamo il benvenuto" avoids the gendered "Benvenuto".
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Ti diamo il benvenuto in Rancher Desktop di SUSE
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop fornisce Kubernetes e la gestione delle immagini tramite un'applicazione desktop.
+  # @reason Established loanword in Italian.
+  # @source Homepage
+  homepage: Homepage
+  # @reason GitHub term; the link points to the issue tracker.
+  # @source Issues
+  issues: Issue
+  # @source General
+  navLabel: Generale
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 'Discussioni sul progetto: <b>#rancher-desktop</b> nello Slack <a href="https://slack.rancher.io/">Rancher Users</a>'
+  # @source Project Links:
+  projectLinks: 'Link del progetto:'
+  # @reason "Ti diamo il benvenuto" avoids the gendered "Benvenuto".
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Ti diamo il benvenuto in Rancher Desktop di SUSE
+generic:
+  # @source  and 
+  and: ' e '
+  # @source Apply
+  apply: Applica
+  # @source Cancel
+  cancel: Annulla
+  # @source Close
+  close: Chiudi
+  # @reason list separator; Italian uses the same comma + space
+  # @source , 
+  comma: ', '
+  # @reason Assumed port-forwarding context; would be "Avanti" if used for navigation.
+  # @source Forward
+  forward: Inoltra
+  # @source Loading&hellip;
+  loading: Caricamento&hellip;
+  # @reason Kubernetes/containerd term, untranslated in Italian.
+  # @source Namespace
+  namespace: Namespace
+  # @reason 'OK' is the standard confirmation button label in Italian dialogs
+  # @source OK
+  ok: OK
+  # @source Rerun
+  rerun: Riesegui
+  # @source Search
+  search: Cerca
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: Seleziona il Dockerfile da usare (potrebbe avere un nome diverso)
+  # @source Pick the build directory
+  buildTitle: Scegli la directory di build
+  # @source Error trying to delete images {ids}
+  deleteBatchError: Errore durante l'eliminazione delle immagini {ids}
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      Errore durante l'eliminazione dell'immagine {name} ({id}):
+
+       {error}
+  # @reason "push" kept: Docker term.
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      Errore durante il push di {name}:
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      Errore durante la scansione di {name}:
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: Aggiungi immagine
+  add:
+    action:
+      # @reason Kept "build": the Docker term; "compila" would be wrong for images.
+      # @source Build
+      build: Esegui build
+      gerund:
+        # @reason Kept the loanword, capitalized: it opens the composed loadingText sentence ('Build dell'immagine in corso...').
+        # @source Building
+        build: Build
+        # @reason Kept the loanword, capitalized: it opens the composed loadingText sentence ('Pull dell'immagine in corso...').
+        # @source Pulling
+        pull: Pull
+      infinitive:
+        # @reason Lowercase noun; errorText composes 'l'operazione di build su ...', matching the pastTense.build convention.
+        # @source build
+        build: build
+        # @reason Lowercase noun; errorText composes 'l'operazione di pull su ...', matching the pastTense.pull convention.
+        # @source pull
+        pull: pull
+      pastTense:
+        # @reason Lowercase noun; successText composes "Operazione di {action} dell'immagine completata", matching pastTense.pull.
+        # @source Built
+        build: build
+        # @reason Inserted into successText as a noun ('Operazione di pull ...'), so lowercase; 'pull' is the standard container term among Italian developers.
+        # @source Pulled
+        pull: pull
+      # @reason Kept English: standard container operation term in Italian dev usage, matches the CLI verb.
+      # @source Pull
+      pull: Pull
+    # @reason { action } is used as a noun ('l'operazione di pull'); an Italian infinitive after 'trying to' would not compose with the loanword verbs.
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Errore durante l'operazione di { action } su ''{ image }'' - consulta l'output della console per maggiori informazioni
+    # @reason Restructured: Italian has no progressive suffix, so the gerund value acts as a noun and 'in corso' carries the ongoing sense, as in scan.loadingText.
+    # @source {action} image...
+    loadingText: '{action} dell''immagine in corso...'
+    # @reason {action} receives images.add.action.pastTense.*; phrased so a lowercase noun-style value composes and the participle agrees with the fixed 'operazione'.
+    # @source {action} image
+    successText: Operazione di {action} dell'immagine completata
+    # @source Add Image
+    title: Aggiungi immagine
+  confirmDelete:
+    # @source Delete
+    confirm: Elimina
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: Eliminare {count} {count, plural, one {immagine} other {immagini}}?
+    # @source Delete image {name}:{tag}?
+    single: Eliminare l'immagine {name}:{tag}?
+    # @source Confirming image deletion
+    title: Conferma dell'eliminazione delle immagini
+  manager:
+    # @source Close Output to Continue
+    close: Chiudi l'output per continuare
+    input:
+      build:
+        # @reason Kept English: 'build' is an established loanword in Italian dev tooling; 'Compila' would be misleading for container images.
+        # @source Build
+        button: Build
+        # @source Name of image to build:
+        label: 'Nome dell''immagine di cui eseguire la build:'
+        # @reason literal example image reference, not translatable text
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @reason 'Pull' kept as Docker term, matching the file's pull/push convention
+        # @source Pull
+        button: Pull
+        # @source Name of image to pull:
+        label: 'Nome dell''immagine di cui eseguire il pull:'
+        # @reason literal example image reference, not translatable text
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: Elimina
+        # @reason Kept English: standard registry operation term in Italian dev usage.
+        # @source Push
+        push: Push
+        # @source Scan...
+        scan: Scansiona...
+      header:
+        # @source Image ID
+        imageId: ID immagine
+        # @source Image
+        imageName: Immagine
+        # @source Size
+        size: Dimensione
+        # @reason 'tag' is the standard loanword for image tags in Italian Docker usage
+        # @source Tag
+        tag: Tag
+      # @source All images
+      label: Tutte le immagini
+    # @source Image Output
+    title: Output delle immagini
+  scan:
+    details:
+      # @source Description
+      description: Descrizione
+      # @source Primary URL
+      primaryUrl: URL principale
+      # @source References
+      references: Riferimenti
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Errore durante la scansione di ''{ image }'' - consulta l'output della console per maggiori informazioni
+    labels:
+      # @reason Severity labels use feminine forms, agreeing with 'gravità'.
+      # @source CRITICAL
+      critical: CRITICA
+      # @source HIGH
+      high: ALTA
+      # @source Issues Found
+      issuesFound: Problemi rilevati
+      # @source LOW
+      low: BASSA
+      # @source MEDIUM
+      medium: MEDIA
+    # @source Scanning ''{ image }''
+    loadingText: Scansione di ''{ image }'' in corso
+    results:
+      headers:
+        # @reason Column shows the version that fixes the vulnerability (Trivy FixedVersion); feminine agrees with 'versione'.
+        # @source Fixed
+        fixed: Risolta in
+        # @reason Column shows the installed version (Trivy InstalledVersion); feminine agrees with 'versione'.
+        # @source Installed
+        installed: Installata
+        # @source Package
+        package: Pacchetto
+        # @source Severity
+        severity: Gravità
+        # @source Vulnerability ID
+        vulnerabilityId: ID vulnerabilità
+    # @source Scan details for ''{ image }''
+    title: Dettagli della scansione di ''{ image }''
+  sortableTables:
+    # @source There are no images to show
+    noRows: Nessuna immagine da visualizzare
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: In attesa che il gestore delle immagini sia pronto
+    # @source Error: Unknown state; please reload.
+    unknown: 'Errore: stato sconosciuto; ricarica la pagina.'
+  # @source Images
+  title: Immagini
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Espone la configurazione Kubernetes e il socket Docker di Rancher Desktop alle distribuzioni Windows Subsystem for Linux (WSL)
+kubernetesError:
+  # @source Context:
+  context: 'Contesto:'
+  # @source Last command run:
+  lastCommand: 'Ultimo comando eseguito:'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 'Alcune righe recenti del <a href="#" data-action="showLogs">file di log</a>:'
+  # @source {appName} Error
+  title: Errore di {appName}
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Abilita Kubernetes
+    # @reason Kubernetes product name
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: Opzioni
+    # @source Install Spin Operator
+    spinkube: Installa Spin Operator
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: Spin Operator richiede che <a href="#" data-navigate="Container Engine,general">WebAssembly</a> sia abilitato.
+    # @source Enable Traefik
+    traefik: Abilita Traefik
+  port:
+    # @source Kubernetes Port
+    legendText: Porta di Kubernetes
+  version:
+    # @source Kubernetes version
+    legendText: Versione di Kubernetes
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Versione di Kubernetes (solo versioni in cache)
+    # @source Other Versions
+    otherVersions: Altre versioni
+    # @source Recommended Versions
+    recommendedVersions: Versioni consigliate
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: Nessuna opzione
+    # @source No matching options
+    noMatch: Nessuna opzione corrispondente
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} elementi'
+    # @source Load More...
+    more: Carica altri...
+locale:
+  # @source German
+  de: Tedesco
+  # @source English
+  en-us: Inglese
+  # @source Spanish
+  es: Spagnolo
+  # @source French
+  fr: Francese
+  # @source Italian
+  it: Italiano
+  # @source Japanese
+  ja: Giapponese
+  # @source Portuguese (Brazilian)
+  pt-br: Portoghese (Brasile)
+  # @source Chinese (Simplified)
+  zh-hans: Cinese (semplificato)
+mainMenu:
+  # @source About {appName}
+  about: Informazioni su {appName}
+  edit:
+    # @source &Copy
+    copy: '&Copia'
+    # @source Cu&t
+    cut: '&Taglia'
+    # @source De&lete
+    delete: '&Elimina'
+    # @reason Accelerators throughout the menus are reassigned to fit the Italian labels; kept unique within each menu.
+    # @source &Edit
+    label: '&Modifica'
+    # @source &Paste
+    paste: '&Incolla'
+    # @source &Redo
+    redo: '&Ripeti'
+    # @source Select &All
+    selectAll: '&Seleziona tutto'
+    # @source &Undo
+    undo: '&Annulla'
+  file:
+    # @source Close
+    close: Chiudi
+    # @source E&xit
+    exit: '&Esci'
+    # @reason Italian Windows/macOS applications keep 'File' as the menu name
+    # @source &File
+    label: '&File'
+  help:
+    # @source &About {appName}
+    about: '&Informazioni su {appName}'
+    # @reason Noun form ('Discussions') reads more naturally than an imperative as an Italian menu item.
+    # @source &Discuss
+    discuss: '&Discussioni'
+    # @source File a &Bug
+    fileABug: Segnala un &bug
+    # @source Get &Help
+    getHelp: Ottieni &aiuto
+    # @source {appName} &Help
+    help: '&Guida di {appName}'
+    # @source &Help
+    label: '&Aiuto'
+    # @source &Project Page
+    projectPage: '&Pagina del progetto'
+  # @source Hide {appName}
+  hide: Nascondi {appName}
+  # @reason Apple's Italian convention for the macOS app menu (feminine, referring to 'le applicazioni').
+  # @source Hide Others
+  hideOthers: Nascondi altre
+  # @source Preferences
+  preferences: Impostazioni
+  # @source Quit {appName}
+  quit: Esci da {appName}
+  # @source Services
+  services: Servizi
+  # @reason Apple's Italian convention for the macOS app menu (feminine, referring to 'le applicazioni').
+  # @source Show All
+  showAll: Mostra tutte
+  view:
+    # @source &Actual Size
+    actualSize: '&Dimensioni effettive'
+    # @source &Force Reload
+    forceReload: '&Forza ricaricamento'
+    # @source &View
+    label: '&Visualizza'
+    # @source &Reload
+    reload: '&Ricarica'
+    # @source Toggle &Developer Tools
+    toggleDevTools: Attiva/disattiva &strumenti di sviluppo
+    # @source Toggle Full &Screen
+    toggleFullScreen: Attiva/disattiva schermo &intero
+    # @reason Accelerator on N: I is taken by 'schermo &intero' in the same menu.
+    # @source Zoom &In
+    zoomIn: I&ngrandisci
+    # @reason Accelerator on U: R is taken by '&Ricarica' in the same menu.
+    # @source Zoom &Out
+    zoomOut: Rid&uci
+  window:
+    # @reason Apple's Italian convention for the macOS Window menu (feminine, referring to 'le finestre').
+    # @source Bring All to Front
+    front: Porta tutte in primo piano
+    # @reason Accelerator on N: F is taken by '&File' in the menu bar.
+    # @source &Window
+    label: Fi&nestra
+    # @reason Apple's Italian term for Minimize in the macOS Window menu.
+    # @source Minimize
+    minimize: Contrai
+    # @reason Apple's Italian term for Zoom in the macOS Window menu.
+    # @source Zoom
+    zoom: Ingrandisci
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: Descrizione
+        # @source Name
+        name: Nome
+        # @source Vendor
+        vendor: Fornitore
+  labels:
+    # @source Install
+    install: Installa
+    # @source Remove
+    uninstall: Rimuovi
+    # @source Upgrade
+    upgrade: Aggiorna
+  loading:
+    # @source Installing...
+    install: Installazione in corso...
+    # @source Removing...
+    uninstall: Rimozione in corso...
+    # @source Upgrading...
+    upgrade: Aggiornamento in corso...
+  # @source More information
+  moreInfo: Maggiori informazioni
+  # @source No extension found for the search criteria
+  noResults: Nessuna estensione trovata per i criteri di ricerca
+  tabs:
+    # @source Catalog
+    catalog: Catalogo
+    # @reason Feminine plural, agreeing with 'estensioni'.
+    # @source Installed
+    installed: Installate
+  # @source Extensions
+  title: Estensioni
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: Dashboard del cluster
+    # @source Preferences
+    preferences: Impostazioni
+pathManagement:
+  # @source Configure PATH
+  label: Configura il PATH
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop non modifica la configurazione del PATH; aggiungi manualmente <code>$HOME/.rd/bin</code> al PATH.
+      # @source Manual
+      label: Manuale
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop modifica il profilo della shell per te. Riavvia le shell aperte affinché le modifiche abbiano effetto.
+      # @reason Feminine, agreeing with the implied 'configurazione (del PATH)'; pairs with the invariant 'Manuale'.
+      # @source Automatic
+      label: Automatica
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop include strumenti come kubectl, nerdctl, helm e docker. Per poterli utilizzare, <code>$HOME/.rd/bin</code> deve essere nel PATH.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Includi i servizi Kubernetes
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: Porta locale
+        # @source Name
+        name: Nome
+        # @reason Kubernetes term, kept English.
+        # @source Namespace
+        namespace: Namespace
+        # @source Port
+        port: Porta
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: Nessuna voce di port forwarding da visualizzare
+  # @reason Kept English: standard networking term in Italian; 'Inoltro porte' is uncommon in dev tooling.
+  # @source Port Forwarding
+  title: Port forwarding
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: Si è verificato un problema con la selezione delle impostazioni.
+      # @source Kubernetes will reset after applying changes.
+      reset: Kubernetes verrà reimpostato dopo l'applicazione delle modifiche.
+      # @source Kubernetes will restart after applying changes.
+      restart: Kubernetes verrà riavviato dopo l'applicazione delle modifiche.
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: WebAssembly deve essere abilitato per poter installare lo <a href="#" data-navigate="Kubernetes">Spin Operator</a>.
+  error:
+    # @source Reload Preferences to try again.
+    body: Ricarica le impostazioni per riprovare.
+    # @source Unable to fetch preferences
+    heading: Impossibile recuperare le impostazioni
+    # @source Reload preferences
+    reload: Ricarica le impostazioni
+  # @source Preferences
+  header: Impostazioni
+  # @source or
+  incompatiblePrefWarningOr: o
+  # @reason Fragment: composed as Pre + linked preference name(s) + Post; masculine default since the inserted names have no fixed gender.
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: sia deselezionato.
+  # @reason Fragment: composed as Pre + linked preference name(s) + Post; masculine default since the inserted names have no fixed gender.
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: sia selezionato.
+  # @reason Fragment: 'che' introduces the subjunctive completed by the Post fragments ('sia selezionato/deselezionato').
+  # @source The option requires
+  incompatibleTypeWarningPre: L'opzione richiede che
+  locked:
+    # @reason Added the subject 'Impostazione' to fix gender agreement; 'criteri' is the standard Italian rendering of 'policy'.
+    # @source Locked due to organization's policy
+    tooltip: Impostazione bloccata dai criteri dell'organizzazione
+  nav:
+    # @source Application
+    application: Applicazione
+    # @reason Kept English: established term among Italian developers for the moby/containerd runtime choice.
+    # @source Container Engine
+    containerEngine: Container engine
+    # @reason Kubernetes product name
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: Macchina virtuale
+    # @reason WSL is the product acronym (Windows Subsystem for Linux)
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: Applica e reimposta
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: Queste modifiche reimposteranno il cluster Kubernetes, con conseguente perdita dei carichi di lavoro e delle immagini container.
+    # @source Apply preferences and reset Kubernetes?
+    message: Applicare le impostazioni e reimpostare Kubernetes?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Reimposta Kubernetes
+  tabs:
+    # @source Allowed Images
+    allowedImages: Immagini consentite
+    # @source Behavior
+    behavior: Comportamento
+    # @source Emulation
+    emulation: Emulazione
+    # @source Environment
+    environment: Ambiente
+    # @source General
+    general: Generale
+    # @reason 'hardware' is a fully assimilated loanword in Italian
+    # @source Hardware
+    hardware: Hardware
+    # @source Integrations
+    integrations: Integrazioni
+    # @reason 'proxy' is the standard Italian networking term, as in macOS/Windows settings
+    # @source Proxy
+    proxy: Proxy
+    # @source Volumes
+    volumes: Volumi
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: Alcune impostazioni hanno modifiche non ancora applicate. Tutte le impostazioni non salvate andranno perse.
+    # @reason 'Scarta' instead of the common 'Annulla modifiche': in a dialog 'Annulla' reads as the Cancel button.
+    # @source Discard changes
+    discardChanges: Scarta le modifiche
+    # @source Close preferences without applying?
+    message: Chiudere le impostazioni senza applicare le modifiche?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - Chiudi impostazioni
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - Impostazioni
+prefs:
+  # @source Experimental
+  experimental: Sperimentale
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: Questa impostazione richiede macOS 13.3 (Ventura) o versioni successive.
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: Questa impostazione richiede macOS 13.0 (Ventura) o versioni successive.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: Questa impostazione richiede la modalità di emulazione VZ. VZ è disponibile solo su macOS 13.3 (Ventura) o versioni successive.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: Questa impostazione richiede la modalità di emulazione VZ. VZ è disponibile solo su macOS 13.0 (Ventura) o versioni successive.
+product:
+  containerEngine:
+    # @reason Abbreviation of 'Container Engine', kept as-is.
+    # @source CE
+    abbreviation: CE
+    # @reason Kept English so it still matches the 'CE' abbreviation.
+    # @source Container Engine
+    fullName: Container Engine
+  # @source deactivated
+  deactivated: disattivato
+  # @reason Kubernetes product name
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: Stato della rete
+  networkStatusValues:
+    # @source checking...
+    checking: verifica in corso...
+    # @reason 'offline' is an assimilated loanword in Italian
+    # @source offline
+    offline: offline
+    # @reason 'online' is an assimilated loanword in Italian
+    # @source online
+    online: online
+  # @source Version
+  version: Versione
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: Richiesta di autorizzazione per eseguire attività come amministratore
+  # @source Bundling certificates
+  bundlingCertificates: Raggruppamento dei certificati
+  # @source Checking k3s images
+  checkingK3sImages: Verifica delle immagini k3s
+  # @source Configuring container engine
+  configuringContainerEngine: Configurazione del container engine
+  # @source Configuring image proxy
+  configuringImageProxy: Configurazione del proxy delle immagini
+  # @source Configuring logrotate
+  configuringLogrotate: Configurazione di logrotate
+  # @source Container engine components
+  containerEngineComponents: Componenti del container engine
+  # @source Copying certificates
+  copyingCertificates: Copia dei certificati
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: Eliminazione dello stato incompatibile di Kubernetes
+  # @source Deleting Kubernetes
+  deletingKubernetes: Eliminazione di Kubernetes
+  # @source Deleting virtual machine
+  deletingVirtualMachine: Eliminazione della macchina virtuale
+  # @source DNS configuration
+  dnsConfiguration: Configurazione DNS
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: Verifica della compatibilità di kubectl
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: Verifica del supporto della virtualizzazione
+  # @source Expecting user permission to continue
+  expectingPermission: In attesa dell'autorizzazione dell'utente per continuare
+  # @source Extracting certificates
+  extractingCertificates: Estrazione dei certificati
+  # @source Fetching certificates
+  fetchingCertificates: Recupero dei certificati
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Inizializzazione di Rancher Desktop
+  # @source Initializing WSL data
+  initializingWslData: Inizializzazione dei dati WSL
+  # @source Installing Buildkit
+  installingBuildkit: Installazione di Buildkit
+  # @source Installing CA certificates
+  installingCaCertificates: Installazione dei certificati CA
+  # @source Installing container engine
+  installingContainerEngine: Installazione del container engine
+  # @reason 'credential helper' is the Docker term, kept English.
+  # @source Installing credential helper
+  installingCredentialHelper: Installazione del credential helper
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: Installazione dell'helper docker-credential
+  # @source Installing helpers
+  installingHelpers: Installazione degli helper
+  # @source Installing image scanner
+  installingImageScanner: Installazione dello scanner di immagini
+  # @source Installing k3s
+  installingK3s: Installazione di k3s
+  # @source Installing Kubernetes
+  installingKubernetes: Installazione di Kubernetes
+  # @source Kubernetes components
+  kubernetesComponents: Componenti di Kubernetes
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Compatibilità di Kubernetes con dockerd
+  # @source Mounting WSL data
+  mountingWslData: Montaggio dei dati WSL
+  # @source Preparing to start
+  preparingToStart: Preparazione all'avvio
+  # @source Proxy Config Setup
+  proxyConfigSetup: Configurazione del proxy
+  # @reason 'guest agent' kept English: it names the rancher-desktop-guestagent component.
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Guest agent di Rancher Desktop
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: Rigenerazione della configurazione per tenere conto della mancanza di autorizzazioni
+  # @source Registering WSL distribution
+  registeringWslDistribution: Registrazione della distribuzione WSL
+  # @source Removing existing certificates
+  removingExistingCertificates: Rimozione dei certificati esistenti
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: Rimozione dell'operatore spinkube
+  # @source Removing stale state
+  removingStaleState: Rimozione dello stato obsoleto
+  # @source Removing Traefik
+  removingTraefik: Rimozione di Traefik
+  # @source Resetting Kubernetes
+  resettingKubernetes: Reimpostazione di Kubernetes
+  # @source Running provisioning scripts
+  runningProvisioningScripts: Esecuzione degli script di provisioning
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: Esecuzione di update-ca-certificates
+  # @source Setting docker context
+  settingDockerContext: Impostazione del contesto docker
+  # @source Setting Lima permissions
+  settingLimaPermissions: Impostazione delle autorizzazioni di Lima
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Configurazione del socket Docker
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: Configurazione della rete ethernet virtuale
+  # @source Shutting down
+  shuttingDown: Arresto in corso
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: Controlli del nodo ignorati, flannel è disabilitato
+  # @source Starting Backend
+  startingBackend: Avvio del backend
+  # @source Starting buildkit
+  startingBuildkit: Avvio di buildkit
+  # @source Starting container engine
+  startingContainerEngine: Avvio del container engine
+  # @source Starting image proxy
+  startingImageProxy: Avvio del proxy delle immagini
+  # @source Starting k3s
+  startingK3s: Avvio di k3s
+  # @source Starting Kubernetes
+  startingKubernetes: Avvio di Kubernetes
+  # @source Starting proxy
+  startingProxy: Avvio del proxy
+  # @source Starting {service}
+  startingService: Avvio di {service}
+  # @source Starting virtual machine
+  startingVirtualMachine: Avvio della macchina virtuale
+  # @source Starting WSL environment
+  startingWslEnvironment: Avvio dell'ambiente WSL
+  # @source Stopping existing instance
+  stoppingExistingInstance: Arresto dell'istanza esistente
+  # @reason 'mock' kept in English; established software-testing term in Italian
+  # @source Stopping mock backend
+  stoppingMockBackend: Arresto del backend mock
+  # @source Stopping services
+  stoppingServices: Arresto dei servizi
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: Aggiornamento della configurazione del cluster
+  # @source Updating /etc/hosts
+  updatingEtcHosts: Aggiornamento di /etc/hosts
+  # @source Updating kubeconfig
+  updatingKubeconfig: Aggiornamento del kubeconfig
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: Aggiornamento della macchina virtuale obsoleta
+  # @source Updating WSL data
+  updatingWslData: Aggiornamento dei dati WSL
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: Aggiornamento della distribuzione WSL
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: In attesa che il container engine sia pronto
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: In attesa dell'API di Kubernetes
+  # @source Waiting for nodes
+  waitingForNodes: In attesa dei nodi
+  # @source Waiting for services
+  waitingForServices: In attesa dei servizi
+  # @source Writing K3s configuration
+  writingK3sConfiguration: Scrittura della configurazione di K3s
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: Crea snapshot
+  card:
+    action:
+      # @source Delete
+      remove: Elimina
+      # @source Restore
+      restore: Ripristina
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: Creato il '<b>'{date}'</b>' alle '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: Annulla
+      # @source Create
+      submit: Crea
+    description:
+      # @source Description
+      label: Descrizione
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: Rancher Desktop sarà temporaneamente non disponibile durante la creazione di un nuovo snapshot
+    name:
+      # @source Snapshot Name
+      label: Nome dello snapshot
+    # @source Create a new Snapshot
+    title: Crea un nuovo snapshot
+  dialog:
+    buttons:
+      # @source Close
+      error: Chiudi
+    creating:
+      actions:
+        # @source Cancel
+        cancel: Annulla
+      # @source Creating {snapshot}
+      header: Creazione di {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: Attendi mentre lo snapshot '<b>'{snapshot}'</b>' viene creato.'<br/>'L'operazione potrebbe richiedere del tempo, a seconda delle risorse della macchina.'<br/>'Rancher Desktop sarà temporaneamente non disponibile durante questa operazione.'<br/><br/>'Una volta completato lo snapshot, la VM verrà riavviata.
+    delete:
+      actions:
+        # @source Cancel
+        cancel: Annulla
+        # @source Delete
+        ok: Elimina
+      # @source Permanently delete snapshot?
+      header: Eliminare definitivamente lo snapshot?
+      # @reason English source is the literal placeholder stub 'text'; kept unchanged until the source gets real content
+      # @source Deleting a snapshot cannot be undone.
+      info: L'eliminazione di uno snapshot non può essere annullata.
+    generic:
+      # @source Snapshot operation in progress
+      header: Operazione snapshot in corso
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: Attendi mentre l'operazione sullo snapshot è in corso.<br/>Potrebbe richiedere del tempo, a seconda delle risorse della macchina.<br/>Rancher Desktop sarà temporaneamente non disponibile durante questa operazione.<br/><br/>Al termine del processo di snapshot, la VM verrà riavviata.
+    restore:
+      actions:
+        # @source Cancel
+        cancel: Annulla
+        # @source Restore
+        ok: Ripristina
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Esci da Rancher Desktop
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: Impossibile ripristinare lo snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop ha eseguito un ripristino di fabbrica e ora verrà chiuso. Prova a risolvere il problema che ha causato questo errore prima di riavviare Rancher Desktop e tentare di nuovo il ripristino dello snapshot.
+        # @source Error restoring snapshot
+        header: Errore durante il ripristino dello snapshot
+      # @source Restore snapshot?
+      header: Ripristinare lo snapshot?
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: Il ripristino di questo snapshot sostituirà l'installazione corrente, incluse le preferenze. Se la finestra delle Impostazioni è aperta, verrà chiusa automaticamente e le eventuali modifiche non salvate andranno perse.
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: Annulla
+      # @source Restoring {snapshot}
+      header: Ripristino di {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: Attendi mentre lo snapshot '<b>'{snapshot}'</b>' viene ripristinato. L'operazione potrebbe richiedere del tempo, a seconda delle risorse della macchina.<br/><br/>Rancher Desktop sarà temporaneamente non disponibile durante questa operazione. Al termine, la VM verrà riavviata con lo snapshot {snapshot} attivo.
+    # @source Show logs
+    showLogs: Mostra log
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: Fai clic su Crea snapshot per iniziare
+    # @source No snapshots found
+    heading: Nessuno snapshot trovato
+    # @reason icon identifier, not user-visible text; kept unchanged
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: Creazione di {snapshot} annullata
+      # @source Created '<b>'{snapshot}'</b>'
+      success: Creato '<b>'{snapshot}'</b>'
+    delete:
+      # @source Delete error: {error}
+      error: 'Errore di eliminazione: {error}'
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: Eliminato '<b>'{snapshot}'</b>'
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: È stato rilevato un file di lock dello snapshot per un tempo insolitamente lungo. Se ritieni che si tratti di un errore, puoi provare a rimuovere il file di lock eseguendo <code>rdctl snapshot unlock</code>.
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: Ripristino di {snapshot} annullato
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: Ripristinato '<b>'{snapshot}'</b>'
+    # @source  at {time}
+    when: ' alle {time}'
+  # @reason 'snapshot' is the established loanword in Italian dev usage; loanwords are invariable, so the plural takes no -s
+  # @source Snapshots
+  title: Snapshot
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: '{actionable} selezionati'
+    # @source Available for {actionable} of the {total} selected
+    some: Disponibile per {actionable} dei {total} selezionati
+  # @source Add
+  add: Aggiungi
+  # @source Add Filter
+  addFilter: Aggiungi filtro
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: Azioni
+  # @source Filter for...
+  filterFor: Filtra per...
+  # @reason the Italian preposition coincides with the English word
+  # @source in
+  in: in
+  # @source No actions available
+  noActions: Nessuna azione disponibile
+  # @source There are no rows which match your search query.
+  noData: Nessuna riga corrisponde ai criteri di ricerca.
+  # @source There are no rows to show.
+  noRows: Non ci sono righe da visualizzare.
+  paging:
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {Nessun elemento}
+        =1 {{count} {count, plural, =1 {elemento} other {elementi}}}
+        other {{from} - {to} di {count} elementi}}
+  # @source Reset
+  resetFilters: Reimposta
+  # @source Filter
+  search: Filtra
+  # @source Select a column
+  selectCol: Seleziona una colonna
+  tableHeader:
+    # @source Group by
+    groupBy: Raggruppa per
+    # @source This column cannot be filtered
+    noFilter: Non è possibile filtrare in base a questa colonna
+    # @source Show
+    show: Mostra
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: Esegui sempre senza accesso amministrativo
+  # @reason 'OK' is the standard confirmation button label in Italian dialogs
+  # @source OK
+  buttonText: OK
+  # @source This will modify the following paths:
+  explanation: 'Verranno modificati i seguenti percorsi:'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'Rancher Desktop richiede l''accesso amministrativo ("accesso sudo") per i seguenti motivi:'
+  # @reason 'context' kept in English; refers to the 'docker context' CLI concept
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: La richiesta verrà visualizzata alla chiusura di questa finestra. Se annulli la richiesta o disabiliti l'accesso amministrativo, dovrai impostare il context docker su rancher-desktop per continuare a usare Rancher Desktop.
+  reasons:
+    dockerSocket:
+      # @reason 'context' kept in English; refers to the 'docker context' CLI concept
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: Garantisce la compatibilità con gli strumenti che usano il socket docker senza poter usare i context docker.
+      # @source Set up default docker socket
+      title: Configura il socket docker predefinito
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: Fornisce la rete in modalità bridge per facilitare l'accesso ai container. Se non è consentito, i container saranno accessibili solo tramite port forwarding.
+      # @source Configure networking
+      title: Configura la rete
+  # @source Administrative Access Required
+  title: Accesso amministrativo richiesto
+systemPreferences:
+  # @reason '#' is not used as a number abbreviation in Italian; 'N.' is standard, and acronyms like CPU are invariable in the plural
+  # @source # CPUs
+  cpus: N. di CPU
+  # @source Memory (GB)
+  memory: Memoria (GB)
+telemetryOptIn:
+  # @reason 'deploy' and 'endpoint' kept in English; established loanwords in Italian dev usage
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Invia informazioni anonime sull'utilizzo, segnalazioni di errori ecc. per contribuire a migliorare Rancher Desktop. I tuoi dati non verranno condivisi con nessun altro e non viene inclusa alcuna informazione sulle risorse o sugli endpoint specifici di cui esegui il deploy.
+tray:
+  # @reason 'container engine' kept in English (established term); the string happens to match the source
+  # @source Container engine: {name}
+  containerEngine: 'Container engine: {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Contesti Kubernetes
+  # @source Network status: {status}
+  networkStatus: 'Stato della rete: {status}'
+  # @source None found
+  noneFound: Nessuno trovato
+  # @source Open cluster dashboard
+  openDashboard: Apri la dashboard del cluster
+  # @source Open main window
+  openMainWindow: Apri la finestra principale
+  # @source Open preferences dialog
+  openPreferences: Apri le Impostazioni
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Esci da Rancher Desktop
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes è disabilitato
+    # @source Kubernetes has encountered an error
+    error: Kubernetes ha riscontrato un errore
+    # @source Kubernetes is running
+    started: Kubernetes è in esecuzione
+    # @source Kubernetes is starting
+    starting: Kubernetes è in fase di avvio
+    # @source Kubernetes is stopped
+    stopped: Kubernetes è arrestato
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes è in fase di arresto
+  # @reason Rancher Desktop product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: Abilita la modalità di debug
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: Ripristino di fabbrica
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: Il ripristino di fabbrica rimuoverà tutte le configurazioni di Rancher Desktop.
+      messageBox:
+        # @source Cancel
+        cancel: Annulla
+        # @source Keep cached Kubernetes images
+        checkboxLabel: Mantieni le immagini Kubernetes nella cache
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>Il ripristino di fabbrica rimuoverà il cluster e tutte le impostazioni di Rancher Desktop e chiuderà Rancher Desktop. Se intendi continuare a usare Rancher Desktop, dovrai avviarlo manualmente e ripetere la configurazione iniziale.</p><p>Confermi di voler ripristinare tutto?</p>
+        # @source Perform a factory reset?
+        message: Eseguire un ripristino di fabbrica?
+        # @source Factory Reset
+        ok: Ripristino di fabbrica
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - Ripristino di fabbrica
+      # @source Factory Reset
+      title: Ripristino di fabbrica
+    logs:
+      # @source Show Logs
+      buttonText: Mostra log
+      # @source Show Rancher Desktop logs
+      description: Mostra i log di Rancher Desktop
+      # @source Logs
+      title: Log
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Reimposta Kubernetes
+      # @reason 'workload' kept in English; the Italian Kubernetes docs leave it untranslated
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: La reimpostazione di Kubernetes eliminerà tutti i workload e la configurazione.
+      messageBox:
+        # @source Cancel
+        cancel: Annulla
+        # @source Delete container images
+        checkboxLabel: Elimina le immagini container
+        # @source Reset Kubernetes?
+        message: Reimpostare Kubernetes?
+        # @source Reset
+        ok: Reimposta
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Reimposta Kubernetes
+      # @source Reset Kubernetes
+      title: Reimposta Kubernetes
+  # @reason 'Rancher Users Slack' kept as the workspace's proper name
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: Hai ancora problemi? Avvia una discussione nel canale <b>#rancher-desktop</b> su <a href="https://slack.rancher.io/">Rancher Users Slack</a> oppure <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">segnala un problema</a>.
+  # @source Troubleshooting
+  title: Risoluzione dei problemi
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: Assicurati che tutti i requisiti siano soddisfatti e riprova. Rancher Desktop verrà ora chiuso.
+  # @reason 'OK' is the standard confirmation button label in Italian dialogs
+  # @source OK
+  buttonText: OK
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 'Rancher Desktop non può avviarsi perché alcuni requisiti sono mancanti o non configurati:'
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop non riesce ad avviarsi
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: Applicazione dell'aggiornamento...
+  # @source An update to version {version} is available
+  available: È disponibile un aggiornamento alla versione {version}
+  # @source Check for updates automatically
+  checkForUpdates: Controlla automaticamente la disponibilità di aggiornamenti
+  # @reason lowercase kept to match the source's inline status style; 'download' is an established loanword
+  # @source downloading... ({percent}%, {speed})
+  downloading: download in corso... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: Si è verificato un errore durante il controllo degli aggiornamenti.
+  # @source Release Notes
+  releaseNotes: Note di rilascio
+  # @source Restart Now
+  restartNow: Riavvia ora
+  # @source Restart the application to apply the update.
+  restartToApply: Riavvia l'applicazione per applicare l'aggiornamento.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: È disponibile una versione più recente di Rancher Desktop, ma non è supportata sul tuo sistema.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: Per maggiori informazioni consulta <a href="https://docs.rancherdesktop.io/getting-started/installation">la documentazione di installazione</a>.
+    # @source Latest Version Not Supported
+    title: Ultima versione non supportata
+  # @source Update Available
+  updateAvailable: Aggiornamento disponibile
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: Impossibile ridurre "{field}" da {from} a {to}
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: Impossibile abilitare WebAssembly con lo storage classico per moby.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: Impossibile passare allo storage classico per moby quando WebAssembly è abilitato.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: Impossibile passare al container engine moby con lo storage classico quando WebAssembly è abilitato.
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 'il campo "{field}" contiene voci duplicate: "{duplicates}"'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 'Errori nelle impostazioni proposte:'
+  # @source field "{field}" is locked
+  fieldLocked: il campo "{field}" è bloccato
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: "{pattern}" non descrive un riferimento a un''immagine'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: "{value}" non è una mappatura valida'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: "{name}" non è un nome valido'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 'il campo "{field}" contiene voci non valide (devono essere indirizzi IP, sottoreti CIDR o nomi di dominio): "{entries}"'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: "{value}" non è un nome di pagina valido per la finestra delle Impostazioni'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: il nome di scheda "{tabName}" non è valido per la pagina "{page}" delle Impostazioni'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: "{name}" ha un tag non valido "{tag}"'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 'Valore non valido per "{field}": <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 'Valore non valido per "{field}": <{value}>; deve essere uno tra {validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Versione di Kubernetes "{version}" non trovata.
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: "{name}" ha un tag non stringa "{tag}"'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: La modifica del campo "{field}" tramite l'API non è supportata.
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 'Errore per il campo ''''{field}'''': previsto un valore di tipo array, ricevuto ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 'Errore per il campo ''''{field}'''': previsto un valore di tipo {expectedType}, ricevuto ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 'Errore per il campo ''''{field}'''': previsto un valore di tipo {expectedType}, ricevuto un array {value}'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: Il campo proposto "{field}" dovrebbe essere un oggetto, ricevuto <{value}>.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: L'impostazione {field} può essere abilitata solo su sistemi aarch64.
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: L'impostazione {field} può essere modificata solo quando virtualMachine.mount.type è "{mountType}".
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: L'impostazione {field} può essere abilitata solo quando virtual-machine.type è "{vmType}".
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: L'impostazione {field} può essere configurata solo se è impostata anche experimental.container-engine.web-assembly.enabled.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: Impostare {field} su "{value}" richiede che {otherField} sia "{required}".
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: Impostare {field} su "{value}" richiede che {otherField} sia "{option1}" o "{option2}".
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: L'impostazione "{field}" dovrebbe contenere un oggetto interno, ma è stato ricevuto <{value}>.
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: L'impostazione "{field}" dovrebbe essere un valore semplice, ma è stato ricevuto <{value}>.
+  # @source One or more fields in this tab contain a form validation error
+  tab: Uno o più campi in questa scheda contengono un errore di convalida del modulo
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: Impostare {field} su "{vmType}" su ARM richiede macOS 13.3 (Ventura) o versioni successive.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Impostare {field} su "{vmType}" su Intel richiede macOS 13.0 (Ventura) o versioni successive.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: Tipo di montaggio
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: Espone il file system usando i dispositivi virtio-9p-pci di QEMU.
+          # @reason literal mount-type value passed to the VM configuration; kept in English
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: Modalità cache
+              options:
+                # @reason literal 9p cache-mode value passed to QEMU; kept in English
+                # @source fscache
+                fscache: fscache
+                # @reason literal 9p cache-mode value passed to QEMU; kept in English
+                # @source loose
+                loose: loose
+                # @reason literal 9p cache-mode value passed to QEMU; kept in English
+                # @source mmap
+                mmap: mmap
+                # @reason literal 9p cache-mode value passed to QEMU; kept in English
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: Criterio di caching da utilizzare
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: Dimensione dei messaggi in KiB
+              # @source Maximum message size in KiB
+              tooltip: Dimensione massima dei messaggi in KiB
+            protocolVersion:
+              # @source Protocol Version
+              legend: Versione del protocollo
+              options:
+                # @reason literal 9p protocol-version identifier; kept in English
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason literal 9p protocol-version identifier; kept in English
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason literal 9p protocol-version identifier; kept in English
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: Versione del protocollo 9P
+            securityModel:
+              # @source Security Model
+              legend: Modello di sicurezza
+              options:
+                # @reason literal 9p security-model value passed to QEMU; kept in English
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason literal 9p security-model value passed to QEMU; kept in English
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason literal 9p security-model value passed to QEMU; kept in English
+                # @source none
+                none: none
+                # @reason literal 9p security-model value passed to QEMU; kept in English
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: Modello di sicurezza usato per il percorso esportato
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: Espone il file system eseguendo un server SFTP.
+          # @reason literal mount-type value passed to the VM configuration; kept in English
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Espone il file system usando un dispositivo di directory condivisa del framework Virtualization di Apple.
+          # @reason literal mount-type value passed to the VM configuration; kept in English
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: Indirizzo
+    # @source Proxy address
+    addressTitle: Indirizzo del proxy
+    # @source Authentication information
+    authTitle: Informazioni di autenticazione
+    # @source Enable the proxy used by rancher-desktop
+    label: Abilita il proxy usato da rancher-desktop
+    # @source WSL Proxy
+    legend: Proxy WSL
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: Questo elemento è un duplicato.
+      # @source Proxy bypass list
+      legend: Elenco di esclusione dal proxy
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: IP, CIDR, dominio o wildcard (*.example.com) da escludere dal proxy
+    # @reason 'password' is the standard term in Italian UIs, unchanged
+    # @source Password
+    password: Password
+    # @source Port
+    port: Porta
+    # @source Username
+    username: Nome utente
+  type:
+    # @source Virtual Machine Type
+    legend: Tipo di macchina virtuale
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: Usa l'emulatore QEMU.
+        # @reason QEMU product name
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @source Use the Apple Virtualization framework.
+        description: Usa il framework Virtualization di Apple.
+        # @reason VZ is the Apple Virtualization framework identifier, not translatable text
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Abilita il supporto per Rosetta
+    # @source VZ Option
+    legend: Opzione VZ
+volumes:
+  files:
+    # @source Available
+    available: Disponibile
+    # @source Error checking volume status
+    checkError: Errore durante il controllo dello stato del volume
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: Nome di volume non valido "{name}"
+    # @source Error listing files: {error}
+    listError: 'Errore nell''elenco dei file: {error}'
+    # @source Loading volume files...
+    loading: Caricamento dei file del volume...
+    # @source This volume is empty
+    noFiles: Questo volume è vuoto
+    # @source Not Found
+    notFound: Non trovato
+    table:
+      header:
+        # @source Modified
+        modified: Ultima modifica
+        # @source Name
+        name: Nome
+        # @source Permissions
+        permissions: Permessi
+        # @source Size
+        size: Dimensione
+    # @source Volume Files
+    title: File del volume
+    # @source Volume "{name}" not found
+    volumeNotFound: Volume "{name}" non trovato
+  manage:
+    table:
+      header:
+        # @source Created
+        created: Data di creazione
+        # @reason 'driver' is the standard loanword in Italian (Docker volume driver)
+        # @source Driver
+        driver: Driver
+        # @source Mount Point
+        mountpoint: Punto di montaggio
+        # @source Volume Name
+        volumeName: Nome del volume
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: Sfoglia file
+        # @source Delete
+        delete: Elimina
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: Non ci sono volumi da visualizzare
+  # @source Volumes
+  title: Volumi
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: Leggi la documentazione prima di abilitare la funzionalità sperimentale WebAssembly!
+  # @source Enabled
+  enabled: Abilitato
+  # @reason WebAssembly/Wasm product name
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -841,6 +841,8 @@ locale:
   it: イタリア語
   # @source Japanese
   ja: 日本語
+  # @source Korean
+  ko: 韓国語
   # @source Portuguese (Brazilian)
   pt-br: ポルトガル語（ブラジル）
   # @source Chinese (Simplified)

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -837,6 +837,8 @@ locale:
   es: スペイン語
   # @source French
   fr: フランス語
+  # @source Italian
+  it: イタリア語
   # @source Japanese
   ja: 日本語
   # @source Portuguese (Brazilian)

--- a/pkg/rancher-desktop/assets/translations/ja.yaml
+++ b/pkg/rancher-desktop/assets/translations/ja.yaml
@@ -1,0 +1,1864 @@
+action:
+  # @source Refresh
+  refresh: 更新
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: イメージ名は、「許可されたイメージ」設定タブで定義されたパターンのいずれかと一致する必要があります。
+  # @source Enable
+  enable: 有効にする
+  errors:
+    # @source This item is a duplicate.
+    duplicate: 項目が重複しています。
+  # @source Allowed Image Patterns
+  label: 許可されたイメージのパターン
+  patterns:
+    # @source Type the image pattern
+    placeholder: イメージパターンを入力
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: ログイン時に自動的に起動する
+      # @source Startup
+      legendText: 起動
+    background:
+      # @source Background
+      legendText: バックグラウンド
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Rancher Desktopがバックグラウンドで実行されているときにアプリウィンドウを非表示にします。通知アイコン（表示されている場合）から開くか、アプリケーションメニューからRancher Desktopを実行して開くことができます。
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: 通知アイコンを非表示にする
+      # @source Notification Icon
+      legendText: 通知アイコン
+    startInBackground:
+      # @source Start in the background
+      label: バックグラウンドで起動する
+    theme:
+      # @source Appearance
+      legendText: 外観
+      options:
+        dark:
+          # @source Always use dark mode
+          description: 常にダークモードを使用する
+          # @source Dark
+          label: ダーク
+        light:
+          # @source Always use light mode
+          description: 常にライトモードを使用する
+          # @source Light
+          label: ライト
+        system:
+          # @source Follow the operating system setting
+          description: オペレーティングシステムの設定に従う
+          # @source System
+          label: システム
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: アプリケーションウィンドウを閉じたときに終了する
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: 管理者資格情報（sudoアクセス）を許可する
+      # @source Administrative Access
+      legendText: 管理者アクセス
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: チェックすると、{appName}は起動時に管理者資格情報（「sudoアクセス」）を取得します。これにより、ブリッジネットワークとデフォルトのdockerソケットのサポートが有効になります。次回起動時に反映されます。
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: 自動的に更新を確認する
+      # @source Automatic Updates
+      legendText: 自動更新
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: '{appName}の改善に役立てるため、匿名の統計情報の収集を許可する'
+      # @source Statistics
+      legendText: 統計情報
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: 翻訳はコミュニティおよびAIツールによって提供されます。英語が正式な言語です。翻訳の問題はGitHubで報告してください。
+    # @source Language
+    legendText: 言語
+asyncButton:
+  activate:
+    # @source Activate
+    action: アクティブ化
+    # @source Activated
+    success: アクティブ化しました
+    # @source Activating&hellip;
+    waiting: アクティブ化中&hellip;
+  apply:
+    # @source Apply
+    action: 適用
+    # @source Applied
+    success: 適用しました
+    # @source Applying&hellip;
+    waiting: 適用中&hellip;
+  continue:
+    # @source Continue
+    action: 続行
+    # @source Saved
+    success: 保存しました
+    # @source Saving&hellip;
+    waiting: 保存中&hellip;
+  copy:
+    # @source Click to Copy
+    action: クリックしてコピー
+    # @source Copied!
+    success: コピーしました！
+  create:
+    # @source Create
+    action: 作成
+    # @source Created
+    success: 作成しました
+    # @source Creating&hellip;
+    waiting: 作成中&hellip;
+  deactivate:
+    # @source Deactivate
+    action: 非アクティブ化
+    # @source Deactivated
+    success: 非アクティブ化しました
+    # @source Deactivating&hellip;
+    waiting: 非アクティブ化中&hellip;
+  default:
+    # @source Action
+    action: アクション
+    # @source Error
+    error: エラー
+    # @source Success
+    success: 成功
+    # @source Waiting
+    waiting: 待機中
+  delete:
+    # @source Delete
+    action: 削除
+    # @source Deleted
+    success: 削除しました
+    # @source Deleting&hellip;
+    waiting: 削除中&hellip;
+  disable:
+    # @source Disable
+    action: 無効化
+    # @source Disabled
+    success: 無効化しました
+    # @source Disabling&hellip;
+    waiting: 無効化中&hellip;
+  done:
+    # @source Done
+    action: 完了
+    # @source Saved
+    success: 保存しました
+    # @source Saving&hellip;
+    waiting: 保存中&hellip;
+  download:
+    # @source Download
+    action: ダウンロード
+    # @reason English source uses the progressive form (Saving) for the success state; mirrored it.
+    # @source Saving
+    success: 保存中
+    # @source Downloading&hellip;
+    waiting: ダウンロード中&hellip;
+  edit:
+    # @source Save
+    action: 保存
+    # @source Saved
+    success: 保存しました
+    # @source Saving&hellip;
+    waiting: 保存中&hellip;
+  enable:
+    # @source Enable
+    action: 有効化
+    # @source Enabled
+    success: 有効化しました
+    # @source Enabling&hellip;
+    waiting: 有効化中&hellip;
+  finish:
+    # @source Finish
+    action: 完了
+    # @source Finished
+    success: 完了しました
+    # @source Finishing&hellip;
+    waiting: 完了処理中&hellip;
+  import:
+    # @source Import
+    action: インポート
+    # @source Imported
+    success: インポートしました
+    # @source Importing&hellip;
+    waiting: インポート中&hellip;
+  install:
+    # @source Install
+    action: インストール
+    # @reason English source uses the progressive form (Installing) for the success state; mirrored it.
+    # @source Installing
+    success: インストール中
+    # @source Starting&hellip;
+    waiting: 開始中&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon identifier, not user-visible text.
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon identifier, not user-visible text.
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon identifier, not user-visible text.
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon identifier, not user-visible text.
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @reason Both Delete and Remove render naturally as 削除 in Japanese UIs.
+    # @source Remove
+    action: 削除
+    # @source Removed
+    success: 削除しました
+    # @source Removing&hellip;
+    waiting: 削除中&hellip;
+  restore:
+    # @source Restore
+    action: 復元
+    # @source Restored
+    success: 復元しました
+    # @source Restoring&hellip;
+    waiting: 復元中&hellip;
+  snapshot:
+    # @source Snapshot Now
+    action: 今すぐスナップショット作成
+    # @source Creating Snapshot
+    success: スナップショットを作成中
+    # @source Snapshotting&hellip;
+    waiting: スナップショット作成中&hellip;
+  uninstall:
+    # @source Uninstall
+    action: アンインストール
+    # @source Uninstalled
+    success: アンインストールしました
+    # @source Uninstalling&hellip;
+    waiting: アンインストール中&hellip;
+  update:
+    # @source Update
+    action: 更新
+    # @source Updated
+    success: 更新しました
+    # @source Updating&hellip;
+    waiting: 更新中&hellip;
+  upgrade:
+    # @source Upgrade
+    action: アップグレード
+    # @reason English source uses the progressive form (Upgrading) for the success state; mirrored it.
+    # @source Upgrading
+    success: アップグレード中
+    # @source Starting&hellip;
+    waiting: 開始中&hellip;
+containerEngine:
+  # @reason Katakana style: Microsoft-style long vowel for -er/-or words (コンテナー、サーバー、ユーザー);
+  # @source Container Engine
+  label: コンテナーエンジン
+  options:
+    containerd:
+      # @source Namespaces for container images; use with nerdctl.
+      description: コンテナーイメージの名前空間。nerdctlと組み合わせて使用します。
+      # @reason product name of the container runtime, always lowercase Latin
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: Docker API。Docker CLIと組み合わせて使用します。
+      # @reason binary name and project name, not translatable text
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: コンテナー情報
+  # @source Info
+  info: 情報
+  # @source Logs
+  logs: ログ
+  search:
+    # @source Search in logs
+    ariaLabel: ログ内を検索
+    # @source Clear search
+    clearSearch: 検索をクリア
+    # @source Next match
+    nextMatch: 次の一致
+    # @source Search logs...
+    placeholder: ログを検索…
+    # @source Previous match
+    previousMatch: 前の一致
+  # @source Shell
+  shell: シェル
+  # @source Stats
+  stats: 統計
+containerInspect:
+  capabilities:
+    # @source Added
+    added: 追加
+    # @reason Established Japanese Linux terminology for dropping capabilities.
+    # @source Dropped
+    dropped: ドロップ
+  command:
+    # @source Args
+    args: 引数
+    # @source Command
+    command: コマンド
+    # @source Entrypoint
+    entrypoint: エントリーポイント
+  error:
+    # @source Failed to load container details.
+    loadFailed: コンテナーの詳細を読み込めませんでした。
+    # @source An unknown error has occurred
+    unknown: 不明なエラーが発生しました
+  # @source Loading container details…
+  loading: コンテナーの詳細を読み込んでいます…
+  mounts:
+    # @source Destination
+    destination: マウント先
+    # @reason Standard read-only abbreviation; kept in English as in common Japanese UIs.
+    # @source RO
+    readOnly: RO
+    # @reason Standard read-write abbreviation; kept in English as in common Japanese UIs.
+    # @source RW
+    readWrite: RW
+    # @reason Column-header abbreviation; kept in English as in common Japanese UIs.
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: マウント元
+    # @source Type
+    type: 種類
+  # @source None
+  none: なし
+  sections:
+    # @reason Established Japanese term for Linux capabilities.
+    # @source Capabilities
+    capabilities: ケーパビリティ
+    # @source Command & Args
+    commandArgs: コマンドと引数
+    # @reason Section lists environment variables, so 環境変数 rather than the literal 環境.
+    # @source Environment
+    environment: 環境変数
+    # @source Labels
+    labels: ラベル
+    # @source Mounts
+    mounts: マウント
+    # @source Ports
+    ports: ポート
+  summary:
+    # @source Created
+    created: 作成日時
+    # @reason Latin abbreviation standard in Japanese UIs (Docker Desktop ja uses ID)
+    # @source ID
+    id: ID
+    # @source Image
+    image: イメージ
+    # @source IP Address
+    ipAddress: IPアドレス
+    # @source Name
+    name: 名前
+    # @source Started
+    started: 開始日時
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: ブロックI/O（バイト/秒）
+    # @reason chart legend; CPU is standard Latin in Japanese UIs, matches Docker Desktop ja
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: メモリ
+    # @source Network I/O (bytes/s)
+    network: ネットワークI/O（バイト/秒）
+  interval:
+    # @source {minutes} min
+    minutes: '{minutes}分'
+    # @source {seconds} s
+    seconds: '{seconds}秒'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: 統計は現在、Docker（Moby）エンジンでのみ利用できます。
+  # @source No processes found.
+  noProcesses: プロセスが見つかりません。
+  # @source Stats are only available for running containers.
+  notRunning: 統計は実行中のコンテナーでのみ利用できます。
+  # @source Processes
+  processes: プロセス
+  # @reason Labels the interval dropdown; plain 更新 would read as a refresh button.
+  # @source Refresh
+  refresh: 更新間隔
+  series:
+    # @source Limit
+    limit: 上限
+    # @source Read
+    read: 読み取り
+    # @reason RX/TX rendered as 受信/送信, the standard Japanese chart-legend terms.
+    # @source RX
+    rx: 受信
+    # @source TX
+    tx: 送信
+    # @source Used
+    used: 使用量
+    # @source Write
+    write: 書き込み
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: 情報
+        # @source Restart
+        restart: 再起動
+        # @source Start
+        start: 開始
+        # @source Stop
+        stop: 停止
+      header:
+        # @source Name
+        containerName: 名前
+        # @source Image
+        image: イメージ
+        # @source Port(s)
+        ports: ポート
+        # @source Uptime
+        started: 稼働時間
+        # @source State
+        state: 状態
+  sortableTables:
+    # @source There are no containers to show
+    noRows: 表示するコンテナーがありません
+  # @source Containers
+  title: コンテナー
+dashboard:
+  # @reason Product name of the Rancher UI; kept in English.
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktopはroot権限では実行できません。通常のユーザーとして再度実行してください。
+  # @source Cannot run as Root
+  title: rootとして実行できません
+deploymentProfile:
+  # @reason version is the literal field name in the file, kept in English.
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: デプロイメントファイル{path}は無効です：バージョンが指定されていません。有効にするにはversionフィールドを追加してください（現在のバージョンは{version}です）。
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: デプロイメントが無効です：{path}にバージョンが指定されていません。有効にするにはversionフィールドを追加してください（現在のバージョンは{version}です）。
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count}件が失敗、さらに{muted}件がミュートされています'
+  # @source Last run:
+  lastRun: 最終実行：
+  # @source (No fixes available)
+  noFixes: （利用可能な修正はありません）
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: ミュートされた診断を表示してみてください。
+      # @source No results found
+      heading: 結果が見つかりませんでした
+      # @reason Icon identifier, not user-visible text.
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktopは正常に動作しているようです。
+      # @source No problems detected
+      heading: 問題は検出されませんでした
+      # @reason Icon identifier, not user-visible text.
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: ミュート済みを表示
+  tableHeaders:
+    # @source Mute
+    mute: ミュート
+    # @source Name
+    name: 名前
+  # @source Diagnostics
+  title: 診断
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: 共有ネットワークも利用できません。ネットワークアクセスはホストへのポートフォワーディング経由のみです。
+    # @source Using shared network address {ip}
+    sharedFallback: 共有ネットワークアドレス{ip}を使用しています
+    # @source Bridged network did not get an IP address.
+    title: ブリッジネットワークがIPアドレスを取得できませんでした。
+  confirmMigration:
+    # @source Delete Workloads
+    delete: ワークロードを削除
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: '{from}から{to}へダウングレードすると、既存のKubernetesワークロードが失われます。データを削除しますか？'
+    # @source Confirming migration
+    title: 移行の確認
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: 推奨される最小アップグレードバージョン{version}にフォールバックします
+    # @reason ICU-escaped quotes ''…'' replaced with Japanese corner brackets 「」.
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: 要求されたKubernetesバージョン「{version}」はサポートされていません。
+    # @source Invalid Kubernetes Version
+    title: 無効なKubernetesバージョン
+  networkFailure:
+    # @reason ICU-escaped quotes ''…'' replaced with Japanese corner brackets 「」.
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: '{range}の範囲のバージョンを入手し、「{path}」にインストールしてください'
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: オフラインモードでは互換性のあるバージョンのkubectlをダウンロードできません
+    # @source Network failure
+    title: ネットワーク障害
+extensions:
+  # @reason Icon identifier, not user-visible text.
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: まだ拡張機能がインストールされていないようです。拡張機能カタログを参照して始めてください。
+      button:
+        # @source Browse Extensions
+        text: 拡張機能を参照
+      # @source No extensions installed
+      heading: 拡張機能はインストールされていません
+      # @reason Icon identifier, not user-visible text.
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: 削除
+      # @source Upgrade
+      upgrade: アップグレード
+  view:
+    emptyState:
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId}は削除されました。拡張機能カタログにアクセスして再インストールするか、他の拡張機能を探してRancher Desktopの体験を向上させてください。'
+      # @source Extension removed
+      heading: 拡張機能が削除されました
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Kubernetesを有効にする
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: （キャッシュされたバージョンのみ）
+    # @source Kubernetes Version
+    legend: Kubernetesバージョン
+    # @source Other Versions
+    otherVersions: その他のバージョン
+    # @source Recommended Versions
+    recommendedVersions: 推奨バージョン
+  # @reason OK button label is kept as-is in Japanese Windows/macOS dialogs
+  # @source OK
+  ok: OK
+  # @reason "Rancher Desktop by SUSE" kept intact as branding.
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Rancher Desktop by SUSEへようこそ
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktopは、デスクトップアプリケーションを通じてKubernetesとイメージ管理を提供します。
+  # @source Homepage
+  homepage: ホームページ
+  # @reason Link to the GitHub Issues page; the English name is standard for Japanese developers.
+  # @source Issues
+  issues: Issues
+  # @source General
+  navLabel: 一般
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: プロジェクトディスカッション：<a href="https://slack.rancher.io/">Rancher Users</a> Slackの<b>#rancher-desktop</b>
+  # @source Project Links:
+  projectLinks: プロジェクトリンク：
+  # @reason "Rancher Desktop by SUSE" kept intact as branding.
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Rancher Desktop by SUSEへようこそ
+generic:
+  # @reason Japanese conjunction と takes no surrounding spaces.
+  # @source  and 
+  and: と
+  # @source Apply
+  apply: 適用
+  # @source Cancel
+  cancel: キャンセル
+  # @source Close
+  close: 閉じる
+  # @reason Fullwidth ideographic comma; Japanese does not use a following space.
+  # @source , 
+  comma: 、
+  # @reason Assumed to be the port-forwarding action; rendered as 転送.
+  # @source Forward
+  forward: 転送
+  # @source Loading&hellip;
+  loading: 読み込み中&hellip;
+  # @source Namespace
+  namespace: 名前空間
+  # @reason OK button label is kept as-is in Japanese Windows/macOS dialogs
+  # @source OK
+  ok: OK
+  # @source Rerun
+  rerun: 再実行
+  # @source Search
+  search: 検索
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: 使用するDockerfileを選択してください（名前が異なる場合もあります）
+  # @source Pick the build directory
+  buildTitle: ビルドディレクトリを選択
+  # @source Error trying to delete images {ids}
+  deleteBatchError: イメージ{ids}の削除中にエラーが発生しました
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      イメージ{name}（{id}）の削除中にエラーが発生しました：
+
+       {error}
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      {name}のプッシュ中にエラーが発生しました：
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      {name}のスキャン中にエラーが発生しました：
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: イメージを追加
+  add:
+    action:
+      # @source Build
+      build: ビルド
+      gerund:
+        # @reason The loadingText template supplies the しています conjugation, so the gerund stays the noun ビルド.
+        # @source Building
+        build: ビルド
+        # @reason The loadingText template supplies the しています conjugation, so the gerund stays the noun プル.
+        # @source Pulling
+        pull: プル
+      infinitive:
+        # @reason The errorText template supplies the しようとして conjugation, so the infinitive stays the noun ビルド.
+        # @source build
+        build: ビルド
+        # @reason The errorText template supplies the しようとして conjugation, so the infinitive stays the noun プル.
+        # @source pull
+        pull: プル
+      pastTense:
+        # @reason Bare noun so successText イメージを{action}しました composes; ビルドしました doubled the verb ending
+        # @source Built
+        build: ビルド
+        # @reason Japanese conjugates the verb in the sentence templates, so both the base and past-tense action variants are the noun プル.
+        # @source Pulled
+        pull: プル
+      # @source Pull
+      pull: プル
+    # @reason Restructured for Japanese word order: image before verb, error clause and console hint as full sentences per the file's scan.errorText.
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: '''''{ image }'''' を{ action }しようとしてエラーが発生しました。詳細はコンソール出力を確認してください。'
+    # @reason Japanese puts the verb last; the template conjugates the action noun, composing to イメージをビルドしています... like the file's other progressive messages.
+    # @source {action} image...
+    loadingText: イメージを{action}しています...
+    # @reason Receives the past-tense action variant; the しました conjugation lives in the template, so the variant stays the noun プル.
+    # @source {action} image
+    successText: イメージを{action}しました
+    # @source Add Image
+    title: イメージの追加
+  confirmDelete:
+    # @source Delete
+    confirm: 削除
+    # @reason Japanese has no grammatical plural, so both branches carry the same counter phrase; dropped the space before the counter 個 as Japanese attaches counters directly to the number.
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: '{count}{count, plural, one {個のイメージ} other {個のイメージ}}を削除しますか？'
+    # @source Delete image {name}:{tag}?
+    single: イメージ {name}:{tag} を削除しますか？
+    # @source Confirming image deletion
+    title: イメージ削除の確認
+  manager:
+    # @source Close Output to Continue
+    close: 出力を閉じて続行
+    input:
+      build:
+        # @source Build
+        button: ビルド
+        # @source Name of image to build:
+        label: ビルドするイメージ名：
+        # @reason Format example for a registry reference, not UI text; kept as-is.
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @source Pull
+        button: プル
+        # @source Name of image to pull:
+        label: プルするイメージ名：
+        # @reason Format example for a registry reference, not UI text; kept as-is.
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: 削除
+        # @source Push
+        push: プッシュ
+        # @source Scan...
+        scan: スキャン...
+      header:
+        # @source Image ID
+        imageId: イメージ ID
+        # @source Image
+        imageName: イメージ
+        # @source Size
+        size: サイズ
+        # @source Tag
+        tag: タグ
+      # @source All images
+      label: すべてのイメージ
+    # @source Image Output
+    title: イメージ出力
+  scan:
+    details:
+      # @source Description
+      description: 説明
+      # @source Primary URL
+      primaryUrl: プライマリ URL
+      # @source References
+      references: 参考情報
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: '''''{ image }'''' のスキャン中にエラーが発生しました。詳細はコンソール出力を確認してください。'
+    labels:
+      # @reason Vulnerability severity scale rendered as 致命的/高/中/低, the common Japanese mapping for CRITICAL/HIGH/MEDIUM/LOW in security scanners.
+      # @source CRITICAL
+      critical: 致命的
+      # @source HIGH
+      high: 高
+      # @source Issues Found
+      issuesFound: 検出された問題
+      # @source LOW
+      low: 低
+      # @source MEDIUM
+      medium: 中
+    # @source Scanning ''{ image }''
+    loadingText: '''''{ image }'''' をスキャンしています'
+    results:
+      headers:
+        # @reason Elliptical column header (the column holds the fixed version); mirrors the terse English "Fixed".
+        # @source Fixed
+        fixed: 修正済み
+        # @reason Elliptical column header (the column holds the installed version); mirrors the terse English "Installed".
+        # @source Installed
+        installed: インストール済み
+        # @source Package
+        package: パッケージ
+        # @source Severity
+        severity: 重大度
+        # @source Vulnerability ID
+        vulnerabilityId: 脆弱性 ID
+    # @source Scan details for ''{ image }''
+    title: '''''{ image }'''' のスキャン詳細'
+  sortableTables:
+    # @source There are no images to show
+    noRows: 表示するイメージがありません
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: イメージマネージャーの準備を待っています
+    # @source Error: Unknown state; please reload.
+    unknown: エラー：不明な状態です。再読み込みしてください。
+  # @source Images
+  title: イメージ
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Rancher Desktop の Kubernetes 設定と Docker ソケットを Windows Subsystem for Linux（WSL）のディストリビューションに公開します
+kubernetesError:
+  # @source Context:
+  context: コンテキスト：
+  # @source Last command run:
+  lastCommand: 最後に実行したコマンド：
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 最近の<a href="#" data-action="showLogs">ログファイル</a>の内容（一部）：
+  # @source {appName} Error
+  title: '{appName} エラー'
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Kubernetes を有効にする
+    # @reason product name, kept in Latin script per Japanese convention
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: オプション
+    # @source Install Spin Operator
+    spinkube: Spin Operator をインストールする
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: Spin Operator を使用するには、<a href="#" data-navigate="Container Engine,general">WebAssembly</a> を有効にする必要があります。
+    # @source Enable Traefik
+    traefik: Traefik を有効にする
+  port:
+    # @source Kubernetes Port
+    legendText: Kubernetes ポート
+  version:
+    # @source Kubernetes version
+    legendText: Kubernetes バージョン
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Kubernetes バージョン（キャッシュ済みのバージョンのみ）
+    # @source Other Versions
+    otherVersions: その他のバージョン
+    # @source Recommended Versions
+    recommendedVersions: 推奨バージョン
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: 選択肢がありません
+    # @source No matching options
+    noMatch: 一致する選択肢がありません
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} 件'
+    # @source Load More...
+    more: さらに読み込む...
+locale:
+  # @source German
+  de: ドイツ語
+  # @source English
+  en-us: 英語
+  # @source Spanish
+  es: スペイン語
+  # @source French
+  fr: フランス語
+  # @source Japanese
+  ja: 日本語
+  # @source Portuguese (Brazilian)
+  pt-br: ポルトガル語（ブラジル）
+  # @source Chinese (Simplified)
+  zh-hans: 中国語（簡体字）
+mainMenu:
+  # @source About {appName}
+  about: '{appName} について'
+  edit:
+    # @source &Copy
+    copy: コピー(&C)
+    # @source Cu&t
+    cut: 切り取り(&T)
+    # @source De&lete
+    delete: 削除(&L)
+    # @source &Edit
+    label: 編集(&E)
+    # @source &Paste
+    paste: 貼り付け(&P)
+    # @source &Redo
+    redo: やり直し(&R)
+    # @source Select &All
+    selectAll: すべて選択(&A)
+    # @source &Undo
+    undo: 元に戻す(&U)
+  file:
+    # @source Close
+    close: 閉じる
+    # @source E&xit
+    exit: 終了(&X)
+    # @source &File
+    label: ファイル(&F)
+  help:
+    # @source &About {appName}
+    about: '{appName} について(&A)'
+    # @source &Discuss
+    discuss: ディスカッション(&D)
+    # @source File a &Bug
+    fileABug: バグを報告(&B)
+    # @source Get &Help
+    getHelp: ヘルプを表示(&H)
+    # @source {appName} &Help
+    help: '{appName} ヘルプ(&H)'
+    # @source &Help
+    label: ヘルプ(&H)
+    # @source &Project Page
+    projectPage: プロジェクトページ(&P)
+  # @source Hide {appName}
+  hide: '{appName} を非表示'
+  # @reason macOS application-menu convention (Apple standard wording).
+  # @source Hide Others
+  hideOthers: ほかを非表示
+  # @reason macOS convention: Preferences in the app menu is 環境設定; used consistently for all Preferences strings.
+  # @source Preferences
+  preferences: 環境設定
+  # @source Quit {appName}
+  quit: '{appName} を終了'
+  # @source Services
+  services: サービス
+  # @source Show All
+  showAll: すべてを表示
+  view:
+    # @source &Actual Size
+    actualSize: 実際のサイズ(&A)
+    # @source &Force Reload
+    forceReload: 強制的に再読み込み(&F)
+    # @source &View
+    label: 表示(&V)
+    # @source &Reload
+    reload: 再読み込み(&R)
+    # @source Toggle &Developer Tools
+    toggleDevTools: 開発者ツールの切り替え(&D)
+    # @source Toggle Full &Screen
+    toggleFullScreen: 全画面表示の切り替え(&S)
+    # @source Zoom &In
+    zoomIn: 拡大(&I)
+    # @source Zoom &Out
+    zoomOut: 縮小(&O)
+  window:
+    # @reason macOS Window-menu convention (Apple standard wording for Bring All to Front).
+    # @source Bring All to Front
+    front: すべてを手前に移動
+    # @source &Window
+    label: ウィンドウ(&W)
+    # @reason Chose the cross-platform 最小化 over Apple's macOS-only しまう, since the menu strings are shared across platforms.
+    # @source Minimize
+    minimize: 最小化
+    # @reason Window-menu Zoom (resize the window), not text zoom; 拡大/縮小 is the macOS standard wording.
+    # @source Zoom
+    zoom: 拡大/縮小
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: 説明
+        # @source Name
+        name: 名前
+        # @source Vendor
+        vendor: ベンダー
+  labels:
+    # @source Install
+    install: インストール
+    # @source Remove
+    uninstall: 削除
+    # @source Upgrade
+    upgrade: アップグレード
+  loading:
+    # @source Installing...
+    install: インストール中...
+    # @source Removing...
+    uninstall: 削除中...
+    # @source Upgrading...
+    upgrade: アップグレード中...
+  # @source More information
+  moreInfo: 詳細情報
+  # @source No extension found for the search criteria
+  noResults: 検索条件に一致する拡張機能が見つかりません
+  tabs:
+    # @source Catalog
+    catalog: カタログ
+    # @source Installed
+    installed: インストール済み
+  # @source Extensions
+  title: 拡張機能
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: クラスターダッシュボード
+    # @source Preferences
+    preferences: 環境設定
+pathManagement:
+  # @source Configure PATH
+  label: PATH の設定
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop は PATH 設定を変更しません。<code>$HOME/.rd/bin</code> を手動で PATH に追加してください。
+      # @source Manual
+      label: 手動
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop がシェルのプロファイルを編集します。変更を反映するには、開いているシェルを再起動してください。
+      # @source Automatic
+      label: 自動
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop には kubectl、nerdctl、helm、docker などのツールが同梱されています。これらのツールを使用するには、<code>$HOME/.rd/bin</code> が PATH に含まれている必要があります。
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Kubernetes サービスを含める
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: ローカルポート
+        # @source Name
+        name: 名前
+        # @reason Katakana ネームスペース matches the Rancher Dashboard Japanese UI; 名前空間 is also common but less usual in Rancher products.
+        # @source Namespace
+        namespace: ネームスペース
+        # @source Port
+        port: ポート
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: 表示するポートフォワーディングのエントリがありません
+  # @source Port Forwarding
+  title: ポートフォワーディング
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: 選択した設定に問題があります。
+      # @source Kubernetes will reset after applying changes.
+      reset: 変更を適用すると Kubernetes がリセットされます。
+      # @source Kubernetes will restart after applying changes.
+      restart: 変更を適用すると Kubernetes が再起動します。
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: <a href="#" data-navigate="Kubernetes">Spin Operator</a> をインストールするには、WebAssembly を有効にする必要があります。
+  error:
+    # @source Reload Preferences to try again.
+    body: 環境設定を再読み込みして、もう一度お試しください。
+    # @source Unable to fetch preferences
+    heading: 環境設定を取得できません
+    # @source Reload preferences
+    reload: 環境設定を再読み込み
+  # @source Preferences
+  header: 環境設定
+  # @source or
+  incompatiblePrefWarningOr: または
+  # @reason Fragment concatenated as Pre + option name + Post; phrased so このオプションには + name + this suffix forms a grammatical sentence.
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: が選択解除されている必要があります。
+  # @reason Fragment concatenated as Pre + option name + Post; phrased so このオプションには + name + this suffix forms a grammatical sentence.
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: が選択されている必要があります。
+  # @reason Fragment concatenated as Pre + option name + Post; Japanese word order forces the requirement verb into the Post fragments.
+  # @source The option requires
+  incompatibleTypeWarningPre: このオプションには
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: 組織のポリシーによりロックされています
+  nav:
+    # @source Application
+    application: アプリケーション
+    # @source Container Engine
+    containerEngine: コンテナーエンジン
+    # @reason product name, kept in Latin script per Japanese convention
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: 仮想マシン
+    # @reason Microsoft product acronym (Windows Subsystem for Linux), never localized
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: 適用してリセット
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: これらの変更により Kubernetes クラスターがリセットされ、ワークロードとコンテナーイメージが失われます。
+    # @source Apply preferences and reset Kubernetes?
+    message: 環境設定を適用して Kubernetes をリセットしますか？
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Kubernetes のリセット
+  tabs:
+    # @reason Compact noun compound for a tab label; 許可されたイメージ would be too long for a tab.
+    # @source Allowed Images
+    allowedImages: 許可イメージ
+    # @source Behavior
+    behavior: 動作
+    # @source Emulation
+    emulation: エミュレーション
+    # @source Environment
+    environment: 環境
+    # @source General
+    general: 全般
+    # @source Hardware
+    hardware: ハードウェア
+    # @source Integrations
+    integrations: 統合
+    # @source Proxy
+    proxy: プロキシ
+    # @source Volumes
+    volumes: ボリューム
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: 適用されていない変更があります。保存されていない設定はすべて失われます。
+    # @source Discard changes
+    discardChanges: 変更を破棄
+    # @source Close preferences without applying?
+    message: 変更を適用せずに環境設定を閉じますか？
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - 環境設定を閉じる
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - 環境設定
+prefs:
+  # @source Experimental
+  experimental: 実験的
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: この設定には macOS 13.3（Ventura）以降が必要です。
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: この設定には macOS 13.0（Ventura）以降が必要です。
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: この設定には VZ エミュレーションモードの使用が必要です。VZ は macOS 13.3（Ventura）以降でのみ利用できます。
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: この設定には VZ エミュレーションモードの使用が必要です。VZ は macOS 13.0（Ventura）以降でのみ利用できます。
+product:
+  containerEngine:
+    # @reason Abbreviation of Container Engine; Japanese has no natural short form, so the Latin abbreviation stays.
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: コンテナーエンジン
+  # @source deactivated
+  deactivated: 無効
+  # @reason status-bar label showing the product name next to the version number
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: ネットワーク状態
+  networkStatusValues:
+    # @source checking...
+    checking: 確認中...
+    # @source offline
+    offline: オフライン
+    # @source online
+    online: オンライン
+  # @source Version
+  version: バージョン
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: 管理者としてタスクを実行する許可を求めています
+  # @source Bundling certificates
+  bundlingCertificates: 証明書をバンドルしています
+  # @source Checking k3s images
+  checkingK3sImages: k3s イメージを確認しています
+  # @source Configuring container engine
+  configuringContainerEngine: コンテナーエンジンを設定しています
+  # @source Configuring image proxy
+  configuringImageProxy: イメージプロキシを設定しています
+  # @source Configuring logrotate
+  configuringLogrotate: logrotate を設定しています
+  # @source Container engine components
+  containerEngineComponents: コンテナーエンジンコンポーネント
+  # @source Copying certificates
+  copyingCertificates: 証明書をコピーしています
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: 互換性のない Kubernetes の状態を削除しています
+  # @source Deleting Kubernetes
+  deletingKubernetes: Kubernetes を削除しています
+  # @source Deleting virtual machine
+  deletingVirtualMachine: 仮想マシンを削除しています
+  # @source DNS configuration
+  dnsConfiguration: DNS 設定
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: 互換性のある kubectl を準備しています
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: 仮想化がサポートされていることを確認しています
+  # @source Expecting user permission to continue
+  expectingPermission: 続行のためユーザーの許可を待っています
+  # @source Extracting certificates
+  extractingCertificates: 証明書を抽出しています
+  # @source Fetching certificates
+  fetchingCertificates: 証明書を取得しています
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Rancher Desktop を初期化しています
+  # @source Initializing WSL data
+  initializingWslData: WSL データを初期化しています
+  # @source Installing Buildkit
+  installingBuildkit: Buildkit をインストールしています
+  # @source Installing CA certificates
+  installingCaCertificates: CA 証明書をインストールしています
+  # @source Installing container engine
+  installingContainerEngine: コンテナーエンジンをインストールしています
+  # @reason Docker term "credential helper" rendered in katakana, the usual form in Japanese Docker documentation.
+  # @source Installing credential helper
+  installingCredentialHelper: クレデンシャルヘルパーをインストールしています
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: docker-credential ヘルパーをインストールしています
+  # @source Installing helpers
+  installingHelpers: ヘルパーをインストールしています
+  # @source Installing image scanner
+  installingImageScanner: イメージスキャナーをインストールしています
+  # @source Installing k3s
+  installingK3s: k3s をインストールしています
+  # @source Installing Kubernetes
+  installingKubernetes: Kubernetes をインストールしています
+  # @source Kubernetes components
+  kubernetesComponents: Kubernetes コンポーネント
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Kubernetes と dockerd の互換性
+  # @source Mounting WSL data
+  mountingWslData: WSL データをマウントしています
+  # @source Preparing to start
+  preparingToStart: 起動の準備をしています
+  # @source Proxy Config Setup
+  proxyConfigSetup: プロキシ設定のセットアップ
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Rancher Desktop ゲストエージェント
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: 権限がないため設定を再生成しています
+  # @source Registering WSL distribution
+  registeringWslDistribution: WSL ディストリビューションを登録しています
+  # @source Removing existing certificates
+  removingExistingCertificates: 既存の証明書を削除しています
+  # @reason "spinkube" kept in lowercase English as in the source; it is a project name.
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: spinkube オペレーターを削除しています
+  # @source Removing stale state
+  removingStaleState: 古い状態を削除しています
+  # @source Removing Traefik
+  removingTraefik: Traefik を削除しています
+  # @source Resetting Kubernetes
+  resettingKubernetes: Kubernetes をリセットしています
+  # @source Running provisioning scripts
+  runningProvisioningScripts: プロビジョニングスクリプトを実行しています
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: update-ca-certificates を実行しています
+  # @source Setting docker context
+  settingDockerContext: docker コンテキストを設定しています
+  # @source Setting Lima permissions
+  settingLimaPermissions: Lima の権限を設定しています
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Docker ソケットをセットアップしています
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: 仮想イーサネットをセットアップしています
+  # @source Shutting down
+  shuttingDown: シャットダウンしています
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: flannel が無効なため、ノードチェックをスキップしています
+  # @source Starting Backend
+  startingBackend: バックエンドを起動しています
+  # @source Starting buildkit
+  startingBuildkit: buildkit を起動しています
+  # @source Starting container engine
+  startingContainerEngine: コンテナーエンジンを起動しています
+  # @source Starting image proxy
+  startingImageProxy: イメージプロキシを起動しています
+  # @source Starting k3s
+  startingK3s: k3s を起動しています
+  # @source Starting Kubernetes
+  startingKubernetes: Kubernetes を起動しています
+  # @source Starting proxy
+  startingProxy: プロキシを起動しています
+  # @source Starting {service}
+  startingService: '{service} を起動しています'
+  # @source Starting virtual machine
+  startingVirtualMachine: 仮想マシンを起動しています
+  # @source Starting WSL environment
+  startingWslEnvironment: WSL 環境を起動しています
+  # @source Stopping existing instance
+  stoppingExistingInstance: 既存のインスタンスを停止しています
+  # @source Stopping mock backend
+  stoppingMockBackend: モックバックエンドを停止しています
+  # @source Stopping services
+  stoppingServices: サービスを停止しています
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: クラスター構成を更新しています
+  # @source Updating /etc/hosts
+  updatingEtcHosts: /etc/hosts を更新しています
+  # @source Updating kubeconfig
+  updatingKubeconfig: kubeconfig を更新しています
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: 古い仮想マシンを更新しています
+  # @source Updating WSL data
+  updatingWslData: WSL データを更新しています
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: WSL ディストリビューションをアップグレードしています
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: コンテナーエンジンの準備ができるのを待機しています
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: Kubernetes API を待機しています
+  # @source Waiting for nodes
+  waitingForNodes: ノードを待機しています
+  # @source Waiting for services
+  waitingForServices: サービスを待機しています
+  # @source Writing K3s configuration
+  writingK3sConfiguration: K3s の構成を書き込んでいます
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: スナップショットの作成
+  card:
+    action:
+      # @source Delete
+      remove: 削除
+      # @source Restore
+      restore: 復元
+    # @reason Date and time reordered to precede the verb; ICU apostrophe-quoting around the tags preserved verbatim.
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: '''<b>''{date}''</b>'' ''<b>''{time}''</b>'' に作成'
+  create:
+    actions:
+      # @source Cancel
+      back: キャンセル
+      # @source Create
+      submit: 作成
+    description:
+      # @source Description
+      label: 説明
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: 新しいスナップショットの作成中、Rancher Desktop は一時的に使用できなくなります
+    name:
+      # @source Snapshot Name
+      label: スナップショット名
+    # @source Create a new Snapshot
+    title: 新しいスナップショットの作成
+  dialog:
+    buttons:
+      # @source Close
+      error: 閉じる
+    creating:
+      actions:
+        # @source Cancel
+        cancel: キャンセル
+      # @source Creating {snapshot}
+      header: '{snapshot} を作成しています'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: スナップショット '<b>'{snapshot}'</b>' が作成されるまでお待ちください。'<br/>'お使いのマシンのリソースによっては時間がかかることがあります。'<br/>'この操作の間、Rancher Desktop は一時的に使用できなくなります。'<br/><br/>'スナップショットの作成が完了すると、VM が再起動します。
+    delete:
+      actions:
+        # @source Cancel
+        cancel: キャンセル
+        # @source Delete
+        ok: 削除
+      # @source Permanently delete snapshot?
+      header: スナップショットを完全に削除しますか？
+      # @reason Source value is the literal placeholder "text"; kept unchanged.
+      # @source Deleting a snapshot cannot be undone.
+      info: スナップショットを削除すると元に戻せません。
+    generic:
+      # @source Snapshot operation in progress
+      header: スナップショット操作が進行中です
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: スナップショット操作が完了するまでお待ちください。<br/>お使いのマシンのリソースによっては時間がかかることがあります。<br/>この操作の間、Rancher Desktop は一時的に使用できなくなります。<br/><br/>スナップショット処理が完了すると、VM が再起動します。
+    restore:
+      actions:
+        # @source Cancel
+        cancel: キャンセル
+        # @source Restore
+        ok: 復元
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Rancher Desktop を終了
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: スナップショット '<b>'{snapshot}'</b>' の復元に失敗しました。'<br/><br/>'Rancher Desktop はファクトリーリセットを実行し、これで終了します。Rancher Desktop を再起動してスナップショットの復元を再試行する前に、このエラーの原因となった問題への対処をお試しください。
+        # @source Error restoring snapshot
+        header: スナップショットの復元エラー
+      # @source Restore snapshot?
+      header: スナップショットを復元しますか？
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: このスナップショットを復元すると、現在のインストール環境が設定も含めて置き換えられます。設定ウィンドウが開いている場合は自動的に閉じられ、保存されていない変更は破棄されます。
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: キャンセル
+      # @source Restoring {snapshot}
+      header: '{snapshot} を復元しています'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: スナップショット '<b>'{snapshot}'</b>' が復元されるまでお待ちください。お使いのマシンのリソースによっては時間がかかることがあります。<br/><br/>この操作の間、Rancher Desktop は一時的に使用できなくなります。完了すると、VM はスナップショット {snapshot} が適用された状態で再起動します。
+    # @source Show logs
+    showLogs: ログを表示
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: 開始するには「スナップショットの作成」をクリックしてください
+    # @source No snapshots found
+    heading: スナップショットが見つかりません
+    # @reason Icon identifier, not user-visible text; kept unchanged.
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: '{snapshot} の作成をキャンセルしました'
+      # @source Created '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' を作成しました'
+    delete:
+      # @source Delete error: {error}
+      error: 削除エラー：{error}
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' を削除しました'
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: スナップショットのロックファイルが異常に長い時間検出されています。これがエラーだと思われる場合は、<code>rdctl snapshot unlock</code> を実行してロックファイルの削除を試すことができます。
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: '{snapshot} の復元をキャンセルしました'
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' を復元しました'
+    # @reason Appended directly after a snapshot event message; a parenthesized time reads naturally in Japanese where English uses " at {time}".
+    # @source  at {time}
+    when: （{time}）
+  # @source Snapshots
+  title: スナップショット
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: '{actionable} 件を選択中'
+    # @source Available for {actionable} of the {total} selected
+    some: 選択した {total} 件のうち {actionable} 件で使用可能
+  # @source Add
+  add: 追加
+  # @source Add Filter
+  addFilter: フィルターを追加
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: アクション
+  # @source Filter for...
+  filterFor: フィルター条件を入力...
+  # @reason Rendered as `"value" in column`; が含まれる列: keeps the fixed value-then-column word order grammatical in Japanese.
+  # @source in
+  in: 'が含まれる列:'
+  # @source No actions available
+  noActions: 使用可能なアクションはありません
+  # @source There are no rows which match your search query.
+  noData: 検索条件に一致する行はありません。
+  # @source There are no rows to show.
+  noRows: 表示する行はありません。
+  paging:
+    # @reason Japanese has no plural but every branch is kept and translated; nested plural preserved.
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {項目なし}
+        =1 {{count} {count, plural, =1 {項目} other {項目}}}
+        other {{count} 項目中 {from} - {to}}}
+  # @source Reset
+  resetFilters: リセット
+  # @source Filter
+  search: フィルター
+  # @source Select a column
+  selectCol: 列を選択
+  tableHeader:
+    # @source Group by
+    groupBy: グループ化
+    # @source This column cannot be filtered
+    noFilter: この列ではフィルターできません
+    # @reason Prefix of the page-size selector（表示: 25）; concise noun form.
+    # @source Show
+    show: 表示
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: 常に管理者権限なしで実行する
+  # @reason OK button label is kept as-is in Japanese Windows/macOS dialogs
+  # @source OK
+  buttonText: OK
+  # @source This will modify the following paths:
+  explanation: これにより、次のパスが変更されます：
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: Rancher Desktop は次の理由により管理者権限（sudo アクセス）を必要とします：
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: このウィンドウを閉じるとプロンプトが表示されます。プロンプトをキャンセルした場合や管理者権限を無効にした場合、Rancher Desktop を引き続き使用するには docker コンテキストを rancher-desktop に切り替える必要があります。
+  reasons:
+    dockerSocket:
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: docker コンテキストを使用できない、docker ソケットを使用するツールとの互換性を提供します。
+      # @source Set up default docker socket
+      title: 既定の docker ソケットの設定
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: ブリッジネットワークを提供し、コンテナーへのアクセスを容易にします。許可されない場合、コンテナーにはポートフォワーディング経由でのみアクセスできます。
+      # @source Configure networking
+      title: ネットワークの構成
+  # @source Administrative Access Required
+  title: 管理者権限が必要です
+systemPreferences:
+  # @source # CPUs
+  cpus: CPU 数
+  # @source Memory (GB)
+  memory: メモリ（GB）
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: 匿名化された使用状況情報やエラーレポートなどを送信して、Rancher Desktop の改善に役立てます。データが第三者と共有されることはなく、デプロイしている具体的なリソースやエンドポイントに関する情報は含まれません。
+tray:
+  # @source Container engine: {name}
+  containerEngine: コンテナーエンジン：{name}
+  # @source Kubernetes Contexts
+  kubernetesContexts: Kubernetes コンテキスト
+  # @source Network status: {status}
+  networkStatus: ネットワーク状態：{status}
+  # @source None found
+  noneFound: 見つかりません
+  # @source Open cluster dashboard
+  openDashboard: クラスターダッシュボードを開く
+  # @source Open main window
+  openMainWindow: メインウィンドウを開く
+  # @source Open preferences dialog
+  openPreferences: 設定ダイアログを開く
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Rancher Desktop を終了
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes は無効です
+    # @source Kubernetes has encountered an error
+    error: Kubernetes でエラーが発生しました
+    # @source Kubernetes is running
+    started: Kubernetes は実行中です
+    # @source Kubernetes is starting
+    starting: Kubernetes は起動中です
+    # @source Kubernetes is stopped
+    stopped: Kubernetes は停止しています
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes はシャットダウン中です
+  # @reason application product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: デバッグモードを有効にする
+  general:
+    factoryReset:
+      # @reason ファクトリーリセット is the common katakana rendering of Factory Reset; used consistently.
+      # @source Factory Reset
+      buttonText: ファクトリーリセット
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: ファクトリーリセットを実行すると、Rancher Desktop のすべての設定が削除されます。
+      messageBox:
+        # @source Cancel
+        cancel: キャンセル
+        # @source Keep cached Kubernetes images
+        checkboxLabel: キャッシュされた Kubernetes イメージを保持する
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>ファクトリーリセットを実行すると、クラスターと Rancher Desktop のすべての設定が削除され、Rancher Desktop がシャットダウンされます。引き続き Rancher Desktop を使用する場合は、手動で起動して初期セットアップをやり直す必要があります。</p><p>本当にすべてをリセットしますか？</p>
+        # @source Perform a factory reset?
+        message: ファクトリーリセットを実行しますか？
+        # @source Factory Reset
+        ok: ファクトリーリセット
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - ファクトリーリセット
+      # @source Factory Reset
+      title: ファクトリーリセット
+    logs:
+      # @source Show Logs
+      buttonText: ログを表示
+      # @source Show Rancher Desktop logs
+      description: Rancher Desktop のログを表示します
+      # @source Logs
+      title: ログ
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Kubernetes をリセット
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: Kubernetes をリセットすると、すべてのワークロードと構成が削除されます。
+      messageBox:
+        # @source Cancel
+        cancel: キャンセル
+        # @source Delete container images
+        checkboxLabel: コンテナーイメージを削除する
+        # @source Reset Kubernetes?
+        message: Kubernetes をリセットしますか？
+        # @source Reset
+        ok: リセット
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Kubernetes のリセット
+      # @source Reset Kubernetes
+      title: Kubernetes のリセット
+  # @reason "Rancher Users Slack" kept in English as a community name; sentence reordered so the channel follows the workspace.
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: 問題が解決しませんか？<a href="https://slack.rancher.io/">Rancher Users Slack</a> の <b>#rancher-desktop</b> チャンネルでディスカッションを開始するか、<a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Issue を報告</a>してください。
+  # @source Troubleshooting
+  title: トラブルシューティング
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: すべての要件が満たされていることを確認してから、もう一度お試しください。Rancher Desktop を終了します。
+  # @reason OK button label is kept as-is in Japanese Windows/macOS dialogs
+  # @source OK
+  buttonText: OK
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 要件が不足しているか構成されていないため、Rancher Desktop を起動できません：
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop を起動できません
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: 更新を適用しています...
+  # @source An update to version {version} is available
+  available: バージョン {version} への更新が利用可能です
+  # @source Check for updates automatically
+  checkForUpdates: 更新を自動的に確認する
+  # @source downloading... ({percent}%, {speed})
+  downloading: ダウンロード中...（{percent}%、{speed}）
+  # @source There was an error checking for updates.
+  errorChecking: 更新の確認中にエラーが発生しました。
+  # @source Release Notes
+  releaseNotes: リリースノート
+  # @source Restart Now
+  restartNow: 今すぐ再起動
+  # @source Restart the application to apply the update.
+  restartToApply: 更新を適用するには、アプリケーションを再起動してください。
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Rancher Desktop の新しいバージョンが利用可能ですが、お使いのシステムではサポートされていません。
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: 詳細については、<a href="https://docs.rancherdesktop.io/getting-started/installation">インストールドキュメント</a>を参照してください。
+    # @source Latest Version Not Supported
+    title: 最新バージョンはサポートされていません
+  # @source Update Available
+  updateAvailable: 更新が利用可能
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: 「{field}」を {from} から {to} に減らすことはできません
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: moby のクラシックストレージでは WebAssembly を有効にできません。
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: WebAssembly が有効な場合、moby のクラシックストレージには切り替えられません。
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: WebAssembly が有効な場合、クラシックストレージの moby コンテナーエンジンには切り替えられません。
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: フィールド「{field}」に重複する項目があります：「{duplicates}」
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 指定された設定にエラーがあります：
+  # @source field "{field}" is locked
+  fieldLocked: フィールド「{field}」はロックされています
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: 「{pattern}」はイメージ参照を表していません'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: 「{value}」は有効なマッピングではありません'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: 「{name}」は無効な名前です'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: フィールド「{field}」に無効な項目があります（IP アドレス、CIDR サブネット、またはドメイン名である必要があります）：「{entries}」
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: 「{value}」は設定ダイアログの有効なページ名ではありません'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: タブ名「{tabName}」は設定ページ「{page}」の有効なタブ名ではありません'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: 「{name}」に無効なタグ「{tag}」があります'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 「{field}」の値が無効です：<{value}>
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 「{field}」の値が無効です：<{value}>。{validValues} のいずれかである必要があります
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Kubernetes バージョン「{version}」が見つかりません。
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: 「{name}」に文字列でないタグ「{tag}」があります'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: API 経由でのフィールド「{field}」の変更はサポートされていません。
+  # @reason Doubled ICU apostrophes (escaped literal quotes) preserved verbatim around the placeholders.
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: フィールド ''{field}'' のエラー：配列型の値が必要ですが、''{value}'' が指定されました
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: フィールド ''{field}'' のエラー：{expectedType} 型の値が必要ですが、''{value}'' が指定されました
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: フィールド ''{field}'' のエラー：{expectedType} 型の値が必要ですが、配列 {value} が指定されました
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: 指定されたフィールド「{field}」はオブジェクトである必要がありますが、<{value}> が指定されました。
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: 設定 {field} は aarch64 システムでのみ有効にできます。
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: 設定 {field} は、virtualMachine.mount.type が「{mountType}」の場合にのみ変更できます。
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: 設定 {field} は、virtual-machine.type が「{vmType}」の場合にのみ有効にできます。
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: 設定 {field} は、experimental.container-engine.web-assembly.enabled も設定されている場合にのみ設定できます。
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: 設定 {field} を「{value}」にするには、{otherField} が「{required}」である必要があります。
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: 設定 {field} を「{value}」にするには、{otherField} が「{option1}」または「{option2}」である必要があります。
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: 設定「{field}」は内部オブジェクトを含む必要がありますが、<{value}> が指定されました。
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: 設定「{field}」は単純な値である必要がありますが、<{value}> が指定されました。
+  # @source One or more fields in this tab contain a form validation error
+  tab: このタブの 1 つ以上のフィールドにフォーム検証エラーがあります
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: ARM で設定 {field} を「{vmType}」にするには、macOS 13.3（Ventura）以降が必要です。
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Intel で設定 {field} を「{vmType}」にするには、macOS 13.0（Ventura）以降が必要です。
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: マウントタイプ
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: QEMU の virtio-9p-pci デバイスを使用してファイルシステムを公開します。
+          # @reason Technical option value; kept in English.
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: キャッシュモード
+              options:
+                # @reason Technical option value; kept in English.
+                # @source fscache
+                fscache: fscache
+                # @reason Technical option value; kept in English.
+                # @source loose
+                loose: loose
+                # @reason Technical option value; kept in English.
+                # @source mmap
+                mmap: mmap
+                # @reason Technical option value; kept in English.
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: 使用するキャッシュポリシー
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: メッセージサイズ（KiB）
+              # @reason English "package size" refers to the 9p msize (maximum message/packet size); rendered as パケット.
+              # @source Maximum message size in KiB
+              tooltip: 最大メッセージサイズ（KiB）
+            protocolVersion:
+              # @source Protocol Version
+              legend: プロトコルバージョン
+              options:
+                # @reason Technical option value; kept in English.
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason Technical option value; kept in English.
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason Technical option value; kept in English.
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: 9P プロトコルのバージョン
+            securityModel:
+              # @source Security Model
+              legend: セキュリティモデル
+              options:
+                # @reason Technical option value; kept in English.
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason Technical option value; kept in English.
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason Technical option value; kept in English.
+                # @source none
+                none: none
+                # @reason Technical option value; kept in English.
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: エクスポートパスに使用するセキュリティモデル
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: SFTP サーバーを実行してファイルシステムを公開します。
+          # @reason Technical option value; kept in English.
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Apple Virtualization フレームワークの共有ディレクトリデバイスを使用してファイルシステムを公開します。
+          # @reason Technical option value; kept in English.
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: アドレス
+    # @source Proxy address
+    addressTitle: プロキシアドレス
+    # @source Authentication information
+    authTitle: 認証情報
+    # @source Enable the proxy used by rancher-desktop
+    label: rancher-desktop が使用するプロキシを有効にする
+    # @source WSL Proxy
+    legend: WSL プロキシ
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: 項目が重複しています。
+      # @source Proxy bypass list
+      legend: プロキシバイパスリスト
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: プロキシをバイパスする IP、CIDR、ドメイン、またはワイルドカード（*.example.com）
+    # @source Password
+    password: パスワード
+    # @source Port
+    port: ポート
+    # @source Username
+    username: ユーザー名
+  type:
+    # @source Virtual Machine Type
+    legend: 仮想マシンタイプ
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: QEMU エミュレーターを使用します。
+        # @reason emulator product name
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @source Use the Apple Virtualization framework.
+        description: Apple Virtualization フレームワークを使用します。
+        # @reason technical identifier for the Apple Virtualization.framework backend
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Rosetta サポートを有効にする
+    # @source VZ Option
+    legend: VZ オプション
+volumes:
+  files:
+    # @source Available
+    available: 利用可能
+    # @source Error checking volume status
+    checkError: ボリューム状態の確認中にエラーが発生しました
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: 無効なボリューム名「{name}」
+    # @source Error listing files: {error}
+    listError: ファイル一覧の取得エラー：{error}
+    # @source Loading volume files...
+    loading: ボリュームのファイルを読み込んでいます...
+    # @source This volume is empty
+    noFiles: このボリュームは空です
+    # @source Not Found
+    notFound: 見つかりません
+    table:
+      header:
+        # @source Modified
+        modified: 更新日時
+        # @source Name
+        name: 名前
+        # @reason パーミッション is the standard Japanese term for Unix file permissions in developer tools; アクセス許可 would suggest Windows ACLs.
+        # @source Permissions
+        permissions: パーミッション
+        # @source Size
+        size: サイズ
+    # @source Volume Files
+    title: ボリュームのファイル
+    # @source Volume "{name}" not found
+    volumeNotFound: ボリューム「{name}」が見つかりません
+  manage:
+    table:
+      header:
+        # @source Created
+        created: 作成日時
+        # @source Driver
+        driver: ドライバー
+        # @source Mount Point
+        mountpoint: マウントポイント
+        # @source Volume Name
+        volumeName: ボリューム名
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: ファイルを参照
+        # @source Delete
+        delete: 削除
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: 表示するボリュームはありません
+  # @source Volumes
+  title: ボリューム
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: 実験的な WebAssembly 機能を有効にする前に、ドキュメントをお読みください！
+  # @source Enabled
+  enabled: 有効
+  # @reason technology name and its standard abbreviation
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/ko.yaml
+++ b/pkg/rancher-desktop/assets/translations/ko.yaml
@@ -1,0 +1,1841 @@
+action:
+  # @source Refresh
+  refresh: 새로 고침
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: 이미지 이름은 허용된 이미지 환경설정 탭에 정의된 패턴 중 하나와 일치해야 합니다.
+  # @source Enable
+  enable: 활성화
+  errors:
+    # @source This item is a duplicate.
+    duplicate: 중복된 항목입니다.
+  # @source Allowed Image Patterns
+  label: 허용된 이미지 패턴
+  patterns:
+    # @source Type the image pattern
+    placeholder: 이미지 패턴 입력
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: 로그인 시 자동으로 시작
+      # @source Startup
+      legendText: 시작
+    background:
+      # @source Background
+      legendText: 백그라운드
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Rancher Desktop이 백그라운드에서 실행 중일 때 앱 창을 숨깁니다. 알림 아이콘(표시되는 경우)을 통해 열거나 응용 프로그램 메뉴에서 Rancher Desktop을 실행하여 열 수 있습니다.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: 알림 아이콘 숨기기
+      # @source Notification Icon
+      legendText: 알림 아이콘
+    startInBackground:
+      # @source Start in the background
+      label: 백그라운드에서 시작
+    theme:
+      # @reason Microsoft-style rendering of Appearance; 테마 would also work but the source says Appearance, not Theme
+      # @source Appearance
+      legendText: 모양
+      options:
+        dark:
+          # @source Always use dark mode
+          description: 항상 다크 모드 사용
+          # @source Dark
+          label: 다크
+        light:
+          # @source Always use light mode
+          description: 항상 라이트 모드 사용
+          # @source Light
+          label: 라이트
+        system:
+          # @source Follow the operating system setting
+          description: 운영 체제 설정을 따름
+          # @source System
+          label: 시스템
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: 애플리케이션 창을 닫을 때 종료
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: 관리자 자격 증명 허용(sudo 액세스)
+      # @source Administrative Access
+      legendText: 관리자 액세스
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: 이 옵션을 선택하면 {appName}이(가) 시작할 때 관리자 자격 증명("sudo 액세스")을 획득합니다. 이를 통해 브리지 네트워킹과 기본 docker 소켓 지원이 활성화됩니다. 다음 시작 시 적용됩니다.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: 자동으로 업데이트 확인
+      # @source Automatic Updates
+      legendText: 자동 업데이트
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: '{appName} 개선에 도움이 되도록 익명 통계 수집 허용'
+      # @source Statistics
+      legendText: 통계
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: 번역은 커뮤니티와 AI 도구가 제공합니다. 영어가 기준 언어입니다. 번역 문제는 GitHub에서 신고해 주십시오.
+    # @source Language
+    legendText: 언어
+asyncButton:
+  activate:
+    # @source Activate
+    action: 활성화
+    # @source Activated
+    success: 활성화됨
+    # @source Activating&hellip;
+    waiting: 활성화 중&hellip;
+  apply:
+    # @source Apply
+    action: 적용
+    # @source Applied
+    success: 적용됨
+    # @source Applying&hellip;
+    waiting: 적용 중&hellip;
+  continue:
+    # @source Continue
+    action: 계속
+    # @source Saved
+    success: 저장됨
+    # @source Saving&hellip;
+    waiting: 저장 중&hellip;
+  copy:
+    # @source Click to Copy
+    action: 클릭하여 복사
+    # @source Copied!
+    success: 복사됨!
+  create:
+    # @source Create
+    action: 생성
+    # @source Created
+    success: 생성됨
+    # @source Creating&hellip;
+    waiting: 생성 중&hellip;
+  deactivate:
+    # @source Deactivate
+    action: 비활성화
+    # @source Deactivated
+    success: 비활성화됨
+    # @source Deactivating&hellip;
+    waiting: 비활성화 중&hellip;
+  default:
+    # @source Action
+    action: 작업
+    # @source Error
+    error: 오류
+    # @source Success
+    success: 성공
+    # @source Waiting
+    waiting: 대기 중
+  delete:
+    # @source Delete
+    action: 삭제
+    # @source Deleted
+    success: 삭제됨
+    # @source Deleting&hellip;
+    waiting: 삭제 중&hellip;
+  disable:
+    # @source Disable
+    action: 비활성화
+    # @source Disabled
+    success: 비활성화됨
+    # @source Disabling&hellip;
+    waiting: 비활성화 중&hellip;
+  done:
+    # @source Done
+    action: 완료
+    # @source Saved
+    success: 저장됨
+    # @source Saving&hellip;
+    waiting: 저장 중&hellip;
+  download:
+    # @source Download
+    action: 다운로드
+    # @reason Source success state is the ongoing form Saving; translated faithfully
+    # @source Saving
+    success: 저장 중
+    # @source Downloading&hellip;
+    waiting: 다운로드 중&hellip;
+  edit:
+    # @source Save
+    action: 저장
+    # @source Saved
+    success: 저장됨
+    # @source Saving&hellip;
+    waiting: 저장 중&hellip;
+  enable:
+    # @source Enable
+    action: 활성화
+    # @source Enabled
+    success: 활성화됨
+    # @source Enabling&hellip;
+    waiting: 활성화 중&hellip;
+  finish:
+    # @source Finish
+    action: 마침
+    # @source Finished
+    success: 완료됨
+    # @source Finishing&hellip;
+    waiting: 완료 중&hellip;
+  import:
+    # @source Import
+    action: 가져오기
+    # @source Imported
+    success: 가져옴
+    # @source Importing&hellip;
+    waiting: 가져오는 중&hellip;
+  install:
+    # @source Install
+    action: 설치
+    # @reason Source success state is the ongoing form Installing; translated faithfully
+    # @source Installing
+    success: 설치 중
+    # @source Starting&hellip;
+    waiting: 시작 중&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon name fragment; component builds CSS class icon-{value}
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon name fragment; component builds CSS class icon-{value}
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon name fragment; component builds CSS class icon-{value}
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon name fragment; component builds CSS class icon-{value}
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @source Remove
+    action: 제거
+    # @source Removed
+    success: 제거됨
+    # @source Removing&hellip;
+    waiting: 제거 중&hellip;
+  restore:
+    # @source Restore
+    action: 복원
+    # @source Restored
+    success: 복원됨
+    # @source Restoring&hellip;
+    waiting: 복원 중&hellip;
+  snapshot:
+    # @source Snapshot Now
+    action: 지금 스냅샷 생성
+    # @reason Source success state is the ongoing form Creating Snapshot; translated faithfully
+    # @source Creating Snapshot
+    success: 스냅샷 생성 중
+    # @source Snapshotting&hellip;
+    waiting: 스냅샷 생성 중&hellip;
+  uninstall:
+    # @source Uninstall
+    action: 제거
+    # @source Uninstalled
+    success: 제거됨
+    # @source Uninstalling&hellip;
+    waiting: 제거 중&hellip;
+  update:
+    # @source Update
+    action: 업데이트
+    # @source Updated
+    success: 업데이트됨
+    # @source Updating&hellip;
+    waiting: 업데이트 중&hellip;
+  upgrade:
+    # @source Upgrade
+    action: 업그레이드
+    # @reason Source success state is the ongoing form Upgrading; translated faithfully
+    # @source Upgrading
+    success: 업그레이드 중
+    # @source Starting&hellip;
+    waiting: 시작 중&hellip;
+containerEngine:
+  # @source Container Engine
+  label: 컨테이너 엔진
+  options:
+    containerd:
+      # @source Namespaces for container images; use with nerdctl.
+      description: 컨테이너 이미지 네임스페이스를 지원합니다. nerdctl과 함께 사용합니다.
+      # @reason Product name of the containerd runtime
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: Docker API를 제공합니다. Docker CLI와 함께 사용합니다.
+      # @reason Product names (dockerd binary, Moby project)
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: 컨테이너 정보
+  # @source Info
+  info: 정보
+  # @source Logs
+  logs: 로그
+  search:
+    # @source Search in logs
+    ariaLabel: 로그 내 검색
+    # @source Clear search
+    clearSearch: 검색 지우기
+    # @source Next match
+    nextMatch: 다음 일치 항목
+    # @source Search logs...
+    placeholder: 로그 검색...
+    # @source Previous match
+    previousMatch: 이전 일치 항목
+  # @source Shell
+  shell: 셸
+  # @source Stats
+  stats: 통계
+containerInspect:
+  capabilities:
+    # @source Added
+    added: 추가됨
+    # @source Dropped
+    dropped: 제거됨
+  command:
+    # @source Args
+    args: 인수
+    # @source Command
+    command: 명령
+    # @source Entrypoint
+    entrypoint: 엔트리포인트
+  error:
+    # @source Failed to load container details.
+    loadFailed: 컨테이너 세부 정보를 불러오지 못했습니다.
+    # @source An unknown error has occurred
+    unknown: 알 수 없는 오류가 발생했습니다
+  # @source Loading container details…
+  loading: 컨테이너 세부 정보를 불러오는 중…
+  mounts:
+    # @source Destination
+    destination: 대상
+    # @reason Standard read-only abbreviation; kept in English as in common Korean dev UIs
+    # @source RO
+    readOnly: RO
+    # @reason Standard read-write abbreviation; kept in English as in common Korean dev UIs
+    # @source RW
+    readWrite: RW
+    # @reason Column-header abbreviation; kept in English as in common Korean dev UIs
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: 소스
+    # @source Type
+    type: 유형
+  # @source None
+  none: 없음
+  sections:
+    # @reason Linux kernel term with no established Korean rendering; transliterations vary, so kept in English
+    # @source Capabilities
+    capabilities: Capabilities
+    # @source Command & Args
+    commandArgs: 명령 및 인수
+    # @source Environment
+    environment: 환경
+    # @source Labels
+    labels: 레이블
+    # @source Mounts
+    mounts: 마운트
+    # @source Ports
+    ports: 포트
+  summary:
+    # @source Created
+    created: 생성됨
+    # @reason Standard identifier abbreviation; kept in English as in common Korean dev UIs
+    # @source ID
+    id: ID
+    # @source Image
+    image: 이미지
+    # @source IP Address
+    ipAddress: IP 주소
+    # @source Name
+    name: 이름
+    # @source Started
+    started: 시작됨
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: 블록 I/O(바이트/초)
+    # @reason Chart legend; CPU is the standard term in Korean UIs
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: 메모리
+    # @source Network I/O (bytes/s)
+    network: 네트워크 I/O(바이트/초)
+  interval:
+    # @source {minutes} min
+    minutes: '{minutes}분'
+    # @source {seconds} s
+    seconds: '{seconds}초'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: 통계는 현재 Docker(Moby) 엔진에서만 사용할 수 있습니다.
+  # @source No processes found.
+  noProcesses: 프로세스를 찾을 수 없습니다.
+  # @source Stats are only available for running containers.
+  notRunning: 통계는 실행 중인 컨테이너에서만 사용할 수 있습니다.
+  # @source Processes
+  processes: 프로세스
+  # @source Refresh
+  refresh: 새로 고침
+  series:
+    # @source Limit
+    limit: 제한
+    # @source Read
+    read: 읽기
+    # @reason Standard network receive abbreviation; kept in English as in common Korean dev UIs
+    # @source RX
+    rx: RX
+    # @reason Standard network transmit abbreviation; kept in English as in common Korean dev UIs
+    # @source TX
+    tx: TX
+    # @source Used
+    used: 사용량
+    # @source Write
+    write: 쓰기
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: 정보
+        # @source Restart
+        restart: 다시 시작
+        # @source Start
+        start: 시작
+        # @source Stop
+        stop: 중지
+      header:
+        # @source Name
+        containerName: 이름
+        # @source Image
+        image: 이미지
+        # @source Port(s)
+        ports: 포트
+        # @source Uptime
+        started: 가동 시간
+        # @source State
+        state: 상태
+  sortableTables:
+    # @source There are no containers to show
+    noRows: 표시할 컨테이너가 없습니다
+  # @source Containers
+  title: 컨테이너
+dashboard:
+  # @reason Product name; kept in English
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop은 root 권한으로 실행할 수 없습니다. 일반 사용자로 다시 실행하십시오.
+  # @source Cannot run as Root
+  title: root로 실행할 수 없음
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: '잘못된 배포 파일 {path}: 버전이 지정되지 않았습니다. 유효하도록 version 필드를 추가하십시오(현재 버전은 {version}입니다).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: '잘못된 배포: {path}에 버전이 지정되지 않았습니다. 유효하도록 version 필드를 추가하십시오(현재 버전은 {version}입니다).'
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count}개 실패 및 {muted}개 무시됨'
+  # @source Last run:
+  lastRun: '마지막 실행:'
+  # @source (No fixes available)
+  noFixes: (사용 가능한 수정 없음)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: 무시된 진단을 표시해 보십시오.
+      # @source No results found
+      heading: 결과를 찾을 수 없음
+      # @reason Icon identifier (CSS class), not translatable text
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop이 정상적으로 작동하고 있는 것으로 보입니다.
+      # @source No problems detected
+      heading: 문제가 감지되지 않음
+      # @reason Icon identifier (CSS class), not translatable text
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: 무시된 항목 표시
+  tableHeaders:
+    # @reason Mute here means silencing a diagnostic check; 음소거 is audio-only in Korean, so 무시 (ignore) as in common dev tools
+    # @source Mute
+    mute: 무시
+    # @source Name
+    name: 이름
+  # @source Diagnostics
+  title: 진단
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: 공유 네트워크도 사용할 수 없습니다. 호스트로의 포트 포워딩을 통해서만 네트워크에 액세스할 수 있습니다.
+    # @source Using shared network address {ip}
+    sharedFallback: 공유 네트워크 주소 {ip}을(를) 사용합니다
+    # @source Bridged network did not get an IP address.
+    title: 브리지 네트워크가 IP 주소를 받지 못했습니다.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: 워크로드 삭제
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: '{from}에서 {to}(으)로 다운그레이드하면 기존 Kubernetes 워크로드가 손실됩니다. 데이터를 삭제하시겠습니까?'
+    # @source Confirming migration
+    title: 마이그레이션 확인
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: 권장 최소 업그레이드 버전인 {version}(으)로 대체합니다
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: 요청한 Kubernetes 버전 ''{version}''은(는) 지원되는 버전이 아닙니다.
+    # @source Invalid Kubernetes Version
+    title: 잘못된 Kubernetes 버전
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: '{range} 범위의 버전을 받아 ''''{path}''''에 설치하십시오'
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: 오프라인 모드에서는 호환되는 버전의 kubectl을 다운로드할 수 없습니다
+    # @source Network failure
+    title: 네트워크 오류
+extensions:
+  # @reason Icon identifier (CSS class), not translatable text
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: 아직 설치된 확장이 없는 것 같습니다. 확장 카탈로그를 둘러보고 시작해 보십시오.
+      button:
+        # @source Browse Extensions
+        text: 확장 찾아보기
+      # @source No extensions installed
+      heading: 설치된 확장 없음
+      # @reason Icon identifier (CSS class), not translatable text
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: 제거
+      # @source Upgrade
+      upgrade: 업그레이드
+  view:
+    emptyState:
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId}이(가) 제거되었습니다. 확장을 다시 설치하거나 Rancher Desktop 사용 환경을 개선할 다른 확장을 찾아보려면 확장 카탈로그를 방문하십시오.'
+      # @source Extension removed
+      heading: 확장 제거됨
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Kubernetes 활성화
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (캐시된 버전만)
+    # @source Kubernetes Version
+    legend: Kubernetes 버전
+    # @source Other Versions
+    otherVersions: 기타 버전
+    # @source Recommended Versions
+    recommendedVersions: 권장 버전
+  # @source OK
+  ok: 확인
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: SUSE의 Rancher Desktop에 오신 것을 환영합니다
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop은 데스크톱 애플리케이션을 통해 Kubernetes와 이미지 관리를 제공합니다.
+  # @source Homepage
+  homepage: 홈페이지
+  # @source Issues
+  issues: 이슈
+  # @source General
+  navLabel: 일반
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: '프로젝트 토론: <a href="https://slack.rancher.io/">Rancher Users</a> Slack의 <b>#rancher-desktop</b> 채널'
+  # @source Project Links:
+  projectLinks: '프로젝트 링크:'
+  # @source Welcome to Rancher Desktop by SUSE
+  title: SUSE의 Rancher Desktop에 오신 것을 환영합니다
+generic:
+  # @reason Korean conjunction 및 keeps the surrounding spaces of the source joiner
+  # @source  and 
+  and: ' 및 '
+  # @source Apply
+  apply: 적용
+  # @source Cancel
+  cancel: 취소
+  # @source Close
+  close: 닫기
+  # @reason List separator; Korean uses the same comma and space
+  # @source , 
+  comma: ', '
+  # @reason Button on the Port Forwarding page; matches the established 포트 포워딩 terminology
+  # @source Forward
+  forward: 포워딩
+  # @source Loading&hellip;
+  loading: 불러오는 중&hellip;
+  # @source Namespace
+  namespace: 네임스페이스
+  # @source OK
+  ok: 확인
+  # @source Rerun
+  rerun: 다시 실행
+  # @source Search
+  search: 검색
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: 사용할 Dockerfile을 선택하십시오(이름이 다를 수 있습니다)
+  # @source Pick the build directory
+  buildTitle: 빌드 디렉터리 선택
+  # @source Error trying to delete images {ids}
+  deleteBatchError: 이미지 {ids}을(를) 삭제하는 중 오류가 발생했습니다
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      이미지 {name}({id})을(를) 삭제하는 중 오류가 발생했습니다:
+
+       {error}
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      {name}을(를) 푸시하는 중 오류가 발생했습니다:
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      {name}을(를) 스캔하는 중 오류가 발생했습니다:
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: 이미지 추가
+  add:
+    action:
+      # @source Build
+      build: 빌드
+      gerund:
+        # @reason Composed into images.add.loadingText, whose Korean template must supply the verb ending (e.g. 이미지를 {action}하는 중); bare noun keeps the composition grammatical
+        # @source Building
+        build: 빌드
+        # @reason Composed into images.add.loadingText, whose Korean template must supply the verb ending; 풀 follows kubernetes.io Korean usage (이미지 풀)
+        # @source Pulling
+        pull: 풀
+      infinitive:
+        # @reason Composed into images.add.errorText, whose Korean template must supply the verb ending (e.g. {action}하는 중 오류); bare noun keeps the composition grammatical
+        # @source build
+        build: 빌드
+        # @reason noun form; composed into other strings, Korean does not inflect for tense here
+        # @source pull
+        pull: 풀
+      pastTense:
+        # @reason noun form; composed as '이미지 {action} 완료' in successText
+        # @source Built
+        build: 빌드
+        # @reason noun form; composed as '이미지 {action} 완료' in successText
+        # @source Pulled
+        pull: 풀
+      # @source Pull
+      pull: 풀
+    # @reason rephrased so the action noun (풀/빌드) composes grammatically
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: '''''{ image }'''' 이미지 { action } 중 오류가 발생했습니다. 자세한 내용은 콘솔 출력을 확인하십시오.'
+    # @reason rephrased around noun-form action; gerund keys must also be noun forms (풀/빌드)
+    # @source {action} image...
+    loadingText: 이미지 {action} 중...
+    # @reason rephrased around noun-form action from pastTense keys
+    # @source {action} image
+    successText: 이미지 {action} 완료
+    # @source Add Image
+    title: 이미지 추가
+  confirmDelete:
+    # @source Delete
+    confirm: 삭제
+    # @reason reordered for Korean word order; plural branches identical since Korean nouns do not inflect
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: '{count, plural, one {이미지} other {이미지}} {count}개를 삭제하시겠습니까?'
+    # @source Delete image {name}:{tag}?
+    single: '{name}:{tag} 이미지를 삭제하시겠습니까?'
+    # @source Confirming image deletion
+    title: 이미지 삭제 확인
+  manager:
+    # @source Close Output to Continue
+    close: 계속하려면 출력 닫기
+    input:
+      build:
+        # @source Build
+        button: 빌드
+        # @source Name of image to build:
+        label: '빌드할 이미지 이름:'
+        # @reason Example image reference; OCI image names are always Latin script
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @source Pull
+        button: 풀
+        # @reason verbified loanword to stay consistent with the 풀 action/button label
+        # @source Name of image to pull:
+        label: '풀할 이미지 이름:'
+        # @reason Example image reference; OCI image names are always Latin script
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: 삭제
+        # @source Push
+        push: 푸시
+        # @source Scan...
+        scan: 스캔...
+      header:
+        # @source Image ID
+        imageId: 이미지 ID
+        # @source Image
+        imageName: 이미지
+        # @source Size
+        size: 크기
+        # @source Tag
+        tag: 태그
+      # @source All images
+      label: 모든 이미지
+    # @source Image Output
+    title: 이미지 출력
+  scan:
+    details:
+      # @source Description
+      description: 설명
+      # @source Primary URL
+      primaryUrl: 기본 URL
+      # @source References
+      references: 참조
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: '''''{ image }'''' 스캔 중 오류가 발생했습니다. 자세한 내용은 콘솔 출력을 확인하십시오.'
+    labels:
+      # @reason Korean has no letter case; standard severity terms used instead of all-caps
+      # @source CRITICAL
+      critical: 심각
+      # @source HIGH
+      high: 높음
+      # @source Issues Found
+      issuesFound: 발견된 문제
+      # @source LOW
+      low: 낮음
+      # @source MEDIUM
+      medium: 중간
+    # @source Scanning ''{ image }''
+    loadingText: '''''{ image }'''' 스캔 중'
+    results:
+      headers:
+        # @reason column shows the fixed package version (Trivy 'Fixed Version')
+        # @source Fixed
+        fixed: 수정 버전
+        # @source Installed
+        installed: 설치 버전
+        # @source Package
+        package: 패키지
+        # @source Severity
+        severity: 심각도
+        # @source Vulnerability ID
+        vulnerabilityId: 취약점 ID
+    # @source Scan details for ''{ image }''
+    title: '''''{ image }'''' 스캔 상세 정보'
+  sortableTables:
+    # @source There are no images to show
+    noRows: 표시할 이미지가 없습니다
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: 이미지 관리자가 준비될 때까지 기다리는 중
+    # @source Error: Unknown state; please reload.
+    unknown: '오류: 알 수 없는 상태입니다. 다시 로드하십시오.'
+  # @source Images
+  title: 이미지
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Rancher Desktop의 Kubernetes 구성과 Docker 소켓을 WSL(Windows Subsystem for Linux) 배포판에 노출합니다
+kubernetesError:
+  # @source Context:
+  context: '컨텍스트:'
+  # @source Last command run:
+  lastCommand: '마지막으로 실행한 명령:'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: '최근 <a href="#" data-action="showLogs">로그 파일</a> 내용 일부:'
+  # @source {appName} Error
+  title: '{appName} 오류'
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Kubernetes 사용
+    # @reason Product name; Kubernetes stays in Latin script throughout this file
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: 옵션
+    # @source Install Spin Operator
+    spinkube: Spin Operator 설치
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: Spin Operator를 사용하려면 <a href="#" data-navigate="Container Engine,general">WebAssembly</a>가 활성화되어 있어야 합니다.
+    # @source Enable Traefik
+    traefik: Traefik 사용
+  port:
+    # @source Kubernetes Port
+    legendText: Kubernetes 포트
+  version:
+    # @source Kubernetes version
+    legendText: Kubernetes 버전
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Kubernetes 버전(캐시된 버전만)
+    # @source Other Versions
+    otherVersions: 기타 버전
+    # @source Recommended Versions
+    recommendedVersions: 권장 버전
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: 옵션 없음
+    # @source No matching options
+    noMatch: 일치하는 옵션 없음
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount}개 항목'
+    # @source Load More...
+    more: 더 보기...
+locale:
+  # @source German
+  de: 독일어
+  # @source English
+  en-us: 영어
+  # @source Spanish
+  es: 스페인어
+  # @source French
+  fr: 프랑스어
+  # @source Italian
+  it: 이탈리아어
+  # @source Japanese
+  ja: 일본어
+  # @source Korean
+  ko: 한국어
+  # @source Portuguese (Brazilian)
+  pt-br: 포르투갈어(브라질)
+  # @source Chinese (Simplified)
+  zh-hans: 중국어(간체)
+mainMenu:
+  # @source About {appName}
+  about: '{appName} 정보'
+  edit:
+    # @source &Copy
+    copy: 복사(&C)
+    # @source Cu&t
+    cut: 잘라내기(&T)
+    # @source De&lete
+    delete: 삭제(&L)
+    # @source &Edit
+    label: 편집(&E)
+    # @source &Paste
+    paste: 붙여넣기(&P)
+    # @source &Redo
+    redo: 다시 실행(&R)
+    # @source Select &All
+    selectAll: 모두 선택(&A)
+    # @source &Undo
+    undo: 실행 취소(&U)
+  file:
+    # @source Close
+    close: 닫기
+    # @source E&xit
+    exit: 종료(&X)
+    # @source &File
+    label: 파일(&F)
+  help:
+    # @source &About {appName}
+    about: '{appName} 정보(&A)'
+    # @source &Discuss
+    discuss: 토론(&D)
+    # @source File a &Bug
+    fileABug: 버그 신고(&B)
+    # @source Get &Help
+    getHelp: 도움말 보기(&H)
+    # @source {appName} &Help
+    help: '{appName} 도움말(&H)'
+    # @source &Help
+    label: 도움말(&H)
+    # @source &Project Page
+    projectPage: 프로젝트 페이지(&P)
+  # @reason macOS Korean app-menu convention (가리기/기타 가리기/모두 보기)
+  # @source Hide {appName}
+  hide: '{appName} 가리기'
+  # @source Hide Others
+  hideOthers: 기타 가리기
+  # @source Preferences
+  preferences: 환경설정
+  # @source Quit {appName}
+  quit: '{appName} 종료'
+  # @source Services
+  services: 서비스
+  # @source Show All
+  showAll: 모두 보기
+  view:
+    # @source &Actual Size
+    actualSize: 실제 크기(&A)
+    # @source &Force Reload
+    forceReload: 강제 새로 고침(&F)
+    # @source &View
+    label: 보기(&V)
+    # @source &Reload
+    reload: 새로 고침(&R)
+    # @source Toggle &Developer Tools
+    toggleDevTools: 개발자 도구 전환(&D)
+    # @source Toggle Full &Screen
+    toggleFullScreen: 전체 화면 전환(&S)
+    # @source Zoom &In
+    zoomIn: 확대(&I)
+    # @source Zoom &Out
+    zoomOut: 축소(&O)
+  window:
+    # @source Bring All to Front
+    front: 모두 앞으로 가져오기
+    # @source &Window
+    label: 창(&W)
+    # @source Minimize
+    minimize: 최소화
+    # @source Zoom
+    zoom: 확대/축소
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: 설명
+        # @source Name
+        name: 이름
+        # @source Vendor
+        vendor: 공급업체
+  labels:
+    # @source Install
+    install: 설치
+    # @source Remove
+    uninstall: 제거
+    # @source Upgrade
+    upgrade: 업그레이드
+  loading:
+    # @source Installing...
+    install: 설치 중...
+    # @source Removing...
+    uninstall: 제거 중...
+    # @source Upgrading...
+    upgrade: 업그레이드 중...
+  # @source More information
+  moreInfo: 자세한 정보
+  # @source No extension found for the search criteria
+  noResults: 검색 조건과 일치하는 확장 프로그램이 없습니다
+  tabs:
+    # @source Catalog
+    catalog: 카탈로그
+    # @source Installed
+    installed: 설치됨
+  # @source Extensions
+  title: 확장 프로그램
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: 클러스터 대시보드
+    # @source Preferences
+    preferences: 환경설정
+pathManagement:
+  # @source Configure PATH
+  label: PATH 구성
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop은 PATH 구성을 변경하지 않습니다. <code>$HOME/.rd/bin</code>을 PATH에 직접 추가하십시오.
+      # @source Manual
+      label: 수동
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop이 셸 프로필을 대신 수정합니다. 변경 사항을 적용하려면 열려 있는 셸을 다시 시작하십시오.
+      # @source Automatic
+      label: 자동
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop에는 kubectl, nerdctl, helm, docker와 같은 도구가 포함되어 있습니다. 이러한 도구를 사용하려면 <code>$HOME/.rd/bin</code>이 PATH에 있어야 합니다.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Kubernetes 서비스 포함
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: 로컬 포트
+        # @source Name
+        name: 이름
+        # @source Namespace
+        namespace: 네임스페이스
+        # @source Port
+        port: 포트
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: 표시할 포트 포워딩 항목이 없습니다
+  # @source Port Forwarding
+  title: 포트 포워딩
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: 환경설정 선택에 문제가 있습니다.
+      # @source Kubernetes will reset after applying changes.
+      reset: 변경 사항을 적용하면 Kubernetes가 재설정됩니다.
+      # @source Kubernetes will restart after applying changes.
+      restart: 변경 사항을 적용하면 Kubernetes가 다시 시작됩니다.
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: <a href="#" data-navigate="Kubernetes">Spin Operator</a>를 설치하려면 WebAssembly가 활성화되어 있어야 합니다.
+  error:
+    # @source Reload Preferences to try again.
+    body: 환경설정을 다시 로드하여 다시 시도하십시오.
+    # @source Unable to fetch preferences
+    heading: 환경설정을 가져올 수 없습니다
+    # @source Reload preferences
+    reload: 환경설정 다시 로드
+  # @source Preferences
+  header: 환경설정
+  # @source or
+  incompatiblePrefWarningOr: 또는
+  # @reason sentence fragment composed after variable pref names; 이(가) covers both particle forms
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: 이(가) 선택 해제되어 있어야 합니다.
+  # @reason sentence fragment composed after variable pref names; 이(가) covers both particle forms
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: 이(가) 선택되어 있어야 합니다.
+  # @reason fragment restructured so the composed sentence reads naturally in Korean SOV order
+  # @source The option requires
+  incompatibleTypeWarningPre: 이 옵션을 사용하려면
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: 조직의 정책에 따라 잠겨 있습니다
+  nav:
+    # @source Application
+    application: 애플리케이션
+    # @source Container Engine
+    containerEngine: 컨테이너 엔진
+    # @reason Product name; Kubernetes stays in Latin script throughout this file
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: 가상 머신
+    # @reason Product acronym (Windows Subsystem for Linux)
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: 적용 및 재설정
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: 이 변경 사항은 Kubernetes 클러스터를 재설정하며, 워크로드와 컨테이너 이미지가 손실됩니다.
+    # @source Apply preferences and reset Kubernetes?
+    message: 환경설정을 적용하고 Kubernetes를 재설정하시겠습니까?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Kubernetes 재설정
+  tabs:
+    # @source Allowed Images
+    allowedImages: 허용된 이미지
+    # @source Behavior
+    behavior: 동작
+    # @source Emulation
+    emulation: 에뮬레이션
+    # @source Environment
+    environment: 환경
+    # @source General
+    general: 일반
+    # @source Hardware
+    hardware: 하드웨어
+    # @source Integrations
+    integrations: 통합
+    # @source Proxy
+    proxy: 프록시
+    # @source Volumes
+    volumes: 볼륨
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: 적용되지 않은 변경 사항이 있는 환경설정이 있습니다. 저장하지 않은 환경설정은 모두 손실됩니다.
+    # @source Discard changes
+    discardChanges: 변경 사항 버리기
+    # @source Close preferences without applying?
+    message: 적용하지 않고 환경설정을 닫으시겠습니까?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - 환경설정 닫기
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - 환경설정
+prefs:
+  # @source Experimental
+  experimental: 실험적
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: 이 설정을 사용하려면 macOS 13.3(Ventura) 이상이 필요합니다.
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: 이 설정을 사용하려면 macOS 13.0(Ventura) 이상이 필요합니다.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: 이 설정을 사용하려면 VZ 에뮬레이션 모드가 필요합니다. VZ는 macOS 13.3(Ventura) 이상에서만 사용할 수 있습니다.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: 이 설정을 사용하려면 VZ 에뮬레이션 모드가 필요합니다. VZ는 macOS 13.0(Ventura) 이상에서만 사용할 수 있습니다.
+product:
+  containerEngine:
+    # @reason Compact status-bar label with no Korean abbreviation for 컨테이너 엔진; the tooltip shows the translated full name
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: 컨테이너 엔진
+  # @source deactivated
+  deactivated: 비활성화됨
+  # @reason Product name used as status-bar label
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: 네트워크 상태
+  networkStatusValues:
+    # @source checking...
+    checking: 확인 중...
+    # @source offline
+    offline: 오프라인
+    # @source online
+    online: 온라인
+  # @source Version
+  version: 버전
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: 관리자 권한으로 작업을 실행하기 위한 권한 요청 중
+  # @source Bundling certificates
+  bundlingCertificates: 인증서 번들 생성 중
+  # @source Checking k3s images
+  checkingK3sImages: k3s 이미지 확인 중
+  # @source Configuring container engine
+  configuringContainerEngine: 컨테이너 엔진 구성 중
+  # @source Configuring image proxy
+  configuringImageProxy: 이미지 프록시 구성 중
+  # @source Configuring logrotate
+  configuringLogrotate: logrotate 구성 중
+  # @source Container engine components
+  containerEngineComponents: 컨테이너 엔진 구성 요소
+  # @source Copying certificates
+  copyingCertificates: 인증서 복사 중
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: 호환되지 않는 Kubernetes 상태 삭제 중
+  # @source Deleting Kubernetes
+  deletingKubernetes: Kubernetes 삭제 중
+  # @source Deleting virtual machine
+  deletingVirtualMachine: 가상 머신 삭제 중
+  # @source DNS configuration
+  dnsConfiguration: DNS 구성
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: 호환되는 kubectl 확인 중
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: 가상화 지원 여부 확인 중
+  # @source Expecting user permission to continue
+  expectingPermission: 계속하기 위한 사용자 권한 대기 중
+  # @source Extracting certificates
+  extractingCertificates: 인증서 추출 중
+  # @source Fetching certificates
+  fetchingCertificates: 인증서 가져오는 중
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Rancher Desktop 초기화 중
+  # @source Initializing WSL data
+  initializingWslData: WSL 데이터 초기화 중
+  # @source Installing Buildkit
+  installingBuildkit: Buildkit 설치 중
+  # @source Installing CA certificates
+  installingCaCertificates: CA 인증서 설치 중
+  # @source Installing container engine
+  installingContainerEngine: 컨테이너 엔진 설치 중
+  # @source Installing credential helper
+  installingCredentialHelper: 자격 증명 도우미 설치 중
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: docker-credential 도우미 설치 중
+  # @source Installing helpers
+  installingHelpers: 도우미 설치 중
+  # @source Installing image scanner
+  installingImageScanner: 이미지 스캐너 설치 중
+  # @source Installing k3s
+  installingK3s: k3s 설치 중
+  # @source Installing Kubernetes
+  installingKubernetes: Kubernetes 설치 중
+  # @source Kubernetes components
+  kubernetesComponents: Kubernetes 구성 요소
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Kubernetes dockerd 호환성
+  # @source Mounting WSL data
+  mountingWslData: WSL 데이터 마운트 중
+  # @source Preparing to start
+  preparingToStart: 시작 준비 중
+  # @source Proxy Config Setup
+  proxyConfigSetup: 프록시 구성 설정
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Rancher Desktop 게스트 에이전트
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: 권한 부족을 반영하여 구성 다시 생성 중
+  # @source Registering WSL distribution
+  registeringWslDistribution: WSL 배포판 등록 중
+  # @source Removing existing certificates
+  removingExistingCertificates: 기존 인증서 제거 중
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: spinkube 오퍼레이터 제거 중
+  # @source Removing stale state
+  removingStaleState: 오래된 상태 제거 중
+  # @source Removing Traefik
+  removingTraefik: Traefik 제거 중
+  # @source Resetting Kubernetes
+  resettingKubernetes: Kubernetes 재설정 중
+  # @source Running provisioning scripts
+  runningProvisioningScripts: 프로비저닝 스크립트 실행 중
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: update-ca-certificates 실행 중
+  # @source Setting docker context
+  settingDockerContext: docker 컨텍스트 설정 중
+  # @source Setting Lima permissions
+  settingLimaPermissions: Lima 권한 설정 중
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Docker 소켓 설정 중
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: 가상 이더넷 설정 중
+  # @source Shutting down
+  shuttingDown: 종료 중
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: flannel이 비활성화되어 노드 검사를 건너뛰는 중
+  # @source Starting Backend
+  startingBackend: 백엔드 시작 중
+  # @source Starting buildkit
+  startingBuildkit: buildkit 시작 중
+  # @source Starting container engine
+  startingContainerEngine: 컨테이너 엔진 시작 중
+  # @source Starting image proxy
+  startingImageProxy: 이미지 프록시 시작 중
+  # @source Starting k3s
+  startingK3s: k3s 시작 중
+  # @source Starting Kubernetes
+  startingKubernetes: Kubernetes 시작 중
+  # @source Starting proxy
+  startingProxy: 프록시 시작 중
+  # @source Starting {service}
+  startingService: '{service} 시작 중'
+  # @source Starting virtual machine
+  startingVirtualMachine: 가상 머신 시작 중
+  # @source Starting WSL environment
+  startingWslEnvironment: WSL 환경 시작 중
+  # @source Stopping existing instance
+  stoppingExistingInstance: 기존 인스턴스 중지 중
+  # @source Stopping mock backend
+  stoppingMockBackend: 모의 백엔드 중지 중
+  # @source Stopping services
+  stoppingServices: 서비스 중지 중
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: 클러스터 구성 업데이트 중
+  # @source Updating /etc/hosts
+  updatingEtcHosts: /etc/hosts 업데이트 중
+  # @source Updating kubeconfig
+  updatingKubeconfig: kubeconfig 업데이트 중
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: 오래된 가상 머신 업데이트 중
+  # @source Updating WSL data
+  updatingWslData: WSL 데이터 업데이트 중
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: WSL 배포판 업그레이드 중
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: 컨테이너 엔진이 준비될 때까지 대기 중
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: Kubernetes API 대기 중
+  # @source Waiting for nodes
+  waitingForNodes: 노드 대기 중
+  # @source Waiting for services
+  waitingForServices: 서비스 대기 중
+  # @source Writing K3s configuration
+  writingK3sConfiguration: K3s 구성 작성 중
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: 스냅샷 생성
+  card:
+    action:
+      # @source Delete
+      remove: 삭제
+      # @source Restore
+      restore: 복원
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: '''<b>''{date}''</b>'' ''<b>''{time}''</b>''에 생성됨'
+  create:
+    actions:
+      # @source Cancel
+      back: 취소
+      # @source Create
+      submit: 생성
+    description:
+      # @source Description
+      label: 설명
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: 새 스냅샷을 생성하는 동안 Rancher Desktop을 일시적으로 사용할 수 없습니다
+    name:
+      # @source Snapshot Name
+      label: 스냅샷 이름
+    # @source Create a new Snapshot
+    title: 새 스냅샷 생성
+  dialog:
+    buttons:
+      # @source Close
+      error: 닫기
+    creating:
+      actions:
+        # @source Cancel
+        cancel: 취소
+      # @source Creating {snapshot}
+      header: '{snapshot} 생성 중'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: 스냅샷 '<b>'{snapshot}'</b>'을(를) 생성하는 동안 잠시 기다려 주십시오.'<br/>'컴퓨터 리소스에 따라 시간이 다소 걸릴 수 있습니다.'<br/>'이 작업이 진행되는 동안 Rancher Desktop을 일시적으로 사용할 수 없습니다.'<br/><br/>'스냅샷 생성이 완료되면 VM이 다시 시작됩니다.
+    delete:
+      actions:
+        # @source Cancel
+        cancel: 취소
+        # @source Delete
+        ok: 삭제
+      # @source Permanently delete snapshot?
+      header: 스냅샷을 영구적으로 삭제하시겠습니까?
+      # @source Deleting a snapshot cannot be undone.
+      info: 삭제한 스냅샷은 되돌릴 수 없습니다.
+    generic:
+      # @source Snapshot operation in progress
+      header: 스냅샷 작업 진행 중
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: 스냅샷 작업이 진행되는 동안 잠시 기다려 주십시오.<br/>컴퓨터 리소스에 따라 시간이 다소 걸릴 수 있습니다.<br/>이 작업이 진행되는 동안 Rancher Desktop을 일시적으로 사용할 수 없습니다.<br/><br/>스냅샷 작업이 완료되면 VM이 다시 시작됩니다.
+    restore:
+      actions:
+        # @source Cancel
+        cancel: 취소
+        # @source Restore
+        ok: 복원
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Rancher Desktop 종료
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: 스냅샷 '<b>'{snapshot}'</b>' 복원에 실패했습니다.'<br/><br/>'Rancher Desktop이 공장 초기화를 수행했으며 이제 종료됩니다. Rancher Desktop을 다시 시작하여 스냅샷 복원을 다시 시도하기 전에 이 오류를 일으킨 문제를 해결해 주십시오.
+        # @source Error restoring snapshot
+        header: 스냅샷 복원 오류
+      # @source Restore snapshot?
+      header: 스냅샷을 복원하시겠습니까?
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: 이 스냅샷을 복원하면 환경설정을 포함한 현재 설치 상태가 대체됩니다. 환경설정 창이 열려 있는 경우 자동으로 닫히며 저장하지 않은 변경 사항은 모두 삭제됩니다.
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: 취소
+      # @source Restoring {snapshot}
+      header: '{snapshot} 복원 중'
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: 스냅샷 '<b>'{snapshot}'</b>'을(를) 복원하는 동안 잠시 기다려 주십시오. 컴퓨터 리소스에 따라 시간이 다소 걸릴 수 있습니다.<br/><br/>이 작업이 진행되는 동안 Rancher Desktop을 일시적으로 사용할 수 없습니다. 완료되면 {snapshot} 스냅샷이 활성화된 상태로 VM이 다시 시작됩니다.
+    # @source Show logs
+    showLogs: 로그 보기
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: 시작하려면 스냅샷 생성을 클릭하십시오
+    # @source No snapshots found
+    heading: 스냅샷 없음
+    # @reason icon identifier passed to the EmptyState component, not user-visible text; kept unchanged
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: '{snapshot} 생성이 취소됨'
+      # @source Created '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' 생성됨'
+    delete:
+      # @source Delete error: {error}
+      error: '삭제 오류: {error}'
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' 삭제됨'
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: 스냅샷 잠금 파일이 비정상적으로 오랫동안 감지되었습니다. 오류라고 판단되는 경우 <code>rdctl snapshot unlock</code>을 실행하여 잠금 파일을 제거해 볼 수 있습니다.
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: '{snapshot} 복원이 취소됨'
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: '''<b>''{snapshot}''</b>'' 복원됨'
+    # @reason code appends this after a finished message (Snapshots.vue); a Korean particle suffix like '{time}에' would be ungrammatical there, so the time is rendered parenthetically
+    # @source  at {time}
+    when: ' ({time})'
+  # @source Snapshots
+  title: 스냅샷
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: '{actionable}개 선택됨'
+    # @source Available for {actionable} of the {total} selected
+    some: 선택한 {total}개 중 {actionable}개에 사용 가능
+  # @source Add
+  add: 추가
+  # @source Add Filter
+  addFilter: 필터 추가
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: 작업
+  # @source Filter for...
+  filterFor: 필터링할 값...
+  # @reason composed in code between filter value and column name ('"x" in Name' chip, and as a label before the column dropdown); a bare Korean postposition cannot precede the column, so rendered as the label '열:'
+  # @source in
+  in: '열:'
+  # @source No actions available
+  noActions: 사용 가능한 작업 없음
+  # @source There are no rows which match your search query.
+  noData: 검색 조건과 일치하는 행이 없습니다.
+  # @source There are no rows to show.
+  noRows: 표시할 행이 없습니다.
+  paging:
+    # @reason placeholders reordered inside the 'other' branch for Korean word order; counter suffix '개' attaches to {count} without a space
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {항목 없음}
+        =1 {{count}{count, plural, =1 {개 항목} other {개 항목}}}
+        other {전체 {count}개 항목 중 {from} - {to}}}
+  # @source Reset
+  resetFilters: 초기화
+  # @source Filter
+  search: 필터
+  # @source Select a column
+  selectCol: 열 선택
+  tableHeader:
+    # @source Group by
+    groupBy: 그룹화 기준
+    # @source This column cannot be filtered
+    noFilter: 이 열은 필터링에 사용할 수 없습니다
+    # @source Show
+    show: 표시
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: 항상 관리자 권한 없이 실행
+  # @source OK
+  buttonText: 확인
+  # @source This will modify the following paths:
+  explanation: '다음 경로가 수정됩니다:'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'Rancher Desktop에는 다음과 같은 이유로 관리자 권한("sudo 권한")이 필요합니다:'
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: 이 창을 닫으면 권한 요청 프롬프트가 표시됩니다. 프롬프트를 취소하거나 관리자 권한을 사용하지 않도록 설정하면, Rancher Desktop을 계속 사용하기 위해 docker 컨텍스트를 rancher-desktop으로 전환해야 합니다.
+  reasons:
+    dockerSocket:
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: docker 컨텍스트를 사용할 수 없고 docker 소켓을 사용하는 도구와의 호환성을 제공합니다.
+      # @source Set up default docker socket
+      title: 기본 docker 소켓 설정
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: 컨테이너에 더 쉽게 접근할 수 있도록 브리지 네트워킹을 제공합니다. 허용하지 않으면 포트 포워딩을 통해서만 컨테이너에 접근할 수 있습니다.
+      # @source Configure networking
+      title: 네트워킹 구성
+  # @source Administrative Access Required
+  title: 관리자 권한 필요
+systemPreferences:
+  # @source # CPUs
+  cpus: CPU 수
+  # @source Memory (GB)
+  memory: 메모리(GB)
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Rancher Desktop 개선에 도움이 되도록 익명화된 사용 정보, 오류 보고서 등을 전송합니다. 데이터는 다른 누구와도 공유되지 않으며, 배포하는 특정 리소스나 엔드포인트에 대한 정보는 포함되지 않습니다.
+tray:
+  # @source Container engine: {name}
+  containerEngine: '컨테이너 엔진: {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Kubernetes 컨텍스트
+  # @source Network status: {status}
+  networkStatus: '네트워크 상태: {status}'
+  # @source None found
+  noneFound: 없음
+  # @source Open cluster dashboard
+  openDashboard: 클러스터 대시보드 열기
+  # @source Open main window
+  openMainWindow: 메인 창 열기
+  # @source Open preferences dialog
+  openPreferences: 환경설정 열기
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Rancher Desktop 종료
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes 비활성화됨
+    # @source Kubernetes has encountered an error
+    error: Kubernetes 오류 발생
+    # @source Kubernetes is running
+    started: Kubernetes 실행 중
+    # @source Kubernetes is starting
+    starting: Kubernetes 시작 중
+    # @source Kubernetes is stopped
+    stopped: Kubernetes 중지됨
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes 종료 중
+  # @reason Product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: 디버그 모드 활성화
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: 공장 초기화
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: 공장 초기화는 모든 Rancher Desktop 구성을 제거합니다.
+      messageBox:
+        # @source Cancel
+        cancel: 취소
+        # @source Keep cached Kubernetes images
+        checkboxLabel: 캐시된 Kubernetes 이미지 유지
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>공장 초기화를 수행하면 클러스터와 모든 Rancher Desktop 설정이 제거되고 Rancher Desktop이 종료됩니다. Rancher Desktop을 계속 사용하려면 수동으로 다시 시작하여 초기 설정을 다시 진행해야 합니다.</p><p>정말 모든 것을 초기화하시겠습니까?</p>
+        # @source Perform a factory reset?
+        message: 공장 초기화를 수행하시겠습니까?
+        # @source Factory Reset
+        ok: 공장 초기화
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - 공장 초기화
+      # @source Factory Reset
+      title: 공장 초기화
+    logs:
+      # @source Show Logs
+      buttonText: 로그 보기
+      # @source Show Rancher Desktop logs
+      description: Rancher Desktop 로그 표시
+      # @source Logs
+      title: 로그
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Kubernetes 초기화
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: Kubernetes를 초기화하면 모든 워크로드와 구성이 삭제됩니다.
+      messageBox:
+        # @source Cancel
+        cancel: 취소
+        # @source Delete container images
+        checkboxLabel: 컨테이너 이미지 삭제
+        # @source Reset Kubernetes?
+        message: Kubernetes를 초기화하시겠습니까?
+        # @source Reset
+        ok: 초기화
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Kubernetes 초기화
+      # @source Reset Kubernetes
+      title: Kubernetes 초기화
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: 여전히 문제가 해결되지 않는 경우 <a href="https://slack.rancher.io/">Rancher Users Slack</a>의 <b>#rancher-desktop</b> 채널에서 토론을 시작하거나 <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">이슈를 보고</a>해 주십시오.
+  # @source Troubleshooting
+  title: 문제 해결
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: 모든 요구 사항이 충족되었는지 확인한 후 다시 시도하십시오. Rancher Desktop이 이제 종료됩니다.
+  # @source OK
+  buttonText: 확인
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: '요구 사항이 누락되었거나 구성되지 않아 Rancher Desktop을 시작할 수 없습니다:'
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop을 시작할 수 없음
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: 업데이트 적용 중...
+  # @source An update to version {version} is available
+  available: 버전 {version} 업데이트를 사용할 수 있습니다
+  # @source Check for updates automatically
+  checkForUpdates: 자동으로 업데이트 확인
+  # @source downloading... ({percent}%, {speed})
+  downloading: 다운로드 중... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: 업데이트를 확인하는 동안 오류가 발생했습니다.
+  # @source Release Notes
+  releaseNotes: 릴리스 노트
+  # @source Restart Now
+  restartNow: 지금 다시 시작
+  # @source Restart the application to apply the update.
+  restartToApply: 업데이트를 적용하려면 애플리케이션을 다시 시작하십시오.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: 최신 버전의 Rancher Desktop을 사용할 수 있지만 현재 시스템에서는 지원되지 않습니다.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: 자세한 내용은 <a href="https://docs.rancherdesktop.io/getting-started/installation">설치 설명서</a>를 참조하십시오.
+    # @source Latest Version Not Supported
+    title: 최신 버전이 지원되지 않음
+  # @source Update Available
+  updateAvailable: 업데이트 사용 가능
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: '"{field}"을(를) {from}에서 {to}(으)로 줄일 수 없습니다'
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: moby에서 classic 스토리지를 사용하는 경우 WebAssembly를 활성화할 수 없습니다.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: WebAssembly가 활성화된 상태에서는 moby의 classic 스토리지로 전환할 수 없습니다.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: WebAssembly가 활성화된 상태에서는 classic 스토리지를 사용하는 moby 컨테이너 엔진으로 전환할 수 없습니다.
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: '"{field}" 필드에 중복된 항목이 있습니다: "{duplicates}"'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: '제안된 설정에 오류가 있습니다:'
+  # @source field "{field}" is locked
+  fieldLocked: '"{field}" 필드는 잠겨 있습니다'
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: "{pattern}"은(는) 이미지 참조를 나타내지 않습니다'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: "{value}"은(는) 유효한 매핑이 아닙니다'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: "{name}"은(는) 유효하지 않은 이름입니다'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: '"{field}" 필드에 유효하지 않은 항목이 있습니다(IP 주소, CIDR 서브넷 또는 도메인 이름이어야 합니다): "{entries}"'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: "{value}"은(는) 환경설정 대화 상자의 유효한 페이지 이름이 아닙니다'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: 탭 이름 "{tabName}"은(는) "{page}" 환경설정 페이지의 유효한 탭 이름이 아닙니다'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: "{name}"에 유효하지 않은 태그 "{tag}"이(가) 있습니다'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: '"{field}"의 값이 유효하지 않습니다: <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: '"{field}"의 값이 유효하지 않습니다: <{value}>; {validValues} 중 하나여야 합니다'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Kubernetes 버전 "{version}"을(를) 찾을 수 없습니다.
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: "{name}"에 문자열이 아닌 태그 "{tag}"이(가) 있습니다'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: API를 통한 "{field}" 필드 변경은 지원되지 않습니다.
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: '''''{field}'''' 필드 오류: 배열 타입 값이 필요하지만 ''''{value}''''을(를) 받았습니다'
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: '''''{field}'''' 필드 오류: {expectedType} 타입 값이 필요하지만 ''''{value}''''을(를) 받았습니다'
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: '''''{field}'''' 필드 오류: {expectedType} 타입 값이 필요하지만 배열 {value}을(를) 받았습니다'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: 제안된 필드 "{field}"은(는) 객체여야 하지만 <{value}>을(를) 받았습니다.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: '{field} 설정은 aarch64 시스템에서만 활성화할 수 있습니다.'
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: '{field} 설정은 virtualMachine.mount.type이 "{mountType}"인 경우에만 변경할 수 있습니다.'
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: '{field} 설정은 virtual-machine.type이 "{vmType}"인 경우에만 활성화할 수 있습니다.'
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: '{field} 설정은 experimental.container-engine.web-assembly.enabled도 함께 설정된 경우에만 설정할 수 있습니다.'
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: '{field}을(를) "{value}"(으)로 설정하려면 {otherField}이(가) "{required}"이어야 합니다.'
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: '{field}을(를) "{value}"(으)로 설정하려면 {otherField}이(가) "{option1}" 또는 "{option2}"이어야 합니다.'
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: '"{field}" 설정은 내부 객체를 감싸야 하지만 <{value}>을(를) 받았습니다.'
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: '"{field}" 설정은 단순 값이어야 하지만 <{value}>을(를) 받았습니다.'
+  # @source One or more fields in this tab contain a form validation error
+  tab: 이 탭의 하나 이상의 필드에 양식 유효성 검사 오류가 있습니다
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: ARM에서 {field}을(를) "{vmType}"(으)로 설정하려면 macOS 13.3(Ventura) 이상이 필요합니다.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Intel에서 {field}을(를) "{vmType}"(으)로 설정하려면 macOS 13.0(Ventura) 이상이 필요합니다.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: 마운트 유형
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: QEMU의 virtio-9p-pci 장치를 사용하여 파일시스템을 노출합니다.
+          # @reason Literal mount type value
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: 캐시 모드
+              options:
+                # @reason Literal 9p cache-mode value
+                # @source fscache
+                fscache: fscache
+                # @reason Literal 9p cache-mode value
+                # @source loose
+                loose: loose
+                # @reason Literal 9p cache-mode value
+                # @source mmap
+                mmap: mmap
+                # @reason Literal 9p cache-mode value
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: 사용할 캐싱 정책
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: 메시지 크기(KiB)
+              # @source Maximum message size in KiB
+              tooltip: 최대 메시지 크기(KiB)
+            protocolVersion:
+              # @source Protocol Version
+              legend: 프로토콜 버전
+              options:
+                # @reason Literal 9p protocol version value
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason Literal 9p protocol version value
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason Literal 9p protocol version value
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: 9P 프로토콜 버전
+            securityModel:
+              # @source Security Model
+              legend: 보안 모델
+              options:
+                # @reason Literal 9p security-model value
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason Literal 9p security-model value
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason Literal 9p security-model value
+                # @source none
+                none: none
+                # @reason Literal 9p security-model value
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: 내보내기 경로에 사용되는 보안 모델
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: SFTP 서버를 실행하여 파일시스템을 노출합니다.
+          # @reason Literal mount type value
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Apple Virtualization 프레임워크의 공유 디렉터리 장치를 사용하여 파일시스템을 노출합니다.
+          # @reason Literal mount type value
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: 주소
+    # @source Proxy address
+    addressTitle: 프록시 주소
+    # @source Authentication information
+    authTitle: 인증 정보
+    # @source Enable the proxy used by rancher-desktop
+    label: rancher-desktop에서 사용하는 프록시 활성화
+    # @source WSL Proxy
+    legend: WSL 프록시
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: 중복된 항목입니다.
+      # @source Proxy bypass list
+      legend: 프록시 우회 목록
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: 프록시를 우회할 IP, CIDR, 도메인 또는 와일드카드(*.example.com)
+    # @source Password
+    password: 암호
+    # @source Port
+    port: 포트
+    # @source Username
+    username: 사용자 이름
+  type:
+    # @source Virtual Machine Type
+    legend: 가상 머신 유형
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: QEMU 에뮬레이터를 사용합니다.
+        # @reason Product name (QEMU emulator)
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @source Use the Apple Virtualization framework.
+        description: Apple Virtualization 프레임워크를 사용합니다.
+        # @reason Apple Virtualization.framework identifier
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Rosetta 지원 활성화
+    # @source VZ Option
+    legend: VZ 옵션
+volumes:
+  files:
+    # @source Available
+    available: 사용 가능
+    # @source Error checking volume status
+    checkError: 볼륨 상태 확인 오류
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: 유효하지 않은 볼륨 이름 "{name}"
+    # @source Error listing files: {error}
+    listError: '파일 목록을 가져오는 중 오류 발생: {error}'
+    # @source Loading volume files...
+    loading: 볼륨 파일을 불러오는 중...
+    # @source This volume is empty
+    noFiles: 이 볼륨은 비어 있습니다
+    # @source Not Found
+    notFound: 찾을 수 없음
+    table:
+      header:
+        # @source Modified
+        modified: 수정일
+        # @source Name
+        name: 이름
+        # @source Permissions
+        permissions: 권한
+        # @source Size
+        size: 크기
+    # @source Volume Files
+    title: 볼륨 파일
+    # @source Volume "{name}" not found
+    volumeNotFound: 볼륨 "{name}"을(를) 찾을 수 없습니다
+  manage:
+    table:
+      header:
+        # @source Created
+        created: 생성일
+        # @source Driver
+        driver: 드라이버
+        # @source Mount Point
+        mountpoint: 마운트 지점
+        # @source Volume Name
+        volumeName: 볼륨 이름
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: 파일 찾아보기
+        # @source Delete
+        delete: 삭제
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: 표시할 볼륨이 없습니다
+  # @source Volumes
+  title: 볼륨
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: 실험적인 WebAssembly 기능을 활성화하기 전에 설명서를 읽어 주십시오!
+  # @source Enabled
+  enabled: 활성화
+  # @reason Technology name; WebAssembly stays in Latin script throughout this file
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -855,6 +855,8 @@ locale:
   it: Italiano
   # @source Japanese
   ja: Japonês
+  # @source Korean
+  ko: Coreano
   # @reason Standard self-designation for the Brazilian Portuguese locale
   # @source Portuguese (Brazilian)
   pt-br: Português (Brasil)

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -1,0 +1,1890 @@
+action:
+  # @source Refresh
+  refresh: Atualizar
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: O nome da imagem precisa corresponder a um dos padrões definidos na aba Imagens permitidas das Configurações.
+  # @source Enable
+  enable: Habilitar
+  errors:
+    # @source This item is a duplicate.
+    duplicate: Este item está duplicado.
+  # @source Allowed Image Patterns
+  label: Padrões de imagens permitidas
+  patterns:
+    # @source Type the image pattern
+    placeholder: Digite o padrão de imagem
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: Iniciar automaticamente ao fazer login
+      # @source Startup
+      legendText: Inicialização
+    background:
+      # @source Background
+      legendText: Segundo plano
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: |
+          Ocultar a janela do aplicativo quando o Rancher Desktop estiver em execução em segundo plano. Ele pode ser aberto pelo ícone de notificação (se visível) ou executando o Rancher Desktop a partir do menu de aplicativos.
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: Ocultar ícone de notificação
+      # @source Notification Icon
+      legendText: Ícone de notificação
+    startInBackground:
+      # @source Start in the background
+      label: Iniciar em segundo plano
+    theme:
+      # @source Appearance
+      legendText: Aparência
+      options:
+        dark:
+          # @source Always use dark mode
+          description: Sempre usar o modo escuro
+          # @source Dark
+          label: Escuro
+        light:
+          # @source Always use light mode
+          description: Sempre usar o modo claro
+          # @source Light
+          label: Claro
+        system:
+          # @source Follow the operating system setting
+          description: Seguir a configuração do sistema operacional
+          # @source System
+          label: Sistema
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: Encerrar ao fechar a janela do aplicativo
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: Permitir credenciais administrativas (acesso sudo)
+      # @source Administrative Access
+      legendText: Acesso administrativo
+      # @reason 'bridge' kept in English: standard networking term in Brazilian technical usage
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: Se marcado, o {appName} obterá credenciais administrativas ("acesso sudo") ao iniciar. Isso habilita a rede em modo bridge e o suporte ao socket padrão do docker. Entra em vigor na próxima inicialização.
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: Verificar atualizações automaticamente
+      # @source Automatic Updates
+      legendText: Atualizações automáticas
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: Permitir a coleta de estatísticas anônimas para ajudar a melhorar o {appName}
+      # @source Statistics
+      legendText: Estatísticas
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: As traduções são fornecidas pela comunidade e por ferramentas de IA. O inglês é o idioma canônico. Relate problemas de tradução no GitHub.
+    # @source Language
+    legendText: Idioma
+asyncButton:
+  activate:
+    # @source Activate
+    action: Ativar
+    # @source Activated
+    success: Ativado
+    # @source Activating&hellip;
+    waiting: Ativando&hellip;
+  apply:
+    # @source Apply
+    action: Aplicar
+    # @source Applied
+    success: Aplicado
+    # @source Applying&hellip;
+    waiting: Aplicando&hellip;
+  continue:
+    # @source Continue
+    action: Continuar
+    # @source Saved
+    success: Salvo
+    # @source Saving&hellip;
+    waiting: Salvando&hellip;
+  copy:
+    # @source Click to Copy
+    action: Clique para copiar
+    # @source Copied!
+    success: Copiado!
+  create:
+    # @source Create
+    action: Criar
+    # @source Created
+    success: Criado
+    # @source Creating&hellip;
+    waiting: Criando&hellip;
+  deactivate:
+    # @source Deactivate
+    action: Desativar
+    # @source Deactivated
+    success: Desativado
+    # @source Deactivating&hellip;
+    waiting: Desativando&hellip;
+  default:
+    # @source Action
+    action: Ação
+    # @source Error
+    error: Erro
+    # @source Success
+    success: Sucesso
+    # @source Waiting
+    waiting: Aguardando
+  delete:
+    # @source Delete
+    action: Excluir
+    # @source Deleted
+    success: Excluído
+    # @source Deleting&hellip;
+    waiting: Excluindo&hellip;
+  disable:
+    # @source Disable
+    action: Desabilitar
+    # @source Disabled
+    success: Desabilitado
+    # @source Disabling&hellip;
+    waiting: Desabilitando&hellip;
+  done:
+    # @reason Infinitive verb form for the button label, matching the other action buttons
+    # @source Done
+    action: Concluir
+    # @source Saved
+    success: Salvo
+    # @source Saving&hellip;
+    waiting: Salvando&hellip;
+  download:
+    # @source Download
+    action: Baixar
+    # @source Saving
+    success: Salvando
+    # @source Downloading&hellip;
+    waiting: Baixando&hellip;
+  edit:
+    # @source Save
+    action: Salvar
+    # @source Saved
+    success: Salvo
+    # @source Saving&hellip;
+    waiting: Salvando&hellip;
+  enable:
+    # @source Enable
+    action: Habilitar
+    # @source Enabled
+    success: Habilitado
+    # @source Enabling&hellip;
+    waiting: Habilitando&hellip;
+  finish:
+    # @source Finish
+    action: Finalizar
+    # @source Finished
+    success: Finalizado
+    # @source Finishing&hellip;
+    waiting: Finalizando&hellip;
+  import:
+    # @source Import
+    action: Importar
+    # @source Imported
+    success: Importado
+    # @source Importing&hellip;
+    waiting: Importando&hellip;
+  install:
+    # @source Install
+    action: Instalar
+    # @source Installing
+    success: Instalando
+    # @source Starting&hellip;
+    waiting: Iniciando&hellip;
+  refresh:
+    # @source
+    action: ''
+    # @reason Icon identifier, not user-visible text
+    # @source refresh
+    actionIcon: refresh
+    # @source
+    error: ''
+    # @reason Icon identifier, not user-visible text
+    # @source error
+    errorIcon: error
+    # @source
+    success: ''
+    # @reason Icon identifier, not user-visible text
+    # @source checkmark
+    successIcon: checkmark
+    # @source
+    waiting: ''
+    # @reason Icon identifier, not user-visible text
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @source Remove
+    action: Remover
+    # @source Removed
+    success: Removido
+    # @source Removing&hellip;
+    waiting: Removendo&hellip;
+  restore:
+    # @source Restore
+    action: Restaurar
+    # @source Restored
+    success: Restaurado
+    # @source Restoring&hellip;
+    waiting: Restaurando&hellip;
+  snapshot:
+    # @reason 'snapshot' kept in English: established term in Brazilian technical usage, matches the feature name
+    # @source Snapshot Now
+    action: Criar snapshot agora
+    # @source Creating Snapshot
+    success: Criando snapshot
+    # @source Snapshotting&hellip;
+    waiting: Criando snapshot&hellip;
+  uninstall:
+    # @source Uninstall
+    action: Desinstalar
+    # @source Uninstalled
+    success: Desinstalado
+    # @source Uninstalling&hellip;
+    waiting: Desinstalando&hellip;
+  update:
+    # @source Update
+    action: Atualizar
+    # @source Updated
+    success: Atualizado
+    # @source Updating&hellip;
+    waiting: Atualizando&hellip;
+  upgrade:
+    # @reason 'upgrade' kept to preserve the update/upgrade distinction; 'Atualizar' already translates 'Update'
+    # @source Upgrade
+    action: Fazer upgrade
+    # @source Upgrading
+    success: Fazendo upgrade
+    # @source Starting&hellip;
+    waiting: Iniciando&hellip;
+containerEngine:
+  # @reason 'Mecanismo de contêiner' follows common Brazilian localization of 'container engine'
+  # @source Container Engine
+  label: Mecanismo de contêiner
+  options:
+    containerd:
+      # @reason 'Namespaces' kept in English: containerd/Kubernetes technical term
+      # @source Namespaces for container images; use with nerdctl.
+      description: Namespaces para imagens de contêiner; use com nerdctl.
+      # @reason product name of the container runtime, not translatable
+      # @source containerd
+      label: containerd
+    moby:
+      # @source Docker API; use with Docker CLI.
+      description: API do Docker; use com a CLI do Docker.
+      # @reason product names: the dockerd daemon and the Moby project
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: Informações do contêiner
+  # @source Info
+  info: Informações
+  # @reason 'Logs' kept in English: standard term among Brazilian developers; 'registros' would be less clear
+  # @source Logs
+  logs: Logs
+  search:
+    # @source Search in logs
+    ariaLabel: Pesquisar nos logs
+    # @source Clear search
+    clearSearch: Limpar pesquisa
+    # @source Next match
+    nextMatch: Próxima ocorrência
+    # @source Search logs...
+    placeholder: Pesquisar logs...
+    # @source Previous match
+    previousMatch: Ocorrência anterior
+  # @reason 'Shell' kept in English: standard term among Brazilian developers; tab label next to Logs/Stats
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: Estatísticas
+containerInspect:
+  capabilities:
+    # @reason Feminine plural, agreeing with 'capacidades' (Linux capabilities)
+    # @source Added
+    added: Adicionadas
+    # @reason Feminine plural, agreeing with 'capacidades' (Linux capabilities)
+    # @source Dropped
+    dropped: Removidas
+  command:
+    # @source Args
+    args: Argumentos
+    # @source Command
+    command: Comando
+    # @reason Docker/Dockerfile technical term, kept in English
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: Falha ao carregar os detalhes do contêiner.
+    # @source An unknown error has occurred
+    unknown: Ocorreu um erro desconhecido
+  # @source Loading container details…
+  loading: Carregando detalhes do contêiner…
+  mounts:
+    # @source Destination
+    destination: Destino
+    # @reason Kept the English abbreviation: 'RO'/'RW' are the standard mount-mode badges (docker inspect output); no established Portuguese abbreviation
+    # @source RO
+    readOnly: RO
+    # @reason Kept the English abbreviation: 'RO'/'RW' are the standard mount-mode badges (docker inspect output); no established Portuguese abbreviation
+    # @source RW
+    readWrite: RW
+    # @reason Kept the English abbreviation for consistency with the RO/RW badges shown in the column
+    # @source R/W
+    rw: R/W
+    # @source Source
+    source: Origem
+    # @source Type
+    type: Tipo
+  # @source None
+  none: Nenhum
+  sections:
+    # @reason Linux capabilities; 'capacidades' is the usual Brazilian rendering in kernel documentation
+    # @source Capabilities
+    capabilities: Capacidades
+    # @source Command & Args
+    commandArgs: Comando e argumentos
+    # @source Environment
+    environment: Ambiente
+    # @source Labels
+    labels: Rótulos
+    # @source Mounts
+    mounts: Montagens
+    # @source Ports
+    ports: Portas
+  summary:
+    # @source Created
+    created: Criado
+    # @reason 'ID' is the same abbreviation in pt-br
+    # @source ID
+    id: ID
+    # @source Image
+    image: Imagem
+    # @source IP Address
+    ipAddress: Endereço IP
+    # @source Name
+    name: Nome
+    # @source Started
+    started: Iniciado
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: E/S de bloco (bytes/s)
+    # @reason 'CPU' and '%' are identical in pt-br
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: Memória
+    # @source Network I/O (bytes/s)
+    network: E/S de rede (bytes/s)
+  interval:
+    # @reason 'min' is the same abbreviation for 'minutos' in pt-br
+    # @source {minutes} min
+    minutes: '{minutes} min'
+    # @reason 's' is the SI symbol for seconds, same in pt-br
+    # @source {seconds} s
+    seconds: '{seconds} s'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: No momento, as estatísticas estão disponíveis apenas para o mecanismo Docker (Moby).
+  # @source No processes found.
+  noProcesses: Nenhum processo encontrado.
+  # @source Stats are only available for running containers.
+  notRunning: As estatísticas estão disponíveis apenas para contêineres em execução.
+  # @source Processes
+  processes: Processos
+  # @reason Noun form: labels the refresh-interval dropdown, not an action button
+  # @source Refresh
+  refresh: Atualização
+  series:
+    # @source Limit
+    limit: Limite
+    # @source Read
+    read: Leitura
+    # @reason Standard network abbreviation (receive), kept in English
+    # @source RX
+    rx: RX
+    # @reason Standard network abbreviation (transmit), kept in English
+    # @source TX
+    tx: TX
+    # @reason Feminine form, agreeing with 'memória' (memory chart legend)
+    # @source Used
+    used: Usada
+    # @source Write
+    write: Escrita
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: Informações
+        # @source Restart
+        restart: Reiniciar
+        # @source Start
+        start: Iniciar
+        # @source Stop
+        stop: Parar
+      header:
+        # @source Name
+        containerName: Nome
+        # @source Image
+        image: Imagem
+        # @source Port(s)
+        ports: Porta(s)
+        # @source Uptime
+        started: Tempo de atividade
+        # @source State
+        state: Estado
+  sortableTables:
+    # @source There are no containers to show
+    noRows: Não há contêineres para exibir
+  # @source Containers
+  title: Contêineres
+dashboard:
+  # @reason Product name, kept in English
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: O Rancher Desktop não pode ser executado com privilégios de root. Execute novamente como um usuário comum.
+  # @source Cannot run as Root
+  title: Não é possível executar como root
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 'Arquivo de implantação inválido {path}: nenhuma versão especificada. Adicione um campo de versão para torná-lo válido (a versão atual é {version}).'
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 'Implantação inválida: nenhuma versão especificada em {path}. Adicione um campo de versão para torná-la válida (a versão atual é {version}).'
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} com falha, mais {muted} silenciados'
+  # @source Last run:
+  lastRun: 'Última execução:'
+  # @source (No fixes available)
+  noFixes: (Nenhuma correção disponível)
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: Tente exibir os diagnósticos silenciados.
+      # @source No results found
+      heading: Nenhum resultado encontrado
+      # @reason Icon identifier, not user-visible text
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: O Rancher Desktop parece estar funcionando corretamente.
+      # @source No problems detected
+      heading: Nenhum problema detectado
+      # @reason Icon identifier, not user-visible text
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: Exibir silenciados
+  tableHeaders:
+    # @source Mute
+    mute: Silenciar
+    # @source Name
+    name: Nome
+  # @source Diagnostics
+  title: Diagnósticos
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: A rede compartilhada também não está disponível. O único acesso à rede é por encaminhamento de portas para o host.
+    # @source Using shared network address {ip}
+    sharedFallback: Usando o endereço de rede compartilhada {ip}
+    # @reason 'bridge' kept in English: standard networking term in Brazilian technical usage
+    # @source Bridged network did not get an IP address.
+    title: A rede em modo bridge não recebeu um endereço IP.
+  confirmMigration:
+    # @source Delete Workloads
+    delete: Excluir cargas de trabalho
+    # @reason 'downgrade' kept in English: common in Brazilian technical usage, mirrors 'upgrade'
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: Fazer downgrade de {from} para {to} perderá as cargas de trabalho existentes do Kubernetes. Excluir os dados?
+    # @source Confirming migration
+    title: Confirmando migração
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: Voltando para a versão mínima de upgrade recomendada, {version}
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: A versão do Kubernetes solicitada ''{version}'' não é uma versão compatível.
+    # @source Invalid Kubernetes Version
+    title: Versão do Kubernetes inválida
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: Obtenha uma versão no intervalo {range} e instale em ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: Não é possível baixar uma versão compatível do kubectl no modo offline
+    # @source Network failure
+    title: Falha de rede
+extensions:
+  # @reason Icon identifier, not user-visible text
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: Parece que você ainda não tem nenhuma extensão instalada. Navegue pelo catálogo de extensões para começar.
+      button:
+        # @source Browse Extensions
+        text: Explorar extensões
+      # @source No extensions installed
+      heading: Nenhuma extensão instalada
+      # @reason Icon identifier, not user-visible text
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: Remover
+      # @reason Consistent with asyncButton.upgrade.action; preserves the update/upgrade distinction
+      # @source Upgrade
+      upgrade: Fazer upgrade
+  view:
+    emptyState:
+      # @reason Feminine agreement ('removida', 'reinstalá-la') because {extensionId} names an extensão
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId} foi removida. Visite o catálogo de extensões para reinstalá-la ou procure outras extensões para aprimorar sua experiência com o Rancher Desktop.'
+      # @source Extension removed
+      heading: Extensão removida
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: Habilitar Kubernetes
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: (apenas versões em cache)
+    # @source Kubernetes Version
+    legend: Versão do Kubernetes
+    # @source Other Versions
+    otherVersions: Outras versões
+    # @source Recommended Versions
+    recommendedVersions: Versões recomendadas
+  # @reason 'OK' is the standard dialog button label in pt-br
+  # @source OK
+  ok: OK
+  # @reason 'Boas-vindas' avoids the gendered 'Bem-vindo/Bem-vinda'; widely used in Brazilian product UI
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: Boas-vindas ao Rancher Desktop da SUSE
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: O Rancher Desktop oferece Kubernetes e gerenciamento de imagens por meio de um aplicativo de desktop.
+  # @source Homepage
+  homepage: Página inicial
+  # @reason Kept in English: links to the GitHub Issues page, where the term is untranslated
+  # @source Issues
+  issues: Issues
+  # @source General
+  navLabel: Geral
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 'Discussões do projeto: <b>#rancher-desktop</b> no Slack <a href="https://slack.rancher.io/">Rancher Users</a>'
+  # @source Project Links:
+  projectLinks: 'Links do projeto:'
+  # @reason 'Boas-vindas' avoids the gendered 'Bem-vindo/Bem-vinda'; widely used in Brazilian product UI
+  # @source Welcome to Rancher Desktop by SUSE
+  title: Boas-vindas ao Rancher Desktop da SUSE
+generic:
+  # @source  and 
+  and: ' e '
+  # @source Apply
+  apply: Aplicar
+  # @source Cancel
+  cancel: Cancelar
+  # @source Close
+  close: Fechar
+  # @reason list separator punctuation, identical in pt-br
+  # @source , 
+  comma: ', '
+  # @reason Used as the port-forwarding action button (PortForwarding.vue), not browser-style navigation
+  # @source Forward
+  forward: Encaminhar
+  # @source Loading&hellip;
+  loading: Carregando&hellip;
+  # @reason Kubernetes/containerd technical term, kept in English
+  # @source Namespace
+  namespace: Namespace
+  # @reason 'OK' is the standard dialog button label in pt-br
+  # @source OK
+  ok: OK
+  # @source Rerun
+  rerun: Executar novamente
+  # @source Search
+  search: Pesquisar
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: Selecione o Dockerfile a ser usado (pode ter um nome diferente)
+  # @reason 'build' kept in English: standard term for container image builds in Brazilian usage
+  # @source Pick the build directory
+  buildTitle: Escolha o diretório de build
+  # @source Error trying to delete images {ids}
+  deleteBatchError: Erro ao tentar excluir as imagens {ids}
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: |-
+      Erro ao tentar excluir a imagem {name} ({id}):
+
+       {error}
+  # @reason 'push' kept in English: refers to the docker/nerdctl push operation
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: |-
+      Erro ao tentar fazer push de {name}:
+
+       {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: |-
+      Erro ao tentar escanear {name}:
+
+       {error}
+images:
+  action:
+    # @source Add Image
+    add: Adicionar imagem
+  add:
+    action:
+      # @source Build
+      build: Construir
+      gerund:
+        # @source Building
+        build: Construindo
+        # @reason "pull" rendered as "baixar", the usual Brazilian term for pulling an image, matching the existing pt-br button and past participle
+        # @source Pulling
+        pull: Baixando
+      infinitive:
+        # @source build
+        build: construir
+        # @reason "pull" rendered as "baixar", the usual Brazilian term for pulling an image
+        # @source pull
+        pull: baixar
+      pastTense:
+        # @reason Past participle interpolated into successText as "Imagem {action}"; feminine and lowercase to agree with "imagem"
+        # @source Built
+        build: construída
+        # @reason "pull" rendered as "baixar", the usual Brazilian term for pulling an image; feminine past participle to fit "Imagem {action}"
+        # @source Pulled
+        pull: baixada
+      # @reason Docker command name kept in English, matching the other locales
+      # @source Pull
+      pull: Pull
+    # @reason { action } receives the pt-br infinitive (construir/baixar), so "ao tentar" composes directly without the old "executar" wrapper
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: Erro ao tentar { action } ''{ image }'' - consulte a saída do console para mais informações
+    # @reason {action} receives the pt-br gerund (Construindo/Baixando), which starts the sentence, so the gerund values are capitalized
+    # @source {action} image...
+    loadingText: '{action} imagem...'
+    # @reason {action} receives the feminine past participle (construída/baixada); Portuguese puts the participle after the noun
+    # @source {action} image
+    successText: Imagem {action}
+    # @source Add Image
+    title: Adicionar imagem
+  confirmDelete:
+    # @source Delete
+    confirm: Excluir
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: Excluir {count} {count, plural, one {imagem} other {imagens}}?
+    # @source Delete image {name}:{tag}?
+    single: Excluir a imagem {name}:{tag}?
+    # @source Confirming image deletion
+    title: Confirmação de exclusão de imagem
+  manager:
+    # @source Close Output to Continue
+    close: Fechar a saída para continuar
+    input:
+      build:
+        # @source Build
+        button: Construir
+        # @source Name of image to build:
+        label: 'Nome da imagem a construir:'
+        # @reason Registry path example kept as-is
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @reason "pull" rendered as "baixar", the usual Brazilian term for pulling an image
+        # @source Pull
+        button: Baixar
+        # @source Name of image to pull:
+        label: 'Nome da imagem a baixar:'
+        # @reason Registry path example kept as-is
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: Excluir
+        # @reason Docker command name kept in English, matching the other locales
+        # @source Push
+        push: Push
+        # @reason "escanear" is the common Brazilian term for vulnerability scanning
+        # @source Scan...
+        scan: Escanear...
+      header:
+        # @source Image ID
+        imageId: ID da imagem
+        # @source Image
+        imageName: Imagem
+        # @source Size
+        size: Tamanho
+        # @reason Docker term widely used untranslated in pt-br
+        # @source Tag
+        tag: Tag
+      # @source All images
+      label: Todas as imagens
+    # @source Image Output
+    title: Saída de imagens
+  scan:
+    details:
+      # @source Description
+      description: Descrição
+      # @source Primary URL
+      primaryUrl: URL principal
+      # @source References
+      references: Referências
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: Erro ao tentar escanear ''{ image }'' - consulte a saída do console para mais informações
+    labels:
+      # @reason Severity labels use the feminine form, agreeing with "vulnerabilidade"/"severidade"
+      # @source CRITICAL
+      critical: CRÍTICA
+      # @source HIGH
+      high: ALTA
+      # @source Issues Found
+      issuesFound: Problemas encontrados
+      # @source LOW
+      low: BAIXA
+      # @source MEDIUM
+      medium: MÉDIA
+    # @source Scanning ''{ image }''
+    loadingText: Escaneando ''{ image }''
+    results:
+      headers:
+        # @reason Column shows the fixed version; feminine agreeing with "versão"
+        # @source Fixed
+        fixed: Corrigida
+        # @reason Column shows the installed version; feminine agreeing with "versão"
+        # @source Installed
+        installed: Instalada
+        # @source Package
+        package: Pacote
+        # @source Severity
+        severity: Severidade
+        # @source Vulnerability ID
+        vulnerabilityId: ID da vulnerabilidade
+    # @source Scan details for ''{ image }''
+    title: Detalhes do escaneamento de ''{ image }''
+  sortableTables:
+    # @source There are no images to show
+    noRows: Não há imagens para exibir
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: Aguardando o gerenciador de imagens ficar pronto
+    # @source Error: Unknown state; please reload.
+    unknown: 'Erro: estado desconhecido; recarregue a página.'
+  # @source Images
+  title: Imagens
+integrations:
+  windows:
+    # @reason "Subsistema do Windows para Linux" is Microsoft's official pt-br name for WSL
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: Expor a configuração do Kubernetes e o socket do Docker do Rancher Desktop para as distribuições do Subsistema do Windows para Linux (WSL)
+kubernetesError:
+  # @source Context:
+  context: 'Contexto:'
+  # @source Last command run:
+  lastCommand: 'Último comando executado:'
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 'Algumas linhas recentes do <a href="#" data-action="showLogs">arquivo de log</a>:'
+  # @source {appName} Error
+  title: Erro do {appName}
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: Habilitar Kubernetes
+    # @reason Kubernetes is a product name
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: Opções
+    # @source Install Spin Operator
+    spinkube: Instalar o Spin Operator
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: O Spin Operator requer que o <a href="#" data-navigate="Container Engine,general">WebAssembly</a> esteja habilitado.
+    # @source Enable Traefik
+    traefik: Habilitar Traefik
+  port:
+    # @source Kubernetes Port
+    legendText: Porta do Kubernetes
+  version:
+    # @source Kubernetes version
+    legendText: Versão do Kubernetes
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Versão do Kubernetes (apenas versões em cache)
+    # @source Other Versions
+    otherVersions: Outras versões
+    # @source Recommended Versions
+    recommendedVersions: Versões recomendadas
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: Sem opções
+    # @source No matching options
+    noMatch: Nenhuma opção correspondente
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} itens'
+    # @source Load More...
+    more: Carregar mais...
+locale:
+  # @source German
+  de: Alemão
+  # @source English
+  en-us: Inglês
+  # @source Spanish
+  es: Espanhol
+  # @source French
+  fr: Francês
+  # @reason Standard self-designation for the Brazilian Portuguese locale
+  # @source Portuguese (Brazilian)
+  pt-br: Português (Brasil)
+  # @source Chinese (Simplified)
+  zh-hans: Chinês (simplificado)
+mainMenu:
+  # @source About {appName}
+  about: Sobre o {appName}
+  edit:
+    # @reason Menu accelerators (&) reassigned to letters in the Portuguese words, kept unique within each menu
+    # @source &Copy
+    copy: '&Copiar'
+    # @source Cu&t
+    cut: Recor&tar
+    # @source De&lete
+    delete: E&xcluir
+    # @source &Edit
+    label: '&Editar'
+    # @source &Paste
+    paste: Co&lar
+    # @source &Redo
+    redo: '&Refazer'
+    # @source Select &All
+    selectAll: '&Selecionar tudo'
+    # @source &Undo
+    undo: '&Desfazer'
+  file:
+    # @source Close
+    close: Fechar
+    # @source E&xit
+    exit: Sai&r
+    # @source &File
+    label: '&Arquivo'
+  help:
+    # @source &About {appName}
+    about: '&Sobre o {appName}'
+    # @source &Discuss
+    discuss: '&Discutir'
+    # @reason "bug" is the standard term among Brazilian users
+    # @source File a &Bug
+    fileABug: Relatar um &bug
+    # @source Get &Help
+    getHelp: '&Obter ajuda'
+    # @source {appName} &Help
+    help: Aj&uda do {appName}
+    # @source &Help
+    label: Aj&uda
+    # @source &Project Page
+    projectPage: '&Página do projeto'
+  # @source Hide {appName}
+  hide: Ocultar {appName}
+  # @source Hide Others
+  hideOthers: Ocultar outros
+  # @source Preferences
+  preferences: Configurações
+  # @reason "Encerrar" is the macOS pt-br convention for Quit
+  # @source Quit {appName}
+  quit: Encerrar {appName}
+  # @source Services
+  services: Serviços
+  # @source Show All
+  showAll: Mostrar tudo
+  view:
+    # @source &Actual Size
+    actualSize: '&Tamanho real'
+    # @source &Force Reload
+    forceReload: '&Forçar recarregamento'
+    # @reason "Exibir" is the Windows pt-br convention for the View menu
+    # @source &View
+    label: E&xibir
+    # @source &Reload
+    reload: '&Recarregar'
+    # @source Toggle &Developer Tools
+    toggleDevTools: Alternar ferramentas do &desenvolvedor
+    # @source Toggle Full &Screen
+    toggleFullScreen: Alternar tela &cheia
+    # @source Zoom &In
+    zoomIn: '&Ampliar'
+    # @source Zoom &Out
+    zoomOut: Red&uzir
+  window:
+    # @source Bring All to Front
+    front: Trazer tudo para a frente
+    # @source &Window
+    label: '&Janela'
+    # @source Minimize
+    minimize: Minimizar
+    # @reason Matches the macOS pt-br Window-menu label
+    # @source Zoom
+    zoom: Zoom
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: Descrição
+        # @source Name
+        name: Nome
+        # @source Vendor
+        vendor: Fornecedor
+  labels:
+    # @source Install
+    install: Instalar
+    # @source Remove
+    uninstall: Remover
+    # @source Upgrade
+    upgrade: Atualizar
+  loading:
+    # @source Installing...
+    install: Instalando...
+    # @source Removing...
+    uninstall: Removendo...
+    # @source Upgrading...
+    upgrade: Atualizando...
+  # @source More information
+  moreInfo: Mais informações
+  # @source No extension found for the search criteria
+  noResults: Nenhuma extensão encontrada para os critérios de busca
+  tabs:
+    # @source Catalog
+    catalog: Catálogo
+    # @reason Feminine plural agreeing with "extensões"
+    # @source Installed
+    installed: Instaladas
+  # @source Extensions
+  title: Extensões
+nav:
+  userMenu:
+    # @reason "dashboard" is the de-facto term among Brazilian users and matches the Rancher product UI
+    # @source Cluster Dashboard
+    clusterDashboard: Dashboard do cluster
+    # @source Preferences
+    preferences: Configurações
+pathManagement:
+  # @source Configure PATH
+  label: Configurar o PATH
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: O Rancher Desktop não altera a configuração do seu PATH; adicione <code>$HOME/.rd/bin</code> ao seu PATH manualmente.
+      # @reason 'Manual' is the same word in Portuguese
+      # @source Manual
+      label: Manual
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: O Rancher Desktop edita o perfil do seu shell para você. Reinicie os shells abertos para que as alterações tenham efeito.
+      # @source Automatic
+      label: Automático
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: O Rancher Desktop inclui ferramentas como kubectl, nerdctl, helm e docker. Para usar essas ferramentas, <code>$HOME/.rd/bin</code> deve estar no seu PATH.
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: Incluir serviços do Kubernetes
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: Porta local
+        # @source Name
+        name: Nome
+        # @reason Kubernetes term kept in English, as is standard in pt-br
+        # @source Namespace
+        namespace: Namespace
+        # @source Port
+        port: Porta
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: Não há entradas de encaminhamento de porta para exibir
+  # @source Port Forwarding
+  title: Encaminhamento de portas
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: Há um problema com a seleção de configurações.
+      # @source Kubernetes will reset after applying changes.
+      reset: O Kubernetes será redefinido após a aplicação das alterações.
+      # @source Kubernetes will restart after applying changes.
+      restart: O Kubernetes será reiniciado após a aplicação das alterações.
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: O WebAssembly deve estar habilitado para que o <a href="#" data-navigate="Kubernetes">Spin Operator</a> possa ser instalado.
+  error:
+    # @source Reload Preferences to try again.
+    body: Recarregue as configurações para tentar novamente.
+    # @source Unable to fetch preferences
+    heading: Não foi possível obter as configurações
+    # @source Reload preferences
+    reload: Recarregar configurações
+  # @source Preferences
+  header: Configurações
+  # @source or
+  incompatiblePrefWarningOr: ou
+  # @reason Fragment completing "A opção requer que <opção> esteja desmarcado."; generic masculine since the option name's gender is unknown
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: esteja desmarcado.
+  # @reason Fragment completing "A opção requer que <opção> esteja selecionado."; generic masculine since the option name's gender is unknown
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: esteja selecionado.
+  # @reason Sentence assembled as Pre + option + Post; phrased with "que ... esteja" so the fragments compose grammatically
+  # @source The option requires
+  incompatibleTypeWarningPre: A opção requer que
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: Bloqueado pela política da organização
+  nav:
+    # @source Application
+    application: Aplicativo
+    # @reason Common pt-br rendering of "container engine" (used in Red Hat and Microsoft documentation)
+    # @source Container Engine
+    containerEngine: Mecanismo de contêiner
+    # @reason Kubernetes is a product name
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: Máquina virtual
+    # @reason WSL is a Microsoft product name (Windows Subsystem for Linux)
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: Aplicar e redefinir
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: Essas alterações redefinirão o cluster Kubernetes, o que resultará na perda de cargas de trabalho e imagens de contêiner.
+    # @source Apply preferences and reset Kubernetes?
+    message: Aplicar as configurações e redefinir o Kubernetes?
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - Redefinir o Kubernetes
+  tabs:
+    # @source Allowed Images
+    allowedImages: Imagens permitidas
+    # @source Behavior
+    behavior: Comportamento
+    # @source Emulation
+    emulation: Emulação
+    # @source Environment
+    environment: Ambiente
+    # @source General
+    general: Geral
+    # @reason 'Hardware' is an established loanword in pt-br
+    # @source Hardware
+    hardware: Hardware
+    # @source Integrations
+    integrations: Integrações
+    # @reason 'Proxy' is the standard term in pt-br, as in Windows/macOS network settings
+    # @source Proxy
+    proxy: Proxy
+    # @reason 'Volumes' is the same word in Portuguese
+    # @source Volumes
+    volumes: Volumes
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: Há configurações com alterações que não foram aplicadas. Todas as configurações não salvas serão perdidas.
+    # @source Discard changes
+    discardChanges: Descartar alterações
+    # @source Close preferences without applying?
+    message: Fechar as configurações sem aplicar?
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - Fechar configurações
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - Configurações
+prefs:
+  # @reason 'Experimental' is the same word in Portuguese
+  # @source Experimental
+  experimental: Experimental
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: Esta configuração requer o macOS 13.3 (Ventura) ou posterior.
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: Esta configuração requer o macOS 13.0 (Ventura) ou posterior.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: Esta configuração requer o uso do modo de emulação VZ. O VZ só está disponível no macOS 13.3 (Ventura) ou posterior.
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: Esta configuração requer o uso do modo de emulação VZ. O VZ só está disponível no macOS 13.0 (Ventura) ou posterior.
+product:
+  containerEngine:
+    # @reason Abbreviation of the English "Container Engine", kept for recognizability
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: Mecanismo de contêiner
+  # @source deactivated
+  deactivated: desativado
+  # @reason Kubernetes is a product name; status bar label for the version
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: Status da rede
+  networkStatusValues:
+    # @source checking...
+    checking: verificando...
+    # @reason "offline"/"online" are standard in pt-br
+    # @source offline
+    offline: offline
+    # @reason 'online' is standard in pt-br, matching sibling 'offline'
+    # @source online
+    online: online
+  # @source Version
+  version: Versão
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: Solicitando permissão para executar tarefas como administrador
+  # @source Bundling certificates
+  bundlingCertificates: Empacotando certificados
+  # @source Checking k3s images
+  checkingK3sImages: Verificando imagens do k3s
+  # @source Configuring container engine
+  configuringContainerEngine: Configurando o mecanismo de contêineres
+  # @source Configuring image proxy
+  configuringImageProxy: Configurando o proxy de imagens
+  # @source Configuring logrotate
+  configuringLogrotate: Configurando o logrotate
+  # @source Container engine components
+  containerEngineComponents: Componentes do mecanismo de contêineres
+  # @source Copying certificates
+  copyingCertificates: Copiando certificados
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: Excluindo estado incompatível do Kubernetes
+  # @source Deleting Kubernetes
+  deletingKubernetes: Excluindo o Kubernetes
+  # @source Deleting virtual machine
+  deletingVirtualMachine: Excluindo a máquina virtual
+  # @source DNS configuration
+  dnsConfiguration: Configuração de DNS
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: Garantindo um kubectl compatível
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: Garantindo suporte à virtualização
+  # @source Expecting user permission to continue
+  expectingPermission: Aguardando permissão do usuário para continuar
+  # @source Extracting certificates
+  extractingCertificates: Extraindo certificados
+  # @source Fetching certificates
+  fetchingCertificates: Obtendo certificados
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: Inicializando o Rancher Desktop
+  # @source Initializing WSL data
+  initializingWslData: Inicializando dados do WSL
+  # @source Installing Buildkit
+  installingBuildkit: Instalando o Buildkit
+  # @source Installing CA certificates
+  installingCaCertificates: Instalando certificados de CA
+  # @source Installing container engine
+  installingContainerEngine: Instalando o mecanismo de contêineres
+  # @reason Docker tooling term kept in English (matches the docker-credential binary naming)
+  # @source Installing credential helper
+  installingCredentialHelper: Instalando o credential helper
+  # @reason docker-credential is the binary name; kept in English
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: Instalando o helper docker-credential
+  # @source Installing helpers
+  installingHelpers: Instalando auxiliares
+  # @source Installing image scanner
+  installingImageScanner: Instalando o scanner de imagens
+  # @source Installing k3s
+  installingK3s: Instalando o k3s
+  # @source Installing Kubernetes
+  installingKubernetes: Instalando o Kubernetes
+  # @source Kubernetes components
+  kubernetesComponents: Componentes do Kubernetes
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Compatibilidade do Kubernetes com o dockerd
+  # @source Mounting WSL data
+  mountingWslData: Montando dados do WSL
+  # @source Preparing to start
+  preparingToStart: Preparando para iniciar
+  # @source Proxy Config Setup
+  proxyConfigSetup: Configuração do proxy
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Agente convidado do Rancher Desktop
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: Regenerando a configuração devido à falta de permissões
+  # @source Registering WSL distribution
+  registeringWslDistribution: Registrando a distribuição WSL
+  # @source Removing existing certificates
+  removingExistingCertificates: Removendo certificados existentes
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: Removendo o operador spinkube
+  # @source Removing stale state
+  removingStaleState: Removendo estado obsoleto
+  # @source Removing Traefik
+  removingTraefik: Removendo o Traefik
+  # @source Resetting Kubernetes
+  resettingKubernetes: Redefinindo o Kubernetes
+  # @source Running provisioning scripts
+  runningProvisioningScripts: Executando scripts de provisionamento
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: Executando update-ca-certificates
+  # @source Setting docker context
+  settingDockerContext: Definindo o contexto do docker
+  # @source Setting Lima permissions
+  settingLimaPermissions: Definindo permissões do Lima
+  # @source Setting up Docker socket
+  settingUpDockerSocket: Configurando o socket do Docker
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: Configurando a ethernet virtual
+  # @source Shutting down
+  shuttingDown: Encerrando
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: Ignorando verificações de nós, o flannel está desabilitado
+  # @source Starting Backend
+  startingBackend: Iniciando o backend
+  # @source Starting buildkit
+  startingBuildkit: Iniciando o buildkit
+  # @source Starting container engine
+  startingContainerEngine: Iniciando o mecanismo de contêineres
+  # @source Starting image proxy
+  startingImageProxy: Iniciando o proxy de imagens
+  # @source Starting k3s
+  startingK3s: Iniciando o k3s
+  # @source Starting Kubernetes
+  startingKubernetes: Iniciando o Kubernetes
+  # @source Starting proxy
+  startingProxy: Iniciando o proxy
+  # @source Starting {service}
+  startingService: Iniciando {service}
+  # @source Starting virtual machine
+  startingVirtualMachine: Iniciando máquina virtual
+  # @source Starting WSL environment
+  startingWslEnvironment: Iniciando ambiente WSL
+  # @source Stopping existing instance
+  stoppingExistingInstance: Parando instância existente
+  # @source Stopping mock backend
+  stoppingMockBackend: Parando backend simulado
+  # @source Stopping services
+  stoppingServices: Parando serviços
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: Atualizando configuração do cluster
+  # @source Updating /etc/hosts
+  updatingEtcHosts: Atualizando /etc/hosts
+  # @source Updating kubeconfig
+  updatingKubeconfig: Atualizando kubeconfig
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: Atualizando máquina virtual desatualizada
+  # @source Updating WSL data
+  updatingWslData: Atualizando dados do WSL
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: Atualizando distribuição WSL
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: Aguardando o mecanismo de contêineres ficar pronto
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: Aguardando API do Kubernetes
+  # @source Waiting for nodes
+  waitingForNodes: Aguardando nós
+  # @source Waiting for services
+  waitingForServices: Aguardando serviços
+  # @source Writing K3s configuration
+  writingK3sConfiguration: Gravando configuração do K3s
+snapshots:
+  action:
+    # @reason 'snapshot' kept in English: established term in Brazilian virtualization/cloud usage
+    # @source Create Snapshot
+    create: Criar snapshot
+  card:
+    action:
+      # @source Delete
+      remove: Excluir
+      # @source Restore
+      restore: Restaurar
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: Criado em '<b>'{date}'</b>' às '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: Cancelar
+      # @source Create
+      submit: Criar
+    description:
+      # @source Description
+      label: Descrição
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: O Rancher Desktop ficará temporariamente indisponível durante a criação de um novo snapshot
+    name:
+      # @source Snapshot Name
+      label: Nome do snapshot
+    # @source Create a new Snapshot
+    title: Criar um novo snapshot
+  dialog:
+    buttons:
+      # @source Close
+      error: Fechar
+    creating:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+      # @source Creating {snapshot}
+      header: Criando {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: Aguarde enquanto o snapshot '<b>'{snapshot}'</b>' é criado.'<br/>'Isso pode levar algum tempo, dependendo dos recursos da sua máquina.'<br/>'O Rancher Desktop ficará temporariamente indisponível durante esta operação.'<br/><br/>'Quando o snapshot estiver concluído, a VM será reiniciada.
+    delete:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Delete
+        ok: Excluir
+      # @source Permanently delete snapshot?
+      header: Excluir o snapshot permanentemente?
+      # @reason source value is the literal placeholder 'text'; kept unchanged
+      # @source Deleting a snapshot cannot be undone.
+      info: A exclusão de um snapshot não pode ser desfeita.
+    generic:
+      # @source Snapshot operation in progress
+      header: Operação de snapshot em andamento
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: Aguarde enquanto a operação de snapshot está ativa.<br/>Isso pode levar algum tempo, dependendo dos recursos da sua máquina.<br/>O Rancher Desktop ficará temporariamente indisponível durante esta operação.<br/><br/>Quando o processo de snapshot for concluído, a VM será reiniciada.
+    restore:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Restore
+        ok: Restaurar
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: Sair do Rancher Desktop
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: Falha ao restaurar o snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'O Rancher Desktop executou uma redefinição de fábrica e será encerrado agora. Tente resolver o problema que causou este erro antes de reiniciar o Rancher Desktop e tentar restaurar o snapshot novamente.
+        # @source Error restoring snapshot
+        header: Erro ao restaurar o snapshot
+      # @source Restore snapshot?
+      header: Restaurar o snapshot?
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: Restaurar este snapshot substituirá sua instalação atual, incluindo as configurações. Se a janela de Configurações estiver aberta, ela será fechada automaticamente e todas as alterações não salvas serão descartadas.
+    restoring:
+      actions:
+        # @source Cancel
+        cancel: Cancelar
+      # @source Restoring {snapshot}
+      header: Restaurando {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: Aguarde enquanto o snapshot '<b>'{snapshot}'</b>' é restaurado. Isso pode levar algum tempo, dependendo dos recursos da sua máquina.<br/><br/>O Rancher Desktop ficará temporariamente indisponível durante esta operação. Ao concluir, a VM será reiniciada com o snapshot {snapshot} ativo.
+    # @source Show logs
+    showLogs: Mostrar logs
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: Clique em Criar snapshot para começar
+    # @source No snapshots found
+    heading: Nenhum snapshot encontrado
+    # @reason icon identifier, not user-visible text
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @source Cancelled creation of {snapshot}
+      cancel: Criação de {snapshot} cancelada
+      # @source Created '<b>'{snapshot}'</b>'
+      success: Snapshot '<b>'{snapshot}'</b>' criado
+    delete:
+      # @source Delete error: {error}
+      error: 'Erro ao excluir: {error}'
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: Snapshot '<b>'{snapshot}'</b>' excluído
+    lock:
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: Um arquivo de bloqueio de snapshot foi detectado por um tempo incomumente longo. Se você acredita que isso é um erro, pode tentar remover o arquivo de bloqueio executando <code>rdctl snapshot unlock</code>.
+    restore:
+      # @source Cancelled restoration of {snapshot}
+      cancel: Restauração de {snapshot} cancelada
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: Snapshot '<b>'{snapshot}'</b>' restaurado
+    # @source  at {time}
+    when: ' às {time}'
+  # @reason 'snapshot' kept in English throughout this file: established term in Brazilian virtualization usage
+  # @source Snapshots
+  title: Snapshots
+sortableTable:
+  actionAvailability:
+    # @reason count unknown at translation time; 'selecionado(s)' covers singular and plural
+    # @source {actionable} selected
+    selected: '{actionable} selecionado(s)'
+    # @source Available for {actionable} of the {total} selected
+    some: Disponível para {actionable} dos {total} selecionados
+  # @source Add
+  add: Adicionar
+  # @source Add Filter
+  addFilter: Adicionar filtro
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: Ações
+  # @source Filter for...
+  filterFor: Filtrar por...
+  # @reason preposition between the filter input and the column selector ('in <column>')
+  # @source in
+  in: em
+  # @source No actions available
+  noActions: Nenhuma ação disponível
+  # @source There are no rows which match your search query.
+  noData: Não há linhas que correspondam à sua pesquisa.
+  # @source There are no rows to show.
+  noRows: Não há linhas para mostrar.
+  paging:
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {Nenhum item}
+        =1 {{count} {count, plural, =1 {item} other {itens}}}
+        other {{from} - {to} de {count} itens}}
+  # @source Reset
+  resetFilters: Redefinir
+  # @source Filter
+  search: Filtrar
+  # @source Select a column
+  selectCol: Selecionar uma coluna
+  tableHeader:
+    # @source Group by
+    groupBy: Agrupar por
+    # @source This column cannot be filtered
+    noFilter: Não é possível filtrar por esta coluna
+    # @source Show
+    show: Mostrar
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: Sempre executar sem acesso administrativo
+  # @reason 'OK' is the standard dialog button label in pt-br
+  # @source OK
+  buttonText: OK
+  # @source This will modify the following paths:
+  explanation: 'Isso modificará os seguintes caminhos:'
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: 'O Rancher Desktop requer acesso administrativo ("acesso sudo") pelos seguintes motivos:'
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: A solicitação será exibida assim que esta janela for fechada. Se você cancelar a solicitação ou desativar o acesso administrativo, será necessário mudar o contexto do docker para rancher-desktop para continuar usando o Rancher Desktop.
+  reasons:
+    dockerSocket:
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: Oferece compatibilidade com ferramentas que usam o socket do docker sem a capacidade de usar contextos do docker.
+      # @source Set up default docker socket
+      title: Configurar o socket padrão do docker
+    networking:
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: Oferece rede em modo bridge para facilitar o acesso aos seus contêineres. Se isso não for permitido, os contêineres só estarão acessíveis por encaminhamento de portas.
+      # @source Configure networking
+      title: Configurar a rede
+  # @source Administrative Access Required
+  title: Acesso administrativo necessário
+systemPreferences:
+  # @reason '#' as number sign is not used in pt-BR; 'Nº' is the standard abbreviation
+  # @source # CPUs
+  cpus: Nº de CPUs
+  # @source Memory (GB)
+  memory: Memória (GB)
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: Envie informações de uso anonimizadas, relatórios de erros etc. para ajudar a melhorar o Rancher Desktop. Seus dados não serão compartilhados com mais ninguém, e nenhuma informação sobre quais recursos ou endpoints específicos você está implantando é incluída.
+tray:
+  # @source Container engine: {name}
+  containerEngine: 'Mecanismo de contêineres: {name}'
+  # @source Kubernetes Contexts
+  kubernetesContexts: Contextos do Kubernetes
+  # @source Network status: {status}
+  networkStatus: 'Status da rede: {status}'
+  # @source None found
+  noneFound: Nenhum encontrado
+  # @reason 'dashboard' kept: common in Brazilian dev usage and matches the Rancher product term
+  # @source Open cluster dashboard
+  openDashboard: Abrir dashboard do cluster
+  # @source Open main window
+  openMainWindow: Abrir janela principal
+  # @source Open preferences dialog
+  openPreferences: Abrir janela de configurações
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: Sair do Rancher Desktop
+  state:
+    # @source Kubernetes is disabled
+    disabled: O Kubernetes está desativado
+    # @source Kubernetes has encountered an error
+    error: O Kubernetes encontrou um erro
+    # @source Kubernetes is running
+    started: O Kubernetes está em execução
+    # @source Kubernetes is starting
+    starting: O Kubernetes está iniciando
+    # @source Kubernetes is stopped
+    stopped: O Kubernetes está parado
+    # @source Kubernetes is shutting down
+    stopping: O Kubernetes está sendo encerrado
+  # @reason Rancher Desktop is the product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: Ativar modo de depuração
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: Redefinição de fábrica
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: A redefinição de fábrica removerá todas as configurações do Rancher Desktop.
+      messageBox:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Keep cached Kubernetes images
+        checkboxLabel: Manter imagens do Kubernetes em cache
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>Fazer uma redefinição de fábrica removerá seu cluster e todas as configurações do Rancher Desktop, e encerrará o Rancher Desktop. Se você pretende continuar usando o Rancher Desktop, será necessário iniciá-lo manualmente e passar pela configuração inicial novamente.</p><p>Tem certeza de que deseja redefinir tudo?</p>
+        # @source Perform a factory reset?
+        message: Executar uma redefinição de fábrica?
+        # @source Factory Reset
+        ok: Redefinição de fábrica
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - Redefinição de fábrica
+      # @source Factory Reset
+      title: Redefinição de fábrica
+    logs:
+      # @source Show Logs
+      buttonText: Mostrar logs
+      # @source Show Rancher Desktop logs
+      description: Mostrar os logs do Rancher Desktop
+      # @reason 'Logs' kept in English: standard term among Brazilian developers, matching containerInfo.logs
+      # @source Logs
+      title: Logs
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: Redefinir Kubernetes
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: Redefinir o Kubernetes excluirá todas as cargas de trabalho e configurações.
+      messageBox:
+        # @source Cancel
+        cancel: Cancelar
+        # @source Delete container images
+        checkboxLabel: Excluir imagens de contêiner
+        # @source Reset Kubernetes?
+        message: Redefinir o Kubernetes?
+        # @source Reset
+        ok: Redefinir
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - Redefinir Kubernetes
+      # @source Reset Kubernetes
+      title: Redefinir Kubernetes
+  # @reason 'Rancher Users Slack' kept as the community's proper name, reordered for Portuguese syntax
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: Ainda com problemas? Inicie uma discussão no canal <b>#rancher-desktop</b> do <a href="https://slack.rancher.io/">Slack Rancher Users</a> ou <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">relate um problema</a>.
+  # @source Troubleshooting
+  title: Solução de problemas
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: Verifique se todos os requisitos foram atendidos e tente novamente. O Rancher Desktop será fechado agora.
+  # @reason 'OK' is the standard dialog button label in pt-br
+  # @source OK
+  buttonText: OK
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: 'O Rancher Desktop não pode iniciar porque há requisitos ausentes ou não configurados:'
+  # @source Rancher Desktop is unable to start
+  title: O Rancher Desktop não consegue iniciar
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: Aplicando atualização...
+  # @source An update to version {version} is available
+  available: Uma atualização para a versão {version} está disponível
+  # @source Check for updates automatically
+  checkForUpdates: Verificar atualizações automaticamente
+  # @reason lowercase kept to match the source register (appended to a status line)
+  # @source downloading... ({percent}%, {speed})
+  downloading: baixando... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: Ocorreu um erro ao verificar atualizações.
+  # @source Release Notes
+  releaseNotes: Notas de versão
+  # @source Restart Now
+  restartNow: Reiniciar agora
+  # @source Restart the application to apply the update.
+  restartToApply: Reinicie o aplicativo para aplicar a atualização.
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Uma versão mais recente do Rancher Desktop está disponível, mas não é compatível com o seu sistema.
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: Para mais informações, consulte <a href="https://docs.rancherdesktop.io/getting-started/installation">a documentação de instalação</a>.
+    # @source Latest Version Not Supported
+    title: Versão mais recente não compatível
+  # @source Update Available
+  updateAvailable: Atualização disponível
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: Não é possível reduzir "{field}" de {from} para {to}
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: Não é possível ativar o WebAssembly com armazenamento clássico para o moby.
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: Não é possível mudar para o armazenamento clássico para o moby quando o WebAssembly está ativado.
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: Não é possível mudar para o mecanismo de contêineres moby com armazenamento clássico quando o WebAssembly está ativado.
+  # @reason lowercase start kept to match the source (fragment composed into a larger message)
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 'o campo "{field}" tem entradas duplicadas: "{duplicates}"'
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 'Erros nas configurações propostas:'
+  # @source field "{field}" is locked
+  fieldLocked: o campo "{field}" está bloqueado
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}: "{pattern}" não descreve uma referência de imagem'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}: "{value}" não é um mapeamento válido'
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}: "{name}" é um nome inválido'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 'o campo "{field}" tem entradas inválidas (devem ser endereços IP, sub-redes CIDR ou nomes de domínio): "{entries}"'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}: "{value}" não é um nome de página válido para a caixa de diálogo de Configurações'
+  # @reason 'aba' preferred over 'guia' as the more common Brazilian term for tab
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}: o nome de aba "{tabName}" não é um nome de aba válido para a página "{page}" das Configurações'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}: "{name}" tem a tag inválida "{tag}"'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: 'Valor inválido para "{field}": <{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: 'Valor inválido para "{field}": <{value}>; deve ser um de {validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: Versão "{version}" do Kubernetes não encontrada.
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}: "{name}" tem uma tag "{tag}" que não é uma string'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: Não há suporte para alterar o campo "{field}" pela API.
+  # @reason 'array' kept in English: standard term among Brazilian developers
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 'Erro no campo ''''{field}'''': era esperado um valor do tipo array, mas foi recebido ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 'Erro no campo ''''{field}'''': era esperado um valor do tipo {expectedType}, mas foi recebido ''''{value}'''''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 'Erro no campo ''''{field}'''': era esperado um valor do tipo {expectedType}, mas foi recebido um array {value}'
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: O campo proposto "{field}" deveria ser um objeto, mas foi recebido <{value}>.
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: A configuração {field} só pode ser ativada em sistemas aarch64.
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: A configuração {field} só pode ser alterada quando virtualMachine.mount.type for "{mountType}".
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: A configuração {field} só pode ser ativada quando virtual-machine.type for "{vmType}".
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: A configuração {field} só pode ser definida quando experimental.container-engine.web-assembly.enabled também estiver definida.
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: Definir {field} como "{value}" exige que {otherField} seja "{required}".
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: Definir {field} como "{value}" exige que {otherField} seja "{option1}" ou "{option2}".
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: A configuração "{field}" deveria conter um objeto interno, mas foi recebido <{value}>.
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: A configuração "{field}" deveria ser um valor simples, mas foi recebido <{value}>.
+  # @source One or more fields in this tab contain a form validation error
+  tab: Um ou mais campos nesta aba contêm um erro de validação de formulário
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: Definir {field} como "{vmType}" em ARM exige o macOS 13.3 (Ventura) ou posterior.
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: Definir {field} como "{vmType}" em Intel exige o macOS 13.0 (Ventura) ou posterior.
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: Tipo de montagem
+      options:
+        9p:
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: Expõe o sistema de arquivos usando os dispositivos virtio-9p-pci do QEMU.
+          # @reason literal mount type value (9p protocol name)
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: Modo de cache
+              options:
+                # @reason literal cache-mode config value
+                # @source fscache
+                fscache: fscache
+                # @reason literal option value passed to QEMU; not translated
+                # @source loose
+                loose: loose
+                # @reason literal cache-mode config value
+                # @source mmap
+                mmap: mmap
+                # @reason literal option value passed to QEMU; not translated
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: Política de cache a ser usada
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: Tamanho de mensagem em KiB
+              # @source Maximum message size in KiB
+              tooltip: Tamanho máximo de mensagem em KiB
+            protocolVersion:
+              # @source Protocol Version
+              legend: Versão do protocolo
+              options:
+                # @reason literal 9p protocol version identifier
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason literal 9p protocol version identifier
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason literal 9p protocol version identifier
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: Versão do protocolo 9P
+            securityModel:
+              # @source Security Model
+              legend: Modelo de segurança
+              options:
+                # @reason literal security-model config value
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason literal security-model config value
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason literal option value passed to QEMU; not translated
+                # @source none
+                none: none
+                # @reason literal security-model config value
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: Modelo de segurança usado para o caminho de exportação
+        reverse-sshfs:
+          # @source Exposes the filesystem by running an SFTP server.
+          description: Expõe o sistema de arquivos executando um servidor SFTP.
+          # @reason literal mount type value
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: Expõe o sistema de arquivos usando um dispositivo de diretório compartilhado do framework Apple Virtualization.
+          # @reason literal mount type value (virtiofs technology name)
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: Endereço
+    # @source Proxy address
+    addressTitle: Endereço do proxy
+    # @source Authentication information
+    authTitle: Informações de autenticação
+    # @source Enable the proxy used by rancher-desktop
+    label: Ativar o proxy usado pelo rancher-desktop
+    # @source WSL Proxy
+    legend: Proxy do WSL
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: Este item está duplicado.
+      # @source Proxy bypass list
+      legend: Lista de exceções do proxy
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: IP, CIDR, domínio ou curinga (*.example.com) para ignorar o proxy
+    # @source Password
+    password: Senha
+    # @source Port
+    port: Porta
+    # @source Username
+    username: Nome de usuário
+  type:
+    # @source Virtual Machine Type
+    legend: Tipo de máquina virtual
+    options:
+      qemu:
+        # @source Use the QEMU emulator.
+        description: Usar o emulador QEMU.
+        # @reason QEMU is a product name
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @source Use the Apple Virtualization framework.
+        description: Usar o framework Apple Virtualization.
+        # @reason literal VM type value, abbreviation of Apple's Virtualization.framework
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: Ativar suporte ao Rosetta
+    # @source VZ Option
+    legend: Opção do VZ
+volumes:
+  files:
+    # @source Available
+    available: Disponível
+    # @source Error checking volume status
+    checkError: Erro ao verificar o status do volume
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: Nome de volume inválido "{name}"
+    # @source Error listing files: {error}
+    listError: 'Erro ao listar arquivos: {error}'
+    # @source Loading volume files...
+    loading: Carregando arquivos do volume...
+    # @source This volume is empty
+    noFiles: Este volume está vazio
+    # @source Not Found
+    notFound: Não encontrado
+    table:
+      header:
+        # @source Modified
+        modified: Modificado
+        # @source Name
+        name: Nome
+        # @source Permissions
+        permissions: Permissões
+        # @source Size
+        size: Tamanho
+    # @source Volume Files
+    title: Arquivos do volume
+    # @source Volume "{name}" not found
+    volumeNotFound: Volume "{name}" não encontrado
+  manage:
+    table:
+      header:
+        # @source Created
+        created: Criado
+        # @reason 'Driver' is an established loanword in pt-br Docker terminology
+        # @source Driver
+        driver: Driver
+        # @source Mount Point
+        mountpoint: Ponto de montagem
+        # @source Volume Name
+        volumeName: Nome do volume
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: Explorar arquivos
+        # @source Delete
+        delete: Excluir
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: Não há volumes para mostrar
+  # @reason 'Volumes' is the same word in Portuguese
+  # @source Volumes
+  title: Volumes
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: Leia a documentação antes de ativar o recurso experimental de WebAssembly!
+  # @source Enabled
+  enabled: Ativado
+  # @reason WebAssembly and Wasm are technology names
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -851,6 +851,8 @@ locale:
   es: Espanhol
   # @source French
   fr: Francês
+  # @source Italian
+  it: Italiano
   # @source Japanese
   ja: Japonês
   # @reason Standard self-designation for the Brazilian Portuguese locale

--- a/pkg/rancher-desktop/assets/translations/pt-br.yaml
+++ b/pkg/rancher-desktop/assets/translations/pt-br.yaml
@@ -851,6 +851,8 @@ locale:
   es: Espanhol
   # @source French
   fr: Francês
+  # @source Japanese
+  ja: Japonês
   # @reason Standard self-designation for the Brazilian Portuguese locale
   # @source Portuguese (Brazilian)
   pt-br: Português (Brasil)

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -877,6 +877,8 @@ locale:
   # @reason locale name for English
   # @source English
   en-us: 英语
+  # @source Spanish
+  es: 西班牙语
   # @source French
   fr: 法语
   # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -881,6 +881,8 @@ locale:
   es: 西班牙语
   # @source French
   fr: 法语
+  # @source Japanese
+  ja: 日语
   # @source Portuguese (Brazilian)
   pt-br: 葡萄牙语（巴西）
   # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -881,6 +881,8 @@ locale:
   es: 西班牙语
   # @source French
   fr: 法语
+  # @source Italian
+  it: 意大利语
   # @source Japanese
   ja: 日语
   # @source Portuguese (Brazilian)

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -885,6 +885,8 @@ locale:
   it: 意大利语
   # @source Japanese
   ja: 日语
+  # @source Korean
+  ko: 韩语
   # @source Portuguese (Brazilian)
   pt-br: 葡萄牙语（巴西）
   # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -881,6 +881,8 @@ locale:
   es: 西班牙语
   # @source French
   fr: 法语
+  # @source Portuguese (Brazilian)
+  pt-br: 葡萄牙语（巴西）
   # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names
   # @source Chinese (Simplified)
   zh-hans: 简体中文

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -1,0 +1,1913 @@
+action:
+  # @source Refresh
+  refresh: 刷新
+allowedImages:
+  # @source The image name needs to match one of the patterns defined in the Allowed Images preference tab.
+  alert: 镜像名称必须匹配"允许的镜像"偏好设置中定义的某个模式。
+  # @source Enable
+  enable: 启用
+  errors:
+    # @source This item is a duplicate.
+    duplicate: 此条目重复。
+  # @source Allowed Image Patterns
+  label: 允许的镜像模式
+  patterns:
+    # @source Type the image pattern
+    placeholder: 输入镜像模式
+application:
+  behavior:
+    autoStart:
+      # @source Automatically start at login
+      label: 登录时自动启动
+      # @source Startup
+      legendText: 启动
+    background:
+      # @source Background
+      legendText: 后台运行
+      # @source Hide the app window when Rancher Desktop is running in the background. It can be opened via the Notification Icon (if visible) or by running Rancher Desktop from the Applications menu.
+      # @source
+      legendTooltip: 当 Rancher Desktop 在后台运行时隐藏应用窗口。可通过通知图标（若可见）或从应用程序菜单启动 Rancher Desktop 来重新打开窗口。
+    notificationIcon:
+      # @source Hide Notification Icon
+      label: 隐藏通知图标
+      # @source Notification Icon
+      legendText: 通知图标
+    startInBackground:
+      # @source Start in the background
+      label: 在后台启动
+    theme:
+      # @source Appearance
+      legendText: 外观
+      options:
+        dark:
+          # @reason 主题选项：深色模式描述，说明始终使用深色界面
+          # @source Always use dark mode
+          description: 始终使用深色模式
+          # @reason 主题选项：深色模式标签，UI标签需简洁
+          # @source Dark
+          label: 深色
+        light:
+          # @reason 主题选项：浅色模式描述，说明始终使用浅色界面
+          # @source Always use light mode
+          description: 始终使用浅色模式
+          # @reason 主题选项：浅色模式标签，UI标签需简洁
+          # @source Light
+          label: 浅色
+        system:
+          # @reason 主题选项：跟随系统描述，说明跟随操作系统设置
+          # @source Follow the operating system setting
+          description: 跟随操作系统设置
+          # @reason 主题选项：系统标签，标准计算机术语
+          # @source System
+          label: 系统
+    windowQuitOnClose:
+      # @source Quit when closing application window
+      label: 关闭应用窗口时退出
+  general:
+    adminAccess:
+      # @source Allow administrative credentials (sudo access)
+      label: 允许管理员凭据（sudo 权限）
+      # @source Administrative Access
+      legendText: 管理员权限
+      # @source If checked, {appName} will acquire administrative credentials ("sudo access") when starting. This enables bridged networking and default docker socket support. Takes effect on next start.
+      legendTooltip: 勾选后，{appName} 将在启动时获取管理员凭据（"sudo 权限"）。此选项可启用桥接网络和默认 Docker 套接字支持。下次启动时生效。
+    automaticUpdates:
+      # @source Check for updates automatically
+      label: 自动检查更新
+      # @source Automatic Updates
+      legendText: 自动更新
+    statistics:
+      # @source Allow collection of anonymous statistics to help improve {appName}
+      label: 允许收集匿名统计数据以帮助改进 {appName}
+      # @source Statistics
+      legendText: 统计
+  locale:
+    # @source Community and AI tools provide translations. English is the canonical language. Report translation issues on GitHub.
+    disclaimer: 翻译由社区和 AI 工具提供。英语为规范语言。如发现翻译问题，请在 GitHub 上报告。
+    # @source Language
+    legendText: 语言
+asyncButton:
+  activate:
+    # @reason 异步按钮：激活操作，动词"激活"
+    # @source Activate
+    action: 激活
+    # @reason 异步按钮：激活成功，过去完成状态
+    # @source Activated
+    success: 已激活
+    # @reason 异步按钮：激活中，进行时状态，保留HTML实体
+    # @source Activating&hellip;
+    waiting: 正在激活&hellip;
+  apply:
+    # @reason 异步按钮：应用操作，动词"应用"
+    # @source Apply
+    action: 应用
+    # @reason 异步按钮：应用成功，过去完成状态
+    # @source Applied
+    success: 已应用
+    # @reason 异步按钮：应用中，进行时状态
+    # @source Applying&hellip;
+    waiting: 正在应用&hellip;
+  continue:
+    # @reason 异步按钮：继续操作，动词"继续"
+    # @source Continue
+    action: 继续
+    # @reason 异步按钮：继续成功，结果是已保存
+    # @source Saved
+    success: 已保存
+    # @reason 异步按钮：继续等待中，正在保存
+    # @source Saving&hellip;
+    waiting: 正在保存&hellip;
+  copy:
+    # @reason 异步按钮：复制操作，提示点击复制
+    # @source Click to Copy
+    action: 点击复制
+    # @reason 异步按钮：复制成功，感叹号保留表达即时反馈
+    # @source Copied!
+    success: 已复制！
+  create:
+    # @reason 异步按钮：创建操作，动词"创建"
+    # @source Create
+    action: 创建
+    # @reason 异步按钮：创建成功，过去完成状态
+    # @source Created
+    success: 已创建
+    # @reason 异步按钮：创建中，进行时状态
+    # @source Creating&hellip;
+    waiting: 正在创建&hellip;
+  deactivate:
+    # @reason 异步按钮：停用操作，动词"停用"
+    # @source Deactivate
+    action: 停用
+    # @reason 异步按钮：停用成功，过去完成状态
+    # @source Deactivated
+    success: 已停用
+    # @reason 异步按钮：停用中，进行时状态
+    # @source Deactivating&hellip;
+    waiting: 正在停用&hellip;
+  default:
+    # @reason 异步按钮：默认操作标签，通用"操作"
+    # @source Action
+    action: 操作
+    # @reason 异步按钮：默认错误标签，通用"错误"
+    # @source Error
+    error: 错误
+    # @reason 异步按钮：默认成功标签，通用"成功"
+    # @source Success
+    success: 成功
+    # @reason 异步按钮：默认等待标签，通用"请稍候"
+    # @source Waiting
+    waiting: 请稍候
+  delete:
+    # @reason 异步按钮：删除操作，动词"删除"
+    # @source Delete
+    action: 删除
+    # @reason 异步按钮：删除成功，过去完成状态
+    # @source Deleted
+    success: 已删除
+    # @reason 异步按钮：删除中，进行时状态
+    # @source Deleting&hellip;
+    waiting: 正在删除&hellip;
+  disable:
+    # @reason 异步按钮：禁用操作，动词"禁用"
+    # @source Disable
+    action: 禁用
+    # @reason 异步按钮：禁用成功，过去完成状态
+    # @source Disabled
+    success: 已禁用
+    # @reason 异步按钮：禁用中，进行时状态
+    # @source Disabling&hellip;
+    waiting: 正在禁用&hellip;
+  done:
+    # @reason 异步按钮：完成操作，动词"完成"
+    # @source Done
+    action: 完成
+    # @reason 异步按钮：完成成功，结果是已保存
+    # @source Saved
+    success: 已保存
+    # @reason 异步按钮：完成等待中，正在保存
+    # @source Saving&hellip;
+    waiting: 正在保存&hellip;
+  download:
+    # @reason 异步按钮：下载操作，动词"下载"
+    # @source Download
+    action: 下载
+    # @reason 异步按钮：下载成功，英文原文为"Saving"表示正在保存到本地
+    # @source Saving
+    success: 正在保存
+    # @reason 异步按钮：下载中，进行时状态
+    # @source Downloading&hellip;
+    waiting: 正在下载&hellip;
+  edit:
+    # @reason 异步按钮：编辑/保存操作，此处action对应"保存"语义
+    # @source Save
+    action: 保存
+    # @reason 异步按钮：编辑成功，过去完成状态
+    # @source Saved
+    success: 已保存
+    # @reason 异步按钮：编辑保存中，进行时状态
+    # @source Saving&hellip;
+    waiting: 正在保存&hellip;
+  enable:
+    # @reason 异步按钮：启用操作，动词"启用"
+    # @source Enable
+    action: 启用
+    # @reason 异步按钮：启用成功，过去完成状态
+    # @source Enabled
+    success: 已启用
+    # @reason 异步按钮：启用中，进行时状态
+    # @source Enabling&hellip;
+    waiting: 正在启用&hellip;
+  finish:
+    # @reason 异步按钮：完成流程操作，动词"完成"
+    # @source Finish
+    action: 完成
+    # @reason 异步按钮：流程完成成功状态
+    # @source Finished
+    success: 已完成
+    # @reason 异步按钮：流程完成中，进行时状态
+    # @source Finishing&hellip;
+    waiting: 正在完成&hellip;
+  import:
+    # @reason 异步按钮：导入操作，动词"导入"
+    # @source Import
+    action: 导入
+    # @reason "Imported" - past tense completion of import action
+    # @source Imported
+    success: 已导入
+    # @reason "Importing…" - in-progress state with ellipsis HTML entity preserved
+    # @source Importing&hellip;
+    waiting: 正在导入&hellip;
+  install:
+    # @reason "Install" - action button label
+    # @source Install
+    action: 安装
+    # @reason "Installing" - past tense, shown after install begins (note: source says "Installing" for success state)
+    # @source Installing
+    success: 正在安装
+    # @reason "Starting…" - in-progress state before install completes
+    # @source Starting&hellip;
+    waiting: 正在启动&hellip;
+  refresh:
+    # @reason empty value preserved as-is per rules
+    # @source
+    action: ''
+    # @reason icon name stays in English per rules
+    # @source refresh
+    actionIcon: refresh
+    # @reason empty value preserved
+    # @source
+    error: ''
+    # @reason icon name stays in English
+    # @source error
+    errorIcon: error
+    # @reason empty value preserved
+    # @source
+    success: ''
+    # @reason icon name stays in English
+    # @source checkmark
+    successIcon: checkmark
+    # @reason empty value preserved
+    # @source
+    waiting: ''
+    # @reason icon name stays in English
+    # @source refresh
+    waitingIcon: refresh
+  remove:
+    # @reason "Remove" - action button label
+    # @source Remove
+    action: 移除
+    # @reason "Removed" - past tense completion
+    # @source Removed
+    success: 已移除
+    # @reason "Removing…" - in-progress state
+    # @source Removing&hellip;
+    waiting: 正在移除&hellip;
+  restore:
+    # @reason "Restore" - action button label
+    # @source Restore
+    action: 恢复
+    # @reason "Restored" - past tense completion
+    # @source Restored
+    success: 已恢复
+    # @reason "Restoring…" - in-progress state
+    # @source Restoring&hellip;
+    waiting: 正在恢复&hellip;
+  snapshot:
+    # @reason "Snapshot Now" - action button label
+    # @source Snapshot Now
+    action: 立即创建快照
+    # @reason "Snapshot Creating" - in-progress success state
+    # @source Creating Snapshot
+    success: 正在创建快照
+    # @reason "Snapshotting…" - in-progress state
+    # @source Snapshotting&hellip;
+    waiting: 正在拍摄快照&hellip;
+  uninstall:
+    # @reason "Uninstall" - action button label
+    # @source Uninstall
+    action: 卸载
+    # @reason "Uninstalled" - past tense completion
+    # @source Uninstalled
+    success: 已卸载
+    # @reason "Uninstalling…" - in-progress state
+    # @source Uninstalling&hellip;
+    waiting: 正在卸载&hellip;
+  update:
+    # @reason "Update" - action button label
+    # @source Update
+    action: 更新
+    # @reason "Updated" - past tense completion
+    # @source Updated
+    success: 已更新
+    # @reason "Updating…" - in-progress state
+    # @source Updating&hellip;
+    waiting: 正在更新&hellip;
+  upgrade:
+    # @reason "Upgrade" - action button label, distinct from update (version bump)
+    # @source Upgrade
+    action: 升级
+    # @reason "Upgrading" - in-progress success state
+    # @source Upgrading
+    success: 正在升级
+    # @reason "Starting…" - in-progress state before upgrade completes
+    # @source Starting&hellip;
+    waiting: 正在启动&hellip;
+containerEngine:
+  # @source Container Engine
+  label: 容器引擎
+  options:
+    containerd:
+      # @reason description for containerd engine option; "nerdctl" is a product name, kept in English
+      # @source Namespaces for container images; use with nerdctl.
+      description: 容器镜像命名空间；与 nerdctl 配合使用。
+      # @reason product name, kept in English per rules
+      # @source containerd
+      label: containerd
+    moby:
+      # @reason description for moby/Docker engine option; "Docker CLI" is a product name
+      # @source Docker API; use with Docker CLI.
+      description: Docker API；与 Docker CLI 配合使用。
+      # @reason product name, kept in English per rules
+      # @source dockerd (moby)
+      label: dockerd (moby)
+containerInfo:
+  # @source Container Info
+  fallbackTitle: 容器信息
+  # @source Info
+  info: 信息
+  # @source Logs
+  logs: 日志
+  search:
+    # @source Search in logs
+    ariaLabel: 在日志中搜索
+    # @source Clear search
+    clearSearch: 清除搜索
+    # @source Next match
+    nextMatch: 下一个匹配
+    # @source Search logs...
+    placeholder: 搜索日志...
+    # @source Previous match
+    previousMatch: 上一个匹配
+  # @reason tab opening a shell in the container; Shell is kept untranslated in Chinese dev UIs (Kubernetes zh docs, VS Code)
+  # @source Shell
+  shell: Shell
+  # @source Stats
+  stats: 统计
+containerInspect:
+  capabilities:
+    # @source Added
+    added: 已添加
+    # @source Dropped
+    dropped: 已移除
+  command:
+    # @source Args
+    args: 参数
+    # @source Command
+    command: 命令
+    # @reason names the Docker config field Entrypoint (ENTRYPOINT directive); kept untranslated in Chinese Docker/Kubernetes docs
+    # @source Entrypoint
+    entrypoint: Entrypoint
+  error:
+    # @source Failed to load container details.
+    loadFailed: 无法加载容器详情。
+    # @source An unknown error has occurred
+    unknown: 发生未知错误
+  # @source Loading container details…
+  loading: 正在加载容器详情…
+  mounts:
+    # @source Destination
+    destination: 目标
+    # @source RO
+    readOnly: 只读
+    # @source RW
+    readWrite: 读写
+    # @source R/W
+    rw: 读/写
+    # @source Source
+    source: 源
+    # @source Type
+    type: 类型
+  # @source None
+  none: 无
+  sections:
+    # @source Capabilities
+    capabilities: 权能
+    # @source Command & Args
+    commandArgs: 命令和参数
+    # @source Environment
+    environment: 环境变量
+    # @source Labels
+    labels: 标签
+    # @source Mounts
+    mounts: 挂载
+    # @source Ports
+    ports: 端口
+  summary:
+    # @source Created
+    created: 创建时间
+    # @reason ID is standard in Chinese UIs; this file already uses 镜像 ID and 漏洞 ID
+    # @source ID
+    id: ID
+    # @source Image
+    image: 镜像
+    # @source IP Address
+    ipAddress: IP 地址
+    # @source Name
+    name: 名称
+    # @source Started
+    started: 启动时间
+containerStats:
+  charts:
+    # @source Block I/O (bytes/s)
+    blockIO: 块 I/O（字节/秒）
+    # @reason CPU is a standard untranslated abbreviation in Chinese (file uses CPU 数量); % is universal
+    # @source CPU %
+    cpu: CPU %
+    # @source Memory
+    memory: 内存
+    # @source Network I/O (bytes/s)
+    network: 网络 I/O（字节/秒）
+  interval:
+    # @source {minutes} min
+    minutes: '{minutes} 分钟'
+    # @source {seconds} s
+    seconds: '{seconds} 秒'
+  # @source Stats are currently only available for the Docker (Moby) engine.
+  mobyOnly: 统计信息目前仅适用于 Docker (Moby) 引擎。
+  # @source No processes found.
+  noProcesses: 未找到进程。
+  # @source Stats are only available for running containers.
+  notRunning: 统计信息仅适用于正在运行的容器。
+  # @source Processes
+  processes: 进程
+  # @source Refresh
+  refresh: 刷新
+  series:
+    # @source Limit
+    limit: 上限
+    # @source Read
+    read: 读取
+    # @source RX
+    rx: 接收
+    # @source TX
+    tx: 发送
+    # @source Used
+    used: 已用
+    # @source Write
+    write: 写入
+containers:
+  manage:
+    table:
+      action:
+        # @source Info
+        info: 信息
+        # @source Restart
+        restart: 重启
+        # @source Start
+        start: 启动
+        # @source Stop
+        stop: 停止
+      header:
+        # @source Name
+        containerName: 名称
+        # @source Image
+        image: 镜像
+        # @source Port(s)
+        ports: 端口
+        # @source Uptime
+        started: 运行时间
+        # @source State
+        state: 状态
+  sortableTables:
+    # @source There are no containers to show
+    noRows: 没有可显示的容器
+  # @source Containers
+  title: 容器
+dashboard:
+  # @reason @no-translate product name
+  # @source Rancher Dashboard
+  windowTitle: Rancher Dashboard
+denyRoot:
+  # @source Rancher Desktop cannot be run with root privileges. Please run again as a regular user.
+  message: Rancher Desktop 不能以 root 权限运行。请以普通用户身份重新运行。
+  # @source Cannot run as Root
+  title: 无法以 Root 身份运行
+deploymentProfile:
+  # @source Invalid deployment file {path}: no version specified. Add a version field to make it valid (current version is {version}).
+  noVersion: 无效的部署文件 {path}：未指定版本。请添加版本字段使其有效（当前版本为 {version}）。
+  # @source Invalid deployment: no version specified at {path}. Add a version field to make it valid (current version is {version}).
+  noVersionRegistry: 无效的部署：未在 {path} 指定版本。请添加版本字段使其有效（当前版本为 {version}）。
+diagnostics:
+  # @source {count} failed plus {muted} muted
+  failedCount: '{count} 项失败，{muted} 项已静音'
+  # @source Last run:
+  lastRun: 上次运行：
+  # @source (No fixes available)
+  noFixes: （无可用修复）
+  results:
+    muted:
+      # @source Try showing muted diagnostics.
+      body: 尝试显示已静音的诊断项。
+      # @source No results found
+      heading: 未找到结果
+      # @reason icon identifier, not translatable text
+      # @source icon-search
+      icon: icon-search
+    success:
+      # @source Rancher Desktop appears to be functioning correctly.
+      body: Rancher Desktop 运行正常。
+      # @source No problems detected
+      heading: 未检测到问题
+      # @reason icon identifier, not translatable text
+      # @source icon-checkmark
+      icon: icon-checkmark
+  # @source Show Muted
+  showMuted: 显示已静音
+  tableHeaders:
+    # @source Mute
+    mute: 静音
+    # @source Name
+    name: 名称
+  # @source Diagnostics
+  title: 诊断
+dialog:
+  bridgedNetwork:
+    # @source Shared network isn't available either. Only network access is via port forwarding to the host.
+    noNetwork: 共享网络也不可用。只能通过端口转发访问主机网络。
+    # @source Using shared network address {ip}
+    sharedFallback: 使用共享网络地址 {ip}
+    # @source Bridged network did not get an IP address.
+    title: 桥接网络未获取到 IP 地址。
+  confirmMigration:
+    # @source Delete Workloads
+    delete: 删除工作负载
+    # @source Downgrading from {from} to {to} will lose existing Kubernetes workloads. Delete the data?
+    message: 从 {from} 降级到 {to} 将丢失现有的 Kubernetes 工作负载。是否删除数据？
+    # @source Confirming migration
+    title: 确认迁移
+  invalidK8sVersion:
+    # @source Falling back to recommended minimum upgrade version of {version}
+    detail: 回退到建议的最低升级版本 {version}
+    # @source Requested Kubernetes version ''{version}'' is not a supported version.
+    message: 请求的 Kubernetes 版本 ''{version}'' 不是受支持的版本。
+    # @source Invalid Kubernetes Version
+    title: 无效的 Kubernetes 版本
+  networkFailure:
+    # @source Please acquire a version in the range {range} and install in ''{path}''
+    detail: 请获取 {range} 范围内的版本并安装到 ''{path}''
+    # @source Can't download a compatible version of kubectl in offline-mode
+    message: 离线模式下无法下载兼容版本的 kubectl
+    # @source Network failure
+    title: 网络故障
+extensions:
+  # @reason icon identifier, not translatable text
+  # @source icon-extension
+  icon: icon-extension
+  installed:
+    emptyState:
+      # @source It looks like you don't have any extensions installed yet. Browse the extensions catalog to get started.
+      body: 您似乎尚未安装任何扩展。浏览扩展目录以开始使用。
+      button:
+        # @source Browse Extensions
+        text: 浏览扩展
+      # @source No extensions installed
+      heading: 未安装扩展
+      # @reason icon identifier, not translatable text
+      # @source icon-extension
+      icon: icon-extension
+    list:
+      # @source Remove
+      uninstall: 移除
+      # @source Upgrade
+      upgrade: 升级
+  view:
+    emptyState:
+      # @source {extensionId} was removed. Please visit the extensions catalog to reinstall the extension or browse for other extensions to enhance your Rancher Desktop experience.
+      body: '{extensionId} 已被移除。请访问扩展目录重新安装该扩展，或浏览其他扩展来增强您的 Rancher Desktop 体验。'
+      # @source Extension removed
+      heading: 扩展已移除
+firstRun:
+  # @source Enable Kubernetes
+  enableKubernetes: 启用 Kubernetes
+  kubernetesVersion:
+    # @source (cached versions only)
+    cachedOnly: （仅缓存版本）
+    # @source Kubernetes Version
+    legend: Kubernetes 版本
+    # @source Other Versions
+    otherVersions: 其他版本
+    # @source Recommended Versions
+    recommendedVersions: 推荐版本
+  # @source OK
+  ok: 确定
+  # @source Welcome to Rancher Desktop by SUSE
+  welcome: 欢迎使用 SUSE Rancher Desktop
+general:
+  # @source Rancher Desktop provides Kubernetes and image management through the use of a desktop application.
+  description: Rancher Desktop 通过桌面应用程序提供 Kubernetes 和镜像管理功能。
+  # @source Homepage
+  homepage: 主页
+  # @source Issues
+  issues: 问题
+  # @source General
+  navLabel: 概览
+  # @source Project Discussions: <b>#rancher-desktop</b> in <a href="https://slack.rancher.io/">Rancher Users</a> Slack
+  projectDiscussions: 项目讨论：<a href="https://slack.rancher.io/">Rancher Users</a> Slack 中的 <b>#rancher-desktop</b>
+  # @source Project Links:
+  projectLinks: 项目链接：
+  # @source Welcome to Rancher Desktop by SUSE
+  title: 欢迎使用 SUSE Rancher Desktop
+generic:
+  # @source  and 
+  and: ' 和 '
+  # @source Apply
+  apply: 应用
+  # @source Cancel
+  cancel: 取消
+  # @source Close
+  close: 关闭
+  # @source , 
+  comma: 、
+  # @source Forward
+  forward: 转发
+  # @source Loading&hellip;
+  loading: 正在加载&hellip;
+  # @source Namespace
+  namespace: 命名空间
+  # @source OK
+  ok: 确定
+  # @source Rerun
+  rerun: 重新运行
+  # @source Search
+  search: 搜索
+imageEvents:
+  # @source Please select the Dockerfile to use (could have a different name)
+  buildMessage: 请选择要使用的 Dockerfile（可能使用了其他名称）
+  # @source Pick the build directory
+  buildTitle: 选择构建目录
+  # @source Error trying to delete images {ids}
+  deleteBatchError: 尝试删除镜像 {ids} 时出错
+  # @source Error trying to delete image {name} ({id}):
+  # @source
+  # @source  {error}
+  deleteError: 尝试删除镜像 {name} ({id}) 时出错：\n\n {error}
+  # @source Error trying to push {name}:
+  # @source
+  # @source  {error}
+  pushError: 尝试推送 {name} 时出错：\n\n {error}
+  # @source Error trying to scan {name}:
+  # @source
+  # @source  {error}
+  scanError: 尝试扫描 {name} 时出错：\n\n {error}
+images:
+  action:
+    # @source Add Image
+    add: 添加镜像
+  add:
+    action:
+      # @source Build
+      build: 构建
+      gerund:
+        # @reason progressive marker 正在 kept in the gerund value (parallel to pastTense 已构建) so loadingText composes as {action}镜像...
+        # @source Building
+        build: 正在构建
+        # @reason progressive marker 正在 kept in the gerund value (parallel to pastTense 已拉取) so loadingText composes as {action}镜像...
+        # @source Pulling
+        pull: 正在拉取
+      infinitive:
+        # @source build
+        build: 构建
+        # @source pull
+        pull: 拉取
+      pastTense:
+        # @reason "Built" - past tense, result of a build action
+        # @source Built
+        build: 已构建
+        # @reason "Pulled" - past tense, result of a pull action
+        # @source Pulled
+        pull: 已拉取
+      # @source Pull
+      pull: 拉取
+    # @reason dropped the space before { action } since the substituted verb is now Chinese; parallels images.scan.errorText 尝试扫描
+    # @source Error trying to { action } ''{ image }'' — see console output for more information
+    errorText: 尝试{ action } ''{ image }'' 时出错 - 详情请查看控制台输出
+    # @reason 正在 moved into the gerund values; composed text 正在构建镜像... matches the previous translation
+    # @source {action} image...
+    loadingText: '{action}镜像...'
+    # @source {action} image
+    successText: '{action}镜像'
+    # @source Add Image
+    title: 添加镜像
+  confirmDelete:
+    # @source Delete
+    confirm: 删除
+    # @source Delete {count} {count, plural, one {image} other {images}}?
+    multiple: 删除 {count} 个{count, plural, one {镜像} other {镜像}}？
+    # @source Delete image {name}:{tag}?
+    single: 删除镜像 {name}:{tag}？
+    # @source Confirming image deletion
+    title: 确认删除镜像
+  manager:
+    # @source Close Output to Continue
+    close: 关闭输出以继续
+    input:
+      build:
+        # @reason "Build" - button label for building an image
+        # @source Build
+        button: 构建
+        # @reason label for image name input field in build context
+        # @source Name of image to build:
+        label: 要构建的镜像名称：
+        # @reason placeholder showing example registry path format; technical value kept as-is
+        # @source registry.example.com/namespace/image:tag
+        placeholder: registry.example.com/namespace/image:tag
+      pull:
+        # @reason "Pull" - button label for pulling an image
+        # @source Pull
+        button: 拉取
+        # @reason label for image name input field in pull context
+        # @source Name of image to pull:
+        label: 要拉取的镜像名称：
+        # @reason placeholder showing example registry path format; technical value kept as-is
+        # @source registry.example.com/namespace/image
+        placeholder: registry.example.com/namespace/image
+    table:
+      action:
+        # @source Delete
+        delete: 删除
+        # @source Push
+        push: 推送
+        # @source Scan...
+        scan: 扫描...
+      header:
+        # @source Image ID
+        imageId: 镜像 ID
+        # @source Image
+        imageName: 镜像
+        # @source Size
+        size: 大小
+        # @source Tag
+        tag: 标签
+      # @source All images
+      label: 所有镜像
+    # @source Image Output
+    title: 镜像输出
+  scan:
+    details:
+      # @source Description
+      description: 描述
+      # @source Primary URL
+      primaryUrl: 主要 URL
+      # @source References
+      references: 参考
+    # @source Error trying to scan ''{ image }'' — see console output for more information
+    errorText: 尝试扫描 ''{ image }'' 时出错 - 详情请查看控制台输出
+    labels:
+      # @source CRITICAL
+      critical: 严重
+      # @source HIGH
+      high: 高
+      # @source Issues Found
+      issuesFound: 发现的问题
+      # @source LOW
+      low: 低
+      # @source MEDIUM
+      medium: 中
+    # @source Scanning ''{ image }''
+    loadingText: 正在扫描 ''{ image }''
+    results:
+      headers:
+        # @source Fixed
+        fixed: 已修复
+        # @source Installed
+        installed: 已安装
+        # @source Package
+        package: 软件包
+        # @source Severity
+        severity: 严重程度
+        # @source Vulnerability ID
+        vulnerabilityId: 漏洞 ID
+    # @source Scan details for ''{ image }''
+    title: '''''{ image }'''' 的扫描详情'
+  sortableTables:
+    # @source There are no images to show
+    noRows: 没有可显示的镜像
+  state:
+    # @source Waiting for image manager to be ready
+    imagesUnready: 正在等待镜像管理器就绪
+    # @source Error: Unknown state; please reload.
+    unknown: 错误：未知状态，请重新加载。
+  # @source Images
+  title: 镜像
+integrations:
+  windows:
+    # @source Expose Rancher Desktop's Kubernetes configuration and Docker socket to Windows Subsystem for Linux (WSL) distros
+    description: 将 Rancher Desktop 的 Kubernetes 配置和 Docker 套接字暴露给 Windows Subsystem for Linux (WSL) 发行版
+kubernetesError:
+  # @source Context:
+  context: 上下文：
+  # @source Last command run:
+  lastCommand: 上次运行的命令：
+  # @source Some recent <a href="#" data-action="showLogs">logfile</a> lines:
+  logLines: 最近的一些<a href="#" data-action="showLogs">日志文件</a>行：
+  # @source {appName} Error
+  title: '{appName} 错误'
+kubernetesPrefs:
+  kubernetes:
+    # @source Enable Kubernetes
+    label: 启用 Kubernetes
+    # @reason product name
+    # @source Kubernetes
+    legendText: Kubernetes
+  options:
+    # @source Options
+    legendText: 选项
+    # @source Install Spin Operator
+    spinkube: 安装 Spin Operator
+    # @source Spin Operator requires <a href="#" data-navigate="Container Engine,general">WebAssembly</a> to be enabled.
+    spinkubeWarning: Spin Operator 需要启用<a href="#" data-navigate="Container Engine,general">WebAssembly</a>。
+    # @source Enable Traefik
+    traefik: 启用 Traefik
+  port:
+    # @source Kubernetes Port
+    legendText: Kubernetes 端口
+  version:
+    # @source Kubernetes version
+    legendText: Kubernetes 版本
+    # @source Kubernetes version (cached versions only)
+    legendTextCached: Kubernetes 版本（仅缓存版本）
+    # @source Other Versions
+    otherVersions: 其他版本
+    # @source Recommended Versions
+    recommendedVersions: 推荐版本
+labelSelect:
+  noOptions:
+    # @source No options
+    empty: 无选项
+    # @source No matching options
+    noMatch: 没有匹配的选项
+  pagination:
+    # @source {count} / {totalCount} items
+    counts: '{count} / {totalCount} 项'
+    # @source Load More...
+    more: 加载更多...
+locale:
+  # @source German
+  de: 德语
+  # @reason locale name for English
+  # @source English
+  en-us: 英语
+  # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names
+  # @source Chinese (Simplified)
+  zh-hans: 简体中文
+mainMenu:
+  # @source About {appName}
+  about: 关于 {appName}
+  edit:
+    # @source &Copy
+    copy: 复制(&C)
+    # @source Cu&t
+    cut: 剪切(&T)
+    # @source De&lete
+    delete: 删除(&L)
+    # @source &Edit
+    label: 编辑(&E)
+    # @source &Paste
+    paste: 粘贴(&P)
+    # @source &Redo
+    redo: 重做(&R)
+    # @source Select &All
+    selectAll: 全选(&A)
+    # @source &Undo
+    undo: 撤销(&U)
+  file:
+    # @source Close
+    close: 关闭
+    # @source E&xit
+    exit: 退出(&X)
+    # @source &File
+    label: 文件(&F)
+  help:
+    # @source &About {appName}
+    about: 关于 {appName}(&A)
+    # @source &Discuss
+    discuss: 讨论(&D)
+    # @source File a &Bug
+    fileABug: 提交 &Bug
+    # @source Get &Help
+    getHelp: 获取帮助(&H)
+    # @source {appName} &Help
+    help: '{appName} 帮助(&H)'
+    # @source &Help
+    label: 帮助(&H)
+    # @source &Project Page
+    projectPage: 项目主页(&P)
+  # @source Hide {appName}
+  hide: 隐藏 {appName}
+  # @source Hide Others
+  hideOthers: 隐藏其他
+  # @source Preferences
+  preferences: 偏好设置
+  # @source Quit {appName}
+  quit: 退出 {appName}
+  # @source Services
+  services: 服务
+  # @source Show All
+  showAll: 显示全部
+  view:
+    # @source &Actual Size
+    actualSize: 实际大小(&A)
+    # @source &Force Reload
+    forceReload: 强制重新加载(&F)
+    # @source &View
+    label: 视图(&V)
+    # @source &Reload
+    reload: 重新加载(&R)
+    # @source Toggle &Developer Tools
+    toggleDevTools: 切换开发者工具(&D)
+    # @source Toggle Full &Screen
+    toggleFullScreen: 切换全屏(&S)
+    # @source Zoom &In
+    zoomIn: 放大(&I)
+    # @source Zoom &Out
+    zoomOut: 缩小(&O)
+  window:
+    # @source Bring All to Front
+    front: 全部置于最前
+    # @source &Window
+    label: 窗口(&W)
+    # @source Minimize
+    minimize: 最小化
+    # @source Zoom
+    zoom: 缩放
+marketplace:
+  installed:
+    table:
+      header:
+        # @source Description
+        description: 描述
+        # @source Name
+        name: 名称
+        # @source Vendor
+        vendor: 供应商
+  labels:
+    # @source Install
+    install: 安装
+    # @source Remove
+    uninstall: 移除
+    # @source Upgrade
+    upgrade: 升级
+  loading:
+    # @reason "Installing..." - in-progress marketplace install state
+    # @source Installing...
+    install: 正在安装...
+    # @reason "Removing..." - in-progress marketplace uninstall state
+    # @source Removing...
+    uninstall: 正在移除...
+    # @reason "Upgrading..." — 升级进行时，状态提示
+    # @source Upgrading...
+    upgrade: 升级中...
+  # @source More information
+  moreInfo: 更多信息
+  # @source No extension found for the search criteria
+  noResults: 未找到符合搜索条件的扩展
+  tabs:
+    # @source Catalog
+    catalog: 目录
+    # @source Installed
+    installed: 已安装
+  # @source Extensions
+  title: 扩展
+nav:
+  userMenu:
+    # @source Cluster Dashboard
+    clusterDashboard: 集群仪表板
+    # @source Preferences
+    preferences: 偏好设置
+pathManagement:
+  # @source Configure PATH
+  label: 配置 PATH
+  options:
+    manual:
+      # @source Rancher Desktop does not change your PATH configuration; add <code>$HOME/.rd/bin</code> to your path manually.
+      description: Rancher Desktop 不会更改您的 PATH 配置；请手动将 <code>$HOME/.rd/bin</code> 添加到您的 PATH。
+      # @source Manual
+      label: 手动
+    rcFiles:
+      # @source Rancher Desktop edits your shell profile for you. Restart any open shells for changes to take effect.
+      description: Rancher Desktop 会自动编辑您的 shell 配置文件。请重新启动所有已打开的 shell 以使更改生效。
+      # @source Automatic
+      label: 自动
+  # @source Rancher Desktop ships with tools, such as kubectl, nerdctl, helm and docker. In order to use these tools, <code>$HOME/.rd/bin</code> must be in your PATH.
+  tooltip: Rancher Desktop 附带 kubectl、nerdctl、helm 和 docker 等工具。要使用这些工具，<code>$HOME/.rd/bin</code> 必须在您的 PATH 中。
+portForwarding:
+  # @source Include Kubernetes services
+  includeKubernetesServices: 包含 Kubernetes 服务
+  manage:
+    table:
+      header:
+        # @source Local Port
+        listenPort: 本地端口
+        # @source Name
+        name: 名称
+        # @source Namespace
+        namespace: 命名空间
+        # @source Port
+        port: 端口
+  sortableTables:
+    # @source There are no port forwarding entries to show
+    noRows: 没有可显示的端口转发条目
+  # @source Port Forwarding
+  title: 端口转发
+preferences:
+  actions:
+    banner:
+      # @source There's a problem with the preferences selection.
+      error: 偏好设置选择存在问题。
+      # @source Kubernetes will reset after applying changes.
+      reset: 应用更改后 Kubernetes 将重置。
+      # @source Kubernetes will restart after applying changes.
+      restart: 应用更改后 Kubernetes 将重新启动。
+  containerEngine:
+    webAssembly:
+      # @source WebAssembly must be enabled for the <a href="#" data-navigate="Kubernetes">Spin Operator</a> to be installed.
+      warning: 必须启用 WebAssembly 才能安装 <a href="#" data-navigate="Kubernetes">Spin Operator</a>。
+  error:
+    # @source Reload Preferences to try again.
+    body: 重新加载偏好设置以重试。
+    # @source Unable to fetch preferences
+    heading: 无法获取偏好设置
+    # @source Reload preferences
+    reload: 重新加载偏好设置
+  # @source Preferences
+  header: 偏好设置
+  # @source or
+  incompatiblePrefWarningOr: 或
+  # @source to be unselected.
+  incompatibleTypeWarningPostDisabled: 处于未选中状态。
+  # @source to be selected.
+  incompatibleTypeWarningPostSelected: 处于选中状态。
+  # @source The option requires
+  incompatibleTypeWarningPre: 该选项要求
+  locked:
+    # @source Locked due to organization's policy
+    tooltip: 已被组织策略锁定
+  nav:
+    # @source Application
+    application: 应用程序
+    # @source Container Engine
+    containerEngine: 容器引擎
+    # @reason product name
+    # @source Kubernetes
+    kubernetes: Kubernetes
+    # @source Virtual Machine
+    virtualMachine: 虚拟机
+    # @reason product name (Windows Subsystem for Linux); kept as-is in Chinese Windows documentation
+    # @source WSL
+    wsl: WSL
+  resetDialog:
+    # @source Apply and reset
+    apply: 应用并重置
+    # @source These changes will reset the Kubernetes cluster, which will result in a loss of workloads and container images.
+    detail: 这些更改将重置 Kubernetes 集群，这会导致工作负载和容器镜像丢失。
+    # @source Apply preferences and reset Kubernetes?
+    message: 应用偏好设置并重置 Kubernetes？
+    # @source Rancher Desktop - Reset Kubernetes
+    title: Rancher Desktop - 重置 Kubernetes
+  tabs:
+    # @source Allowed Images
+    allowedImages: 允许的镜像
+    # @source Behavior
+    behavior: 行为
+    # @source Emulation
+    emulation: 模拟
+    # @source Environment
+    environment: 环境
+    # @source General
+    general: 常规
+    # @source Hardware
+    hardware: 硬件
+    # @source Integrations
+    integrations: 集成
+    # @source Proxy
+    proxy: 代理
+    # @source Volumes
+    volumes: 卷
+preferencesWindow:
+  close:
+    # @source There are preferences with changes that have not been applied. All unsaved preferences will be lost.
+    detail: 有未应用的偏好设置更改。所有未保存的偏好设置将丢失。
+    # @source Discard changes
+    discardChanges: 放弃更改
+    # @source Close preferences without applying?
+    message: 关闭偏好设置而不应用？
+    # @source Rancher Desktop - Close Preferences
+    title: Rancher Desktop - 关闭偏好设置
+  # @source Rancher Desktop - Preferences
+  title: Rancher Desktop - 偏好设置
+prefs:
+  # @source Experimental
+  experimental: 实验性
+  # @reason macOS version requirement for arm64; Ventura is proper noun kept as-is
+  # @source This setting requires macOS 13.3 (Ventura) or later.
+  onlyFromVentura_arm64: 此设置需要 macOS 13.3（Ventura）或更高版本。
+  # @reason macOS version requirement for x64; same pattern
+  # @source This setting requires macOS 13.0 (Ventura) or later.
+  onlyFromVentura_x64: 此设置需要 macOS 13.0（Ventura）或更高版本。
+  # @reason VZ emulation mode requirement for arm64; VZ and Ventura kept in English
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.3 (Ventura) or later.
+  onlyWithVZ_arm64: 此设置需要使用 VZ 仿真模式。VZ 仅在 macOS 13.3（Ventura）或更高版本上可用。
+  # @reason VZ emulation mode requirement for x64; same pattern
+  # @source This setting requires using the VZ emulation mode. VZ is only available on macOS 13.0 (Ventura) or later.
+  onlyWithVZ_x64: 此设置需要使用 VZ 仿真模式。VZ 仅在 macOS 13.0（Ventura）或更高版本上可用。
+product:
+  containerEngine:
+    # @reason space-constrained status-bar abbreviation; the tooltip shows the translated full name 容器引擎
+    # @source CE
+    abbreviation: CE
+    # @source Container Engine
+    fullName: 容器引擎
+  # @source deactivated
+  deactivated: 已停用
+  # @reason product name (status-bar label next to the version number)
+  # @source Kubernetes
+  kubernetesVersion: Kubernetes
+  # @source Network status
+  networkStatus: 网络状态
+  networkStatusValues:
+    # @reason network status indicator; ellipsis preserved
+    # @source checking...
+    checking: 检查中...
+    # @reason network status: no connectivity
+    # @source offline
+    offline: 离线
+    # @reason network status: connected
+    # @source online
+    online: 在线
+  # @source Version
+  version: 版本
+progress:
+  # @source Asking for permission to run tasks as administrator
+  askingPermission: 正在请求以管理员身份运行任务的权限
+  # @source Bundling certificates
+  bundlingCertificates: 正在打包证书
+  # @source Checking k3s images
+  checkingK3sImages: 正在检查 k3s 镜像
+  # @source Configuring container engine
+  configuringContainerEngine: 正在配置容器引擎
+  # @source Configuring image proxy
+  configuringImageProxy: 正在配置镜像代理
+  # @source Configuring logrotate
+  configuringLogrotate: 正在配置 logrotate
+  # @source Container engine components
+  containerEngineComponents: 容器引擎组件
+  # @source Copying certificates
+  copyingCertificates: 正在复制证书
+  # @source Deleting incompatible Kubernetes state
+  deletingIncompatibleState: 正在删除不兼容的 Kubernetes 状态
+  # @source Deleting Kubernetes
+  deletingKubernetes: 正在删除 Kubernetes
+  # @source Deleting virtual machine
+  deletingVirtualMachine: 正在删除虚拟机
+  # @source DNS configuration
+  dnsConfiguration: DNS 配置
+  # @source Ensuring compatible kubectl
+  ensuringCompatibleKubectl: 正在确保 kubectl 兼容
+  # @source Ensuring virtualization is supported
+  ensuringVirtualizationSupported: 正在确保支持虚拟化
+  # @source Expecting user permission to continue
+  expectingPermission: 等待用户授权以继续
+  # @source Extracting certificates
+  extractingCertificates: 正在提取证书
+  # @source Fetching certificates
+  fetchingCertificates: 正在获取证书
+  # @source Initializing Rancher Desktop
+  initializingRancherDesktop: 正在初始化 Rancher Desktop
+  # @source Initializing WSL data
+  initializingWslData: 正在初始化 WSL 数据
+  # @source Installing Buildkit
+  installingBuildkit: 正在安装 Buildkit
+  # @source Installing CA certificates
+  installingCaCertificates: 正在安装 CA 证书
+  # @source Installing container engine
+  installingContainerEngine: 正在安装容器引擎
+  # @source Installing credential helper
+  installingCredentialHelper: 正在安装凭据助手
+  # @source Installing the docker-credential helper
+  installingDockerCredentialHelper: 正在安装 docker-credential 助手
+  # @source Installing helpers
+  installingHelpers: 正在安装辅助工具
+  # @source Installing image scanner
+  installingImageScanner: 正在安装镜像扫描器
+  # @source Installing k3s
+  installingK3s: 正在安装 k3s
+  # @source Installing Kubernetes
+  installingKubernetes: 正在安装 Kubernetes
+  # @source Kubernetes components
+  kubernetesComponents: Kubernetes 组件
+  # @source Kubernetes dockerd compatibility
+  kubernetesDockerCompatibility: Kubernetes dockerd 兼容性
+  # @source Mounting WSL data
+  mountingWslData: 正在挂载 WSL 数据
+  # @source Preparing to start
+  preparingToStart: 正在准备启动
+  # @source Proxy Config Setup
+  proxyConfigSetup: 代理配置设置
+  # @source Rancher Desktop guest agent
+  rancherDesktopGuestAgent: Rancher Desktop 来宾代理
+  # @source Regenerating configuration to account for lack of permissions
+  regeneratingConfiguration: 正在重新生成配置以适应权限不足的情况
+  # @source Registering WSL distribution
+  registeringWslDistribution: 正在注册 WSL 发行版
+  # @source Removing existing certificates
+  removingExistingCertificates: 正在移除现有证书
+  # @source Removing spinkube operator
+  removingSpinkubeOperator: 正在移除 spinkube operator
+  # @source Removing stale state
+  removingStaleState: 正在移除过期状态
+  # @source Removing Traefik
+  removingTraefik: 正在移除 Traefik
+  # @source Resetting Kubernetes
+  resettingKubernetes: 正在重置 Kubernetes
+  # @source Running provisioning scripts
+  runningProvisioningScripts: 正在运行预配脚本
+  # @source Running update-ca-certificates
+  runningUpdateCaCertificates: 正在运行 update-ca-certificates
+  # @source Setting docker context
+  settingDockerContext: 正在设置 docker context
+  # @source Setting Lima permissions
+  settingLimaPermissions: 正在设置 Lima 权限
+  # @source Setting up Docker socket
+  settingUpDockerSocket: 正在设置 Docker socket
+  # @source Setting up virtual ethernet
+  settingUpVirtualEthernet: 正在设置虚拟以太网
+  # @source Shutting down
+  shuttingDown: 正在关闭
+  # @source Skipping node checks, flannel is disabled
+  skippingNodeChecksFlannel: 跳过节点检查，flannel 已禁用
+  # @source Starting Backend
+  startingBackend: 正在启动后端
+  # @source Starting buildkit
+  startingBuildkit: 正在启动 buildkit
+  # @source Starting container engine
+  startingContainerEngine: 正在启动容器引擎
+  # @source Starting image proxy
+  startingImageProxy: 正在启动镜像代理
+  # @source Starting k3s
+  startingK3s: 正在启动 k3s
+  # @source Starting Kubernetes
+  startingKubernetes: 正在启动 Kubernetes
+  # @source Starting proxy
+  startingProxy: 正在启动代理
+  # @source Starting {service}
+  startingService: 正在启动 {service}
+  # @source Starting virtual machine
+  startingVirtualMachine: 正在启动虚拟机
+  # @source Starting WSL environment
+  startingWslEnvironment: 正在启动 WSL 环境
+  # @source Stopping existing instance
+  stoppingExistingInstance: 正在停止现有实例
+  # @source Stopping mock backend
+  stoppingMockBackend: 正在停止模拟后端
+  # @source Stopping services
+  stoppingServices: 正在停止服务
+  # @source Updating cluster configuration
+  updatingClusterConfiguration: 正在更新集群配置
+  # @source Updating /etc/hosts
+  updatingEtcHosts: 正在更新 /etc/hosts
+  # @source Updating kubeconfig
+  updatingKubeconfig: 正在更新 kubeconfig
+  # @source Updating outdated virtual machine
+  updatingOutdatedVm: 正在更新过期的虚拟机
+  # @source Updating WSL data
+  updatingWslData: 正在更新 WSL 数据
+  # @source Upgrading WSL distribution
+  upgradingWslDistribution: 正在升级 WSL 发行版
+  # @source Waiting for container engine to be ready
+  waitingForContainerEngine: 正在等待容器引擎就绪
+  # @source Waiting for Kubernetes API
+  waitingForKubernetesApi: 正在等待 Kubernetes API
+  # @source Waiting for nodes
+  waitingForNodes: 正在等待节点
+  # @source Waiting for services
+  waitingForServices: 正在等待服务
+  # @source Writing K3s configuration
+  writingK3sConfiguration: 正在写入 K3s 配置
+snapshots:
+  action:
+    # @source Create Snapshot
+    create: 创建快照
+  card:
+    action:
+      # @source Delete
+      remove: 删除
+      # @source Restore
+      restore: 恢复
+    # @source Created on '<b>'{date}'</b>' at '<b>'{time}'</b>'
+    created: 创建于 '<b>'{date}'</b>' '<b>'{time}'</b>'
+  create:
+    actions:
+      # @source Cancel
+      back: 取消
+      # @source Create
+      submit: 创建
+    description:
+      # @source Description
+      label: 描述
+    # @source Rancher Desktop will be temporarily unavailable while creating a new Snapshot
+    info: 创建新快照期间 Rancher Desktop 将暂时不可用
+    name:
+      # @source Snapshot Name
+      label: 快照名称
+    # @source Create a new Snapshot
+    title: 创建新快照
+  dialog:
+    buttons:
+      # @source Close
+      error: 关闭
+    creating:
+      actions:
+        # @source Cancel
+        cancel: 取消
+      # @source Creating {snapshot}
+      header: 正在创建 {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being created.'<br/>'This may take some time depending on your machine's resources.'<br/>'Rancher Desktop will be temporarily unavailable during this operation.'<br/><br/>'Once the snapshot is complete, the VM will restart.
+      message: 正在创建快照 '<b>'{snapshot}'</b>'，请稍候。'<br/>'此操作可能需要一些时间，具体取决于您的计算机资源。'<br/>'在此期间 Rancher Desktop 将暂时不可用。'<br/><br/>'快照创建完成后，虚拟机将重新启动。
+    delete:
+      actions:
+        # @reason cancel button label in delete confirmation dialog
+        # @source Cancel
+        cancel: 取消
+        # @reason confirm button for permanent deletion
+        # @source Delete
+        ok: 删除
+      # @reason dialog header asking for confirmation before permanent deletion
+      # @source Permanently delete snapshot?
+      header: 永久删除快照？
+      # @reason placeholder text value; keep as "text" per source
+      # @source Deleting a snapshot cannot be undone.
+      info: 删除快照后无法撤销。
+    generic:
+      # @source Snapshot operation in progress
+      header: 快照操作进行中
+      # @source Please wait while the snapshot operation is active.<br/>This may take some time depending on your machine's resources.<br/>Rancher Desktop will be temporarily unavailable during this operation.<br/><br/>Once the snapshot process is complete, the VM will restart.
+      message: 正在执行快照操作，请稍候。<br/>此操作可能需要一些时间，具体取决于您的计算机资源。<br/>在此期间 Rancher Desktop 将暂时不可用。<br/><br/>快照操作完成后，虚拟机将重新启动。
+    restore:
+      actions:
+        # @reason cancel button label in restore confirmation dialog
+        # @source Cancel
+        cancel: 取消
+        # @reason confirm button to proceed with restore
+        # @source Restore
+        ok: 还原
+      error:
+        # @source Quit Rancher Desktop
+        buttonText: 退出 Rancher Desktop
+        # @source Failed to restore snapshot '<b>'{snapshot}'</b>'.'<br/><br/>'Rancher Desktop has performed a Factory Reset and will now exit. Please try to address the issue that led to this error before restarting Rancher Desktop and attempting to restore the snapshot again.
+        description: 快照 '<b>'{snapshot}'</b>' 恢复失败。'<br/><br/>'Rancher Desktop 已执行恢复出厂设置并将立即退出。请在重新启动 Rancher Desktop 并再次尝试恢复快照之前，先解决导致此错误的问题。
+        # @source Error restoring snapshot
+        header: 恢复快照时出错
+      # @reason dialog header asking for confirmation before restoring snapshot
+      # @source Restore snapshot?
+      header: 还原快照？
+      # @reason explains consequences of restoring: replaces installation and prefs, closes Preferences window, discards unsaved changes
+      # @source Restoring this snapshot will replace your current installation, including preferences. If the Preferences window is open, it will be automatically closed and any unsaved changes will be discarded.
+      info: 还原此快照将替换您当前的安装内容，包括偏好设置。如果"偏好设置"窗口已打开，它将自动关闭，所有未保存的更改将被丢弃。
+    restoring:
+      actions:
+        # @reason cancel button label in the "restoring in progress" dialog
+        # @source Cancel
+        cancel: 取消
+      # @source Restoring {snapshot}
+      header: 正在恢复 {snapshot}
+      # @source Please wait while snapshot '<b>'{snapshot}'</b>' is being restored. This may take some time depending on your machine's resources.<br/><br/>Rancher Desktop will be temporarily unavailable during this operation. Once completed, the VM will restart with the {snapshot} snapshot active.
+      message: 正在恢复快照 '<b>'{snapshot}'</b>'，请稍候。此操作可能需要一些时间，具体取决于您的计算机资源。<br/><br/>在此期间 Rancher Desktop 将暂时不可用。完成后，虚拟机将使用快照 {snapshot} 重新启动。
+    # @source Show logs
+    showLogs: 显示日志
+  empty:
+    # @source Click on Create Snapshot to get started
+    body: 点击"创建快照"开始
+    # @source No snapshots found
+    heading: 未找到快照
+    # @reason icon identifier, not translatable text
+    # @source icon-search
+    icon: icon-search
+  info:
+    create:
+      # @reason notification that snapshot creation was cancelled; {snapshot} is the snapshot name
+      # @source Cancelled creation of {snapshot}
+      cancel: 已取消创建 {snapshot}
+      # @reason success notification for snapshot creation; HTML bold tags preserved
+      # @source Created '<b>'{snapshot}'</b>'
+      success: 已创建 '<b>'{snapshot}'</b>'
+    delete:
+      # @reason error notification for snapshot deletion; {error} is the error message
+      # @source Delete error: {error}
+      error: 删除错误：{error}
+      # @reason success notification for snapshot deletion; HTML bold tags preserved
+      # @source Deleted '<b>'{snapshot}'</b>'
+      success: 已删除 '<b>'{snapshot}'</b>'
+    lock:
+      # @reason info message about a stale lock file; rdctl and code tag preserved; rdctl snapshot unlock is a command kept in English
+      # @source A snapshot lock file has been detected for an unusually long time. If you believe this is an error, you can try to remove the lock file by running <code>rdctl snapshot unlock</code>.
+      info: 已检测到快照锁定文件持续时间异常。如果您认为这是错误，可以运行 <code>rdctl snapshot unlock</code> 尝试删除该锁定文件。
+    restore:
+      # @reason notification that snapshot restoration was cancelled; {snapshot} is the snapshot name
+      # @source Cancelled restoration of {snapshot}
+      cancel: 已取消还原 {snapshot}
+      # @reason success notification for snapshot restoration; HTML bold tags preserved
+      # @source Restored '<b>'{snapshot}'</b>'
+      success: 已还原 '<b>'{snapshot}'</b>'
+    # @source  at {time}
+    when: ' 于 {time}'
+  # @source Snapshots
+  title: 快照
+sortableTable:
+  actionAvailability:
+    # @source {actionable} selected
+    selected: 已选择 {actionable} 项
+    # @source Available for {actionable} of the {total} selected
+    some: 一共有 {total} 项，符合条件的有 {actionable} 项
+  # @source Add
+  add: 添加
+  # @source Add Filter
+  addFilter: 添加过滤器
+  bulkActions:
+    collapsed:
+      # @source Actions
+      label: 操作
+  # @source Filter for...
+  filterFor: 过滤条件...
+  # @source in
+  in: 在
+  # @source No actions available
+  noActions: 没有可用操作
+  # @source There are no rows which match your search query.
+  noData: 没有匹配项
+  # @source There are no rows to show.
+  noRows: 没有内容显示
+  paging:
+    # @reason Chinese has no plural forms; the inner plural keeps ICU structure parity with identical branches
+    # @source {pages, plural,
+    # @source =0 {No Items}
+    # @source =1 {{count} {count, plural, =1 {Item} other {Items}}}
+    # @source other {{from} - {to} of {count} Items}}
+    generic: |-
+        {pages, plural,
+        =0 {无项目}
+        =1 {{count}{count, plural, =1 {项} other {项}}}
+        other {{count}项中的第{from} - {to}项}}
+  # @source Reset
+  resetFilters: 重置
+  # @reason placeholder of the table filter box (en source is Filter despite the key name); 过滤 matches addFilter/filterFor terminology
+  # @source Filter
+  search: 过滤
+  # @source Select a column
+  selectCol: 选择列
+  tableHeader:
+    # @source Group by
+    groupBy: 分组依据
+    # @source This column cannot be filtered
+    noFilter: 此列无法用于过滤
+    # @source Show
+    show: 显示
+sudoPrompt:
+  # @source Always run without administrative access
+  alwaysRunWithout: 始终在无管理员权限的情况下运行
+  # @source OK
+  buttonText: 确定
+  # @source This will modify the following paths:
+  explanation: 此操作将修改以下路径：
+  # @source Rancher Desktop requires administrative access ("sudo access") for the following reasons:
+  message: Rancher Desktop 需要管理员权限（"sudo 权限"），原因如下：
+  # @source The prompt will be displayed once this window is closed. Cancelling the prompt or disabling administrative access requires you to switch the docker context to rancher-desktop in order to continue using Rancher Desktop.
+  messageSecondPart: 此窗口关闭后将显示权限提示。取消提示或禁用管理员权限后，您需要将 docker context 切换到 rancher-desktop 才能继续使用 Rancher Desktop。
+  reasons:
+    dockerSocket:
+      # @reason describes why docker socket sudo permission is needed; "docker" and "docker contexts" kept in English
+      # @source Provides compatibility with tools that use the docker socket without the ability to use docker contexts.
+      description: 为不支持 docker contexts 的工具提供与 docker socket 的兼容性。
+      # @reason short title for docker socket sudo prompt item
+      # @source Set up default docker socket
+      title: 设置默认 docker socket
+    networking:
+      # @reason describes why networking sudo permission is needed; explains fallback to port forwarding
+      # @source Provides bridged networking so that it is easier to access your containers. If this is not allowed, containers will only be accessible via port forwarding.
+      description: 提供桥接网络，以便更轻松地访问容器。如果不允许此操作，容器将只能通过端口转发访问。
+      # @reason short title for networking sudo prompt item
+      # @source Configure networking
+      title: 配置网络
+  # @source Administrative Access Required
+  title: 需要管理员权限
+systemPreferences:
+  # @source # CPUs
+  cpus: CPU 数量
+  # @source Memory (GB)
+  memory: 内存 (GB)
+telemetryOptIn:
+  # @source Send anonymized usage info, error reports, etc. to help improve Rancher Desktop. Your data will not be shared with anyone else, and no information about what specific resources or endpoints you are deploying is included.
+  fineprint: 发送匿名使用信息、错误报告等，帮助改进 Rancher Desktop。您的数据不会与任何第三方共享，也不会包含您所部署的具体资源或端点信息。
+tray:
+  # @source Container engine: {name}
+  containerEngine: 容器引擎：{name}
+  # @source Kubernetes Contexts
+  kubernetesContexts: Kubernetes 上下文
+  # @source Network status: {status}
+  networkStatus: 网络状态：{status}
+  # @source None found
+  noneFound: 未找到
+  # @source Open cluster dashboard
+  openDashboard: 打开集群仪表板
+  # @source Open main window
+  openMainWindow: 打开主窗口
+  # @source Open preferences dialog
+  openPreferences: 打开偏好设置
+  # @source Quit Rancher Desktop
+  quitRancherDesktop: 退出 Rancher Desktop
+  state:
+    # @source Kubernetes is disabled
+    disabled: Kubernetes 已禁用
+    # @source Kubernetes has encountered an error
+    error: Kubernetes 遇到错误
+    # @source Kubernetes is running
+    started: Kubernetes 正在运行
+    # @source Kubernetes is starting
+    starting: Kubernetes 正在启动
+    # @source Kubernetes is stopped
+    stopped: Kubernetes 已停止
+    # @source Kubernetes is shutting down
+    stopping: Kubernetes 正在关闭
+  # @reason product name
+  # @source Rancher Desktop
+  tooltip: Rancher Desktop
+troubleshooting:
+  # @source Enable debug mode
+  debugMode: 启用调试模式
+  general:
+    factoryReset:
+      # @source Factory Reset
+      buttonText: 恢复出厂设置
+      # @source Factory Reset will remove all Rancher Desktop Configurations.
+      description: 恢复出厂设置将移除所有 Rancher Desktop 配置。
+      messageBox:
+        # @source Cancel
+        cancel: 取消
+        # @source Keep cached Kubernetes images
+        checkboxLabel: 保留已缓存的 Kubernetes 镜像
+        # @source <p>Doing a factory reset will remove your cluster and all Rancher Desktop settings, and shut down Rancher Desktop. If you intend to continue using Rancher Desktop, you will need to manually start it and go through the initial set up again.</p><p>Are you sure you want to reset everything?</p>
+        detail: <p>恢复出厂设置将移除您的集群和所有 Rancher Desktop 设置，并关闭 Rancher Desktop。如果您打算继续使用 Rancher Desktop，需要手动启动并重新完成初始设置。</p><p>确定要重置所有内容吗？</p>
+        # @source Perform a factory reset?
+        message: 执行恢复出厂设置？
+        # @source Factory Reset
+        ok: 恢复出厂设置
+        # @source Rancher Desktop - Factory Reset
+        title: Rancher Desktop - 恢复出厂设置
+      # @source Factory Reset
+      title: 恢复出厂设置
+    logs:
+      # @source Show Logs
+      buttonText: 显示日志
+      # @source Show Rancher Desktop logs
+      description: 显示 Rancher Desktop 日志
+      # @source Logs
+      title: 日志
+  kubernetes:
+    resetKubernetes:
+      # @source Reset Kubernetes
+      buttonText: 重置 Kubernetes
+      # @source Resetting Kubernetes will delete all workloads and configuration.
+      description: 重置 Kubernetes 将删除所有工作负载和配置。
+      messageBox:
+        # @source Cancel
+        cancel: 取消
+        # @source Delete container images
+        checkboxLabel: 删除容器镜像
+        # @source Reset Kubernetes?
+        message: 重置 Kubernetes？
+        # @source Reset
+        ok: 重置
+        # @source Rancher Desktop - Reset Kubernetes
+        title: Rancher Desktop - 重置 Kubernetes
+      # @source Reset Kubernetes
+      title: 重置 Kubernetes
+  # @source Still having problems? Start a discussion in the <b>#rancher-desktop</b> channel on the <a href="https://slack.rancher.io/">Rancher Users Slack</a> or <a href="https://github.com/rancher-sandbox/rancher-desktop/issues">Report an Issue</a>.
+  needHelp: 仍有问题？请在 <a href="https://slack.rancher.io/">Rancher Users Slack</a> 的 <b>#rancher-desktop</b> 频道发起讨论，或<a href="https://github.com/rancher-sandbox/rancher-desktop/issues">报告问题</a>。
+  # @source Troubleshooting
+  title: 故障排除
+unmetPrerequisites:
+  # @source Please ensure all requirements are met and try again. Rancher Desktop will now close.
+  action: 请确保满足所有前提条件后重试。Rancher Desktop 将立即关闭。
+  # @source OK
+  buttonText: 确定
+  # @source Rancher Desktop cannot start because requirements are missing or not configured:
+  message: Rancher Desktop 无法启动，因为缺少必要条件或配置不正确：
+  # @source Rancher Desktop is unable to start
+  title: Rancher Desktop 无法启动
+updateStatus:
+  # @source Applying update...
+  applyingUpdate: 正在应用更新...
+  # @source An update to version {version} is available
+  available: 版本 {version} 的更新可用
+  # @source Check for updates automatically
+  checkForUpdates: 自动检查更新
+  # @source downloading... ({percent}%, {speed})
+  downloading: 正在下载... ({percent}%, {speed})
+  # @source There was an error checking for updates.
+  errorChecking: 检查更新时出错。
+  # @source Release Notes
+  releaseNotes: 发行说明
+  # @source Restart Now
+  restartNow: 立即重启
+  # @source Restart the application to apply the update.
+  restartToApply: 重启应用程序以应用更新。
+  unsupported:
+    # @source A newer version of Rancher Desktop is available, but not supported on your system.
+    message: Rancher Desktop 有新版本可用，但您的系统不支持该版本。
+    # @source For more information please see <a href="https://docs.rancherdesktop.io/getting-started/installation">the installation documentation</a>.
+    seeDocumentation: 如需了解更多信息，请参阅<a href="https://docs.rancherdesktop.io/getting-started/installation">安装文档</a>。
+    # @source Latest Version Not Supported
+    title: 不支持最新版本
+  # @source Update Available
+  updateAvailable: 有可用更新
+validation:
+  # @source Cannot decrease "{field}" from {from} to {to}
+  cannotDecrease: 无法将"{field}"从 {from} 减小到 {to}
+  # @source Cannot enable WebAssembly with classic storage for moby.
+  cannotEnableWasmClassic: 无法在 moby 经典存储模式下启用 WebAssembly。
+  # @source Cannot switch to classic storage for moby when WebAssembly is enabled.
+  cannotSwitchClassicWasm: 启用 WebAssembly 时无法切换到 moby 的经典存储模式。
+  # @source Cannot switch to moby container engine with classic storage when WebAssembly is enabled.
+  cannotSwitchMobyClassicWasm: 启用 WebAssembly 时无法切换到使用经典存储的 moby 容器引擎。
+  # @source field "{field}" has duplicate entries: "{duplicates}"
+  duplicateEntries: 字段"{field}"存在重复条目："{duplicates}"
+  # @source Errors in proposed settings:
+  errorsInProposedSettings: 建议的设置中存在错误：
+  # @source field "{field}" is locked
+  fieldLocked: 字段"{field}"已锁定
+  # @source {field}: "{pattern}" does not describe an image reference
+  invalidImageReference: '{field}："{pattern}"不是有效的镜像引用'
+  # @source {field}: "{value}" is not a valid mapping
+  invalidMapping: '{field}："{value}"不是有效的映射'
+  # @source field "{field}" has invalid entries (must be IP addresses, CIDR subnets, or domain names): "{entries}"
+  invalidNoproxyEntries: 字段"{field}"包含无效条目（必须为 IP 地址、CIDR 子网或域名）："{entries}"
+  # @source {field}: "{name}" is an invalid name
+  invalidName: '{field}："{name}"是无效的名称'
+  # @source {field}: "{value}" is not a valid page name for Preferences Dialog
+  invalidPageName: '{field}："{value}"不是偏好设置对话框的有效页面名称'
+  # @source {field}: tab name "{tabName}" is not a valid tab name for "{page}" Preference page
+  invalidTabName: '{field}：标签页名称"{tabName}"不是"{page}"偏好设置页面的有效标签页名称'
+  # @source {field}: "{name}" has invalid tag "{tag}"
+  invalidTag: '{field}："{name}"的标签"{tag}"无效'
+  # @source Invalid value for "{field}": <{value}>
+  invalidValue: '"{field}"的值无效：<{value}>'
+  # @source Invalid value for "{field}": <{value}>; must be one of {validValues}
+  invalidValueEnum: '"{field}"的值无效：<{value}>；必须是以下之一：{validValues}'
+  # @source Kubernetes version "{version}" not found.
+  kubernetesVersionNotFound: 未找到 Kubernetes 版本"{version}"。
+  # @source {field}: "{name}" has non-string tag "{tag}"
+  nonStringTag: '{field}："{name}"的标签"{tag}"不是字符串'
+  # @source Changing field "{field}" via the API isn't supported.
+  notSupported: 不支持通过 API 更改字段"{field}"。
+  # @source Error for field ''{field}'': expecting value of type array, got ''{value}''
+  profileExpectedArray: 字段 ''{field}'' 出错：期望类型为 array，得到 ''{value}''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got ''{value}''
+  profileExpectedType: 字段 ''{field}'' 出错：期望类型为 {expectedType}，得到 ''{value}''
+  # @source Error for field ''{field}'': expecting value of type {expectedType}, got an array {value}
+  profileExpectedTypeGotArray: 字段 ''{field}'' 出错：期望类型为 {expectedType}，得到数组 {value}
+  # @source Proposed field "{field}" should be an object, got <{value}>.
+  proposedShouldBeObject: 提议的字段"{field}"应为对象，得到 <{value}>。
+  # @source Setting {field} can only be enabled on aarch64 systems.
+  requiresArm: 设置 {field} 仅可在 aarch64 系统上启用。
+  # @source Setting {field} can only be changed when virtualMachine.mount.type is "{mountType}".
+  requiresNineP: 设置 {field} 仅可在 virtualMachine.mount.type 为"{mountType}"时更改。
+  # @source Setting {field} can only be enabled when virtual-machine.type is "{vmType}".
+  requiresVz: 设置 {field} 仅可在 virtual-machine.type 为"{vmType}"时启用。
+  # @source Setting {field} can only be set when experimental.container-engine.web-assembly.enabled is set as well.
+  requiresWebAssembly: 设置 {field} 时还需启用 experimental.container-engine.web-assembly.enabled。
+  # @source Setting {field} to "{value}" requires that {otherField} is "{required}".
+  settingRequires: 将 {field} 设置为"{value}"需要 {otherField} 为"{required}"。
+  # @source Setting {field} to "{value}" requires that {otherField} is "{option1}" or "{option2}".
+  settingRequiresEither: 将 {field} 设置为"{value}"需要 {otherField} 为"{option1}"或"{option2}"。
+  # @source Setting "{field}" should wrap an inner object, but got <{value}>.
+  shouldBeObject: 设置"{field}"应包含内部对象，但得到 <{value}>。
+  # @source Setting "{field}" should be a simple value, but got <{value}>.
+  shouldBeSimple: 设置"{field}"应为简单值，但得到 <{value}>。
+  # @source One or more fields in this tab contain a form validation error
+  tab: 此标签页中有一个或多个字段存在验证错误
+  # @source Setting {field} to "{vmType}" on ARM requires macOS 13.3 (Ventura) or later.
+  vzArmMacOs: 在 ARM 上将 {field} 设置为"{vmType}"需要 macOS 13.3 (Ventura) 或更高版本。
+  # @source Setting {field} to "{vmType}" on Intel requires macOS 13.0 (Ventura) or later.
+  vzIntelMacOs: 在 Intel 上将 {field} 设置为"{vmType}"需要 macOS 13.0 (Ventura) 或更高版本。
+virtualMachine:
+  mount:
+    type:
+      # @source Mount Type
+      legend: 挂载类型
+      options:
+        9p:
+          # @reason describes 9p mount type using QEMU virtio device; QEMU and virtio-9p-pci are technical identifiers kept as-is
+          # @source Exposes the filesystem by using QEMU's virtio-9p-pci devices.
+          description: 通过 QEMU 的 virtio-9p-pci 设备公开文件系统。
+          # @reason label for 9p mount option; technical identifier kept as-is
+          # @source 9p
+          label: 9p
+          options:
+            cacheMode:
+              # @source Cache Mode
+              legend: 缓存模式
+              options:
+                # @reason technical identifier for cache mode option; kept as-is per rules
+                # @source fscache
+                fscache: fscache
+                # @reason technical identifier for cache mode option; kept as-is per rules
+                # @source loose
+                loose: loose
+                # @reason technical identifier for cache mode option; kept as-is per rules
+                # @source mmap
+                mmap: mmap
+                # @reason technical identifier for cache mode option; kept as-is per rules
+                # @source none
+                none: none
+              # @source Caching policy to be used
+              tooltip: 使用的缓存策略
+            mSizeInKib:
+              # @source Message Size In KiB
+              legend: 消息大小 (KiB)
+              # @source Maximum message size in KiB
+              tooltip: 最大消息大小 (KiB)
+            protocolVersion:
+              # @source Protocol Version
+              legend: 协议版本
+              options:
+                # @reason technical identifier for protocol version; kept as-is per rules
+                # @source 9p2000
+                9p2000: 9p2000
+                # @reason technical identifier for protocol version; kept as-is per rules
+                # @source 9p2000.L
+                9p2000L: 9p2000.L
+                # @reason technical identifier for protocol version; kept as-is per rules
+                # @source 9p2000.u
+                9p2000u: 9p2000.u
+              # @source 9P protocol version
+              tooltip: 9P 协议版本
+            securityModel:
+              # @source Security Model
+              legend: 安全模型
+              options:
+                # @reason technical identifier for security model option; kept as-is per rules
+                # @source mapped-file
+                mapped-file: mapped-file
+                # @reason technical identifier for security model option; kept as-is per rules
+                # @source mapped-xattr
+                mapped-xattr: mapped-xattr
+                # @reason technical identifier for security model option; kept as-is per rules
+                # @source none
+                none: none
+                # @reason technical identifier for security model option; kept as-is per rules
+                # @source passthrough
+                passthrough: passthrough
+              # @source Security model used for the export path
+              tooltip: 用于导出路径的安全模型
+        reverse-sshfs:
+          # @reason describes reverse-sshfs mount type using an SFTP server; SFTP kept in English
+          # @source Exposes the filesystem by running an SFTP server.
+          description: 通过运行 SFTP 服务器公开文件系统。
+          # @reason label for reverse-sshfs mount option; technical identifier kept as-is
+          # @source reverse-sshfs
+          label: reverse-sshfs
+        virtiofs:
+          # @reason describes virtiofs mount type using Apple Virtualization framework; "Apple Virtualization" kept in English
+          # @source Exposes the filesystem by using an Apple Virtualization framework shared directory device.
+          description: 通过 Apple Virtualization 框架共享目录设备公开文件系统。
+          # @reason label for virtiofs mount option; technical identifier kept as-is
+          # @source virtiofs
+          label: virtiofs
+  proxy:
+    # @source Address
+    address: 地址
+    # @source Proxy address
+    addressTitle: 代理地址
+    # @source Authentication information
+    authTitle: 身份验证信息
+    # @source Enable the proxy used by rancher-desktop
+    label: 启用 rancher-desktop 使用的代理
+    # @source WSL Proxy
+    legend: WSL 代理
+    noproxy:
+      errors:
+        # @source This item is a duplicate.
+        duplicate: 此条目重复。
+      # @source Proxy bypass list
+      legend: 不使用代理的主机名列表
+      # @source IP, CIDR, domain, or wildcard (*.example.com) to bypass the proxy
+      placeholder: 不通过代理访问的主机名
+    # @source Password
+    password: 密码
+    # @source Port
+    port: 端口
+    # @source Username
+    username: 用户名
+  type:
+    # @source Virtual Machine Type
+    legend: 虚拟机类型
+    options:
+      qemu:
+        # @reason describes QEMU emulator option; QEMU kept in English
+        # @source Use the QEMU emulator.
+        description: 使用 QEMU 模拟器。
+        # @reason label for QEMU VM type option; technical identifier kept in English
+        # @source QEMU
+        label: QEMU
+      vz:
+        # @reason describes Apple Virtualization framework option; "Apple Virtualization" kept in English
+        # @source Use the Apple Virtualization framework.
+        description: 使用 Apple Virtualization 框架。
+        # @reason label for VZ VM type option; technical identifier kept in English
+        # @source VZ
+        label: VZ
+  useRosetta:
+    # @source Enable Rosetta support
+    label: 启用 Rosetta 支持
+    # @source VZ Option
+    legend: VZ 选项
+volumes:
+  files:
+    # @source Available
+    available: 可用
+    # @source Error checking volume status
+    checkError: 检查卷状态时出错
+    # @source Invalid volume name "{name}"
+    invalidVolumeName: 无效的卷名称"{name}"
+    # @source Error listing files: {error}
+    listError: 列出文件时出错：{error}
+    # @source Loading volume files...
+    loading: 正在加载卷文件...
+    # @source This volume is empty
+    noFiles: 此卷为空
+    # @source Not Found
+    notFound: 未找到
+    table:
+      header:
+        # @source Modified
+        modified: 修改时间
+        # @source Name
+        name: 名称
+        # @source Permissions
+        permissions: 权限
+        # @source Size
+        size: 大小
+    # @source Volume Files
+    title: 卷文件
+    # @source Volume "{name}" not found
+    volumeNotFound: 未找到卷"{name}"
+  manage:
+    table:
+      header:
+        # @source Created
+        created: 创建时间
+        # @source Driver
+        driver: 驱动
+        # @source Mount Point
+        mountpoint: 挂载点
+        # @source Volume Name
+        volumeName: 卷名称
+  manager:
+    table:
+      action:
+        # @source Browse Files
+        browse: 浏览文件
+        # @source Delete
+        delete: 删除
+  sortableTables:
+    # @source There are no volumes to show
+    noRows: 没有可显示的卷
+  # @source Volumes
+  title: 卷
+webAssembly:
+  # @source Please read the documentation before enabling the experimental WebAssembly feature!
+  description: 启用实验性 WebAssembly 功能前请先阅读文档！
+  # @source Enabled
+  enabled: 已启用
+  # @reason technology name; kept as-is in Chinese documentation
+  # @source WebAssembly (Wasm)
+  label: WebAssembly (Wasm)

--- a/pkg/rancher-desktop/assets/translations/zh-hans.yaml
+++ b/pkg/rancher-desktop/assets/translations/zh-hans.yaml
@@ -877,6 +877,8 @@ locale:
   # @reason locale name for English
   # @source English
   en-us: 英语
+  # @source French
+  fr: 法语
   # @reason locale name for Simplified Chinese - using the Chinese name per rules for locale names
   # @source Chinese (Simplified)
   zh-hans: 简体中文

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'pt-br' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'ja' | 'pt-br' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'it' | 'ja' | 'pt-br' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us';
+export type Locale = 'de' | 'en-us' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'pt-br' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'ja' | 'pt-br' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -56,6 +56,9 @@ export enum Theme {
   DARK = 'dark',
 }
 
+/** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
+export type Locale = 'de' | 'en-us';
+
 export class SettingsError extends Error {
   toString() {
     // This is needed on linux. Without it, we get a randomish replacement
@@ -84,7 +87,7 @@ export const defaultSettings = {
     autoStart:              false,
     startInBackground:      false,
     hideNotificationIcon:   false,
-    locale:                 'none',
+    locale:                 'en-us' as Locale,
     window:                 { quitOnClose: false },
     theme:                  Theme.SYSTEM,
   },

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'fr' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'fr' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/config/settings.ts
+++ b/pkg/rancher-desktop/config/settings.ts
@@ -57,7 +57,7 @@ export enum Theme {
 }
 
 /** Locales with a bundled translation file; keep in sync with the enum in command-api.yaml. */
-export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'it' | 'ja' | 'pt-br' | 'zh-hans';
+export type Locale = 'de' | 'en-us' | 'es' | 'fr' | 'it' | 'ja' | 'ko' | 'pt-br' | 'zh-hans';
 
 export class SettingsError extends Error {
   toString() {

--- a/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 
-import { availableLocales, t } from '@pkg/main/i18n';
+import { availableLocales, initMainI18n, onLocaleChange, t } from '@pkg/main/i18n';
+import mainEvents from '@pkg/main/mainEvents';
 
 describe('main-process i18n', () => {
   it('translates from the default locale', () => {
@@ -33,6 +34,32 @@ describe('main-process i18n', () => {
   });
 
   it('lists the bundled locales', () => {
-    expect(availableLocales).toEqual(expect.arrayContaining(['en-us']));
+    expect(availableLocales).toEqual(expect.arrayContaining(['en-us', 'de']));
+  });
+
+  it('switches locale on settings-update and notifies callbacks', async() => {
+    await initMainI18n();
+    const changed = new Promise<void>((resolve) => {
+      const off = onLocaleChange(() => {
+        off();
+        resolve();
+      });
+    });
+
+    mainEvents.emit('settings-update', { application: { locale: 'de' } } as any);
+    await changed;
+
+    expect(t('generic.cancel')).toEqual('Abbrechen');
+    const reverted = new Promise<void>((resolve) => {
+      const off = onLocaleChange(() => {
+        off();
+        resolve();
+      });
+    });
+
+    mainEvents.emit('settings-update', { application: { locale: 'en-us' } } as any);
+    await reverted;
+
+    expect(t('generic.cancel')).toEqual('Cancel');
   });
 });

--- a/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/i18n.spec.ts
@@ -34,7 +34,7 @@ describe('main-process i18n', () => {
   });
 
   it('lists the bundled locales', () => {
-    expect(availableLocales).toEqual(expect.arrayContaining(['en-us', 'de']));
+    expect(availableLocales).toEqual(expect.arrayContaining(['en-us', 'de', 'zh-hans']));
   });
 
   it('switches locale on settings-update and notifies callbacks', async() => {

--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -470,7 +470,7 @@ describe('SettingsValidator', () => {
       const [needToUpdate, errors] = subject.validateSettings({
         ...cfg,
         application: { ...cfg.application, locale: 'en-us' },
-      }, { application: { locale: 'none' } });
+      }, { application: { locale: 'de' } });
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: true,
@@ -480,7 +480,7 @@ describe('SettingsValidator', () => {
 
     it('should accept no-op changes', () => {
       const [needToUpdate, errors] = subject.validateSettings(cfg,
-        { application: { locale: 'none' } });
+        { application: { locale: 'en-us' } });
 
       expect({ needToUpdate, errors }).toEqual({
         needToUpdate: false,

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -101,7 +101,7 @@ export default class SettingsValidator {
         autoStart:              this.checkBoolean,
         startInBackground:      this.checkBoolean,
         hideNotificationIcon:   this.checkBoolean,
-        locale:                 this.checkEnum('none', ...availableLocales),
+        locale:                 this.checkEnum(...availableLocales),
         window:                 { quitOnClose: this.checkBoolean },
         theme:                  this.checkEnum('system', 'light', 'dark'),
       },

--- a/pkg/rancher-desktop/main/i18n.ts
+++ b/pkg/rancher-desktop/main/i18n.ts
@@ -131,9 +131,7 @@ export function onLocaleChange(callback: () => void): () => void {
 export async function initMainI18n(): Promise<void> {
   try {
     const settings = await mainEvents.invoke('settings-fetch');
-    // 'none' means the language selector is disabled; use English.
-    const raw = settings?.application?.locale;
-    const locale = (!raw || raw === 'none') ? 'en-us' : raw;
+    const locale = settings?.application?.locale || 'en-us';
 
     if (locale !== currentLocale && loadLocale(locale)) {
       currentLocale = locale;
@@ -144,8 +142,7 @@ export async function initMainI18n(): Promise<void> {
   }
 
   mainEvents.on('settings-update', (settings) => {
-    const raw = settings?.application?.locale;
-    const locale = (!raw || raw === 'none') ? 'en-us' : raw;
+    const locale = settings?.application?.locale || 'en-us';
 
     if (locale !== currentLocale) {
       if (!loadLocale(locale)) {

--- a/pkg/rancher-desktop/store/i18n.js
+++ b/pkg/rancher-desktop/store/i18n.js
@@ -186,10 +186,8 @@ export const actions = {
       ipcListenersBound = true;
 
       // Listen for settings changes (from preferences UI or rdctl) to sync locale.
-      // 'none' means the language selector is disabled; use the default locale.
       ipcRenderer.on('settings-update', (_, settings) => {
-        const raw = settings?.application?.locale;
-        const locale = (!raw || raw === 'none') ? state.default : raw;
+        const locale = settings?.application?.locale || state.default;
 
         if ( locale !== state.selected ) {
           dispatch('switchTo', locale);
@@ -209,7 +207,7 @@ export const actions = {
   },
 
   async switchTo({ state, commit, dispatch }, locale) {
-    if ( !locale || locale === 'none' ) {
+    if ( !locale ) {
       locale = state.default;
     }
 

--- a/src/go/i18n-report/report_check.go
+++ b/src/go/i18n-report/report_check.go
@@ -156,9 +156,8 @@ func reportCheckRegistration(w io.Writer, root string, locales []string) error {
 		return err
 	}
 
-	// The expected enum: "none" (no language selected), the source locale,
-	// and every translation file on disk.
-	expected := map[string]bool{"none": true, sourceLocale: true}
+	// The expected enum: the source locale and every translation file on disk.
+	expected := map[string]bool{sourceLocale: true}
 	for _, code := range locales {
 		expected[code] = true
 	}

--- a/src/go/i18n-report/report_check_test.go
+++ b/src/go/i18n-report/report_check_test.go
@@ -166,9 +166,9 @@ func writeCrossValidationFiles(t *testing.T, dir string, apiEnum string, validat
 	// settingsValidator.ts
 	validatorDir := filepath.Join(dir, "pkg", "rancher-desktop", "main", "commandServer")
 	os.MkdirAll(validatorDir, 0o755)
-	validatorContent := "locale: this.checkEnum('none', 'de'),\n"
+	validatorContent := "locale: this.checkEnum('de'),\n"
 	if validatorDynamic {
-		validatorContent = "locale: this.checkEnum('none', ...availableLocales),\n"
+		validatorContent = "locale: this.checkEnum(...availableLocales),\n"
 	}
 	os.WriteFile(filepath.Join(validatorDir, "settingsValidator.ts"), []byte(validatorContent), 0o644)
 
@@ -200,7 +200,7 @@ func checkRegistration(t *testing.T, dir string) error {
 
 func TestCheckRegistrationMatch(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
-	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+	writeCrossValidationFiles(t, dir, "de, en-us", true,
 		"{ application: { locale: 'en-us' } }, { application: { locale: 'de' } }")
 
 	if err := checkRegistration(t, dir); err != nil {
@@ -212,7 +212,7 @@ func TestCheckRegistrationMissingFromEnum(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml", "fa.yaml"})
 
 	// The API enum is missing "fa".
-	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+	writeCrossValidationFiles(t, dir, "de, en-us", true,
 		"{ application: { locale: 'de' } }")
 
 	err := checkRegistration(t, dir)
@@ -224,11 +224,23 @@ func TestCheckRegistrationMissingFromEnum(t *testing.T) {
 	}
 }
 
+func TestCheckRegistrationRejectsNone(t *testing.T) {
+	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
+
+	// "none" is not a locale; the enum must list translation files only.
+	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+		"{ application: { locale: 'de' } }")
+
+	if err := checkRegistration(t, dir); err == nil {
+		t.Error(`registration checks should fail when the enum still lists "none"`)
+	}
+}
+
 func TestCheckRegistrationEnumWithoutFile(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
 
 	// The API enum lists "fa", but fa.yaml does not exist.
-	writeCrossValidationFiles(t, dir, "none, de, en-us, fa", true,
+	writeCrossValidationFiles(t, dir, "de, en-us, fa", true,
 		"{ application: { locale: 'de' } }")
 
 	if err := checkRegistration(t, dir); err == nil {
@@ -240,7 +252,7 @@ func TestCheckRegistrationHardcodedValidator(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
 
 	// settingsValidator.ts uses a hardcoded list instead of ...availableLocales.
-	writeCrossValidationFiles(t, dir, "none, de, en-us", false,
+	writeCrossValidationFiles(t, dir, "de, en-us", false,
 		"{ application: { locale: 'de' } }")
 
 	if err := checkRegistration(t, dir); err == nil {
@@ -252,7 +264,7 @@ func TestCheckRegistrationSpecUnknownLocale(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml"})
 
 	// The spec references 'fr', which has no translation file.
-	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+	writeCrossValidationFiles(t, dir, "de, en-us", true,
 		"{ application: { locale: 'fr' } }")
 
 	if err := checkRegistration(t, dir); err == nil {
@@ -264,7 +276,7 @@ func TestCheckRegistrationMissingDisplayName(t *testing.T) {
 	dir := setupRegistrationTestRepo(t, []string{"de.yaml", "pt.yaml"})
 
 	// en-us.yaml has no locale.pt display name.
-	writeCrossValidationFiles(t, dir, "none, de, en-us, pt", true,
+	writeCrossValidationFiles(t, dir, "de, en-us, pt", true,
 		"{ application: { locale: 'de' } }")
 
 	if err := checkRegistration(t, dir); err == nil {
@@ -313,7 +325,7 @@ func setupCheckRepo(t *testing.T, referenced bool) string {
 		os.WriteFile(filepath.Join(compDir, "Sample.vue"), []byte(src), 0o644)
 	}
 
-	writeCrossValidationFiles(t, dir, "none, de, en-us", true,
+	writeCrossValidationFiles(t, dir, "de, en-us", true,
 		"{ application: { locale: 'de' } }")
 	return dir
 }


### PR DESCRIPTION
Eight locales for the extracted UI strings: German, Simplified Chinese, French, Spanish, Brazilian Portuguese, Japanese, Italian, and Korean. Each was produced through the i18n-report translate/merge workflow and carries `@source` snapshots plus `@reason` marks on values deliberately kept identical to English. Four keys fall back to English across every locale by design: two `progress.*`, `diagnostics.never`, and `troubleshooting.debugModeLockedTooltip`.