### PR TITLE
Retry the rancher dashboard check when Traefik returns 503

### DIFF
--- a/bats/tests/k8s/helm-install-rancher.bats
+++ b/bats/tests/k8s/helm-install-rancher.bats
@@ -134,7 +134,9 @@ verify_rancher() {
     local host
     host=$(traefik_hostname)
 
-    run try --max 9 --delay 10 curl --insecure --silent --show-error "https://${host}/dashboard/auth/login"
+    # Without `--fail`, Traefik's "no available server" 503 counts as a
+    # successful curl, and `try` returns after the first attempt.
+    run try --max 9 --delay 10 curl --insecure --silent --show-error --fail "https://${host}/dashboard/auth/login"
     assert_success
     assert_output --partial 'src="/dashboard/'
     run kubectl get secret --namespace cattle-system bootstrap-secret -o json


### PR DESCRIPTION
An Intel macOS BATS run failed `verify_rancher` seconds after `deploy_rancher` had confirmed the rancher deployment was Available. Traefik had not picked up the endpoint yet, and the retry loop took its 503 error page for a result.

The test failed in 283 ms, so none of the 9 retries ran. Without `--fail`, curl exits 0 on the "no available server" page and `try` stops at the first attempt. Every other retrying curl in the suite already passes `--fail`.