### PR TITLE
Create the updater's cache directory before writing to it

### DIFF
--- a/pkg/rancher-desktop/main/update/LonghornProvider.ts
+++ b/pkg/rancher-desktop/main/update/LonghornProvider.ts
@@ -513,6 +513,9 @@ export default class LonghornProvider extends Provider<LonghornUpdateInfo> {
       },
     };
 
+    // Only the Kubernetes code path creates paths.cache, and a factory reset
+    // deletes it.
+    await fs.promises.mkdir(path.dirname(gCachePath), { recursive: true });
     await fs.promises.writeFile(gCachePath, JSON.stringify(cache),
       { encoding: 'utf-8', mode: 0o600 });
 

--- a/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
+++ b/pkg/rancher-desktop/main/update/__tests__/LonghornProvider.spec.ts
@@ -434,6 +434,7 @@ describe('LonghornProvider.checkForUpdates', () => {
   afterEach(() => {
     modules.electron.net.fetch.mockReset();
     fs.rmSync(cacheFile, { force: true });
+    fs.mkdirSync(cacheDir, { recursive: true });
   });
 
   /** Answer the upgrade responder, the release lookup, and the checksum, in that order. */
@@ -501,6 +502,17 @@ describe('LonghornProvider.checkForUpdates', () => {
     process.env.RD_GITHUB_API_URL = serverURL;
 
     await expect(releaseLookupURL()).resolves.toBe(githubURL);
+  });
+
+  it('writes the cache when the cache directory is missing', async() => {
+    // Only the Kubernetes code path creates paths.cache, so it is missing on
+    // a launch with Kubernetes disabled after a factory reset.
+    fs.rmSync(cacheDir, { force: true, recursive: true });
+    mockRelease();
+
+    await makeProvider()['checkForUpdates']();
+    expect(JSON.parse(fs.readFileSync(cacheFile, 'utf-8')).file.url)
+      .toBe(`${ serverURL }/msi`);
   });
 
   it('discards a cached release that came from a different API', async() => {


### PR DESCRIPTION
Only the Kubernetes code path creates `paths.cache`, so after a factory reset, a launch with Kubernetes disabled cannot write `updater-longhorn.json` and never offers an update.

The provider now creates the directory before writing the file.
