### PR TITLE
Fix "Waiting for Kubernetes API" hanging forever on Windows

### DIFF
--- a/e2e/rdctl.e2e.spec.ts
+++ b/e2e/rdctl.e2e.spec.ts
@@ -876,7 +876,7 @@ test.describe('Command server', () => {
           });
           const newSettings: Settings = JSON.parse((await rdctl(['list-settings'])).stdout);
 
-          expect(newSettings).toEqual(_.merge(oldSettings, body));
+          expect(newSettings).toEqual(_.merge({}, oldSettings, body));
 
           // And now reinstate the old prefs so other tests that count on them will pass.
           const result = await rdctl(['api', '/v1/settings', '-X', 'PUT', '-b', JSON.stringify(oldSettings)]);

--- a/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
+++ b/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
@@ -16,6 +16,7 @@ command_args="
   ${GUESTAGENT_DOCKER:+-docker=${GUESTAGENT_DOCKER}}
   ${GUESTAGENT_CONTAINERD:+-containerd=${GUESTAGENT_CONTAINERD}}
   ${GUESTAGENT_K8S_SVC_ADDR:+-k8sServiceListenerAddr=${GUESTAGENT_K8S_SVC_ADDR}}
+  ${GUESTAGENT_K8S_API_PORT:+-k8sAPIPort=${GUESTAGENT_K8S_API_PORT}}
   ${GUESTAGENT_DEBUG:+-debug}
   "
 command_args="${command_args//$'\n'/ }"

--- a/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
+++ b/pkg/rancher-desktop/assets/scripts/rancher-desktop-guestagent.initd
@@ -16,6 +16,7 @@ command_args="
   ${GUESTAGENT_DOCKER:+-docker=${GUESTAGENT_DOCKER}}
   ${GUESTAGENT_CONTAINERD:+-containerd=${GUESTAGENT_CONTAINERD}}
   ${GUESTAGENT_K8S_SVC_ADDR:+-k8sServiceListenerAddr=${GUESTAGENT_K8S_SVC_ADDR}}
+  ${GUESTAGENT_K8S_API_PORT:+-k8sAPIPort=${GUESTAGENT_K8S_API_PORT}}
   ${GUESTAGENT_DEBUG:+-debug=${GUESTAGENT_DEBUG}}
   "
 command_args="${command_args//$'\n'/ }"

--- a/pkg/rancher-desktop/backend/k3sHelper.ts
+++ b/pkg/rancher-desktop/backend/k3sHelper.ts
@@ -24,7 +24,6 @@ import { loadFromString, exportConfig } from '@pkg/backend/kubeconfig';
 import { ContainerEngine } from '@pkg/config/settings';
 import { t } from '@pkg/main/i18n';
 import mainEvents from '@pkg/main/mainEvents';
-import { isUnixError } from '@pkg/typings/unix.interface';
 import DownloadProgressListener from '@pkg/utils/DownloadProgressListener';
 import * as childProcess from '@pkg/utils/childProcess';
 import { SemanticVersionEntry } from '@pkg/utils/kubeVersions';
