### PR TITLE
Delete leftover downloaded updates on factory reset

### DIFF
--- a/bats/tests/containers/factory-reset.bats
+++ b/bats/tests/containers/factory-reset.bats
@@ -41,6 +41,7 @@ local_setup_file() {
 }
 @test 'factory-reset when Rancher Desktop is not running' {
     touch_updater_longhorn
+    stage_pending_update
     rdctl_factory_reset --verbose
 }
 
@@ -70,6 +71,10 @@ local_setup_file() {
 
 @test 'Verify updater-longhorn.json was deleted' {
     check_updater_longhorn_gone
+}
+
+@test 'Verify the staged update was deleted' {
+    check_pending_update_gone
 }
 
 @test 'Start Rancher Desktop 2' {
@@ -165,8 +170,6 @@ check_directories() {
         # So just assert on the other members of AppHome
         # TODO on macOS (not implemented by `rdctl factory-reset`)
         # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
-        # this one only exists after an update has been downloaded
-        # ~/Library/Caches/rancher-desktop-updater
     fi
 
     if is_windows; then
@@ -250,4 +253,19 @@ check_updater_longhorn_gone() {
 
 touch_updater_longhorn() {
     touch "$PATH_CACHE/updater-longhorn.json"
+}
+
+# electron-updater stages a downloaded update beside the app cache, so a reset
+# that keeps the cache has to remove the sibling directory on its own. Windows
+# stages inside the app home, which the reset already clears.
+stage_pending_update() {
+    if is_unix; then
+        mkdir -p "${PATH_CACHE}-updater/pending"
+        touch "${PATH_CACHE}-updater/pending/update.zip"
+    fi
+}
+
+check_pending_update_gone() {
+    skip_on_windows
+    assert_not_exists "${PATH_CACHE}-updater"
 }

--- a/bats/tests/containers/reset.bats
+++ b/bats/tests/containers/reset.bats
@@ -42,6 +42,7 @@ local_setup_file() {
 
 @test 'factory-reset when Rancher Desktop is not running' {
     touch_updater_longhorn
+    stage_pending_update
     rdctl_reset --factory
 }
 
@@ -71,6 +72,10 @@ local_setup_file() {
 
 @test 'Verify updater-longhorn.json was deleted' {
     check_updater_longhorn_gone
+}
+
+@test 'Verify the staged update was deleted' {
+    check_pending_update_gone
 }
 
 @test 'Start Rancher Desktop 2' {
@@ -214,8 +219,6 @@ check_directories() {
         # So just assert on the other members of AppHome
         # TODO on macOS (not implemented by `rdctl factory-reset`)
         # ~/Library/Saved Application State/io.rancherdesktop.app.savedState
-        # this one only exists after an update has been downloaded
-        # ~/Library/Caches/rancher-desktop-updater
     fi
 
     if is_windows; then
@@ -307,4 +310,19 @@ check_updater_longhorn_gone() {
 
 touch_updater_longhorn() {
     touch "$PATH_CACHE/updater-longhorn.json"
+}
+
+# electron-updater stages a downloaded update beside the app cache, so a reset
+# that keeps the cache has to remove the sibling directory on its own. Windows
+# stages inside the app home, which the reset already clears.
+stage_pending_update() {
+    if is_unix; then
+        mkdir -p "${PATH_CACHE}-updater/pending"
+        touch "${PATH_CACHE}-updater/pending/update.zip"
+    fi
+}
+
+check_pending_update_gone() {
+    skip_on_windows
+    assert_not_exists "${PATH_CACHE}-updater"
 }

--- a/bats/tests/updater/upgrade.bats
+++ b/bats/tests/updater/upgrade.bats
@@ -19,6 +19,15 @@ local_setup_file() {
     # Not a `.log`: the application deletes every log file it does not own.
     export UPDATE_SERVER_LOG="$PATH_LOGS/update-server.txt"
 
+    # electron-updater stages the download in the directory that
+    # updaterCacheDirName names: a "-updater" sibling of the app cache when
+    # packaged, the cache itself under `yarn dev`.
+    if using_dev_mode; then
+        export UPDATE_PENDING_DIR="$PATH_CACHE/pending"
+    else
+        export UPDATE_PENDING_DIR="${PATH_CACHE}-updater/pending"
+    fi
+
     if is_linux; then
         skip 'the updater only downloads on Linux when the app runs from an AppImage'
     fi
@@ -87,6 +96,13 @@ assert_update_log_contains() { # <pattern>
     # update.log is expected, and installs nothing.
 }
 
+@test 'the update is staged where factory reset looks for it' {
+    # `rdctl factory-reset` derives this path from the app cache directory, so a
+    # layout change in electron-updater leaves the download behind.
+    assert_update_log_contains " has been downloaded to ${UPDATE_PENDING_DIR}/"
+    assert_exists "$UPDATE_PENDING_DIR"
+}
+
 @test 'the updater resolved its bundled dependencies' {
     # `(0 , o.readFile) is not a function`: electron-updater got bundled into the
     # main process, and its own imports lost the exports Node cannot see.
@@ -99,4 +115,14 @@ assert_update_log_contains() { # <pattern>
 
 @test 'shut down' {
     rdctl shutdown
+}
+
+@test 'factory reset deletes the staged update' {
+    if using_dev_mode; then
+        skip 'the dev update config stages inside the app cache, which the reset keeps'
+    fi
+    # Not the `factory_reset` helper: it deletes the staged update itself, and
+    # would hide a reset that leaves it behind.
+    rdctl reset --factory
+    assert_not_exists "$UPDATE_PENDING_DIR"
 }

--- a/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_darwin.go
@@ -30,9 +30,12 @@ func DeleteData(ctx context.Context, appPaths *paths.Paths, removeKubernetesCach
 	}
 	pathList = append(pathList, appHomeDirectories(appPaths)...)
 
-	// Get path that electron-updater stores cache data in. Technically this
-	// is the wrong directory to use for cache data, but it is set by electron-updater.
-	// TODO: investigate changing the directory electron-updater uses
+	// Remove a downloaded update so it is not installed after the reset.
+	pathList = append(pathList, updaterCacheDir(appPaths))
+
+	// Older electron-updater versions staged updates under
+	// ~/Library/Application Support/Caches; remove that legacy location too, so a
+	// large update downloaded on an earlier release is not left behind.
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		logrus.Errorf("failed to get config dir: %s", err)

--- a/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_linux.go
@@ -43,6 +43,9 @@ func DeleteData(ctx context.Context, appPaths *paths.Paths, removeKubernetesCach
 		pathList = append(pathList, filepath.Join(configPath, "Rancher Desktop"))
 	}
 
+	// Remove a downloaded update so it is not installed after the reset.
+	pathList = append(pathList, updaterCacheDir(appPaths))
+
 	if removeKubernetesCache {
 		pathList = append(pathList, appPaths.Cache)
 	} else {

--- a/src/go/rdctl/pkg/factoryreset/delete_data_unix.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_unix.go
@@ -73,6 +73,14 @@ func appHomeDirectories(appPaths *paths.Paths) []string {
 	return pathList
 }
 
+// updaterCacheDir returns the directory where electron-updater stages a
+// downloaded update that is not yet installed. electron-updater puts that
+// directory beside the app cache with a "-updater" suffix, so deriving it from
+// appPaths.Cache keeps the path correct if the app cache directory ever moves.
+func updaterCacheDir(appPaths *paths.Paths) string {
+	return appPaths.Cache + "-updater"
+}
+
 // Most of the errors in this function are reported, but we continue to try to delete things,
 // because there isn't really a dependency graph here.
 // For example, if we can't delete the Lima VM, that doesn't mean we can't remove docker files

--- a/src/go/rdctl/pkg/factoryreset/delete_data_unix_test.go
+++ b/src/go/rdctl/pkg/factoryreset/delete_data_unix_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
 )
 
 /**
@@ -187,6 +189,16 @@ func verifyMgmtRemoved(t *testing.T, dotFile string) {
 	expectedContents, err := getExpectedContents(path.Base(dotFile))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedContents, string(byteContents))
+}
+
+func TestUpdaterCacheDir(t *testing.T) {
+	cache := path.Join("/home", "user", ".cache", "rancher-desktop")
+	got := updaterCacheDir(&paths.Paths{Cache: cache})
+
+	// electron-updater stages updates in a sibling of the app cache directory,
+	// not a subdirectory (which a cache wipe would already remove).
+	assert.Equal(t, cache+"-updater", got)
+	assert.Equal(t, path.Dir(cache), path.Dir(got))
 }
 
 func TestRemoveManagedBlock(t *testing.T) {


### PR DESCRIPTION
On macOS, `rdctl factory-reset` left a downloaded-but-not-installed update on disk, so the next launch installed it. The cleanup deleted the directory electron-updater staged into when the code was written, but the dependency has since moved its cache under the OS cache directory, so that path no longer held the pending update.

Linux cleaned up no updater cache either, but nothing stages one there today. The updater is off for deb/rpm installs, and the AppImage ships through OBS while the updater looks only at GitHub releases, so it never finds an update to download. The Linux deletion is therefore dormant, kept for completeness.

The staging path is a dependency's internal layout, so it drifted with no compile error and no failing test. Deriving it from the app cache directory keeps it aligned across future electron-updater bumps. The old macOS directory is still removed for anyone who downloaded an update before the move.

Fixes #10658
