### PR TITLE
Match the capitalized Kubernetes in the k8s version check

### DIFF
--- a/bats/tests/k8s/specify-invalid-k8s-version.bats
+++ b/bats/tests/k8s/specify-invalid-k8s-version.bats
@@ -17,7 +17,7 @@ load '../helpers/load'
     # No way there's a race-condition here.
     # The version was checked and written to the log file before starting k8s,
     # and we have to wait a few minutes before k8s is ready and we're at the next line.
-    assert_file_contains "$PATH_LOGS/kube.log" "Requested kubernetes version 'moose' is not a supported version. Falling back to"
+    assert_file_contains "$PATH_LOGS/kube.log" "Requested Kubernetes version 'moose' is not a supported version. Falling back to"
 }
 
 # on macOS it still hangs without this


### PR DESCRIPTION
`specify-invalid-k8s-version.bats` has been failing since #10637. Extracting the warning into `en-us.yaml` capitalized "Kubernetes", so the assertion stopped matching a message the app was still logging correctly.

No other BATS assertion depends on a string that PR changed.