### PR TITLE
fix: reject malformed object settings

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -888,6 +888,21 @@ describe('SettingsValidator', () => {
     ]);
   });
 
+  it('rejects null and arrays for object settings', () => {
+    for (const [field, value, expectedValue] of [
+      ['kubernetes', null, 'null'],
+      ['kubernetes.options', [], '[]'],
+    ] as const) {
+      const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, _.set({}, field, value));
+
+      expect({ needToUpdate, errors, isFatal }).toEqual({
+        needToUpdate: false,
+        errors:       [`Setting "${ field }" should wrap an inner object, but got <${ expectedValue }>.`],
+        isFatal:      false,
+      });
+    }
+  });
+
   // Add some fields that are very unlikely to ever collide with newly introduced fields.
   it('should ignore unrecognized settings', () => {
     const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, {

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -258,10 +258,13 @@ export default class SettingsValidator {
         continue;
       }
       if (typeof (allowedSettings[k]) === 'object') {
-        if (typeof (newSettings[k]) === 'object') {
-          changeNeeded = this.checkProposedSettings(mergedSettings, allowedSettings[k], currentSettings[k], newSettings[k], errors, fqname) || changeNeeded;
+        const proposedValue = newSettings[k];
+        if (typeof proposedValue === 'object' && proposedValue && !Array.isArray(proposedValue)) {
+          changeNeeded = this.checkProposedSettings(mergedSettings, allowedSettings[k], currentSettings[k], proposedValue, errors, fqname) || changeNeeded;
+        } else if (typeof proposedValue === 'object') {
+          errors.push(t('validation.shouldBeObject', { field: fqname, value: JSON.stringify(proposedValue) }));
         } else {
-          errors.push(t('validation.shouldBeObject', { field: fqname, value: newSettings[k] }));
+          errors.push(t('validation.shouldBeObject', { field: fqname, value: proposedValue }));
         }
       } else if (typeof (newSettings[k]) === 'object') {
         if (typeof allowedSettings[k] === 'function') {


### PR DESCRIPTION
## Description

Reject `null` and array values for settings that expect an object.

Following mook-as's advice on [#10755](https://github.com/rancher-sandbox/rancher-desktop/pull/10755), I kept this PR focused and used the same concise validation and verification format.

## Reproduction

Before:

- `kubernetes: null` was silently ignored.
- `kubernetes.options: []` was silently ignored.

After:

- Both inputs return validation errors.
- Array values are preserved as JSON in the error message.

## Verification

- Added focused regression tests.
- The external settings-validation fuzzer reproduced the issue across structural object settings.
- Fork CI passed the test, macOS/Windows lint, spelling, path, and Linux/Windows e2e checks.

I’m currently studying fuzz testing and can mainly contribute small, reproducible bug fixes for now. I’m sorry I cannot contribute broader changes yet, and I’ll keep future contributions focused.
