### PR TITLE
Keep the top of the update card in view

### DIFF
--- a/pkg/rancher-desktop/components/UpdateStatus.vue
+++ b/pkg/rancher-desktop/components/UpdateStatus.vue
@@ -4,6 +4,7 @@
       <h3>{{ t('updateStatus.updateAvailable') }}</h3>
       <card
         ref="updateInfo"
+        sticky
         :show-highlight-border="false"
       >
         <template #body>
@@ -199,21 +200,6 @@ export default defineComponent({
   :deep(.card-title),
   :deep(.card-wrap > hr) {
     display: none;
-  }
-
-  // card-wrap is a plain block here; make it a column so the body can scroll.
-  :deep(.card-wrap) {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  // Scroll long notes inside the card; anchor to the top (the Card centres it).
-  :deep(.card-body) {
-    flex: 1;
-    min-height: 0;
-    overflow-y: auto;
-    justify-content: flex-start;
   }
 
   .update-notification {

--- a/pkg/rancher-desktop/components/__tests__/UpdateStatus.spec.ts
+++ b/pkg/rancher-desktop/components/__tests__/UpdateStatus.spec.ts
@@ -179,6 +179,20 @@ describe('UpdateStatus.vue', () => {
         .toContain('<strong>hello</strong>');
     });
 
+    it('should keep the top of the card in view', () => {
+      const wrapper = wrap({
+        enabled:     true,
+        updateState: {
+          available: true,
+          info:      { version: 'v1.2.3', releaseNotes: 'hello' },
+        } as UpdateState,
+      });
+
+      // The Card centres an overflowing body, which hides the status line and
+      // the notes toggle. Its sticky layout anchors the content to the top.
+      expect(wrapper.find('.card-container.card-sticky').exists()).toBeTruthy();
+    });
+
     it('should not support scripting', () => {
       const wrapper = wrap({
         enabled:     true,


### PR DESCRIPTION
With long release notes the card centres its body. The status line and the Release Notes toggle scroll off the top, out of reach, and the notes open halfway down. Nothing says which version is on offer, or that its download failed.

The scoped override meant to prevent this had the same specificity as the Card's own rule, so the last stylesheet to load wins, and in a packaged build that is the Card's. Its sticky mode does the same thing with a selector that wins outright.

The card has clipped this way since #10599 bounded its height. In Chrome, with the library's real stylesheet, the body computes to `center` before the change and `flex-start` after, and the notes still scroll inside the card.