### PR TITLE
screenshots: build the intro image by compositing screenshots

### DIFF
--- a/.github/workflows/screenshot.yaml
+++ b/.github/workflows/screenshot.yaml
@@ -128,9 +128,6 @@ jobs:
           if [[ $name =~ ^[0-9]+_ ]]; then
               name="${name#*_}"
           fi
-          if [[ name == "intro" ]]; then
-            continue
-          fi
           out="out/${window}/${platform}_${name}"
           mkdir -p "$(dirname "$out")"
           cp "$line" "$out"
@@ -138,11 +135,24 @@ jobs:
         done < <(find in -name '*.png' -print0)
     - name: Generate introduction image
       run: |
-        # The intro image consists of the mac image on the left and the Windows
-        # image on the right, each showing Kubernetes settings.
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install graphicsmagick # spellcheck-ignore-line
+        # Place the Preferences window (Kubernetes tab) over the main window, macOS
+        # on the left and Windows on the right.  Both windows are white, so give the
+        # Preferences window a drop shadow to separate them.
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install imagemagick # spellcheck-ignore-line
         mkdir -p out/getting-started
-        gm convert in/darwin/light/main/*_intro.png in/win32/light/main/*_intro.png +append out/getting-started/introduction_preferences_tabKubernetes.png
+        for platform in darwin win32; do
+          main=(in/"$platform"/light/main/*_General.png)
+          prefs=(in/"$platform"/light/preferences/*_kubernetes.png)
+          convert "${prefs[0]}" \( +clone -background black -shadow 55x12+0+9 \) \
+            +swap -background none -layers merge +repage "shadow-$platform.png"
+          convert "${main[0]}" "shadow-$platform.png" -gravity center -composite "half-$platform.png"
+        done
+        # The two captures differ slightly in height; scale the Windows half to the
+        # macOS height so they line up when joined.
+        height=$(identify -format '%h' half-darwin.png)
+        convert half-win32.png -resize "x$height" half-win32-scaled.png
+        convert half-darwin.png half-win32-scaled.png +append \
+          out/getting-started/introduction_preferences_tabKubernetes.png
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: screenshots.zip

--- a/screenshots/Screenshots.ts
+++ b/screenshots/Screenshots.ts
@@ -51,19 +51,19 @@ export class Screenshots {
     );
   }
 
-  protected async screenshot(title: string, includeAll = false) {
+  protected async screenshot(title: string) {
     const outPath = this.buildPath(title);
 
     try {
       switch (process.platform) {
       case 'darwin':
-        await this.screenshotDarwin(outPath, includeAll);
+        await this.screenshotDarwin(outPath);
         break;
       case 'win32':
-        await this.screenshotWindows(outPath, includeAll);
+        await this.screenshotWindows(outPath);
         break;
       default:
-        await this.screenshotLinux(outPath, includeAll);
+        await this.screenshotLinux(outPath);
       }
     } catch (e) {
       console.error('Failed to take screenshot', { error: e });
@@ -71,28 +71,24 @@ export class Screenshots {
     }
   }
 
-  protected async screenshotDarwin(outPath: string, includeAll: boolean) {
+  protected async screenshotDarwin(outPath: string) {
     const { stdout: windowId, stderr } = await spawnFile('GetWindowID', [this.appBundleTitle, this.windowTitle], { stdio: 'pipe' });
 
     if (!windowId) {
       throw new Error(`Failed to find window ID for ${ this.windowTitle }: ${ stderr || '(no stderr)' }`);
     }
-    const args = [...(includeAll ? [] : ['-a']), '-o', '-l', windowId.trim(), outPath];
 
-    await spawnFile('screencapture', args, { stdio: this.log });
+    await spawnFile('screencapture', ['-a', '-o', '-l', windowId.trim(), outPath], { stdio: this.log });
   }
 
-  protected async screenshotWindows(outPath: string, includeAll: boolean) {
+  protected async screenshotWindows(outPath: string) {
     const script = path.resolve(import.meta.dirname, 'screenshot.ps1');
-    const args = ['-ExecutionPolicy', 'Bypass', script, '-FilePath', outPath, '-Title', `'${ this.windowTitle }'`];
+    const args = ['-ExecutionPolicy', 'Bypass', script, '-FilePath', outPath, '-Title', `'${ this.windowTitle }'`, '-Foreground'];
 
-    if (!includeAll) {
-      args.push('-Foreground');
-    }
     await spawnFile('powershell.exe', args, { stdio: this.log });
   }
 
-  protected async screenshotLinux(outPath: string, includeAll: boolean) {
+  protected async screenshotLinux(outPath: string) {
     // Find the target window; note that this is a child window of the window
     // frame, so we can't use it directly.
     let windowId;
@@ -129,23 +125,14 @@ export class MainWindowScreenshots extends Screenshots {
     this.windowTitle = 'Rancher Desktop';
   }
 
-  async take(tabName: Parameters<NavPage['navigateTo']>[0], navPage?: NavPage, timeout?: number, includeAll?: boolean): Promise<void>;
-  async take(screenshotName: string, includeAll?: boolean): Promise<void>;
-  async take(name: string, navPageOrIncludeAll?: NavPage | boolean, timeout = 200, includeAll = false) {
-    let navPage: NavPage | undefined;
-
-    if (typeof navPageOrIncludeAll === 'boolean') {
-      includeAll = navPageOrIncludeAll;
-    } else {
-      navPage = navPageOrIncludeAll;
-    }
+  async take(name: Parameters<NavPage['navigateTo']>[0] | string, navPage?: NavPage, timeout = 200) {
     if (navPage) {
       await navPage.navigateTo(name as Parameters<NavPage['navigateTo']>[0]);
       await this.page.waitForTimeout(timeout);
     }
 
     await this.createScreenshotsDirectory();
-    await this.screenshot(name, includeAll);
+    await this.screenshot(name);
   }
 }
 

--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -625,36 +625,4 @@ test.describe.serial('Main App Test', () => {
       await prefScreenshot.take('kubernetes', 'lockedFields');
     });
   });
-
-  test('Intro Image', async({ colorScheme }) => {
-    await navPage.navigateTo('General');
-    const bounds = await navPage.page.evaluate(() => {
-      window.resizeTo(1024, 768);
-
-      return {
-        top: window.screenTop, left: window.screenLeft, width: window.outerWidth, height: window.outerHeight,
-      };
-    });
-
-    await navPage.preferencesButton.click();
-    await electronApp.waitForEvent('window', page => /preferences/i.test(page.url()));
-    const preferencesPage = electronApp.windows()[1];
-
-    await preferencesPage.evaluate((bounds) => {
-      const {
-        top, left, width, height,
-      } = bounds;
-
-      window.moveTo(left + (width - window.outerWidth) / 2, top + (height - window.outerHeight) / 2);
-    }, bounds);
-
-    try {
-      await preferencesPage.emulateMedia({ colorScheme });
-      await preferencesPage.waitForTimeout(250);
-      await preferencesPage.bringToFront();
-      await screenshot.take('intro', true);
-    } finally {
-      preferencesPage.close({ runBeforeUnload: true });
-    }
-  });
 });


### PR DESCRIPTION
The intro image stacks the Preferences window over the main window, which never captured cleanly on macOS. Both windows are white, and the only separator is the drop shadow. A window capture drops the shadow, and a screen capture that keeps it needs a screen-recording permission the CI runner cannot grant. So the docs kept reusing a years-old screenshot.

This composites the image instead from the General and Kubernetes screenshots we already capture, giving the Preferences window a synthetic drop shadow. It needs no screen capture, works on every platform, and drops the dedicated intro capture along with the now-unused capture machinery.

Fixes #6960.
