### PR TITLE
Show the real error when the backend fails to start

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -590,21 +590,31 @@ async function startK8sManager() {
   }
   await k8smanager.start(cfg);
 
+  // start() resolves without a client when the start was aborted, and stop()
+  // clears the client, which can happen while the import below loads.  The
+  // getter then throws and masks the real failure.
+  if (![K8s.State.STARTED, K8s.State.DISABLED].includes(k8smanager.state)) {
+    console.log(`Backend is ${ k8smanager.state } after start; skipping post-start setup.`);
+
+    return;
+  }
+  const containerEngineClient = k8smanager.containerEngineClient;
+
   const { initializeExtensionManager } = await import('@pkg/main/extensions/manager');
 
-  await initializeExtensionManager(k8smanager.containerEngineClient, cfg);
+  await initializeExtensionManager(containerEngineClient, cfg);
   window.send('extensions/changed');
 
   if (!containerExecHandler) {
-    containerExecHandler = new ContainerExecHandler(k8smanager.containerEngineClient);
+    containerExecHandler = new ContainerExecHandler(containerEngineClient);
   } else {
-    containerExecHandler.updateClient(k8smanager.containerEngineClient);
+    containerExecHandler.updateClient(containerEngineClient);
   }
 
   if (!containerStatsHandler) {
-    containerStatsHandler = new ContainerStatsHandler(k8smanager.containerEngineClient);
+    containerStatsHandler = new ContainerStatsHandler(containerEngineClient);
   } else {
-    containerStatsHandler.updateClient(k8smanager.containerEngineClient);
+    containerStatsHandler.updateClient(containerEngineClient);
   }
 }
 

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -2064,11 +2064,6 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       } catch (err) {
         console.error('Error starting lima:', err);
         await this.setState(State.ERROR);
-        if (err instanceof BackendError) {
-          if (!err.fatal) {
-            return;
-          }
-        }
         throw err;
       } finally {
         this.currentAction = Action.NONE;


### PR DESCRIPTION
Fixes #8525.

The first commit reads the container engine client once, as soon as `k8smanager.start()` returns, and skips the post-start setup when the backend did not reach STARTED or DISABLED. `rdctl snapshot create` against a backend that has just come up no longer makes the app report "Invalid state, no container engine client available" and, under `--no-modal-dialogs`, quit.

The second commit stops lima from swallowing a non-fatal `BackendError`, so the error dialog shows its message. Without this commit, the first one would replace the misleading dialog with none at all.

Neither path has a unit test, so both were tested against a dev build, with a 15-second sleep after `start()` to widen the race and a synthetic non-fatal `BackendError` for the second commit.
