### PR TITLE
Skip loading airgap images that are already present

### DIFF
--- a/bats/tests/k8s/airgap-image-load.bats
+++ b/bats/tests/k8s/airgap-image-load.bats
@@ -1,0 +1,114 @@
+load '../helpers/load'
+
+local_setup() {
+    if ! using_docker; then
+        skip "dangling image records only occur in the moby containerd image store"
+    fi
+}
+
+# k3s backported the switch to the OCI archive layout across its branches, so
+# no version comparison tells us whether this archive has an index.json to
+# filter; only the archive itself does.
+skip_unless_loader_can_filter() {
+    run -0 --separate-stderr ctrctl info --format '{{.Driver}}'
+    if [[ ${output} != "overlayfs" ]]; then
+        skip "the classic image store (${output}) loads every image"
+    fi
+    # Both guests install GNU tar, which reads the .tar.zst that k3sHelper
+    # prefers over the plain .tar. Listing into a variable first keeps a tar
+    # failure out of the count, where it would read as an archive with no index.
+    # shellcheck disable=SC2016 # the guest shell expands these, not this one
+    local probe='
+        set -o errexit
+        for archive in /var/lib/rancher/k3s/agent/images/k3s-airgap-images-*.tar.zst \
+            /var/lib/rancher/k3s/agent/images/k3s-airgap-images-*.tar; do
+            if [ -f "$archive" ]; then break; fi
+        done
+        members=$(tar -tf "$archive")
+        printf "%s\n" "$members" | grep -c "^index.json$" || true
+    '
+    run -0 --separate-stderr rdsudo sh -c "$probe"
+    assert_output --regexp '^[0-9]+$'
+    if [[ ${output} == "0" ]]; then
+        skip "this k3s airgap archive has no index.json to filter"
+    fi
+}
+
+# A redundant load leaves a moby-dangling@<digest> record beside the tag it
+# duplicates, which dockerd logs on every inspect.
+assert_no_dangling_records() {
+    skip_unless_loader_can_filter
+    if is_windows; then
+        # On WSL dockerd logs to the host log directory instead of /var/log.
+        refute_file_contains "$PATH_LOGS/docker.log" 'still dangling'
+    else
+        # rdctl collapses any remote failure to status 1 with nothing on
+        # stdout, which is also what a grep that matched nothing returns.
+        # Counting matches makes the count itself proof that the grep ran.
+        run -0 --separate-stderr rdsudo sh -c "grep -c 'still dangling' /var/log/docker.log || true"
+        assert_output '0'
+    fi
+}
+
+@test 'factory reset' {
+    factory_reset
+}
+
+@test 'start rancher desktop with kubernetes enabled' {
+    start_kubernetes
+    wait_for_kubelet
+    wait_for_service_status k3s started
+}
+
+# The k3s init script loads the airgap images from start_pre, on every start.
+@test 'restart kubernetes to load the airgap images again' {
+    rdctl set --kubernetes.enabled=false
+    wait_for_service_status k3s stopped
+    rdctl set --kubernetes.enabled=true
+    wait_for_kubelet
+    wait_for_service_status k3s started
+}
+
+@test 'the airgap images are loaded' {
+    run -0 ctrctl images --format '{{.Repository}}'
+    assert_line --partial 'rancher/mirrored-pause'
+}
+
+@test 'no image has a dangling duplicate' {
+    assert_no_dangling_records
+}
+
+# Removing one image makes the next start filter index.json down to that image
+# and repack the archive. A filter that emits invalid JSON fails "docker load",
+# and the k3s start_pre with it.
+@test 'removing one image reloads only that image' {
+    skip_unless_loader_can_filter
+
+    run -0 --separate-stderr ctrctl images --format '{{.Repository}}:{{.Tag}}'
+    assert_output --partial 'rancher/'
+
+    local removed=""
+    for image in "${lines[@]}"; do
+        # Most of these images back a running pod, and those cannot be removed.
+        if ctrctl rmi "$image" >/dev/null 2>&1; then
+            removed=$image
+            break
+        fi
+    done
+    if [[ -z ${removed} ]]; then
+        fail "could not remove any of the ${#lines[@]} images"
+    fi
+
+    rdctl set --kubernetes.enabled=false
+    wait_for_service_status k3s stopped
+    rdctl set --kubernetes.enabled=true
+    wait_for_kubelet
+    wait_for_service_status k3s started
+
+    run -0 --separate-stderr ctrctl images --format '{{.Repository}}:{{.Tag}}'
+    assert_line "$removed"
+}
+
+@test 'the partial load leaves no dangling duplicate' {
+    assert_no_dangling_records
+}

