### PR TITLE
Group the vue and @vue/compiler-sfc Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,10 @@ updates:
     # TypeError.  Drop this rule once they support 7.x.
     dependency-name: "typescript"
     update-types: [version-update:semver-major]
+  groups:
+    # vue pins @vue/compiler-sfc exactly, so separate bumps break the lockfile.
+    vue:
+      patterns: ["vue", "@vue/compiler-sfc"]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"


### PR DESCRIPTION
vue pins @vue/compiler-sfc to its exact version, so bumping them in separate PRs merges into a lockfile neither one generated, and every job then fails `yarn install --immutable`. Six episodes since April.