### PR TITLE
Bump Epinio Docker Desktop extension version to 0.1.6

### DIFF
--- a/pkg/rancher-desktop/assets/extension-data.yaml
+++ b/pkg/rancher-desktop/assets/extension-data.yaml
@@ -102,7 +102,7 @@
   publisher: SUSE LLC
   short_description: AI Workbench extension
 - slug: splatform/epinio-docker-desktop
-  version: 0.1.3
+  version: 0.1.6
   containerd_compatible: true
   labels:
     com.docker.desktop.extension.api.version: ">= 0.2.0"


### PR DESCRIPTION
Updated the version of the Epinio Docker Desktop extension from 0.1.3 to 0.1.6.