### PR TITLE
fix: remove leading slash from container names

### DIFF
--- a/pkg/rancher-desktop/store/__tests__/container-engine.spec.ts
+++ b/pkg/rancher-desktop/store/__tests__/container-engine.spec.ts
@@ -1,0 +1,38 @@
+/** @jest-environment node */
+
+import { jest } from '@jest/globals';
+
+import { actions, state as createState } from '@pkg/store/container-engine';
+
+describe('container store', () => {
+  it.each([
+    ['/web', 'web'],
+    ['web', 'web'],
+  ])('normalizes the container name %s to %s for the UI', async(apiName, expectedName) => {
+    const listContainers = jest.fn().mockResolvedValue([{
+      Id:       'container-id',
+      Names:    [apiName],
+      Image:    'nginx',
+      ImageID:  'sha256:image-id',
+      Status:   'Up 5 minutes',
+      State:    'running',
+      Started:  '2024-01-01T00:00:00Z',
+      Labels:   {},
+      Ports:    {},
+    }]);
+    const commit = jest.fn();
+    const currentState = createState();
+
+    currentState.client = { docker: { listContainers } } as any;
+
+    await (actions.fetchContainers as any)({
+      commit,
+      getters: { supportsNamespaces: false },
+      state:   currentState,
+    });
+
+    const containersCommit = commit.mock.calls.find(([mutation]) => mutation === 'SET_CONTAINERS');
+
+    expect(containersCommit?.[1]['container-id'].containerName).toBe(expectedName);
+  });
+});

--- a/pkg/rancher-desktop/store/container-engine.ts
+++ b/pkg/rancher-desktop/store/container-engine.ts
@@ -365,7 +365,7 @@ export const actions = {
 
         const info: Container = {
           id:            container.Id,
-          containerName: container.Names[0].replace(/_[a-z0-9-]{36}_[0-9]+/, ''),
+          containerName: container.Names[0].replace(/^\//, '').replace(/_[a-z0-9-]{36}_[0-9]+/, ''),
           imageName:     container.Image,
           state,
           started:       undefined,


### PR DESCRIPTION
## Description

Hello,

Thank you for maintaining Rancher Desktop. I use it regularly and have found
it very useful. I encountered a specific UI bug and added a small fix with
regression coverage.

When a container is listed through the container engine API, its name may have
a leading `/`. The Containers UI should display the name without that API
prefix.

Closes #10717

## Reproduction and result

Before the fix:

- A container such as `ecstatic_shannon` was displayed as
  `/ecstatic_shannon`.

After the fix:

- The UI displays `ecstatic_shannon`.

## Test code

The regression test covers both API forms:

```ts
it.each([
  ['/web', 'web'],
  ['web', 'web'],
])('normalizes the container name %s to %s for the UI', async(apiName, expectedName) => {
  // fetchContainers(...)
  expect(containerName).toBe(expectedName);
});
```

## Verification

- Related Jest tests: 2 suites / 4 tests passed.
- TypeScript lint passed.
- `git diff --check` passed.
