### PR TITLE
rddepman: quote release notes without pinging upstream

### DIFF
--- a/scripts/lib/__tests__/release-notes.spec.ts
+++ b/scripts/lib/__tests__/release-notes.spec.ts
@@ -1,0 +1,38 @@
+import { quoteReleaseNotes } from '../release-notes';
+
+describe('quoteReleaseNotes', () => {
+  /** A mention in its quoted form. */
+  function code(handle: string): string {
+    return `<code>@\u200B${ handle }</code>`;
+  }
+
+  /** An issue reference in its quoted form. */
+  function link(repository: string, number: number): string {
+    return `[${ repository }#${ number }](https://redirect.github.com/${ repository }/issues/${ number })`;
+  }
+
+  it.each([
+    ['* Fix it by @someone in #12', `* Fix it by ${ code('someone') } in ${ link('example/tool', 12) }`],
+    ['Thanks (@another-person)', `Thanks (${ code('another-person') })`],
+    ['cc @example/maintainers', `cc ${ code('example/maintainers') }`],
+    ['See other/project#34', `See ${ link('other/project', 34) }`],
+    ['See [#34]', `See [${ link('example/tool', 34) }]`],
+    ['in https://github.com/example/tool/pull/56', 'in https://redirect.github.com/example/tool/pull/56'],
+    ['[fixes #56](https://github.com/example/tool/pull/56)', '[fixes #56](https://redirect.github.com/example/tool/pull/56)'],
+  ])('rewrites %j', (body, expected) => {
+    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(expected);
+  });
+
+  it.each([
+    'Write to someone@example.com',
+    'Read https://blog.example.com/@someone/post',
+    '[found by @someone](https://example.com)',
+    'Run `npm install @scope/package`',
+    '```\n@someone fixed #12\n```',
+    'https://example.com/page#12',
+    'Zero&#8203;width',
+    'https://github.com/example/tool/compare/v1.0.0...v1.1.0',
+  ])('leaves %j unchanged', (body) => {
+    expect(quoteReleaseNotes(body, 'example', 'tool')).toEqual(body);
+  });
+});

--- a/scripts/lib/release-notes.ts
+++ b/scripts/lib/release-notes.ts
@@ -1,0 +1,40 @@
+const quotablePattern = new RegExp([
+  // Code spans, fenced code blocks and link text, copied unchanged, since
+  // GitHub finds no mentions or references inside them.
+  /(?<ticks>`+)[\s\S]*?\k<ticks>/.source,
+  /\[[^\]\n]*\](?=\()/.source,
+  // A link to an issue or pull request.
+  /https:\/\/github\.com\/(?<path>[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+)/.source,
+  // An issue reference, `#12` or `owner/repo#12`, outside URLs and HTML entities.
+  /(?<![\w.&/-])(?:(?<repository>[\w-]+\/[\w.-]+))?#(?<number>\d+)\b/.source,
+  // A user or team mention, outside email addresses and URLs.
+  /(?<![\w/])@(?<mention>[a-z\d](?:-?[a-z\d])*(?:\/[\w.-]+)?)(?![\w-])/.source,
+].join('|'), 'gi');
+
+/**
+ * Rewrite upstream release notes for quoting in a pull request body.
+ * GitHub notifies every user a body mentions and adds a backlink to every
+ * issue or pull request it references, so mentions become code and references
+ * link through redirect.github.com, which GitHub renders as a plain link.
+ */
+export function quoteReleaseNotes(body: string, owner: string, repo: string): string {
+  return body.replace(quotablePattern, (match, ...args) => {
+    // The last argument to a replacer is the named groups object.
+    const { path, repository, number, mention } = args.at(-1);
+
+    if (path) {
+      return `https://redirect.github.com/${ path }`;
+    }
+    if (number) {
+      const target = repository ?? `${ owner }/${ repo }`;
+
+      return `[${ target }#${ number }](https://redirect.github.com/${ target }/issues/${ number })`;
+    }
+    if (mention) {
+      // The zero-width space keeps a copy of the rendered text from mentioning anyone.
+      return `<code>@\u200B${ mention }</code>`;
+    }
+
+    return match;
+  });
+}

--- a/scripts/rddepman.ts
+++ b/scripts/rddepman.ts
@@ -31,6 +31,7 @@ import {
   Version,
   VersionedDependency,
 } from '@/scripts/lib/dependencies';
+import { quoteReleaseNotes } from '@/scripts/lib/release-notes';
 
 const MAIN_BRANCH = 'main';
 const GITHUB_OWNER = process.env.GITHUB_REPOSITORY?.split('/')[0] || 'rancher-sandbox';
@@ -162,7 +163,7 @@ async function getBody(dependency: VersionedDependency, currentVersion: Version,
   let lastVersion = dependency.versionToTagName(currentVersion);
 
   return releaseNotes.map(([, release]) => {
-    const body = release.body?.replace(/(?<!\w)(#\d+)\b/g, (n) => `${ owner }/${ repo }${ n }`) || `Release ${ release.name } does not have release notes.`;
+    const body = release.body ? quoteReleaseNotes(release.body, owner, repo) : `Release ${ release.name } does not have release notes.`;
     const compareLink = [
       `[Compare between ${ lastVersion } and ${ release.tag_name }]`,
       `(https://github.com/${ owner }/${ repo }/compare/${ lastVersion }...${ release.tag_name })`,


### PR DESCRIPTION
rddepman quotes upstream release notes in its bump PRs, so GitHub notified everyone those notes mentioned and added a backlink to every issue they referenced.

This turns mentions into code and links issue references through redirect.github.com, which GitHub renders as a plain link.

It also quotes only the newest release's notes and links the notes of each older release, because GitHub rejects a pull request body over 65,536 characters and rancher-desktop-2's nerdctl bump from 2.2.2 to 2.3.5 exceeds it (https://github.com/rancher-sandbox/rancher-desktop-2/actions/runs/34683522022).

Backported from rancher-sandbox/rancher-desktop-2#753.
