### PR TITLE
Reject fractional values for integer settings

### DIFF
--- a/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
+++ b/pkg/rancher-desktop/main/commandServer/__tests__/settingsValidator.spec.ts
@@ -84,6 +84,48 @@ describe('SettingsValidator', () => {
     });
   });
 
+  it('should reject a fractional port', () => {
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { kubernetes: { port: '6443.7' as unknown as number } });
+
+    expect({ needToUpdate, errors, isFatal }).toEqual({
+      needToUpdate: false,
+      errors:       ['Invalid value for "kubernetes.port": <6443.7>'],
+      isFatal:      false,
+    });
+  });
+
+  it('should reject a fractional CPU count', () => {
+    modules.os.platform.mockReturnValue('linux');
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { virtualMachine: { numberCPUs: 2.5 } });
+
+    expect({ needToUpdate, errors, isFatal }).toEqual({
+      needToUpdate: false,
+      errors:       ['Invalid value for "virtualMachine.numberCPUs": <2.5>'],
+      isFatal:      false,
+    });
+  });
+
+  it('should reject a fractional CPU count given as a string', () => {
+    modules.os.platform.mockReturnValue('linux');
+    const [needToUpdate, errors, isFatal] = subject.validateSettings(cfg, { virtualMachine: { numberCPUs: '2.5' as unknown as number } });
+
+    expect({ needToUpdate, errors, isFatal }).toEqual({
+      needToUpdate: false,
+      errors:       ['Invalid value for "virtualMachine.numberCPUs": <2.5>'],
+      isFatal:      false,
+    });
+  });
+
+  it('should accept a fractional memory size', () => {
+    modules.os.platform.mockReturnValue('linux');
+    const [needToUpdate, errors] = subject.validateSettings(cfg, { virtualMachine: { memoryInGB: cfg.virtualMachine.memoryInGB + 0.5 } });
+
+    expect({ needToUpdate, errors }).toEqual({
+      needToUpdate: true,
+      errors:       [],
+    });
+  });
+
   describe('all standard fields', () => {
     // Special fields that cannot be checked here; this includes enums and maps.
     const specialFields = [

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -122,7 +122,7 @@ export default class SettingsValidator {
       },
       virtualMachine: {
         memoryInGB: this.checkLima(this.checkNumber(1, Number.POSITIVE_INFINITY)),
-        numberCPUs: this.checkLima(this.checkNumber(1, Number.POSITIVE_INFINITY)),
+        numberCPUs: this.checkLima(this.checkInteger(1, Number.POSITIVE_INFINITY)),
         useRosetta: this.checkPlatform('darwin', this.checkRosetta),
         type:       this.checkPlatform('darwin', this.checkMulti(
           this.checkEnum(...Object.values(VMType)),
@@ -144,7 +144,7 @@ export default class SettingsValidator {
             '9p': {
               securityModel:   this.checkLima(this.check9P(this.checkEnum(...Object.values(SecurityModel)))),
               protocolVersion: this.checkLima(this.check9P(this.checkEnum(...Object.values(ProtocolVersion)))),
-              msizeInKib:      this.checkLima(this.check9P(this.checkNumber(4, Number.POSITIVE_INFINITY))),
+              msizeInKib:      this.checkLima(this.check9P(this.checkInteger(4, Number.POSITIVE_INFINITY))),
               cacheMode:       this.checkLima(this.check9P(this.checkEnum(...Object.values(CacheMode)))),
             },
           },
@@ -152,7 +152,7 @@ export default class SettingsValidator {
             enabled:  this.checkPlatform('win32', this.checkBoolean),
             address:  this.checkPlatform('win32', this.checkString),
             password: this.checkPlatform('win32', this.checkString),
-            port:     this.checkPlatform('win32', this.checkNumber(1, 65535)),
+            port:     this.checkPlatform('win32', this.checkInteger(1, 65535)),
             username: this.checkPlatform('win32', this.checkString),
             noproxy:  this.checkPlatform('win32', this.checkNoproxyList),
           },
@@ -162,7 +162,7 @@ export default class SettingsValidator {
       WSL:        { integrations: this.checkPlatform('win32', this.checkBooleanMapping) },
       kubernetes: {
         version: this.checkKubernetesVersion,
-        port:    this.checkNumber(1, 65535),
+        port:    this.checkInteger(1, 65535),
         enabled: this.checkBoolean,
         options: { traefik: this.checkBoolean, flannel: this.checkBoolean },
         ingress: { localhostOnly: this.checkPlatform('win32', this.checkBoolean) },
@@ -528,6 +528,25 @@ export default class SettingsValidator {
       }
 
       return currentValue !== desiredValue;
+    };
+  }
+
+  /**
+   * checkInteger returns a checker for a whole number in the given range,
+   * inclusive.  Use it for counts, sizes and ports, where the backend has
+   * no sensible reading of a fractional value.
+   */
+  protected checkInteger(min: number, max: number) {
+    const checkRange = this.checkNumber(min, max);
+
+    return <S>(mergedSettings: S, currentValue: number, desiredValue: number, errors: string[], fqname: string) => {
+      if (typeof desiredValue === 'number' && !Number.isInteger(desiredValue)) {
+        errors.push(this.invalidSettingMessage(fqname, desiredValue));
+
+        return false;
+      }
+
+      return checkRange(mergedSettings, currentValue, desiredValue, errors, fqname);
     };
   }
 

--- a/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
+++ b/pkg/rancher-desktop/main/commandServer/settingsValidator.ts
@@ -533,8 +533,8 @@ export default class SettingsValidator {
 
   /**
    * checkInteger returns a checker for a whole number in the given range,
-   * inclusive.  Use it for counts, sizes and ports, where the backend has
-   * no sensible reading of a fractional value.
+   * inclusive.  Use it for counts, sizes and ports, where fractional
+   * values do not make sense.
    */
   protected checkInteger(min: number, max: number) {
     const checkRange = this.checkNumber(min, max);


### PR DESCRIPTION
The validator never checked for whole numbers. `parseInt` hid that for command-line options, which arrive as strings, by truncating them. #10755 changed `canonicalizeNumber` to `Number`, so `--kubernetes.port=6443.7` now sets the port to 6443.7. JSON numbers never went through `parseInt`, so `virtualMachine.numberCPUs` 2.5 has always been accepted, and reaches Lima's config.

Adds `checkInteger` for the CPU count, the 9p msize and both ports. `memoryInGB` and the two `diagnostics.connectivity` timers stay on `checkNumber`, because a fraction there still converts to a usable byte count or timer delay.

Measured against all three states:

| input | pre-#10755 | main today | this branch |
|---|---|---|---|
| `kubernetes.port` `"6443.7"` | `6443`, truncated | `6443.7`, accepted | rejected |
| `virtualMachine.numberCPUs` `2.5` | `2.5`, accepted | `2.5`, accepted | rejected |
| `virtualMachine.numberCPUs` `"2.5"` | `2`, truncated | `2.5`, accepted | rejected |

rdctl types these flags as `IntVar`, so a fraction now arrives only through the raw API, a hand-edited `settings.json`, or deployment profiles.
