### PR TITLE
Say what to do when the Go module lint fails

### DIFF
--- a/scripts/lint-go.ts
+++ b/scripts/lint-go.ts
@@ -147,7 +147,7 @@ async function syncModules(fix: boolean): Promise<boolean> {
     if (changes) {
       const { stdout } = await spawnFile('git', ['diff', '--', ...files], { stdio: 'pipe' });
 
-      console.log('Had to make modifications');
+      console.log("go mod tidy modified the Go module files. Run 'yarn lint:go:fix' locally and commit the result.");
       console.log(changes);
       console.log(stdout);
 

--- a/scripts/lint-go.ts
+++ b/scripts/lint-go.ts
@@ -128,7 +128,7 @@ async function syncModules(fix: boolean): Promise<boolean> {
     const changes = await getChanges();
 
     if (changes) {
-      console.log('Cannot run lint without fix with local changes');
+      console.log('This check runs go mod tidy and compares the result against git, so uncommitted changes to the Go module files break it. Commit or stash them first.');
       console.log(changes);
 
       return false;


### PR DESCRIPTION
Both failure messages in `syncModules` leave the reader to work out what happened.

"Had to make modifications" never names `yarn lint:go:fix`, so whoever hits it in CI has to read `lint-go.ts` to find it. That check fails whenever a dependabot bump in guestagent or rdctl changes a requirement that networking or wsl-helper also needs, most recently in #10885. "Cannot run lint without fix with local changes" names neither the files it means nor why they stop the check.

I verified both by running `syncModules` against a tree in each state. Untidy modules:

```
go mod tidy modified the Go module files. Run 'yarn lint:go:fix' locally and commit the result.
M src/go/networking/go.mod
diff --git src/go/networking/go.mod src/go/networking/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/mod v0.40.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
 )
```

Uncommitted module changes:

```
This check runs go mod tidy and compares the result against git, so uncommitted changes to the Go module files break it. Commit or stash them first.
M src/go/networking/go.mod
```