@@ -73,6 +72,14 @@ interface cacheData {
   versions:      string[];
   /** Mapping of channel labels to current version (excluding build information). */
   channels:      Record<string, ShortVersion>;
+}
+
+function isErrorWithCode(error: unknown): error is { code: string | number } {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+
+  return typeof error.code === 'string' || typeof error.code === 'number';
 }
 
 /**
@@ -864,6 +871,7 @@ export default class K3sHelper extends events.EventEmitter {
    */
   async waitForServerReady(getHost: () => Promise<string | undefined>, port: number): Promise<void> {
     let host: string | undefined;
+    let waitingForHost = false;
 
     console.log(`Waiting for K3s server to be ready on port ${ port }...`);
     while (true) {
@@ -871,6 +879,10 @@ export default class K3sHelper extends events.EventEmitter {
         host = await getHost();
 
         if (typeof host === 'undefined') {
+          if (!waitingForHost) {
+            console.log('Server host address is not known yet; waiting...');
+            waitingForHost = true;
+          }
           await util.promisify(setTimeout)(500);
           continue;
         }
@@ -908,7 +920,7 @@ export default class K3sHelper extends events.EventEmitter {
         });
         break;
       } catch (error) {
-        if (!isUnixError(error)) {
+        if (!isErrorWithCode(error)) {
           console.error(error);
 
           return;

--- a/pkg/rancher-desktop/backend/kube/wsl.ts
+++ b/pkg/rancher-desktop/backend/kube/wsl.ts
@@ -263,7 +263,10 @@ export default class WSLKubernetesBackend extends events.EventEmitter implements
     await this.progressTracker.action(
       t('progress.waitingForKubernetesApi'),
       100,
-      this.k3sHelper.waitForServerReady(() => this.vm.ipAddress, config.kubernetes?.port));
+      // The network tunnel publishes the API on the host at 127.0.0.1 only
+      // (and includes it in the server certificate's SANs); the VM's own
+      // eth0 address is not reachable from the host.
+      this.k3sHelper.waitForServerReady(() => Promise.resolve('127.0.0.1'), config.kubernetes?.port));
 
     const client = this.client = kubeClient?.() || new KubeClient();
 

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -121,7 +121,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         const args: string[] = [];
 
         if (this.cfg?.kubernetes.enabled) {
-          const k8sPort = 6443;
+          const k8sPort = this.cfg.kubernetes.port;
           const eth0IP = '192.168.127.2';
           const k8sPortForwarding = `127.0.0.1:${ k8sPort }=${ eth0IP }:${ k8sPort }`;
 
@@ -831,6 +831,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       GUESTAGENT_DOCKER:        cfg?.containerEngine.name === ContainerEngine.MOBY ? 'true' : 'false',
       GUESTAGENT_DEBUG:         this.debug ? 'true' : 'false',
       GUESTAGENT_K8S_SVC_ADDR:  isAdminInstall && !cfg?.kubernetes.ingress.localhostOnly ? '0.0.0.0' : '127.0.0.1',
+      // An empty value makes the init script omit the flag, so the agent keeps its default.
+      GUESTAGENT_K8S_API_PORT:  cfg ? cfg.kubernetes.port.toString() : '',
     };
 
     await Promise.all([

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -123,7 +123,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
         const args: string[] = [];
 
         if (this.cfg?.kubernetes.enabled) {
-          const k8sPort = 6443;
+          const k8sPort = this.cfg.kubernetes.port;
           const eth0IP = '192.168.127.2';
           const k8sPortForwarding = `127.0.0.1:${ k8sPort }=${ eth0IP }:${ k8sPort }`;
 
@@ -833,6 +833,8 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
       GUESTAGENT_DOCKER:        cfg?.containerEngine.name === ContainerEngine.MOBY ? 'true' : 'false',
       GUESTAGENT_DEBUG:         this.debug ? 'true' : 'false',
       GUESTAGENT_K8S_SVC_ADDR:  isAdminInstall && !cfg?.kubernetes.ingress.localhostOnly ? '0.0.0.0' : '127.0.0.1',
+      // An empty value makes the init script omit the flag, so the agent keeps its default.
+      GUESTAGENT_K8S_API_PORT:  cfg ? cfg.kubernetes.port.toString() : '',
     };
 
     await Promise.all([


### PR DESCRIPTION
Fixes #10657

One commit per fix. The first two are described in [the root-cause analysis](https://github.com/rancher-sandbox/rancher-desktop/issues/10657#issuecomment-5148377777); repairing the readiness check then exposed the hardcoded API port forward that the third fixes. The fourth is a test that left `kubernetes.port` bumped for the rest of the run. Same root cause as #9570 and #9591.