--- a/pkg/rancher-desktop/assets/scripts/docker-load-airgap-images
+++ b/pkg/rancher-desktop/assets/scripts/docker-load-airgap-images
@@ -1,0 +1,124 @@
+#!/bin/sh
+# Load the k3s airgap images into moby, skipping any already present at the
+# same digest.
+#
+# Re-importing an image whose tag already points at the same target leaves a
+# moby-dangling@<digest> record that nothing removes, and every later inspect
+# then logs "multiple images have the same target, but one of them is still
+# dangling".
+
+set -o errexit -o nounset -o pipefail
+
+TARBALL="$1"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+decompress() {
+    case "$TARBALL" in
+    *.zst) zstd -f -c -d "$TARBALL" ;;
+    *) cat "$TARBALL" ;;
+    esac
+}
+
+load_everything() { # <message>
+    echo "airgap images: $1"
+    decompress | docker load
+    exit 0
+}
+
+# The archive includes an oci-layout file, so containerd reads index.json and
+# ignores the docker-style manifest.json beside it. An archive in any other
+# format has no index to filter, so load it whole.
+decompress | tar -xf - -C "$WORK" index.json 2>/dev/null || true
+[ -f "$WORK/index.json" ] || load_everything "no index.json in the archive, loading all images"
+
+cat >"$WORK/index.awk" <<'AWK'
+function value_of(entry, pattern,   v) {
+    if (!match(entry, pattern)) return ""
+    v = substr(entry, RSTART, RLENGTH)
+    sub(/^[^:]*:"/, "", v)
+    sub(/"$/, "", v)
+    return v
+}
+# Pass the patterns as strings. awk evaluates a regex literal in an argument
+# as $0 ~ /re/, so the callee would receive 0 or 1.
+function entry_name(entry) {
+    return value_of(entry, "\"io\\.containerd\\.image\\.name\":\"[^\"]*\"")
+}
+function entry_digest(entry) {
+    return value_of(entry, "\"digest\":\"[^\"]*\"")
+}
+# Split the manifests array into ENTRIES, dropping the delimiters between
+# them; restore() puts them back.
+function split_manifests(line,   body) {
+    body = line
+    sub(/^.*"manifests":\[/, "", body)
+    sub(/\][^]]*$/, "", body)
+    return split(body, ENTRIES, /\},\{"mediaType"/)
+}
+function restore(i, n,   entry) {
+    entry = ENTRIES[i]
+    if (i > 1) entry = "{\"mediaType\"" entry
+    if (i < n) entry = entry "}"
+    return entry
+}
+
+mode == "filter" && NR == FNR { keep[$0] = 1; next }
+
+{
+    n = split_manifests($0)
+
+    if (mode == "list") {
+        for (i = 1; i <= n; i++) {
+            entry = restore(i, n)
+            name = entry_name(entry)
+            digest = entry_digest(entry)
+            if (name != "" && digest != "") print digest " " name
+        }
+        next
+    }
+
+    header = $0
+    sub(/"manifests":\[.*$/, "", header)
+    out = ""
+    for (i = 1; i <= n; i++) {
+        entry = restore(i, n)
+        if (entry_name(entry) in keep) {
+            out = (out == "") ? entry : out "," entry
+        }
+    }
+    print header "\"manifests\":[" out "]}"
+}
+AWK
+
+awk -v mode=list -f "$WORK/index.awk" "$WORK/index.json" >"$WORK/archive-images"
+total=$(wc -l <"$WORK/archive-images")
+
+[ "$total" -gt 0 ] || load_everything "cannot read index.json, loading all images"
+
+# The classic image store reports an empty .Descriptor.Digest, so every image
+# looks absent and the whole archive loads.
+: >"$WORK/wanted"
+while read -r digest name; do
+    if [ "$(docker image inspect --format '{{.Descriptor.Digest}}' "$name" 2>/dev/null || true)" != "$digest" ]; then
+        echo "$name" >>"$WORK/wanted"
+    fi
+done <"$WORK/archive-images"
+wanted=$(wc -l <"$WORK/wanted")
+
+if [ "$wanted" -eq 0 ]; then
+    echo "airgap images: all $total already present, nothing to load"
+    exit 0
+fi
+
+[ "$wanted" -lt "$total" ] || load_everything "loading all $total"
+
+# Load only the missing images by dropping the rest from index.json. Docker
+# ingests every blob either way; dropping the entries skips the re-tag that
+# creates the dangling record.
+echo "airgap images: loading $wanted of $total"
+mkdir -p "$WORK/archive"
+decompress | tar -xf - -C "$WORK/archive"
+awk -v mode=filter -f "$WORK/index.awk" "$WORK/wanted" "$WORK/archive/index.json" >"$WORK/index.filtered"
+mv "$WORK/index.filtered" "$WORK/archive/index.json"
+tar -cf - -C "$WORK/archive" . | docker load

--- a/pkg/rancher-desktop/assets/scripts/service-k3s.initd
+++ b/pkg/rancher-desktop/assets/scripts/service-k3s.initd
@@ -43,9 +43,9 @@ start_pre() {
   IMAGEPATH="/var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}"
   if [ "${ENGINE}" == "moby" ]; then
     if [ -f ${IMAGEPATH}.tar.zst ]; then
-      zstd -f -c -d ${IMAGEPATH}.tar.zst | docker load
+      docker-load-airgap-images ${IMAGEPATH}.tar.zst
     elif [ -f ${IMAGEPATH}.tar ]; then
-      docker load --input ${IMAGEPATH}.tar
+      docker-load-airgap-images ${IMAGEPATH}.tar
     fi
   else
     if [ -f ${IMAGEPATH}.tar.zst ]; then

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -12,6 +12,7 @@ import BackendHelper, { MANIFEST_CERT_MANAGER, MANIFEST_SPIN_OPERATOR } from '..
 import K3sHelper, { ExtraRequiresReasons, NoCachedK3sVersionsError, ShortVersion } from '../k3sHelper';
 import LimaBackend, { Action } from '../lima';
 
+import DOCKER_LOAD_AIRGAP_IMAGES_SCRIPT from '@pkg/assets/scripts/docker-load-airgap-images';
 import INSTALL_K3S_SCRIPT from '@pkg/assets/scripts/install-k3s';
 import LOGROTATE_K3S_SCRIPT from '@pkg/assets/scripts/logrotate-k3s';
 import SERVICE_CRI_DOCKERD_SCRIPT from '@pkg/assets/scripts/service-cri-dockerd.initd';
@@ -403,6 +404,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
       LOG_DIR: paths.logs,
       ENGINE:  cfg.containerEngine.name ?? ContainerEngine.NONE,
     });
+    await this.vm.writeFile('/usr/local/bin/docker-load-airgap-images', DOCKER_LOAD_AIRGAP_IMAGES_SCRIPT, 0o755);
     await this.vm.writeFile('/etc/init.d/k3s', SERVICE_K3S_SCRIPT, 0o755);
     await this.vm.writeConf('k3s', config);
     await this.vm.writeFile('/etc/logrotate.d/k3s', LOGROTATE_K3S_SCRIPT);

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -35,6 +35,7 @@ import SERVICE_BUILDKITD_CONF from '@pkg/assets/scripts/buildkit.confd';
 import SERVICE_BUILDKITD_INIT from '@pkg/assets/scripts/buildkit.initd';
 import CONFIGURE_IMAGE_ALLOW_LIST from '@pkg/assets/scripts/configure-allowed-images';
 import DOCKER_CREDENTIAL_SCRIPT from '@pkg/assets/scripts/docker-credential-rancher-desktop';
+import DOCKER_LOAD_AIRGAP_IMAGES_SCRIPT from '@pkg/assets/scripts/docker-load-airgap-images';
 import INSTALL_WSL_HELPERS_SCRIPT from '@pkg/assets/scripts/install-wsl-helpers';
 import LOGROTATE_K3S_SCRIPT from '@pkg/assets/scripts/logrotate-k3s';
 import LOGROTATE_OPENRESTY_SCRIPT from '@pkg/assets/scripts/logrotate-openresty';
@@ -1339,6 +1340,7 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
                   });
                 }),
                 this.progressTracker.action(t('progress.kubernetesComponents'), 50, async() => {
+                  await this.writeFile('/usr/local/bin/docker-load-airgap-images', DOCKER_LOAD_AIRGAP_IMAGES_SCRIPT, 0o755);
                   await this.writeFile('/etc/init.d/k3s', SERVICE_SCRIPT_K3S, 0o755);
                   await this.writeFile('/etc/logrotate.d/k3s', rotateConf);
                   await this.execCommand('mkdir', '-p', '/etc/cni/net.d');


### PR DESCRIPTION
Fixes #10876.

Tested by hand in a Lima VM on macOS, Docker 29.5.3 with the containerd snapshotter. A restart with every image present skips the load in 0.29s and adds no dangling records; with one missing it loads only that image; an archive without `index.json` loads everything. The same restart previously left 8 dangling records and 6 warnings every 10 seconds.

Only an OCI-layout archive has an `index.json` to filter, so the fix applies from these k3s releases onward. On anything older the script loads everything, as before.

| k3s branch | First release with the OCI layout |
|---|---|
| 1.25 - 1.29 | none; all ended before the switch |
| 1.30 | v1.30.14+k3s2 (v1.30.14+k3s1 is still docker-save) |
| 1.31 | v1.31.11+k3s1 |
| 1.32 | v1.32.7+k3s1 |
| 1.33 | v1.33.3+k3s1 |
| 1.34 and later | every release |

k3s backported the switch to all four maintained branches on 2025-07-26, so the boundary is a date rather than a version ordering. v1.32.7 has the new layout while v1.33.0 through v1.33.2 do not, which is why the BATS test reads the archive instead of comparing versions.

The change is also preventive. It creates no new `moby-dangling@` records but doesn't removes any that exist. `docker image prune` also keeps any whose digest is in use by a container.

---

Using `awk` feels a little brittle and is vulnerable to format changes in the embedded `index.json`. But in the WSL tarball we have neither `jq` nor `yq` (with Lima we have `lima-guestagent yq`), so `awk` it is.

This is only a temporary workaround. I will file an issue against upstream to hopefully get this fixed in a future moby release.

Also there is nothing we can do if the user selects an older k3s version that doesn't include an `index.json` file.

Another workaround would be to switch to the "classic" storage driver, but that kind of implies a factory reset and a reinstall of all images and workloads.
