### PR TITLE
Ignore TypeScript major updates until the toolchain supports 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     # updates of webpack until we can migrate off @vue/cli-service (which is
     # unlikely to be fixed as it is in maintenance mode).
     dependency-name: "webpack"
+  - # TypeScript 7 is the Go port; its npm package exports only version and
+    # versionMajorMinor, so ts-loader and @typescript-eslint fail with a
+    # TypeError.  Drop this rule once they support 7.x.
+    dependency-name: "typescript"
+    update-types: [version-update:semver-major]
 
 # Maintain dependencies for Golang
 - package-ecosystem: "gomod"


### PR DESCRIPTION
Dependabot's #10744 bump to 7.0.2 fails both the lint and the test job. Nothing upstream is ready. The typescript-eslint canary still caps its peer range at `<6.1.0`, and ts-jest at `<7`. Without this rule, Dependabot reopens the same unmergeable PR for every 7.x release.
