### PR TITLE
Filesystem viewer - first cut

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -26,6 +26,7 @@ import { getPathManagerFor } from '@pkg/integrations/pathManagerImpl';
 import { BackendState, CommandWorkerInterface, HttpCommandServer } from '@pkg/main/commandServer/httpCommandServer';
 import SettingsValidator from '@pkg/main/commandServer/settingsValidator';
 import { ContainerExecHandler } from '@pkg/main/containerExec';
+import { ContainerFilesHandler } from '@pkg/main/containerFiles';
 import { ContainerStatsHandler } from '@pkg/main/containerStats';
 import { HttpCredentialHelperServer } from '@pkg/main/credentialServer/httpCredentialHelperServer';
 import { DeploymentProfileError, readDeploymentProfiles } from '@pkg/main/deploymentProfiles';
@@ -92,6 +93,7 @@ let firstRunDialogComplete = false;
 let gone = false; // when true indicates app is shutting down
 let imageEventHandler: ImageEventHandler | null = null;
 let containerExecHandler: ContainerExecHandler | null = null;
+let containerFilesHandler: ContainerFilesHandler | null = null;
 let containerStatsHandler: ContainerStatsHandler | null = null;
 let currentContainerEngine = settings.ContainerEngine.NONE;
 let currentImageProcessor: ImageProcessor | null = null;
@@ -605,6 +607,12 @@ async function startK8sManager() {
     containerStatsHandler = new ContainerStatsHandler(k8smanager.containerEngineClient);
   } else {
     containerStatsHandler.updateClient(k8smanager.containerEngineClient);
+  }
+
+  if (!containerFilesHandler) {
+    containerFilesHandler = new ContainerFilesHandler(k8smanager.containerEngineClient);
+  } else {
+    containerFilesHandler.updateClient(k8smanager.containerEngineClient);
   }
 }
 

--- a/e2e/containers.e2e.spec.ts
+++ b/e2e/containers.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, ElectronApplication, Page } from '@playwright/test';
 
+import { ContainerFilesPage } from './pages/container-files-page';
 import { ContainerInspectPage } from './pages/container-inspect-page';
 import { ContainerLogsPage } from './pages/container-logs-page';
 import { ContainerShellPage } from './pages/container-shell-page';
@@ -643,5 +644,110 @@ test.describe.serial('Container Stats Tab', () => {
 
     await expect(statsPage.notRunningBanner).toBeVisible({ timeout: 10_000 });
     await expect(statsPage.cpuChart).not.toBeVisible();
+  });
+});
+
+test.describe.serial('Container Files Tab', () => {
+  let electronApp: ElectronApplication;
+  let runningContainerId: string;
+  let stoppedContainerId: string;
+
+  test.beforeAll(async({ colorScheme }, testInfo) => {
+    [electronApp, page] = await startSlowerDesktop(testInfo, {
+      kubernetes:      { enabled: false },
+      containerEngine: { name: ContainerEngine.MOBY, allowedImages: { enabled: false } },
+    });
+
+    const navPage = new NavPage(page);
+    await navPage.progressBecomesReady();
+
+    // Long-running container for the "running" tests.
+    const runOutput = await tool('docker', 'run', '--detach', 'alpine', 'sleep', 'infinity');
+
+    runningContainerId = runOutput.trim();
+
+    // Stopped container (exits immediately) — exercises the `cp`/tar listing path.
+    const stopOutput = await tool('docker', 'run', '--detach', 'alpine', 'echo', 'done');
+
+    stoppedContainerId = stopOutput.trim();
+    // Give it a moment to exit.
+    await new Promise(resolve => setTimeout(resolve, 2_000));
+  });
+
+  test.afterAll(async({ colorScheme }, testInfo) => {
+    for (const id of [runningContainerId, stoppedContainerId]) {
+      if (id) {
+        try {
+          await tool('docker', 'rm', '-f', id);
+        } catch {}
+      }
+    }
+    await teardown(electronApp, testInfo);
+  });
+
+  async function navigateToFilesTab(containerId: string): Promise<ContainerFilesPage> {
+    const navPage = new NavPage(page);
+    await navPage.navigateTo('Containers');
+    const containersPage = new ContainersPage(page);
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(containerId);
+    await containersPage.clickContainerAction(containerId, 'info');
+    await page.waitForURL(`**/containers/info/${ containerId }**`, { timeout: 10_000 });
+    const filesPage = new ContainerFilesPage(page);
+    await filesPage.clickTab();
+
+    return filesPage;
+  }
+
+  test('Files tab appears after the Shell tab', async() => {
+    const navPage = new NavPage(page);
+    await navPage.navigateTo('Containers');
+    const containersPage = new ContainersPage(page);
+    await containersPage.waitForTableToLoad();
+    await containersPage.waitForContainerToAppear(runningContainerId);
+    await containersPage.clickContainerAction(runningContainerId, 'info');
+    await page.waitForURL(`**/containers/info/${ runningContainerId }**`, { timeout: 10_000 });
+
+    const tabs = page.locator('.tabs li.tab');
+    const names = (await tabs.allTextContents()).map((t: string) => t.trim());
+
+    const shellIdx = names.findIndex((n: string) => n === 'Shell');
+    const filesIdx = names.findIndex((n: string) => n === 'Files');
+
+    expect(filesIdx).toBeGreaterThan(shellIdx);
+    expect(filesIdx).toBe(names.length - 1);
+  });
+
+  test('lists the root filesystem of a running container', async() => {
+    const filesPage = await navigateToFilesTab(runningContainerId);
+
+    await filesPage.waitForTree();
+
+    // Well-known top-level directories from the alpine image.
+    await expect(filesPage.node('/etc')).toBeVisible();
+    await expect(filesPage.node('/bin')).toBeVisible();
+  });
+
+  test('expands a directory and previews a text file', async() => {
+    const filesPage = await navigateToFilesTab(runningContainerId);
+
+    await filesPage.waitForTree();
+    await filesPage.expandDirectory('/etc', '/etc/hosts');
+    await filesPage.openFile('/etc/hosts');
+
+    // /etc/hosts always contains a localhost entry.
+    await expect(filesPage.previewText).toContainText('localhost', { timeout: 15_000 });
+    // The breadcrumb should reflect the selected file.
+    await expect(filesPage.breadcrumbs).toContainText('hosts');
+  });
+
+  test('lists the filesystem of a stopped container', async() => {
+    // Regression guard: stopped containers are browsed via `<engine> cp` + tar,
+    // whose archive wraps root entries under `./`; the tree must still populate.
+    const filesPage = await navigateToFilesTab(stoppedContainerId);
+
+    await filesPage.waitForTree();
+    await expect(filesPage.node('/etc')).toBeVisible();
+    await expect(filesPage.node('/bin')).toBeVisible();
   });
 });

--- a/e2e/pages/container-files-page.ts
+++ b/e2e/pages/container-files-page.ts
@@ -1,0 +1,54 @@
+import { expect } from '@playwright/test';
+
+import type { Locator, Page } from '@playwright/test';
+
+export class ContainerFilesPage {
+  readonly page:           Page;
+  readonly tab:            Locator;
+  readonly tree:           Locator;
+  readonly breadcrumbs:    Locator;
+  readonly preview:        Locator;
+  readonly previewText:    Locator;
+  readonly binaryNotice:   Locator;
+  readonly downloadButton: Locator;
+  readonly refreshButton:  Locator;
+  readonly errorBanner:    Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.tab = page.getByTestId('tab-files');
+    this.tree = page.getByTestId('files-tree');
+    this.breadcrumbs = page.getByTestId('files-breadcrumbs');
+    this.preview = page.getByTestId('files-preview');
+    this.previewText = page.getByTestId('files-content');
+    this.binaryNotice = page.getByTestId('files-binary');
+    this.downloadButton = page.getByTestId('files-download');
+    this.refreshButton = page.getByTestId('files-refresh');
+    this.errorBanner = page.getByTestId('files-error');
+  }
+
+  async clickTab() {
+    await this.tab.click();
+  }
+
+  /** A tree row for the given absolute container path, e.g. `/etc/hosts`. */
+  node(path: string): Locator {
+    return this.page.getByTestId(`files-node-${ path }`);
+  }
+
+  /** Wait for the directory tree to finish its initial load. */
+  async waitForTree(timeout = 30_000) {
+    await expect(this.tree.locator('li.tree-row').first()).toBeVisible({ timeout });
+  }
+
+  /** Click a directory node to expand it, then wait for a known child to appear. */
+  async expandDirectory(dirPath: string, expectChild: string, timeout = 30_000) {
+    await this.node(dirPath).click();
+    await expect(this.node(expectChild)).toBeVisible({ timeout });
+  }
+
+  /** Select a file node to load its preview. */
+  async openFile(filePath: string) {
+    await this.node(filePath).click();
+  }
+}

