### PR TITLE
Add --wait to rdctl start

### DIFF
--- a/src/go/rdctl/cmd/start.go
+++ b/src/go/rdctl/cmd/start.go
@@ -18,17 +18,20 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	options "github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/options/generated"
 	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/paths"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/startwait"
 )
 
 // startCmd represents the start command
@@ -48,12 +51,23 @@ If it's running, behaves the same as 'rdctl set ...'.
 
 var applicationPath string
 var noModalDialogs bool
+var waitForStart bool
+var waitTimeout time.Duration
+
+// startPollInterval paces the backend_state polling done by --wait, and
+// defaultWaitTimeout bounds how long that polling continues.
+const (
+	startPollInterval  = 2 * time.Second
+	defaultWaitTimeout = 10 * time.Minute
+)
 
 func init() {
 	rootCmd.AddCommand(startCmd)
 	options.UpdateCommonStartAndSetCommands(startCmd)
 	startCmd.Flags().StringVarP(&applicationPath, "path", "p", "", "path to main executable")
 	startCmd.Flags().BoolVarP(&noModalDialogs, "no-modal-dialogs", "", false, "avoid displaying dialog boxes")
+	startCmd.Flags().BoolVar(&waitForStart, "wait", false, "wait until the backend has finished starting")
+	startCmd.Flags().DurationVar(&waitTimeout, "wait-timeout", defaultWaitTimeout, "how long to wait for start before giving up")
 }
 
 /**
@@ -70,10 +84,34 @@ func doStartOrSetCommand(cmd *cobra.Command) error {
 			// `--path | -p` is not a valid option for `rdctl set...`
 			return fmt.Errorf("--path %q specified but Rancher Desktop is already running", applicationPath)
 		}
-		return doSetCommand(cmd)
+		if err := doSetCommand(cmd); err != nil {
+			return err
+		}
+	} else {
+		cmd.SilenceUsage = true
+		if err := doStartCommand(cmd); err != nil {
+			return err
+		}
 	}
-	cmd.SilenceUsage = true
-	return doStartCommand(cmd)
+	if waitForStart {
+		return waitForBackendStart(cmd.Context())
+	}
+	return nil
+}
+
+// waitForBackendStart blocks until the backend is ready or waitTimeout elapses.
+func waitForBackendStart(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(startPollInterval)
+	defer ticker.Stop()
+
+	err := startwait.Wait(ctx, ticker.C, startwait.LiveState)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("timed out after %s waiting for Rancher Desktop to start", waitTimeout)
+	}
+	return err
 }
 
 func doStartCommand(cmd *cobra.Command) error {

--- a/src/go/rdctl/pkg/startwait/startwait.go
+++ b/src/go/rdctl/pkg/startwait/startwait.go
@@ -1,0 +1,92 @@
+/*
+Copyright © 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package startwait blocks until the Rancher Desktop backend has finished
+// starting, so that `rdctl start --wait` returns only once the container
+// engine is usable.
+package startwait
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/config"
+)
+
+// ErrBackendFailed is returned when the backend reports the ERROR state.
+var ErrBackendFailed = errors.New("the Rancher Desktop backend failed to start; check the application logs")
+
+// vmState values that end the wait. STARTED and DISABLED are both terminal
+// successes: setState(STARTED/DISABLED) runs only after the container engine
+// reports ready, so the docker socket is usable by the time either appears.
+// DISABLED differs only in that Kubernetes is turned off.
+const (
+	stateStarted  = "STARTED"
+	stateDisabled = "DISABLED"
+	stateError    = "ERROR"
+)
+
+// GetStateFunc reads the current backend state. It exists so tests can drive
+// the poll loop without a running application.
+type GetStateFunc func(context.Context) (client.BackendState, error)
+
+// LiveState reads the backend state over the command-server API. During a cold
+// start the connection file has not been written yet, or names a server that
+// is not listening; both surface as ErrConnectionRefused so the caller keeps
+// polling until the new instance takes over.
+func LiveState(ctx context.Context) (client.BackendState, error) {
+	connInfo, err := config.GetConnectionInfo(true)
+	if err != nil || connInfo == nil {
+		return client.BackendState{}, client.ErrConnectionRefused
+	}
+	return client.NewRDClient(connInfo).GetBackendState(ctx)
+}
+
+// Wait polls getState until the backend is ready, fails, or ctx is done. tick
+// paces the polling; each receive triggers the next poll. It returns nil once
+// the backend is up, ErrBackendFailed on a reported failure, or ctx.Err() on
+// timeout or cancellation. Connection errors before the server is up are
+// expected and do not end the wait.
+func Wait(ctx context.Context, tick <-chan time.Time, getState GetStateFunc) error {
+	for {
+		state, err := getState(ctx)
+		switch {
+		case err == nil:
+			switch state.VMState {
+			case stateStarted, stateDisabled:
+				return nil
+			case stateError:
+				return ErrBackendFailed
+			}
+		case errors.Is(err, client.ErrConnectionRefused):
+			// The server is not up yet; keep waiting.
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return err
+		default:
+			logrus.WithError(err).Trace("ignoring transient error while waiting for start")
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick:
+		}
+	}
+}

--- a/src/go/rdctl/pkg/startwait/startwait_test.go
+++ b/src/go/rdctl/pkg/startwait/startwait_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package startwait
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rancher-sandbox/rancher-desktop/src/go/rdctl/pkg/client"
+)
+
+type poll struct {
+	state string
+	err   error
+}
+
+// stubStates returns a GetStateFunc that yields the given polls in order,
+// repeating the last one once exhausted.
+func stubStates(polls ...poll) GetStateFunc {
+	i := 0
+	return func(context.Context) (client.BackendState, error) {
+		p := polls[i]
+		if i < len(polls)-1 {
+			i++
+		}
+		return client.BackendState{VMState: p.state}, p.err
+	}
+}
+
+// ticker returns a channel that fires until the test ends, so Wait polls
+// without a real delay between iterations.
+func ticker(t *testing.T) <-chan time.Time {
+	t.Helper()
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	tick := make(chan time.Time)
+	go func() {
+		for {
+			select {
+			case tick <- time.Now():
+			case <-done:
+				return
+			}
+		}
+	}()
+	return tick
+}
+
+func TestWaitReturnsWhenStarted(t *testing.T) {
+	getState := stubStates(
+		poll{err: client.ErrConnectionRefused},
+		poll{state: "STARTING"},
+		poll{state: "STARTED"},
+	)
+	require.NoError(t, Wait(context.Background(), ticker(t), getState))
+}
+
+func TestWaitReturnsWhenDisabled(t *testing.T) {
+	getState := stubStates(poll{state: "DISABLED"})
+	require.NoError(t, Wait(context.Background(), ticker(t), getState))
+}
+
+func TestWaitFailsOnErrorState(t *testing.T) {
+	getState := stubStates(poll{state: "ERROR"})
+	assert.ErrorIs(t, Wait(context.Background(), ticker(t), getState), ErrBackendFailed)
+}
+
+func TestWaitStopsOnTimeout(t *testing.T) {
+	// The backend never leaves STARTING, so the wait ends only when ctx does.
+	getState := stubStates(poll{state: "STARTING"})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	assert.ErrorIs(t, Wait(ctx, ticker(t), getState), context.DeadlineExceeded)
+}
+
+func TestWaitIgnoresTransientErrors(t *testing.T) {
+	getState := stubStates(
+		poll{err: errors.New("temporary read failure")},
+		poll{state: "STARTED"},
+	)
+	require.NoError(t, Wait(context.Background(), ticker(t), getState))
+}


### PR DESCRIPTION
rdctl start launches the app and returns right away, so scripts that run rdctl start and then use docker/kubectl race the backend coming up. shutdown already has `--wait`; start didn't.

Add `--wait` (and `--wait-timeout`, default 10m) to poll `/v1/backend_state` until the backend reaches `STARTED` or `DISABLED`, fail on `ERROR`, and give up after the timeout. Off by default, so existing behaviour is unchanged.

The backend only reports STARTED after the container engine is ready, so the docker socket is usable once the command returns.

Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/6915