### PR TITLE
Sort the language picker by name

### DIFF
--- a/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
@@ -97,3 +97,58 @@ describe('i18n store getters', () => {
     expect(exists('no.such.key')).toBe(false);
   });
 });
+
+describe('availableLocales getter', () => {
+  const availableLocales = (state: unknown) => (i18n.getters as any).availableLocales(state);
+
+  // Codes whose alphabetical order differs from their labels', as in the real
+  // locale set: by code ja < ko < pt-br, by label Português < 한국어 < 日本語.
+  function scriptState(selected: string | null) {
+    return {
+      default:      'en-us',
+      selected,
+      available:    ['ja', 'ko', 'pt-br'],
+      translations: {
+        'en-us': {
+          locale: {
+            ja: 'Japanese', ko: 'Korean', 'pt-br': 'Portuguese (Brazilian)',
+          },
+        },
+        ja:      { locale: { ja: '日本語' } },
+        ko:      { locale: { ko: '한국어' } },
+        'pt-br': { locale: { 'pt-br': 'Português (Brasil)' } },
+      },
+    };
+  }
+
+  // German collates Ä with A, Swedish sorts it after Z.
+  function collationState(selected: string) {
+    return {
+      default:      'en-us',
+      selected,
+      available:    ['de', 'sv'],
+      translations: {
+        'en-us': { locale: { de: 'Zebra', sv: 'Äpfel' } },
+        de:      { locale: { de: 'Zebra' } },
+        sv:      { locale: { sv: 'Äpfel' } },
+      },
+    };
+  }
+
+  it('orders locales by label rather than by locale code', () => {
+    expect(Object.keys(availableLocales(scriptState('en-us')))).toEqual(['pt-br', 'ko', 'ja']);
+  });
+
+  it('collates in the selected locale', () => {
+    expect(Object.keys(availableLocales(collationState('de')))).toEqual(['sv', 'de']);
+    expect(Object.keys(availableLocales(collationState('sv')))).toEqual(['de', 'sv']);
+  });
+
+  it('collates with the default locale before a selection is made', () => {
+    expect(Object.keys(availableLocales(scriptState(null)))).toEqual(['pt-br', 'ko', 'ja']);
+  });
+
+  it('collates with the default locale when the selection is not a bundled locale', () => {
+    expect(Object.keys(availableLocales(scriptState('none')))).toEqual(['pt-br', 'ko', 'ja']);
+  });
+});

--- a/pkg/rancher-desktop/store/i18n.js
+++ b/pkg/rancher-desktop/store/i18n.js
@@ -25,21 +25,28 @@ export const state = function() {
 
 export const getters = {
   availableLocales(state) {
-    const out = {};
-
-    for ( const locale of state.available ) {
+    const labelled = state.available.map((locale) => {
       const nativeName = get(state.translations[locale], `locale.${ locale }`);
       const translatedName = get(state.translations[state.selected], `locale.${ locale }`) ??
                           get(state.translations[state.default], `locale.${ locale }`);
 
       if ( !nativeName || !translatedName || nativeName === translatedName ) {
-        out[locale] = nativeName ?? translatedName ?? locale;
-      } else {
-        out[locale] = `${ nativeName } (${ translatedName })`;
+        return [locale, nativeName ?? translatedName ?? locale];
       }
-    }
 
-    return out;
+      return [locale, `${ nativeName } (${ translatedName })`];
+    });
+
+    // Sort by the label the user reads, collated in the selected locale.
+    // Fall back to the default when the selection is not a bundled locale,
+    // because Intl.Collator rejects an unknown tag. The selection is null
+    // until init runs, and older settings can carry 'none'.
+    const collationLocale = state.available.includes(state.selected) ? state.selected : state.default;
+    const collator = new Intl.Collator(collationLocale);
+
+    labelled.sort(([, a], [, b]) => collator.compare(a, b));
+
+    return Object.fromEntries(labelled);
   },
 
   t: state => (key, args) => {


### PR DESCRIPTION
The picker order came from webpack's context module, which sorts the bundled YAML files by filename, so the list was ordered by locale code, a key the user never sees. Portuguese sat after the CJK entries for no visible reason.

Sort by the displayed label instead, collated in the selected locale so each language orders the list by its own rules. With English selected only two entries move: Português rises above 한국어 and 日本語.

Worth a reviewer's eye: collation follows the selected locale, so with 简体中文 selected ICU sorts the CJK names ahead of the Latin ones, and the list leads with 简体中文 instead of Deutsch. Intended, but a bigger visual change than the English case.
