### PR TITLE
Remove AutomaticEnv in DockerProxy

### DIFF
--- a/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_linux.go
@@ -39,6 +39,7 @@ var dockerproxyServeCmd = &cobra.Command{
 		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		proxyEndpoint := dockerproxyServeViper.GetString("proxy-endpoint")
+		logrus.WithFields(logrus.Fields{"endpoint": endpoint, "proxy-endpoint": proxyEndpoint}).Debug("starting docker proxy")
 		err := process.KillOthers("docker-proxy", "serve")
 		if err != nil {
 			return err
@@ -62,7 +63,6 @@ func init() {
 	}
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().String("proxy-endpoint", defaultProxyEndpoint, "Endpoint dockerd is listening on")
-	dockerproxyServeViper.AutomaticEnv()
 	if err := dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags()); err != nil {
 		logrus.WithError(err).Fatal("Failed to set up flags")
 	}

--- a/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_serve_windows.go
@@ -39,6 +39,7 @@ var dockerproxyServeCmd = &cobra.Command{
 		cmd.SilenceErrors = true
 		endpoint := dockerproxyServeViper.GetString("endpoint")
 		port := dockerproxyServeViper.GetUint32("port")
+		logrus.WithFields(logrus.Fields{"endpoint": endpoint, "port": port}).Debug("starting docker proxy")
 		dialer, err := platform.MakeDialer(port)
 		if err != nil {
 			return err
@@ -54,7 +55,6 @@ var dockerproxyServeCmd = &cobra.Command{
 func init() {
 	dockerproxyServeCmd.Flags().String("endpoint", platform.DefaultEndpoint, "Endpoint to listen on")
 	dockerproxyServeCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port docker is listening on")
-	dockerproxyServeViper.AutomaticEnv()
 	if err := dockerproxyServeViper.BindPFlags(dockerproxyServeCmd.Flags()); err != nil {
 		logrus.WithError(err).Fatal("Failed to set up flags")
 	}

--- a/src/go/wsl-helper/cmd/dockerproxy_start.go
+++ b/src/go/wsl-helper/cmd/dockerproxy_start.go
@@ -36,6 +36,7 @@ var dockerproxyStartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		port := dockerproxyStartViper.GetUint32("port")
 		endpoint := dockerproxyStartViper.GetString("endpoint")
+		logrus.WithFields(logrus.Fields{"endpoint": endpoint, "port": port}).Debug("starting docker daemon over vsock")
 		return dockerproxy.Start(cmd.Context(), port, endpoint, args)
 	},
 }
@@ -47,7 +48,6 @@ func init() {
 	}
 	dockerproxyStartCmd.Flags().Uint32("port", dockerproxy.DefaultPort, "Vsock port to listen on")
 	dockerproxyStartCmd.Flags().String("endpoint", defaultProxyEndpoint, "Dockerd socket endpoint")
-	dockerproxyStartViper.AutomaticEnv()
 	if err := dockerproxyStartViper.BindPFlags(dockerproxyStartCmd.Flags()); err != nil {
 		logrus.WithError(err).Fatal("Failed to set up flags")
 	}


### PR DESCRIPTION
No `AutomaticEnv()`: the "port" and "endpoint" flags would otherwise pick up unrelated ambient `PORT/ENDPOINT` variables. See https://github.com/rancher-sandbox/rancher-desktop/issues/10946.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/10946