### PR TITLE
fix: reject malformed settings input

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -74,6 +74,16 @@ describe('SettingsValidator', () => {
     });
   });
 
+  it('should reject numeric strings with trailing characters', () => {
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { kubernetes: { port: '6443oops' as unknown as number } });
+
+    expect({ needToUpdate, errors, isFatal }).toEqual({
+      needToUpdate: false,
+      errors:       ['Invalid value for "kubernetes.port": <"6443oops">'],
+      isFatal:      false,
+    });
+  });
+
   describe('all standard fields', () => {
     // Special fields that cannot be checked here; this includes enums and maps.
     const specialFields = [
@@ -345,6 +355,16 @@ describe('SettingsValidator', () => {
       expect({ needToUpdate, errors, isFatal }).toEqual({
         needToUpdate: false,
         errors:       ['Proposed field "WSL.integrations" should be an object, got <3>.'],
+        isFatal:      false,
+      });
+    });
+
+    test.each([null, [true]])('should reject %p', (integrations) => {
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { WSL: { integrations: integrations as unknown as Record<string, boolean> } });
+
+      expect({ needToUpdate, errors, isFatal }).toEqual({
+        needToUpdate: false,
+        errors:       [expect.stringContaining('Proposed field "WSL.integrations" should be an object')],
         isFatal:      false,
       });
     });
@@ -804,6 +824,13 @@ describe('SettingsValidator', () => {
       const [, errors] = subject.validateSettings(cfg, { application: { extensions: { installed: input } } });
 
       expect(errors).toEqual(expectedErrors);
+    });
+
+    it('should reject arrays', () => {
+      const [, errors] = subject.validateSettings(cfg, { application: { extensions: { installed: ['tag'] as unknown as Record<string, string> } } });
+
+      expect(errors).toEqual([expect.stringContaining('application.extensions.installed')]);
+      expect(errors[0]).toContain('not a valid mapping');
     });
   });
 

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -633,7 +633,7 @@ export default class SettingsValidator {
    */
   protected checkBooleanMapping<S>(mergedSettings: S, currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
     if (typeof (desiredValue) !== 'object' || desiredValue === null || Array.isArray(desiredValue)) {
-      errors.push(t('validation.proposedShouldBeObject', { field: fqname, value: desiredValue }));
+      errors.push(t('validation.proposedShouldBeObject', { field: fqname, value: String(desiredValue) }));
 
       return false;
     }

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -632,7 +632,7 @@ export default class SettingsValidator {
    * and mutedChecks.
    */
   protected checkBooleanMapping<S>(mergedSettings: S, currentValue: Record<string, boolean>, desiredValue: Record<string, boolean>, errors: string[], fqname: string): boolean {
-    if (typeof (desiredValue) !== 'object') {
+    if (typeof (desiredValue) !== 'object' || desiredValue === null || Array.isArray(desiredValue)) {
       errors.push(t('validation.proposedShouldBeObject', { field: fqname, value: desiredValue }));
 
       return false;
@@ -778,7 +778,7 @@ export default class SettingsValidator {
       return false;
     }
 
-    if (typeof desiredValue !== 'object' || !desiredValue) {
+    if (typeof desiredValue !== 'object' || !desiredValue || Array.isArray(desiredValue)) {
       errors.push(t('validation.invalidMapping', { field: fqname, value: desiredValue }));
 
       return false;
@@ -925,10 +925,10 @@ export default class SettingsValidator {
     const desiredValue: number | string = newSettings[index];
 
     if (typeof desiredValue === 'string') {
-      const parsedValue = parseInt(desiredValue, 10);
+      const parsedValue = Number(desiredValue);
 
-      // Ignore NaN; we'll fail validation later.
-      if (!Number.isNaN(parsedValue)) {
+      // Ignore invalid values; we'll fail validation later.
+      if (desiredValue.trim() !== '' && Number.isFinite(parsedValue)) {
         newSettings[index] = parsedValue;
       }
     }


### PR DESCRIPTION
## Description

Reject malformed settings values during validation.

## Reproduction

Before:
- `kubernetes.port: "6443oops"` was silently accepted as `6443`.
- `WSL.integrations: null` raised `TypeError`.
- Arrays were accepted for mapping settings.

After:
- These inputs return validation errors.

## Verification

- Added focused regression tests.

---

Thanks for your patience with my recent small PRs. I’m trying to follow the project’s contribution guidelines, and I’m happy to adapt if there is a preferred format.

I’m currently studying fuzz testing and built a small local harness to investigate reproducible validation issues. This PR contains only the minimal fixes and regression tests for the confirmed cases. I’ll keep future findings focused and separate where appropriate.