### PR TITLE
screenshots: show the stable Kubernetes version

### DIFF
--- a/screenshots/screenshots.e2e.spec.ts
+++ b/screenshots/screenshots.e2e.spec.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -30,6 +31,12 @@ const isWin = os.platform() === 'win32';
 const isMac = os.platform() === 'darwin';
 let console: Log;
 
+// A fresh install defaults to the oldest supported Kubernetes version so that a
+// later upgrade never forces a downgrade; show the current stable one instead.
+const stableKubernetesVersion: string = JSON.parse(
+  fs.readFileSync(path.resolve(import.meta.dirname, '..', 'resources', 'k3s-versions.json'), 'utf8'),
+).channels.stable;
+
 test.describe.serial('Main App Test', () => {
   let electronApp: ElectronApplication;
   let page: Page;
@@ -53,6 +60,7 @@ test.describe.serial('Main App Test', () => {
         allowedImages: { enabled: false, patterns: ['rancher/example'] },
         name:          ContainerEngine.MOBY,
       },
+      kubernetes:  { version: stableKubernetesVersion },
       diagnostics: { showMuted: true, mutedChecks: { MOCK_CHECKER: true } },
     });
 


### PR DESCRIPTION
A fresh install defaults to the oldest supported Kubernetes version, so a later upgrade never forces a data-losing downgrade. The docs screenshots inherited that floor (v1.25.16), which reads as if Rancher Desktop ships an ancient Kubernetes. This pins the version shown in the screenshots to the stable channel from the bundled version list (currently v1.36.2) instead.

Fixes #9635