--- a/pkg/rancher-desktop/assets/translations/en-us.yaml
+++ b/pkg/rancher-desktop/assets/translations/en-us.yaml
@@ -877,12 +877,23 @@ containerInfo:
   logs: Logs
   shell: Shell
   stats: Stats
+  files: Files
   search:
     ariaLabel: Search in logs
     clearSearch: Clear search
     nextMatch: Next match
     placeholder: Search logs...
     previousMatch: Previous match
+containerFiles:
+  loading: Loading…
+  refresh: Refresh
+  download: Download
+  selectPrompt: Select a file to preview its contents.
+  binary: This file appears to be binary and cannot be previewed. Use Download to save it.
+  truncated: This file is large; only the beginning is shown. Use Download to save the whole file.
+  errors:
+    list: Failed to list directory.
+    read: Failed to read file.
 containerInspect:
   loading: Loading container details…
   error:

--- a/pkg/rancher-desktop/components/ContainerFiles.vue
+++ b/pkg/rancher-desktop/components/ContainerFiles.vue
@@ -1,0 +1,608 @@
+<template>
+  <div class="container-files-component">
+    <div class="files-toolbar">
+      <div
+        class="breadcrumbs"
+        data-testid="files-breadcrumbs"
+      >
+        <button
+          v-for="(crumb, i) in breadcrumbs"
+          :key="crumb.path"
+          class="crumb"
+          :class="{ 'crumb-current': i === breadcrumbs.length - 1 }"
+          type="button"
+          @click="revealPath(crumb.path)"
+        >
+          {{ crumb.label }}<span
+            v-if="i < breadcrumbs.length - 1"
+            class="crumb-sep"
+          >/</span>
+        </button>
+      </div>
+      <button
+        class="btn role-tertiary btn-sm"
+        data-testid="files-refresh"
+        :title="t('containerFiles.refresh')"
+        type="button"
+        @click="refresh"
+      >
+        <i
+          aria-hidden="true"
+          class="icon icon-refresh"
+        />
+      </button>
+    </div>
+
+    <div class="files-body">
+      <div
+        class="tree-pane"
+        data-testid="files-tree"
+      >
+        <banner
+          v-if="rootError"
+          class="content-state"
+          color="error"
+          data-testid="files-error"
+        >
+          <span class="icon icon-info-circle icon-lg" />
+          {{ rootError }}
+        </banner>
+        <div
+          v-else-if="rootLoading"
+          class="content-state muted"
+        >
+          {{ t('containerFiles.loading') }}
+        </div>
+        <ul
+          v-else
+          class="tree"
+        >
+          <li
+            v-for="node in visibleNodes"
+            :key="node.path"
+            class="tree-row"
+            :class="{ selected: node.path === selectedPath }"
+            :style="{ paddingLeft: `${node.depth * 14 + 4}px` }"
+            :data-testid="`files-node-${node.path}`"
+            @click="onNodeClick(node)"
+          >
+            <span
+              class="twisty"
+              :class="{ invisible: node.type !== 'directory' }"
+            >
+              <i
+                aria-hidden="true"
+                class="icon"
+                :class="node.loading ? 'icon-spinner icon-spin' : (node.expanded ? 'icon-chevron-down' : 'icon-chevron-right')"
+              />
+            </span>
+            <i
+              aria-hidden="true"
+              class="icon type-icon"
+              :class="iconFor(node)"
+            />
+            <span class="node-name">{{ node.name }}</span>
+            <span
+              v-if="node.type === 'symlink' && node.linkTarget"
+              class="link-target"
+            >→ {{ node.linkTarget }}</span>
+            <span
+              v-if="node.type === 'file'"
+              class="node-size"
+            >{{ formatBytes(node.size) }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <div
+        class="preview-pane"
+        data-testid="files-preview"
+      >
+        <template v-if="selectedPath">
+          <div class="preview-header">
+            <span class="preview-path">{{ selectedPath }}</span>
+            <button
+              class="btn role-secondary btn-sm"
+              data-testid="files-download"
+              :disabled="downloading"
+              type="button"
+              @click="download"
+            >
+              {{ t('containerFiles.download') }}
+            </button>
+          </div>
+          <div
+            v-if="preview.loading"
+            class="content-state muted"
+          >
+            {{ t('containerFiles.loading') }}
+          </div>
+          <banner
+            v-else-if="preview.error"
+            class="content-state"
+            color="error"
+          >
+            <span class="icon icon-info-circle icon-lg" />
+            {{ preview.error }}
+          </banner>
+          <div
+            v-else-if="preview.encoding === 'base64'"
+            class="content-state muted"
+            data-testid="files-binary"
+          >
+            {{ t('containerFiles.binary') }}
+          </div>
+          <template v-else>
+            <banner
+              v-if="preview.truncated"
+              class="truncation-note"
+              color="info"
+            >
+              {{ t('containerFiles.truncated') }}
+            </banner>
+            <pre
+              class="preview-content"
+              data-testid="files-content"
+            >{{ preview.content }}</pre>
+          </template>
+        </template>
+        <div
+          v-else
+          class="content-state muted"
+        >
+          {{ t('containerFiles.selectPrompt') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Banner } from '@rancher/components';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useStore } from 'vuex';
+
+import type { ContainerFileEntry } from '@pkg/main/containerFiles';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+
+defineOptions({ name: 'ContainerFiles' });
+
+const props = defineProps<{
+  containerId:         string;
+  isContainerRunning?: boolean;
+  namespace?:          string;
+}>();
+
+const store = useStore();
+const t = (key: string, args?: Record<string, unknown>) => store.getters['i18n/t'](key, args);
+
+interface TreeNode extends ContainerFileEntry {
+  path:      string;
+  depth:     number;
+  expanded:  boolean;
+  loaded:    boolean;
+  loading:   boolean;
+  children?: TreeNode[];
+}
+
+const rootChildren = ref<TreeNode[]>([]);
+const rootLoading = ref(true);
+const rootError = ref<string | null>(null);
+const selectedPath = ref<string | null>(null);
+
+const preview = ref<{
+  loading:   boolean;
+  error:     string | null;
+  content:   string;
+  encoding:  'utf-8' | 'base64';
+  truncated: boolean;
+}>({
+  loading: false, error: null, content: '', encoding: 'utf-8', truncated: false,
+});
+const downloading = ref(false);
+
+function ipcOptions() {
+  return { namespace: props.namespace, running: !!props.isContainerRunning };
+}
+
+function makeNode(entry: ContainerFileEntry, parentPath: string, depth: number): TreeNode {
+  const path = parentPath === '/' ? `/${ entry.name }` : `${ parentPath }/${ entry.name }`;
+
+  return {
+    ...entry, path, depth, expanded: false, loaded: false, loading: false,
+  };
+}
+
+function sortEntries(entries: ContainerFileEntry[]): ContainerFileEntry[] {
+  // Directories first, then alphabetical (case-insensitive).
+  return [...entries].sort((a, b) => {
+    const aDir = a.type === 'directory' ? 0 : 1;
+    const bDir = b.type === 'directory' ? 0 : 1;
+
+    if (aDir !== bDir) {
+      return aDir - bDir;
+    }
+
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+}
+
+async function loadChildren(parentPath: string): Promise<TreeNode[]> {
+  const result = await ipcRenderer.invoke('container-files/list', props.containerId, parentPath, ipcOptions());
+  const depth = parentPath === '/' ? 0 : parentPath.split('/').length - 1;
+
+  return sortEntries(result.entries).map(entry => makeNode(entry, parentPath, depth));
+}
+
+async function loadRoot() {
+  rootLoading.value = true;
+  rootError.value = null;
+  rootChildren.value = [];
+  selectedPath.value = null;
+  try {
+    rootChildren.value = await loadChildren('/');
+  } catch (ex: any) {
+    rootError.value = ex?.message ? String(ex.message) : t('containerFiles.errors.list');
+  } finally {
+    rootLoading.value = false;
+  }
+}
+
+async function toggle(node: TreeNode) {
+  if (node.type !== 'directory') {
+    return;
+  }
+  if (node.expanded) {
+    node.expanded = false;
+
+    return;
+  }
+  if (!node.loaded) {
+    node.loading = true;
+    try {
+      node.children = await loadChildren(node.path);
+      node.loaded = true;
+    } catch (ex: any) {
+      node.children = [];
+      node.loaded = true;
+      console.error(`Failed to list ${ node.path }:`, ex);
+    } finally {
+      node.loading = false;
+    }
+  }
+  node.expanded = true;
+}
+
+async function onNodeClick(node: TreeNode) {
+  if (node.type === 'directory') {
+    await toggle(node);
+
+    return;
+  }
+  // v1 limitation: symlinks (including directory symlinks such as the usrmerge
+  // /bin -> /usr/bin) are treated as previewable leaves rather than being
+  // followed/expanded. Making dir-symlinks browsable is tracked as a follow-up.
+  selectedPath.value = node.path;
+  await loadPreview(node.path);
+}
+
+async function loadPreview(filePath: string) {
+  preview.value = {
+    loading: true, error: null, content: '', encoding: 'utf-8', truncated: false,
+  };
+  try {
+    const result = await ipcRenderer.invoke('container-files/read', props.containerId, filePath, ipcOptions());
+
+    preview.value = {
+      loading:   false,
+      error:     null,
+      content:   result.content,
+      encoding:  result.encoding,
+      truncated: result.truncated,
+    };
+  } catch (ex: any) {
+    preview.value = {
+      loading:   false,
+      error:     ex?.message ? String(ex.message) : t('containerFiles.errors.read'),
+      content:   '',
+      encoding:  'utf-8',
+      truncated: false,
+    };
+  }
+}
+
+async function download() {
+  if (!selectedPath.value) {
+    return;
+  }
+  downloading.value = true;
+  try {
+    await ipcRenderer.invoke('container-files/download', props.containerId, selectedPath.value, false, ipcOptions());
+  } catch (ex) {
+    console.error('Download failed:', ex);
+  } finally {
+    downloading.value = false;
+  }
+}
+
+/**
+ * Expand the tree down to (and including) the given directory path, loading
+ * intermediate levels as needed.
+ */
+async function revealPath(target: string) {
+  if (target === '/') {
+    return;
+  }
+  const segments = target.split('/').filter(Boolean);
+  let list = rootChildren.value;
+  let current = '';
+
+  for (const segment of segments) {
+    current += `/${ segment }`;
+    const node = list.find(n => n.name === segment);
+
+    if (node?.type !== 'directory') {
+      break;
+    }
+    if (!node.loaded) {
+      await toggle(node);
+    } else {
+      node.expanded = true;
+    }
+    list = node.children ?? [];
+  }
+}
+
+const visibleNodes = computed<TreeNode[]>(() => {
+  const out: TreeNode[] = [];
+  const walk = (nodes: TreeNode[]) => {
+    for (const node of nodes) {
+      out.push(node);
+      if (node.type === 'directory' && node.expanded && node.children) {
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(rootChildren.value);
+
+  return out;
+});
+
+const breadcrumbs = computed(() => {
+  const crumbs = [{ label: '/', path: '/' }];
+
+  if (selectedPath.value) {
+    const segments = selectedPath.value.split('/').filter(Boolean);
+    let current = '';
+
+    for (const segment of segments) {
+      current += `/${ segment }`;
+      crumbs.push({ label: segment, path: current });
+    }
+  }
+
+  return crumbs;
+});
+
+function iconFor(node: TreeNode): string {
+  switch (node.type) {
+  case 'directory':
+    return node.expanded ? 'icon-folder-open' : 'icon-folder';
+  case 'symlink':
+    return 'icon-external-link';
+  default:
+    return 'icon-file';
+  }
+}
+
+function formatBytes(b: number): string {
+  if (b >= 1024 ** 3) {
+    return `${ (b / 1024 ** 3).toFixed(1) } GiB`;
+  }
+  if (b >= 1024 ** 2) {
+    return `${ (b / 1024 ** 2).toFixed(1) } MiB`;
+  }
+  if (b >= 1024) {
+    return `${ (b / 1024).toFixed(1) } KiB`;
+  }
+
+  return `${ b } B`;
+}
+
+function refresh() {
+  loadRoot();
+}
+
+onMounted(loadRoot);
+
+watch(() => props.containerId, loadRoot);
+</script>
+
+<style lang="scss" scoped>
+.container-files-component {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  flex: 1;
+}
+
+.files-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.breadcrumbs {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 13px;
+  overflow: hidden;
+}
+
+.crumb {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--link);
+  font-size: 13px;
+
+  &.crumb-current {
+    color: var(--body-text);
+    cursor: default;
+  }
+}
+
+.crumb-sep {
+  color: var(--muted);
+  margin: 0 0.25rem;
+}
+
+.btn-sm {
+  padding: 0.15rem 0.5rem;
+  min-height: 28px;
+}
+
+.files-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tree-pane {
+  width: 45%;
+  min-width: 240px;
+  overflow: auto;
+  border-right: 1px solid var(--border);
+}
+
+.tree {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+}
+
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 2px 8px 2px 0;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--body-text);
+
+  &:hover {
+    background: var(--nav-hover, var(--dropdown-hover-bg, rgba(0, 0, 0, 0.05)));
+  }
+
+  &.selected {
+    background: var(--primary-hover-bg, rgba(0, 0, 0, 0.08));
+  }
+}
+
+.twisty {
+  width: 14px;
+  display: inline-flex;
+  justify-content: center;
+  color: var(--muted);
+  flex-shrink: 0;
+
+  &.invisible {
+    visibility: hidden;
+  }
+
+  .icon {
+    font-size: 10px;
+  }
+}
+
+.type-icon {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.node-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.link-target {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.node-size {
+  margin-left: auto;
+  padding-left: 1rem;
+  color: var(--muted);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.preview-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.preview-path {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--body-text);
+}
+
+.truncation-note {
+  margin: 0.5rem;
+  flex-shrink: 0;
+}
+
+.preview-content {
+  flex: 1;
+  margin: 0;
+  padding: 0.75rem;
+  overflow: auto;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+  color: var(--body-text);
+}
+
+.content-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  gap: 0.5rem;
+
+  &.muted {
+    color: var(--muted);
+    font-size: 13px;
+  }
+}
+</style>

--- a/pkg/rancher-desktop/components/ContainerFiles.vue
+++ b/pkg/rancher-desktop/components/ContainerFiles.vue
@@ -5,19 +5,31 @@
         class="breadcrumbs"
         data-testid="files-breadcrumbs"
       >
-        <button
-          v-for="(crumb, i) in breadcrumbs"
-          :key="crumb.path"
+        <span
           class="crumb"
-          :class="{ 'crumb-current': i === breadcrumbs.length - 1 }"
-          type="button"
-          @click="revealPath(crumb.path)"
+          :class="{ 'crumb-current': breadcrumbs.length === 1 }"
+          role="button"
+          tabindex="0"
+          @click="revealPath('/')"
+          @keydown.enter.space.prevent="revealPath('/')"
+        >/</span>
+        <template
+          v-for="(crumb, i) in segmentCrumbs"
+          :key="crumb.path"
         >
-          {{ crumb.label }}<span
-            v-if="i < breadcrumbs.length - 1"
+          <span
+            v-if="i > 0"
             class="crumb-sep"
           >/</span>
-        </button>
+          <span
+            class="crumb"
+            :class="{ 'crumb-current': i === segmentCrumbs.length - 1 }"
+            role="button"
+            tabindex="0"
+            @click="revealPath(crumb.path)"
+            @keydown.enter.space.prevent="revealPath(crumb.path)"
+          >{{ crumb.label }}</span>
+        </template>
       </div>
       <button
         class="btn role-tertiary btn-sm"
@@ -385,6 +397,9 @@ const breadcrumbs = computed(() => {
   return crumbs;
 });
 
+// Everything after the leading "/" crumb, which is rendered separately.
+const segmentCrumbs = computed(() => breadcrumbs.value.slice(1));
+
 function iconFor(node: TreeNode): string {
   switch (node.type) {
   case 'directory':
@@ -442,28 +457,39 @@ watch(() => props.containerId, loadRoot);
   flex: 1;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-family: 'Courier New', monospace;
   font-size: 13px;
-  overflow: hidden;
+  // Native form-control text on macOS Electron can render subpixel-antialiased
+  // (and the overflow container promoted a compositing layer); force grayscale
+  // antialiasing on plain spans to avoid coloured-fringe / repaint artifacts.
+  -webkit-font-smoothing: antialiased;
 }
 
 .crumb {
-  background: none;
-  border: none;
-  padding: 0;
   cursor: pointer;
   color: var(--link);
-  font-size: 13px;
+
+  &:hover:not(.crumb-current) {
+    text-decoration: underline;
+  }
 
   &.crumb-current {
     color: var(--body-text);
     cursor: default;
   }
+
+  &:focus-visible {
+    outline: 1px solid var(--primary);
+    outline-offset: 1px;
+  }
 }
 
 .crumb-sep {
   color: var(--muted);
-  margin: 0 0.25rem;
+  user-select: none;
 }
 
 .btn-sm {

--- a/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
@@ -1,6 +1,10 @@
 /** @jest-environment node */
 
 import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
 
 import { jest } from '@jest/globals';
 import tar from 'tar-stream';
@@ -9,11 +13,27 @@ import mockModules from '@pkg/utils/testUtils/mockModules';
 
 const fakeProxy = { handle: jest.fn() };
 
+// electron mock with a driveable dialog/BrowserWindow for the download tests.
+const showSaveDialog = jest.fn<(...args: any[]) => Promise<any>>();
+const fromWebContents = jest.fn<(...args: any[]) => any>(() => null);
+const electronMock = {
+  app:           { isPackaged: false, getAppPath: () => path.resolve('.') },
+  BrowserWindow: { fromWebContents },
+  dialog:        { showSaveDialog },
+  ipcMain:       {},
+  ipcRenderer:   {},
+  nativeTheme:   {},
+  screen:        {},
+  shell:         {},
+};
+
 mockModules({
-  electron:             undefined,
+  electron:             electronMock,
   '@pkg/utils/logging': undefined,
   '@pkg/main/ipcMain':  { getIpcMainProxy: jest.fn(() => fakeProxy) },
-});
+// mockModules' param union does not accept a concrete module mixed with
+// `undefined` defaults; the values are validated structurally at runtime.
+} as any);
 
 let ContainerFilesHandler: Awaited<typeof import('@pkg/main/containerFiles')>['ContainerFilesHandler'];
 
@@ -31,6 +51,28 @@ function makeCpProcess(pack: any) {
   // Emit a successful `exit` once the archive has been fully streamed, mirroring
   // a real `cp` process that exits 0 after writing the tar to stdout.
   pack.on('end', () => proc.emit('exit', 0, null));
+
+  return proc;
+}
+
+/**
+ * Build a fake ReadableProcess that mimics a failed `cp` (empty stdout, a
+ * message on stderr, and a non-zero exit once stdout has been consumed).
+ */
+function makeFailingCpProcess(stderrText: string) {
+  const proc = new EventEmitter() as any;
+  const stdout = new Readable({ read() {} });
+
+  proc.stdout = stdout;
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  // Exit non-zero only after stdout has ended (deferred a tick), so the tar
+  // consumer settles first and `withCpStream` is already awaiting the exit.
+  stdout.on('end', () => setImmediate(() => proc.emit('exit', 1, null)));
+  setImmediate(() => {
+    proc.stderr.emit('data', Buffer.from(stderrText));
+    stdout.push(null);
+  });
 
   return proc;
 }
@@ -71,6 +113,8 @@ describe('ContainerFilesHandler', () => {
   beforeEach(() => {
     mockClient = { runClient: jest.fn() };
     handler = new ContainerFilesHandler(mockClient as any);
+    showSaveDialog.mockReset();
+    fromWebContents.mockReset().mockReturnValue(null);
   });
 
   describe('parseLsOutput', () => {
@@ -205,6 +249,153 @@ describe('ContainerFilesHandler', () => {
 
       expect(result.encoding).toBe('base64');
       expect(Buffer.from(result.content, 'base64')).toEqual(binary);
+    });
+
+    it('caps the preview at 1 MiB and marks it truncated', async() => {
+      const big = Buffer.alloc((1024 * 1024) + 4096, 0x61); // 1 MiB + 4 KiB of 'a'
+
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'big.log', body: big },
+      ])));
+
+      const result = await handler.readFile('abc', '/big.log', {});
+
+      expect(result.truncated).toBe(true);
+      expect(result.size).toBe(1024 * 1024);
+      expect(result.content.length).toBe(1024 * 1024);
+    });
+  });
+
+  describe('list (running vs stopped dispatch)', () => {
+    // Route `exec ... ls` and `cp ... -` to different fakes based on argv.
+    function routeRunClient(opts: { ls?: string | Error, cp?: any }) {
+      mockClient.runClient.mockImplementation((args: any) => {
+        if (args[0] === 'exec') {
+          if (opts.ls instanceof Error) {
+            return Promise.reject(opts.ls);
+          }
+
+          return Promise.resolve({ stdout: opts.ls ?? '', stderr: '' });
+        }
+        if (args[0] === 'cp') {
+          return opts.cp;
+        }
+        throw new Error(`unexpected runClient args: ${ args.join(' ') }`);
+      });
+    }
+
+    it('uses `ls` (not cp) for a running container', async() => {
+      routeRunClient({ ls: '-rw-r--r--    1 0        0               10 Jan  1 00:00 hello.txt' });
+
+      const result = await handler.list('abc', '/app', { running: true });
+
+      expect(result.entries).toEqual([
+        { name: 'hello.txt', type: 'file', size: 10, modeString: 'rw-r--r--', linkTarget: undefined },
+      ]);
+      // Only `exec` should have been invoked; no cp fallback.
+      expect(mockClient.runClient.mock.calls.every((c: any) => c[0][0] === 'exec')).toBe(true);
+    });
+
+    it('falls back to cp when `ls` fails (e.g. distroless without ls)', async() => {
+      routeRunClient({
+        ls: new Error('OCI runtime exec failed: exec: "ls": not found'),
+        cp: makeCpProcess(makePack([{ name: 'app/', type: 'directory', mode: 0o755 }, { name: 'app/main', body: 'x' }])),
+      });
+
+      const result = await handler.list('abc', '/app', { running: true });
+
+      expect(result.entries.map((e: any) => e.name)).toEqual(['main']);
+      expect(mockClient.runClient.mock.calls.some((c: any) => c[0][0] === 'cp')).toBe(true);
+    });
+
+    it('uses cp directly for a stopped container (no exec attempt)', async() => {
+      routeRunClient({ cp: makeCpProcess(makePack([{ name: 'app/', type: 'directory' }, { name: 'app/main', body: 'x' }])) });
+
+      const result = await handler.list('abc', '/app', { running: false });
+
+      expect(result.entries.map((e: any) => e.name)).toEqual(['main']);
+      expect(mockClient.runClient.mock.calls.every((c: any) => c[0][0] === 'cp')).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('rejects readFile with the cp stderr when the copy fails', async() => {
+      mockClient.runClient.mockReturnValue(
+        makeFailingCpProcess('Error: No such container:path: /nope'),
+      );
+
+      await expect(handler.readFile('abc', '/nope', {})).rejects.toThrow('No such container:path');
+    });
+
+    it('rejects listViaCp when the copy fails rather than returning empty', async() => {
+      mockClient.runClient.mockReturnValue(makeFailingCpProcess('lstat /bogus: no such file or directory'));
+
+      await expect(handler.listViaCp('abc', '/bogus', undefined)).rejects.toThrow('no such file or directory');
+    });
+  });
+
+  describe('download', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rd-files-test-'));
+    });
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns { canceled: true } and writes nothing when the dialog is cancelled', async() => {
+      showSaveDialog.mockResolvedValue({ canceled: true, filePath: undefined });
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([{ name: 'hostname', body: 'x' }])));
+
+      const result = await handler.download({ sender: {} }, 'abc', '/etc/hostname', false, {});
+
+      expect(result).toEqual({ canceled: true });
+      expect(mockClient.runClient).not.toHaveBeenCalled();
+    });
+
+    it('extracts a single file to the chosen path', async() => {
+      const dest = path.join(tmpDir, 'hostname');
+
+      showSaveDialog.mockResolvedValue({ canceled: false, filePath: dest });
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([{ name: 'hostname', body: 'my-host\n' }])));
+
+      const result = await handler.download({ sender: {} }, 'abc', '/etc/hostname', false, {});
+
+      expect(result).toEqual({ canceled: false, path: dest });
+      expect(fs.readFileSync(dest, 'utf-8')).toBe('my-host\n');
+    });
+
+    it('saves a directory as a .tar archive', async() => {
+      const dest = path.join(tmpDir, 'log.tar');
+
+      showSaveDialog.mockResolvedValue({ canceled: false, filePath: dest });
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'log/', type: 'directory', mode: 0o755 },
+        { name: 'log/apk.log', body: 'installed\n' },
+      ])));
+
+      const result = await handler.download({ sender: {} }, 'abc', '/var/log', true, {});
+
+      expect(result.canceled).toBe(false);
+
+      // The saved file should be a valid tar containing the entries verbatim.
+      const names: string[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        const extract = tar.extract();
+
+        extract.on('entry', (header, stream, next) => {
+          names.push(header.name);
+          stream.on('end', next);
+          stream.resume();
+        });
+        extract.on('finish', () => resolve());
+        extract.on('error', reject);
+        fs.createReadStream(dest).pipe(extract);
+      });
+
+      expect(names).toContain('log/apk.log');
     });
   });
 

