### PR TITLE
Give the General page boxes a sharp edge

### DIFF
--- a/pkg/rancher-desktop/components/BlogFeed.vue
+++ b/pkg/rancher-desktop/components/BlogFeed.vue
@@ -122,11 +122,10 @@ export default defineComponent({
   overflow-y: auto;
   padding: 1rem;
   // Tint the feed so it reads as one imported widget, set apart from the
-  // app's own content above it. Carry the same shadow as the update card.
+  // app's own content above it.
   background: var(--box-bg);
   border: 1px solid var(--border);
   border-radius: var(--border-radius);
-  box-shadow: 0 0 20px var(--shadow);
 }
 
 .blog-entry + .blog-entry {

--- a/pkg/rancher-desktop/components/UpdateStatus.vue
+++ b/pkg/rancher-desktop/components/UpdateStatus.vue
@@ -194,6 +194,10 @@ export default defineComponent({
     // Fill and shrink past the Card's 100px minimum, so the body scrolls.
     flex: 1;
     min-height: 0;
+    // In light mode the Card's shadow is the border colour, so its 20px blur
+    // would smear the box's edge.
+    box-shadow: none;
+    border: 1px solid var(--border);
   }
 
   // Hide the empty title and <hr> the Card draws with no title slot.


### PR DESCRIPTION
In light mode the box shadow is the border colour, so its 20px blur smears the edge into a blurry border. Troubleshooting already drops the Card's shadow this way.