### PR TITLE
Windows: Let UDP through the host-switch firewall exception

### DIFF
--- a/build/wix/main.wxs
+++ b/build/wix/main.wxs
@@ -186,16 +186,14 @@
         Description="Rancher Desktop host-switch.exe profile exception for private networks"
         Program="[APPLICATIONFOLDER]resources\resources\win32\internal\host-switch.exe"
         Profile="private"
-        Scope="any"
-        Protocol="tcp" />
+        Scope="any" />
       <fire:FirewallException
         Id="HostSwitchFirewallDomainException"
         Name="Rancher Desktop Networking Domain Exception"
         Description="Rancher Desktop host-switch.exe profile exception for domain networks"
         Program="[APPLICATIONFOLDER]resources\resources\win32\internal\host-switch.exe"
         Profile="domain"
-        Scope="any"
-        Protocol="tcp" />
+        Scope="any" />
     </Component>
 
     <!-- If required, run the app after install (for updates) -->


### PR DESCRIPTION
On a machine-wide install, a container's published UDP port is reachable only from localhost, because the MSI's firewall exceptions for host-switch.exe name tcp. WiX defaults an exception's protocol to tcp only when it names a port. Ours name a program, so dropping `Protocol="tcp"` lets both exceptions allow any protocol.
