### PR TITLE
Bump tachometer to unblock rddepman, with the MUI themes it needs

### DIFF
--- a/pkg/rancher-desktop/assets/extension-data.yaml
+++ b/pkg/rancher-desktop/assets/extension-data.yaml
@@ -124,23 +124,32 @@
   publisher: Epinio by Krumware and SUSE
   short_description: Push from source to Kubernetes in one step
 - slug: julianb90/tachometer
-  version: 0.1.1
+  version: 0.2.6
   containerd_compatible: true
   labels:
-    com.docker.desktop.extension.api.version: 0.3.4
+    com.docker.desktop.extension.api.version: 0.4.2
     com.docker.desktop.extension.icon: https://raw.githubusercontent.com/julian-b90/tachometer/main/speedometer.png
     com.docker.extension.additional-urls: '[{"title":"Issues","url":"https://github.com/julian-b90/tachometer/issues"}]'
     com.docker.extension.categories: development,utility-tools
-    com.docker.extension.changelog: "<p>V 0.1.1 <br /> ### Changed <ul><li>update
-      dependencies</li><li>update node to latest LTS 20.17.0</li></ul></p>"
+    com.docker.extension.changelog: <p>V 0.2.6 <br />
+      <h4>Changed</h4><ul><li>Updated react and react-dom to
+      19.2.8</li><li>Updated react-router-dom to 7.18.2</li><li>Updated recharts
+      to 3.10.1</li><li>Updated vite to 8.2.2</li><li>Updated TypeScript type
+      definitions</li></ul></p>
     com.docker.extension.detailed-description: Extension shows real-time cpu and memory usage of containers
     com.docker.extension.publisher-url: https://github.com/julian-b90/tachometer
     com.docker.extension.screenshots: '[{"alt":"tachometer",
       "url":"https://raw.githubusercontent.com/julian-b90/tachometer/main/screenshot.png"},
       {"alt":"details view",
       "url":"https://raw.githubusercontent.com/julian-b90/tachometer/main/screenshot_2.png"}]'
+    dev.chainguard.image.title: static
+    dev.chainguard.package.main: ""
+    org.opencontainers.image.authors: Chainguard Team https://www.chainguard.dev/
+    org.opencontainers.image.created: 2026-07-08T23:06:13Z
     org.opencontainers.image.description: Extension shows real-time cpu and memory usage of containers
+    org.opencontainers.image.source: https://github.com/chainguard-images/images/tree/main/images/static
     org.opencontainers.image.title: Tachometer
+    org.opencontainers.image.url: https://images.chainguard.dev/directory/image/static/overview
     org.opencontainers.image.vendor: julian-b90
   title: Tachometer
   logo: https://raw.githubusercontent.com/julian-b90/tachometer/main/speedometer.png

