### PR TITLE
CI: Honour sign=false in the package workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -138,7 +138,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
+      (github.event_name == 'workflow_dispatch' && inputs.sign)
     permissions:
       contents: read
     steps:
@@ -191,7 +191,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.sign)
+      (github.event_name == 'workflow_dispatch' && inputs.sign)
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
`github.event.inputs` holds every `workflow_dispatch` input as a string, so `"false"` is truthy and a dispatch with `sign: false` still ran both Test Signing jobs. Both gates now read the typed `inputs.sign`.

PR CI never dispatches this workflow, but on the fork a `sign: false` dispatch with this change skipped both Test Signing jobs ([run 34178342390](https://github.com/jandubois/rancher-desktop/actions/runs/34178342390)).
