### PR TITLE
guestagent: treat "proxy already running" as delegation, not failure

### DIFF
--- a/src/go/guestagent/pkg/containerd/events_linux.go
+++ b/src/go/guestagent/pkg/containerd/events_linux.go
@@ -120,8 +120,11 @@ func (e *EventMonitor) MonitorPorts(ctx context.Context) {
 					log.Errorf("failed running iptable rules to update DNAT rule in CNI-HOSTPORT-DNAT chain: %v", err)
 				}
 
-				err = e.portTracker.Add(startTask.ContainerID, ports)
-				if err != nil {
+				switch err = e.portTracker.Add(startTask.ContainerID, ports); {
+				case err == nil:
+				case errors.Is(err, tracker.ErrPortAlreadyExposed):
+					log.Debugf("ports for container %s already exposed elsewhere", startTask.ContainerID)
+				default:
 					log.Errorf("adding port mapping to tracker failed: %v", err)
 
 					continue
@@ -156,8 +159,11 @@ func (e *EventMonitor) MonitorPorts(ctx context.Context) {
 							log.Errorf("failed to remove port mapping from container update event: %v", err)
 						}
 
-						err = e.portTracker.Add(cuEvent.ID, ports)
-						if err != nil {
+						switch err = e.portTracker.Add(cuEvent.ID, ports); {
+						case err == nil:
+						case errors.Is(err, tracker.ErrPortAlreadyExposed):
+							log.Debugf("updated ports for container %s already exposed elsewhere", cuEvent.ID)
+						default:
 							log.Errorf("failed to add port mapping from container update event: %v", err)
 
 							continue
@@ -167,7 +173,11 @@ func (e *EventMonitor) MonitorPorts(ctx context.Context) {
 					continue
 				}
 				// Not 100% sure if we ever get here...
-				if err = e.portTracker.Add(cuEvent.ID, ports); err != nil {
+				switch err = e.portTracker.Add(cuEvent.ID, ports); {
+				case err == nil:
+				case errors.Is(err, tracker.ErrPortAlreadyExposed):
+					log.Debugf("updated ports for container %s already exposed elsewhere", cuEvent.ID)
+				default:
 					log.Errorf("failed to add port mapping from container update event: %v", err)
 				}
 
@@ -284,8 +294,11 @@ func (e *EventMonitor) initializeRunningContainers(ctx context.Context) {
 			log.Errorf("failed running iptable rules to update DNAT rule in CNI-HOSTPORT-DNAT chain: %v", err)
 		}
 
-		err = e.portTracker.Add(c.ID(), ports)
-		if err != nil {
+		switch err = e.portTracker.Add(c.ID(), ports); {
+		case err == nil:
+		case errors.Is(err, tracker.ErrPortAlreadyExposed):
+			log.Debugf("ports for running container %s already exposed elsewhere", c.ID())
+		default:
 			log.Errorf("adding port mapping to tracker failed: %v", err)
 
 			continue

--- a/src/go/guestagent/pkg/docker/events.go
+++ b/src/go/guestagent/pkg/docker/events.go
@@ -17,6 +17,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -97,8 +98,11 @@ func (e *EventMonitor) MonitorPorts(ctx context.Context) {
 			case events.ActionStart:
 				if len(container.NetworkSettings.Ports) != 0 {
 					validatePortMapping(container.NetworkSettings.Ports)
-					err = e.portTracker.Add(container.ID, container.NetworkSettings.Ports)
-					if err != nil {
+					switch err = e.portTracker.Add(container.ID, container.NetworkSettings.Ports); {
+					case err == nil:
+					case errors.Is(err, tracker.ErrPortAlreadyExposed):
+						log.Debugf("ports for container %s already exposed elsewhere", container.ID)
+					default:
 						log.Errorf("adding port mapping to tracker failed: %s", err)
 					}
 
@@ -161,7 +165,14 @@ func (e *EventMonitor) initializeRunningContainers(ctx context.Context) error {
 
 				continue
 			}
-			if err := e.portTracker.Add(container.ID, portMap); err != nil {
+			// A port another component already exposes still needs the
+			// loopback DNAT rules below: they route bindIP:port to the
+			// container's 127.0.0.1 listener whoever called expose.
+			switch err := e.portTracker.Add(container.ID, portMap); {
+			case err == nil:
+			case errors.Is(err, tracker.ErrPortAlreadyExposed):
+				log.Debugf("ports for already running container %s exposed elsewhere", container.ID)
+			default:
 				log.Errorf("registering already running containers failed: %v", err)
 				continue
 			}

--- a/src/go/guestagent/pkg/iptables/iptables.go
+++ b/src/go/guestagent/pkg/iptables/iptables.go
@@ -16,6 +16,7 @@ package iptables
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 	"strings"
@@ -99,8 +100,6 @@ func (i *Iptables) ForwardPorts() error {
 			log.Infof("iptables scanner removed portmap for %s", name)
 		}
 
-		portMap := make(nat.PortMap)
-
 		// Add new forwards
 		for _, p := range added {
 			if !p.TCP {
@@ -112,19 +111,22 @@ func (i *Iptables) ForwardPorts() error {
 				log.Errorf("failed to create a corresponding key for the portMap: %s", err)
 				continue
 			}
-			portBinding := nat.PortBinding{
+			// One map per entry: Remove is keyed by this entry's own
+			// id, so a shared map would unexpose ports belonging to
+			// the other entries stored under it.
+			portMap := nat.PortMap{portMapKey: []nat.PortBinding{{
 				HostIP:   i.listenerIP.String(),
 				HostPort: port,
-			}
-			if _, ok := portMap[portMapKey]; !ok {
-				portMap[portMapKey] = []nat.PortBinding{portBinding}
-			}
+			}}}
 			name := entryToString(p)
-			if err := i.apiTracker.Add(utils.GenerateID(name), portMap); err != nil {
+			switch err := i.apiTracker.Add(utils.GenerateID(name), portMap); {
+			case err == nil:
+				log.Infof("iptables scanner forwarded portmap for %s", name)
+			case errors.Is(err, tracker.ErrPortAlreadyExposed):
+				log.Infof("iptables scanner: portmap for %s already exposed elsewhere", name)
+			default:
 				log.Errorf("iptables scanner failed to forward portmap for %s: %s", name, err)
-				continue
 			}
-			log.Infof("iptables scanner forwarded portmap for %s", name)
 		}
 	}
 }

--- a/src/go/guestagent/pkg/kube/watcher_linux.go
+++ b/src/go/guestagent/pkg/kube/watcher_linux.go
@@ -174,16 +174,23 @@ func WatchForServices(
 
 						continue
 					}
-					if err := portTracker.Add(string(event.UID), portMapping); err != nil {
+					switch err := portTracker.Add(string(event.UID), portMapping); {
+					case err == nil:
+						log.Debugf("kubernetes service: port mapping added %s/%s:%v",
+							event.namespace, event.name, event.portMapping)
+					case errors.Is(err, tracker.ErrPortAlreadyExposed):
+						// Debug, unlike the other scanners, which log this
+						// at Info once per port: this fires on every
+						// watcher event for as long as the Service exists.
+						log.Debugf("kubernetes service: port mapping already exposed elsewhere %s/%s:%v",
+							event.namespace, event.name, event.portMapping)
+					default:
 						log.Errorf("failed to add port mapping: %v from tracker UID: %v namespace: %s name: %s failed: %s",
 							event.portMapping,
 							event.UID,
 							event.namespace,
 							event.name,
 							err)
-					} else {
-						log.Debugf("kubernetes service: port mapping added %s/%s:%v",
-							event.namespace, event.name, event.portMapping)
 					}
 				}
 			}

--- a/src/go/guestagent/pkg/procnet/scanner_linux.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux.go
@@ -20,7 +20,11 @@ a userspace forwarder on the namespace's tap IP so traffic arriving
 from host-switch reaches the in-namespace 127.0.0.1 listener. A
 two-scan stability gate filters out the transient reservation socket
 nerdctl's OCI createRuntime hook opens before CNI installs its
-iptables rules.
+iptables rules. Ports another component already exposes -- e.g.
+docker-proxy's persistent per-published-port listeners, which the
+docker events handler owns -- are recorded as delegated and skipped
+until their listener disappears, its binding shape changes, or the
+delegation ages out and the scanner re-establishes who owns the port.
 
 IPv6 limitation: procnettcp.ParseFiles returns entries from
 /proc/net/{tcp,tcp6,udp,udp6}, but addValidProtoEntryToPortMap
@@ -37,6 +41,7 @@ package procnet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -54,6 +59,13 @@ import (
 const (
 	loopbackIP = "127.0.0.1"
 	wildcardIP = "0.0.0.0"
+
+	// ownershipRecheckInterval bounds how long the scanner trusts what
+	// it believes about a port. APITracker.RemoveAll clears every
+	// expose in the shared tracker without touching a listener, and the
+	// kube watcher and the iptables scanner never re-register. Long
+	// enough not to become the per-tick retry it replaced.
+	ownershipRecheckInterval = 5 * time.Minute
 )
 
 // loopbackController is what the scanner calls to manage userspace
@@ -79,6 +91,22 @@ type ProcNetScanner struct {
 	published nat.PortMap
 	pending   map[nat.Port]struct{}
 
+	// delegated holds ports whose expose is owned by another component
+	// (host-switch answered "proxy already running"). Under moby,
+	// docker-proxy holds a persistent listener in this namespace for
+	// every published port; it passes the stability gate and, without
+	// this set, the scanner would collide with the docker events
+	// handler and retry every tick for the container's lifetime.
+	delegated nat.PortMap
+
+	// recheckTicks counts Ticks since the scanner last verified who
+	// exposes each port it tracks, whether published or delegated.
+	recheckTicks map[nat.Port]int
+
+	// ownershipRecheckTicks is ownershipRecheckInterval expressed in
+	// Ticks for the scanInterval this scanner was built with.
+	ownershipRecheckTicks int
+
 	// addErrorLogged throttles publish-failure logs to one Error line
 	// per port; subsequent failures for the same port log at Debug
 	// until the port either publishes successfully or leaves both
@@ -102,6 +130,11 @@ func NewProcNetScanner(ctx context.Context, t tracker.Tracker, bindIP net.IP, sc
 }
 
 func newScanner(ctx context.Context, t tracker.Tracker, f loopbackController, bindIP net.IP, scanInterval time.Duration) *ProcNetScanner {
+	ticks := int(ownershipRecheckInterval / scanInterval)
+	if ticks < 1 {
+		ticks = 1
+	}
+
 	return &ProcNetScanner{
 		ctx:            ctx,
 		tracker:        t,
@@ -110,7 +143,11 @@ func newScanner(ctx context.Context, t tracker.Tracker, f loopbackController, bi
 		scanInterval:   scanInterval,
 		published:      make(nat.PortMap),
 		pending:        make(map[nat.Port]struct{}),
+		delegated:      make(nat.PortMap),
+		recheckTicks:   make(map[nat.Port]int),
 		addErrorLogged: make(map[nat.Port]bool),
+
+		ownershipRecheckTicks: ticks,
 	}
 }
 
@@ -145,6 +182,12 @@ func (p *ProcNetScanner) ForwardPorts() error {
 func (p *ProcNetScanner) Tick(scanned nat.PortMap) {
 	for port, bindings := range p.published {
 		if newBindings, ok := scanned[port]; ok && bindingsEqual(bindings, newBindings) {
+			p.recheckTicks[port]++
+			if p.recheckTicks[port] >= p.ownershipRecheckTicks {
+				p.recheckTicks[port] = 0
+				p.reassert(port, bindings)
+			}
+
 			continue
 		}
 		// Either the port vanished or its bind addresses changed
@@ -153,6 +196,30 @@ func (p *ProcNetScanner) Tick(scanned nat.PortMap) {
 		// preserves the two-scan gate semantics for the new shape.
 		p.unpublish(port, bindings)
 		delete(p.published, port)
+		delete(p.recheckTicks, port)
+	}
+
+	// Ports whose delegation expired this tick. They go back through
+	// the publish path below, and a renewal there logs at Debug so a
+	// long-lived delegation does not emit an Info line every recheck.
+	expiring := make(map[nat.Port]struct{})
+
+	for port, bindings := range p.delegated {
+		if newBindings, ok := scanned[port]; ok && bindingsEqual(bindings, newBindings) {
+			p.recheckTicks[port]++
+			if p.recheckTicks[port] < p.ownershipRecheckTicks {
+				continue
+			}
+			// Re-publish in this tick rather than the next. The port
+			// has been present for every scan since the delegation, so
+			// the two-scan gate has nothing left to filter.
+			expiring[port] = struct{}{}
+			p.pending[port] = struct{}{}
+		}
+		// Nothing to unexpose: the owning component cleans up its
+		// own ports.
+		delete(p.delegated, port)
+		delete(p.recheckTicks, port)
 	}
 
 	for port := range p.pending {
@@ -161,14 +228,29 @@ func (p *ProcNetScanner) Tick(scanned nat.PortMap) {
 			continue
 		}
 		if err := p.publish(port, bindings); err != nil {
+			// Another component already exposes this port; hand it off
+			// and stop retrying until the delegation is released.
+			if errors.Is(err, tracker.ErrPortAlreadyExposed) {
+				if _, renewed := expiring[port]; renewed {
+					log.Debugf("/proc/net scanner still delegating port %s to its existing exposer", port)
+				} else {
+					log.Infof("/proc/net scanner delegating port %s to its existing exposer", port)
+				}
+				p.delegated[port] = bindings
+				p.recheckTicks[port] = 0
+			}
 			continue
 		}
 		p.published[port] = bindings
+		p.recheckTicks[port] = 0
 	}
 
 	p.pending = make(map[nat.Port]struct{})
 	for port := range scanned {
 		if _, ok := p.published[port]; ok {
+			continue
+		}
+		if _, ok := p.delegated[port]; ok {
 			continue
 		}
 		p.pending[port] = struct{}{}
@@ -193,10 +275,18 @@ func (p *ProcNetScanner) Tick(scanned nat.PortMap) {
 // userspace forwarder for each loopback binding. It returns an error
 // if either step fails after rolling back the tracker entry, so the
 // caller can leave the port in pending for next-tick retry instead
-// of recording it as published.
+// of recording it as published. A tracker.ErrPortAlreadyExposed
+// return is not a failure: it tells the caller to record the port as
+// delegated instead.
 func (p *ProcNetScanner) publish(port nat.Port, bindings []nat.PortBinding) error {
 	id := utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))
 	if err := p.tracker.Add(id, nat.PortMap{port: bindings}); err != nil {
+		if errors.Is(err, tracker.ErrPortAlreadyExposed) {
+			// No rollback: Add stored nothing under the scanner's id.
+			// The caller logs, since only it knows whether this is a
+			// new delegation or a renewal.
+			return err
+		}
 		p.logAddFailure(port, fmt.Sprintf("failed to add: %s", err))
 		if removeErr := p.tracker.Remove(id); removeErr != nil {
 			p.logAddFailure(port, fmt.Sprintf("rollback after tracker.Add failure: %s", removeErr))
@@ -247,6 +337,25 @@ func (p *ProcNetScanner) publish(port nat.Port, bindings []nat.PortBinding) erro
 	delete(p.addErrorLogged, port)
 	log.Infof("/proc/net scanner added port: %s -> %+v", port, bindings)
 	return nil
+}
+
+// reassert re-exposes a port the scanner already published. Only the
+// tracker entry needs restoring: the loopback forwarder is the
+// scanner's own and RemoveAll does not touch it.
+//
+// Best-effort: Add exposes, stores, then notifies wsl-proxy, so a
+// failure at the notify step leaves the port exposed and stored but
+// unknown to wsl-proxy. Rolling back is unsafe, since Remove would
+// unexpose whatever an earlier publish left under this id. Every
+// later recheck then answers with the sentinel and hides the gap.
+func (p *ProcNetScanner) reassert(port nat.Port, bindings []nat.PortBinding) {
+	id := utils.GenerateID(fmt.Sprintf("%s/%s", port.Proto(), port.Port()))
+	// The sentinel here is the scanner's own proxy still standing,
+	// which is the expected answer.
+	if err := p.tracker.Add(id, nat.PortMap{port: bindings}); err != nil &&
+		!errors.Is(err, tracker.ErrPortAlreadyExposed) {
+		p.logAddFailure(port, fmt.Sprintf("re-asserting expose: %s", err))
+	}
 }
 
 // logAddFailure emits the first publish-failure message for port at

--- a/src/go/guestagent/pkg/procnet/scanner_linux_test.go
+++ b/src/go/guestagent/pkg/procnet/scanner_linux_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/docker/go-connections/nat"
 	"github.com/lima-vm/lima/pkg/guestagent/procnettcp"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/tracker"
 )
 
 // fakeTracker records Add/Remove calls keyed by the containerID the
@@ -452,6 +454,204 @@ func TestRollbackAfterForwarderAddFailure(t *testing.T) {
 	}
 	if _, published := s.published[mustPort(t, "tcp", 8009)]; published {
 		t.Fatal("port recorded as published despite forwarder.Add error")
+	}
+}
+
+// TestOwnershipRecheckDerivedFromScanInterval pins the recheck to
+// wall-clock time rather than to a tick count. A tick count would drift
+// silently the day the scan interval changes, turning the re-probe back
+// into the per-tick retry the delegation mechanism replaced.
+func TestOwnershipRecheckDerivedFromScanInterval(t *testing.T) {
+	for _, tc := range []struct {
+		scanInterval time.Duration
+		want         int
+	}{
+		{time.Second, 300},
+		{3 * time.Second, 100},
+		{time.Hour, 1},
+	} {
+		s := newScanner(context.Background(), &fakeTracker{}, &fakeForwarder{}, nil, tc.scanInterval)
+		if s.ownershipRecheckTicks != tc.want {
+			t.Errorf("scanInterval %v: ownershipRecheckTicks = %d, want %d",
+				tc.scanInterval, s.ownershipRecheckTicks, tc.want)
+		}
+	}
+}
+
+// TestPublishedPortReassertedPeriodically covers the scanner's own
+// ports going quiet, with nothing in /proc/net to mark them as no
+// longer forwarded. Re-asserting must not disturb the forwarder or
+// unexpose anything.
+func TestPublishedPortReassertedPeriodically(t *testing.T) {
+	tr := &fakeTracker{}
+	fwd := &fakeForwarder{}
+	s := newScanner(context.Background(), tr, fwd, nil, time.Second)
+
+	scan := loopbackPortMap(t, 8009)
+	s.Tick(scan)
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add expected exactly once, got %v", tr.added)
+	}
+
+	for range s.ownershipRecheckTicks - 1 {
+		s.Tick(scan)
+	}
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add = %v, want no re-assert before the recheck falls due", tr.added)
+	}
+
+	s.Tick(scan)
+	if len(tr.added) != 2 {
+		t.Fatalf("tracker.Add = %v, want the expose re-asserted once", tr.added)
+	}
+	if len(tr.removed) != 0 {
+		t.Fatalf("tracker.Remove called while re-asserting: %v", tr.removed)
+	}
+	if got, want := fwd.added, []string{"tcp/8009"}; !equalStringSlices(got, want) {
+		t.Fatalf("forwarder.Add = %v, want the original bind untouched %v", got, want)
+	}
+	if len(fwd.removed) != 0 {
+		t.Fatalf("forwarder.Remove called while re-asserting: %v", fwd.removed)
+	}
+	if _, ok := s.published[mustPort(t, "tcp", 8009)]; !ok {
+		t.Fatal("port dropped from published by the re-assert")
+	}
+}
+
+// TestDelegatedPortRepublishedAfterOwnerLosesExpose covers ownership
+// ending without the listener changing, which the scanner cannot
+// observe, so the delegation has to expire on its own or the port
+// stays exposed by nobody.
+func TestDelegatedPortRepublishedAfterOwnerLosesExpose(t *testing.T) {
+	tr := &fakeTracker{addErr: tracker.ErrPortAlreadyExposed}
+	fwd := &fakeForwarder{}
+	s := newScanner(context.Background(), tr, fwd, nil, time.Second)
+
+	scan := loopbackPortMap(t, 8009)
+	s.Tick(scan)
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add expected exactly once, got %v", tr.added)
+	}
+
+	// While the delegation is young the scanner must leave it alone;
+	// re-probing sooner is the retry storm this whole mechanism exists
+	// to stop.
+	for range s.ownershipRecheckTicks - 1 {
+		s.Tick(scan)
+	}
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add = %v, want no re-probe before the delegation ages out", tr.added)
+	}
+
+	// The owner's expose is gone and host-switch accepts the port
+	// again.
+	tr.addErr = nil
+	s.Tick(scan)
+	if len(tr.added) != 2 {
+		t.Fatalf("tracker.Add = %v, want the port republished exactly once", tr.added)
+	}
+	if got, want := fwd.added, []string{"tcp/8009"}; !equalStringSlices(got, want) {
+		t.Fatalf("forwarder.Add = %v, want %v", got, want)
+	}
+}
+
+// TestAlreadyExposedPortDelegatesInsteadOfRetrying pins the moby
+// scenario from issue 10737, where docker-proxy holds a persistent
+// listener for a published port that the docker events handler has
+// already exposed.
+func TestAlreadyExposedPortDelegatesInsteadOfRetrying(t *testing.T) {
+	tr := &fakeTracker{addErr: tracker.ErrPortAlreadyExposed}
+	fwd := &fakeForwarder{}
+	s := newScanner(context.Background(), tr, fwd, nil, time.Second)
+
+	scan := loopbackPortMap(t, 8009)
+	s.Tick(scan)
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add expected exactly once, got %v", tr.added)
+	}
+
+	s.Tick(scan)
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add retried for delegated port: %v", tr.added)
+	}
+	if len(fwd.added) != 0 {
+		t.Fatalf("forwarder.Add called for delegated port: %v", fwd.added)
+	}
+	if len(tr.removed) != 0 {
+		t.Fatalf("tracker.Remove called to roll back a delegation: %v", tr.removed)
+	}
+}
+
+// TestDelegatedPortReleasedWhenListenerVanishes verifies that a
+// delegated port is dropped without any unexpose traffic when its
+// listener disappears -- cleanup belongs to the owning component --
+// and that a later listener on the same port goes through the normal
+// gate-then-publish path again.
+func TestDelegatedPortReleasedWhenListenerVanishes(t *testing.T) {
+	tr := &fakeTracker{addErr: tracker.ErrPortAlreadyExposed}
+	fwd := &fakeForwarder{}
+	s := newScanner(context.Background(), tr, fwd, nil, time.Second)
+
+	scan := wildcardPortMap(t, 8009)
+	s.Tick(scan)
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add expected exactly once, got %v", tr.added)
+	}
+
+	s.Tick(nat.PortMap{})
+	if len(tr.removed) != 0 {
+		t.Fatalf("tracker.Remove called for delegated port: %v", tr.removed)
+	}
+	if len(fwd.removed) != 0 {
+		t.Fatalf("forwarder.Remove called for delegated port: %v", fwd.removed)
+	}
+
+	tr.addErr = nil
+	s.Tick(scan)
+	if len(tr.added) != 1 {
+		t.Fatalf("gate skipped for re-appearing port: %v", tr.added)
+	}
+	s.Tick(scan)
+	if len(tr.added) != 2 {
+		t.Fatalf("tracker.Add not retried after delegation released: %v", tr.added)
+	}
+}
+
+// TestDelegatedPortReleasedOnBindingShapeChange verifies that a
+// binding-shape change releases the delegation even while a listener
+// on the port persists, so the scanner re-evaluates ownership on the
+// next tick.
+func TestDelegatedPortReleasedOnBindingShapeChange(t *testing.T) {
+	tr := &fakeTracker{addErr: tracker.ErrPortAlreadyExposed}
+	fwd := &fakeForwarder{}
+	s := newScanner(context.Background(), tr, fwd, nil, time.Second)
+
+	wildcard := wildcardPortMap(t, 8009)
+	s.Tick(wildcard)
+	s.Tick(wildcard)
+	if len(tr.added) != 1 {
+		t.Fatalf("tracker.Add expected exactly once, got %v", tr.added)
+	}
+
+	// The owner's 0.0.0.0 listener is replaced by a loopback-only
+	// listener (e.g. a --network=host process reusing the port).
+	tr.addErr = nil
+	loopback := loopbackPortMap(t, 8009)
+	s.Tick(loopback)
+	if len(tr.added) != 1 {
+		t.Fatalf("publish fired on the shape-change tick, before re-pend: %v", tr.added)
+	}
+	s.Tick(loopback)
+	if len(tr.added) != 2 {
+		t.Fatalf("tracker.Add not retried after shape change: %v", tr.added)
+	}
+	if got, want := fwd.added, []string{"tcp/8009"}; !equalStringSlices(got, want) {
+		t.Fatalf("forwarder.Add = %v, want %v", got, want)
 	}
 }
 

--- a/src/go/guestagent/pkg/tracker/apitracker.go
+++ b/src/go/guestagent/pkg/tracker/apitracker.go
@@ -38,7 +38,21 @@ var (
 	ErrAPI         = errors.New("error from API")
 	ErrInvalidIPv4 = errors.New("not an IPv4 address")
 	ErrWSLProxy    = errors.New("error from Rancher Desktop WSL Proxy")
+	// ErrPortAlreadyExposed signals that Add was a no-op because another
+	// component had already exposed every port in the request. Callers
+	// that scan for ports another actor may own (kube watcher, iptables
+	// scanner, /proc/net scanner) should treat this as successful
+	// delegation rather than a failure to retry.
+	ErrPortAlreadyExposed = errors.New("port already exposed by another component")
 )
+
+// portAlreadyExposedSubstring is the substring host-switch's
+// /services/forwarder/expose response carries when the port is already
+// bound. Upstream exports no sentinel to match against.
+// gvisor-tap-vsock pkg/services/forwarder/ports.go (v0.8.9) returns
+// errors.New("proxy already running") and the /expose handler passes
+// it through verbatim, so re-check this on a dependency bump.
+const portAlreadyExposedSubstring = "proxy already running"
 
 // APITracker keeps track of the port mappings and calls the
 // corresponding API endpoints that is responsible for exposing
@@ -80,8 +94,13 @@ func NewAPITracker(ctx context.Context, wslProxyForwarder forwarder.Forwarder, b
 
 // Add a container ID and port mapping to the tracker and calls the
 // /services/forwarder/expose endpoint to forward the port mappings.
+//
+// If the expose API reports every port it was called for as already
+// exposed and no other failures occurred, Add returns
+// ErrPortAlreadyExposed.
 func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 	var errs []error
+	var alreadyExposed int
 
 	successfullyForwarded := make(nat.PortMap)
 
@@ -107,6 +126,11 @@ func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 					Protocol: types.TransportProtocol(strings.ToLower(portProto.Proto())),
 				})
 			if err != nil {
+				if strings.Contains(err.Error(), portAlreadyExposedSubstring) {
+					alreadyExposed++
+
+					continue
+				}
 				errs = append(errs, fmt.Errorf("exposing %+v failed: %w", portBinding, err))
 
 				continue
@@ -135,6 +159,12 @@ func (a *APITracker) Add(containerID string, portMap nat.PortMap) error {
 
 	if len(errs) != 0 {
 		return fmt.Errorf("%w: %+v", forwarder.ErrExposeAPI, errs)
+	}
+
+	// Every Expose call that ran reported the port as already exposed:
+	// no successful forwards, no other failures.
+	if alreadyExposed > 0 && len(successfullyForwarded) == 0 {
+		return ErrPortAlreadyExposed
 	}
 
 	return nil

--- a/src/go/guestagent/pkg/tracker/apitracker_test.go
+++ b/src/go/guestagent/pkg/tracker/apitracker_test.go
@@ -683,6 +683,147 @@ func TestNonAdminInstall(t *testing.T) {
 	assert.Nil(t, portMapping)
 }
 
+// TestAddReturnsPortAlreadyExposedSentinel verifies that when host-switch
+// rejects every Expose with the "proxy already running" body, Add returns
+// the typed sentinel so callers can downgrade the result to a delegation
+// no-op.
+func TestAddReturnsPortAlreadyExposedSentinel(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "host port forwarding: cannot expose 127.0.0.1:80: proxy already running", http.StatusInternalServerError)
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{{HostIP: hostIP, HostPort: hostPort}},
+	})
+	require.ErrorIs(t, err, tracker.ErrPortAlreadyExposed)
+	require.NotErrorIs(t, err, forwarder.ErrExposeAPI,
+		"the sentinel must replace the generic ErrExposeAPI wrap, not be joined with it")
+
+	// portStorage stays empty: no port was successfully forwarded.
+	assert.Empty(t, apiTracker.Get(containerID))
+}
+
+// TestAddPartialAlreadyExposedReturnsNil verifies that when some ports
+// succeed and others are already exposed elsewhere, Add returns nil --
+// the call did real work and the sentinel only applies when nothing was
+// forwarded.
+func TestAddPartialAlreadyExposedReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.ExposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.Local == ipPortBuilder(hostIP2, hostPort) {
+			http.Error(w, "proxy already running", http.StatusInternalServerError)
+		}
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{
+			{HostIP: hostIP, HostPort: hostPort},  // succeeds
+			{HostIP: hostIP2, HostPort: hostPort}, // already exposed
+		},
+	})
+	require.NoError(t, err)
+
+	stored := apiTracker.Get(containerID)
+	require.Len(t, stored[protoPort], 1)
+	assert.Equal(t, hostIP, stored[protoPort][0].HostIP)
+}
+
+// TestAddAlreadyExposedPlusRealFailureReturnsRealFailure verifies that a
+// real Expose failure beats the "already exposed" signal: callers must
+// see the genuine ErrExposeAPI wrap so they retry, not the sentinel that
+// would have them treat the call as delegation.
+func TestAddAlreadyExposedPlusRealFailureReturnsRealFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.ExposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		switch req.Local {
+		case ipPortBuilder(hostIP, hostPort):
+			http.Error(w, "proxy already running", http.StatusInternalServerError)
+		case ipPortBuilder(hostIP2, hostPort):
+			http.Error(w, "transient backend error", http.StatusInternalServerError)
+		}
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort: []nat.PortBinding{
+			{HostIP: hostIP, HostPort: hostPort},  // already exposed
+			{HostIP: hostIP2, HostPort: hostPort}, // real failure
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, forwarder.ErrExposeAPI,
+		"a real Expose failure must surface, not be masked by the sentinel")
+	require.NotErrorIs(t, err, tracker.ErrPortAlreadyExposed,
+		"the sentinel only applies when every port was already exposed")
+}
+
+// TestAddAcrossPortsOneAlreadyExposed covers a request spanning two
+// distinct nat.Ports rather than two bindings of one port: the
+// alreadyExposed tally is per binding but the sentinel is decided
+// against successfullyForwarded, which is keyed by port.
+func TestAddAcrossPortsOneAlreadyExposed(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/services/forwarder/expose", func(w http.ResponseWriter, r *http.Request) {
+		var req *types.ExposeRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.Local == ipPortBuilder(hostIP, hostPort2) {
+			http.Error(w, "proxy already running", http.StatusInternalServerError)
+		}
+	})
+	testSrv := httptest.NewServer(mux)
+	defer testSrv.Close()
+
+	apiTracker := tracker.NewAPITracker(context.Background(), &testForwarder{}, testSrv.URL, hostSwitchIP, true)
+
+	protoPort, err := nat.NewPort(protocolTCP, hostPort)
+	require.NoError(t, err)
+	protoPort2, err := nat.NewPort(protocolTCP, hostPort2)
+	require.NoError(t, err)
+
+	err = apiTracker.Add(containerID, nat.PortMap{
+		protoPort:  []nat.PortBinding{{HostIP: hostIP, HostPort: hostPort}},  // forwarded
+		protoPort2: []nat.PortBinding{{HostIP: hostIP, HostPort: hostPort2}}, // already exposed
+	})
+	require.NoError(t, err, "one forwarded port means the call did real work")
+
+	stored := apiTracker.Get(containerID)
+	require.Len(t, stored[protoPort], 1)
+	assert.Empty(t, stored[protoPort2], "an already-exposed port must not be recorded as forwarded")
+}
+
 func ipPortBuilder(ip, port string) string {
 	return ip + ":" + port
 }

--- a/src/go/guestagent/pkg/tracker/tracker.go
+++ b/src/go/guestagent/pkg/tracker/tracker.go
@@ -27,6 +27,9 @@ type Tracker interface {
 	// Add adds a portMap to the storage using the containerID as a Key.
 	// It replaces all existing portMappings, without attempting to unbind listeners,
 	// so the caller is responsible for calling Remove first if necessary.
+	// Add returns ErrPortAlreadyExposed when every port it called the
+	// expose API for was already exposed by another component and
+	// nothing else failed.
 	Add(containerID string, portMapping nat.PortMap) error
 
 	// Remove removes a portMap using the containerID as a key.


### PR DESCRIPTION
When another component has already exposed a port, host-switch answers "proxy already running", which surfaced as a generic Expose failure, so every scanning caller retried and logged on each tick. Under moby that is one retry per published port for the container's lifetime, the log-growth amplifier behind #10737. That issue's root cause, the guest agent always running with `-debug`, is fixed separately in #10751; the ERROR lines below appear whatever the debug setting.

`APITracker.Add` now reports that case as a typed sentinel and every caller classifies it. Docker's `initializeRunningContainers` previously treated it as fatal and skipped the loopback DNAT rules that make a `127.0.0.1` publish reachable, so that path lost traffic too.

A listener staying put is not proof the expose survived, though. `RemoveAll` drops every port in the shared tracker when an event monitor reconnects, and the kube watcher and the iptables scanner never re-register. So the scanner re-examines what it believes every five minutes.

Unrelated but adjacent: the iptables scanner built one `nat.PortMap` outside its loop over added entries, so each `Add` resubmitted every earlier port.

Fixes #10337
Fixes #10338
Issue #10737