--- a/pkg/rancher-desktop/preload/__tests__/extension-themes.spec.ts
+++ b/pkg/rancher-desktop/preload/__tests__/extension-themes.spec.ts
@@ -1,0 +1,25 @@
+import { extensionThemes } from '../extension-themes';
+
+/**
+ * Extensions that bundle a fallback theme switch to ours as soon as it exists,
+ * so a gap here breaks extensions that work without any theme at all.
+ */
+describe('extensionThemes', () => {
+  const colors = ['amber', 'blue', 'green', 'grey', 'red', 'violet'] as const;
+  const shades = [100, 200, 300, 400, 500, 600, 700, 800] as const;
+
+  it.each(['light', 'dark'] as const)('describes the %s theme', (mode) => {
+    expect(extensionThemes[mode].palette.mode).toEqual(mode);
+  });
+
+  it.each(colors)('gives %s every shade', (color) => {
+    for (const bag of [extensionThemes.light, extensionThemes.dark]) {
+      const ramp = bag.palette.docker[color];
+
+      expect(Object.keys(ramp).map(Number).sort((a, b) => a - b)).toEqual([...shades]);
+      for (const shade of shades) {
+        expect(ramp[shade]).toMatch(/^#[0-9A-F]{6}$/);
+      }
+    }
+  });
+});

--- a/pkg/rancher-desktop/preload/extension-themes.ts
+++ b/pkg/rancher-desktop/preload/extension-themes.ts
@@ -1,0 +1,126 @@
+/**
+ * Theme options for Docker Desktop extension UIs.
+ *
+ * `@docker/docker-mui-theme` reads its themes from `window.__ddMuiV5Themes` and
+ * `window.__ddMuiV6Themes`, which the host application has to provide; the
+ * package itself ships no colours.  An extension built against it renders a
+ * blank page when the host leaves those globals undefined.
+ *
+ * The bag has to carry `palette.docker` in full.  MUI adds that palette through
+ * a module augmentation, so `createTheme()` cannot supply defaults for it the
+ * way it does for `background`, `primary` and the rest, and extensions read it
+ * directly (Docker's own logs-explorer wants `palette.docker.grey[600]`).  An
+ * incomplete bag is worse than none at all.  Extensions carrying a bundled
+ * fallback theme switch to ours the moment it exists, so leaving a colour out
+ * breaks extensions that work today.
+ */
+
+/** A shade ramp, keyed by the weights the extension SDK's `CustomColor` declares. */
+type ColorRamp = Record<100 | 200 | 300 | 400 | 500 | 600 | 700 | 800, string>;
+
+interface ThemeOptions {
+  palette: {
+    mode:   'light' | 'dark';
+    docker: Record<'amber' | 'blue' | 'green' | 'grey' | 'red' | 'violet', ColorRamp>;
+  };
+}
+
+export interface ThemeOptionsBag {
+  light: ThemeOptions;
+  dark:  ThemeOptions;
+}
+
+/**
+ * Colour ramps for `palette.docker`.  Docker Desktop puts its own brand colours
+ * here; ours come from Rancher Desktop's stylesheets so extensions look like the
+ * rest of the application.
+ *
+ * Each ramp runs from 100 (lightest) to 800 (darkest).  The seed colour sits at
+ * 500 and is an existing Rancher Desktop colour; the steps above and below it
+ * are mixes towards white and towards `$darkest` (#141419).  Origins:
+ *
+ * - `grey` needs no seed.  All eight shades are Rancher Desktop neutrals
+ *   already, `$lighter` through `$darker` from `assets/styles/themes/_light.scss`
+ *   and `$medium` through `$dark` from `_dark.scss`.
+ * - `blue` is `$primary`, which `_light.scss` also uses for `$link` and `$info`.
+ * - `green` is the SUSE brand green from `_suse.scss`, `hsl(151, 59%, 46%)`.
+ *   `$success` (#5D995D) is the semantic green, but it reads muted next to the
+ *   other ramps, and this palette is for branding rather than state.
+ * - `amber` is `$warning`, `red` is `$error`.
+ * - `violet` has no Rancher Desktop equivalent.  It is tuned to sit near `blue`
+ *   in saturation so the family stays coherent.
+ */
+const dockerPalette: ThemeOptions['palette']['docker'] = {
+  amber: {
+    100: '#F8F4DD',
+    200: '#F1E8B7',
+    300: '#E9DB8E',
+    400: '#E1CF68',
+    500: '#DAC342',
+    600: '#B6A43B',
+    700: '#938433',
+    800: '#6F642C',
+  },
+  blue: {
+    100: '#DCECF7',
+    200: '#B5D8EE',
+    300: '#8BC1E5',
+    400: '#64ADDC',
+    500: '#3D98D3',
+    600: '#3680B2',
+    700: '#2E6890',
+    800: '#27516F',
+  },
+  green: {
+    100: '#DAF3E7',
+    200: '#B0E5CC',
+    300: '#83D6AE',
+    400: '#59C993',
+    500: '#30BB78',
+    600: '#2B9D67',
+    700: '#267F56',
+    800: '#216145',
+  },
+  grey: {
+    100: '#F4F5FA',
+    200: '#EEEFF4',
+    300: '#DCDEE7',
+    400: '#B6B6C2',
+    500: '#6C6C76',
+    600: '#4A4B52',
+    700: '#27292E',
+    800: '#1B1C21',
+  },
+  red: {
+    100: '#FDDEDE',
+    200: '#FCB9B9',
+    300: '#FA9191',
+    400: '#F86C6C',
+    500: '#F64747',
+    600: '#CD3E3F',
+    700: '#A53536',
+    800: '#7C2B2E',
+  },
+  violet: {
+    100: '#EAE5F5',
+    200: '#D3C8EA',
+    300: '#B9A9DF',
+    400: '#A28CD4',
+    500: '#8B6FC9',
+    600: '#765FA9',
+    700: '#604E8A',
+    800: '#4B3E6A',
+  },
+};
+
+/**
+ * The themes to expose as both `__ddMuiV5Themes` and `__ddMuiV6Themes`.  MUI
+ * accepts the same options in either version, so one definition serves both.
+ * `@docker/docker-mui-theme` picks the entry matching `prefers-color-scheme`,
+ * which the extension's view already reports from the application theme, and
+ * `createTheme()` fills in everything we leave out.
+ */
+export const extensionThemes: ThemeOptionsBag = {
+  light: { palette: { mode: 'light', docker: dockerPalette } },
+  dark:  { palette: { mode: 'dark', docker: dockerPalette } },
+};

--- a/pkg/rancher-desktop/preload/extensions.ts
+++ b/pkg/rancher-desktop/preload/extensions.ts
@@ -5,6 +5,8 @@
 
 import Electron from 'electron';
 
+import { extensionThemes } from './extension-themes';
+
 import type { SpawnOptions } from '@pkg/main/extensions/types';
 import clone from '@pkg/utils/clone';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
@@ -725,6 +727,16 @@ export default function initExtensions(): void {
   switch (document.location.protocol) {
   case 'x-rd-extension:': {
     Electron.contextBridge.exposeInMainWorld('ddClient', new RDXClient());
+    // Assigning from inside the main world keeps these writable.  Some
+    // extensions ship their own themes and assign over ours, which a
+    // contextBridge exposure would break.
+    Electron.contextBridge.executeInMainWorld({
+      func: (themes: unknown) => {
+        (globalThis as any).__ddMuiV5Themes = themes;
+        (globalThis as any).__ddMuiV6Themes = themes;
+      },
+      args: [extensionThemes],
+    });
     break;
   }
   case 'app:': {

--- a/scripts/assets/extension-data.yaml
+++ b/scripts/assets/extension-data.yaml
@@ -14,7 +14,7 @@ ghcr.io/rancher-sandbox/rancher-desktop-rdx-ai-workbench:0.2.0:
   github_repo: rancher-sandbox/rancher-desktop-rdx-ai-workbench
 splatform/epinio-docker-desktop:0.1.3:
   github_repo: epinio/extension-docker-desktop
-julianb90/tachometer:0.1.1: {}
+julianb90/tachometer:0.2.6: {}
 docker/logs-explorer-extension:0.2.5: {}
 prakhar1989/dive-in:0.0.8:
   containerd_compatible: false


### PR DESCRIPTION
`julianb90/tachometer:0.1.1` is gone from Docker Hub, and bumping any extension regenerates the whole marketplace file, pulling every image. That has kept the daily "Update external dependencies" workflow red since 2026-08-21.

Repinning tachometer needs the theme globals `@docker/docker-mui-theme` expects the host to define, which Rancher Desktop lacked, so 0.2.5 and later render blank. Hence the first commit; the second does the bump.

Verified on a dev build: 0.2.6 renders with live stats, and `docker/logs-explorer`, which bundles a fallback theme, still renders on the injected palette.
