### PR TITLE
Show extension versions without a "v" prefix

### DIFF
--- a/pkg/rancher-desktop/components/MarketplaceCard.vue
+++ b/pkg/rancher-desktop/components/MarketplaceCard.vue
@@ -11,7 +11,7 @@
           <span class="extensions-card-header-subtitle">{{
             extension.publisher
           }}</span>
-          <span class="extensions-card-header-version">{{ extension.version }}</span>
+          <span class="extensions-card-header-version">{{ extension.version.replace(/^v(?=\d)/, '') }}</span>
         </div>
       </div>
       <div class="extensions-card-content">


### PR DESCRIPTION
The version in the marketplace catalog is also the tag we pull, so it has to keep whatever prefix the publisher pushed. Only the label drops the "v", and only where a digit follows, so a tag like vNext keeps its name.
