### PR TITLE
Match newer curl connection-failure wording in the nginx check

### DIFF
--- a/bats/tests/k8s/up-downgrade-k8s.bats
+++ b/bats/tests/k8s/up-downgrade-k8s.bats
@@ -118,7 +118,9 @@ verify_kuberlr_for_version() {
 verify_nginx_after_change_k8s() {
     run curl http://localhost:8686
     assert_failure
-    assert_output --partial "Failed to connect to localhost port 8686"
+    # curl 8.6+ reports "...localhost:8686 after N ms..." instead of the older
+    # "...localhost port 8686..."; match both spellings.
+    assert_output --regexp "Failed to connect to localhost(:| port )8686"
 
     run curl http://localhost:8585
     assert_success


### PR DESCRIPTION
curl 8.6+ changed the failed-connection message from "Failed to connect to localhost port 8686: Connection refused" to "Failed to connect to localhost:8686 after N ms: Could not connect to server". The hardcoded --partial substring stopped matching on hosts with a newer curl (e.g. Windows' bundled curl 8.19), so "verify nginx after upgrade" and "...after downgrade" failed even though the --restart=no container was correctly gone. Match both spellings with a regexp.