### PR TITLE
Bump yarn to 4.17.1 so the Dependabot npm job stops failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": "^22.14.0"
   },
   "type": "module",
-  "packageManager": "yarn@4.15.0",
+  "packageManager": "yarn@4.17.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/rancher-sandbox/rancher-desktop.git"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15036,14 +15036,14 @@ __metadata:
 
 "resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>":
   version: 1.22.10
-  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=9bd1a5"
   dependencies:
     is-core-module: "npm:^2.16.0"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/52a4e505bbfc7925ac8f4cd91fd8c4e096b6a89728b9f46861d3b405ac9a1ccf4dcbf8befb4e89a2e11370dacd0160918163885cbc669369590f2f31f4c58939
+  checksum: 10c0/da5c4a85971e6eeb821805d117092321c6c257a6e1e45382c0b7ef41368a7e98690e01a08bac88b111443410a49e2fb17d1802ac5c51c8fc5532d77bef9f4be9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Yarn's builtin compat patch for typescript rewrites `lib/_tsc.js`, which TypeScript 7 no longer ships. 7.0 is the native Go port, so the package carries a launcher plus platform binaries. The patch then fails with ENOENT, `yarn add typescript@7.0.2` dies in the fetch step, and the daily `npm_and_yarn` Dependabot job has exited 1 every run since 2026-07-16, after opening its other pull requests.

plugin-compat 4.0.13 caps that patch at `<7.0.0-0` and yarn 4.17.1 bundles it. We already resolve 4.0.13 through the `@yarnpkg/cli` devDependency; only the `packageManager` pin corepack reads was behind. The lockfile moves because the same plugin release also changed the `resolve` compat patch, which shifts its hash and checksum.

Dependabot's own `corepack yarn add typescript@7.0.2` fails on `upstream/main` and passes here. No CI job covers it; the failure lives in the updater container.