--- a/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
@@ -150,6 +150,35 @@ describe('ContainerFilesHandler', () => {
 
       expect(result.entries.map((e: any) => e.name).sort()).toEqual(['bin', 'etc']);
     });
+
+    it('lists the root when the archive wraps entries under "./" (docker cp)', async() => {
+      // `docker cp <id>:/ -` emits a `.`-rooted archive; ensure the wrapper is
+      // stripped rather than collapsing everything into a single "." node.
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: './', type: 'directory', mode: 0o755 },
+        { name: './bin/', type: 'directory', mode: 0o755 },
+        { name: './bin/sh', body: 'x' },
+        { name: './etc/', type: 'directory', mode: 0o755 },
+        { name: './usr/local/bin/', type: 'directory', mode: 0o755 },
+      ])));
+
+      const result = await handler.listViaCp('abc', '/', undefined);
+
+      expect(result.entries.map((e: any) => e.name).sort()).toEqual(['bin', 'etc', 'usr']);
+      expect(result.entries.every((e: any) => e.type === 'directory')).toBe(true);
+    });
+
+    it('strips a base-name wrapper for nested directories', async() => {
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'ssl/', type: 'directory', mode: 0o755 },
+        { name: 'ssl/openssl.cnf', body: 'x' },
+        { name: 'ssl/certs/', type: 'directory', mode: 0o755 },
+      ])));
+
+      const result = await handler.listViaCp('abc', '/etc/ssl', undefined);
+
+      expect(result.entries.map((e: any) => e.name).sort()).toEqual(['certs', 'openssl.cnf']);
+    });
   });
 
   describe('readFile', () => {

--- a/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/containerFiles.spec.ts
@@ -1,0 +1,192 @@
+/** @jest-environment node */
+
+import { EventEmitter } from 'events';
+
+import { jest } from '@jest/globals';
+import tar from 'tar-stream';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const fakeProxy = { handle: jest.fn() };
+
+mockModules({
+  electron:             undefined,
+  '@pkg/utils/logging': undefined,
+  '@pkg/main/ipcMain':  { getIpcMainProxy: jest.fn(() => fakeProxy) },
+});
+
+let ContainerFilesHandler: Awaited<typeof import('@pkg/main/containerFiles')>['ContainerFilesHandler'];
+
+beforeAll(async() => {
+  ({ ContainerFilesHandler } = await import('@pkg/main/containerFiles'));
+});
+
+/** Build a fake ReadableProcess whose stdout is the given tar `pack` stream. */
+function makeCpProcess(pack: any) {
+  const proc = new EventEmitter() as any;
+
+  proc.stdout = pack;
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  // Emit a successful `exit` once the archive has been fully streamed, mirroring
+  // a real `cp` process that exits 0 after writing the tar to stdout.
+  pack.on('end', () => proc.emit('exit', 0, null));
+
+  return proc;
+}
+
+interface PackEntry {
+  name:      string;
+  type?:     string;
+  mode?:     number;
+  linkname?: string;
+  body?:     string | Buffer;
+}
+
+/** Assemble a tar stream from the given entries. */
+function makePack(entries: PackEntry[]) {
+  const pack = tar.pack();
+
+  for (const entry of entries) {
+    const body = entry.body ?? '';
+    const size = Buffer.byteLength(body);
+
+    pack.entry({
+      name:     entry.name,
+      type:     (entry.type as any) ?? 'file',
+      mode:     entry.mode ?? 0o644,
+      size,
+      linkname: entry.linkname,
+    }, body as any);
+  }
+  pack.finalize();
+
+  return pack;
+}
+
+describe('ContainerFilesHandler', () => {
+  let mockClient: { runClient: jest.Mock };
+  let handler: any;
+
+  beforeEach(() => {
+    mockClient = { runClient: jest.fn() };
+    handler = new ContainerFilesHandler(mockClient as any);
+  });
+
+  describe('parseLsOutput', () => {
+    it('parses GNU-style long listings', () => {
+      const output = [
+        'total 20',
+        'drwxr-xr-x    2 0        0             4096 Jan  1 00:00 bin',
+        '-rw-r--r--    1 0        0              220 Jan  1 00:00 .bashrc',
+        'lrwxrwxrwx    1 0        0                7 Jan  1 00:00 sh -> busybox',
+      ].join('\n');
+
+      const entries = handler.parseLsOutput(output);
+
+      expect(entries).toEqual([
+        {
+          name: 'bin', type: 'directory', size: 4096, modeString: 'rwxr-xr-x', linkTarget: undefined,
+        },
+        {
+          name: '.bashrc', type: 'file', size: 220, modeString: 'rw-r--r--', linkTarget: undefined,
+        },
+        {
+          name: 'sh', type: 'symlink', size: 7, modeString: 'rwxrwxrwx', linkTarget: 'busybox',
+        },
+      ]);
+    });
+
+    it('skips the total line and blank lines', () => {
+      const entries = handler.parseLsOutput('total 0\n\n');
+
+      expect(entries).toEqual([]);
+    });
+
+    it('handles file names containing spaces', () => {
+      const entries = handler.parseLsOutput('-rw-r--r--    1 0        0               10 Jan  1 00:00 my file.txt');
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('my file.txt');
+    });
+  });
+
+  describe('listViaCp', () => {
+    it('returns only immediate children of the directory', async() => {
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'etc/', type: 'directory', mode: 0o755 },
+        { name: 'etc/hostname', body: 'host\n' },
+        { name: 'etc/ssl/', type: 'directory', mode: 0o755 },
+        { name: 'etc/ssl/certs/ca.pem', body: 'x' },
+      ])));
+
+      const result = await handler.listViaCp('abc', '/etc', undefined);
+      const byName = Object.fromEntries(result.entries.map((e: any) => [e.name, e]));
+
+      expect(result.truncated).toBe(false);
+      expect(Object.keys(byName).sort()).toEqual(['hostname', 'ssl']);
+      expect(byName.hostname.type).toBe('file');
+      expect(byName.hostname.size).toBe(5);
+      expect(byName.ssl.type).toBe('directory');
+    });
+
+    it('infers intermediate directories when no explicit entry exists', async() => {
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'etc/deep/file', body: 'x' },
+      ])));
+
+      const result = await handler.listViaCp('abc', '/etc', undefined);
+
+      expect(result.entries).toEqual([{ name: 'deep', type: 'directory', size: 0 }]);
+    });
+
+    it('lists top-level entries when browsing the root', async() => {
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'bin/', type: 'directory', mode: 0o755 },
+        { name: 'etc/', type: 'directory', mode: 0o755 },
+      ])));
+
+      const result = await handler.listViaCp('abc', '/', undefined);
+
+      expect(result.entries.map((e: any) => e.name).sort()).toEqual(['bin', 'etc']);
+    });
+  });
+
+  describe('readFile', () => {
+    it('reads a text file as utf-8', async() => {
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'hostname', body: 'my-host\n' },
+      ])));
+
+      const result = await handler.readFile('abc', '/etc/hostname', {});
+
+      expect(result.encoding).toBe('utf-8');
+      expect(result.content).toBe('my-host\n');
+      expect(result.truncated).toBe(false);
+    });
+
+    it('returns binary files as base64', async() => {
+      const binary = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+
+      mockClient.runClient.mockReturnValue(makeCpProcess(makePack([
+        { name: 'blob', body: binary },
+      ])));
+
+      const result = await handler.readFile('abc', '/blob', {});
+
+      expect(result.encoding).toBe('base64');
+      expect(Buffer.from(result.content, 'base64')).toEqual(binary);
+    });
+  });
+
+  describe('normalizePath', () => {
+    it.each([
+      ['', '/'],
+      ['/', '/'],
+      ['/etc/', '/etc'],
+      ['/etc/../etc/ssl', '/etc/ssl'],
+    ])('normalizes %j to %j', (input, expected) => {
+      expect(handler.normalizePath(input)).toBe(expected);
+    });
+  });
+});

