### PR TITLE
Ignore net.fetch status-0 RangeError on network failure

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -141,6 +141,24 @@ process.on('unhandledRejection', (reason: any, promise: any) => {
   }
 });
 
+process.on('uncaughtException', (error: any) => {
+  if (error instanceof RangeError &&
+      error.message.includes('init["status"] must be in the range of 200 to 599')) {
+    // net.fetch's status-0 RangeError is thrown from Electron's 'response'
+    // listener, outside the promise chain, so no call-site catch can reach it.
+    console.error('Ignoring net.fetch RangeError on network failure:', error);
+
+    return;
+  }
+
+  // Registering this listener suppresses Electron's built-in crash dialog
+  // (it bails when listenerCount('uncaughtException') > 1), so re-show it.
+  const stack = error?.stack ?? `${ error?.name }: ${ error?.message }`;
+
+  console.error('UncaughtException:', error);
+  showErrorDialog('A JavaScript error occurred in the main process', `Uncaught Exception:\n${ stack }`);
+});
+
 Electron.app.on('second-instance', async() => {
   await protocolsRegistered;
   console.warn('A second instance was started');


### PR DESCRIPTION
case: a dialog popped up
```
Uncaught Exception:
RangeError: init["status"] must be in the range of 200 to 599, inclusive.
at initializeResponse (node:internal/deps/undici/undici:11635:15)
at new Response (node:internal/deps/undici/undici:11393:9)
at ClientRequest.<anonymous> (node:electron/js2c/browser_init:2:55032)
at ClientRequest.emit (node:events:509:28)
at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:133356)
at SimpleURLLoaderWrapper.emit (node:events:509:28)
```
still relates to #5158
When the network drops, in my case, coming back from sleep/wake, net.fetch returns a response with status 0 inside the ClientRequest's response handler. undici throws the RangeError synchronously from the event emitter, so it escapes the promise net.fetch returned and can't be caught at the call site.

This PR tries to provide an uncaughtException handler in `background.ts` file that ignores the 
`RangeError: init["status"] must be in the range of 200 to 599 ...` 
thrown by net.fetch when a request fails / status 0.