### PR TITLE
fix: harden image reference parsing

### DIFF
--- a/pkg/rancher-desktop/config/__tests__/settings.spec.ts
+++ b/pkg/rancher-desktop/config/__tests__/settings.spec.ts
@@ -717,13 +717,15 @@ describe('settings', () => {
         6: [
           {
             extensions: {
-              'mice:oldest':   true,
-              'cats:youngest': false,
+              'mice:oldest':                         true,
+              'cats:youngest':                       false,
+              'registry.example:5000/org/image:tag': true,
             },
           },
           {
             extensions: {
-              mice: 'oldest',
+              mice:                              'oldest',
+              'registry.example:5000/org/image': 'tag',
             },
           },
         ],

--- a/pkg/rancher-desktop/config/settingsImpl.ts
+++ b/pkg/rancher-desktop/config/settingsImpl.ts
@@ -17,6 +17,7 @@ import {
 } from '@pkg/config/settings';
 import { PathManagementStrategy } from '@pkg/integrations/pathManager';
 import clone from '@pkg/utils/clone';
+import { splitImageReference } from '@pkg/utils/dockerUtils';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { RecursivePartial, RecursiveReadonly } from '@pkg/utils/typeUtils';
@@ -437,9 +438,7 @@ export const updateTable: Record<number, (settings: any, locked : boolean) => vo
     // by the image (without tag) with the value being the tag.
     if (_.hasIn(settings, 'extensions')) {
       const withTags = Object.entries(settings.extensions ?? {}).filter(([, v]) => v).map(([k]) => k);
-      const extensions = withTags.map((image) => {
-        return image.split(':', 2).concat('latest').slice(0, 2) as [string, string];
-      });
+      const extensions = withTags.map(splitImageReference);
 
       settings.extensions = Object.fromEntries(extensions);
     }

--- a/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/dockerUtils.spec.ts
@@ -1,4 +1,15 @@
-import { imageInfo, parseImageReference } from '../dockerUtils';
+import { imageInfo, parseImageReference, splitImageReference } from '../dockerUtils';
+
+describe('splitImageReference', () => {
+  test.each([
+    ['image', ['image', 'latest']],
+    ['image:tag', ['image', 'tag']],
+    ['registry.example:5000/org/image:tag', ['registry.example:5000/org/image', 'tag']],
+    ['registry.example:5000/org/image', ['registry.example:5000/org/image', 'latest']],
+  ])('%s', (input, expected) => {
+    expect(splitImageReference(input)).toEqual(expected);
+  });
+});
 
 describe('parseImageReference', () => {
   const dockerHub = new URL('https://index.docker.io');
@@ -8,6 +19,8 @@ describe('parseImageReference', () => {
     'dir/name':                         new imageInfo(dockerHub, 'dir/name'),
     'registry.test/thing':              new imageInfo(new URL('https://registry.test/'), 'thing' ),
     'registry.test:5000/org/thing:tag': new imageInfo(new URL('https://registry.test:5000/'), 'org/thing', 'tag'),
+    'registry.test:65536/thing':         null,
+    'registry.6/thing':                  null,
     _:                                  null,
     ':10/tag':                          null,
     [`xxx:${ Array(130).join('x') }`]:  null,

--- a/pkg/rancher-desktop/utils/dockerUtils.ts
+++ b/pkg/rancher-desktop/utils/dockerUtils.ts
@@ -111,6 +111,20 @@ const ImageRefPrefixRegExp = makeRE`
   `;
 
 /**
+ * Split an image reference into its name and tag without mistaking a registry
+ * port for the tag separator.
+ */
+export function splitImageReference(reference: string): [string, string] {
+  const colon = reference.lastIndexOf(':');
+
+  if (colon > reference.lastIndexOf('/')) {
+    return [reference.slice(0, colon), reference.slice(colon + 1)];
+  }
+
+  return [reference, 'latest'];
+}
+
+/**
  * Given an image reference, parse it into (possibly) registry, name, and
  * (possibly) tag components.
  * @param prefix If set, accept prefixes (names that end with a slash).
@@ -138,11 +152,22 @@ export function parseImageReference(reference: string, prefix = false): imageInf
     registry = `https://${ registry }`;
   }
 
+  let registryUrl: URL;
+
+  try {
+    registryUrl = new URL(registry);
+  } catch {
+    // The image-name regular expression is intentionally smaller than URL's
+    // host validation. Reject values such as out-of-range ports rather than
+    // leaking a TypeError to callers that are validating user input.
+    return null;
+  }
+
   if (registry.endsWith('.docker.io') && !name.includes('/')) {
     name = `library/${ name }`;
   }
 
-  return new imageInfo(new URL(registry), name, result.groups['tag']);
+  return new imageInfo(registryUrl, name, result.groups['tag']);
 }
 
 /**

--- a/scripts/lib/__tests__/extension-data.spec.ts
+++ b/scripts/lib/__tests__/extension-data.spec.ts
@@ -1,0 +1,12 @@
+/** @jest-environment node */
+
+import { Extension } from '../extension-data';
+
+describe('Extension', () => {
+  it('keeps a registry port when splitting an image reference', async() => {
+    const extension = new Extension('registry.example:5000/org/image:tag', {});
+
+    expect(extension.name).toBe('registry.example:5000/org/image');
+    await expect(extension.currentVersion).resolves.toBe('tag');
+  });
+});

--- a/scripts/lib/extension-data.ts
+++ b/scripts/lib/extension-data.ts
@@ -11,6 +11,8 @@ import yaml from 'yaml';
 
 import { DependencyAsset, DownloadContext, getPublishedReleaseTagNames, VersionedDependency } from './dependencies';
 
+import { splitImageReference } from '@pkg/utils/dockerUtils';
+
 const EXTENSION_PATH = 'scripts/assets/extension-data.yaml';
 const EXTENSION_OUTPUT_PATH = 'pkg/rancher-desktop/assets/extension-data.yaml';
 
@@ -30,7 +32,7 @@ interface ExtensionInfo {
 export class Extension extends VersionedDependency {
   constructor(ref: string, info: ExtensionInfo) {
     super();
-    const [name, tag] = ref.split(':', 2);
+    const [name, tag] = splitImageReference(ref);
 
     this.name = name;
     this.currentVersion = Promise.resolve(tag);


### PR DESCRIPTION
## Description

Hello,

This PR contains the image-reference parsing fixes split from #10724.

- Malformed image references no longer throw `TypeError: Invalid URL`.
- Registry ports are preserved when legacy extension settings and extension
  data split an image reference into its name and tag.

## Reproduction and result

Before the fix:

- `parseImageReference('registry.example:65536/image')` threw
  `TypeError: Invalid URL`.
- `registry.example:5000/org/image:tag` was split as
  `registry.example -> 5000/org/image`.

After the fix:

- Invalid image references return `null` instead of throwing.
- `registry.example:5000/org/image:tag` remains
  `registry.example:5000/org/image` with tag `tag`.

## Test code

```ts
expect(parseImageReference('registry.test:65536/thing')).toBeNull();
expect(splitImageReference('registry.example:5000/org/image:tag')).toEqual([
  'registry.example:5000/org/image',
  'tag',
]);
```

## Verification

- Related Jest tests: 3 suites / 48 tests passed.
- TypeScript lint passed.
- External fuzz tests: 5 settings-migration inputs and 100006
  image-reference inputs passed.
- `git diff --check` passed.