--- a/pkg/rancher-desktop/main/containerFiles.ts
+++ b/pkg/rancher-desktop/main/containerFiles.ts
@@ -1,0 +1,540 @@
+/**
+ * This module backs the "Files" tab of the container info screen.  It lets the
+ * renderer browse a container's filesystem one directory at a time, preview
+ * small files, and download files/directories to the host.
+ *
+ * Two mechanisms are used:
+ *  - For running containers we `exec ... ls` to list a single directory level,
+ *    which is cheap and does not transfer file contents.
+ *  - For stopped containers (or when `ls` is unavailable, e.g. distroless
+ *    images) we fall back to `<engine> cp <id>:<path> -`, which streams a tar
+ *    archive of the path.  We parse only the tar headers, so no file contents
+ *    are read while listing.
+ *
+ * Reading and downloading always go through the tar (`cp`) path so they work
+ * regardless of whether the container is running and without depending on any
+ * particular in-container tooling.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import Electron from 'electron';
+import tar from 'tar-stream';
+
+import type { ContainerEngineClient } from '@pkg/backend/containerClient';
+import type { ReadableProcess } from '@pkg/backend/containerClient/types';
+import { getIpcMainProxy } from '@pkg/main/ipcMain';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.containerFiles;
+const ipcMainProxy = getIpcMainProxy(console);
+
+/** Maximum number of bytes read when previewing a file (1 MiB). */
+const MAX_PREVIEW_BYTES = 1024 * 1024;
+
+/**
+ * Maximum number of tar entries scanned when listing a directory of a stopped
+ * container.  `cp` archives the directory recursively and depth-first, so a
+ * very large subtree could otherwise be streamed in full; we cap the scan and
+ * mark the result as truncated instead.
+ */
+const MAX_LIST_ENTRIES = 20_000;
+
+export type ContainerFileType = 'file' | 'directory' | 'symlink' | 'other';
+
+export interface ContainerFileEntry {
+  /** The base name of the entry (no path separators). */
+  name:        string;
+  type:        ContainerFileType;
+  /** Size in bytes.  Meaningful for regular files; 0 otherwise. */
+  size:        number;
+  /** Permission string such as `rwxr-xr-x`, when known. */
+  modeString?: string;
+  /** Modification time in milliseconds since the epoch, when known. */
+  mtimeMs?:    number;
+  /** For symlinks, the link target as stored in the container. */
+  linkTarget?: string;
+}
+
+export interface ContainerFileListResult {
+  entries:   ContainerFileEntry[];
+  /** True when the listing was capped and may be incomplete. */
+  truncated: boolean;
+}
+
+export interface ContainerFileReadResult {
+  /** File contents; `utf-8` text or `base64` for binary data. */
+  content:   string;
+  encoding:  'utf-8' | 'base64';
+  /** Byte length of the returned content (before base64 encoding). */
+  size:      number;
+  /** True when the file was larger than the preview cap and was truncated. */
+  truncated: boolean;
+}
+
+export interface ContainerFileDownloadResult {
+  /** True when the user cancelled the save dialog. */
+  canceled: boolean;
+  /** The host path the file/archive was written to, when not cancelled. */
+  path?:    string;
+}
+
+interface FileOptions {
+  namespace?: string;
+  /** Hint from the renderer that the container is currently running. */
+  running?:   boolean;
+}
+
+/** Convert a numeric file mode into an `rwxr-xr-x` style string. */
+function modeToString(mode: number): string {
+  const bits = ['r', 'w', 'x'];
+
+  return [6, 3, 0].map((shift) => {
+    const perm = (mode >> shift) & 0b111;
+
+    return bits.map((ch, i) => ((perm >> (2 - i)) & 1) ? ch : '-').join('');
+  }).join('');
+}
+
+/** Map a tar header type onto our simplified file type. */
+function tarTypeToFileType(type: string | null | undefined): ContainerFileType {
+  switch (type) {
+  case 'directory':
+    return 'directory';
+  case 'symlink':
+    return 'symlink';
+  case 'file':
+  case 'contiguous-file':
+    return 'file';
+  default:
+    return 'other';
+  }
+}
+
+export class ContainerFilesHandler {
+  constructor(protected client: ContainerEngineClient) {
+    this.initHandlers();
+  }
+
+  updateClient(client: ContainerEngineClient) {
+    this.client = client;
+  }
+
+  /**
+   * List a single directory level.  Tries `ls` for running containers and falls
+   * back to streaming a tar archive otherwise.
+   */
+  protected async list(containerId: string, dirPath: string, options: FileOptions): Promise<ContainerFileListResult> {
+    const normalized = this.normalizePath(dirPath);
+
+    if (options.running) {
+      try {
+        return await this.listViaExec(containerId, normalized, options.namespace);
+      } catch (ex) {
+        console.debug(`ls listing failed for ${ containerId }:${ normalized }, falling back to cp:`, ex);
+      }
+    }
+
+    return await this.listViaCp(containerId, normalized, options.namespace);
+  }
+
+  /** List a directory using `exec ... ls -lnA`. */
+  protected async listViaExec(containerId: string, dirPath: string, namespace: string | undefined): Promise<ContainerFileListResult> {
+    // -l long format, -n numeric uid/gid (avoids names containing spaces),
+    // -A almost-all (no `.`/`..`).  Works on both GNU coreutils and busybox.
+    const { stdout } = await this.client.runClient(
+      ['exec', containerId, 'ls', '-lnA', dirPath],
+      'pipe',
+      { namespace },
+    );
+
+    return { entries: this.parseLsOutput(stdout), truncated: false };
+  }
+
+  /**
+   * Parse the output of `ls -lnA`.  Each line looks like:
+   *   drwxr-xr-x    2 0        0             4096 Jan  1 00:00 bin
+   *   lrwxrwxrwx    1 0        0                7 Jan  1 00:00 sh -> busybox
+   */
+  parseLsOutput(stdout: string): ContainerFileEntry[] {
+    const entries: ContainerFileEntry[] = [];
+
+    for (const rawLine of stdout.split('\n')) {
+      const line = rawLine.replace(/\r$/, '');
+
+      if (!line.trim()) {
+        continue;
+      }
+
+      const tokens = line.split(/\s+/);
+
+      // perms links uid gid size mon day time name...  => at least 9 tokens.
+      if (tokens.length < 9) {
+        continue;
+      }
+
+      const perms = tokens[0];
+
+      // Skip the leading "total N" summary line and anything that is not a
+      // recognizable long-format entry.
+      if (!/^[-dlbcps][-rwxsStT]{9}[.+]?$/.test(perms)) {
+        continue;
+      }
+
+      const size = parseInt(tokens[4], 10);
+      // The name begins after the 8th field (perms links uid gid size mon day
+      // time).  Re-join with single spaces; the only ambiguity this loses is
+      // runs of whitespace inside names, which is rare and non-critical here.
+      let name = tokens.slice(8).join(' ');
+      let linkTarget: string | undefined;
+
+      const typeChar = perms[0];
+      let type: ContainerFileType = 'other';
+
+      if (typeChar === 'd') {
+        type = 'directory';
+      } else if (typeChar === 'l') {
+        type = 'symlink';
+        const arrow = name.indexOf(' -> ');
+
+        if (arrow >= 0) {
+          linkTarget = name.slice(arrow + 4);
+          name = name.slice(0, arrow);
+        }
+      } else if (typeChar === '-') {
+        type = 'file';
+      }
+
+      entries.push({
+        name,
+        type,
+        size:       Number.isFinite(size) ? size : 0,
+        modeString: perms.slice(1, 10),
+        linkTarget,
+      });
+    }
+
+    return entries;
+  }
+
+  /** List a directory by streaming and parsing a `cp` tar archive. */
+  protected listViaCp(containerId: string, dirPath: string, namespace: string | undefined): Promise<ContainerFileListResult> {
+    const rootPrefix = dirPath === '/' ? '' : `${ path.posix.basename(dirPath) }/`;
+
+    return this.withCpStream(containerId, dirPath, namespace, (proc, stop) => {
+      return new Promise<ContainerFileListResult>((resolve, reject) => {
+        const extract = tar.extract();
+        const children = new Map<string, ContainerFileEntry>();
+        let scanned = 0;
+        let truncated = false;
+        let settled = false;
+
+        const finish = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          resolve({ entries: [...children.values()], truncated });
+        };
+
+        extract.on('entry', (header, stream, next) => {
+          if (settled) {
+            stream.resume();
+
+            return;
+          }
+
+          if (++scanned > MAX_LIST_ENTRIES) {
+            truncated = true;
+            // We have scanned enough; stop the copy and return what we have.
+            stop();
+            finish();
+            stream.resume();
+
+            return;
+          }
+
+          // Strip the archive root so `rel` is relative to `dirPath`.
+          let rel = header.name;
+
+          if (rootPrefix && rel.startsWith(rootPrefix)) {
+            rel = rel.slice(rootPrefix.length);
+          } else if (rootPrefix && `${ rel }/` === rootPrefix) {
+            // The archive root entry itself.
+            rel = '';
+          }
+          rel = rel.replace(/\/$/, '');
+
+          if (rel) {
+            const segment = rel.split('/')[0];
+            const isImmediate = rel === segment;
+
+            if (isImmediate) {
+              children.set(segment, {
+                name:       segment,
+                type:       tarTypeToFileType(header.type),
+                size:       header.size ?? 0,
+                modeString: header.mode === undefined ? undefined : modeToString(header.mode),
+                mtimeMs:    header.mtime ? header.mtime.getTime() : undefined,
+                linkTarget: header.linkname || undefined,
+              });
+            } else if (!children.has(segment)) {
+              // Only a deeper entry was seen; infer the intermediate directory.
+              children.set(segment, { name: segment, type: 'directory', size: 0 });
+            }
+          }
+
+          stream.on('end', next);
+          stream.resume();
+        });
+
+        extract.on('finish', finish);
+        extract.on('error', (err) => {
+          if (!settled) {
+            settled = true;
+            reject(err);
+          }
+        });
+
+        proc.stdout.pipe(extract);
+      });
+    });
+  }
+
+  /** Read (a prefix of) a file's contents for previewing. */
+  protected readFile(containerId: string, filePath: string, options: FileOptions): Promise<ContainerFileReadResult> {
+    const normalized = this.normalizePath(filePath);
+
+    return this.withCpStream(containerId, normalized, options.namespace, (proc, stop) => {
+      return new Promise<ContainerFileReadResult>((resolve, reject) => {
+        const extract = tar.extract();
+        let settled = false;
+
+        const fail = (err: Error) => {
+          if (!settled) {
+            settled = true;
+            reject(err);
+          }
+        };
+
+        extract.on('entry', (header, stream, next) => {
+          if (settled || header.type !== 'file') {
+            stream.on('end', next);
+            stream.resume();
+
+            return;
+          }
+
+          const chunks: Buffer[] = [];
+          let total = 0;
+          let truncated = false;
+
+          stream.on('data', (chunk: Buffer) => {
+            total += chunk.length;
+            if (total <= MAX_PREVIEW_BYTES) {
+              chunks.push(chunk);
+            } else if (!truncated) {
+              truncated = true;
+              const keep = MAX_PREVIEW_BYTES - (total - chunk.length);
+
+              if (keep > 0) {
+                chunks.push(chunk.subarray(0, keep));
+              }
+              // Stop pulling more of this file from the container.
+              stop();
+            }
+          });
+          stream.on('end', () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+
+            const buffer = Buffer.concat(chunks);
+            const isBinary = buffer.includes(0);
+
+            resolve({
+              content:  isBinary ? buffer.toString('base64') : buffer.toString('utf-8'),
+              encoding: isBinary ? 'base64' : 'utf-8',
+              size:     buffer.length,
+              truncated,
+            });
+            next();
+          });
+          stream.on('error', fail);
+        });
+
+        extract.on('finish', () => {
+          if (!settled) {
+            settled = true;
+            resolve({
+              content: '', encoding: 'utf-8', size: 0, truncated: false,
+            });
+          }
+        });
+        extract.on('error', fail);
+
+        proc.stdout.pipe(extract);
+      });
+    });
+  }
+
+  /**
+   * Prompt for a save location and copy the given path from the container to
+   * the host.  Directories are saved as a `.tar` archive.
+   */
+  protected async download(
+    event: Electron.IpcMainInvokeEvent,
+    containerId: string,
+    filePath: string,
+    isDirectory: boolean,
+    options: FileOptions,
+  ): Promise<ContainerFileDownloadResult> {
+    const normalized = this.normalizePath(filePath);
+    const baseName = path.posix.basename(normalized) || 'download';
+    const defaultName = isDirectory ? `${ baseName }.tar` : baseName;
+    const window = Electron.BrowserWindow.fromWebContents(event.sender) ?? undefined;
+    const dialogOptions: Electron.SaveDialogOptions = { defaultPath: defaultName };
+
+    const result = window
+      ? await Electron.dialog.showSaveDialog(window, dialogOptions)
+      : await Electron.dialog.showSaveDialog(dialogOptions);
+
+    if (result.canceled || !result.filePath) {
+      return { canceled: true };
+    }
+
+    const destination = result.filePath;
+
+    await this.withCpStream(containerId, normalized, options.namespace, (proc) => {
+      return new Promise<void>((resolve, reject) => {
+        if (isDirectory) {
+          // Save the tar archive verbatim.
+          const out = fs.createWriteStream(destination);
+
+          out.on('error', reject);
+          out.on('finish', resolve);
+          proc.stdout.pipe(out);
+
+          return;
+        }
+
+        // Extract the single file entry from the archive to `destination`.
+        const extract = tar.extract();
+        let wrote = false;
+
+        extract.on('entry', (header, stream, next) => {
+          if (!wrote && header.type === 'file') {
+            wrote = true;
+            const out = fs.createWriteStream(destination);
+
+            out.on('error', reject);
+            stream.pipe(out);
+            out.on('finish', next);
+
+            return;
+          }
+          stream.on('end', next);
+          stream.resume();
+        });
+        extract.on('finish', resolve);
+        extract.on('error', reject);
+        proc.stdout.pipe(extract);
+      });
+    });
+
+    return { canceled: false, path: destination };
+  }
+
+  /**
+   * Spawn `<engine> cp <id>:<path> -` and hand its stdout to `consume`.  The
+   * consumer is also given a `stop()` callback to end the copy early (e.g. once
+   * enough of a large file has been read); when used, the resulting non-zero
+   * exit is treated as success.  Otherwise a non-zero exit rejects with the
+   * captured stderr so callers see a useful error rather than an empty result.
+   */
+  protected async withCpStream<T>(
+    containerId: string,
+    srcPath: string,
+    namespace: string | undefined,
+    consume: (proc: ReadableProcess, stop: () => void) => Promise<T>,
+  ): Promise<T> {
+    const proc = this.client.runClient(
+      ['cp', `${ containerId }:${ srcPath }`, '-'],
+      'stream',
+      { namespace },
+    );
+
+    let stderr = '';
+    let stoppedEarly = false;
+
+    const stop = () => {
+      stoppedEarly = true;
+      try {
+        proc.kill();
+      } catch {
+        // ignore
+      }
+    };
+
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString('utf-8');
+    });
+
+    const exited = new Promise<void>((resolve, reject) => {
+      proc.on('error', reject);
+      proc.on('exit', (code, signal) => {
+        if (stoppedEarly || code === 0 || signal) {
+          resolve();
+        } else {
+          reject(new Error(stderr.trim() || `container cp exited with code ${ code }`));
+        }
+      });
+    });
+
+    try {
+      const result = await consume(proc, stop);
+
+      // Surface a copy failure (e.g. no such file) even if the tar parse
+      // completed with an empty result.
+      await exited;
+
+      return result;
+    } catch (ex) {
+      stop();
+      exited.catch(() => {
+        // avoid an unhandled rejection when we are already throwing
+      });
+      throw ex;
+    }
+  }
+
+  /** Normalize a POSIX path, defaulting to root and stripping trailing slashes. */
+  protected normalizePath(input: string): string {
+    if (!input) {
+      return '/';
+    }
+    const normalized = path.posix.normalize(input);
+
+    if (normalized.length > 1 && normalized.endsWith('/')) {
+      return normalized.slice(0, -1);
+    }
+
+    return normalized;
+  }
+
+  protected initHandlers() {
+    ipcMainProxy.handle('container-files/list', (_event, containerId, dirPath, options) => {
+      return this.list(containerId, dirPath, options ?? {});
+    });
+
+    ipcMainProxy.handle('container-files/read', (_event, containerId, filePath, options) => {
+      return this.readFile(containerId, filePath, options ?? {});
+    });
+
+    ipcMainProxy.handle('container-files/download', (event, containerId, filePath, isDirectory, options) => {
+      return this.download(event, containerId, filePath, isDirectory, options ?? {});
+    });
+  }
+}

