### PR TITLE
Log why the container engine is not ready yet

### DIFF
--- a/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
+++ b/pkg/rancher-desktop/backend/containerClient/nerdctlClient.ts
@@ -145,12 +145,23 @@ export class NerdctlClient implements ContainerEngineClient {
     ];
 
     for (const cmd of commandsToCheck) {
+      let failureCount = 0;
+
       while (true) {
         try {
           await this.vm.execCommand({ expectFailure: true, root: true }, ...cmd);
           break;
         } catch (ex) {
-          // Ignore the error, try again
+          failureCount++;
+          // Nothing bounds this loop, so an engine that never becomes ready
+          // stalls the whole start with no log line naming the command that
+          // fails.  A production SpawnError prints neither stdout nor stderr,
+          // so read stderr off the exception.
+          if (failureCount % 10 === 0) {
+            const stderr = ex && typeof ex === 'object' && 'stderr' in ex && typeof ex.stderr === 'string' ? ex.stderr.trim() : '';
+
+            console.error(`Failed to run ${ cmd.join(' ') } ${ failureCount } times (will retry): ${ ex }${ stderr ? `\n${ stderr }` : '' }`);
+          }
           await util.promisify(setTimeout)(1_000);
         }
       }


### PR DESCRIPTION
`NerdctlClient.waitForReady` retries `nerdctl system info` and `buildctl debug info` with no limit and discards every error, so an engine that never comes up leaves Rancher Desktop at "Waiting for container engine to be ready" with nothing in any log.

It now logs the failing command and its stderr on every tenth failure.
