### PR TITLE
Declare the app locale as the document language

### DIFF
--- a/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/i18n.spec.ts
@@ -152,3 +152,38 @@ describe('availableLocales getter', () => {
     expect(Object.keys(availableLocales(scriptState('none')))).toEqual(['pt-br', 'ko', 'ja']);
   });
 });
+
+describe('switchTo action', () => {
+  const store = { $cookies: { set: jest.fn() } };
+
+  function context(loaded: string[] = ['en-us', 'zh-hans']) {
+    return {
+      state: {
+        default:      'en-us',
+        selected:     'en-us',
+        available:    ['en-us', 'zh-hans'],
+        translations: Object.fromEntries(loaded.map(locale => [locale, {}])),
+      },
+      commit:   jest.fn(),
+      dispatch: jest.fn(() => Promise.reject(new Error('cannot load'))),
+    };
+  }
+
+  const switchTo = (ctx: unknown, locale: string) => (i18n.actions as any).switchTo.call(store, ctx, locale);
+
+  beforeEach(() => {
+    document.documentElement.lang = '';
+  });
+
+  it('declares the language on the document', async() => {
+    await switchTo(context(), 'zh-hans');
+
+    expect(document.documentElement.lang).toBe('zh-hans');
+  });
+
+  it('declares the fallback language when the translation cannot be loaded', async() => {
+    await switchTo(context(['en-us']), 'zh-hans');
+
+    expect(document.documentElement.lang).toBe('en-us');
+  });
+});

--- a/pkg/rancher-desktop/store/i18n.js
+++ b/pkg/rancher-desktop/store/i18n.js
@@ -12,6 +12,13 @@ import { availableLocales, loadTranslations } from '@pkg/utils/translationLoader
 const intlCache = {};
 let ipcListenersBound = false;
 
+// Chromium uses the document language to pick a fallback font for characters
+// Lato lacks. Without one, Han text can come out with Japanese or Traditional
+// Chinese glyphs.
+function setDocumentLanguage(locale) {
+  document.documentElement.lang = locale;
+}
+
 export const state = function() {
   const out = {
     default:      'en-us',
@@ -226,6 +233,7 @@ export const actions = {
           // Try to show something...
 
           commit('setSelected', 'en-us');
+          setDocumentLanguage('en-us');
 
           return;
         }
@@ -237,6 +245,7 @@ export const actions = {
     }
 
     commit('setSelected', locale);
+    setDocumentLanguage(locale);
     this.$cookies.set(LOCALE, locale, {
       encode: x => x,
       maxAge: 86400 * 365,


### PR DESCRIPTION
The bundled fonts are Latin only, so Chromium falls back for CJK text, and it uses the document language to choose between the Simplified Chinese, Traditional Chinese, and Japanese forms of a Han character. The renderer left that language empty, so Chinese text could come out in Traditional Chinese glyphs, and on Windows the fallback face varied from one run of text to the next.

Confirmed in Chromium that the document language picks the regional face; the Windows rendering in the issue is unverified.

Closes #10698