--- a/pkg/rancher-desktop/main/containerFiles.ts
+++ b/pkg/rancher-desktop/main/containerFiles.ts
@@ -220,7 +220,12 @@ export class ContainerFilesHandler {
 
   /** List a directory by streaming and parsing a `cp` tar archive. */
   protected listViaCp(containerId: string, dirPath: string, namespace: string | undefined): Promise<ContainerFileListResult> {
-    const rootPrefix = dirPath === '/' ? '' : `${ path.posix.basename(dirPath) }/`;
+    // `<engine> cp <id>:<dir> -` wraps the entries under a leading path
+    // component: the directory's base name (e.g. `etc/hostname` for `/etc`),
+    // or `.` for the container root (`./bin`, ...).  Some engines omit the
+    // wrapper entirely (`bin/`).  We tolerate all of these by treating a
+    // leading segment equal to the base name (or `.`) as the wrapper.
+    const base = dirPath === '/' ? '' : path.posix.basename(dirPath);
 
     return this.withCpStream(containerId, dirPath, namespace, (proc, stop) => {
       return new Promise<ContainerFileListResult>((resolve, reject) => {
@@ -255,33 +260,35 @@ export class ContainerFilesHandler {
             return;
           }
 
-          // Strip the archive root so `rel` is relative to `dirPath`.
-          let rel = header.name;
+          // Split the entry path into segments and locate the child of
+          // `dirPath`, skipping the optional archive-root wrapper segment.
+          const segments = header.name.split('/').filter(Boolean);
+          let childName: string | undefined;
+          let isImmediate: boolean;
 
-          if (rootPrefix && rel.startsWith(rootPrefix)) {
-            rel = rel.slice(rootPrefix.length);
-          } else if (rootPrefix && `${ rel }/` === rootPrefix) {
-            // The archive root entry itself.
-            rel = '';
+          if (segments.length > 0 && (segments[0] === base || segments[0] === '.')) {
+            // Entry is wrapped: <base>/<child>/...
+            childName = segments[1];
+            isImmediate = segments.length === 2;
+          } else {
+            // Entry is not wrapped: <child>/...
+            childName = segments[0];
+            isImmediate = segments.length === 1;
           }
-          rel = rel.replace(/\/$/, '');
 
-          if (rel) {
-            const segment = rel.split('/')[0];
-            const isImmediate = rel === segment;
-
+          if (childName) {
             if (isImmediate) {
-              children.set(segment, {
-                name:       segment,
+              children.set(childName, {
+                name:       childName,
                 type:       tarTypeToFileType(header.type),
                 size:       header.size ?? 0,
                 modeString: header.mode === undefined ? undefined : modeToString(header.mode),
                 mtimeMs:    header.mtime ? header.mtime.getTime() : undefined,
                 linkTarget: header.linkname || undefined,
               });
-            } else if (!children.has(segment)) {
+            } else if (!children.has(childName)) {
               // Only a deeper entry was seen; infer the intermediate directory.
-              children.set(segment, { name: segment, type: 'directory', size: 0 });
+              children.set(childName, { name: childName, type: 'directory', size: 0 });
             }
           }
 

--- a/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
+++ b/pkg/rancher-desktop/pages/containers/ContainerInfo.vue
@@ -39,6 +39,12 @@
         :disabled="!isRunning"
         @active="activeTab = 'tab-shell'"
       />
+      <tab
+        :label="t('containerInfo.files')"
+        name="tab-files"
+        :weight="-1"
+        @active="activeTab = 'tab-files'"
+      />
       <template #tab-row-extras>
         <li
           v-if="activeTab === 'tab-logs'"
@@ -124,6 +130,12 @@
           :is-container-running="isRunning"
           :namespace="namespace"
         />
+        <container-files
+          v-if="containerId && activeTab === 'tab-files'"
+          :container-id="containerId"
+          :is-container-running="isRunning"
+          :namespace="namespace"
+        />
       </div>
     </rd-tabbed>
   </div>
@@ -134,6 +146,7 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { useRoute } from 'vue-router';
 import { useStore } from 'vuex';
 
+import ContainerFiles from '@pkg/components/ContainerFiles.vue';
 import ContainerInspect from '@pkg/components/ContainerInspect.vue';
 import ContainerLogs from '@pkg/components/ContainerLogs.vue';
 import ContainerShell from '@pkg/components/ContainerShell.vue';
@@ -158,7 +171,7 @@ const searchInput = ref<HTMLInputElement | null>(null);
 const settings = ref<Settings>();
 const subscribeTimer = ref<ReturnType<typeof setTimeout>>();
 const searchTerm = ref('');
-const activeTab = ref<'tab-info' | 'tab-stats' | 'tab-logs' | 'tab-shell'>('tab-info');
+const activeTab = ref<'tab-info' | 'tab-stats' | 'tab-logs' | 'tab-shell' | 'tab-files'>('tab-info');
 const shellEverActivated = ref(false);
 
 // Vuex integration

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -165,6 +165,28 @@ export interface IpcMainInvokeEvents {
   'show-snapshots-confirm-dialog':  (options: { window: Partial<Electron.MessageBoxOptions>, format: SnapshotDialog }) => any;
   'show-snapshots-blocking-dialog': (options: { window: Partial<Electron.MessageBoxOptions>, format: SnapshotDialog }) => any;
   // #endregion
+
+  // #region main/containerFiles
+  /** List a single directory level inside a container. */
+  'container-files/list': (
+    containerId: string,
+    dirPath: string,
+    options?: { namespace?: string, running?: boolean },
+  ) => import('@pkg/main/containerFiles').ContainerFileListResult;
+  /** Read (a capped prefix of) a file inside a container for previewing. */
+  'container-files/read': (
+    containerId: string,
+    filePath: string,
+    options?: { namespace?: string, running?: boolean },
+  ) => import('@pkg/main/containerFiles').ContainerFileReadResult;
+  /** Copy a file or directory out of a container to a host path chosen by the user. */
+  'container-files/download': (
+    containerId: string,
+    filePath: string,
+    isDirectory: boolean,
+    options?: { namespace?: string, running?: boolean },
+  ) => import('@pkg/main/containerFiles').ContainerFileDownloadResult;
+  // #endregion
 }
 
 /**


### PR DESCRIPTION
First attempt to address https://github.com/rancher-sandbox/rancher-desktop/issues/10723 and see if I'm going in the right direction.

There are 2 main mechanisms:
- when the container is live and support exec'ing ls we run ls directly
- when the container is stopped or there is not ls, we get a cp tar archive from docker

It is not particularly fast as it is explored only on demand. I am expecting that the new backend in v2 might allow us to do things differently so I have not really looked into it.

I am unsure how to deal with symlinks since at this stage this feature is not supposed to mimic a local file browser but be more like an ftp client of sort. So, for now I just show them as symlinks rather than going to their target.

I have also not added any option to edit as it adds its own can of worms but you can download the file. This makes this feature still  super valuable, especially when you forgot to point that output to a local mount and would have to re-run the entire docker job (ask me how I know).

Basic content display exists which at this stage is only really useful for text stuff (it's just passed through, no rendering).

Examples
-  running container:
<img width="2094" height="1182" alt="image" src="https://github.com/user-attachments/assets/5f6f74b5-0686-486d-b7a9-8a21b88b5589" />
- stopped container:
<img width="1047" height="591" alt="image" src="https://github.com/user-attachments/assets/d8ee4ccd-721d-4c84-9c32-76fd8ef4a066" />

Feedback welcome.